### PR TITLE
feat(identity-vault): encrypted IndexedDB vault with migration

### DIFF
--- a/packages/identity-vault/package.json
+++ b/packages/identity-vault/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@vh/identity-vault",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "vitest run --config ../../vitest.config.ts --dir ../../",
+    "lint": "echo 'No lint yet'"
+  },
+  "devDependencies": {
+    "fake-indexeddb": "^6.0.0",
+    "typescript": "^5.4.5",
+    "vitest": "^2.1.4"
+  }
+}

--- a/packages/identity-vault/src/crypto.ts
+++ b/packages/identity-vault/src/crypto.ts
@@ -1,0 +1,49 @@
+/**
+ * SubtleCrypto wrappers for the identity vault.
+ * Uses AES-GCM with a non-extractable CryptoKey stored in IndexedDB.
+ */
+
+const AES_ALGO = 'AES-GCM';
+const AES_KEY_LENGTH = 256;
+const IV_BYTES = 12;
+
+/** Generate a new AES-GCM master key (non-extractable). */
+export async function generateMasterKey(): Promise<CryptoKey> {
+  return crypto.subtle.generateKey(
+    { name: AES_ALGO, length: AES_KEY_LENGTH },
+    false, // non-extractable
+    ['encrypt', 'decrypt']
+  );
+}
+
+/** Encrypt plaintext bytes with AES-GCM. Returns fresh IV + ciphertext. */
+export async function encrypt(
+  key: CryptoKey,
+  plaintext: Uint8Array
+): Promise<{ iv: Uint8Array; ciphertext: ArrayBuffer }> {
+  const iv = crypto.getRandomValues(new Uint8Array(IV_BYTES));
+  const ciphertext = await crypto.subtle.encrypt(
+    { name: AES_ALGO, iv: iv as BufferSource },
+    key,
+    plaintext as BufferSource
+  );
+  return { iv, ciphertext };
+}
+
+/** Decrypt AES-GCM ciphertext. Returns plaintext bytes or null on failure. */
+export async function decrypt(
+  key: CryptoKey,
+  iv: Uint8Array,
+  ciphertext: ArrayBuffer
+): Promise<Uint8Array | null> {
+  try {
+    const plaintext = await crypto.subtle.decrypt(
+      { name: AES_ALGO, iv: iv as BufferSource },
+      key,
+      ciphertext
+    );
+    return new Uint8Array(plaintext);
+  } catch {
+    return null;
+  }
+}

--- a/packages/identity-vault/src/db.ts
+++ b/packages/identity-vault/src/db.ts
@@ -1,0 +1,63 @@
+/**
+ * IndexedDB helpers for the identity vault.
+ * Handles open/get/put/delete with lazy database creation.
+ */
+
+import { DB_NAME, VAULT_STORE, KEYS_STORE } from './types';
+
+/** Open (or create) the vault database. */
+export function openVaultDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, 1);
+
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(VAULT_STORE)) {
+        db.createObjectStore(VAULT_STORE);
+      }
+      if (!db.objectStoreNames.contains(KEYS_STORE)) {
+        db.createObjectStore(KEYS_STORE);
+      }
+    };
+
+    request.onsuccess = () => resolve(request.result);
+    /* v8 ignore next */
+    request.onerror = () => reject(request.error);
+  });
+}
+
+/** Get a value from an object store by key. */
+export function idbGet<T>(db: IDBDatabase, storeName: string, key: string): Promise<T | undefined> {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(storeName, 'readonly');
+    const store = tx.objectStore(storeName);
+    const request = store.get(key);
+    request.onsuccess = () => resolve(request.result as T | undefined);
+    /* v8 ignore next */
+    request.onerror = () => reject(request.error);
+  });
+}
+
+/** Put a value into an object store. */
+export function idbPut(db: IDBDatabase, storeName: string, key: string, value: unknown): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(storeName, 'readwrite');
+    const store = tx.objectStore(storeName);
+    const request = store.put(value, key);
+    request.onsuccess = () => resolve();
+    /* v8 ignore next */
+    request.onerror = () => reject(request.error);
+  });
+}
+
+/** Delete a value from an object store. */
+export function idbDelete(db: IDBDatabase, storeName: string, key: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(storeName, 'readwrite');
+    const store = tx.objectStore(storeName);
+    const request = store.delete(key);
+    request.onsuccess = () => resolve();
+    /* v8 ignore next */
+    request.onerror = () => reject(request.error);
+  });
+}

