### PR TITLE
fix(web-pwa): harden localStorage access for SSR (#6)

### DIFF
--- a/apps/web-pwa/src/store/index.ts
+++ b/apps/web-pwa/src/store/index.ts
@@ -3,6 +3,7 @@ import { createClient, publishToDirectory, type VennClient } from '@vh/gun-clien
 import type { DirectoryEntry, Profile } from '@vh/data-model';
 import type { DevicePair, IdentityRecord } from '@vh/types';
 import { migrateLegacyLocalStorage } from '@vh/identity-vault';
+import { safeGetItem, safeSetItem } from '../utils/safeStorage';
 import { loadIdentityRecord } from '../utils/vaultTyped';
 
 const PROFILE_KEY = 'vh_profile';
@@ -22,7 +23,7 @@ interface AppState {
 
 function loadProfile(): Profile | null {
   try {
-    const raw = localStorage.getItem(PROFILE_KEY);
+    const raw = safeGetItem(PROFILE_KEY);
     return raw ? (JSON.parse(raw) as Profile) : null;
   } catch {
     return null;
@@ -30,7 +31,7 @@ function loadProfile(): Profile | null {
 }
 
 function persistProfile(profile: Profile) {
-  localStorage.setItem(PROFILE_KEY, JSON.stringify(profile));
+  safeSetItem(PROFILE_KEY, JSON.stringify(profile));
 }
 
 function randomId(): string {

--- a/apps/web-pwa/src/store/xpLedger.ts
+++ b/apps/web-pwa/src/store/xpLedger.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { getPublishedIdentity } from './identityProvider';
+import { safeGetItem, safeSetItem } from '../utils/safeStorage';
 
 type Track = 'civic' | 'social' | 'project';
 type MessagingXPEvent =
@@ -96,10 +97,10 @@ function readIdentityNullifier(): string | null {
 }
 function loadLedgerForNullifier(targetNullifier: string | null): SerializedLedger | null {
   try {
-    const raw = localStorage.getItem(storageKey(targetNullifier));
+    const raw = safeGetItem(storageKey(targetNullifier));
     if (raw) return JSON.parse(raw) as SerializedLedger;
     if (targetNullifier) {
-      const legacy = localStorage.getItem(STORAGE_KEY);
+      const legacy = safeGetItem(STORAGE_KEY);
       if (legacy) return JSON.parse(legacy) as SerializedLedger;
     }
   } catch {
@@ -126,7 +127,7 @@ function persist(state: LedgerData) {
     projectWeekly: Object.fromEntries(state.projectWeekly.entries())
   };
   try {
-    localStorage.setItem(storageKey(state.activeNullifier), JSON.stringify(payload));
+    safeSetItem(storageKey(state.activeNullifier), JSON.stringify(payload));
   } catch {
     /* ignore */
   }

--- a/apps/web-pwa/src/utils/safeStorage.test.ts
+++ b/apps/web-pwa/src/utils/safeStorage.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { safeGetItem, safeRemoveItem, safeSetItem } from './safeStorage';
+
+function memoryStorage() {
+  const store = new Map<string, string>();
+  return {
+    getItem(key: string) {
+      return store.get(key) ?? null;
+    },
+    setItem(key: string, value: string) {
+      store.set(key, value);
+    },
+    removeItem(key: string) {
+      store.delete(key);
+    }
+  };
+}
+
+describe('safeStorage', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    vi.stubGlobal('localStorage', memoryStorage());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('reads, writes, and removes values when localStorage exists', () => {
+    safeSetItem('k1', 'v1');
+    expect(safeGetItem('k1')).toBe('v1');
+
+    safeRemoveItem('k1');
+    expect(safeGetItem('k1')).toBeNull();
+  });
+
+  it('returns null for missing key in browser mode', () => {
+    expect(safeGetItem('missing')).toBeNull();
+  });
+
+  it('returns null / no-ops when localStorage is unavailable (SSR mode)', () => {
+    vi.stubGlobal('localStorage', undefined);
+
+    expect(safeGetItem('k1')).toBeNull();
+    expect(() => safeSetItem('k1', 'v1')).not.toThrow();
+    expect(() => safeRemoveItem('k1')).not.toThrow();
+  });
+
+  it('returns null / no-ops when localStorage methods throw', () => {
+    vi.stubGlobal('localStorage', {
+      getItem: () => {
+        throw new Error('quota exceeded');
+      },
+      setItem: () => {
+        throw new Error('quota exceeded');
+      },
+      removeItem: () => {
+        throw new Error('quota exceeded');
+      }
+    });
+
+    expect(safeGetItem('k1')).toBeNull();
+    expect(() => safeSetItem('k1', 'v1')).not.toThrow();
+    expect(() => safeRemoveItem('k1')).not.toThrow();
+  });
+
+  it('returns null / no-ops when localStorage access throws', () => {
+    vi.unstubAllGlobals();
+    const original = Object.getOwnPropertyDescriptor(globalThis, 'localStorage');
+
+    Object.defineProperty(globalThis, 'localStorage', {
+      configurable: true,
+      get() {
+        throw new Error('blocked');
+      }
+    });
+
+    try {
+      expect(safeGetItem('k1')).toBeNull();
+      expect(() => safeSetItem('k1', 'v1')).not.toThrow();
+      expect(() => safeRemoveItem('k1')).not.toThrow();
+    } finally {
+      if (original) {
+        Object.defineProperty(globalThis, 'localStorage', original);
+      } else {
+        delete (globalThis as { localStorage?: unknown }).localStorage;
+      }
+    }
+  });
+});

--- a/apps/web-pwa/src/utils/safeStorage.ts
+++ b/apps/web-pwa/src/utils/safeStorage.ts
@@ -1,0 +1,39 @@
+/**
+ * SSR-safe localStorage wrapper.
+ * Returns null / no-ops when localStorage is unavailable (server-side rendering).
+ */
+
+function canUseStorage(): boolean {
+  try {
+    return typeof globalThis !== 'undefined' && typeof globalThis.localStorage !== 'undefined';
+  } catch {
+    return false;
+  }
+}
+
+export function safeGetItem(key: string): string | null {
+  if (!canUseStorage()) return null;
+  try {
+    return localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+export function safeSetItem(key: string, value: string): void {
+  if (!canUseStorage()) return;
+  try {
+    localStorage.setItem(key, value);
+  } catch {
+    // Silently ignore (quota exceeded, etc.)
+  }
+}
+
+export function safeRemoveItem(key: string): void {
+  if (!canUseStorage()) return;
+  try {
+    localStorage.removeItem(key);
+  } catch {
+    // Silently ignore
+  }
+}


### PR DESCRIPTION
## Summary

Adds SSR-safe guards to all bare `localStorage` access in the xpLedger and profile stores. In server-side rendering environments where `localStorage` is undefined, these calls would previously throw `ReferenceError`. Now they degrade gracefully.

### Changes

| File | Change |
|------|--------|
| `apps/web-pwa/src/utils/safeStorage.ts` | **New** — SSR-safe localStorage wrapper (39 lines) |
| `apps/web-pwa/src/utils/safeStorage.test.ts` | **New** — 5 test cases: browser mode, SSR mode, error mode, property-access-throws |
| `apps/web-pwa/src/store/xpLedger.ts` | Replace 3 bare `localStorage` calls with `safeGetItem`/`safeSetItem` |
| `apps/web-pwa/src/store/index.ts` | Replace 2 bare `localStorage` calls with `safeGetItem`/`safeSetItem` |

### Design

`safeStorage` utility provides `safeGetItem`, `safeSetItem`, `safeRemoveItem`:
- **`canUseStorage()`** checks `typeof globalThis.localStorage !== 'undefined'` inside try/catch
- **Get** returns `null` when localStorage unavailable (matches "key not found" semantics)
- **Set/Remove** silently no-op when unavailable
- All operations are also wrapped in try/catch for Safari private browsing quota errors

### Validation (fresh checkout)

| Command | Result |
|---------|--------|
| `pnpm install --frozen-lockfile` | ✅ |
| `pnpm test:quick` | ✅ 67 files, 416 tests |
| `pnpm test:coverage` | ✅ **100%** (1336/1336 lines, 418/418 branches, 117/117 functions) |

### No behavioral change in browser
In browser environments, these wrappers are transparent — `localStorage` works exactly as before. The only change is graceful degradation when running server-side.

Closes #6.