### PR TITLE
docs(status): add #40 to active follow-ups (smoke test #4)

### DIFF
--- a/docs/foundational/STATUS.md
+++ b/docs/foundational/STATUS.md
@@ -47,6 +47,7 @@
 ## Active Follow-ups
 
 - **Issue #4** — SMOKE: agent loop end-to-end (open).
+- **Issue #40** — migrate remaining bare localStorage calls to safeStorage utility (open).
 
 ---
 


### PR DESCRIPTION
## Issue #4 — SMOKE: agent loop end-to-end

**What changed:** Added Issue #40 to Active Follow-ups in STATUS.md (fixes STATUS drift noted in state check).

**Why:** Proves the full agent ritual works: impl → QA → maint → chief merge. Also fixes a real doc gap.

**Branch:** smoke/issue-4-agent-loop
**Commit:** 46eba01
**Tests:** `pnpm test:coverage` passes — 100% statements/branches/functions/lines (1336/1336, 418/418, 117/117, 1336/1336)

**Validation:**
- Impl: doc-only single-line change ✅
- QA: fresh-checkout validation (chief-verified independently) ✅
- Maint: trivial diff, no code changes ✅
- Coverage gate: 100% ✅

Closes #4