--- a/packages/identity-vault/src/env.ts
+++ b/packages/identity-vault/src/env.ts
@@ -1,0 +1,24 @@
+/**
+ * Environment guards for SSR/Node safety.
+ * When these return false, vault functions become safe no-ops.
+ */
+
+/** Returns true if IndexedDB is available in the current environment. */
+export function isIdbAvailable(): boolean {
+  return typeof globalThis.indexedDB !== 'undefined' && globalThis.indexedDB !== null;
+}
+
+/** Returns true if SubtleCrypto is available in the current environment. */
+export function isSubtleCryptoAvailable(): boolean {
+  return (
+    typeof globalThis.crypto !== 'undefined' &&
+    globalThis.crypto !== null &&
+    typeof globalThis.crypto.subtle !== 'undefined' &&
+    globalThis.crypto.subtle !== null
+  );
+}
+
+/** Returns true if the vault can operate (both IDB and SubtleCrypto available). */
+export function isVaultAvailable(): boolean {
+  return isIdbAvailable() && isSubtleCryptoAvailable();
+}

--- a/packages/identity-vault/src/index.ts
+++ b/packages/identity-vault/src/index.ts
@@ -1,0 +1,4 @@
+export type { Identity, VaultRecord } from './types';
+export { LEGACY_STORAGE_KEY, isValidIdentity } from './types';
+export { loadIdentity, saveIdentity, clearIdentity } from './vault';
+export { migrateLegacyLocalStorage } from './migrate';

--- a/packages/identity-vault/src/migrate.ts
+++ b/packages/identity-vault/src/migrate.ts
@@ -1,0 +1,54 @@
+/**
+ * Legacy localStorage → encrypted vault migration.
+ */
+
+import { isVaultAvailable } from './env';
+import { LEGACY_STORAGE_KEY, isValidIdentity } from './types';
+import type { Identity } from './types';
+import { saveIdentity } from './vault';
+
+/**
+ * Migrate identity from plaintext localStorage to the encrypted vault.
+ *
+ * - "noop": no legacy entry found (or vault unavailable)
+ * - "migrated": successfully migrated and removed legacy entry
+ * - "invalid": legacy entry exists but is not valid JSON / not a valid identity
+ */
+export async function migrateLegacyLocalStorage(): Promise<'noop' | 'migrated' | 'invalid'> {
+  // If vault is unavailable, don't destroy source data
+  if (!isVaultAvailable()) {
+    return 'noop';
+  }
+
+  let raw: string | null;
+  try {
+    raw = globalThis.localStorage?.getItem(LEGACY_STORAGE_KEY) ?? null;
+  } catch {
+    return 'noop';
+  }
+
+  if (raw === null) {
+    return 'noop';
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return 'invalid';
+  }
+
+  if (!isValidIdentity(parsed)) {
+    return 'invalid';
+  }
+
+  await saveIdentity(parsed as Identity);
+
+  try {
+    globalThis.localStorage.removeItem(LEGACY_STORAGE_KEY);
+  } catch {
+    // Best-effort removal
+  }
+
+  return 'migrated';
+}

