### PR TITLE
docs(STATUS): record Issue #129 merge — engine default truth-alignment

### DIFF
--- a/docs/foundational/STATUS.md
+++ b/docs/foundational/STATUS.md
@@ -23,7 +23,7 @@
 
 ---
 
-## Recently Completed (Issues #3, #4, #6, #11, #12, #15, #18, #19, #22, #23, #24, #27, #33, #40, #44, #46, #47, #50, #53, #56, #59, #61, #63, #66, #68, #69, #70, #71, #72, #73, #77, #80, #87, #90, #98, #106, #112, #115, #120, #126)
+## Recently Completed (Issues #3, #4, #6, #11, #12, #15, #18, #19, #22, #23, #24, #27, #33, #40, #44, #46, #47, #50, #53, #56, #59, #61, #63, #66, #68, #69, #70, #71, #72, #73, #77, #80, #87, #90, #98, #106, #112, #115, #120, #126, #129)
 
 - ✅ **Issue #3** — Chief token smoke test: validated agent loop smoke test infrastructure.
 - ✅ **Issue #11** — Added root `pnpm typecheck` script.
@@ -70,6 +70,7 @@
 - ✅ **Issue #115** — TOCTOU hardening for `shares/day` in AnalysisFeed share flow: added synchronous guard to prevent concurrent double-consume race in share budget enforcement, mirroring the pattern established in #68 for analysis requests. 7 new tests, 751 tests total, 100% coverage maintained (PR #116, SHA `662b7fa`, merged 2026-02-08).
 - ✅ **Issue #120** — VENN De-Mock: routed analysis generation through `ai-engine` pipeline end-to-end. Removed inline mock generator from `AnalysisFeed.tsx`; UI now calls `createAnalysisPipeline()` (new `pipeline.ts`) which exercises the full `buildPrompt → EngineRouter → parse → validate` chain. Mock engine moved from `worker.ts` inline to `createDefaultEngine()` in `engines.ts` (engine-layer default, not UI-level bypass). `CanonicalAnalysis` type aligned with v1 contract: added `schemaVersion: 'canonical-analysis-v1'`, `engine?`, `warnings?` fields. `EngineUnavailableError` typed error added, EngineRouter fallback logic improved for all policy modes. 10 new tests, 761 tests total, 100% coverage maintained (PR #121, SHA `b5c922d`, merged 2026-02-08).
 - ✅ **Issue #126** — WebLLM LocalMlEngine: added `LocalMlEngine` class with lazy WebGPU initialization and `EngineUnavailableError` safe failure path. Wired AnalysisFeed to use `LocalMlEngine` when not in E2E mode (explicit opt-in for real inference). Refactored `createDefaultEngine()` → extracted `createMockEngine()` + `isE2EMode()` helper. `createDefaultEngine()` remains mock for safe fallback; consumers explicitly opt into `LocalMlEngine`. 7 new localMlEngine tests + updated engine/AnalysisFeed tests. `localMlEngine.ts` coverage-exempt (browser-only WebGPU boundary). 773 tests total, 100% coverage maintained (PR #127, SHA `35229c7`, merged 2026-02-08).
+- ✅ **Issue #129** — Engine Default Truth-Alignment: made `createDefaultEngine()` truthful — returns `LocalMlEngine` in non-E2E mode, `createMockEngine()` in E2E/test mode. Simplified `AnalysisFeed.tsx` to use `createAnalysisPipeline()` without manual engine construction. Extracted shared types (`JsonCompletionEngine`, `EnginePolicy`, `EngineUnavailableError`) into `engineTypes.ts` to break `engines.ts` ↔ `localMlEngine.ts` circular dependency. `isE2EMode()` now checks both `import.meta.env` and `process.env` for dual Vite/Node context. 776 tests total, 100% coverage maintained (PR #130, SHA `52c3cdc`, merged 2026-02-08).
 
 ---
 
