### PR TITLE
docs: fix spec drift after #22/#23/#24 merges

### DIFF
--- a/docs/foundational/ARCHITECTURE_LOCK.md
+++ b/docs/foundational/ARCHITECTURE_LOCK.md
@@ -22,6 +22,7 @@ This document summarizes the non-negotiable guardrails for the TRINITY Bio-Econo
     - **Pinning**: Root `package.json` must use `pnpm.overrides` to force a single version of `@types/node` and other conflicting globals.
     - **Leaf Isolation**: Pure data/logic packages (`types`, `crdt`) must strictly limit global types in `tsconfig.json` (e.g., `"types": []` or `"types": ["node"]`) to prevent pollution from test runners.
 - **Lockstep Updates**: Adding or changing workspace packages requires regenerating `pnpm-lock.yaml` with `pnpm install`; choose published versions only. CI uses `--frozen-lockfile` and will fail otherwise.
+- **Typecheck Entry Point**: Repo-wide typechecking runs via root `pnpm typecheck` (workspace orchestrated).
 
 ### 2.2 Testing Discipline - 100% Line/Branch coverage required
 - **Source-Based Testing**: Unit tests (`test:quick`) run against `src/`, not `dist/`.
@@ -36,8 +37,8 @@ This document summarizes the non-negotiable guardrails for the TRINITY Bio-Econo
     - *Impl*: `vite.config.ts` uses `define: { 'process.env': {}, global: 'window' }` to satisfy strict browser environments without polyfilling Node core.
 
 ### 2.3 Build Hygiene
-- **Strict Exclusion**: Production builds (`tsc`) must exclude test files.
-    - *Impl*: `tsconfig.json` excludes `src/**/*.test.ts`.
+- **Strict Exclusion**: Production builds (`tsc`) must exclude test files, while test files have their own explicit typecheck path.
+    - *Impl*: `apps/web-pwa/tsconfig.json` excludes `src/**/*.test.ts(x)` and `apps/web-pwa/tsconfig.test.json` handles test-file typechecking (`vitest/globals`).
 - **Browser-Safe Dependencies**: Packages consumed by the web app must avoid Node core modules (e.g., `crypto`, `node:` imports) and expose browser-safe entrypoints. Use pure JS implementations for hashing/utility functions or ship explicit browser bundles to prevent bundler externalization errors.
 - **Bundle Budget**:
     - **Initial Load**: Critical-path bundles must be < **1 MiB gzip**.

--- a/docs/foundational/Hero_Paths.md
+++ b/docs/foundational/Hero_Paths.md
@@ -12,11 +12,11 @@ Each path is described from the user’s point of view and then mapped to concre
 
 - `System_Architecture.md`
 - `docs/specs/spec-identity-trust-constituency.md`
-- `docs/specs/docs/specs/spec-civic-sentiment.md`
+- `docs/specs/spec-civic-sentiment.md`
 - `docs/specs/spec-rvu-economics-v0.md`
 - `docs/specs/canonical-analysis-v1.md`
 - `docs/foundational/AI_ENGINE_CONTRACT.md`
-- `docs/specs/docs/specs/spec-data-topology-privacy-v0.md`
+- `docs/specs/spec-data-topology-privacy-v0.md`
 
 ---
 

--- a/docs/foundational/STATUS.md
+++ b/docs/foundational/STATUS.md
@@ -23,19 +23,29 @@
 
 ---
 
-## Recently Merged (PR #10, commit `813558c`)
+## Recently Completed (Issues #11, #12, #15, #18, #22, #23, #24)
 
