### PR TITLE
fix: complete XP ledger mock in integration test

### DIFF
--- a/apps/web-pwa/src/routes/FeedForum.integration.test.tsx
+++ b/apps/web-pwa/src/routes/FeedForum.integration.test.tsx
@@ -125,12 +125,14 @@ describe('Feed ↔ Forum integration', () => {
     useXpLedger.getState().setActiveNullifier(nullifier);
 
     // Stub budget + XP methods on the singleton so createThread doesn't throw
-    // when consumeAction/applyProjectXP check for active nullifier state.
+    // when canPerformAction/consumeAction/applyProjectXP check for active nullifier state.
     const realGetState = useXpLedger.getState;
     vi.spyOn(useXpLedger, 'getState').mockImplementation(() => ({
       ...realGetState(),
+      canPerformAction: () => ({ allowed: true }),
       consumeAction: () => {},
       applyProjectXP: () => {},
+      applyForumXP: () => {},
     }));
 
     const forumStore = createForumStore({


### PR DESCRIPTION
Follow-up to #83 — the original fix only mocked `consumeAction` and `applyProjectXP` but missed `canPerformAction` (which gates thread creation at line 63 of forum/index.ts) and `applyForumXP`. This caused the integration test to still fail in CI because `canPerformAction` returned `{ allowed: false }` and the thread was never created.

This commit mocks all four XP ledger methods: `canPerformAction`, `consumeAction`, `applyProjectXP`, `applyForumXP`.