### PR TITLE
feat: route analysis through ai-engine pipeline, align with v1 contract (#120)

### DIFF
--- a/packages/ai-engine/src/analysis.test.ts
+++ b/packages/ai-engine/src/analysis.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
-import { getOrGenerate, hashUrl, type AnalysisStore, type CanonicalAnalysis } from './analysis';
+import {
+  getOrGenerate,
+  hashUrl,
+  type AnalysisStore,
+  type CanonicalAnalysis,
+  type GenerateResult
+} from './analysis';
 
 class MemoryStore implements AnalysisStore {
   private items = new Map<string, CanonicalAnalysis>();
@@ -15,6 +21,21 @@ class MemoryStore implements AnalysisStore {
   async listRecent(): Promise<CanonicalAnalysis[]> {
     return Array.from(this.items.values());
   }
+}
+
+function buildGenerateResult(overrides: Partial<GenerateResult> = {}): GenerateResult {
+  return {
+    analysis: {
+      summary: 'generated',
+      biases: ['bias-1'],
+      counterpoints: ['counter-1'],
+      sentimentScore: 0.1,
+      bias_claim_quote: [],
+      justify_bias_claim: [],
+      confidence: 0.8
+    },
+    ...overrides
+  };
 }
 
 describe('analysis first-to-file', () => {
@@ -33,6 +54,7 @@ describe('analysis first-to-file', () => {
     const url = 'https://example.com/post';
     const urlHash = hashUrl(url);
     const existing: CanonicalAnalysis = {
+      schemaVersion: 'canonical-analysis-v1',
       url,
       urlHash,
       summary: 'cached',
@@ -45,33 +67,49 @@ describe('analysis first-to-file', () => {
       timestamp: Date.now() - 1000
     };
     await store.save(existing);
-    const generate = vi.fn();
+    const generate = vi.fn(async (_targetUrl: string): Promise<GenerateResult> => buildGenerateResult());
 
-    const { analysis, reused } = await getOrGenerate(url, store, generate as any);
+    const { analysis, reused } = await getOrGenerate(url, store, generate);
 
     expect(reused).toBe(true);
     expect(analysis).toEqual(existing);
     expect(generate).not.toHaveBeenCalled();
   });
 
-  it('saves new analysis when missing', async () => {
+  it('saves new analysis with v1 schema version', async () => {
     const store = new MemoryStore();
     const url = 'https://new.com/article';
-    const generate = vi.fn().mockResolvedValue({
-      summary: 'new',
-      biases: ['b'],
-      counterpoints: ['c'],
-      sentimentScore: 0.1,
-      bias_claim_quote: [],
-      justify_bias_claim: [],
-      confidence: 0.8
-    });
+    const generate = vi.fn().mockResolvedValue(buildGenerateResult());
 
     const { analysis, reused } = await getOrGenerate(url, store, generate);
 
     expect(reused).toBe(false);
     expect(analysis.url).toBe(url);
     expect(analysis.urlHash).toBe(hashUrl(url));
+    expect(analysis.schemaVersion).toBe('canonical-analysis-v1');
+    expect(analysis.engine).toBeUndefined();
+    expect(analysis.warnings).toBeUndefined();
     expect(await store.getByHash(hashUrl(url))).toEqual(analysis);
+  });
+
+  it('flows engine metadata and warnings into canonical record', async () => {
+    const store = new MemoryStore();
+    const url = 'https://meta.com/article';
+    const generate = vi.fn().mockResolvedValue(
+      buildGenerateResult({
+        engine: { id: 'mock-local-engine', kind: 'local', modelName: 'mock-local-v1' },
+        warnings: ['Summary mentions year 2099 not in source']
+      })
+    );
+
+    const { analysis, reused } = await getOrGenerate(url, store, generate);
+
+    expect(reused).toBe(false);
+    expect(analysis.engine).toEqual({
+      id: 'mock-local-engine',
+      kind: 'local',
+      modelName: 'mock-local-v1'
+    });
+    expect(analysis.warnings).toEqual(['Summary mentions year 2099 not in source']);
   });
 });

--- a/packages/ai-engine/src/engines.test.ts
+++ b/packages/ai-engine/src/engines.test.ts
@@ -1,57 +1,119 @@
 import { describe, expect, it, vi } from 'vitest';
-import { EngineRouter, type JsonCompletionEngine } from './engines';
+import {
+  createDefaultEngine,
+  EngineRouter,
+  EngineUnavailableError,
+  type JsonCompletionEngine
+} from './engines';
+
+function makeEngine(
+  name: string,
+  kind: 'local' | 'remote',
+  generate: JsonCompletionEngine['generate']
+): JsonCompletionEngine {
+  return { name, kind, generate };
+}
+
+describe('EngineUnavailableError', () => {
+  it('sets policy, name, and message', () => {
+    const error = new EngineUnavailableError('local-only');
+    expect(error).toBeInstanceOf(Error);
+    expect(error.name).toBe('EngineUnavailableError');
+    expect(error.policy).toBe('local-only');
+    expect(error.message).toBe('No engine available for policy: local-only');
+  });
+});
+
+describe('createDefaultEngine', () => {
+  it('returns a local mock engine that emits valid analysis JSON with sentimentScore', async () => {
+    const engine = createDefaultEngine();
+
+    expect(engine.kind).toBe('local');
+    expect(engine.name).toBe('mock-local-engine');
+
+    const output = await engine.generate('prompt');
+    const parsed = JSON.parse(output) as {
+      final_refined: { sentimentScore: number; summary: string };
+    };
+
+    expect(parsed.final_refined.summary).toBe('Mock summary');
+    expect(parsed.final_refined.sentimentScore).toBeTypeOf('number');
+  });
+});
 
 describe('EngineRouter', () => {
-  const mockLocal: JsonCompletionEngine = {
-    name: 'local-mock',
-    kind: 'local',
-    generate: vi.fn().mockResolvedValue('local-response')
-  };
-
-  const mockRemote: JsonCompletionEngine = {
-    name: 'remote-mock',
-    kind: 'remote',
-    generate: vi.fn().mockResolvedValue('remote-response')
-  };
-
   it('local-only uses local engine', async () => {
-    const router = new EngineRouter(mockLocal, mockRemote, 'local-only');
-    const result = await router.generate('prompt');
-    expect(result.engine).toBe('local-mock');
-    expect(result.text).toBe('local-response');
-  });
+    const local = makeEngine('local-mock', 'local', vi.fn().mockResolvedValue('local-response'));
+    const remote = makeEngine('remote-mock', 'remote', vi.fn().mockResolvedValue('remote-response'));
+    const router = new EngineRouter(local, remote, 'local-only');
 
-  it('local-only throws without local engine', async () => {
-    const router = new EngineRouter(undefined, mockRemote, 'local-only');
-    await expect(router.generate('prompt')).rejects.toThrow('Local engine required');
+    const result = await router.generate('prompt');
+
+    expect(result).toEqual({ engine: 'local-mock', text: 'local-response' });
+    expect(local.generate).toHaveBeenCalledTimes(1);
+    expect(remote.generate).not.toHaveBeenCalled();
   });
 
   it('remote-only uses remote engine', async () => {
-    const router = new EngineRouter(mockLocal, mockRemote, 'remote-only');
+    const local = makeEngine('local-mock', 'local', vi.fn().mockResolvedValue('local-response'));
+    const remote = makeEngine('remote-mock', 'remote', vi.fn().mockResolvedValue('remote-response'));
+    const router = new EngineRouter(local, remote, 'remote-only');
+
     const result = await router.generate('prompt');
-    expect(result.engine).toBe('remote-mock');
-    expect(result.text).toBe('remote-response');
+
+    expect(result).toEqual({ engine: 'remote-mock', text: 'remote-response' });
+    expect(remote.generate).toHaveBeenCalledTimes(1);
+    expect(local.generate).not.toHaveBeenCalled();
   });
 
-  it('remote-only throws without remote engine', async () => {
-    const router = new EngineRouter(mockLocal, undefined, 'remote-only');
-    await expect(router.generate('prompt')).rejects.toThrow('Remote engine required');
-  });
+  it('local-first falls back to remote when local engine is missing', async () => {
+    const remote = makeEngine('remote-mock', 'remote', vi.fn().mockResolvedValue('remote-response'));
+    const router = new EngineRouter(undefined, remote, 'local-first');
 
-  it('local-first prefers local when available', async () => {
-    const router = new EngineRouter(mockLocal, mockRemote, 'local-first');
     const result = await router.generate('prompt');
-    expect(result.engine).toBe('local-mock');
+
+    expect(result).toEqual({ engine: 'remote-mock', text: 'remote-response' });
+    expect(remote.generate).toHaveBeenCalledTimes(1);
   });
 
-  it('remote-first prefers remote when available', async () => {
-    const router = new EngineRouter(mockLocal, mockRemote, 'remote-first');
+  it('remote-first falls back to local when remote engine is missing', async () => {
+    const local = makeEngine('local-mock', 'local', vi.fn().mockResolvedValue('local-response'));
+    const router = new EngineRouter(local, undefined, 'remote-first');
+
     const result = await router.generate('prompt');
-    expect(result.engine).toBe('remote-mock');
+
+    expect(result).toEqual({ engine: 'local-mock', text: 'local-response' });
+    expect(local.generate).toHaveBeenCalledTimes(1);
   });
 
-  it('throws when no engine available for policy', async () => {
+  it('local-first falls back when preferred engine throws', async () => {
+    const local = makeEngine('local-mock', 'local', vi.fn().mockRejectedValue(new Error('local failed')));
+    const remote = makeEngine('remote-mock', 'remote', vi.fn().mockResolvedValue('remote-response'));
+    const router = new EngineRouter(local, remote, 'local-first');
+
+    const result = await router.generate('prompt');
+
+    expect(result).toEqual({ engine: 'remote-mock', text: 'remote-response' });
+    expect(local.generate).toHaveBeenCalledTimes(1);
+    expect(remote.generate).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws preferred error when both candidates fail', async () => {
+    const local = makeEngine('local-mock', 'local', vi.fn().mockRejectedValue(new Error('local failed')));
+    const remote = makeEngine('remote-mock', 'remote', vi.fn().mockRejectedValue(new Error('remote failed')));
+    const router = new EngineRouter(local, remote, 'local-first');
+
+    await expect(router.generate('prompt')).rejects.toThrow('remote failed');
+    expect(local.generate).toHaveBeenCalledTimes(1);
+    expect(remote.generate).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws EngineUnavailableError when no engine is available for policy', async () => {
     const router = new EngineRouter(undefined, undefined, 'shadow');
-    await expect(router.generate('prompt')).rejects.toThrow('No engine available');
+
+    await expect(router.generate('prompt')).rejects.toBeInstanceOf(EngineUnavailableError);
+    await expect(router.generate('prompt')).rejects.toMatchObject({
+      message: 'No engine available for policy: shadow'
+    });
   });
 });

--- a/packages/ai-engine/src/engines.ts
+++ b/packages/ai-engine/src/engines.ts
@@ -1,41 +1,91 @@
 export interface JsonCompletionEngine {
-    name: string;
-    kind: 'local' | 'remote';
-    generate(prompt: string): Promise<string>;
+  name: string;
+  kind: 'local' | 'remote';
+  modelName?: string;
+  generate(prompt: string): Promise<string>;
 }
 
 export type EnginePolicy =
-    | 'remote-first'
-    | 'local-first'
-    | 'remote-only'
-    | 'local-only'
-    | 'shadow';
+  | 'remote-first'
+  | 'local-first'
+  | 'remote-only'
+  | 'local-only'
+  | 'shadow';
+
+export class EngineUnavailableError extends Error {
+  constructor(public readonly policy: EnginePolicy) {
+    super(`No engine available for policy: ${policy}`);
+    this.name = 'EngineUnavailableError';
+  }
+}
+
+function hasEngine(engine?: JsonCompletionEngine): engine is JsonCompletionEngine {
+  return Boolean(engine);
+}
+
+function policyCandidates(
+  policy: EnginePolicy,
+  localEngine?: JsonCompletionEngine,
+  remoteEngine?: JsonCompletionEngine
+): JsonCompletionEngine[] {
+  switch (policy) {
+    case 'local-only':
+      return [localEngine].filter(hasEngine);
+    case 'remote-only':
+      return [remoteEngine].filter(hasEngine);
+    case 'local-first':
+      return [localEngine, remoteEngine].filter(hasEngine);
+    case 'remote-first':
+      return [remoteEngine, localEngine].filter(hasEngine);
+    case 'shadow':
+      return [localEngine, remoteEngine].filter(hasEngine);
+  }
+}
 
 export class EngineRouter {
-    constructor(
-        private localEngine?: JsonCompletionEngine,
-        private remoteEngine?: JsonCompletionEngine,
-        private policy: EnginePolicy = 'local-first'
-    ) { }
+  constructor(
+    private localEngine?: JsonCompletionEngine,
+    private remoteEngine?: JsonCompletionEngine,
+    private policy: EnginePolicy = 'local-first'
+  ) {}
 
-    async generate(prompt: string): Promise<{ text: string; engine: string }> {
-        // Simple implementation for now, can be expanded for full policy support
-        if (this.policy === 'local-only' || (this.policy === 'local-first' && this.localEngine)) {
-            if (!this.localEngine) throw new Error('Local engine required but not available');
-            return {
-                text: await this.localEngine.generate(prompt),
-                engine: this.localEngine.name
-            };
+  async generate(prompt: string): Promise<{ text: string; engine: string }> {
+    const candidates = policyCandidates(this.policy, this.localEngine, this.remoteEngine);
+
+    for (const [index, engine] of candidates.entries()) {
+      try {
+        return {
+          text: await engine.generate(prompt),
+          engine: engine.name
+        };
+      } catch (error) {
+        if (index === candidates.length - 1) {
+          throw error;
         }
-
-        if (this.policy === 'remote-only' || (this.policy === 'remote-first' && this.remoteEngine)) {
-            if (!this.remoteEngine) throw new Error('Remote engine required but not available');
-            return {
-                text: await this.remoteEngine.generate(prompt),
-                engine: this.remoteEngine.name
-            };
-        }
-
-        throw new Error(`No engine available for policy: ${this.policy}`);
+      }
     }
+
+    throw new EngineUnavailableError(this.policy);
+  }
+}
+
+export function createDefaultEngine(): JsonCompletionEngine {
+  return {
+    name: 'mock-local-engine',
+    modelName: 'mock-local-v1',
+    kind: 'local',
+    async generate() {
+      return JSON.stringify({
+        final_refined: {
+          summary: 'Mock summary',
+          bias_claim_quote: ['quote'],
+          justify_bias_claim: ['justification'],
+          biases: ['bias'],
+          counterpoints: ['counter'],
+          sentimentScore: 0.5,
+          confidence: 0.9
+        }
+      });
+    }
+  };
 }

--- a/packages/ai-engine/src/pipeline.test.ts
+++ b/packages/ai-engine/src/pipeline.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createAnalysisPipeline } from './pipeline';
+import { AnalysisParseError } from './schema';
+import type { JsonCompletionEngine } from './engines';
+
+function validWrappedResult(summary = 'Source summary') {
+  return JSON.stringify({
+    final_refined: {
+      summary,
+      bias_claim_quote: ['quote'],
+      justify_bias_claim: ['justification'],
+      biases: ['bias'],
+      counterpoints: ['counterpoint'],
+      sentimentScore: 0.5,
+      confidence: 0.9
+    }
+  });
+}
+
+describe('createAnalysisPipeline', () => {
+  it('runs prompt -> engine -> parse -> validation success path', async () => {
+    const articleText = 'A source article body about 2024 elections.';
+    const engine: JsonCompletionEngine = {
+      name: 'local-engine',
+      kind: 'local',
+      modelName: 'local-model-v1',
+      generate: vi.fn().mockResolvedValue(validWrappedResult('A source article body about 2024 elections.'))
+    };
+
+    const pipeline = createAnalysisPipeline(engine);
+    const result = await pipeline(articleText);
+
+    expect(engine.generate).toHaveBeenCalledTimes(1);
+    expect(engine.generate).toHaveBeenCalledWith(expect.stringContaining(articleText));
+    expect(result.analysis.sentimentScore).toBe(0.5);
+    expect(result.engine).toEqual({
+      id: 'local-engine',
+      kind: 'local',
+      modelName: 'local-model-v1'
+    });
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('throws parse error on malformed JSON', async () => {
+    const engine: JsonCompletionEngine = {
+      name: 'bad-json-engine',
+      kind: 'local',
+      generate: vi.fn().mockResolvedValue('{"final_refined": }')
+    };
+
+    const pipeline = createAnalysisPipeline(engine);
+
+    await expect(pipeline('article text')).rejects.toThrow(AnalysisParseError.JSON_PARSE_ERROR);
+  });
+
+  it('throws schema validation error for missing required fields', async () => {
+    const engine: JsonCompletionEngine = {
+      name: 'schema-invalid-engine',
+      kind: 'local',
+      generate: vi.fn().mockResolvedValue(
+        JSON.stringify({
+          final_refined: {
+            summary: 'Missing sentiment score',
+            bias_claim_quote: ['quote'],
+            justify_bias_claim: ['justification'],
+            biases: ['bias'],
+            counterpoints: ['counterpoint']
+          }
+        })
+      )
+    };
+
+    const pipeline = createAnalysisPipeline(engine);
+
+    await expect(pipeline('article text')).rejects.toThrow(AnalysisParseError.SCHEMA_VALIDATION_ERROR);
+  });
+
+  it('propagates engine failures', async () => {
+    const engine: JsonCompletionEngine = {
+      name: 'failing-engine',
+      kind: 'local',
+      generate: vi.fn().mockRejectedValue(new Error('engine unavailable'))
+    };
+
+    const pipeline = createAnalysisPipeline(engine);
+
+    await expect(pipeline('article text')).rejects.toThrow('engine unavailable');
+  });
+
+  it('returns validation warnings for hallucinated years', async () => {
+    const engine: JsonCompletionEngine = {
+      name: 'warning-engine',
+      kind: 'local',
+      generate: vi.fn().mockResolvedValue(validWrappedResult('In 2099 this happened.'))
+    };
+
+    const pipeline = createAnalysisPipeline(engine);
+    const result = await pipeline('Source does not mention the future.');
+
+    expect(result.warnings).toEqual([
+      expect.stringContaining('2099')
+    ]);
+  });
+
+  it('includes engine metadata and defaults modelName to engine name', async () => {
+    const engine: JsonCompletionEngine = {
+      name: 'remote-engine',
+      kind: 'remote',
+      generate: vi.fn().mockResolvedValue(validWrappedResult())
+    };
+
+    const pipeline = createAnalysisPipeline(engine);
+    const result = await pipeline('remote article text');
+
+    expect(result.engine).toEqual({
+      id: 'remote-engine',
+      kind: 'remote',
+      modelName: 'remote-engine'
+    });
+  });
+
+  it('uses default local engine when no engine is provided', async () => {
+    const pipeline = createAnalysisPipeline();
+    const result = await pipeline('default engine article text');
+
+    expect(result.engine).toEqual({
+      id: 'mock-local-engine',
+      kind: 'local',
+      modelName: 'mock-local-v1'
+    });
+    expect(result.analysis.sentimentScore).toBeTypeOf('number');
+  });
+});

--- a/packages/ai-engine/src/pipeline.ts
+++ b/packages/ai-engine/src/pipeline.ts
@@ -1,0 +1,49 @@
+import { buildPrompt } from './prompts';
+import { parseAnalysisResponse, type AnalysisResult } from './schema';
+import { validateAnalysisAgainstSource } from './validation';
+import { createDefaultEngine, EngineRouter, type JsonCompletionEngine } from './engines';
+
+export interface PipelineResult {
+  analysis: AnalysisResult;
+  engine: {
+    id: string;
+    kind: 'remote' | 'local';
+    modelName: string;
+  };
+  warnings: string[];
+}
+
+function createRouter(engine: JsonCompletionEngine) {
+  if (engine.kind === 'remote') {
+    return new EngineRouter(undefined, engine, 'remote-only');
+  }
+  return new EngineRouter(engine, undefined, 'local-only');
+}
+
+function toEngineMetadata(engine: JsonCompletionEngine): PipelineResult['engine'] {
+  return {
+    id: engine.name,
+    kind: engine.kind,
+    modelName: engine.modelName ?? engine.name
+  };
+}
+
+export function createAnalysisPipeline(
+  engine?: JsonCompletionEngine
+): (articleText: string) => Promise<PipelineResult> {
+  const activeEngine = engine ?? createDefaultEngine();
+  const router = createRouter(activeEngine);
+
+  return async (articleText: string): Promise<PipelineResult> => {
+    const prompt = buildPrompt(articleText);
+    const { text } = await router.generate(prompt);
+    const analysis = parseAnalysisResponse(text);
+    const warnings = validateAnalysisAgainstSource(articleText, analysis).map((warning) => warning.message);
+
+    return {
+      analysis,
+      engine: toEngineMetadata(activeEngine),
+      warnings
+    };
+  };
+}

--- a/packages/ai-engine/src/worker.ts
+++ b/packages/ai-engine/src/worker.ts
@@ -1,58 +1,28 @@
-import { EngineRouter } from './engines';
-import { parseAnalysisResponse } from './schema';
-import { validateAnalysisAgainstSource } from './validation';
-import { buildPrompt } from './prompts';
+import { createDefaultEngine } from './engines';
+import { createAnalysisPipeline } from './pipeline';
 
-// Mock engine for now, will be replaced by real implementation
-const mockEngine = {
-  name: 'mock-engine',
-  kind: 'local' as const,
-  generate: async () => JSON.stringify({
-    final_refined: {
-      summary: 'Mock summary',
-      bias_claim_quote: ['quote'],
-      justify_bias_claim: ['justification'],
-      biases: ['bias'],
-      counterpoints: ['counter'],
-      sentimentScore: 0.5,
-      confidence: 0.9
-    }
-  })
-};
-
-const router = new EngineRouter(mockEngine, undefined, 'local-only');
+const runPipeline = createAnalysisPipeline(createDefaultEngine());
 
 export type WorkerMessage =
-  | { type: "ANALYZE"; payload: { articleText: string; urlHash: string } };
+  | { type: 'ANALYZE'; payload: { articleText: string; urlHash: string } };
 
 export type WorkerResponse =
-  | { type: "SUCCESS"; payload: { analysis: any; engine: string; warnings: any[] } }
-  | { type: "ERROR"; payload: { message: string } };
+  | { type: 'SUCCESS'; payload: { analysis: any; engine: string; warnings: any[] } }
+  | { type: 'ERROR'; payload: { message: string } };
 
 self.onmessage = async (e: MessageEvent) => {
   const { id, type, payload } = e.data;
 
   if (type === 'ANALYZE') {
     try {
-      const { articleText } = payload;
-      const prompt = buildPrompt(articleText);
-
-      // 1. Generate
-      const { text, engine } = await router.generate(prompt);
-
-      // 2. Parse
-      const analysis = parseAnalysisResponse(text);
-
-      // 3. Validate
-      const warnings = validateAnalysisAgainstSource(articleText, analysis as any);
-
+      const result = await runPipeline(payload.articleText);
       self.postMessage({
         id,
         type: 'SUCCESS',
         payload: {
-          analysis,
-          engine,
-          warnings
+          analysis: result.analysis,
+          engine: result.engine.id,
+          warnings: result.warnings
         }
       });
     } catch (err) {

--- a/specs/120-venn-demock.md
+++ b/specs/120-venn-demock.md
@@ -1,0 +1,191 @@
+# Spec: Issue #120 — VENN De-Mock (Contract-True)
+
+**Issue:** https://github.com/HumblePiCCI/VHC/issues/120
+**Baseline SHA:** `c423429`
+**Author:** Chief (spec phase)
+**Date:** 2026-02-08
+
+## 1. Acceptance Criteria
+
+1. `AnalysisFeed.tsx` no longer contains inline `setTimeout`/mock generation for analysis content.
+2. Analysis generation in `AnalysisFeed` calls through `packages/ai-engine` pipeline: `buildPrompt → EngineRouter.generate → parseAnalysisResponse → validateAnalysisAgainstSource`.
+3. `CanonicalAnalysis` type in `analysis.ts` includes `schemaVersion: 'canonical-analysis-v1'`, optional `engine?: { id: string; kind: 'remote' | 'local'; modelName: string }`, optional `warnings?: string[]`.
+4. `getOrGenerate` constructs records with `schemaVersion: 'canonical-analysis-v1'` and optional `engine`/`warnings` fields.
+5. Persisted canonical records validate against `data-model/schemas.ts:CanonicalAnalysisSchema`.
+6. Default engine policy remains `local-only`.
+7. If engine is unavailable or throws, error propagates before `consumeAction` — no budget consumption on failure.
+8. All existing budget, TOCTOU, and share behavior is preserved exactly.
+9. No identity/nullifier/constituency data appears in `CanonicalAnalysis` records.
+10. 100% line + branch coverage on all touched files.
+
+## 2. Edge Cases & Abuse Cases
+
+| # | Case | Expected Behavior |
+|---|------|-------------------|
+| E1 | Engine throws (unavailable/crash) | Error propagates to `getOrGenerate` caller; `consumeAction` never called; user sees error message |
+| E2 | Engine returns malformed JSON | `parseAnalysisResponse` throws `AnalysisParseError`; no budget consumption |
+| E3 | Engine returns valid JSON but schema-invalid | `parseAnalysisResponse` throws `SCHEMA_VALIDATION_ERROR`; no budget consumption |
+| E4 | Concurrent double-submit (TOCTOU) | `isRunningRef` guard prevents second invocation (existing behavior, preserved) |
+| E5 | Budget denied before engine call | Short-circuit returns `createBudgetDeniedResult` (existing behavior, preserved) |
+| E6 | Engine returns warnings from validation | Warnings attached to `CanonicalAnalysis.warnings`; record still persisted |
+| E7 | Reused analysis from cache/mesh | No engine call, no budget consumption, existing canonical record returned as-is |
+| E8 | No nullifier present | Analysis generated without budget check (existing behavior, preserved) |
+| E9 | Analysis result has `sentimentScore` missing from `AnalysisResult` (prompts.ts type) | `parseAnalysisResponse` enforces `sentimentScore` via `AnalysisResultSchema` — schema validation error |
+| E10 | Share concurrent double-click | `isSharingRef` guard prevents (existing behavior, preserved) |
+
+## 3. Touched-File Plan
+
+### Modified Files
+
+| File | Changes | Current LOC | Est. New LOC |
+|------|---------|-------------|--------------|
+| `packages/ai-engine/src/analysis.ts` | Add `schemaVersion`, `engine?`, `warnings?` to `CanonicalAnalysis`. Add `GenerateResult` type for enriched generator return. Update `getOrGenerate` signature + body. | 49 | ~70 |
+| `packages/ai-engine/src/worker.ts` | Remove hardcoded `mockEngine`. Accept engine via factory/injection. Export `createAnalysisPipeline` for direct (non-worker) use. | 66 | ~75 |
+| `packages/ai-engine/src/engines.ts` | Add `EngineUnavailableError` typed error. Improve fallback logic for `local-first`/`remote-first`. Add `createDefaultEngine` factory exporting the mock engine. | 41 | ~65 |
+| `apps/web-pwa/src/routes/AnalysisFeed.tsx` | Replace inline mock `generate` function with pipeline call via imported `createAnalysisPipeline`. | 331 | ~320 |
+| `packages/ai-engine/src/analysis.test.ts` | Update tests for new `CanonicalAnalysis` shape, `GenerateResult`, engine/warnings. | 77 | ~130 |
+| `packages/ai-engine/src/worker.test.ts` | Update for pipeline extraction, remove mock-engine hardcoding from test setup. | 119 | ~140 |
+| `packages/ai-engine/src/engines.test.ts` | Add tests for `EngineUnavailableError`, `createDefaultEngine`, improved fallback. | 57 | ~90 |
+| `apps/web-pwa/src/routes/AnalysisFeed.test.tsx` | Update mock generator to match pipeline return type. Add tests for engine failure → no budget consumption. | 1081 | ~1120 |
+
+### New Files
+
+| File | Purpose | Est. LOC |
+|------|---------|----------|
+| `packages/ai-engine/src/pipeline.ts` | Extract `createAnalysisPipeline(engine?)` — reusable pipeline function: prompt → engine → parse → validate → attach metadata. Used by both worker.ts and direct import. | ~60 |
+| `packages/ai-engine/src/pipeline.test.ts` | Tests for pipeline: success, parse error, validation warnings, engine failure. | ~100 |
+
+### Unchanged Files (verify no regression)
+
+- `packages/ai-engine/src/schema.ts` — no changes needed
+- `packages/ai-engine/src/validation.ts` — no changes needed
+- `packages/ai-engine/src/prompts.ts` — no changes needed
+- `packages/data-model/src/schemas.ts` — no changes needed (already has correct `CanonicalAnalysisSchema`)
+
+## 4. Type Changes
+
+### `packages/ai-engine/src/analysis.ts`
+
+```typescript
+// BEFORE
+export interface CanonicalAnalysis extends AnalysisResult {
+  url: string;
+  urlHash: string;
+  timestamp: number;
+}
+
+// AFTER
+export interface CanonicalAnalysis extends AnalysisResult {
+  schemaVersion: 'canonical-analysis-v1';
+  url: string;
+  urlHash: string;
+  timestamp: number;
+  engine?: {
+    id: string;
+    kind: 'remote' | 'local';
+    modelName: string;
+  };
+  warnings?: string[];
+}
+```
+
+### `packages/ai-engine/src/pipeline.ts` (new)
+
+```typescript
+export interface PipelineResult {
+  analysis: AnalysisResult;
+  engine: { id: string; kind: 'remote' | 'local'; modelName: string };
+  warnings: string[];
+}
+
+export function createAnalysisPipeline(
+  engine?: JsonCompletionEngine
+): (articleText: string) => Promise<PipelineResult>;
+```
+
+### `packages/ai-engine/src/engines.ts`
+
+```typescript
+// NEW
+export class EngineUnavailableError extends Error {
+  constructor(policy: EnginePolicy) {
+    super(`No engine available for policy: ${policy}`);
+    this.name = 'EngineUnavailableError';
+  }
+}
+
+export function createDefaultEngine(): JsonCompletionEngine;
+```
+
+### `packages/ai-engine/src/analysis.ts` (getOrGenerate update)
+
+```typescript
+// BEFORE
+export async function getOrGenerate(
+  url: string,
+  store: AnalysisStore,
+  generate: (url: string) => Promise<AnalysisResult>
+): Promise<{ analysis: CanonicalAnalysis; reused: boolean }>
+
+// AFTER — accepts enriched generator
+export interface GenerateResult {
+  analysis: AnalysisResult;
+  engine?: { id: string; kind: 'remote' | 'local'; modelName: string };
+  warnings?: string[];
+}
+
+export async function getOrGenerate(
+  url: string,
+  store: AnalysisStore,
+  generate: (url: string) => Promise<GenerateResult>
+): Promise<{ analysis: CanonicalAnalysis; reused: boolean }>
+```
+
+## 5. Test Plan
+
+### New Tests
+
+| Test File | Tests | Coverage Target |
+|-----------|-------|-----------------|
+| `pipeline.test.ts` | 1) Pipeline success: prompt built, engine called, parse succeeds, warnings attached | 100% |
+| | 2) Pipeline parse error: engine returns malformed JSON → AnalysisParseError thrown |
+| | 3) Pipeline schema validation error: engine returns JSON missing required fields |
+| | 4) Pipeline engine failure: engine.generate throws → EngineUnavailableError or original error propagates |
+| | 5) Pipeline validation warnings: engine returns valid analysis with hallucinated year → warnings populated |
+| | 6) Pipeline engine metadata: returned PipelineResult includes engine name/kind |
+
+### Updated Tests
+
+| Test File | Updates |
+|-----------|---------|
+| `analysis.test.ts` | Update `CanonicalAnalysis` fixtures to include `schemaVersion`. Update `getOrGenerate` tests: generator now returns `GenerateResult`. Add test: engine metadata flows through to canonical record. Add test: warnings flow through. |
+| `engines.test.ts` | Add test: `EngineUnavailableError` is thrown with correct message. Add test: `createDefaultEngine` returns functional engine. |
+| `worker.test.ts` | Update to use pipeline import instead of hardcoded mock. Verify worker still posts SUCCESS/ERROR correctly. |
+| `AnalysisFeed.test.tsx` | Update mock generator to return `GenerateResult` shape. Add test: engine failure → no `consumeAction` call. Add test: parse failure → no `consumeAction` call. Verify existing budget/TOCTOU/share tests still pass. |
+
+### Coverage Gate
+
+- `pnpm test:coverage` must report 100% line + branch for:
+  - `packages/ai-engine/src/analysis.ts`
+  - `packages/ai-engine/src/pipeline.ts`
+  - `packages/ai-engine/src/engines.ts`
+  - `packages/ai-engine/src/worker.ts`
+  - `apps/web-pwa/src/routes/AnalysisFeed.tsx`
+
+## 6. Open Questions
+
+| # | Question | Resolution |
+|---|----------|------------|
+| Q1 | Should `sentimentScore` be added to `AnalysisResult` in `prompts.ts`? Currently the type there omits it, but `schema.ts:AnalysisResultSchema` requires it. | **Resolution:** Leave `prompts.ts` type as-is (it represents the prompt's expected shape). The `schema.ts` `AnalysisResult` (Zod-inferred) is the runtime authority. The mock engine in `engines.ts` must include `sentimentScore`. |
+| Q2 | Should `CanonicalAnalysis` in `analysis.ts` stay as `extends AnalysisResult` from `prompts.ts`, or switch to extending the Zod-inferred type from `schema.ts`? | **Resolution:** Switch to importing `AnalysisResult` from `schema.ts` instead of `prompts.ts`. This ensures `sentimentScore` is included and the type matches what `parseAnalysisResponse` returns. |
+| Q3 | Should the mock engine be moved out of `worker.ts` into `engines.ts`? | **Resolution:** Yes — export `createDefaultEngine()` from `engines.ts`. Both `worker.ts` and `pipeline.ts` use it as the fallback local engine. |
+
+## 7. Risk Notes
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Existing AnalysisFeed tests mock the `generate` function directly — changing its return type will require test updates | Medium | Careful, file-by-file test updates; run coverage after each change |
+| `CanonicalAnalysis` shape change may break existing persisted data in localStorage | Low | Old records lacking `schemaVersion` will fail `CanonicalAnalysisSchema.parse()` but `AnalysisFeed` reads them via `loadFeed()` which doesn't validate. Add read-time migration or graceful fallback. |
+| Worker uses `self.onmessage` which is Web Worker API — pipeline extraction must not break worker context | Medium | Keep worker.ts as a thin wrapper around the extracted pipeline. Pipeline function has no `self` dependency. |
+| `AnalysisResult` type divergence between `prompts.ts` and `schema.ts` | Low | Resolved by Q2: switch analysis.ts to use schema.ts type |
+| LOC budget for AnalysisFeed.tsx (currently 331, cap 350) | Medium | Pipeline extraction removes ~15 lines of mock code; net should stay under 350 |

--- a/specs/issue-098-consume-on-null-analysis.md
+++ b/specs/issue-098-consume-on-null-analysis.md
@@ -1,0 +1,79 @@
+# Spec: Issue #98 — consumeAction called on null analysis result
+
+**Status:** APPROVED  
+**Baseline:** `a73d05a` (main)  
+**Author:** Chief (inline spec — scope too narrow for full spec ritual)
+
+## Problem
+
+In `AnalysisFeed.tsx` line ~162, the `.then()` handler after `getOrGenerate()` calls:
+
+```typescript
+if (!result.reused && nullifier) {
+  useXpLedger.getState().consumeAction('analyses/day', 1, topicId);
+}
+```
+
+This does NOT check whether `result.analysis` is non-null. After PR #96 (Issue #69), `getOrGenerate` can return `{ analysis: null, reused: false }` when generation is denied/fails. The current code incorrectly consumes a budget unit for a null analysis.
+
+Additionally, the existing test at line ~267 **asserts this buggy behavior**: it expects `mockConsumeAction` to have been called when analysis is null. This test must be corrected.
+
+## Fix
+
+**Single-line code change:**
+```typescript
+// Before:
+if (!result.reused && nullifier) {
+// After:
+if (!result.reused && nullifier && result.analysis) {
+```
+
+**Test correction:**
+Change the existing null-analysis test assertion from:
+```typescript
+expect(mockConsumeAction).toHaveBeenCalledWith('analyses/day', 1, hashUrl(targetUrl));
+```
+to:
+```typescript
+expect(mockConsumeAction).not.toHaveBeenCalled();
+```
+
+## Acceptance Criteria
+
+1. **AC-1:** Fresh valid analysis generation with identity → `consumeAction` called exactly once
+2. **AC-2:** Reused/cached analysis → `consumeAction` NOT called (regression guard)
+3. **AC-3:** Null/invalid analysis result → `consumeAction` NOT called (core #98 fix)
+4. **AC-4:** Budget-denied path → `consumeAction` NOT called (regression guard)
+5. **AC-5:** Generation error/rejection → `consumeAction` NOT called (regression guard)
+6. **AC-6:** All gates green: typecheck, lint, test:quick, test:coverage
+7. **AC-7:** Coverage remains 100% lines/branches/functions/statements
+
+## Edge Cases
+
+- `result.analysis` is `undefined` vs `null` → truthiness check covers both
+- `result.analysis` is empty object `{}` → truthy, would consume (correct — object exists)
+- Double-submit race → out of scope (#68 TOCTOU)
+
+## Touched Files
+
+| File | Change |
+|------|--------|
+| `apps/web-pwa/src/routes/AnalysisFeed.tsx` | Add `&& result.analysis` to consume guard (~1 line) |
+| `apps/web-pwa/src/routes/AnalysisFeed.test.tsx` | Fix null-analysis test assertion; add explicit consume-guard tests |
+
+## Test Plan
+
+All in `apps/web-pwa/src/routes/AnalysisFeed.test.tsx`:
+
+1. **Existing T1** (allowed path): verify `consumeAction` called once — already passes, keep as regression
+2. **Existing T3** (denied path): verify `consumeAction` NOT called — already passes, keep as regression
+3. **Existing T4** (reused path): verify `consumeAction` NOT called — already passes, keep as regression
+4. **Fix existing null-analysis test** (~line 267): change assertion to `not.toHaveBeenCalled()`
+5. **Existing T9** (generation error): verify `consumeAction` NOT called — already passes, keep as regression
+
+## Out of Scope
+
+- #68 TOCTOU budget hardening
+- #47 CSP hardening  
+- #61 ProposalList cleanup
+- Broader denial UX redesign


### PR DESCRIPTION
## Summary

Removes the inline `setTimeout` mock generator from `AnalysisFeed.tsx` and routes analysis generation through the canonical `packages/ai-engine` pipeline. Aligns `CanonicalAnalysis` type with the v1 contract spec.

## Changes

### New files
- `packages/ai-engine/src/pipeline.ts` — Main-thread-safe pipeline: `createAnalysisPipeline(engine?) → (articleText) → PipelineResult`
- `packages/ai-engine/src/pipeline.test.ts` — 7 tests covering success, parse errors, schema validation, engine failure, warnings, metadata

### Modified files
- **`packages/ai-engine/src/engines.ts`** — Added `EngineUnavailableError`, `createDefaultEngine()` factory, improved EngineRouter fallback logic for all policy modes
- **`packages/ai-engine/src/analysis.ts`** — `CanonicalAnalysis` now includes `schemaVersion: 'canonical-analysis-v1'`, `engine?`, `warnings?`. New `GenerateResult` type. `getOrGenerate` accepts enriched generator.
- **`packages/ai-engine/src/worker.ts`** — Thin wrapper around `createAnalysisPipeline`; removed hardcoded mock
- **`apps/web-pwa/src/routes/AnalysisFeed.tsx`** — Replaced inline mock with pipeline call. All budget/TOCTOU guards preserved.
- Test files updated: `engines.test.ts`, `analysis.test.ts`, `worker.test.ts`, `AnalysisFeed.test.tsx`

## Gates

| Gate | Result |
|------|--------|
| `pnpm typecheck` | ✅ Pass |
| `pnpm lint` | ✅ Pass |
| `pnpm test:quick` | ✅ 761 tests (751→761, +10 new) |
| `pnpm test:coverage` | ✅ 100% Statements/Branches/Functions/Lines |

## LOC Check

| File | LOC |
|------|-----|
| pipeline.ts | 49 |
| engines.ts | 103 |
| analysis.ts | 69 |
| worker.ts | 36 |
| AnalysisFeed.tsx | 330 |

All under 350 LOC cap.

## Risk Notes

- Mock engine stays at engine layer (`createDefaultEngine()`) — this is intentional. Real engine wiring (WebLLM/remote) is a separate slice.
- Old persisted analyses in localStorage lack `schemaVersion`; `loadFeed()` does not validate, so they render fine. New analyses get the full contract shape.
- No identity/nullifier data in CanonicalAnalysis records.

## Preserves

- Budget checks + consume-after-generate (#68, #98, #106, #115)
- TOCTOU guards (`isRunningRef`, `isSharingRef`)
- Shares/day flow with navigator.share/clipboard fallback
- Mesh persistence via gunStore

Closes #120