### PR TITLE
docs: update STATUS.md for participation governor runtime utils (#53)

### DIFF
--- a/docs/foundational/STATUS.md
+++ b/docs/foundational/STATUS.md
@@ -23,7 +23,7 @@
 
 ---
 
-## Recently Completed (Issues #4, #6, #11, #12, #15, #18, #19, #22, #23, #24, #27, #33, #40, #46, #50)
+## Recently Completed (Issues #4, #6, #11, #12, #15, #18, #19, #22, #23, #24, #27, #33, #40, #46, #50, #53)
 
 - ✅ **Issue #11** — Added root `pnpm typecheck` script.
 - ✅ **Issue #12** — Landed defensive-copy semantics for `getFullIdentity()` plus race test harness coverage.
@@ -45,6 +45,7 @@
 - ✅ **Issue #40** — Migrated all remaining bare `localStorage` calls to `safeStorage` utility (13 files), added ESLint `no-restricted-globals` rule to prevent regressions (PR #42, merged 2026-02-06).
 - ✅ **Issue #46** — Added canonical delegation/familiar type foundations: `FamiliarRecord`, `DelegationGrant`, `OnBehalfOfAssertion` interfaces + Zod schemas, `DelegationTier`/`DelegationScope` types, `TIER_SCOPES` constant (PR #48, merged 2026-02-07).
 - ✅ **Issue #50** — Added participation governor type foundations: `BudgetActionKey` (8-key string literal union), `BudgetLimit`/`DailyUsage`/`NullifierBudget` interfaces + Zod schemas, `BUDGET_ACTION_KEYS` runtime tuple, `SEASON_0_BUDGET_DEFAULTS` constant. Full test suite with 100% coverage (PR #51, merged 2026-02-07).
+- ✅ **Issue #53** — Added participation governor runtime utilities: `initializeNullifierBudget`, `rolloverBudgetIfNeeded`, `canConsumeBudget`, `consumeBudget` pure functions + `BudgetCheckResult` interface. 52 tests, 100% coverage (PR #54, merged 2026-02-07).
 
 ---
 
@@ -63,7 +64,7 @@ None — all tracked issues resolved. Next work: Sprint 4 planning.
 | **Sprint 2** (Civic Nervous System) | ✅ Complete | ⚠️ 85% Complete | AI engine mocked; no WebLLM/remote; Engine router exists but unused |
 | **Sprint 3** (Communication) | ✅ Complete | ✅ Complete | Messaging E2EE working; Forum working; XP integrated |
 | **Sprint 3.5** (UI Refinement) | ✅ Complete | ✅ Complete | Stance-based threading; design unification |
-| **Sprint 4** (Agentic Foundation) | ⚪ Planning | 🟡 In Progress | Delegation + participation governor types landed; runtime enforcement + unified topics pending |
+| **Sprint 4** (Agentic Foundation) | ⚪ Planning | 🟡 In Progress | Delegation types + participation governor types & runtime utils landed; enforcement wiring into stores/flows + unified topics pending |
 | **Sprint 5** (Bridge + Docs) | ⚪ Planning | ⚪ Not Started | Docs updated for Civic Action Kit (facilitation model); no code yet (`docs/sprints/05-sprint-the-bridge.md`) |
 
 ---
@@ -78,7 +79,7 @@ None — all tracked issues resolved. Next work: Sprint 4 planning.
 | Hero_Paths / Sentiment Spec | Constituency proofs + district aggregates | SentimentSignal emission requires constituency proof; no RegionProof generation or aggregates | `apps/web-pwa/src/hooks/useSentimentState.ts:76-100` |
 | Sprint 5 Bridge Plan | Civic Action Kit facilitation (reports + native intents) | Bridge is stubbed; facilitation features not implemented | `services/bridge-stub/index.ts` + `docs/sprints/05-sprint-the-bridge.md` |
 | Agentic Familiars (Delegation) | Delegation grants + OBO assertions | 🟡 Types + Zod schemas defined; runtime not implemented | `packages/types/src/delegation.ts` (PR #48); no familiar runtime yet |
-| Participation Governors | Action/analysis budgets per principal | 🟡 Types + defaults defined; runtime enforcement not implemented | `packages/types/src/budget.ts` (PR #51); no runtime `canPerformAction` checks yet |
+| Participation Governors | Action/analysis budgets per principal | 🟡 Types + defaults + runtime utils defined; enforcement wiring not implemented | `packages/types/src/budget.ts` (PR #51) + `packages/types/src/budget-utils.ts` (PR #54); store/flow integration pending |
 | Unified Topics Model | Headlines ↔ threads share `topicId` + proposal threads | Not implemented | Thread schema lacks `topicId`/`proposal` extension |
 | Topic Reanalysis Epochs | Frame/Reframe table updates after N posts via reanalysis | Not implemented | No reanalysis loop or digest types in app state |
 
@@ -101,8 +102,9 @@ The following tasks are required to align the codebase with the updated specs (a
 | Task | Spec Reference | Files to Modify |
 |------|----------------|-----------------|
 | ✅ ~~Define `BudgetActionKey`, `BudgetLimit`, `DailyUsage`, `NullifierBudget` types + Zod schemas, `SEASON_0_BUDGET_DEFAULTS`~~ | `spec-xp-ledger-v0.md` §4 | Done — `packages/types/src/budget.ts` (PR #51) |
-| Add budget counter interface to XP ledger | `spec-xp-ledger-v0.md` §4 | `apps/web-pwa/src/store/xpLedger.ts` |
-| Implement `canPerformAction(type)` budget check | `spec-xp-ledger-v0.md` §4 | `apps/web-pwa/src/store/xpLedger.ts` |
+| ✅ ~~Implement runtime utilities: `initializeNullifierBudget`, `rolloverBudgetIfNeeded`, `canConsumeBudget`, `consumeBudget`, `BudgetCheckResult`~~ | `spec-xp-ledger-v0.md` §4 | Done — `packages/types/src/budget-utils.ts` (PR #54) |
+| Wire budget enforcement into XP ledger store | `spec-xp-ledger-v0.md` §4 | `apps/web-pwa/src/store/xpLedger.ts` |
+| Implement `canPerformAction(type)` budget check in stores | `spec-xp-ledger-v0.md` §4 | `apps/web-pwa/src/store/xpLedger.ts` |
 | Enforce budgets: posts/day=20, comments/day=50 | `spec-xp-ledger-v0.md` §4 | `apps/web-pwa/src/store/forum/index.ts` |
 | Enforce budgets: sentiment_votes/day=200, governance_votes/day=20 | `spec-xp-ledger-v0.md` §4 | `useSentimentState.ts`, `useGovernance.ts` |
 | Enforce budgets: analyses/day=25 (max 5/topic) | `canonical-analysis-v1.md` §4.2 | `packages/ai-engine/src/analysis.ts` |
@@ -191,7 +193,7 @@ fn verify_web(payload, mock_mode) -> f32 {
 |---------|----------------|----------|
 | Delegation grants / OBO assertions | 🟡 Types + schemas defined | `packages/types/src/delegation.ts` (PR #48) |
 | Familiar runtime modes (suggest/act/high-impact) | ❌ Not implemented | No familiar orchestration layer |
-| Action/compute budgets per nullifier | 🟡 Types + defaults defined | `packages/types/src/budget.ts` (PR #51); runtime enforcement pending |
+| Action/compute budgets per nullifier | 🟡 Types + runtime utils defined | `packages/types/src/budget.ts` (PR #51) + `packages/types/src/budget-utils.ts` (PR #54); enforcement wiring into stores/flows pending |
 
 **Invariant:** Familiars inherit the principal’s trust gate and budgets; they never add influence.
 
@@ -313,7 +315,7 @@ const router = new EngineRouter(mockEngine, undefined, 'local-only');
 | Critique/refine prior analyses | `canonical-analysis-v2.md` §4.1 | ❌ Missing |
 | Synthesis engine (divergence table) | `canonical-analysis-v2.md` §4.2 | ❌ Missing |
 | Comment-driven re-synthesis | `canonical-analysis-v2.md` §4.3 | ❌ Missing |
-| Per-principal analysis budget (25/day, 5/topic) | `spec-xp-ledger-v0.md` §4 | 🟡 Types defined (`BudgetLimit` w/ `perTopicCap`); enforcement missing |
+| Per-principal analysis budget (25/day, 5/topic) | `spec-xp-ledger-v0.md` §4 | 🟡 Types + runtime utils defined (`BudgetLimit` w/ `perTopicCap`, `canConsumeBudget`/`consumeBudget`); store enforcement missing |
 
 ---
 


### PR DESCRIPTION
## Summary

Updates `docs/foundational/STATUS.md` to reflect the merge of PR #54 (Issue #53) — participation governor runtime utilities.

### Changes

- **Recently Completed**: Added Issue #53 entry with PR #54 details (`initializeNullifierBudget`, `rolloverBudgetIfNeeded`, `canConsumeBudget`, `consumeBudget`, `BudgetCheckResult`, 52 tests, 100% coverage)
- **Sprint 4 row**: Updated to reflect runtime utils landed alongside delegation + governor types
- **Docs vs Code Alignment**: Updated Participation Governors row from types-only to types + runtime utils; noted store/flow enforcement pending
- **Agentic Familiars section**: Updated budget row to reflect runtime utils defined
- **Outstanding Work (P0)**: Marked runtime utilities task as ✅ done; added explicit enforcement wiring task as next step
- **VENN section**: Updated per-principal analysis budget row to note runtime utils available

### What's still future work
- Enforcement wiring into stores/flows (XP ledger, forum, sentiment, governance, etc.)
- No UI/store integration yet — pure utility functions only so far

### Quality gates
- `pnpm lint` ✅ passes
- `pnpm typecheck` — pre-existing `contracts` package failure (missing chai/mocha types), identical on `main`; no new issues introduced

Closes #53