### PR TITLE
cleanup(web-pwa): remove redundant setActiveNullifier useEffect in ProposalList (#61)

### DIFF
--- a/apps/web-pwa/src/components/ProposalList.test.tsx
+++ b/apps/web-pwa/src/components/ProposalList.test.tsx
@@ -1,13 +1,198 @@
 /* @vitest-environment jsdom */
 
-import { render, screen } from '@testing-library/react';
+import { cleanup, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Proposal } from '../hooks/useGovernance';
 import ProposalList from './ProposalList';
+import { useXpLedger } from '../store/xpLedger';
+
+const mockUseGovernance = vi.fn();
+const mockUseIdentity = vi.fn();
+
+vi.mock('../hooks/useGovernance', () => ({
+  __esModule: true,
+  default: (...args: unknown[]) => mockUseGovernance(...args),
+  MIN_TRUST_TO_VOTE: 0.7
+}));
+
+vi.mock('../hooks/useIdentity', () => ({
+  useIdentity: (...args: unknown[]) => mockUseIdentity(...args)
+}));
+
+interface ProposalCardStubProps {
+  proposal: Proposal;
+  canVote?: boolean;
+  votedDirection?: 'for' | 'against';
+}
+
+vi.mock('./ProposalCard', () => ({
+  __esModule: true,
+  default: ({ proposal, canVote, votedDirection }: ProposalCardStubProps) => (
+    <article
+      data-testid={`proposal-card-${proposal.id}`}
+      data-can-vote={String(canVote)}
+      data-voted-direction={votedDirection ?? ''}
+    >
+      <h3>{proposal.title}</h3>
+    </article>
+  )
+}));
+
+const mockProposals: Proposal[] = [
+  {
+    id: 'proposal-1',
+    title: 'Expand EV Charging Network',
+    summary: 'Fund community-owned charging hubs in underserved areas.',
+    author: '0xabc',
+    fundingRequest: 1500,
+    recipient: '0xrecipient1',
+    votesFor: 12,
+    votesAgainst: 3
+  },
+  {
+    id: 'proposal-2',
+    title: 'Civic Data Trust',
+    summary: 'Create a public data trust for local governance metrics.',
+    author: '0xdef',
+    fundingRequest: 2300,
+    recipient: '0xrecipient2',
+    votesFor: 8,
+    votesAgainst: 1
+  }
+];
+
+function makeGovernanceMock(overrides: Record<string, unknown> = {}) {
+  return {
+    proposals: mockProposals,
+    loading: false,
+    error: null,
+    submitVote: vi.fn(),
+    lastAction: null,
+    votedDirections: {},
+    ...overrides
+  };
+}
+
+function makeIdentityMock(overrides: Record<string, unknown> = {}) {
+  return {
+    identity: {
+      session: {
+        nullifier: 'voter-1',
+        trustScore: 0.95,
+        ...overrides
+      }
+    }
+  };
+}
 
 describe('ProposalList', () => {
-  it('renders proposals', async () => {
+  beforeEach(() => {
+    mockUseGovernance.mockReset();
+    mockUseIdentity.mockReset();
+    mockUseGovernance.mockReturnValue(makeGovernanceMock());
+    mockUseIdentity.mockReturnValue(makeIdentityMock());
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('PL-1: renders "Loading proposals..." when loading=true', () => {
+    mockUseGovernance.mockReturnValue(makeGovernanceMock({ loading: true }));
+
     render(<ProposalList />);
-    expect(await screen.findByText(/Expand EV Charging/)).toBeInTheDocument();
+
+    expect(screen.getByText('Loading proposals...')).toBeInTheDocument();
+  });
+
+  it('PL-2: renders error message when error is set', () => {
+    mockUseGovernance.mockReturnValue(makeGovernanceMock({ error: 'Failed to load proposals' }));
+
+    render(<ProposalList />);
+
+    expect(screen.getByText('Failed to load proposals')).toBeInTheDocument();
+  });
+
+  it('PL-3: renders "No proposals yet." when proposals=[]', () => {
+    mockUseGovernance.mockReturnValue(makeGovernanceMock({ proposals: [] }));
+
+    render(<ProposalList />);
+
+    expect(screen.getByText('No proposals yet.')).toBeInTheDocument();
+  });
+
+  it('PL-4: renders proposal cards with titles', () => {
+    render(<ProposalList />);
+
+    expect(screen.getByText('Expand EV Charging Network')).toBeInTheDocument();
+    expect(screen.getByText('Civic Data Trust')).toBeInTheDocument();
+  });
+
+  it('PL-5: renders lastAction banner when lastAction is set', () => {
+    mockUseGovernance.mockReturnValue(makeGovernanceMock({ lastAction: 'Vote recorded!' }));
+
+    render(<ProposalList />);
+
+    expect(screen.getByText('Vote recorded!')).toBeInTheDocument();
+  });
+
+  it('PL-6: does NOT render lastAction banner when null', () => {
+    mockUseGovernance.mockReturnValue(makeGovernanceMock({ lastAction: null }));
+
+    render(<ProposalList />);
+
+    expect(screen.queryByText('Vote recorded!')).not.toBeInTheDocument();
+  });
+
+  it('PL-7: canVote=false when voterId is null (no identity)', () => {
+    mockUseIdentity.mockReturnValue({ identity: null });
+
+    render(<ProposalList />);
+
+    expect(screen.getByTestId('proposal-card-proposal-1')).toHaveAttribute('data-can-vote', 'false');
+  });
+
+  it('PL-8: canVote=false when trustScore < MIN_TRUST_TO_VOTE', () => {
+    mockUseIdentity.mockReturnValue(makeIdentityMock({ trustScore: undefined, scaledTrustScore: 6999 }));
+
+    render(<ProposalList />);
+
+    expect(screen.getByTestId('proposal-card-proposal-1')).toHaveAttribute('data-can-vote', 'false');
+    expect(mockUseGovernance).toHaveBeenCalledWith('voter-1', 0.6999);
+  });
+
+  it('PL-9: canVote=true when voterId present and trustScore >= 0.7', () => {
+    mockUseIdentity.mockReturnValue(makeIdentityMock({ trustScore: undefined, scaledTrustScore: 7000 }));
+
+    render(<ProposalList />);
+
+    expect(screen.getByTestId('proposal-card-proposal-1')).toHaveAttribute('data-can-vote', 'true');
+    expect(mockUseGovernance).toHaveBeenCalledWith('voter-1', 0.7);
+  });
+
+  it('PL-10: useXpLedger.setActiveNullifier is NOT called on render', () => {
+    const setActiveNullifierSpy = vi.spyOn(useXpLedger.getState(), 'setActiveNullifier');
+
+    render(<ProposalList />);
+
+    expect(setActiveNullifierSpy).not.toHaveBeenCalled();
+  });
+
+  it('PL-11: passes votedDirection to ProposalCard correctly', () => {
+    mockUseGovernance.mockReturnValue(
+      makeGovernanceMock({
+        votedDirections: {
+          'proposal-1': 'for',
+          'proposal-2': 'against'
+        }
+      })
+    );
+
+    render(<ProposalList />);
+
+    expect(screen.getByTestId('proposal-card-proposal-1')).toHaveAttribute('data-voted-direction', 'for');
+    expect(screen.getByTestId('proposal-card-proposal-2')).toHaveAttribute('data-voted-direction', 'against');
   });
 });

--- a/apps/web-pwa/src/components/ProposalList.tsx
+++ b/apps/web-pwa/src/components/ProposalList.tsx
@@ -1,8 +1,7 @@
-import React, { useEffect, useMemo } from 'react';
+import React, { useMemo } from 'react';
 import useGovernance, { MIN_TRUST_TO_VOTE } from '../hooks/useGovernance';
 import ProposalCard from './ProposalCard';
 import { useIdentity } from '../hooks/useIdentity';
-import { useXpLedger } from '../store/xpLedger';
 
 export const ProposalList: React.FC = () => {
   const { identity } = useIdentity();
@@ -14,10 +13,6 @@ export const ProposalList: React.FC = () => {
   }, [identity]);
   const canVote = voterId != null && trustScore != null && trustScore >= MIN_TRUST_TO_VOTE;
   const { proposals, loading, error, submitVote, lastAction, votedDirections } = useGovernance(voterId, trustScore);
-
-  useEffect(() => {
-    useXpLedger.getState().setActiveNullifier(voterId);
-  }, [voterId]);
 
   if (loading) return <p className="text-sm text-slate-500">Loading proposals...</p>;
   if (error) return <p className="text-sm text-red-600">{error}</p>;


### PR DESCRIPTION
## Summary
Closes #61 — Removes the redundant `useEffect` in `ProposalList.tsx` that eagerly called `setActiveNullifier(voterId)` on mount/change. This was dead code: `useGovernance.submitVote()` already sets the nullifier at point-of-use before every budget check, following the established pattern across all budget consumers.

### Changes

**`ProposalList.tsx` (−4 lines, 41 → 37 LOC):**
- Removed `useEffect` import
- Removed `useXpLedger` import  
- Removed useEffect block (lines 19-21)

**`ProposalList.test.tsx` (+188 lines, 1 → 11 tests):**
- PL-1: Loading state renders correctly
- PL-2: Error state renders correctly
- PL-3: Empty state renders correctly
- PL-4: Proposal cards render with titles
- PL-5: lastAction banner renders when set
- PL-6: lastAction banner hidden when null
- PL-7: canVote=false when voterId is null
- PL-8: canVote=false when trustScore < MIN_TRUST_TO_VOTE
- PL-9: canVote=true when trust sufficient
- PL-10: **setActiveNullifier NOT called on render** (regression guard)
- PL-11: votedDirection forwarded to ProposalCard

### Gates
- Impl: typecheck ✅, lint ✅, test:quick ✅, coverage 100% ✅
- QA fresh-checkout: all gates ✅, SHA confirmed
- Maint: 0 Must, 0 Should, 3 Nits (cosmetic)

Closes #61