--- a/packages/identity-vault/src/types.ts
+++ b/packages/identity-vault/src/types.ts
@@ -1,0 +1,52 @@
+/**
+ * Minimum identity shape. Extra fields MUST survive round-trip.
+ */
+export interface Identity {
+  displayName: string;
+  pub: string;
+  priv: string;
+  [extra: string]: unknown;
+}
+
+/**
+ * Record stored in IndexedDB "vault" object store.
+ */
+export interface VaultRecord {
+  version: number;
+  iv: Uint8Array;
+  ciphertext: ArrayBuffer;
+}
+
+/** Database name for the identity vault. */
+export const DB_NAME = 'vh-vault';
+
+/** Object store for encrypted identity blobs. */
+export const VAULT_STORE = 'vault';
+
+/** Object store for CryptoKeys. */
+export const KEYS_STORE = 'keys';
+
+/** Key under which the identity record is stored. */
+export const IDENTITY_KEY = 'identity';
+
+/** Key under which the master CryptoKey is stored. */
+export const MASTER_KEY = 'master';
+
+/** Current vault record version. */
+export const VAULT_VERSION = 1;
+
+/** Legacy localStorage key consumed during migration. */
+export const LEGACY_STORAGE_KEY = 'vh_identity';
+
+/** Runtime shape check for Identity objects. */
+export function isValidIdentity(value: unknown): value is Identity {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const obj = value as Record<string, unknown>;
+  return (
+    typeof obj.displayName === 'string' &&
+    typeof obj.pub === 'string' &&
+    typeof obj.priv === 'string'
+  );
+}

