### PR TITLE
docs: fix stale AI engine implementation note

### DIFF
--- a/docs/foundational/AI_ENGINE_CONTRACT.md
+++ b/docs/foundational/AI_ENGINE_CONTRACT.md
@@ -2,7 +2,7 @@
 
 Version: 0.1  
 Status: Canonical for Sprints 2–3  
-Implementation note (2026-02-02): Worker currently uses a mock engine; real engine wiring is pending and defaults to `local-only`.
+Implementation note (2026-02-08): Default runtime path uses `LocalMlEngine` in non-E2E mode; mock engine is E2E/test-only. Remote fallback is opt-in and policy-gated (`local-first` when enabled).
 
 Defines the contract between raw article text, AI engines (remote/local), JSON responses, validation/guardrails, and `CanonicalAnalysisV1` objects.
 


### PR DESCRIPTION
## Summary
- update stale implementation note in `AI_ENGINE_CONTRACT.md`
- reflect current runtime truth: `LocalMlEngine` default in non-E2E, mock only in E2E/test, remote fallback opt-in (`local-first` when enabled)

## Scope
- docs-only, 1 line updated

## Why
- aligns contract doc with current `origin/main` behavior after #129/#133