-- ✅ Identity persistence migrated to encrypted IndexedDB vault (`vh-vault` database, `vault` object store) with a per-device master key.
-- ✅ Legacy `vh_identity` path is migration-only (read once, then deleted); migration clobber guard prevents stale local data from overwriting an existing vault identity.
-- ✅ Identity hydration bridge hardened: `vh:identity-published` is signal-only (no identity payload), eliminating DOM event data leakage.
-- ✅ Master-key race hardening landed via atomic IndexedDB `add` semantics for key initialization.
+- ✅ **Issue #11** — Added root `pnpm typecheck` script.
+- ✅ **Issue #12** — Landed defensive-copy semantics for `getFullIdentity()` plus race test harness coverage.
+- ✅ **Issue #15** — Extended typecheck coverage to remaining packages.
+- ✅ **Issue #18** — Fixed ~100 web-pwa typecheck errors.
+- ✅ **Issue #22** — Split `DevColorPanel.tsx` into 5 focused files in `apps/web-pwa/src/components/`:
+  - `DevColorPanel.tsx`
+  - `ColorControl.tsx`
+  - `colorConfigs.ts`
+  - `colorUtils.ts`
+  - `useColorPanel.ts`
+- ✅ **Issue #23** — Aligned `Identity` / `IdentityRecord` types across packages.
+- ✅ **Issue #24** — Added `apps/web-pwa/tsconfig.test.json` for test-file typechecking.
 
 ---
 
 ## Active Follow-ups
 
-- **Issue #11** — add a repo-level `typecheck` script (open).
-- **Issue #12** — defensive-copy hardening + test harness docs follow-up (open).
+- **Issue #27** — infra: fresh-checkout `pnpm typecheck` requires prior build artifacts (open).
+- **Issue #19** — fix contracts and e2e typecheck errors (open).
+- **Issue #6** — harden xpLedger/profile localStorage for SSR (open).
+- **Issue #4** — SMOKE: agent loop end-to-end (open).
 
 ---
 
@@ -480,11 +490,11 @@ const router = new EngineRouter(mockEngine, undefined, 'local-only');
 - `docs/specs/canonical-analysis-v1.md` — Analysis schema contract (implemented)
 - `docs/specs/canonical-analysis-v2.md` — Quorum synthesis contract (planned)
 - `docs/foundational/AI_ENGINE_CONTRACT.md` — AI engine pipeline contract (pipeline implemented, engine mocked)
-- `docs/specs/docs/specs/spec-civic-sentiment.md` — Eye/Lightbulb/Sentiment spec (implemented locally)
+- `docs/specs/spec-civic-sentiment.md` — Eye/Lightbulb/Sentiment spec (implemented locally)
 - `docs/specs/spec-xp-ledger-v0.md` — XP ledger spec (fully implemented)
 - `docs/specs/spec-identity-trust-constituency.md` — Identity contract (partially implemented)
 - `docs/specs/spec-rvu-economics-v0.md` — RVU/UBE/QF economics (contracts ready, undeployed)
-- `docs/specs/docs/specs/spec-data-topology-privacy-v0.md` — Data placement rules (implemented)
+- `docs/specs/spec-data-topology-privacy-v0.md` — Data placement rules (implemented)
 - `docs/specs/spec-hermes-messaging-v0.md` — Messaging spec (implemented)
 - `docs/specs/spec-hermes-forum-v0.md` — Forum spec (implemented)
 
@@ -499,5 +509,5 @@ const router = new EngineRouter(mockEngine, undefined, 'local-only');
 
 ### Developer Resources
 - `CONTRIBUTING.md` — Engineering standards (enforced)
-- `docs/Hero_Paths.md` — Canonical user journeys
+- `docs/foundational/Hero_Paths.md` — Canonical user journeys
 - `docs/sprints/MANUAL_TEST_CHECKLIST_SPRINT3.md` — Manual testing guide

--- a/docs/foundational/System_Architecture.md
+++ b/docs/foundational/System_Architecture.md
@@ -301,7 +301,7 @@ Rules:
 * Legacy key `vh_identity` is migration-only input (read once, then deleted) and is **not** an active persistence layer.
 * `vh:identity-published` is a hydration signal `CustomEvent` with no identity payload.
 
-See `docs/specs/docs/specs/spec-data-topology-privacy-v0.md` for the canonical Season 0 topology and invariants.
+See `docs/specs/spec-data-topology-privacy-v0.md` for the canonical Season 0 topology and invariants.
 
 ## 5. Unified Development Roadmap
 
