### PR TITLE
fix(web-pwa): migrate remaining localStorage to safeStorage (#40)

### DIFF
--- a/apps/web-pwa/src/components/ThemeProvider.tsx
+++ b/apps/web-pwa/src/components/ThemeProvider.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useContext, useEffect, useMemo, useState } from 'react';
+import { safeGetItem, safeRemoveItem, safeSetItem } from '../utils/safeStorage';
 
 type Theme = 'light' | 'dark' | 'system';
 type ResolvedTheme = 'light' | 'dark';
@@ -13,8 +14,7 @@ const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
 const STORAGE_KEY = 'vh_theme_pref';
 
 function getStoredTheme(): Theme {
-  if (typeof localStorage === 'undefined') return 'system';
-  const stored = localStorage.getItem(STORAGE_KEY) as Theme | null;
+  const stored = safeGetItem(STORAGE_KEY) as Theme | null;
   return stored ?? 'system';
 }
 
@@ -37,9 +37,9 @@ export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     root.classList.remove('light', 'dark');
     root.classList.add(resolved);
     if (theme !== 'system') {
-      localStorage.setItem(STORAGE_KEY, theme);
+      safeSetItem(STORAGE_KEY, theme);
     } else {
-      localStorage.removeItem(STORAGE_KEY);
+      safeRemoveItem(STORAGE_KEY);
     }
   }, [resolved, theme]);
 

--- a/apps/web-pwa/src/components/hermes/forum/ThreadView.tsx
+++ b/apps/web-pwa/src/components/hermes/forum/ThreadView.tsx
@@ -8,6 +8,7 @@ import { CommunityReactionSummary } from '../CommunityReactionSummary';
 import { EngagementIcons } from '../../EngagementIcons';
 import { useSentimentState } from '../../../hooks/useSentimentState';
 import { useViewTracking } from '../../../hooks/useViewTracking';
