### PR TITLE
chore: extend typecheck coverage to data-model and gun-client

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Lint (LOC & Rules)
         run: pnpm lint
 
+      - name: Build (for cross-package types)
+        run: pnpm build
+
       - name: Typecheck
         run: pnpm typecheck
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "build": "pnpm -r --workspace-root=false build",
-    "typecheck": "pnpm -r typecheck",
+    "typecheck": "pnpm -r --workspace-root=false typecheck",
     "test": "pnpm -r --workspace-root=false test",
     "lint": "pnpm -r --workspace-root=false lint",
     "vh": "pnpm --filter \"@vh/cli\" exec tsx src/index.ts",

--- a/packages/data-model/package.json
+++ b/packages/data-model/package.json
@@ -13,6 +13,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run --config ../../vitest.config.ts --dir ../../"
   },
   "dependencies": {

--- a/packages/gun-client/package.json
+++ b/packages/gun-client/package.json
@@ -13,6 +13,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "lint": "echo 'No lint yet'"
   },


### PR DESCRIPTION
## Summary
- Extend workspace typecheck coverage to include `@vh/data-model` and `@vh/gun-client`.
- Root `typecheck` script now matches `build`/`test`/`lint` recursion behavior (`--workspace-root=false`).
- Add CI build step before typecheck in `quality` to ensure cross-package type exports are available.

## What’s now covered
`pnpm typecheck` now runs in **8 packages** (up from 6):
- `@vh/ai-engine`
- `@vh/crdt`
- `@vh/crypto`
- `@vh/data-model` ✅ (new)
- `@vh/gun-client` ✅ (new)
- `@vh/identity-vault`
- `@vh/types`
- `@vh/ui`

## Why CI needs build before typecheck
`@vh/data-model` and `@vh/gun-client` depend on workspace packages (`@vh/crypto`, `@vh/types`, and `@vh/data-model`) that expose types via `dist/` exports. Running `pnpm build` before `pnpm typecheck` in the `quality` job ensures those exports exist and type resolution succeeds in CI.

## Deferred (intentionally out of scope)
- `apps/web-pwa`: ~100 type errors across components, hooks, and stores (needs dedicated cleanup PR).
- `packages/contracts`: missing `@types/chai` and `@types/mocha` devDependencies for Hardhat typing.
- `packages/e2e`: 3 errors (implicit `any` params + `Uint8Array`/`BufferSource` Node.js types version mismatch).

## Verification
- `pnpm build`
- `pnpm typecheck`
- `pnpm test:quick`
- `pnpm lint`