--- a/packages/identity-vault/src/vault.test.ts
+++ b/packages/identity-vault/src/vault.test.ts
@@ -1,0 +1,388 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import 'fake-indexeddb/auto';
+import { loadIdentity, saveIdentity, clearIdentity } from './vault';
+import { migrateLegacyLocalStorage } from './migrate';
+import { openVaultDb, idbGet, idbPut, idbDelete } from './db';
+import { VAULT_STORE, KEYS_STORE, IDENTITY_KEY, MASTER_KEY, LEGACY_STORAGE_KEY, VAULT_VERSION } from './types';
+import type { Identity, VaultRecord } from './types';
+
+const TEST_IDENTITY: Identity = {
+  displayName: 'Alice Nakamoto',
+  pub: 'pk_abc123_public_key_data',
+  priv: 'sk_secret_private_key_data',
+  customField: 42,
+};
+
+/**
+ * Helper: delete the entire IDB database between tests for isolation.
+ */
+function deleteDatabase(name: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.deleteDatabase(name);
+    req.onsuccess = () => resolve();
+    req.onerror = () => reject(req.error);
+  });
+}
+
+beforeEach(async () => {
+  await deleteDatabase('vh-vault');
+  localStorage.clear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('T-7: Round-trip', () => {
+  it('saveIdentity → loadIdentity returns deep-equal identity', async () => {
+    await saveIdentity(TEST_IDENTITY);
+    const loaded = await loadIdentity();
+    expect(loaded).toEqual(TEST_IDENTITY);
+  });
+
+  it('preserves extra fields through round-trip', async () => {
+    const withExtras: Identity = { ...TEST_IDENTITY, nested: { a: 1 }, arr: [1, 2, 3] };
+    await saveIdentity(withExtras);
+    const loaded = await loadIdentity();
+    expect(loaded).toEqual(withExtras);
+  });
+});
+
+describe('T-1: Encrypt at rest', () => {
+  it('raw IDB blob does not contain plaintext markers', async () => {
+    await saveIdentity(TEST_IDENTITY);
+
+    const db = await openVaultDb();
+    const record = await idbGet<VaultRecord>(db, VAULT_STORE, IDENTITY_KEY);
+    db.close();
+
+    expect(record).toBeDefined();
+
+    // Convert ciphertext to string to search for plaintext leaks
+    const bytes = new Uint8Array(record!.ciphertext);
+    const asString = new TextDecoder().decode(bytes);
+
+    expect(asString).not.toContain(TEST_IDENTITY.displayName);
+    expect(asString).not.toContain(TEST_IDENTITY.pub);
+    expect(asString).not.toContain(TEST_IDENTITY.priv);
+  });
+});
+
+describe('T-2: Tamper detection', () => {
+  it('flipping a byte in ciphertext → loadIdentity returns null', async () => {
+    await saveIdentity(TEST_IDENTITY);
+
+    const db = await openVaultDb();
+    const record = await idbGet<VaultRecord>(db, VAULT_STORE, IDENTITY_KEY);
+    expect(record).toBeDefined();
+
+    // Flip first byte of ciphertext
+    const tampered = new Uint8Array(record!.ciphertext);
+    tampered[0] ^= 0xff;
+    const tamperedRecord: VaultRecord = {
+      version: record!.version,
+      iv: record!.iv,
+      ciphertext: tampered.buffer,
+    };
+    await idbPut(db, VAULT_STORE, IDENTITY_KEY, tamperedRecord);
+    db.close();
+
+    const loaded = await loadIdentity();
+    expect(loaded).toBeNull();
+  });
+
+  it('flipping a byte in IV → loadIdentity returns null', async () => {
+    await saveIdentity(TEST_IDENTITY);
+
+    const db = await openVaultDb();
+    const record = await idbGet<VaultRecord>(db, VAULT_STORE, IDENTITY_KEY);
+    expect(record).toBeDefined();
+
+    // Flip first byte of IV
+    const tamperedIv = new Uint8Array(record!.iv);
+    tamperedIv[0] ^= 0xff;
+    const tamperedRecord: VaultRecord = {
+      version: record!.version,
+      iv: tamperedIv,
+      ciphertext: record!.ciphertext,
+    };
+    await idbPut(db, VAULT_STORE, IDENTITY_KEY, tamperedRecord);
+    db.close();
+
+    const loaded = await loadIdentity();
+    expect(loaded).toBeNull();
+  });
+});
+
+describe('T-3: Legacy migration (happy path)', () => {
+  it('migrates localStorage identity to vault and removes legacy key', async () => {
+    localStorage.setItem(LEGACY_STORAGE_KEY, JSON.stringify(TEST_IDENTITY));
+
+    const result = await migrateLegacyLocalStorage();
+    expect(result).toBe('migrated');
+
+    const loaded = await loadIdentity();
+    expect(loaded).toEqual(TEST_IDENTITY);
+
+    expect(localStorage.getItem(LEGACY_STORAGE_KEY)).toBeNull();
+  });
+});
+
+describe('T-4: Migration noop', () => {
+  it('returns "noop" when no localStorage entry exists', async () => {
+    const result = await migrateLegacyLocalStorage();
+    expect(result).toBe('noop');
+  });
+});
+
+describe('T-5: Migration invalid', () => {
+  it('returns "invalid" for non-JSON localStorage', async () => {
+    localStorage.setItem(LEGACY_STORAGE_KEY, '<<<not json>>>');
+    const result = await migrateLegacyLocalStorage();
+    expect(result).toBe('invalid');
+  });
+
+  it('returns "invalid" for JSON that is not a valid identity', async () => {
+    localStorage.setItem(LEGACY_STORAGE_KEY, JSON.stringify({ foo: 'bar' }));
+    const result = await migrateLegacyLocalStorage();
+    expect(result).toBe('invalid');
+  });
+});
+
+describe('T-6: Missing crypto key', () => {
+  it('returns null when master key is deleted but ciphertext remains', async () => {
+    await saveIdentity(TEST_IDENTITY);
+
+    // Delete the master key
+    const db = await openVaultDb();
+    await idbDelete(db, KEYS_STORE, MASTER_KEY);
+    db.close();
+
+    const loaded = await loadIdentity();
+    expect(loaded).toBeNull();
+  });
+});
+
+describe('T-8: Clear identity', () => {
+  it('clearIdentity → loadIdentity returns null', async () => {
+    await saveIdentity(TEST_IDENTITY);
+    expect(await loadIdentity()).toEqual(TEST_IDENTITY);
+
+    await clearIdentity();
+    expect(await loadIdentity()).toBeNull();
+  });
+});
+
+describe('T-9: SSR/Node fallback', () => {
+  it('loadIdentity returns null when indexedDB unavailable', async () => {
+    const original = globalThis.indexedDB;
+    try {
+      // @ts-expect-error — intentionally removing for test
+      delete globalThis.indexedDB;
+      const loaded = await loadIdentity();
+      expect(loaded).toBeNull();
+    } finally {
+      globalThis.indexedDB = original;
+    }
+  });
+
+  it('saveIdentity is a no-op when indexedDB unavailable', async () => {
+    const original = globalThis.indexedDB;
+    try {
+      // @ts-expect-error — intentionally removing for test
+      delete globalThis.indexedDB;
+      await expect(saveIdentity(TEST_IDENTITY)).resolves.toBeUndefined();
+    } finally {
+      globalThis.indexedDB = original;
+    }
+  });
+
+  it('clearIdentity is a no-op when indexedDB unavailable', async () => {
+    const original = globalThis.indexedDB;
+    try {
+      // @ts-expect-error — intentionally removing for test
+      delete globalThis.indexedDB;
+      await expect(clearIdentity()).resolves.toBeUndefined();
+    } finally {
+      globalThis.indexedDB = original;
+    }
+  });
+
+  it('migrateLegacyLocalStorage returns "noop" when indexedDB unavailable', async () => {
+    const original = globalThis.indexedDB;
+    try {
+      // @ts-expect-error — intentionally removing for test
+      delete globalThis.indexedDB;
+      const result = await migrateLegacyLocalStorage();
+      expect(result).toBe('noop');
+    } finally {
+      globalThis.indexedDB = original;
+    }
+  });
+
+  it('loadIdentity returns null when crypto.subtle unavailable', async () => {
+    const originalSubtle = crypto.subtle;
+    Object.defineProperty(crypto, 'subtle', { value: undefined, configurable: true });
+    try {
+      const loaded = await loadIdentity();
+      expect(loaded).toBeNull();
+    } finally {
+      Object.defineProperty(crypto, 'subtle', { value: originalSubtle, configurable: true });
+    }
+  });
+});
+
+describe('Error branches', () => {
+  it('loadIdentity returns null when openVaultDb fails', async () => {
+    const original = globalThis.indexedDB;
+    // Save first while IDB works
+    await saveIdentity(TEST_IDENTITY);
+
+    // Now break IDB open by replacing it with a throwing proxy
+    const brokenIdb = {
+      ...original,
+      open: () => { throw new Error('IDB broken'); },
+    };
+    Object.defineProperty(globalThis, 'indexedDB', { value: brokenIdb, configurable: true });
+    try {
+      const loaded = await loadIdentity();
+      expect(loaded).toBeNull();
+    } finally {
+      Object.defineProperty(globalThis, 'indexedDB', { value: original, configurable: true });
+    }
+  });
+
+  it('clearIdentity is safe when openVaultDb fails', async () => {
+    const original = globalThis.indexedDB;
+    const brokenIdb = {
+      ...original,
+      open: () => { throw new Error('IDB broken'); },
+    };
+    Object.defineProperty(globalThis, 'indexedDB', { value: brokenIdb, configurable: true });
+    try {
+      await expect(clearIdentity()).resolves.toBeUndefined();
+    } finally {
+      Object.defineProperty(globalThis, 'indexedDB', { value: original, configurable: true });
+    }
+  });
+
+  it('loadIdentity returns null when vault record has wrong version', async () => {
+    await saveIdentity(TEST_IDENTITY);
+
+    const db = await openVaultDb();
+    const record = await idbGet<VaultRecord>(db, VAULT_STORE, IDENTITY_KEY);
+    expect(record).toBeDefined();
+
+    // Write a record with a future version
+    const futureRecord: VaultRecord = { ...record!, version: 999 };
+    await idbPut(db, VAULT_STORE, IDENTITY_KEY, futureRecord);
+    db.close();
+
+    const loaded = await loadIdentity();
+    expect(loaded).toBeNull();
+  });
+
+  it('loadIdentity returns null when decrypted data is valid JSON but invalid Identity shape', async () => {
+    await saveIdentity(TEST_IDENTITY);
+
+    const db = await openVaultDb();
+    const key = await idbGet<CryptoKey>(db, KEYS_STORE, MASTER_KEY);
+    expect(key).toBeDefined();
+
+    // Encrypt valid JSON that is NOT a valid Identity (missing required fields)
+    const { encrypt } = await import('./crypto');
+    const badShape = new TextEncoder().encode(JSON.stringify({ foo: 'bar', num: 42 }));
+    const { iv, ciphertext } = await encrypt(key!, badShape);
+    await idbPut(db, VAULT_STORE, IDENTITY_KEY, { version: VAULT_VERSION, iv, ciphertext });
+    db.close();
+
+    const loaded = await loadIdentity();
+    expect(loaded).toBeNull();
+
+    // Verify corrupt record was wiped
+    const db2 = await openVaultDb();
+    const remaining = await idbGet<VaultRecord>(db2, VAULT_STORE, IDENTITY_KEY);
+    db2.close();
+    expect(remaining).toBeUndefined();
+  });
+
+  it('loadIdentity returns null when decrypted data is not valid JSON', async () => {
+    // Save a valid identity first to get a key
+    await saveIdentity(TEST_IDENTITY);
+
+    // Now replace the ciphertext with encrypted non-JSON data
+    const db = await openVaultDb();
+    const key = await idbGet<CryptoKey>(db, KEYS_STORE, MASTER_KEY);
+    expect(key).toBeDefined();
+
+    // Encrypt some non-JSON bytes
+    const { encrypt } = await import('./crypto');
+    const nonJson = new TextEncoder().encode('<<<not json>>>');
+    const { iv, ciphertext } = await encrypt(key!, nonJson);
+    await idbPut(db, VAULT_STORE, IDENTITY_KEY, { version: 1, iv, ciphertext });
+    db.close();
+
+    const loaded = await loadIdentity();
+    expect(loaded).toBeNull();
+  });
+
+  it('migrateLegacyLocalStorage returns "noop" when localStorage.getItem throws', async () => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('SecurityError');
+    });
+    const result = await migrateLegacyLocalStorage();
+    expect(result).toBe('noop');
+  });
+
+  it('migrateLegacyLocalStorage still returns "migrated" when localStorage.removeItem throws', async () => {
+    localStorage.setItem(LEGACY_STORAGE_KEY, JSON.stringify(TEST_IDENTITY));
+    vi.spyOn(Storage.prototype, 'removeItem').mockImplementation(() => {
+      throw new Error('SecurityError');
+    });
+    const result = await migrateLegacyLocalStorage();
+    expect(result).toBe('migrated');
+    // Identity should still be in the vault
+    const loaded = await loadIdentity();
+    expect(loaded).toEqual(TEST_IDENTITY);
+  });
+
+  it('migrateLegacyLocalStorage returns "invalid" for non-object JSON (number)', async () => {
+    localStorage.setItem(LEGACY_STORAGE_KEY, '42');
+    const result = await migrateLegacyLocalStorage();
+    expect(result).toBe('invalid');
+  });
+
+  it('migrateLegacyLocalStorage returns "invalid" for null JSON', async () => {
+    localStorage.setItem(LEGACY_STORAGE_KEY, 'null');
+    const result = await migrateLegacyLocalStorage();
+    expect(result).toBe('invalid');
+  });
+});
+
+describe('Edge cases', () => {
+  it('loadIdentity returns null when no identity saved', async () => {
+    const loaded = await loadIdentity();
+    expect(loaded).toBeNull();
+  });
+
+  it('empty identity round-trips', async () => {
+    const empty: Identity = { displayName: '', pub: '', priv: '' };
+    await saveIdentity(empty);
+    const loaded = await loadIdentity();
+    expect(loaded).toEqual(empty);
+  });
+
+  it('multiple migrations: first migrated, second noop', async () => {
+    localStorage.setItem(LEGACY_STORAGE_KEY, JSON.stringify(TEST_IDENTITY));
+    expect(await migrateLegacyLocalStorage()).toBe('migrated');
+    expect(await migrateLegacyLocalStorage()).toBe('noop');
+  });
+
+  it('save overwrites previous identity (last-write-wins)', async () => {
+    await saveIdentity(TEST_IDENTITY);
+    const updated: Identity = { displayName: 'Bob', pub: 'pk2', priv: 'sk2' };
+    await saveIdentity(updated);
+    expect(await loadIdentity()).toEqual(updated);
+  });
+});

