### PR TITLE
feat: enforce analyses/day budget in AnalysisFeed (#66)

### DIFF
--- a/apps/web-pwa/src/routes/AnalysisFeed.test.tsx
+++ b/apps/web-pwa/src/routes/AnalysisFeed.test.tsx
@@ -7,9 +7,15 @@ import { AnalysisFeed } from './AnalysisFeed';
 import '@testing-library/jest-dom/vitest';
 import { hashUrl } from '../../../../packages/ai-engine/src/analysis';
 import * as AnalysisModule from '../../../../packages/ai-engine/src/analysis';
+import { useXpLedger } from '../store/xpLedger';
 
 const mockUseAppStore = vi.fn();
 const mockUseIdentity = vi.fn();
+
+const originalGetXpLedgerState = useXpLedger.getState;
+const mockSetActiveNullifier = vi.fn();
+const mockCanPerformAction = vi.fn();
+const mockConsumeAction = vi.fn();
 
 vi.mock('../store', () => ({
   useAppStore: (...args: unknown[]) => mockUseAppStore(...args)
@@ -46,16 +52,36 @@ function createFakeGunChain() {
   return { chain, map };
 }
 
+function submitUrl(targetUrl: string) {
+  fireEvent.change(screen.getByTestId('analysis-url-input'), { target: { value: targetUrl } });
+  fireEvent.click(screen.getByText('Analyze'));
+}
+
 describe('AnalysisFeed', () => {
   beforeEach(() => {
     localStorage.clear();
     mockUseAppStore.mockReturnValue({ client: null });
     mockUseIdentity.mockReturnValue({ identity: null });
+
+    mockSetActiveNullifier.mockReset();
+    mockCanPerformAction.mockReset();
+    mockConsumeAction.mockReset();
+    mockCanPerformAction.mockReturnValue({ allowed: true });
+
+    useXpLedger.getState =
+      () =>
+        ({
+          ...originalGetXpLedgerState(),
+          setActiveNullifier: mockSetActiveNullifier,
+          canPerformAction: mockCanPerformAction,
+          consumeAction: mockConsumeAction
+        } as any);
   });
 
   afterEach(() => {
     cleanup();
     localStorage.clear();
+    useXpLedger.getState = originalGetXpLedgerState;
   });
 
   it('generates a local analysis and caches by url hash', async () => {
@@ -243,5 +269,146 @@ describe('AnalysisFeed', () => {
     fireEvent.click(screen.getByText('Analyze'));
 
     await waitFor(() => expect(screen.getByText(/stored locally only/i)).toBeInTheDocument());
+  });
+
+  describe('analyses/day budget enforcement', () => {
+    it('T1: allowed path generates and consumes budget', async () => {
+      const targetUrl = 'https://allowed.com';
+      mockUseIdentity.mockReturnValue({ identity: { did: 'did:example', session: { nullifier: 'nul-abc' } } });
+
+      render(<AnalysisFeed />);
+      submitUrl(targetUrl);
+
+      await waitFor(() => expect(screen.getByText(/stored locally only/i)).toBeInTheDocument());
+
+      expect(mockSetActiveNullifier).toHaveBeenCalledWith('nul-abc');
+      expect(mockCanPerformAction).toHaveBeenCalledWith('analyses/day', 1, hashUrl(targetUrl));
+      expect(mockConsumeAction).toHaveBeenCalledWith('analyses/day', 1, hashUrl(targetUrl));
+    });
+
+    it('T2: denied path blocks generation and shows reason', async () => {
+      const targetUrl = 'https://blocked.com';
+      const reason = 'Daily limit of 25 reached for analyses/day';
+      mockUseIdentity.mockReturnValue({ identity: { did: 'did:example', session: { nullifier: 'nul-abc' } } });
+      mockCanPerformAction.mockReturnValue({ allowed: false, reason });
+      const getOrGenerateSpy = vi
+        .spyOn(AnalysisModule, 'getOrGenerate')
+        .mockResolvedValue({ analysis: {} as any, reused: false });
+
+      try {
+        render(<AnalysisFeed />);
+        submitUrl(targetUrl);
+
+        await waitFor(() => expect(screen.getByText(reason)).toBeInTheDocument());
+
+        expect(mockSetActiveNullifier).toHaveBeenCalledWith('nul-abc');
+        expect(mockCanPerformAction).toHaveBeenCalledWith('analyses/day', 1, hashUrl(targetUrl));
+        expect(getOrGenerateSpy).not.toHaveBeenCalled();
+        expect(mockConsumeAction).not.toHaveBeenCalled();
+      } finally {
+        getOrGenerateSpy.mockRestore();
+      }
+    });
+
+    it('T3: denied path does not consume budget', async () => {
+      const reason = 'Daily limit reached';
+      mockUseIdentity.mockReturnValue({ identity: { did: 'did:example', session: { nullifier: 'nul-denied' } } });
+      mockCanPerformAction.mockReturnValue({ allowed: false, reason });
+
+      render(<AnalysisFeed />);
+      submitUrl('https://denied-no-consume.com');
+
+      await waitFor(() => expect(screen.getByText(reason)).toBeInTheDocument());
+      expect(mockConsumeAction).not.toHaveBeenCalled();
+    });
+
+    it('T4: reused/cached path does not consume budget', async () => {
+      const targetUrl = 'https://cached-budget.com';
+      const existing = {
+        url: targetUrl,
+        urlHash: hashUrl(targetUrl),
+        summary: 'cached',
+        biases: ['b'],
+        counterpoints: ['c'],
+        sentimentScore: 0,
+        bias_claim_quote: [],
+        justify_bias_claim: [],
+        confidence: 0.9,
+        timestamp: Date.now()
+      };
+      localStorage.setItem('vh_canonical_analyses', JSON.stringify([existing]));
+      mockUseIdentity.mockReturnValue({ identity: { did: 'did:example', session: { nullifier: 'nul-abc' } } });
+
+      render(<AnalysisFeed />);
+      submitUrl(targetUrl);
+
+      await waitFor(() => expect(screen.getByText(/Analysis already exists/)).toBeInTheDocument());
+      expect(mockCanPerformAction).toHaveBeenCalledWith('analyses/day', 1, hashUrl(targetUrl));
+      expect(mockConsumeAction).not.toHaveBeenCalled();
+    });
+
+    it('T5: topicId is hashUrl(url) for check and consume', async () => {
+      const targetUrl = 'https://specific-topic.com/article';
+      const expectedTopicId = hashUrl(targetUrl);
+      mockUseIdentity.mockReturnValue({ identity: { did: 'did:example', session: { nullifier: 'nul-topic' } } });
+
+      render(<AnalysisFeed />);
+      submitUrl(targetUrl);
+
+      await waitFor(() => expect(screen.getByText(/stored locally only/i)).toBeInTheDocument());
+      expect(mockCanPerformAction).toHaveBeenCalledWith('analyses/day', 1, expectedTopicId);
+      expect(mockConsumeAction).toHaveBeenCalledWith('analyses/day', 1, expectedTopicId);
+    });
+
+    it('T6: no-identity path skips all budget APIs', async () => {
+      mockUseIdentity.mockReturnValue({ identity: null });
+
+      render(<AnalysisFeed />);
+      submitUrl('https://anon.com');
+
+      await waitFor(() => expect(screen.getByText(/stored locally only/i)).toBeInTheDocument());
+      expect(mockSetActiveNullifier).not.toHaveBeenCalled();
+      expect(mockCanPerformAction).not.toHaveBeenCalled();
+      expect(mockConsumeAction).not.toHaveBeenCalled();
+    });
+
+    it('T7: identity with falsy nullifier skips budget APIs', async () => {
+      mockUseIdentity.mockReturnValue({ identity: { did: 'did:example', session: { nullifier: null } } });
+
+      render(<AnalysisFeed />);
+      submitUrl('https://no-nullifier.com');
+
+      await waitFor(() => expect(screen.getByText(/stored locally only/i)).toBeInTheDocument());
+      expect(mockSetActiveNullifier).not.toHaveBeenCalled();
+      expect(mockCanPerformAction).not.toHaveBeenCalled();
+      expect(mockConsumeAction).not.toHaveBeenCalled();
+    });
+
+    it('T8: per-topic cap denial displays per-topic reason', async () => {
+      const reason = 'Per-topic cap of 5 reached for analyses/day on topic abc123';
+      mockUseIdentity.mockReturnValue({ identity: { did: 'did:example', session: { nullifier: 'nul-topic-cap' } } });
+      mockCanPerformAction.mockReturnValue({ allowed: false, reason });
+
+      render(<AnalysisFeed />);
+      submitUrl('https://topic-cap.com');
+
+      await waitFor(() => expect(screen.getByText(reason)).toBeInTheDocument());
+    });
+
+    it('T9: generation error does not consume budget', async () => {
+      mockUseIdentity.mockReturnValue({ identity: { did: 'did:example', session: { nullifier: 'nul-error' } } });
+      mockCanPerformAction.mockReturnValue({ allowed: true });
+      const getOrGenerateSpy = vi.spyOn(AnalysisModule, 'getOrGenerate').mockRejectedValue(new Error('generation failed'));
+
+      try {
+        render(<AnalysisFeed />);
+        submitUrl('https://error.com');
+
+        await waitFor(() => expect(screen.getByText('generation failed')).toBeInTheDocument());
+        expect(mockConsumeAction).not.toHaveBeenCalled();
+      } finally {
+        getOrGenerateSpy.mockRestore();
+      }
+    });
   });
 });


### PR DESCRIPTION
## Summary
Wires `analyses/day` budget enforcement into `AnalysisFeed.tsx`.

### Changes
- Before `getOrGenerate`, checks `canPerformAction('analyses/day', 1, topicId)` — blocks with user message if denied
- After generation, calls `consumeAction` only when result is not reused and nullifier is present
- 9 new test cases covering allowed/denied/reused/no-identity/error paths

### Quality Gates
- ✅ typecheck, lint, test:coverage all pass
- ✅ 100% statement/branch/function/line coverage (1559/1559)
- ✅ QA validated in fresh worktree checkout
- ✅ Maint review: no Musts (3 Shoulds, 4 Nits — tracked as follow-ups)

### Follow-ups (from Maint review)
- S1: TOCTOU race window between canPerformAction and consumeAction (async gap)
- S2: Silent denial in useSentimentState.setAgreement (no user feedback)
- S3: Empty-object resolve on budget denial (type safety improvement)

Closes #66