### PR TITLE
feat: wire budget enforcement into forum posts/comments (#56)

### DIFF
--- a/apps/web-pwa/src/store/hermesForum.commentsAndHydration.test.ts
+++ b/apps/web-pwa/src/store/hermesForum.commentsAndHydration.test.ts
@@ -105,6 +105,7 @@ const createHydrationClient = () => {
 beforeEach(() => {
   (globalThis as any).localStorage = memoryStorage();
   clearPublishedIdentity();
+  useXpLedger.getState().setActiveNullifier(null);
   threadWrites.length = 0;
   commentWrites.length = 0;
   dateIndexWrites.length = 0;
@@ -118,8 +119,10 @@ beforeEach(() => {
 });
 
 describe('hermesForum store (comments & hydration)', () => {
-  const setIdentity = (nullifier: string, trustScore = 1) =>
+  const setIdentity = (nullifier: string, trustScore = 1) => {
     publishIdentity({ session: { nullifier, trustScore, scaledTrustScore: Math.round(trustScore * 10000) } });
+    useXpLedger.getState().setActiveNullifier(nullifier);
+  };
 
   it('createComment marks substantive comments', async () => {
     setIdentity('commenter');

--- a/apps/web-pwa/src/store/xpLedgerBudget.test.ts
+++ b/apps/web-pwa/src/store/xpLedgerBudget.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { initializeNullifierBudget, consumeBudget } from '@vh/types';
+import { todayISO, ensureBudget, checkBudget, consumeFromBudget } from './xpLedgerBudget';
+
+describe('xpLedgerBudget', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-01-01T00:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('todayISO returns YYYY-MM-DD format', () => {
+    expect(todayISO()).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it('ensureBudget initializes when current is null', () => {
+    const budget = ensureBudget(null, 'n1');
+    expect(budget.nullifier).toBe('n1');
+    expect(budget.date).toBe('2024-01-01');
+    expect(budget.usage).toEqual([]);
+  });
+
+  it('ensureBudget rolls over when date differs', () => {
+    const yesterday = initializeNullifierBudget('n1', '2023-12-31');
+    const used = consumeBudget(yesterday, 'posts/day');
+    const rolled = ensureBudget(used, 'n1');
+    expect(rolled.date).toBe('2024-01-01');
+    expect(rolled.usage).toEqual([]);
+  });
+
+  it('ensureBudget returns same-day budget unchanged', () => {
+    const todayBudget = initializeNullifierBudget('n1', '2024-01-01');
+    const used = consumeFromBudget(todayBudget, 'n1', 'posts/day');
+    const ensured = ensureBudget(used, 'n1');
+    expect(ensured).toEqual(used);
+    expect(ensured.usage.find((entry) => entry.actionKey === 'posts/day')?.count).toBe(1);
+  });
+
+  it('checkBudget returns allowed when under limit', () => {
+    const budget = initializeNullifierBudget('n1', '2024-01-01');
+    const checked = checkBudget(budget, 'n1', 'posts/day');
+    expect(checked.result).toEqual({ allowed: true });
+  });
+
+  it('checkBudget returns denied when at limit', () => {
+    let budget = initializeNullifierBudget('n1', '2024-01-01');
+    for (let i = 0; i < 20; i += 1) {
+      budget = consumeFromBudget(budget, 'n1', 'posts/day');
+    }
+    const checked = checkBudget(budget, 'n1', 'posts/day');
+    expect(checked.result).toEqual({ allowed: false, reason: 'Daily limit of 20 reached for posts/day' });
+  });
+
+  it('checkBudget initializes budget when null', () => {
+    const checked = checkBudget(null, 'n1', 'comments/day');
+    expect(checked.budget.nullifier).toBe('n1');
+    expect(checked.budget.date).toBe('2024-01-01');
+    expect(checked.result.allowed).toBe(true);
+  });
+
+  it('consumeFromBudget increments usage', () => {
+    const budget = initializeNullifierBudget('n1', '2024-01-01');
+    const next = consumeFromBudget(budget, 'n1', 'posts/day');
+    expect(next.usage.find((entry) => entry.actionKey === 'posts/day')?.count).toBe(1);
+  });
+
+  it('consumeFromBudget throws when denied', () => {
+    let budget = initializeNullifierBudget('n1', '2024-01-01');
+    for (let i = 0; i < 20; i += 1) {
+      budget = consumeFromBudget(budget, 'n1', 'posts/day');
+    }
+    expect(() => consumeFromBudget(budget, 'n1', 'posts/day')).toThrow('Daily limit of 20 reached for posts/day');
+  });
+
+  it('consumeFromBudget initializes budget when null then consumes', () => {
+    const next = consumeFromBudget(null, 'n1', 'posts/day');
+    expect(next.usage.find((entry) => entry.actionKey === 'posts/day')?.count).toBe(1);
+  });
+});

--- a/apps/web-pwa/src/store/xpLedgerBudget.ts
+++ b/apps/web-pwa/src/store/xpLedgerBudget.ts
@@ -1,0 +1,59 @@
+import {
+  initializeNullifierBudget,
+  rolloverBudgetIfNeeded,
+  canConsumeBudget,
+  consumeBudget,
+  type BudgetCheckResult
+} from '@vh/types';
+import type { BudgetActionKey, NullifierBudget } from '@vh/types';
+
+/** Get today as YYYY-MM-DD (UTC) */
+export function todayISO(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+/**
+ * Ensure budget exists and is rolled over to today.
+ * Returns a fresh or rolled-over NullifierBudget.
+ */
+export function ensureBudget(current: NullifierBudget | null, nullifier: string): NullifierBudget {
+  const date = todayISO();
+  if (!current) {
+    return initializeNullifierBudget(nullifier, date);
+  }
+  return rolloverBudgetIfNeeded(current, date);
+}
+
+/**
+ * Check whether an action is allowed under the current budget.
+ * Handles rollover transparently.
+ * Returns { result, budget } so caller can persist the rolled-over budget.
+ */
+export function checkBudget(
+  current: NullifierBudget | null,
+  nullifier: string,
+  action: BudgetActionKey,
+  amount?: number,
+  topicId?: string
+): { result: BudgetCheckResult; budget: NullifierBudget } {
+  const budget = ensureBudget(current, nullifier);
+  const result = canConsumeBudget(budget, action, amount, topicId);
+  return { result, budget };
+}
+
+/**
+ * Consume an action from the budget.
+ * Handles rollover transparently.
+ * Returns the updated NullifierBudget.
+ * Throws Error if denied.
+ */
+export function consumeFromBudget(
+  current: NullifierBudget | null,
+  nullifier: string,
+  action: BudgetActionKey,
+  amount?: number,
+  topicId?: string
+): NullifierBudget {
+  const budget = ensureBudget(current, nullifier);
+  return consumeBudget(budget, action, amount, topicId);
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,7 +9,8 @@ export default defineConfig({
       '@vh/crypto/provider': resolve(__dirname, 'packages/crypto/src/provider.ts'),
       '@vh/data-model': resolve(__dirname, 'packages/data-model/src/index.ts'),
       '@vh/ai-engine': resolve(__dirname, 'packages/ai-engine/src/index.ts'),
-      '@vh/identity-vault': resolve(__dirname, 'packages/identity-vault/src/index.ts')
+      '@vh/identity-vault': resolve(__dirname, 'packages/identity-vault/src/index.ts'),
+      '@vh/types': resolve(__dirname, 'packages/types/src/index.ts')
     }
   },
   test: {


### PR DESCRIPTION
## Summary

Wires participation governor budget runtime utilities into the XP ledger store and enforces `posts/day` and `comments/day` limits in the forum store.

Closes #56

## Changes

### New: `apps/web-pwa/src/store/xpLedgerBudget.ts` (59 LOC)
Budget bridge between pure `@vh/types` utils and Zustand store:
- `todayISO()` — UTC date as YYYY-MM-DD
- `ensureBudget(current, nullifier)` — init or daily rollover
- `checkBudget(current, nullifier, action, amount?, topicId?)` — check + return rolled budget
- `consumeFromBudget(current, nullifier, action, amount?, topicId?)` — consume, throws on denied

### Modified: `apps/web-pwa/src/store/xpLedger.ts` (350 LOC)
- Added `budget: NullifierBudget | null` to `LedgerData` / `SerializedLedger`
- Added `canPerformAction(action, amount?, topicId?) → BudgetCheckResult`
- Added `consumeAction(action, amount?, topicId?) → void` (throws on denied)
- Budget persists/restores alongside existing ledger data (backward-compatible)
- `setActiveNullifier` eagerly initializes budget for non-null nullifiers

### Modified: `apps/web-pwa/src/store/forum/index.ts` (313 LOC)
- `createThread`: budget check before Gun write, consumption after successful write
- `createComment`: same pattern
- On denial: deterministic error (`"Budget denied: <reason>"`), no Gun write, no state mutation, no XP award

### Modified: `vitest.config.ts`
- Added `@vh/types` path alias for runtime imports

## Validation
- **QA (fresh checkout):** 582 tests passed, 0 failed, 100% coverage (statements/branches/functions/lines)
- **Typecheck:** ✓
- **Lint:** ✓
- **LOC caps:** 59 / 350 / 313 (all ≤ 350)

## Maint Review
- **Musts:** None
- **Shoulds:** (1) Add TOCTOU comment at consume call site for concurrent calls at budget boundary, (2) Add try/catch around ensureBudget in restore for corrupted localStorage objects — both deferred to follow-up
- **Nits:** todayISO dedup with existing today(), line compression readability, removed inline comments — deferred to follow-up
- **Verdict:** Merge

## Follow-ups
- [ ] Add TOCTOU comment at forum budget consume sites (Should #1)
- [ ] Add try/catch for corrupted budget objects on restore (Should #2)
- [ ] Dedup todayISO/today and restore removed inline comments (Nits)