### PR TITLE
fix(config): tighten types coverage exclusion — explicit paths over glob

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -109,8 +109,11 @@ export default defineConfig({
         'packages/ai-engine/src/prompts.ts',
 
         // --- Type-Only Files ---
-        // Pure TypeScript interfaces with no runtime code; compile to empty JS.
-        'packages/types/src/**/*.ts',
+        // Pure TypeScript interfaces/types with no runtime statements.
+        // Note: index.ts in this package has Zod schemas + decodeRegionProof()
+        // but is already excluded via the packages/*/src/index.ts rule below.
+        'packages/types/src/attestation.ts',
+        'packages/types/src/identity.ts',
 
         // --- Re-export Index Files ---
         'packages/*/src/index.ts'


### PR DESCRIPTION
## Summary

Addresses maint review findings from PR #35 (#33):

**Should #1:** Replace `packages/types/src/**/*.ts` glob with explicit file paths (`attestation.ts`, `identity.ts`) to prevent silently excluding future runtime code added to the types package.

**Should #2:** Update comment to note that `index.ts` in the types package contains Zod schemas + `decodeRegionProof()` (real runtime code) — already excluded by the separate `packages/*/src/index.ts` rule.

### Change
`vitest.config.ts`: +5 / -2 lines (comment + paths)

### Validation
`pnpm test:coverage` still passes at 100% (1307/1307 lines).