### PR TITLE
chore: add root pnpm typecheck script

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Lint (LOC & Rules)
         run: pnpm lint
 
+      - name: Typecheck
+        run: pnpm typecheck
+
       - name: Circular Dependency Check
         run: pnpm deps:check
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,7 @@ pnpm vh dev
 ```
 
 ## Tests & CI
+- Typecheck: `pnpm typecheck`
 - Quick tests: `pnpm test:quick`
 - Dependency graph check: `pnpm deps:check`
 - CI mirrors these steps (see `.github/workflows/main.yml`).

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "scripts": {
     "build": "pnpm -r --workspace-root=false build",
+    "typecheck": "pnpm -r typecheck",
     "test": "pnpm -r --workspace-root=false test",
     "lint": "pnpm -r --workspace-root=false lint",
     "vh": "pnpm --filter \"@vh/cli\" exec tsx src/index.ts",

--- a/packages/ai-engine/package.json
+++ b/packages/ai-engine/package.json
@@ -12,7 +12,8 @@
     }
   },
   "scripts": {
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@mlc-ai/web-llm": "^0.2.79",

--- a/packages/crdt/package.json
+++ b/packages/crdt/package.json
@@ -13,6 +13,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc --noEmit",
     "test": "echo 'No tests yet'",
     "lint": "echo 'No lint yet'"
   },

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -21,6 +21,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run --config ../../vitest.config.ts --dir ../../",
     "lint": "echo 'No lint yet'"
   },

--- a/packages/identity-vault/package.json
+++ b/packages/identity-vault/package.json
@@ -13,6 +13,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run --config ../../vitest.config.ts --dir ../../",
     "lint": "echo 'No lint yet'"
   },

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -15,6 +15,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc --noEmit",
     "test": "echo 'No tests yet'",
     "lint": "echo 'No lint yet'"
   },

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -10,6 +10,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc --noEmit",
     "lint": "echo 'No lint yet'"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

Adds a root `pnpm typecheck` script that runs `tsc --noEmit` across workspace packages, and enforces it in CI.

### Changes
- **Root `package.json`**: add `"typecheck": "pnpm -r typecheck"` script
- **6 passing packages**: add `"typecheck": "tsc --noEmit"` to ai-engine, crdt, crypto, identity-vault, types, ui
- **CI** (`.github/workflows/main.yml`): add Typecheck step in Quality Guard job (after lint, before circular dep check)
- **CONTRIBUTING.md**: add `pnpm typecheck` to the command list

### Deferred (pre-existing type errors)
The following have pre-existing type errors and are not yet wired:
- `packages/contracts` (hardhat types)
- `packages/data-model` (missing cross-package ref)
- `packages/e2e` (playwright types)
- `packages/gun-client` (missing cross-package refs)
- `apps/web-pwa` (vite moduleResolution mismatch)

### Verification
- `pnpm typecheck` — 6 packages pass
- `pnpm test:quick` — 390 tests, 64 files pass
- `pnpm lint` — pass

Closes #11