### PR TITLE
fix(web-pwa): reject arrays in governance storage guards (#87)

### DIFF
--- a/apps/web-pwa/src/hooks/useGovernance.ts
+++ b/apps/web-pwa/src/hooks/useGovernance.ts
@@ -66,7 +66,7 @@ function readFromStorage(storage: Storage | undefined, key: string): StoredVotes
     const raw = storage.getItem(key);
     if (!raw) return {};
     const parsed = JSON.parse(raw) as StoredVotes;
-    if (parsed && typeof parsed === 'object') return parsed;
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) return parsed;
     return {};
   } catch {
     console.warn('[vh:governance] Storage read failed for key', key);
@@ -80,7 +80,7 @@ function readStoreMap(storage: Storage | undefined): Record<string, StoredVotes>
     const raw = storage.getItem(VOTE_STORAGE_KEY);
     if (!raw) return {};
     const parsed = JSON.parse(raw) as Record<string, StoredVotes>;
-    if (parsed && typeof parsed === 'object') return parsed;
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) return parsed;
     return {};
   } catch {
     console.warn('[vh:governance] Storage map read failed');


### PR DESCRIPTION
## Summary

Hardens `readFromStorage` and `readStoreMap` in `useGovernance.ts` to reject JSON arrays via `&& !Array.isArray(parsed)`. Previously, arrays passed the `typeof parsed === 'object'` guard (since `typeof [] === 'object'` in JS), which could cause type confusion downstream.

## Changes
- **Source:** 2 lines changed in `useGovernance.ts` (lines 69, 83)
- **Tests:** 8 new test cases in `useGovernance.test.ts` (T-1 through T-8) covering array rejection, valid object regression, null/primitive handling

## Validation
- ✅ QA: fresh checkout, 693 tests, 100% coverage (1825 stmts, 602 branches, 148 functions)
- ✅ Maint: 0 Must, 1 Should (follow-up audit of forum/helpers.ts), 1 Nit
- ✅ All gates: typecheck, lint, test:quick, test:coverage

## Context
- Issue: #87
- Origin: Maint Should finding from PR #86 (#71 review)
- Impl commit: `bedfb61`

Closes #87