### PR TITLE
fix: budget test scaffolding dedup + code comments cleanup (#72)

### DIFF
--- a/apps/web-pwa/src/hooks/useSentimentState.test.ts
+++ b/apps/web-pwa/src/hooks/useSentimentState.test.ts
@@ -2,16 +2,20 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useSentimentState } from './useSentimentState';
-import { useXpLedger } from '../store/xpLedger';
+import { createBudgetMock } from '../test-utils/budgetMock';
 
 const TOPIC = 't1';
 const POINT = 'p1';
 const ANALYSIS = 'a1';
 
-const originalGetXpLedgerState = useXpLedger.getState;
 const mockSetActiveNullifier = vi.fn();
 const mockCanPerformAction = vi.fn();
 const mockConsumeAction = vi.fn();
+const budgetMock = createBudgetMock({
+  setActiveNullifier: mockSetActiveNullifier,
+  canPerformAction: mockCanPerformAction,
+  consumeAction: mockConsumeAction
+});
 let activeNullifier: string | null = null;
 
 function proofFor(nullifier = 'n') {
@@ -32,14 +36,7 @@ describe('useSentimentState', () => {
     });
     mockCanPerformAction.mockReturnValue({ allowed: true });
 
-    useXpLedger.getState =
-      () =>
-        ({
-          ...originalGetXpLedgerState(),
-          setActiveNullifier: mockSetActiveNullifier,
-          canPerformAction: mockCanPerformAction,
-          consumeAction: mockConsumeAction
-        } as any);
+    budgetMock.install();
 
     useSentimentState.setState({
       agreements: {},
@@ -56,7 +53,7 @@ describe('useSentimentState', () => {
   });
 
   afterEach(() => {
-    useXpLedger.getState = originalGetXpLedgerState;
+    budgetMock.restore();
   });
 
   it('cycles agreement and emits signals', () => {

--- a/apps/web-pwa/src/hooks/useSentimentState.ts
+++ b/apps/web-pwa/src/hooks/useSentimentState.ts
@@ -81,7 +81,9 @@ export const useSentimentState = create<SentimentStore>((set, get) => ({
       return;
     }
 
+    // intentional: must activate nullifier before checking its budget
     useXpLedger.getState().setActiveNullifier(constituency_proof.nullifier);
+    // no per-topic sub-cap for sentiment votes
     const budgetCheck = useXpLedger.getState().canPerformAction('sentiment_votes/day', 1);
     if (!budgetCheck.allowed) return;
 

--- a/apps/web-pwa/src/routes/AnalysisFeed.tsx
+++ b/apps/web-pwa/src/routes/AnalysisFeed.tsx
@@ -9,7 +9,7 @@ import { useIdentity } from '../hooks/useIdentity';
 import { useXpLedger } from '../store/xpLedger';
 import { safeGetItem, safeSetItem } from '../utils/safeStorage';
 
-const FEED_KEY = 'vh_canonical_analyses';
+export const ANALYSIS_FEED_STORAGE_KEY = 'vh_canonical_analyses';
 
 interface FeedStore {
   data: CanonicalAnalysis[];
@@ -18,12 +18,12 @@ interface FeedStore {
 
 function loadFeed(): FeedStore {
   try {
-    const raw = safeGetItem(FEED_KEY);
+    const raw = safeGetItem(ANALYSIS_FEED_STORAGE_KEY);
     const data = raw ? (JSON.parse(raw) as CanonicalAnalysis[]) : [];
     return {
       data,
       save(items: CanonicalAnalysis[]) {
-        safeSetItem(FEED_KEY, JSON.stringify(items));
+        safeSetItem(ANALYSIS_FEED_STORAGE_KEY, JSON.stringify(items));
       }
     };
   } catch {

--- a/apps/web-pwa/src/test-utils/budgetMock.ts
+++ b/apps/web-pwa/src/test-utils/budgetMock.ts
@@ -1,0 +1,22 @@
+import { useXpLedger } from '../store/xpLedger';
+
+type BudgetOverrides = Pick<
+  ReturnType<typeof useXpLedger.getState>,
+  'setActiveNullifier' | 'canPerformAction' | 'consumeAction'
+>;
+
+export function createBudgetMock(overrides: BudgetOverrides) {
+  const originalGetXpLedgerState = useXpLedger.getState;
+
+  return {
+    install() {
+      useXpLedger.getState = () => ({
+        ...originalGetXpLedgerState(),
+        ...overrides
+      });
+    },
+    restore() {
+      useXpLedger.getState = originalGetXpLedgerState;
+    }
+  };
+}


### PR DESCRIPTION
## Issue #72 — Budget test scaffolding dedup + code comments cleanup

Addresses 5 consolidated nits from maint reviews of #56, #63, #66.

### Changes
- **N1:** Dedup `today()`/`todayISO()` — removed local `today()` from `xpLedger.ts`, imports shared `todayISO()` from `xpLedgerBudget.ts`
- **N2:** Extracted shared `createBudgetMock()` test helper in `src/test-utils/budgetMock.ts` — eliminates duplicate scaffolding in `AnalysisFeed.test.tsx` and `useSentimentState.test.ts`
- **N3:** Added intentionality comments in `useSentimentState.ts` for budget call sites
- **N4:** Restored helpful inline docs in `xpLedger.ts` (Map type annotations, civic bonus comment)
- **N5:** Exported `ANALYSIS_FEED_STORAGE_KEY` constant from `AnalysisFeed.tsx`, test uses constant instead of hardcoded string

### Stats
6 files changed, +56 −40 (net −16 lines)

### Gates
- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `pnpm test:quick` ✅ (711 tests)
- `pnpm test:coverage` ✅ (100% statements/branches/functions/lines)

### Review
- QA: fresh-checkout validation passed, SHA confirmed
- Maint: approved, zero Must/Should findings

Closes #72