### PR TITLE
test(web-pwa): harden useGovernance coverage (#71)

### DIFF
--- a/apps/web-pwa/src/hooks/useGovernance.test.ts
+++ b/apps/web-pwa/src/hooks/useGovernance.test.ts
@@ -2,8 +2,40 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
-import { useGovernance, useGovernanceStore } from './useGovernance';
+import { MIN_TRUST_TO_VOTE, useGovernance, useGovernanceStore } from './useGovernance';
 import { useXpLedger } from '../store/xpLedger';
+
+const originalXpLedgerGetState = useXpLedger.getState;
+
+function mockXpLedger(overrides: Record<string, unknown> = {}) {
+  const setActiveNullifier = vi.fn();
+  const canPerformAction = vi.fn(() => ({ allowed: true }));
+  const consumeAction = vi.fn();
+  const addXp = vi.fn();
+
+  const mockedState = {
+    setActiveNullifier,
+    canPerformAction,
+    consumeAction,
+    addXp,
+    ...overrides
+  };
+
+  useXpLedger.getState =
+    () =>
+      ({
+        ...originalXpLedgerGetState(),
+        ...mockedState
+      } as any);
+
+  return mockedState as {
+    setActiveNullifier: ReturnType<typeof vi.fn>;
+    canPerformAction: ReturnType<typeof vi.fn>;
+    consumeAction: ReturnType<typeof vi.fn>;
+    addXp: ReturnType<typeof vi.fn>;
+    [key: string]: unknown;
+  };
+}
 
 describe('useGovernance', () => {
   beforeEach(() => {
@@ -11,6 +43,12 @@ describe('useGovernance', () => {
     sessionStorage.clear();
     // Reset zustand store to initial state (re-read from cleared storage)
     useGovernanceStore.setState({ storedVotesMap: {}, lastActions: {}, error: null });
+  });
+
+  afterEach(() => {
+    useXpLedger.getState = originalXpLedgerGetState;
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   it('loads proposals and tracks totals', () => {
@@ -331,4 +369,330 @@ describe('useGovernance', () => {
       expect(mockAddXp).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe('coverage hardening matrix (T1-T26)', () => {
+    it('T1: readFromStorage returns {} for non-object JSON (string primitive)', () => {
+      localStorage.setItem('vh_governance_votes:edge-voter', '"just a string"');
+
+      expect(useGovernanceStore.getState().getVotesForVoter('edge-voter')).toEqual({});
+    });
+
+    it('T2: readFromStorage returns {} for JSON number literal', () => {
+      localStorage.setItem('vh_governance_votes:num-voter', '42');
+
+      expect(useGovernanceStore.getState().getVotesForVoter('num-voter')).toEqual({});
+    });
+
+    it('T3: readStoreMap returns {} when map storage contains a JSON primitive', () => {
+      localStorage.setItem('vh_governance_votes', '"not an object"');
+      sessionStorage.setItem('vh_governance_votes', '"still not an object"');
+
+      expect(useGovernanceStore.getState().getVotesForVoter('map-voter')).toEqual({});
+    });
+
+    it('T4: readFromStorage returns {} when storage value is JSON null', () => {
+      localStorage.setItem('vh_governance_votes:null-voter', 'null');
+
+      expect(useGovernanceStore.getState().getVotesForVoter('null-voter')).toEqual({});
+    });
+
+    it('T5: readFromStorage path handles one undefined storage global', () => {
+      vi.stubGlobal('sessionStorage', undefined);
+      localStorage.setItem(
+        'vh_governance_votes:partial-storage-voter',
+        JSON.stringify({ 'proposal-1': { amount: 2, direction: 'for' } })
+      );
+
+      expect(useGovernanceStore.getState().getVotesForVoter('partial-storage-voter')).toEqual({
+        'proposal-1': { amount: 2, direction: 'for' }
+      });
+    });
+
+    it('T6: gracefully handles undefined storage globals', () => {
+      vi.stubGlobal('localStorage', undefined);
+      vi.stubGlobal('sessionStorage', undefined);
+      useGovernanceStore.setState({ storedVotesMap: {}, lastActions: {}, error: null });
+
+      const { result } = renderHook(() => useGovernance('no-storage-voter', 0.95));
+      expect(result.current.votedDirections).toEqual({});
+      expect(result.current.proposals.find((p) => p.id === 'proposal-1')?.votesFor).toBe(12);
+    });
+
+    it('T7: persistStoredVotes is no-op when storage globals are undefined', () => {
+      vi.stubGlobal('localStorage', undefined);
+      vi.stubGlobal('sessionStorage', undefined);
+      const ledger = mockXpLedger();
+
+      const voteResult = useGovernanceStore.getState().submitVote({
+        proposalId: 'proposal-1',
+        amount: 1,
+        direction: 'for',
+        voterId: 'no-storage-write-voter',
+        trustScore: 0.95,
+        proposalTitle: undefined
+      });
+
+      expect(voteResult).toBe('recorded');
+      expect(useGovernanceStore.getState().storedVotesMap['no-storage-write-voter']?.['proposal-1']).toEqual({
+        amount: 1,
+        direction: 'for'
+      });
+      expect(ledger.consumeAction).toHaveBeenCalledWith('governance_votes/day', 1);
+    });
+
+    it('T8: loadAllStoredVotes outer catch is defensive (branch ignored via v8 comment)', () => {
+      localStorage.setItem('vh_governance_votes', '{not-json');
+
+      expect(useGovernanceStore.getState().getVotesForVoter('outer-catch-voter')).toEqual({});
+    });
+
+    it('T9: submitVote rejects NaN trust score', () => {
+      expect(() =>
+        useGovernanceStore.getState().submitVote({
+          proposalId: 'proposal-1',
+          amount: 1,
+          direction: 'for',
+          voterId: 'nan-trust-voter',
+          trustScore: Number.NaN,
+          proposalTitle: 'NaN trust'
+        })
+      ).toThrow('Trust score below voting threshold');
+      expect(useGovernanceStore.getState().error).toBe('Trust score below voting threshold');
+    });
+
+    it('T10: submitVote rejects negative trust score', () => {
+      expect(() =>
+        useGovernanceStore.getState().submitVote({
+          proposalId: 'proposal-1',
+          amount: 1,
+          direction: 'for',
+          voterId: 'negative-trust-voter',
+          trustScore: -0.5,
+          proposalTitle: 'Negative trust'
+        })
+      ).toThrow('Trust score below voting threshold');
+      expect(useGovernanceStore.getState().error).toBe('Trust score below voting threshold');
+    });
+
+    it('T11: submitVote accepts trust score > 1 (clamped to 1)', () => {
+      const ledger = mockXpLedger();
+
+      const voteResult = useGovernanceStore.getState().submitVote({
+        proposalId: 'proposal-2',
+        amount: 1,
+        direction: 'for',
+        voterId: 'high-trust-voter',
+        trustScore: 5,
+        proposalTitle: 'High trust vote'
+      });
+
+      expect(voteResult).toBe('recorded');
+      expect(ledger.canPerformAction).toHaveBeenCalledWith('governance_votes/day', 1);
+    });
+
+    it('T12: submitVote rejects null trust score', () => {
+      expect(() =>
+        useGovernanceStore.getState().submitVote({
+          proposalId: 'proposal-1',
+          amount: 1,
+          direction: 'for',
+          voterId: 'null-trust-voter',
+          trustScore: null,
+          proposalTitle: 'Null trust'
+        })
+      ).toThrow('Trust score below voting threshold');
+      expect(useGovernanceStore.getState().error).toBe('Trust score below voting threshold');
+    });
+
+    it('T13: submitVote rejects trust score below MIN_TRUST_TO_VOTE', () => {
+      expect(MIN_TRUST_TO_VOTE).toBe(0.7);
+
+      expect(() =>
+        useGovernanceStore.getState().submitVote({
+          proposalId: 'proposal-1',
+          amount: 1,
+          direction: 'for',
+          voterId: 'below-threshold-trust-voter',
+          trustScore: MIN_TRUST_TO_VOTE - 0.01,
+          proposalTitle: 'Below threshold trust'
+        })
+      ).toThrow('Trust score below voting threshold');
+      expect(useGovernanceStore.getState().error).toBe('Trust score below voting threshold');
+    });
+
+    it('T14: store.getProposals returns seed proposals for null voterId', () => {
+      const proposals = useGovernanceStore.getState().getProposals(null);
+
+      expect(proposals).toHaveLength(2);
+      expect(proposals[0]).toMatchObject({ id: 'proposal-1', votesFor: 12, votesAgainst: 3 });
+      expect(proposals[1]).toMatchObject({ id: 'proposal-2', votesFor: 8, votesAgainst: 1 });
+    });
+
+    it('T15: store.getProposals applies stored votes for valid voterId', () => {
+      useGovernanceStore.setState({
+        storedVotesMap: {
+          'store-proposals-voter': {
+            'proposal-1': { amount: 4, direction: 'against' }
+          }
+        },
+        lastActions: {},
+        error: null
+      });
+
+      const proposals = useGovernanceStore.getState().getProposals('store-proposals-voter');
+      const proposal = proposals.find((p) => p.id === 'proposal-1');
+
+      expect(proposal?.votesFor).toBe(12);
+      expect(proposal?.votesAgainst).toBe(7);
+    });
+
+    it('T16: store.getVotedDirections returns {} for null voterId', () => {
+      expect(useGovernanceStore.getState().getVotedDirections(null)).toEqual({});
+    });
+
+    it('T17: store.getVotedDirections returns vote directions for valid voterId', () => {
+      useGovernanceStore.setState({
+        storedVotesMap: {
+          'directions-voter': {
+            'proposal-1': { amount: 3, direction: 'for' },
+            'proposal-2': { amount: 1, direction: 'against' }
+          }
+        },
+        lastActions: {},
+        error: null
+      });
+
+      expect(useGovernanceStore.getState().getVotedDirections('directions-voter')).toEqual({
+        'proposal-1': 'for',
+        'proposal-2': 'against'
+      });
+    });
+
+    it('T18: store.clearError resets error to null', () => {
+      useGovernanceStore.setState({ error: 'some error' });
+
+      useGovernanceStore.getState().clearError();
+
+      expect(useGovernanceStore.getState().error).toBeNull();
+    });
+
+    it('T19: submitVote is no-op for amount 0', () => {
+      useGovernanceStore.setState({ error: 'existing error' });
+
+      const voteResult = useGovernanceStore.getState().submitVote({
+        proposalId: 'proposal-1',
+        amount: 0,
+        direction: 'for',
+        voterId: 'amount-zero-voter',
+        trustScore: 0.95,
+        proposalTitle: 'Amount zero vote'
+      });
+
+      expect(voteResult).toBeUndefined();
+      expect(useGovernanceStore.getState().error).toBe('existing error');
+      expect(useGovernanceStore.getState().storedVotesMap['amount-zero-voter']).toBeUndefined();
+    });
+
+    it('T20: submitVote is no-op for negative amount', () => {
+      useGovernanceStore.setState({ error: 'still set' });
+
+      const voteResult = useGovernanceStore.getState().submitVote({
+        proposalId: 'proposal-1',
+        amount: -5,
+        direction: 'for',
+        voterId: 'negative-amount-voter',
+        trustScore: 0.95,
+        proposalTitle: 'Negative amount vote'
+      });
+
+      expect(voteResult).toBeUndefined();
+      expect(useGovernanceStore.getState().error).toBe('still set');
+      expect(useGovernanceStore.getState().storedVotesMap['negative-amount-voter']).toBeUndefined();
+    });
+
+    it('T21: store.getVotesForVoter returns {} for falsy voterId', () => {
+      expect(useGovernanceStore.getState().getVotesForVoter(null)).toEqual({});
+      expect(useGovernanceStore.getState().getVotesForVoter(undefined)).toEqual({});
+      expect(useGovernanceStore.getState().getVotesForVoter('')).toEqual({});
+    });
+
+    it('T22: submitVote uses default reason when budgetCheck.reason is undefined', () => {
+      const canPerformAction = vi.fn(() => ({ allowed: false }));
+      mockXpLedger({ canPerformAction });
+
+      expect(() =>
+        useGovernanceStore.getState().submitVote({
+          proposalId: 'proposal-1',
+          amount: 1,
+          direction: 'for',
+          voterId: 'default-reason-voter',
+          trustScore: 0.95,
+          proposalTitle: 'Budget default reason'
+        })
+      ).toThrow('Governance vote budget exhausted');
+
+      expect(useGovernanceStore.getState().error).toBe('Governance vote budget exhausted');
+    });
+
+    it('T23: submitVote falls through curated title fallback to curated.title', () => {
+      const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+      mockXpLedger();
+
+      const voteResult = useGovernanceStore.getState().submitVote({
+        proposalId: 'proposal-1',
+        amount: 1,
+        direction: 'for',
+        voterId: 'curated-title-voter',
+        trustScore: 0.95,
+        proposalTitle: undefined
+      });
+
+      expect(voteResult).toBe('recorded');
+      expect(infoSpy).toHaveBeenCalledWith(expect.stringContaining('Expand EV Charging Network'));
+    });
+
+    it('T24: submitVote uses proposalId when proposalTitle is undefined', () => {
+      mockXpLedger();
+
+      const voterId = 'proposal-id-fallback-voter';
+      const proposalId = 'proposal-999';
+      const voteResult = useGovernanceStore.getState().submitVote({
+        proposalId,
+        amount: 2,
+        direction: 'against',
+        voterId,
+        trustScore: 0.95,
+        proposalTitle: undefined
+      });
+
+      expect(voteResult).toBe('recorded');
+      expect(useGovernanceStore.getState().lastActions[voterId]).toContain(`"${proposalId}"`);
+    });
+
+    it('T25: hook submitVote passes null when trustScore is undefined', async () => {
+      const { result } = renderHook(() => useGovernance('hook-null-trust-voter'));
+
+      await expect(result.current.submitVote({ proposalId: 'proposal-1', amount: 1, direction: 'for' })).rejects.toThrow(
+        'Trust score below voting threshold'
+      );
+      expect(useGovernanceStore.getState().error).toBe('Trust score below voting threshold');
+    });
+
+    it('T26: loadStoredVotes returns mergedFallback object when no voter entry exists in map', () => {
+      localStorage.setItem(
+        'vh_governance_votes:merged-fallback-voter',
+        JSON.stringify({ 'proposal-1': { amount: 2, direction: 'for' } })
+      );
+      sessionStorage.setItem(
+        'vh_governance_votes:merged-fallback-voter',
+        JSON.stringify({ 'proposal-2': { amount: 1, direction: 'against' } })
+      );
+
+      expect(useGovernanceStore.getState().getVotesForVoter('merged-fallback-voter')).toEqual({
+        'proposal-1': { amount: 2, direction: 'for' },
+        'proposal-2': { amount: 1, direction: 'against' }
+      });
+    });
+  });
+
 });

--- a/apps/web-pwa/src/hooks/useGovernance.ts
+++ b/apps/web-pwa/src/hooks/useGovernance.ts
@@ -93,6 +93,7 @@ function loadAllStoredVotes(): Record<string, StoredVotes> {
     const sessionMap = readStoreMap(typeof sessionStorage !== 'undefined' ? sessionStorage : undefined);
     const localMap = readStoreMap(typeof localStorage !== 'undefined' ? localStorage : undefined);
     return { ...localMap, ...sessionMap };
+  /* v8 ignore next 3 -- defensive outer catch; inner readers already guard parse/storage errors */
   } catch {
     return {};
   }
@@ -103,7 +104,7 @@ function loadStoredVotes(voterId: string): StoredVotes {
   const sessionFallback = readFromStorage(typeof sessionStorage !== 'undefined' ? sessionStorage : undefined, storageKey(voterId));
   const localFallback = readFromStorage(typeof localStorage !== 'undefined' ? localStorage : undefined, storageKey(voterId));
   const mergedFallback = mergeVoteStores(localFallback, sessionFallback);
-  return combinedMap[voterId] ?? mergedFallback ?? {};
+  return combinedMap[voterId] ?? mergedFallback ?? /* v8 ignore next -- mergeVoteStores always returns an object */ {};
 }
 
 function persistStoredVotes(voterId: string, votes: StoredVotes) {
@@ -221,7 +222,7 @@ export const useGovernanceStore = create<GovernanceStore>((set, get) => ({
 
     const curated = CURATED_PROJECTS[proposalId];
     if (curated) {
-      const title = proposalTitle ?? curated.title ?? proposalId;
+      const title = proposalTitle ?? curated.title ?? /* v8 ignore next -- curated titles are always defined in Season 0 mapping */ proposalId;
       console.info(
         `[Season 0] Vote recorded locally for "${title}" (On-chain ID: ${curated.onChainId}). No RVU transaction sent.`
       );

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -83,7 +83,6 @@ export default defineConfig({
         // --- React Hooks (stateful wiring validated via E2E) ---
         'apps/web-pwa/src/hooks/useIdentity.ts',
         'apps/web-pwa/src/hooks/useRegion.ts',
-        'apps/web-pwa/src/hooks/useGovernance.ts',
         'apps/web-pwa/src/hooks/useFeedStore.ts',
         'apps/web-pwa/src/hooks/useSentimentState.ts',
 


### PR DESCRIPTION
## Summary
Harden `useGovernance` coverage to 100% lines/branches/functions.

### Changes
- Remove `useGovernance.ts` from coverage exclusion in `vitest.config.ts`
- Add 26 new tests (T1–T26), 39 total in `useGovernance.test.ts`
- Add `v8 ignore` annotations on 3 unreachable defensive branches (no behavior change)

### Verification
- **QA**: All gates green from fresh checkout (`typecheck`, `lint`, `test:quick`, `test:coverage`)
- **Maint**: Zero Must findings (1 pre-existing Should flagged for follow-up)
- **Coverage**: 100% statements / branches / functions / lines on `useGovernance.ts`
- **685 tests passing**, 77 test files

### Follow-ups
- S1: Array type guard in `readFromStorage` (pre-existing, tracked separately)

Closes #71