### PR TITLE
docs: update STATUS.md for budget enforcement wiring (Issue #56)

### DIFF
--- a/docs/foundational/STATUS.md
+++ b/docs/foundational/STATUS.md
@@ -23,7 +23,7 @@
 
 ---
 
-## Recently Completed (Issues #4, #6, #11, #12, #15, #18, #19, #22, #23, #24, #27, #33, #40, #46, #50, #53)
+## Recently Completed (Issues #4, #6, #11, #12, #15, #18, #19, #22, #23, #24, #27, #33, #40, #46, #50, #53, #56)
 
 - ✅ **Issue #11** — Added root `pnpm typecheck` script.
 - ✅ **Issue #12** — Landed defensive-copy semantics for `getFullIdentity()` plus race test harness coverage.
@@ -46,6 +46,7 @@
 - ✅ **Issue #46** — Added canonical delegation/familiar type foundations: `FamiliarRecord`, `DelegationGrant`, `OnBehalfOfAssertion` interfaces + Zod schemas, `DelegationTier`/`DelegationScope` types, `TIER_SCOPES` constant (PR #48, merged 2026-02-07).
 - ✅ **Issue #50** — Added participation governor type foundations: `BudgetActionKey` (8-key string literal union), `BudgetLimit`/`DailyUsage`/`NullifierBudget` interfaces + Zod schemas, `BUDGET_ACTION_KEYS` runtime tuple, `SEASON_0_BUDGET_DEFAULTS` constant. Full test suite with 100% coverage (PR #51, merged 2026-02-07).
 - ✅ **Issue #53** — Added participation governor runtime utilities: `initializeNullifierBudget`, `rolloverBudgetIfNeeded`, `canConsumeBudget`, `consumeBudget` pure functions + `BudgetCheckResult` interface. 52 tests, 100% coverage (PR #54, merged 2026-02-07).
+- ✅ **Issue #56** — Wired participation governor budget enforcement into forum store: budget state persisted per-nullifier in XP ledger, `canPerformAction`/`consumeAction` methods exposed, `posts/day` (20) and `comments/day` (50) enforced in `createThread`/`createComment` with check-before/consume-after pattern. New `xpLedgerBudget.ts` bridge file (59 LOC). 582 tests, 100% coverage (PR #57, merged 2026-02-07).
 
 ---
 
@@ -64,7 +65,7 @@ None — all tracked issues resolved. Next work: Sprint 4 planning.
 | **Sprint 2** (Civic Nervous System) | ✅ Complete | ⚠️ 85% Complete | AI engine mocked; no WebLLM/remote; Engine router exists but unused |
 | **Sprint 3** (Communication) | ✅ Complete | ✅ Complete | Messaging E2EE working; Forum working; XP integrated |
 | **Sprint 3.5** (UI Refinement) | ✅ Complete | ✅ Complete | Stance-based threading; design unification |
-| **Sprint 4** (Agentic Foundation) | ⚪ Planning | 🟡 In Progress | Delegation types + participation governor types & runtime utils landed; enforcement wiring into stores/flows + unified topics pending |
+| **Sprint 4** (Agentic Foundation) | ⚪ Planning | 🟡 In Progress | Delegation types + participation governor types, runtime utils & forum enforcement wiring landed; remaining budget enforcement (sentiment/governance/analysis/moderation/civic/shares) + unified topics pending |
 | **Sprint 5** (Bridge + Docs) | ⚪ Planning | ⚪ Not Started | Docs updated for Civic Action Kit (facilitation model); no code yet (`docs/sprints/05-sprint-the-bridge.md`) |
 
 ---
@@ -79,7 +80,7 @@ None — all tracked issues resolved. Next work: Sprint 4 planning.
 | Hero_Paths / Sentiment Spec | Constituency proofs + district aggregates | SentimentSignal emission requires constituency proof; no RegionProof generation or aggregates | `apps/web-pwa/src/hooks/useSentimentState.ts:76-100` |
 | Sprint 5 Bridge Plan | Civic Action Kit facilitation (reports + native intents) | Bridge is stubbed; facilitation features not implemented | `services/bridge-stub/index.ts` + `docs/sprints/05-sprint-the-bridge.md` |
 | Agentic Familiars (Delegation) | Delegation grants + OBO assertions | 🟡 Types + Zod schemas defined; runtime not implemented | `packages/types/src/delegation.ts` (PR #48); no familiar runtime yet |
-| Participation Governors | Action/analysis budgets per principal | 🟡 Types + defaults + runtime utils defined; enforcement wiring not implemented | `packages/types/src/budget.ts` (PR #51) + `packages/types/src/budget-utils.ts` (PR #54); store/flow integration pending |
+| Participation Governors | Action/analysis budgets per principal | 🟡 Types + defaults + runtime utils defined; forum enforcement wired (posts/comments) | `packages/types/src/budget.ts` (PR #51) + `packages/types/src/budget-utils.ts` (PR #54) + `apps/web-pwa/src/store/xpLedgerBudget.ts` (PR #57); remaining store/flow integration pending |
 | Unified Topics Model | Headlines ↔ threads share `topicId` + proposal threads | Not implemented | Thread schema lacks `topicId`/`proposal` extension |
 | Topic Reanalysis Epochs | Frame/Reframe table updates after N posts via reanalysis | Not implemented | No reanalysis loop or digest types in app state |
 
@@ -103,9 +104,9 @@ The following tasks are required to align the codebase with the updated specs (a
 |------|----------------|-----------------|
 | ✅ ~~Define `BudgetActionKey`, `BudgetLimit`, `DailyUsage`, `NullifierBudget` types + Zod schemas, `SEASON_0_BUDGET_DEFAULTS`~~ | `spec-xp-ledger-v0.md` §4 | Done — `packages/types/src/budget.ts` (PR #51) |
 | ✅ ~~Implement runtime utilities: `initializeNullifierBudget`, `rolloverBudgetIfNeeded`, `canConsumeBudget`, `consumeBudget`, `BudgetCheckResult`~~ | `spec-xp-ledger-v0.md` §4 | Done — `packages/types/src/budget-utils.ts` (PR #54) |
-| Wire budget enforcement into XP ledger store | `spec-xp-ledger-v0.md` §4 | `apps/web-pwa/src/store/xpLedger.ts` |
-| Implement `canPerformAction(type)` budget check in stores | `spec-xp-ledger-v0.md` §4 | `apps/web-pwa/src/store/xpLedger.ts` |
-| Enforce budgets: posts/day=20, comments/day=50 | `spec-xp-ledger-v0.md` §4 | `apps/web-pwa/src/store/forum/index.ts` |
+| ✅ ~~Wire budget enforcement into XP ledger store~~ | `spec-xp-ledger-v0.md` §4 | Done — `apps/web-pwa/src/store/xpLedgerBudget.ts` (PR #57) |
+| ✅ ~~Implement `canPerformAction(type)` budget check in stores~~ | `spec-xp-ledger-v0.md` §4 | Done — `canPerformAction`/`consumeAction` exposed via `xpLedgerBudget.ts` (PR #57) |
+| ✅ ~~Enforce budgets: posts/day=20, comments/day=50~~ | `spec-xp-ledger-v0.md` §4 | Done — enforced in `createThread`/`createComment` with check-before/consume-after pattern (PR #57) |
 | Enforce budgets: sentiment_votes/day=200, governance_votes/day=20 | `spec-xp-ledger-v0.md` §4 | `useSentimentState.ts`, `useGovernance.ts` |
 | Enforce budgets: analyses/day=25 (max 5/topic) | `canonical-analysis-v1.md` §4.2 | `packages/ai-engine/src/analysis.ts` |
 | Enforce budgets: moderation/day=10, civic_actions/day=3, shares/day=10 | `spec-xp-ledger-v0.md` §4 | Various stores |
@@ -193,7 +194,7 @@ fn verify_web(payload, mock_mode) -> f32 {
 |---------|----------------|----------|
 | Delegation grants / OBO assertions | 🟡 Types + schemas defined | `packages/types/src/delegation.ts` (PR #48) |
 | Familiar runtime modes (suggest/act/high-impact) | ❌ Not implemented | No familiar orchestration layer |
-| Action/compute budgets per nullifier | 🟡 Types + runtime utils defined | `packages/types/src/budget.ts` (PR #51) + `packages/types/src/budget-utils.ts` (PR #54); enforcement wiring into stores/flows pending |
+| Action/compute budgets per nullifier | 🟡 Types + runtime utils defined; forum enforcement wired | `packages/types/src/budget.ts` (PR #51) + `packages/types/src/budget-utils.ts` (PR #54) + `apps/web-pwa/src/store/xpLedgerBudget.ts` (PR #57); posts/day & comments/day enforced; remaining action types pending |
 
 **Invariant:** Familiars inherit the principal’s trust gate and budgets; they never add influence.
 
@@ -422,7 +423,7 @@ const router = new EngineRouter(mockEngine, undefined, 'local-only');
 
 ## Test Coverage
 
-**Repo-wide (Vitest `pnpm test:quick`):** 68 test files, 430 tests (unit + component + integration).
+**Repo-wide (Vitest `pnpm test:quick`):** 582 tests (unit + component + integration).
 
 **Coverage (`pnpm test:coverage`, last validated 2026-02-07):**
 


### PR DESCRIPTION
## Summary

Updates `docs/foundational/STATUS.md` to reflect the merge of PR #57 (Issue #56 — Participation Governors Enforcement Wiring for forum posts/comments).

### Changes

1. **Recently Completed:** Added Issue #56 entry with full details (budget state per-nullifier, `canPerformAction`/`consumeAction`, posts/day=20, comments/day=50, `xpLedgerBudget.ts` bridge, 582 tests).
2. **Sprint 4 row:** Updated to note forum enforcement wiring is now landed (remaining: sentiment/governance/analysis/moderation/civic/shares + unified topics).
3. **P0 — Participation Governors table:** Marked 3 tasks as ✅ Done:
   - Wire budget enforcement into XP ledger store
   - Implement `canPerformAction(type)` budget check in stores
   - Enforce budgets: posts/day=20, comments/day=50
4. **Agentic Familiars:** Updated budget row to note forum enforcement is wired.
5. **Docs vs. Code Alignment:** Updated Participation Governors row to reflect partial wiring.
6. **Test Coverage:** Updated count to 582 tests.

Closes no issue (docs-only update tracking Issue #56 / PR #57 completion).