@@ -442,7 +442,7 @@ Invariants:
 * `AggregateSentiment` is a deterministic function of the stream of SentimentSignal events.
 * `constituency_proof` MUST be derived from a valid RegionProof: `district_hash = publicSignals[0]`, `nullifier = publicSignals[1]` (same UniquenessNullifier as identity), `merkle_root = publicSignals[2]`.
 
-See `docs/specs/docs/specs/spec-civic-sentiment.md` for the normative contract across client, mesh, and chain.
+See `docs/specs/spec-civic-sentiment.md` for the normative contract across client, mesh, and chain.
 
 -----
 
@@ -547,13 +547,13 @@ cd core
 pnpm i
 
 # 3. Start Local Universe (Docker: Gun, MinIO, Anvil)
-vh bootstrap up
+pnpm vh bootstrap up
 
 # 4. Initialize Keys & Contracts
-vh bootstrap init --deploy-contracts
+pnpm vh bootstrap init --deploy-contracts
 
 # 5. Run the Client (PWA + Edge AI)
-pnpm --filter apps/web-pwa dev
+pnpm --filter @vh/web-pwa dev
 ```
 
 -----

--- a/docs/foundational/dev-color-panel.md
+++ b/docs/foundational/dev-color-panel.md
@@ -2,6 +2,16 @@
 
 Applies across sprints. Extracted from Sprint 3.5.
 
+### Implementation Layout (Issue #22 complete)
+
+`apps/web-pwa/src/components/` now uses a 5-file split for the panel:
+
+- `DevColorPanel.tsx` (panel shell + rendering)
+- `ColorControl.tsx` (per-variable control UI)
+- `colorConfigs.ts` (canonical variable catalog)
+- `colorUtils.ts` (color parsing/format helpers)
+- `useColorPanel.ts` (state/actions, inspect/search/export logic)
+
 ### Controlled CSS Variables (57 total)
 
 **Page Backgrounds (6):**
@@ -93,7 +103,7 @@ Each color has three sliders:
 ### How to Use
 
 1. Click the **🎨 button** (bottom-right, dev mode only)
-2. Select category tab (Page, VENN Cards, HERMES Cards, Thread List, etc.)
+2. Select a top-level category tab (`Global`, `VENN`, `Forum`, `Controls`, `Icons`, `Messaging`) and then tune grouped variables within that tab
 3. Adjust colors via:
    - Color picker (hue)
    - Saturation/Lightness/Opacity sliders
@@ -118,4 +128,4 @@ Each color has three sliders:
 4. Replace the entire `plugins: [...]` section with the copied code
 5. Restart dev server
 
-**Status:** Ready for manual color tuning
+**Status:** Ready for manual color tuning (split refactor landed in #22)


### PR DESCRIPTION
## Summary
This docs-only PR resolves spec/documentation drift after the recent merges for #22, #23, and #24.

### What was stale
- `docs/foundational/STATUS.md` still showed #11/#12 as open and did not reflect completed work for #22/#23/#24.
- Follow-up issue list was outdated (missing active #27, #19, #6, #4).
- Several canonical docs had stale/mistyped spec paths (e.g. `docs/specs/docs/specs/...`).
- Command guidance was mixed between `vh ...` and actual root workflow (`pnpm vh ...` / `pnpm typecheck`).
- Dev Color Panel foundational doc did not reflect the post-#22 5-file split structure.

### What was fixed
- Updated `docs/foundational/STATUS.md` to mark #22/#23/#24 completed and list #27 as active/open follow-up (plus #19/#6/#4).
- Corrected stale file paths in foundational references (`spec-civic-sentiment`, `spec-data-topology-privacy-v0`, Hero Paths path).
- Updated command guidance in foundational/spec docs to current root usage (`pnpm vh ...`, `pnpm typecheck`).
- Added explicit typecheck workflow snapshot updates (including `apps/web-pwa/tsconfig.test.json`) and linked open follow-up #27.
- Updated `docs/foundational/dev-color-panel.md` to document the 5-file split in `apps/web-pwa/src/components/`.

### Validation
- Ran `pnpm lint` successfully.

No runtime/code changes — docs only