+import { safeGetItem, safeSetItem } from '../../../utils/safeStorage';
 import type { HermesComment } from '@vh/types';
 
 interface Props {
@@ -59,7 +60,7 @@ export const ThreadView: React.FC<Props> = ({ threadId }) => {
   const [showCallout, setShowCallout] = useState(() => {
     if (typeof window === 'undefined') return false;
     try {
-      return !window.localStorage.getItem(CALLOUT_KEY);
+      return !safeGetItem(CALLOUT_KEY);
     } catch {
       return false;
     }
@@ -78,7 +79,7 @@ export const ThreadView: React.FC<Props> = ({ threadId }) => {
 
   const dismissCallout = () => {
     try {
-      window.localStorage.setItem(CALLOUT_KEY, 'true');
+      safeSetItem(CALLOUT_KEY, 'true');
     } catch {
       // ignore
     }

--- a/apps/web-pwa/src/components/useColorPanel.ts
+++ b/apps/web-pwa/src/components/useColorPanel.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type Dispatch, type MutableRefObject, type SetStateAction } from 'react';
 import { COLOR_CONFIGS, STORAGE_KEY, categories } from './colorConfigs';
 import { type ColorConfig } from './colorUtils';
+import { safeGetItem, safeRemoveItem, safeSetItem } from '../utils/safeStorage';
 
 type ColorValues = { light: string; dark: string };
 type GroupedConfigs = Array<{ key: string; title: string; items: ColorConfig[] }>;
@@ -53,7 +54,7 @@ export function useColorPanel(): UseColorPanelResult {
 
   useEffect(() => {
     const defaults = getDefaults();
-    const stored = localStorage.getItem(STORAGE_KEY);
+    const stored = safeGetItem(STORAGE_KEY);
     if (stored) {
       try {
         // Merge stored values with defaults (so new variables get defaults)
@@ -248,14 +249,14 @@ export function useColorPanel(): UseColorPanelResult {
           dark: config?.defaultDark ?? '',
         };
       const updated = { ...prev, [cssVar]: { ...current, [mode]: value } };
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+      safeSetItem(STORAGE_KEY, JSON.stringify(updated));
       return updated;
     });
   };
 
   const resetColors = () => {
     initDefaults();
-    localStorage.removeItem(STORAGE_KEY);
+    safeRemoveItem(STORAGE_KEY);
   };
 
   const exportCSS = () => {

--- a/apps/web-pwa/src/hooks/useFeedStore.ts
+++ b/apps/web-pwa/src/hooks/useFeedStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { safeGetItem, safeSetItem } from '../utils/safeStorage';
 
 export interface Perspective {
   id: string;
@@ -88,7 +89,7 @@ const seedItems: FeedItem[] = [
 
 function loadCached(): { items: FeedItem[]; page: number } {
   try {
-    const raw = localStorage.getItem(STORAGE_KEY);
+    const raw = safeGetItem(STORAGE_KEY);
     if (!raw) return { items: seedItems, page: 1 };
     const parsed = JSON.parse(raw) as FeedItem[];
     if (parsed.length === 0) return { items: seedItems, page: 1 };
@@ -113,7 +114,7 @@ function loadCached(): { items: FeedItem[]; page: number } {
 
 function persist(items: FeedItem[]) {
   try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
+    safeSetItem(STORAGE_KEY, JSON.stringify(items));
   } catch {
     /* ignore */
   }

--- a/apps/web-pwa/src/hooks/useForumPreferences.ts
+++ b/apps/web-pwa/src/hooks/useForumPreferences.ts
@@ -1,60 +1,32 @@
 import { useCallback, useState } from 'react';
+import { safeGetItem, safeSetItem } from '../utils/safeStorage';
 
 export type SlideToPostSetting = boolean | null;
 
 const SLIDE_TO_POST_KEY = 'vh_forum_slide_to_post_v1';
 const COMMENT_POST_COUNT_KEY = 'vh_forum_comment_post_count_v1';
 
-function getStorage(): Storage | null {
-  if (typeof localStorage === 'undefined') return null;
-  return localStorage;
-}
-
 function readSlideToPostSetting(): SlideToPostSetting {
-  const storage = getStorage();
-  if (!storage) return null;
-  try {
-    const raw = storage.getItem(SLIDE_TO_POST_KEY);
-    if (raw === null) return null;
-    if (raw === 'true') return true;
-    if (raw === 'false') return false;
-    return null;
-  } catch {
-    return null;
-  }
+  const raw = safeGetItem(SLIDE_TO_POST_KEY);
+  if (raw === null) return null;
+  if (raw === 'true') return true;
+  if (raw === 'false') return false;
+  return null;
 }
 
 function writeSlideToPostSetting(value: boolean) {
-  const storage = getStorage();
-  if (!storage) return;
-  try {
-    storage.setItem(SLIDE_TO_POST_KEY, value ? 'true' : 'false');
-  } catch {
-    /* ignore */
-  }
+  safeSetItem(SLIDE_TO_POST_KEY, value ? 'true' : 'false');
 }
 
 function readCommentPostCount(): number {
-  const storage = getStorage();
-  if (!storage) return 0;
-  try {
-    const raw = storage.getItem(COMMENT_POST_COUNT_KEY);
-    const parsed = raw ? Number(raw) : 0;
-    if (!Number.isFinite(parsed) || parsed < 0) return 0;
-    return parsed;
-  } catch {
-    return 0;
-  }
+  const raw = safeGetItem(COMMENT_POST_COUNT_KEY);
+  const parsed = raw ? Number(raw) : 0;
+  if (!Number.isFinite(parsed) || parsed < 0) return 0;
+  return parsed;
 }
 
 function writeCommentPostCount(count: number) {
-  const storage = getStorage();
-  if (!storage) return;
-  try {
-    storage.setItem(COMMENT_POST_COUNT_KEY, String(count));
-  } catch {
-    /* ignore */
-  }
+  safeSetItem(COMMENT_POST_COUNT_KEY, String(count));
 }
 
 export function useForumPreferences() {

--- a/apps/web-pwa/src/hooks/useSentimentState.ts
+++ b/apps/web-pwa/src/hooks/useSentimentState.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import type { SentimentSignal, ConstituencyProof } from '@vh/types';
+import { safeGetItem, safeSetItem } from '../utils/safeStorage';
 
 type Agreement = -1 | 0 | 1;
 
@@ -29,7 +30,7 @@ const EYE_KEY = 'vh_eye_weights_v1';
 
 function loadMap(key: string): Record<string, number> {
   try {
-    const raw = localStorage.getItem(key);
+    const raw = safeGetItem(key);
     return raw ? (JSON.parse(raw) as Record<string, number>) : {};
   } catch {
     return {};
@@ -38,7 +39,7 @@ function loadMap(key: string): Record<string, number> {
 
 function persistMap(key: string, value: Record<string, number>) {
   try {
-    localStorage.setItem(key, JSON.stringify(value));
+    safeSetItem(key, JSON.stringify(value));
   } catch {
     /* ignore */
   }

--- a/apps/web-pwa/src/routes/AnalysisFeed.tsx
+++ b/apps/web-pwa/src/routes/AnalysisFeed.tsx
@@ -6,6 +6,7 @@ import { getOrGenerate, type CanonicalAnalysis } from '../../../../packages/ai-e
 import type { VennClient } from '@vh/gun-client';
 import { useAppStore } from '../store';
 import { useIdentity } from '../hooks/useIdentity';
+import { safeGetItem, safeSetItem } from '../utils/safeStorage';
 
 const FEED_KEY = 'vh_canonical_analyses';
 
@@ -16,12 +17,12 @@ interface FeedStore {
 
 function loadFeed(): FeedStore {
   try {
-    const raw = localStorage.getItem(FEED_KEY);
+    const raw = safeGetItem(FEED_KEY);
     const data = raw ? (JSON.parse(raw) as CanonicalAnalysis[]) : [];
     return {
       data,
       save(items: CanonicalAnalysis[]) {
-        localStorage.setItem(FEED_KEY, JSON.stringify(items));
+        safeSetItem(FEED_KEY, JSON.stringify(items));
       }
     };
   } catch {

--- a/apps/web-pwa/src/routes/WalletPanel.tsx
+++ b/apps/web-pwa/src/routes/WalletPanel.tsx
@@ -4,6 +4,7 @@ import { useWallet } from '../hooks/useWallet';
 import { useIdentity } from '../hooks/useIdentity';
 import { useXpLedger } from '../store/xpLedger';
 import { useForumPreferences } from '../hooks/useForumPreferences';
+import { safeGetItem, safeSetItem } from '../utils/safeStorage';
 
 function shortAddress(address: string | null) {
   if (!address) return 'Wallet not connected';
@@ -47,7 +48,7 @@ export const WalletPanel: React.FC = () => {
 
   // Persist local cooldown per device to avoid accidental spam
   useEffect(() => {
-    const stored = localStorage.getItem('vh_local_boost_next');
+    const stored = safeGetItem('vh_local_boost_next');
     if (stored) {
       const ts = Number(stored);
       if (!Number.isNaN(ts)) {
@@ -58,7 +59,7 @@ export const WalletPanel: React.FC = () => {
 
   useEffect(() => {
     if (localNextClaimAt) {
-      localStorage.setItem('vh_local_boost_next', String(localNextClaimAt));
+      safeSetItem('vh_local_boost_next', String(localNextClaimAt));
     }
   }, [localNextClaimAt]);
 

--- a/apps/web-pwa/src/routes/dashboardContent.tsx
+++ b/apps/web-pwa/src/routes/dashboardContent.tsx
@@ -5,6 +5,7 @@ import { useAppStore } from '../store';
 import { useIdentity } from '../hooks/useIdentity';
 import { getHandleError } from '../utils/handle';
 import { HandleEditor } from '../components/HandleEditor';
+import { safeGetItem, safeSetItem } from '../utils/safeStorage';
 
 const WalletPanel = lazy(() => import('./WalletPanel').then((mod) => ({ default: mod.WalletPanel })));
 const AnalysisFeed = lazy(() => import('./AnalysisFeed').then((mod) => ({ default: mod.AnalysisFeed })));
@@ -59,7 +60,7 @@ export const DashboardContent: React.FC = () => {
 
   const [history, setHistory] = useState<AnalysisResult[]>(() => {
     try {
-      const raw = localStorage.getItem('vh_analysis_history');
+      const raw = safeGetItem('vh_analysis_history');
       return raw ? (JSON.parse(raw) as AnalysisResult[]) : [];
     } catch {
       return [];
@@ -70,7 +71,7 @@ export const DashboardContent: React.FC = () => {
     if (result) {
       setHistory((prev) => {
         const next = [result, ...prev].slice(0, 5);
-        localStorage.setItem('vh_analysis_history', JSON.stringify(next));
+        safeSetItem('vh_analysis_history', JSON.stringify(next));
         return next;
       });
     }

--- a/apps/web-pwa/src/store/chat/helpers.ts
+++ b/apps/web-pwa/src/store/chat/helpers.ts
@@ -4,6 +4,7 @@ import type { VennClient } from '@vh/gun-client';
 import type { ChatState, ContactRecord, ChatIdentity, MessageStatus } from './types';
 import { SEEN_TTL_MS, SEEN_CLEANUP_THRESHOLD } from './types';
 import { getFullIdentity } from '../identityProvider';
+import { safeGetItem } from '../../utils/safeStorage';
 
 export function ensureIdentity(): ChatIdentity {
   const record = getFullIdentity<ChatIdentity>();
@@ -31,7 +32,7 @@ export function isValidInboundMessage(message: HermesMessage): boolean {
 
 export function isChatDebug(): boolean {
   try {
-    return localStorage.getItem('vh_debug_chat') === 'true';
+    return safeGetItem('vh_debug_chat') === 'true';
   } catch {
     return false;
   }

--- a/apps/web-pwa/src/store/chat/persistence.ts
+++ b/apps/web-pwa/src/store/chat/persistence.ts
@@ -2,6 +2,7 @@ import type { HermesChannel } from '@vh/types';
 import type { ChatIdentity, ContactRecord, ChatState } from './types';
 import { CHANNELS_KEY_PREFIX, CONTACTS_KEY_PREFIX } from './types';
 import { getFullIdentity } from '../identityProvider';
+import { safeGetItem, safeSetItem } from '../../utils/safeStorage';
 
 /**
  * Load identity for chat operations from the in-memory identity provider.
@@ -32,7 +33,7 @@ function contactsKey(nullifier: string): string {
 export function loadChannelsFromStorage(nullifier: string | null): Map<string, HermesChannel> {
   if (!nullifier) return new Map();
   try {
-    const raw = localStorage.getItem(channelsKey(nullifier));
+    const raw = safeGetItem(channelsKey(nullifier));
     if (!raw) return new Map();
     const parsed = JSON.parse(raw) as Record<string, HermesChannel>;
     return new Map(Object.entries(parsed));
@@ -45,7 +46,7 @@ export function persistChannels(nullifier: string | null, channels: Map<string, 
   if (!nullifier) return;
   try {
     const serialized = JSON.stringify(Object.fromEntries(channels));
-    localStorage.setItem(channelsKey(nullifier), serialized);
+    safeSetItem(channelsKey(nullifier), serialized);
   } catch {
     /* ignore */
   }
@@ -54,7 +55,7 @@ export function persistChannels(nullifier: string | null, channels: Map<string, 
 export function loadContactsFromStorage(nullifier: string | null): Map<string, ContactRecord> {
   if (!nullifier) return new Map();
   try {
-    const raw = localStorage.getItem(contactsKey(nullifier));
+    const raw = safeGetItem(contactsKey(nullifier));
     if (!raw) return new Map();
     const parsed = JSON.parse(raw) as Record<string, ContactRecord>;
     return new Map(Object.entries(parsed));
@@ -67,7 +68,7 @@ export function persistContacts(nullifier: string | null, contacts: Map<string, 
   if (!nullifier) return;
   try {
     const serialized = JSON.stringify(Object.fromEntries(contacts));
-    localStorage.setItem(contactsKey(nullifier), serialized);
+    safeSetItem(contactsKey(nullifier), serialized);
   } catch {
     /* ignore */
   }

--- a/apps/web-pwa/src/store/forum/persistence.ts
+++ b/apps/web-pwa/src/store/forum/persistence.ts
@@ -1,6 +1,7 @@
 import type { ForumIdentity } from './types';
 import { VOTES_KEY_PREFIX } from './types';
 import { getPublishedIdentity } from '../identityProvider';
+import { safeGetItem, safeSetItem } from '../../utils/safeStorage';
 
 export function loadIdentity(): ForumIdentity | null {
   const snapshot = getPublishedIdentity();
@@ -10,7 +11,7 @@ export function loadIdentity(): ForumIdentity | null {
 
 export function loadVotesFromStorage(nullifier: string): Map<string, 'up' | 'down' | null> {
   try {
-    const raw = localStorage.getItem(`${VOTES_KEY_PREFIX}${nullifier}`);
+    const raw = safeGetItem(`${VOTES_KEY_PREFIX}${nullifier}`);
     if (!raw) return new Map();
     return new Map(Object.entries(JSON.parse(raw)));
   } catch {
@@ -19,6 +20,6 @@ export function loadVotesFromStorage(nullifier: string): Map<string, 'up' | 'dow
 }
 
 export function persistVotes(nullifier: string, votes: Map<string, 'up' | 'down' | null>): void {
-  localStorage.setItem(`${VOTES_KEY_PREFIX}${nullifier}`, JSON.stringify(Object.fromEntries(votes)));
+  safeSetItem(`${VOTES_KEY_PREFIX}${nullifier}`, JSON.stringify(Object.fromEntries(votes)));
 }
 

--- a/apps/web-pwa/src/store/index.ts
+++ b/apps/web-pwa/src/store/index.ts
@@ -90,7 +90,7 @@ const sharedMeshOps = {
       // Fallback to localStorage
       const key = '__VH_MESH_STORE__';
       try {
-        const store = JSON.parse(localStorage.getItem(key) || '{}') as Record<string, unknown>;
+        const store = JSON.parse(safeGetItem(key) || '{}') as Record<string, unknown>;
         const parts = path.split('/');
         let current: Record<string, unknown> = store;
         for (let i = 0; i < parts.length - 1; i++) {
@@ -105,7 +105,7 @@ const sharedMeshOps = {
         const leaf = parts[parts.length - 1];
         if (!leaf) return;
         current[leaf] = value;
-        localStorage.setItem(key, JSON.stringify(store));
+        safeSetItem(key, JSON.stringify(store));
       } catch {
         /* ignore */
       }
@@ -119,7 +119,7 @@ const sharedMeshOps = {
       // Fallback to localStorage
       const key = '__VH_MESH_STORE__';
       try {
-        const store = JSON.parse(localStorage.getItem(key) || '{}');
+        const store = JSON.parse(safeGetItem(key) || '{}');
         const parts = path.split('/');
         let current = store;
         for (const part of parts) {

--- a/apps/web-pwa/src/store/xpLedger.ts
+++ b/apps/web-pwa/src/store/xpLedger.ts
@@ -126,11 +126,7 @@ function persist(state: LedgerData) {
     sustainedAwards: Object.fromEntries(state.sustainedAwards.entries()),
     projectWeekly: Object.fromEntries(state.projectWeekly.entries())
   };
-  try {
-    safeSetItem(storageKey(state.activeNullifier), JSON.stringify(payload));
-  } catch {
-    /* ignore */
-  }
+  safeSetItem(storageKey(state.activeNullifier), JSON.stringify(payload));
 }
 function clampRvu(value: number): number {
   if (Number.isNaN(value)) return 0;

--- a/apps/web-pwa/src/utils/safeStorage.ts
+++ b/apps/web-pwa/src/utils/safeStorage.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 /**
  * SSR-safe localStorage wrapper.
  * Returns null / no-ops when localStorage is unavailable (server-side rendering).

--- a/tools/eslint-config/index.js
+++ b/tools/eslint-config/index.js
@@ -59,6 +59,28 @@ module.exports = [
     }
   },
   {
+    files: ['apps/web-pwa/src/**/*.{ts,tsx,js,jsx}'],
+    ignores: [
+      'apps/web-pwa/src/**/*.test.ts',
+      'apps/web-pwa/src/**/*.test.tsx',
+      'apps/web-pwa/src/hooks/useGovernance.ts'
+    ],
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'module'
+    },
+    rules: {
+      'no-restricted-globals': [
+        'error',
+        {
+          name: 'localStorage',
+          message:
+            'Use safeGetItem/safeSetItem/safeRemoveItem from src/utils/safeStorage instead of direct localStorage access.'
+        }
+      ]
+    }
+  },
+  {
     files: codeGlobs,
     ignores: ['packages/gun-client/**/*'],
     languageOptions: {


### PR DESCRIPTION
## Summary
Migrates all bare `localStorage` usage in `apps/web-pwa/src/` to the project's `safeStorage` utility (`safeGetItem`, `safeSetItem`, `safeRemoveItem`), closing #40.

### Changes
- **13 files migrated** from bare `localStorage` to `safeStorage`
- **ESLint rule** added: `no-restricted-globals` for `localStorage` in web-pwa scope
- **Cleanup:** removed redundant try/catch wrappers in `useForumPreferences.ts` and `xpLedger.ts`
- **Excluded:** `useGovernance.ts` (intentionally uses both `localStorage` and `sessionStorage` with SSR guards)

### Validation
- QA: fresh-checkout validation ✅ (416 tests, 100% coverage, no flakes)
- Maint: no Musts (3 non-blocking Shoulds for follow-up)
- Typecheck: clean
- LOC cap: all files ≤ 350

### Follow-up items (from maint review)
- Inconsistent redundant try/catch cleanup (some files cleaned, some not)
- Leftover `typeof window` guard in `ThreadView.tsx`
- ESLint rule doesn't catch `window.localStorage` variant

Closes #40