### PR TITLE
fix: align CanonicalAnalysisSchema with v1 contract (add engine?, warnings?)

### DIFF
--- a/packages/data-model/src/schemas.test.ts
+++ b/packages/data-model/src/schemas.test.ts
@@ -102,6 +102,46 @@ describe('data-model schemas', () => {
       timestamp: 123
     });
     expect(valid.urlHash).toBe('abc');
+    expect(valid.engine).toBeUndefined();
+    expect(valid.warnings).toBeUndefined();
+  });
+
+  it('accepts optional engine and warnings in canonical analysis', () => {
+    const withEngine = CanonicalAnalysisSchema.parse({
+      schemaVersion: 'canonical-analysis-v1',
+      url: 'https://example.com',
+      urlHash: 'abc',
+      summary: 'test',
+      bias_claim_quote: ['quote'],
+      justify_bias_claim: ['justification'],
+      biases: ['bias'],
+      counterpoints: ['counter'],
+      sentimentScore: 0.5,
+      timestamp: 123,
+      engine: { id: 'mock-local-engine', kind: 'local', modelName: 'mock-local-v1' },
+      warnings: ['hallucinated year 2099']
+    });
+    expect(withEngine.engine?.id).toBe('mock-local-engine');
+    expect(withEngine.engine?.kind).toBe('local');
+    expect(withEngine.warnings).toEqual(['hallucinated year 2099']);
+  });
+
+  it('rejects invalid engine kind in canonical analysis', () => {
+    expect(() =>
+      CanonicalAnalysisSchema.parse({
+        schemaVersion: 'canonical-analysis-v1',
+        url: 'https://example.com',
+        urlHash: 'abc',
+        summary: 'test',
+        bias_claim_quote: ['q'],
+        justify_bias_claim: ['j'],
+        biases: ['b'],
+        counterpoints: ['c'],
+        sentimentScore: 0,
+        timestamp: 0,
+        engine: { id: 'e', kind: 'invalid', modelName: 'm' }
+      })
+    ).toThrow();
 
     expect(() =>
       CanonicalAnalysisSchema.parse({

--- a/packages/data-model/src/schemas.ts
+++ b/packages/data-model/src/schemas.ts
@@ -56,6 +56,12 @@ export const CanonicalAnalysisSchema = z.object({
   ).optional(),
   sentimentScore: z.number().min(-1).max(1),
   confidence: z.number().min(0).max(1).optional(),
+  engine: z.object({
+    id: z.string(),
+    kind: z.union([z.literal('remote'), z.literal('local')]),
+    modelName: z.string()
+  }).optional(),
+  warnings: z.array(z.string()).optional(),
   timestamp: z.number().int().nonnegative()
 });
 


### PR DESCRIPTION
## Summary

Adds optional `engine` and `warnings` fields to `data-model/schemas.ts:CanonicalAnalysisSchema` to align with `canonical-analysis-v1.md` spec and `ai-engine/analysis.ts:CanonicalAnalysis` type.

## Motivation

Maint review of PR #121 identified a Must finding: the `CanonicalAnalysis` type in `ai-engine` now includes `engine?` and `warnings?`, but the Zod schema in `data-model` didn't. Records with engine/warnings metadata would lose those fields if validated through `CanonicalAnalysisSchema.parse()`.

## Changes

- `packages/data-model/src/schemas.ts`: Add `engine` (optional object: id, kind, modelName) and `warnings` (optional string array) to `CanonicalAnalysisSchema`
- `packages/data-model/src/schemas.test.ts`: 2 new tests — acceptance of engine/warnings, rejection of invalid engine kind

## Gates

| Gate | Result |
|------|--------|
| typecheck | ✅ |
| lint | ✅ |
| test:quick | ✅ 763 tests |
| test:coverage | ✅ 100% |

2 files changed, +46 lines. Scope-limited follow-up fix.