### PR TITLE
fix: close #120 contract gap — tighten WorkerResponse types + align CanonicalAnalysisSchema (#124)

### DIFF
--- a/packages/ai-engine/src/worker.test.ts
+++ b/packages/ai-engine/src/worker.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { WorkerResponse } from './worker';
 
 const posts: any[] = [];
 (globalThis as any).self = globalThis;
@@ -91,6 +92,27 @@ describe('worker', () => {
         warnings: []
       }
     });
+  });
+
+  it('WorkerResponse success payload is strongly typed (no any)', () => {
+    // Type-level assertion: if WorkerResponse used `any`, this would not catch mismatches
+    const success: Extract<WorkerResponse, { type: 'SUCCESS' }> = {
+      type: 'SUCCESS',
+      payload: {
+        analysis: {
+          summary: 's',
+          bias_claim_quote: [],
+          justify_bias_claim: [],
+          biases: [],
+          counterpoints: [],
+          sentimentScore: 0
+        },
+        engine: 'test-engine',
+        warnings: ['w1']
+      }
+    };
+    expect(success.payload.analysis.summary).toBe('s');
+    expect(success.payload.warnings).toEqual(['w1']);
   });
 
   it('handles ANALYZE failures from pipeline', async () => {

--- a/packages/ai-engine/src/worker.ts
+++ b/packages/ai-engine/src/worker.ts
@@ -1,5 +1,6 @@
 import { createDefaultEngine } from './engines';
 import { createAnalysisPipeline } from './pipeline';
+import type { AnalysisResult } from './schema';
 
 const runPipeline = createAnalysisPipeline(createDefaultEngine());
 
@@ -7,7 +8,7 @@ export type WorkerMessage =
   | { type: 'ANALYZE'; payload: { articleText: string; urlHash: string } };
 
 export type WorkerResponse =
-  | { type: 'SUCCESS'; payload: { analysis: any; engine: string; warnings: any[] } }
+  | { type: 'SUCCESS'; payload: { analysis: AnalysisResult; engine: string; warnings: string[] } }
   | { type: 'ERROR'; payload: { message: string } };
 
 self.onmessage = async (e: MessageEvent) => {

--- a/packages/data-model/src/schemas.test.ts
+++ b/packages/data-model/src/schemas.test.ts
@@ -102,6 +102,47 @@ describe('data-model schemas', () => {
       timestamp: 123
     });
     expect(valid.urlHash).toBe('abc');
+    expect(valid.engine).toBeUndefined();
+    expect(valid.warnings).toBeUndefined();
+  });
+
+  it('accepts optional engine and warnings in canonical analysis', () => {
+    const withMeta = CanonicalAnalysisSchema.parse({
+      schemaVersion: 'canonical-analysis-v1',
+      url: 'https://example.com',
+      urlHash: 'abc',
+      summary: 'test',
+      bias_claim_quote: ['quote'],
+      justify_bias_claim: ['justification'],
+      biases: ['bias'],
+      counterpoints: ['counter'],
+      sentimentScore: 0.5,
+      timestamp: 123,
+      engine: { id: 'mock-local-engine', kind: 'local', modelName: 'mock-local-v1' },
+      warnings: ['hallucinated year 2099']
+    });
+    expect(withMeta.engine?.id).toBe('mock-local-engine');
+    expect(withMeta.engine?.kind).toBe('local');
+    expect(withMeta.engine?.modelName).toBe('mock-local-v1');
+    expect(withMeta.warnings).toEqual(['hallucinated year 2099']);
+  });
+
+  it('rejects invalid engine kind in canonical analysis', () => {
+    expect(() =>
+      CanonicalAnalysisSchema.parse({
+        schemaVersion: 'canonical-analysis-v1',
+        url: 'https://example.com',
+        urlHash: 'abc',
+        summary: 'test',
+        bias_claim_quote: ['q'],
+        justify_bias_claim: ['j'],
+        biases: ['b'],
+        counterpoints: ['c'],
+        sentimentScore: 0,
+        timestamp: 0,
+        engine: { id: 'e', kind: 'invalid', modelName: 'm' }
+      })
+    ).toThrow();
 
     expect(() =>
       CanonicalAnalysisSchema.parse({

--- a/packages/data-model/src/schemas.ts
+++ b/packages/data-model/src/schemas.ts
@@ -56,6 +56,12 @@ export const CanonicalAnalysisSchema = z.object({
   ).optional(),
   sentimentScore: z.number().min(-1).max(1),
   confidence: z.number().min(0).max(1).optional(),
+  engine: z.object({
+    id: z.string(),
+    kind: z.union([z.literal('remote'), z.literal('local')]),
+    modelName: z.string()
+  }).optional(),
+  warnings: z.array(z.string()).optional(),
   timestamp: z.number().int().nonnegative()
 });
 


### PR DESCRIPTION
## Summary

Surgical closure of two contract gaps remaining from #120 merge.

## Changes

### `packages/ai-engine/src/worker.ts`
- `WorkerResponse` success payload: `analysis: any` → `AnalysisResult`, `warnings: any[]` → `string[]`

### `packages/data-model/src/schemas.ts`
- `CanonicalAnalysisSchema`: added optional `engine` (`{ id, kind, modelName }`) and `warnings` (`string[]`) fields to match v1 contract and `ai-engine/analysis.ts:CanonicalAnalysis`

### Tests
- Schema accepts records with engine/warnings (+1 test)
- Schema rejects invalid engine kind (+1 test)
- WorkerResponse strong-typing assertion — no `any` boundary regression (+1 test)

## Gates

| Gate | Result |
|------|--------|
| typecheck | ✅ |
| lint | ✅ |
| test:quick | ✅ 764 tests |
| test:coverage | ✅ 100% (1926/1926) |

4 files, +71 lines. No behavior changes.

Closes #124. Supersedes stalled PR #123.