### PR TITLE
fix: add defensive-copy semantics to getFullIdentity (#12)

### DIFF
--- a/apps/web-pwa/src/store/identityProvider.test.ts
+++ b/apps/web-pwa/src/store/identityProvider.test.ts
@@ -79,6 +79,22 @@ describe('identityProvider', () => {
     expect(getPublishedIdentity()!.session.nullifier).toBe('original');
   });
 
+  it('getFullIdentity returns a defensive copy — mutations do not affect the singleton', () => {
+    const record = {
+      session: { nullifier: 'original', trustScore: 0.9, scaledTrustScore: 9000 },
+      devicePair: { pub: 'pub', priv: 'priv', epub: 'epub', epriv: 'epriv' },
+    };
+    publishIdentity(record);
+
+    const full1 = getFullIdentity<typeof record>()!;
+    full1.session.nullifier = 'mutated';
+    full1.devicePair.priv = 'hacked';
+
+    const full2 = getFullIdentity<typeof record>()!;
+    expect(full2.session.nullifier).toBe('original');
+    expect(full2.devicePair.priv).toBe('priv');
+  });
+
   it('sets __vh_identity_published flag on globalThis', () => {
     expect((globalThis as any).__vh_identity_published).toBeFalsy();
     publishIdentity({

--- a/apps/web-pwa/src/store/identityProvider.ts
+++ b/apps/web-pwa/src/store/identityProvider.ts
@@ -58,7 +58,8 @@ export function getPublishedIdentity(): PublicIdentitySnapshot | null {
  * require private fields (e.g. chat encryption keys).
  */
 export function getFullIdentity<T = Record<string, unknown>>(): T | null {
-  return fullRecord as T | null;
+  if (!fullRecord) return null;
+  return structuredClone(fullRecord) as T;
 }
 
 /** Clear published identity (for tests or sign-out). */


### PR DESCRIPTION
## Summary
- harden `getFullIdentity()` in `apps/web-pwa/src/store/identityProvider.ts` to return `structuredClone(fullRecord)` (or `null`) so callers cannot mutate the shared singleton
- add a mutation-safety unit test in `apps/web-pwa/src/store/identityProvider.test.ts` proving mutations on one `getFullIdentity()` result do not affect subsequent reads
- add a block comment at the top of `createSaveIdentityHarness` in `packages/identity-vault/src/vault.master-key-race.test.ts` documenting the `vi.doMock` race simulation strategy and what harness controls/asserts

## Verification
- `pnpm test:quick`
- `pnpm typecheck`
- `pnpm lint`