### PR TITLE
fix(infra): point workspace exports.types at src/ for fresh-checkout typecheck

### DIFF
--- a/packages/ai-engine/package.json
+++ b/packages/ai-engine/package.json
@@ -8,7 +8,7 @@
   "exports": {
     ".": {
       "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./src/index.ts"
     }
   },
   "scripts": {

--- a/packages/crdt/package.json
+++ b/packages/crdt/package.json
@@ -8,7 +8,7 @@
   "exports": {
     ".": {
       "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./src/index.ts"
     }
   },
   "scripts": {

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -8,15 +8,15 @@
   "exports": {
     ".": {
       "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./src/index.ts"
     },
     "./primitives": {
       "import": "./dist/primitives.js",
-      "types": "./dist/primitives.d.ts"
+      "types": "./src/primitives.ts"
     },
     "./provider": {
       "import": "./dist/provider.js",
-      "types": "./dist/provider.d.ts"
+      "types": "./src/provider.ts"
     }
   },
   "scripts": {

--- a/packages/data-model/package.json
+++ b/packages/data-model/package.json
@@ -8,7 +8,7 @@
   "exports": {
     ".": {
       "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./src/index.ts"
     }
   },
   "scripts": {

--- a/packages/data-model/tsconfig.json
+++ b/packages/data-model/tsconfig.json
@@ -5,7 +5,7 @@
     "rootDir": "src",
     "composite": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "target": "ES2022",
     "declaration": true,
     "declarationMap": true,

--- a/packages/gun-client/tsconfig.json
+++ b/packages/gun-client/tsconfig.json
@@ -14,6 +14,5 @@
     "skipLibCheck": true
   },
   "include": ["src/**/*"],
-  "exclude": ["src/**/*.test.ts"],
-  "references": [{ "path": "../types" }, { "path": "../crypto" }, { "path": "../crdt" }, { "path": "../data-model" }]
+  "exclude": ["src/**/*.test.ts"]
 }

--- a/packages/identity-vault/package.json
+++ b/packages/identity-vault/package.json
@@ -8,7 +8,7 @@
   "exports": {
     ".": {
       "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./src/index.ts"
     }
   },
   "scripts": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -8,7 +8,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./src/index.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     }


### PR DESCRIPTION
## Summary
- point `exports.types` to `src/*.ts` in the six workspace packages that previously referenced `dist/*.d.ts`
- keep top-level `main`/`types` fields unchanged (still `dist/*`) for backward compatibility
- align `@vh/data-model` typecheck resolution for fresh checkouts (`moduleResolution: "bundler"`)
- remove `@vh/gun-client` project references that required prebuilt declaration outputs during `tsc --noEmit`

## Validation (fresh worktree)
- `pnpm install --frozen-lockfile`
- `pnpm typecheck`
- `pnpm --filter @vh/web-pwa typecheck:test`
- `pnpm test:quick`
- `pnpm lint`

All commands passed in a clean worktree.

Closes #27