@@ -87,10 +88,10 @@ Next work: planned backlog slices for remaining budget enforcement (moderation, 
 |--------|------------|---------------|----------|
 | **Sprint 0** (Foundation) | ✅ Archived | ✅ Complete | None — monorepo, CLI, CI, core packages done |
 | **Sprint 1** (Core Bedrock) | ✅ Archived | ⚠️ 90% Complete | Testnet deployment never done (localhost only); attestation is stub |
-| **Sprint 2** (Civic Nervous System) | ✅ Complete | ⚠️ 95% Complete | Pipeline exercised end-to-end via `createAnalysisPipeline`; EngineRouter active; `LocalMlEngine` (WebLLM) wired in AnalysisFeed for non-E2E mode (#126); remote engine not wired |
+| **Sprint 2** (Civic Nervous System) | ✅ Complete | ⚠️ 97% Complete | Pipeline exercised end-to-end; `createDefaultEngine()` returns `LocalMlEngine` (WebLLM) in non-E2E mode (#129); EngineRouter active; remote engine not wired |
 | **Sprint 3** (Communication) | ✅ Complete | ✅ Complete | Messaging E2EE working; Forum working; XP integrated |
 | **Sprint 3.5** (UI Refinement) | ✅ Complete | ✅ Complete | Stance-based threading; design unification |
-| **Sprint 4** (Agentic Foundation) | ⚪ Planning | 🟡 In Progress | Delegation types + participation governor types, runtime utils, forum, governance vote, sentiment vote, analyses & shares enforcement wiring landed; budget model defines 8 keys and 6 are currently enforced in runtime flows (`shares/day` added in #106); budget denial UX hardened (#69); consume-on-null fix (#98); TOCTOU budget hardening (#68, #115); unified topics fully landed (schema + derivation + Feed↔Forum integration, PRs #78/#81); ProposalList cleanup landed (#61); CSP documentation follow-up landed (#47); VENN pipeline de-mocked — analysis generation now routes through `ai-engine` pipeline end-to-end, mock moved to engine-layer default (#120); WebLLM `LocalMlEngine` wired into AnalysisFeed for non-E2E mode (#126); remaining budget enforcement (moderation/civic_actions) is backlog-scoped (no active issue currently filed) |
+| **Sprint 4** (Agentic Foundation) | ⚪ Planning | 🟡 In Progress | Delegation types + participation governor types, runtime utils, forum, governance vote, sentiment vote, analyses & shares enforcement wiring landed; budget model defines 8 keys and 6 are currently enforced in runtime flows (`shares/day` added in #106); budget denial UX hardened (#69); consume-on-null fix (#98); TOCTOU budget hardening (#68, #115); unified topics fully landed (schema + derivation + Feed↔Forum integration, PRs #78/#81); ProposalList cleanup landed (#61); CSP documentation follow-up landed (#47); VENN pipeline de-mocked — analysis generation now routes through `ai-engine` pipeline end-to-end (#120); default engine truthful — `createDefaultEngine()` returns `LocalMlEngine` (WebLLM) in non-E2E mode (#129); remaining budget enforcement (moderation/civic_actions) is backlog-scoped (no active issue currently filed) |
 | **Sprint 5** (Bridge + Docs) | ⚪ Planning | ⚪ Not Started | Docs updated for Civic Action Kit (facilitation model); no code yet (`docs/sprints/05-sprint-the-bridge.md`) |
 
 ---
@@ -101,7 +102,7 @@ Next work: planned backlog slices for remaining budget enforcement (moderation, 
 |------------|----------------|--------------------|----------|
 | Sprint 1 Core Bedrock | Attestation verifier validates Apple/Google chains | Stub logic (token prefix/length); no real chain validation | `services/attestation-verifier/src/main.rs:105-136` |
 | Sprint 1 Core Bedrock | Contracts deployed to Sepolia/Base with verified sources | Deploy script exists; only localhost deployments committed | `packages/contracts/scripts/deploy-testnet.ts` + `packages/contracts/deployments/localhost.json` |
-| AI_ENGINE_CONTRACT + Sprint 2 | Remote/local engines + policy routing (remote-first etc.) | Pipeline exercised end-to-end: worker uses `createAnalysisPipeline` → `EngineRouter` → `createDefaultEngine` (mock). EngineRouter active with fallback logic for all policy modes. Only real engine implementations (WebLLM/Remote) remain unwired | `packages/ai-engine/src/pipeline.ts` + `packages/ai-engine/src/engines.ts` + `packages/ai-engine/src/worker.ts` |
+| AI_ENGINE_CONTRACT + Sprint 2 | Remote/local engines + policy routing (remote-first etc.) | Pipeline exercised end-to-end: `createDefaultEngine()` returns `LocalMlEngine` (WebLLM) in non-E2E mode (#129). EngineRouter active with fallback logic for all policy modes. Remote engine not yet wired | `packages/ai-engine/src/pipeline.ts` + `packages/ai-engine/src/engines.ts` + `packages/ai-engine/src/engineTypes.ts` + `packages/ai-engine/src/worker.ts` |
 | Hero_Paths / Sentiment Spec | Constituency proofs + district aggregates | SentimentSignal emission requires constituency proof; no RegionProof generation or aggregates | `apps/web-pwa/src/hooks/useSentimentState.ts:76-100` |
 | Sprint 5 Bridge Plan | Civic Action Kit facilitation (reports + native intents) | Bridge is stubbed; facilitation features not implemented | `services/bridge-stub/index.ts` + `docs/sprints/05-sprint-the-bridge.md` |
 | Agentic Familiars (Delegation) | Delegation grants + OBO assertions | 🟡 Types + Zod schemas defined; runtime not implemented | `packages/types/src/delegation.ts` (PR #48); no familiar runtime yet |
@@ -158,7 +159,7 @@ The following tasks are required to align the codebase with the updated specs (a
 | Add verified-only candidate submission gate | `canonical-analysis-v2.md` §4.1 | `packages/ai-engine/src/analysis.ts` |
 | Implement critique/refine mandate (candidates compare to prior analyses) | `canonical-analysis-v2.md` §4.1 | `packages/ai-engine/src/prompts.ts` |
 | Implement synthesis engine (candidates → synthesis + divergence) | `canonical-analysis-v2.md` §4.2 | New: `packages/ai-engine/src/synthesis.ts` |
-| Wire real AI engine (WebLLM or consented remote) to replace `createDefaultEngine()` | `AI_ENGINE_CONTRACT.md` | `packages/ai-engine/src/engines.ts` (supply real engine to `createAnalysisPipeline()`) |
+| ✅ ~~Wire real AI engine (WebLLM) to replace mock default~~ | `AI_ENGINE_CONTRACT.md` | Done — `createDefaultEngine()` returns `LocalMlEngine` in non-E2E mode (#129); remote engine consent flow still pending |
 
 ### P1 — Comment-Driven Re-Synthesis
 
@@ -273,7 +274,7 @@ packages/contracts/deployments/
 
 ### VENN (Canonical Analysis Layer)
 
-**Status:** 🟡 **Pipeline Exercised End-to-End, Engine Still Mock**
+**Status:** 🟡 **Pipeline Exercised End-to-End, Default Engine Truthful (WebLLM)**
 
 | Feature | Implementation | Evidence |
 |---------|----------------|----------|
@@ -286,7 +287,7 @@ packages/contracts/deployments/
 | Engine router | ✅ Exercised | `engines.ts` — `EngineRouter` active with fallback logic for all policy modes |
 | AI engine (WebLLM) | ✅ Wired (non-E2E) | `localMlEngine.ts` — `LocalMlEngine` class with lazy WebGPU init; wired into AnalysisFeed when `!isE2EMode()` (#126) |
 | AI engine (Remote) | ❌ Not wired | Interface exists, no `RemoteApiEngine` wired |
-| Mock engine | ⚠️ E2E/fallback only | `engines.ts` — `createMockEngine()` used via `createDefaultEngine()` as safe fallback; AnalysisFeed uses `LocalMlEngine` in non-E2E mode (#126) |
+| Mock engine | ⚠️ E2E/test only | `engines.ts` — `createMockEngine()` returned by `createDefaultEngine()` only when `isE2EMode()` is true; non-E2E callers get `LocalMlEngine` by default (#129) |
 
 **Sprint 2 AI Engine Contract Status:**
 - ✅ `AI_ENGINE_CONTRACT.md` spec written
@@ -294,11 +295,11 @@ packages/contracts/deployments/
 - ✅ `EngineRouter` class implemented with fallback logic for all policy modes
 - ✅ `EngineUnavailableError` typed error for exhausted fallback chains
 - ✅ `createAnalysisPipeline()` exercises full pipeline: buildPrompt → EngineRouter → parse → validate
-- ✅ Worker uses `createAnalysisPipeline(createDefaultEngine())` — pipeline is real, engine is mock
+- ✅ Worker uses `createAnalysisPipeline(createDefaultEngine())` — pipeline and engine are both real in non-E2E mode (#129)
 - ✅ `CanonicalAnalysis` aligned with v1 contract: `schemaVersion`, `engine?`, `warnings?`
 - ✅ Tests cover policy behaviors, fallbacks, and pipeline end-to-end
 - ✅ `LocalMlEngine` class wired — lazy WebGPU init, `EngineUnavailableError` safe failure, used by AnalysisFeed in non-E2E mode (#126)
-- ⚠️ **Default engine fallback is still mock** — `createDefaultEngine()` returns `createMockEngine()` for safe fallback; consumers must explicitly opt into `LocalMlEngine`
+- ✅ **Default engine is now truthful** — `createDefaultEngine()` returns `LocalMlEngine` in non-E2E mode, `createMockEngine()` only when `isE2EMode()` (#129)
 - ⚠️ **Remote API engine not wired** — no `RemoteApiEngine` implementation
 
 **Current AI Architecture (pipeline exercised, engine mocked):**
@@ -316,16 +317,10 @@ export function createAnalysisPipeline(engine?: JsonCompletionEngine) {
   };
 }
 
-// packages/ai-engine/src/engines.ts — mock at engine layer (not UI bypass)
+// packages/ai-engine/src/engines.ts — default engine is now truthful (#129)
 export function createDefaultEngine(): JsonCompletionEngine {
-  return {
-    name: 'mock-local-engine',
-    modelName: 'mock-local-v1',
-    kind: 'local',
-    async generate() {
-      return JSON.stringify({ final_refined: { summary: 'Mock summary', ... } });
-    }
-  };
+  if (isE2EMode()) return createMockEngine();  // E2E/test → mock
+  return new LocalMlEngine();                   // production → real WebLLM
 }
 
 // packages/ai-engine/src/worker.ts — worker wires pipeline + default engine
@@ -431,7 +426,7 @@ const runPipeline = createAnalysisPipeline(createDefaultEngine());
 | "Holographic vectors" (LUMA) | Not implemented |
 | "Mathematically private" (LUMA) | Device-bound nullifier, not human-bound |
 | "BMR compliance" (GWC) | No compliance implementation |
-| "Local AI inference" (VENN) | Pipeline exercised end-to-end; engine still mock (`createDefaultEngine`), no WebLLM |
+| "Local AI inference" (VENN) | ✅ `createDefaultEngine()` returns `LocalMlEngine` (WebLLM) in non-E2E mode (#126, #129); remote engine not wired |
 | "Sovereign Delivery" (HERMES) | Redesigning as facilitation (Civic Action Kit) |
 
 **⚠️ Whitepapers describe target architecture, not current implementation.**
@@ -446,7 +441,7 @@ const runPipeline = createAnalysisPipeline(createDefaultEngine());
 |------|----------|--------|----------|
 | No sybil defense | 🔴 High | Open | `main.rs:162` (device-only nullifier) |
 | Trust scores spoofable | 🔴 High | Open | `main.rs:105-116` |
-| AI engine implementation mocked | 🟡 Medium | Open | `engines.ts` — `createDefaultEngine()` (pipeline exercised, engine returns hardcoded response) |
+| AI engine default truthful (WebLLM) | 🟢 Resolved | Closed | `engines.ts` — `createDefaultEngine()` returns `LocalMlEngine` in non-E2E mode (#129); mock only in E2E/test |
 | First-to-file poisoning | 🟡 Medium | Open | `analysis.ts:30-48` (no supersession) |
 
 ### Mitigations in Place
@@ -465,7 +460,7 @@ const runPipeline = createAnalysisPipeline(createDefaultEngine());
 
 ## Test Coverage
 
-**Repo-wide (Vitest `pnpm test:quick`):** 773 tests (unit + component + integration).
+**Repo-wide (Vitest `pnpm test:quick`):** 776 tests (unit + component + integration).
 
 **Coverage (`pnpm test:coverage`, last validated 2026-02-08):**
 
@@ -499,7 +494,7 @@ const runPipeline = createAnalysisPipeline(createDefaultEngine());
 
 | Blocker | Severity | Sprint Gap | Fix |
 |---------|----------|------------|-----|
-| AI engine implementation mocked | 🟡 Medium | Sprint 2 | Pipeline exercised end-to-end (#120); wire real engine (WebLLM or consented remote API) to replace `createDefaultEngine()` |
+| ~~AI engine implementation mocked~~ | ~~🟡 Medium~~ | ~~Sprint 2~~ | ✅ Resolved — `createDefaultEngine()` returns `LocalMlEngine` (WebLLM) in non-E2E mode (#129); remote engine not yet wired |
 | Testnet undeployed | 🟡 Medium | Sprint 1 | Run `deploy-testnet.ts` to Sepolia |
 | Attestation is stub | 🟡 Medium | Sprint 1 | Label as DEV ONLY or implement real validation |
 | No sybil defense | 🔴 High | N/A (LUMA gap) | Research pragmatic uniqueness checking |
@@ -507,7 +502,7 @@ const runPipeline = createAnalysisPipeline(createDefaultEngine());
 ### Phase 1: Complete Sprint Gaps (Immediate)
 
 - [ ] **Deploy contracts to Sepolia** — Run existing `deploy-testnet.ts`, commit artifact
-- [ ] **Integrate real AI engine** — Pipeline is exercised end-to-end (#120); wire WebLLM (local) or consented remote API to replace `createDefaultEngine()`
+- [x] **Integrate real AI engine** — `createDefaultEngine()` returns `LocalMlEngine` (WebLLM) in non-E2E mode (#126, #129); remote engine consent flow still pending
 - [ ] **Label attestation as DEV ONLY** — Prevent false security assumptions
 - [ ] **Add beta warnings to UI** — Prominent disclaimers on analyses/governance
 
@@ -553,7 +548,7 @@ const runPipeline = createAnalysisPipeline(createDefaultEngine());
 ### Canonical Specs
 - `docs/specs/canonical-analysis-v1.md` — Analysis schema contract (implemented)
 - `docs/specs/canonical-analysis-v2.md` — Quorum synthesis contract (planned)
-- `docs/foundational/AI_ENGINE_CONTRACT.md` — AI engine pipeline contract (pipeline exercised end-to-end via `createAnalysisPipeline`, engine implementation mocked via `createDefaultEngine`)
+- `docs/foundational/AI_ENGINE_CONTRACT.md` — AI engine pipeline contract (pipeline exercised end-to-end via `createAnalysisPipeline`; default engine is `LocalMlEngine` (WebLLM) in non-E2E mode, mock in E2E/test — #129)
 - `docs/specs/spec-civic-sentiment.md` — Eye/Lightbulb/Sentiment spec (implemented locally)
 - `docs/specs/spec-xp-ledger-v0.md` — XP ledger spec (fully implemented)
 - `docs/specs/spec-identity-trust-constituency.md` — Identity contract (partially implemented)


### PR DESCRIPTION
Records the #129 merge (PR #130, SHA `52c3cdc`):

- `createDefaultEngine()` now returns `LocalMlEngine` (WebLLM) in non-E2E mode
- AI engine mock blocker resolved
- Test count 773 → 776
- Sprint 2 progress 95% → 97%
- Circular dependency resolved via `engineTypes.ts` extraction
- Updated VENN status, security table, roadmap, known gaps, and architecture code blocks

Phase 5 closeout for Issue #129.