### PR TITLE
fix(typecheck): add typecheck scripts for contracts and e2e (#19)

### DIFF
--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -5,6 +5,7 @@
   "description": "TRINITY smart contracts workspace",
   "scripts": {
     "build": "hardhat compile",
+    "typecheck": "tsc --noEmit",
     "test": "hardhat test",
     "deploy:localhost": "hardhat run scripts/deploy.ts --network localhost",
     "deploy:testnet:sepolia": "hardhat run scripts/deploy-testnet.ts --network sepolia",
@@ -12,11 +13,16 @@
   },
   "license": "UNLICENSED",
   "devDependencies": {
+    "@nomicfoundation/hardhat-chai-matchers": "^2.1.0",
+    "@nomicfoundation/hardhat-ethers": "^3.1.2",
     "@nomicfoundation/hardhat-toolbox": "^6.1.0",
     "@openzeppelin/contracts": "5.0.2",
+    "@types/chai": "^4.3.20",
+    "@types/mocha": "^10.0.10",
     "@types/node": "^20.11.30",
     "chai": "^4.4.1",
     "dotenv": "^16.4.5",
+    "ethers": "^6.13.4",
     "hardhat": "^2.27.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.4.5"

--- a/packages/contracts/tsconfig.json
+++ b/packages/contracts/tsconfig.json
@@ -9,6 +9,6 @@
     "types": ["node", "chai", "mocha", "hardhat"],
     "outDir": "dist"
   },
-  "include": ["hardhat.config.ts", "scripts", "test", "contracts"],
+  "include": ["hardhat.config.ts", "scripts", "test", "contracts", "typechain-types"],
   "files": ["./hardhat.config.ts"]
 }

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -6,7 +6,8 @@
         "test": "VITE_E2E_MODE=true pnpm --filter @vh/web-pwa build && VITE_E2E_MODE=true playwright test",
         "test:ui": "playwright test --ui",
         "test:debug": "playwright test --debug",
-        "codegen": "playwright codegen"
+        "codegen": "playwright codegen",
+        "typecheck": "tsc --noEmit"
     },
     "devDependencies": {
         "@playwright/test": "^1.42.1",

--- a/packages/e2e/src/fixtures/multi-user.ts
+++ b/packages/e2e/src/fixtures/multi-user.ts
@@ -19,7 +19,7 @@
  *   });
  */
 
-import { test as base, type Page, type BrowserContext } from '@playwright/test';
+import { test as base, type Page, type BrowserContext, type ConsoleMessage } from '@playwright/test';
 
 /**
  * Shared mesh store that simulates Gun relay sync between contexts.
@@ -95,14 +95,14 @@ async function createUser(
   const page = await context.newPage();
   
   // Add console logging for debugging
-  page.on('console', (msg) => {
+  page.on('console', (msg: ConsoleMessage) => {
     const text = msg.text();
     if (msg.type() === 'error' || text.includes('[vh:')) {
       console.log(`[${name}] ${text}`);
     }
   });
   
-  page.on('pageerror', (err) => {
+  page.on('pageerror', (err: Error) => {
     console.error(`[${name}] PAGE ERROR: ${err.message}`);
   });
 

--- a/packages/e2e/src/helpers/vault-identity.ts
+++ b/packages/e2e/src/helpers/vault-identity.ts
@@ -113,9 +113,9 @@ export async function readVaultIdentity(page: Page): Promise<VaultIdentity | nul
       }
 
       const decrypted = await crypto.subtle.decrypt(
-        { name: 'AES-GCM', iv },
+        { name: 'AES-GCM', iv: iv as unknown as BufferSource },
         rawMasterKey,
-        ciphertext,
+        ciphertext as ArrayBuffer,
       );
 
       const json = new TextDecoder().decode(decrypted);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,12 +155,24 @@ importers:
 
   packages/contracts:
     devDependencies:
+      '@nomicfoundation/hardhat-chai-matchers':
+        specifier: ^2.1.0
+        version: 2.1.0(@nomicfoundation/hardhat-ethers@3.1.2(ethers@6.15.0)(hardhat@2.27.0(ts-node@10.9.2(@types/node@20.17.19)(typescript@5.9.3))(typescript@5.9.3)))(chai@4.5.0)(ethers@6.15.0)(hardhat@2.27.0(ts-node@10.9.2(@types/node@20.17.19)(typescript@5.9.3))(typescript@5.9.3))
+      '@nomicfoundation/hardhat-ethers':
+        specifier: ^3.1.2
+        version: 3.1.2(ethers@6.15.0)(hardhat@2.27.0(ts-node@10.9.2(@types/node@20.17.19)(typescript@5.9.3))(typescript@5.9.3))
       '@nomicfoundation/hardhat-toolbox':
         specifier: ^6.1.0
         version: 6.1.0(kwxxzchaxhfcg3irsizpogb3p4)
       '@openzeppelin/contracts':
         specifier: 5.0.2
         version: 5.0.2
+      '@types/chai':
+        specifier: ^4.3.20
+        version: 4.3.20
+      '@types/mocha':
+        specifier: ^10.0.10
+        version: 10.0.10
       '@types/node':
         specifier: 20.17.19
         version: 20.17.19
@@ -170,6 +182,9 @@ importers:
       dotenv:
         specifier: ^16.4.5
         version: 16.6.1
+      ethers:
+        specifier: ^6.13.4
+        version: 6.15.0
       hardhat:
         specifier: ^2.27.0
         version: 2.27.0(ts-node@10.9.2(@types/node@20.17.19)(typescript@5.9.3))(typescript@5.9.3)


### PR DESCRIPTION
## Summary
Adds `typecheck` scripts to `@vh/contracts` and `@vh/e2e`, fixing Issue #19.

### Changes
- **`packages/contracts`**: Added `typecheck` script, missing type deps (`@types/chai`, `@types/mocha`), peer deps for pnpm strict resolution, and `typechain-types` to tsconfig include
- **`packages/e2e`**: Added `typecheck` script, fixed implicit `any` errors in `multi-user.ts`, fixed `BufferSource` typing in `vault-identity.ts`

### Validation
- ✅ `pnpm typecheck` passes (full workspace including contracts + e2e)
- ✅ `pnpm test` passes (no regressions)
- ✅ QA validated in fresh checkout
- ✅ Maint review: zero Musts, all files under LOC cap, crypto casts confirmed safe

Closes #19