### PR TITLE
fix(web-pwa): gate consumeAction on non-null analysis result (#98)

### DIFF
--- a/apps/web-pwa/src/routes/AnalysisFeed.test.tsx
+++ b/apps/web-pwa/src/routes/AnalysisFeed.test.tsx
@@ -265,7 +265,7 @@ describe('AnalysisFeed', () => {
       submitUrl(targetUrl);
 
       await waitFor(() => expect(screen.getByText('Analysis unavailable')).toBeInTheDocument());
-      expect(mockConsumeAction).toHaveBeenCalledWith('analyses/day', 1, hashUrl(targetUrl));
+      expect(mockConsumeAction).not.toHaveBeenCalled();
     } finally {
       getOrGenerateSpy.mockRestore();
     }

--- a/apps/web-pwa/src/routes/AnalysisFeed.tsx
+++ b/apps/web-pwa/src/routes/AnalysisFeed.tsx
@@ -158,7 +158,7 @@ export const AnalysisFeed: React.FC = () => {
 
         void getOrGenerate(targetUrl, analysisStore, generate)
           .then((result) => {
-            if (!result.reused && nullifier) {
+            if (!result.reused && nullifier && result.analysis) {
               useXpLedger.getState().consumeAction('analyses/day', 1, topicId);
             }
             let notice: string | undefined;


### PR DESCRIPTION
## Summary
Fixes #98 — `consumeAction('analyses/day')` was called even when `getOrGenerate` returned a null analysis (e.g., generation denied/failed). This incorrectly decremented the daily budget for analyses that were never produced.

### Root Cause
After PR #96 (Issue #69), `getOrGenerate` can return `{ analysis: null, reused: false }`. The `.then()` handler's consume guard only checked `!result.reused && nullifier` — missing a check on `result.analysis`.

### Fix
Add `&& result.analysis` to the consume guard (1 line):
```typescript
// Before:
if (!result.reused && nullifier) {
// After:
if (!result.reused && nullifier && result.analysis) {
```

### Test Change
The existing null-analysis test was asserting the **buggy** behavior (`toHaveBeenCalledWith`). Corrected to `not.toHaveBeenCalled()`.

### Files Changed
- `apps/web-pwa/src/routes/AnalysisFeed.tsx` (+1/-1)
- `apps/web-pwa/src/routes/AnalysisFeed.test.tsx` (+1/-1)

### Gates
- Local: typecheck ✅, lint ✅, test:quick ✅, coverage ✅ (100% all metrics)
- QA fresh-checkout: pending
- Maint review: pending

Closes #98