--- a/packages/identity-vault/src/vault.ts
+++ b/packages/identity-vault/src/vault.ts
@@ -1,0 +1,132 @@
+/**
+ * Core vault operations: load, save, clear.
+ */
+
+import { isVaultAvailable } from './env';
+import { openVaultDb, idbGet, idbPut, idbDelete } from './db';
+import { generateMasterKey, encrypt, decrypt } from './crypto';
+import {
+  VAULT_STORE,
+  KEYS_STORE,
+  IDENTITY_KEY,
+  MASTER_KEY,
+  VAULT_VERSION,
+  isValidIdentity,
+} from './types';
+import type { Identity, VaultRecord } from './types';
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+/**
+ * Retrieve the master CryptoKey, or null if none exists.
+ */
+async function getMasterKey(db: IDBDatabase): Promise<CryptoKey | null> {
+  const key = await idbGet<CryptoKey>(db, KEYS_STORE, MASTER_KEY);
+  return key ?? null;
+}
+
+/**
+ * Ensure a master CryptoKey exists; create one if needed.
+ */
+async function ensureMasterKey(db: IDBDatabase): Promise<CryptoKey> {
+  const existing = await getMasterKey(db);
+  if (existing) return existing;
+
+  const key = await generateMasterKey();
+  await idbPut(db, KEYS_STORE, MASTER_KEY, key);
+  return key;
+}
+
+/** Open the vault DB, returning null on failure. */
+async function tryOpenDb(): Promise<IDBDatabase | null> {
+  try {
+    return await openVaultDb();
+  } catch {
+    return null;
+  }
+}
+
+/** Run a callback with an open DB, closing it afterward. */
+async function withDb<T>(fallback: T, fn: (db: IDBDatabase) => Promise<T>): Promise<T> {
+  const db = await tryOpenDb();
+  if (!db) return fallback;
+  try {
+    return await fn(db);
+  } catch {
+    return fallback;
+    /* v8 ignore next 2 -- v8 phantom branch on finally entry */
+  } finally {
+    db.close();
+  }
+}
+
+/**
+ * Load the encrypted identity from the vault.
+ * Returns null if: no record, no key, decryption fails (tamper), or vault unavailable.
+ */
+export async function loadIdentity(): Promise<Identity | null> {
+  if (!isVaultAvailable()) return null;
+
+  return withDb(null, async (db) => {
+    const record = await idbGet<VaultRecord>(db, VAULT_STORE, IDENTITY_KEY);
+    if (!record) return null;
+
+    // M2: version gate — reject records from incompatible future versions
+    if (record.version !== VAULT_VERSION) return null;
+
+    const key = await getMasterKey(db);
+    if (!key) return null;
+
+    const plaintext = await decrypt(key, record.iv, record.ciphertext);
+    if (!plaintext) {
+      // Tamper detected — wipe corrupt record
+      await idbDelete(db, VAULT_STORE, IDENTITY_KEY).catch(() => {});
+      return null;
+    }
+
+    const json = decoder.decode(plaintext);
+    const parsed: unknown = JSON.parse(json);
+
+    // M1: runtime shape validation — zero-trust on stored data
+    if (!isValidIdentity(parsed)) {
+      await idbDelete(db, VAULT_STORE, IDENTITY_KEY).catch(() => {});
+      return null;
+    }
+
+    return parsed;
+  });
+}
+
+/**
+ * Encrypt and save an identity to the vault.
+ * Creates the master key lazily if needed.
+ */
+export async function saveIdentity(identity: Identity): Promise<void> {
+  if (!isVaultAvailable()) return;
+
+  return withDb(undefined, async (db) => {
+    const key = await ensureMasterKey(db);
+    const plaintext = encoder.encode(JSON.stringify(identity));
+    const { iv, ciphertext } = await encrypt(key, plaintext);
+
+    const record: VaultRecord = {
+      version: VAULT_VERSION,
+      iv,
+      ciphertext,
+    };
+
+    await idbPut(db, VAULT_STORE, IDENTITY_KEY, record);
+  });
+}
+
+/**
+ * Remove the identity from the vault (keeps the master key).
+ */
+export async function clearIdentity(): Promise<void> {
+  if (!isVaultAvailable()) return;
+
+  return withDb(undefined, async (db) => {
+    await idbDelete(db, VAULT_STORE, IDENTITY_KEY);
+  });
+}

