### PR TITLE
fix: await thread materialization in feed-forum integration test

### DIFF
--- a/apps/web-pwa/src/routes/FeedForum.integration.test.tsx
+++ b/apps/web-pwa/src/routes/FeedForum.integration.test.tsx
@@ -170,6 +170,7 @@ describe('Feed ↔ Forum integration', () => {
     fireEvent.click(screen.getByTestId('submit-thread-btn'));
 
     await waitFor(() => expect(createThreadBridge).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(forumStore.getState().threads.has('thread-feed-forum')).toBe(true));
 
     const createdThread = forumStore.getState().threads.get('thread-feed-forum');
     expect(createdThread).toBeDefined();


### PR DESCRIPTION
## Problem
CI main #119 (run `21781036058`) failing at `FeedForum.integration.test.tsx:175`.

The test asserts on store state immediately after `createThread` is called, but in CI timing the async store write hasn't finalized — `threads.get('thread-feed-forum')` is still `undefined`.

## Fix
Added `waitFor(() => expect(forumStore.getState().threads.has('thread-feed-forum')).toBe(true))` between the call assertion and the state read.

## Validation
- `pnpm typecheck`: ✅
- `pnpm lint`: ✅
- `pnpm test:quick`: ✅ (659 tests)
- `pnpm test:coverage`: ✅ (100% — 1606/1606 stmts, 474/474 branches, 130/130 functions)
- Targeted test repeated 10×: no flakes

Closes CI regression introduced by #81.