--- a/packages/identity-vault/tsconfig.json
+++ b/packages/identity-vault/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -268,6 +268,18 @@ importers:
         specifier: ^2.1.4
         version: 2.1.9(@types/node@20.17.19)(jsdom@24.1.3)
 
+  packages/identity-vault:
+    devDependencies:
+      fake-indexeddb:
+        specifier: ^6.0.0
+        version: 6.2.5
+      typescript:
+        specifier: ^5.4.5
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.4
+        version: 2.1.9(@types/node@20.17.19)(jsdom@24.1.3)
+
   packages/types:
     dependencies:
       zod:
@@ -2820,11 +2832,11 @@ packages:
 
   glob@5.0.15:
     resolution: {integrity: sha512-c9IPMazfRITpmAAKi22dK1VKxGDX9ehhqfABDriL/lzO92xcUKEJPQHrVA/2YHSNFB4iFlykVmWvwo48nr3OxA==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@7.1.7:
     resolution: {integrity: sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,7 +8,8 @@ export default defineConfig({
       '@vh/crypto/primitives': resolve(__dirname, 'packages/crypto/src/primitives.ts'),
       '@vh/crypto/provider': resolve(__dirname, 'packages/crypto/src/provider.ts'),
       '@vh/data-model': resolve(__dirname, 'packages/data-model/src/index.ts'),
-      '@vh/ai-engine': resolve(__dirname, 'packages/ai-engine/src/index.ts')
+      '@vh/ai-engine': resolve(__dirname, 'packages/ai-engine/src/index.ts'),
+      '@vh/identity-vault': resolve(__dirname, 'packages/identity-vault/src/index.ts')
     }
   },
   test: {


### PR DESCRIPTION
## P01A: @vh/identity-vault

Adds `packages/identity-vault` — a standalone encrypted identity storage module.

### What
- AES-GCM encrypted identity storage in IndexedDB
- Non-extractable CryptoKey management (device-bound)
- Runtime shape validation on load (zero-trust)
- Version gating on vault records (forward-compat safe)
- Legacy `localStorage` migration (`vh_identity` key)
- Tamper detection with automatic corrupt record cleanup
- SSR/Node safety (no-op when IndexedDB or SubtleCrypto unavailable)

### Tests
- 29 tests covering all 9 spec cases + error branches + maint review findings
- 100% line, branch, function, and statement coverage
- No regressions (373 total tests pass)

### Files
New package: `packages/identity-vault/src/` — crypto.ts, db.ts, env.ts, migrate.ts, types.ts, vault.ts, index.ts
Modified: `vitest.config.ts` (alias), `pnpm-lock.yaml` (fake-indexeddb dev dep)

### Review
- Spec: `docs/specs/p01a-identity-vault.md`
- Maint review: 2 Musts fixed (M1: shape validation, M2: version gating), 0 remaining
- QA: fresh checkout validated at `5a7c44c`, 100% coverage

### No existing app code modified
This is P01A — the vault module only. P01B will wire it into `useIdentity` + app bootstrap.