### PR TITLE
docs: align TRINITY Season 0 SoT, V2 specs, and sprint docs

### DIFF
--- a/docs/foundational/GWC_BriefWhitePaper.md
+++ b/docs/foundational/GWC_BriefWhitePaper.md
@@ -67,13 +67,13 @@ We explicitly separate the economy into two lanes to prevent AI dominance:
 
 Human Lane: Requires Hardware Attestation. Can mint AU.
 
-Agent Lane: Can only spend RVU to buy Compute. Cannot mint AU. This ensures that the upside of the AI economy flows to human participants.
+Agent Lane: Includes familiars and other delegated agents. They can only act within the principal human's budgets/trust gates, can spend RVU to buy Compute, and cannot mint AU. This ensures that the upside of the AI economy flows to human participants.
 
 3.3 Civic Sentiment Channel
 
 GWC is not just a wallet and a marketplace; it is wired into a continuous stream of civic sentiment.
 
-At the application layer (VENN), each verified human can read canonical analyses (Eye: decayed read interest) and take stances on specific claims (Lightbulb: decayed engagement weight for the topic). Each human is represented by a stable, pseudonymous nullifier derived from LUMA; trustScores from hardware attestation gate which economic and governance actions they may take (e.g., UBE claims, QF votes). These micro-decisions are converted into typed Civic Sentiment Signals for claims and decayed read metrics for topics:
+At the application layer (VENN), each verified human can read Topic Synthesis V2 outputs for clustered stories/topics (Eye: decayed read interest) and take stances on specific claims (Lightbulb: decayed engagement weight for the topic). Each human is represented by a stable, pseudonymous nullifier derived from LUMA; trustScores from hardware attestation gate which economic and governance actions they may take (e.g., UBE claims, QF votes). These micro-decisions are converted into typed civic signals for claims and decayed read metrics for topics:
 
 - Per-claim stance (agree / neutral / disagree).
 - Per-topic engagement weight (bounded, anti-spam).

--- a/docs/foundational/Hero_Paths.md
+++ b/docs/foundational/Hero_Paths.md
@@ -1,556 +1,469 @@
-# E2E Hero Paths – Season 0
+# E2E Hero Paths - Season 0 (V2-first)
 
-Version: 0.1  
-Status: Canonical Storyboards for Sprints 2–3
+Version: 0.3  
+Status: Canonical storyboards for Season 0 implementation and testing
 
-This document captures two end-to-end “hero paths” for Season 0:
+This document defines the core user loops and maps each loop to concrete contracts, trust gates, privacy boundaries, and test assertions.
 
-- **Civic Dignity Loop** (news → influence → reward)
-- **Governance Loop** (idea → proposal → support)
+References:
 
-Each path is described from the user’s point of view and then mapped to concrete types, contracts, and tests across LUMA (identity), VENN (application), and GWC (economics). These loops must remain consistent with:
-
-- `System_Architecture.md`
-- `docs/specs/spec-identity-trust-constituency.md`
-- `docs/specs/spec-civic-sentiment.md`
-- `docs/specs/spec-rvu-economics-v0.md`
-- `docs/specs/canonical-analysis-v1.md`
+- `docs/foundational/TRINITY_Season0_SoT.md`
+- `docs/foundational/System_Architecture.md`
 - `docs/foundational/AI_ENGINE_CONTRACT.md`
+- `docs/specs/topic-synthesis-v2.md`
+- `docs/specs/spec-topic-discovery-ranking-v0.md`
+- `docs/specs/spec-hermes-forum-v0.md`
+- `docs/specs/spec-hermes-docs-v0.md`
+- `docs/specs/spec-civic-action-kit-v0.md`
+- `docs/specs/spec-civic-sentiment.md`
 - `docs/specs/spec-data-topology-privacy-v0.md`
 
----
+`CanonicalAnalysisV1` is legacy/compat only and is not the design target for these loops.
 
-## 1. Hero Path 1 – Civic Dignity Loop
+## 1. Hero Path A: Civic Dignity Loop
 
-> *“I read, I judge, my district’s signal moves, and the system recognizes that.”*
+User sentence:
 
-### 1.1 Narrative (User Perspective)
+"I open one feed, understand a story from many sources, register my stance, and see district-level signal move without exposing who I am."
 
-1. **I become “real” in the system**
+### 1.1 UX narrative (detailed)
 
-   - I install the app or open the PWA.
-   - I go through onboarding and end up with an account that is “me”: one human, not just one device.
-   - At some point I complete Proof of Human (attestation). Optionally, I prove my region so the app knows I am a constituent of District X.
-   - After this, the app treats me differently from a guest:
-     - My actions can move civic metrics,
-     - I am eligible for a small daily boost.
-   - Optional: I configure a **familiar** (delegated agent) to draft/triage. It acts on my behalf with scoped, expiring grants; all actions count against my budgets and do not multiply my influence. I manage it in Messaging via a Familiar Control Panel (local-only).
+1. I become a verified participant.
 
-2. **I scroll my Topics stream**
+- I complete onboarding.
+- I may complete proof-of-human and optionally constituency proof.
+- I see role progression: Guest -> Human -> Constituent.
+- If I link a familiar, it appears as a delegated assistant, not a separate identity.
 
-   - I see a list of Topics (external headlines + user threads + linked-socials notifications).
-   - Each card shows:
-     - Headline & source,
-     - A small **Eye** indicator (how much real reading interest the story has),
-     - A **Lightbulb** indicator (how much engaged judgment the story has attracted).
-   - I can scroll this stream even as a guest; but only as an attested human do my actions move those metrics.
+2. I land on one unified feed.
 
-3. **I open a topic and get the “clean view”**
+- Feed includes three surfaces:
+  - News story cards (clustered multi-source bundles)
+  - Topic/thread cards (community-originated discussion)
+  - Linked-social notification cards
+- I can filter by `All`, `News`, `Topics`, `Social` and sort by `Latest`, `Hottest`, `My Activity`.
 
-   - Clicking any Topic card opens a single, familiar screen:
-     - **Neutral summary** at the top (facts only),
-     - A **Frame / Reframe table** directly beneath,
-     - The **discussion thread** continues below the table.
-
-   - The Frame/Reframe table is the *system’s current best synthesis* of:
-     - the source article (if there is one), **and**
-     - the evolving forum discussion for this Topic.
-
-   - The page feels like one object with two lenses:
-     - **Analysis lens:** “What’s going on, and what are the competing frames?”
-     - **Forum lens:** “What do people in the network actually think and say?”
-
-   - **Reanalysis cadence (discrete refresh, not continuous churn):**
-     - During the **first N opens** (default: 5), each analysis re‑reads the original article/post and **critiques/refines** the prior summary + Frame/Reframe table with the express intent of maximum accuracy. Each candidate is distributed on the mesh.
-     - Every **N verified comments** thereafter (default: 10, min 3 unique verified principals), the Topic is re-analyzed using:
-       - the original article/topic context, plus
-       - a digest of the newest discussion.
-     - Debounce: at most one refresh per 30 minutes; daily cap: 4 per topic.
-     - If the synthesis changes, the Frame/Reframe table updates (and a new analysis version is shown).
-
-   - Direction note: v1 is first-to-file; v2 will synthesize from a quorum of candidate analyses.
-
-4. **I express my judgement**
-
-   - For each cell (frame or reframe) I can:
-     - Agree (**+1**),
-     - Disagree (**-1**),
-     - Or stay neutral (**0**).
-   - The controls are simple 3‑state toggles:
-     - Tapping + again returns to neutral,
-     - Switching from + to – flips the stance.
-   - When I interact:
-     - The row’s local sentiment indicator moves (ratio of agree/disagree),
-     - The article’s **Lightbulb** (engagement) increases slightly for *me*,
-     - My personal “score” on the control panel ticks up (civic XP track).
-
-5. **I see my district’s signal**
-
-   - In a **Constituent Dashboard**, I can see:
-
-     - For my district:
-       - % agree / disagree on specific claims (aggregated per bias row),
-       - Which topics are “hot” by engagement.
-     - For the wider network:
-       - How my district compares to others on the same topic.
-
-   - My individual stance is not displayed beyond the read/lightbulb indicators being illuminated if I've read/registered sentiment by tapping on **+ / –** controls; I only see aggregated results. But it’s clear that my actions contribute to these curves.
-
-6. **I get a small daily boost**
-
-   - Once per day, as an attested human, I can claim a **Daily Boost**.
-   - In the UI this shows up as:
-     - A “Boost” button / status in the control panel,
-     - An increase in my visible score (XP).
-   - Under the hood, this is backed by a UBE claim (Season 0) and an off‑chain XP ledger.
-
-7. **Being a good citizen is legible**
-
-   - My stream is cleaner than a standard doomscroll,
-   - I can see all sides of stories,
-   - My reactions roll up into district‑level signals,
-   - I get tangible recognition (score now, RVU later) for participating thoughtfully.
-
-This is the **Civic Dignity Loop**: identity → news → analysis → stance → district‑level influence → daily recognition.
-
----
-
-### 1.2 Under the Hood (S0–S2 Implementation)
-
-#### 1.2.1 Identity & Trust (LUMA)
-
-- **Types & specs:**
-  - `TrustScore` (0..1) and `ScaledTrustScore` (0..10000) per `spec-identity-trust-constituency.md`.
-  - `UniquenessNullifier` – stable per-human key (string off-chain, `bytes32` on-chain).
-  - `RegionProof` → `ConstituencyProof { district_hash, nullifier, merkle_root }`.
-
-- **Client:**
-  - `useIdentity` calls the attestation-verifier and persists `IdentityRecord` in the encrypted IndexedDB vault (`vh-vault` database, `vault` object store) protected by a per-device master key.
-  - Runtime identity access is in-memory via identity provider APIs:
-    - `getPublishedIdentity()` returns the public session snapshot (`nullifier`, `trustScore`, `scaledTrustScore`).
-    - `getFullIdentity()` returns the full same-process record for consumers that require private fields (for example, chat encryption helpers).
-  - Legacy key `vh_identity` is migration-only input (read once, then deleted), not active persistence.
-  - `vh:identity-published` is emitted only as a hydration signal and carries no identity payload.
-
-- **Roles:**
-  - **Guest:** no trustScore/nullifier in state; can read but does not move canonical metrics or earn XP.
-  - **Human (PoH):** trustScore ≥ 0.5 (scaled ≥ 5000).
-    - Eligible for UBE/Faucet.
-    - Their sentiment & engagement contribute to aggregates.
-  - **Constituent:** Human + valid RegionProof.
-    - Their sentiment participates in district-level aggregates (by `district_hash`).
-
-> Invariant: For the same human, the `nullifier` is consistent across identity, sentiment (SentimentSignal.constituency_proof.nullifier), and UBE/QF attestations.
-
-#### 1.2.2 Feed → Canonical Analysis (VENN + AI Engine)
-
-- **Data model:**
-  - `CanonicalAnalysisV1` from `docs/specs/canonical-analysis-v1.md`:
-    - `url`, `urlHash`,
-    - `summary`,
-    - `bias_claim_quote`, `justify_bias_claim`, `biases`, `counterpoints`,
-    - Optional `perspectives: { frame, reframe }[]`,
-    - `sentimentScore`, `confidence?`,
-    - Optional `engine` metadata and `warnings[]`.
-
-- **Generation:**
-  - AI pipeline per `AI_ENGINE_CONTRACT.md`:
-    - `buildPrompt(articleText)` constructs the prompt with goals/guidelines and JSON wrapper.
-    - `EngineRouter` chooses a remote or local model (Season 0 default: `local-only`; remote requires explicit opt-in).
-    - Model returns wrapped JSON (`step_by_step` + `final_refined`) parsed and validated via `AnalysisResultSchema`.
-    - Output is canonicalized into `CanonicalAnalysisV1` and validated by `CanonicalAnalysisSchema`.
-
-- **Storage & topology:**
-  - Per `docs/specs/spec-data-topology-privacy-v0.md`:
-    - CanonicalAnalyses are **public**:
-      - Stored on-device: `localStorage: vh_canonical_analyses` and IndexedDB `vh-ai-cache/analyses`.
-      - Optionally replicated plaintext to mesh: `vh/analyses/<urlHash>`.
-    - They do **not** include any identity or constituency data.
-
-- **UI:**
-- Topics stream reads `CanonicalAnalysisV1` to render summary and bias table.
-  - Eye & Lightbulb are computed from per-topic Eye/Lightbulb weights (see below).
-
-##### 1.2.2.1 Topic Digest → Reanalysis Loop (Frame/Reframe evolves)
-
-- **Goal:** Keep the Topic’s summary + Frame/Reframe table aligned with the live conversation without allowing constant churn or spam-driven drift.
-
-- **Digest (local-first, policy-driven):**
-  - The client (or a familiar in **Suggest** mode) maintains a rolling `TopicDigest` for each `topicId`.
-  - The digest is derived from recent comments and includes:
-    - recurring claims/themes,
-    - the strongest competing frames,
-    - representative quotes (comment excerpts) for each frame,
-    - and a bounded window of recent comment IDs.
-
-- **Reanalysis trigger (discrete epochs):**
-  - During the **first N opens** (default: 5), each analysis re‑reads the original article/post and critiques/refines the prior summary + Frame/Reframe table for accuracy.
-  - After canonicalization, when the thread receives **N verified** new posts since the last reanalysis epoch (default: 10, min 3 unique verified principals), a new analysis job is created.
-  - Qualifying posts are trust-gated, rate-limited, and count only toward the principal nullifier.
-  - Debounce: at most one refresh per 30 minutes; daily cap: 4 per topic.
-
-- **Reanalysis input:**
-  - `articleText` (if external headline) OR `topicSeed` (if user-born thread)
-  - `TopicDigest` (new discussion window)
-
-- **Reanalysis output:**
-  - A new canonical analysis (`CanonicalAnalysisV2` when quorum mode is enabled) is produced with updated:
-    - `summary`
-    - `perspectives[]` (Frame/Reframe rows)
-    - optional `warnings[]` (mismatch/uncertainty)
-
-- **Anti-churn rule:**
-  - Treat reanalysis as **epochs** (versioned refreshes). “First-to-file” applies per epoch window, not forever.
-  - Clients display the latest accepted epoch by deterministic selection (same for all peers).
-
-#### 1.2.3 Sentiment, Eye & Lightbulb (VENN + Sentiment Spec)
-
-- **Types & schemas:**
-  - `SentimentSignal` and `AggregateSentiment` from `docs/specs/spec-civic-sentiment.md`.
-  - Event-level:
-
-    ```ts
-    interface SentimentSignal {
-      topic_id: string;
-      analysis_id: string;
-      point_id: string;
-      agreement: 1 | 0 | -1;
-      weight: number; // Lightbulb engagement weight [0,2]
-
-      constituency_proof: {
-        district_hash: string;
-        nullifier: string;
-        merkle_root: string;
-      };
-
-      emitted_at: number;
-    }
-    ```
-
-  - Aggregate:
-
-    ```ts
-    interface PointStats {
-      agree: number;
-      disagree: number;
-    }
-
-    interface AggregateSentiment {
-      topic_id: string;
-      analysis_id: string;
-      point_stats: Record<string, PointStats>;
-      bias_vector: Record<string, 1 | 0 | -1>;
-      weight: number;          // aggregate Lightbulb
-      engagementScore: number; // optional dispersion/spread metric
-    }
-    ```
-
-- **Per-user state (client):**
-  - `useSentimentState`:
-    - Stores `agreement ∈ {-1,0,1}` per `(topic_id, point_id)` (3‑state toggle).
-  - `useEngagementState`:
-    - Stores **Lightbulb** `lightbulb_weight(topic_id, user)` ∈ `[0,2]`.
-    - Updates via Civic Decay on *engagement interactions* (stance changes).
-  - `useReadState` (or `useReadTracker`):
-    - Stores **Eye** `eye_weight(topic_id, user)` ∈ `[0,2]`.
-    - Updates via Civic Decay on each full read/expand of the analysis.
-
-- **Civic Decay function:**
-
-  From `docs/specs/spec-civic-sentiment.md`:
-
-  ```ts
-  // One step toward 2.0
-  next = current + 0.3 * (2.0 - current);
-  ```
-
-Invariants:
-  - Monotonic
-  - Bounded in [0,2]
-  - One qualifying interaction = one step
-
-  Metrics semantics:
-  - Eye (Read Interest):
-    - Per-user-per-topic `eye_weight` updated on read/expand.
-    - Aggregate Eye is a deterministic function of all `eye_weight` values (sum).
-    - Optional secondary metric: count of users with `eye_weight > 0`.
-  - Lightbulb (Engagement):
-    - Per-user-per-topic `lightbulb_weight` updated on each stance change / engagement.
-    - `SentimentSignal.weight = current lightbulb_weight` for that topic.
-    - Aggregate Lightbulb is a deterministic aggregate of per-user `lightbulb_weight` (sum/avg).
-  - Per-point sentiment:
-    - `agreement` changes update local state per `(topic_id, point_id)`.
-    - Aggregate `point_stats[point_id]` count only committed votes:
-      - `agree` = count of `agreement = +1`
-      - `disagree` = count of `agreement = -1`
-      - Neutral (`0`) is excluded from counts.
-  - Privacy & topology:
-    - Per `docs/specs/spec-data-topology-privacy-v0.md`, event-level `SentimentSignal` is sensitive.
-    - It lives on-device and/or is sent encrypted to a Guardian Node.
-    - It is never stored plaintext in the public mesh.
-    - Mesh/public surfaces expose only `AggregateSentiment` and other aggregates.
-    - No `{district_hash, nullifier}` pairs in any public structure.
-
-#### 1.2.4 XP & Daily Boost (GWC)
-  - Contracts:
-    - `RVU.sol`, `UBE.sol`, `Faucet.sol`, `QuadraticFunding.sol` per `spec-rvu-economics-v0.md`.
-  - UBE parameters (Season 0):
-    - `minTrustScore = 5000` (`0.5`)
-    - `claimInterval = 1 day`
-    - `dripAmount ~25 RVU`
-  - UX decision (Season 0):
-    - UBE is surfaced in the app as a Daily Boost, not as a DeFi income product.
-  - Behind the scenes:
-    - Successful `UBE.claim()` can mint testnet RVU to the user wallet and/or increment a per-nullifier civic XP ledger.
-    - Faucet remains dev/onboarding-only and is not part of the visible dignity loop.
-  - UI:
-    - `useWallet` + `WalletPanel` show RVU balance and raw UBE claim status for advanced users/testers.
-    - Control panel shows Daily Boost status and XP growth.
-
-⸻
-
-1.3 E2E Test Outline – Civic Dignity Loop
-
-A Season 0 E2E test suite should demonstrate:
-	1.	Identity and trust gating
-	•	Create a new identity via useIdentity with mocked attestation:
-	•	Ensure trustScore ≥ 0.5.
-	•	Ensure nullifier is present.
-	•	Optionally attach a mock RegionProof and verify ConstituencyProof decoding.
-	2.	Daily Boost / UBE link
-	•	Call UBE.claim() in mock mode (or equivalent XP-only path).
-	•	Assert:
-	•	Claim succeeds only if trustScore ≥ minTrustScore.
-	•	User’s civic XP track increases by the expected amount.
-	3.	Canonical analysis loading
-	•	Paste a known URL into the app.
-	•	Assert:
-	•	CanonicalAnalysisV1 is generated or reused (First-to-File behavior).
-	•	Entry passes CanonicalAnalysisSchema.parse.
-	•	It is stored in the local topics stream and, if configured, appears in vh/analyses/<urlHash> in the mesh.
-	4.	Bias table interaction
-	•	On a canonical analysis:
-	•	Toggle + on a specific point_id.
-	•	Assert:
-	•	agreement(topic_id, point_id) moves from 0 → +1.
-	•	lightbulb_weight(topic_id, user) increases via Civic Decay.
-	•	Aggregate sentiment for that point (point_stats) reflects this vote.
-	5.	Eye/Lightbulb updates
-	•	Open and close the same analysis multiple times:
-	•	Assert eye_weight(topic_id, user) increases monotonically and is bounded in [0,2].
-	•	Engage multiple times with the table:
-	•	Assert lightbulb_weight(topic_id, user) increases monotonically and is bounded in [0,2].
-	6.	District dashboard
-	•	With a mock district_hash:
-	•	Feed several SentimentSignal events (or mocked equivalents) into an aggregate pipeline.
-	•	Assert:
-	•	Per-district aggregates (point_stats, Eye, Lightbulb) are computed correctly.
-	•	No per-user identifiers appear in the public dashboard data structures.
-
-⸻
-
-2. Hero Path 2 – Governance Loop
-
-“This article is biased → here’s a better idea → look, people support it.”
-
-2.1 Narrative (User Perspective)
-	1.	I start from a topic
-	•	I’m on a topic (e.g., “local transit funding”) reading a canonical analysis and its bias/counter table.
-	•	Below the analysis, I see the **thread** (discussion) for this Topic.
-	2.	Ideas emerge from the thread
-	•	Discussion happens in the thread (forum votes affect visibility).
-	•	When an idea crystallizes, the thread can be **elevated to a proposal**.
-	3.	I elevate a thread to a proposal (verified)
-	•	I add funding details (RVU request + recipient).
-	•	A familiar can draft these fields, but I must approve elevation.
-	•	The thread gets a **Proposal** badge and a Support widget.
-	4.	I stake my support (Season 0)
-	•	I enter an amount (in “RVU units”) representing my support weight.
-	•	The UI shows voice credits = amount² to give me the quadratic feel.
-	•	I submit my support:
-	•	The proposal’s support metrics update,
-	•	My governance/project XP increases,
-	•	My control panel shows that I’ve backed this proposal.
-	•	In Season 0:
-	•	This does not move real RVU for general users;
-	•	It is tracked off-chain (and optionally in the mesh) as simulated QF-style voting.
-	5.	I see hypothetical funding outcomes
-	•	The proposal UI shows “What if this were in a QF round?”:
-	•	Estimated matching given a hypothetical pool,
-	•	How this proposal compares to others in terms of voice credits.
-	6.	Later, proposals become QF-eligible
-	•	In future seasons, some proposal-threads become QF projects:
-	•	They get a real projectId in the QuadraticFunding contract,
-	•	My attested votes can actually route RVU (subject to trust gates).
-	•	My earlier participation (XP footprint) influences how the system invites me into these higher-stakes rounds.
-
-This is the Governance Loop: news → idea → proposal → committed support → eventual routing of value through QF.
-
-⸻
-
-2.2 Under the Hood (S0–S2 Implementation)
-
-2.2.1 Proposal & vote data model
-	•	Proposals are **threads with a proposal extension** (see `spec-hermes-forum-v0.md`):
-
-```typescript
-interface ProposalExtension {
-  fundingRequest: string;         // RVU amount (display)
-  recipient: string;              // recipient address
-  status: 'draft' | 'active' | 'elevated' | 'funded' | 'closed';
-  qfProjectId?: string;           // set when elevated on-chain
-  sourceTopicId?: string;         // optional link when multiple proposals exist
-  attestationProof?: string;      // optional
-  createdAt: number;
-  updatedAt: number;
+3. I open a topic and get stable synthesis + discussion.
+
+- Topic detail renders one object with two lenses:
+  - Synthesis panel (`TopicSynthesisV2`)
+  - Thread lens (forum)
+- Synthesis shows facts, frames/reframes, warnings, and epoch badge.
+- I can inspect provenance and see when synthesis refreshed.
+
+4. I express stance with bounded influence.
+
+- For each point I select `+1`, `0`, or `-1`.
+- Repeat taps toggle state; no multi-vote spamming.
+- My per-topic engagement weight increases asymptotically and is capped.
+
+5. I see district-level aggregates, not identities.
+
+- Dashboard displays per-district aggregate trends.
+- I never see per-user stance identity data.
+- Public charts remain aggregate-only and cohort-safe.
+
+6. I receive daily recognition.
+
+- If eligible, I claim one daily boost.
+- UX remains XP-first in Season 0.
+- Advanced users can inspect wallet/claim details separately.
+
+7. My familiar remains constrained.
+
+- Familiar can suggest summaries or draft text.
+- High-impact actions require explicit human confirmation.
+- Familiar consumes my budgets; it does not mint extra influence.
+
+### 1.2 Contract mapping
+
+#### 1.2.1 Identity, trust, and constituency
+
+```ts
+interface PublishedIdentity {
+  nullifier: string;
+  trustScore: number; // 0..1
+  scaledTrustScore: number; // 0..10000
+}
+
+interface ConstituencyProof {
+  district_hash: string;
+  nullifier: string;
+  merkle_root: string;
 }
 ```
 
-	•	Vote representation (off-chain):
-	•	Season 0: votes are represented as off-chain objects (e.g., ProposalSupport) with fields like:
-	•	threadId (proposal thread),
-	•	direction (“support” / “oppose”),
-	•	amount (numeric),
-	•	voter (nullifier in private context),
-	•	timestamp.
-	•	Front-end:
-	•	useGovernance (PWA):
-	•	Seeds example proposal-threads and maintains support aggregates locally.
-	•	In future, will persist proposal extensions + support events via mesh or local storage.
-	•	Topology & privacy:
-	•	Per docs/specs/spec-data-topology-privacy-v0.md:
-	•	Proposal threads are public objects and may be stored in mesh.
-	•	Raw per-user support events may be sensitive depending on identity/constituency linkage:
-	•	Publicly: only aggregate support counts and voice credits per proposal.
-	•	Privately: structured support histories keyed by nullifier may be kept on-device or via encrypted channels.
+Required gates:
 
-2.2.2 Quadratic Funding Engine (GWC)
-	•	Contract: QuadraticFunding.sol
-	•	Supports:
-	•	recordParticipant(address, scaledTrustScore, expiresAt) – attested participants (trust-gated).
-	•	registerProject(recipient) – admin/curator registers projects.
-	•	castVote(projectId, amount) – contributions (RVU) from participants.
-	•	Quadratic weight accounting (sumOfSqrtContributions).
-	•	Matching pool funding (fundMatchingPool / poolFunds).
-	•	Settlement (closeRound, matchFunds, withdraw).
-	•	Season 0 scope (per spec-rvu-economics-v0.md):
-	•	Public UX:
-	•	Off-chain simulated QF voting (no direct castVote from general users).
-	•	Internal/developer use:
-	•	Curators and dev accounts exercise full QF flows on testnet with RVU:
-	•	Register projects,
-	•	Record participants,
-	•	Cast votes,
-	•	Close and match rounds,
-	•	Withdraw funds.
+- Write/vote in discourse requires `trustScore >= 0.5`.
+- Higher-impact governance/forwarding requires `trustScore >= 0.7`.
 
-2.2.3 Season 0 decision: sandboxed public governance
-	•	Public PWA:
-	•	Proposal creation & voting:
-	•	Remains off-chain and (initially) local/mesh-only.
-	•	Votes update proposal-level aggregates (votesFor, votesAgainst, derived voice credits).
-	•	XP:
-	•	Supporting proposals increases governance/project XP for the user (ledger keyed by nullifier off-chain).
-	•	No on-chain RVU is moved directly from public PWA interactions in Season 0.
-	•	Internal QF testing:
-	•	Curated proposals are mapped to QF projectIds:
-	•	Off-chain mapping: proposalId → projectId.
-	•	Curators and test participants:
-	•	Use wallets, attestation bridge, and QF contracts to run real matches.
-	•	This validates the economic engine without exposing public users to real-money governance yet.
+#### 1.2.2 Topic and synthesis identity
 
-2.2.4 Proposal lifecycle in S0
-Off-chain / app level:
-	1.	Draft:
-	•	User with identity (nullifier) discusses in the thread.
-	•	A familiar may draft proposal fields, but elevation requires explicit human approval.
-	2.	Elevation:
-	•	Thread is elevated to a proposal by adding `thread.proposal`.
-	• Proposal references:
-	•	Topic(s) (`topic_id` = urlHash or deterministic thread-derived hash),
-	•	Optional tags/categories,
-	•	Optional attestationProof that the author is in an affected district.
-	3.	Support / voting:
-	•	When a user supports via the Proposal widget:
-	•	A ProposalSupport event is created locally and/or in mesh/private storage.
-	•	Support aggregates (support/oppose, voice credits) update.
-	•	The user’s project/governance XP increases.
+```ts
+type TopicId = string;
 
-On-chain / internal:
-	4.	Curation & registration:
-	•	Admin/curators select certain proposal-threads for on-chain QF testing.
-	•	They call QuadraticFunding.registerProject(recipient) and maintain mapping to threadId (`qfProjectId`).
-	5.	QF test rounds:
-	•	Using dev/test accounts:
-	•	Participants are attested (recordParticipant).
-	•	They cast real castVote transactions.
-	•	After the round, curators call closeRound, matchFunds, and withdraw.
-	•	Internal dashboards compare:
-	•	Off-chain simulated outcomes vs. on-chain actual matches.
+interface TopicRef {
+  topic_id: TopicId;
+  kind: 'NEWS_STORY' | 'USER_TOPIC' | 'SOCIAL_NOTIFICATION';
+}
 
-Future seasons:
-	6.	Public QF activation:
-	•	Proposal extension grows an onChainProjectId / `qfProjectId` field.
-	•	For QF-enabled proposal-threads, public PWA:
-	•	Allows attested users (trustScore ≥ QF threshold) to cast real RVU votes via castVote.
-	•	Shows both:
-	•	Off-chain voice metrics,
-	•	On-chain contribution/match status.
+interface TopicSynthesisRef {
+  topic_id: TopicId;
+  synthesis_id: string;
+  epoch: number;
+}
+```
 
-⸻
+Notes:
 
-2.3 E2E Test Outline – Governance Loop
+- News topics derive from clustered stories (`StoryBundle`).
+- User topics and social notifications share the same TopicId abstraction.
+- Legacy `analysis_id` is compatibility-only.
 
-Season 0 tests should demonstrate that the governance loop works end-to-end at the UX and contract levels (even though they are only partially wired together for public users).
+#### 1.2.3 Sentiment, Eye, and Lightbulb
 
-2.3.1 App-level governance tests
-	1.	Thread elevation
-	•	With an attested identity:
-	•	Elevate a thread to proposal via the UI.
-	•	Assert proposal extension fields are stored on the thread.
-	•	Assert the thread shows a Proposal badge + Support widget.
-	2.	Support & aggregates
-	•	On a proposal-thread:
-	•	Submit a “Support” vote with amount A.
-	•	Assert:
-	•	Local aggregates (support/oppose, derived voice credits) update as expected.
-	•	A ProposalSupport record is stored (local or mesh/private).
-	•	User’s governance/project XP increased.
-	3.	Hypothetical QF projection
-	•	Provide a mock QF pool and emulate QF math client-side.
-	•	Assert:
-	•	The UI’s “Estimated match” matches the math used in QuadraticFunding tests (for the same inputs).
+```ts
+interface SentimentSignal {
+  topic_id: TopicId;
+  synthesis_id: string;
+  epoch: number;
+  point_id: string;
+  agreement: -1 | 0 | 1;
+  weight: number; // [0, 2]
+  constituency_proof: ConstituencyProof;
+  emitted_at: number;
+}
+```
 
-2.3.2 Contract-level QF tests (internal)
-	1.	Participant & project registration
-	•	Deploy RVU and QuadraticFunding to a testnet/anvil.
-	•	Register:
-	•	Two projects via registerProject.
-	•	Several participants via recordParticipant with trustScore ≥ min QF threshold.
-	2.	Voting & matching
-	•	Mint RVU to participants.
-	•	Have participants cast QF votes (castVote) with varying amounts.
-	•	Fund the matching pool via fundMatchingPool / poolFunds.
-	•	Close the round and call matchFunds.
-	3.	Assertions
-	•	Verify:
-	•	Quadratic contributions and matching weights align with spec.
-	•	withdraw(projectId) transfers the correct total (contributions + matches) to the recipient.
-	•	Trust gating works: unregistered/low-trust participants cannot cast votes.
-	4.	Simulation alignment
-	•	Cross-check:
-	•	Off-chain simulated matches (used in the UI) against on-chain matches for the same contributions.
+Civic Decay step:
 
-⸻
+```ts
+next = current + 0.3 * (2 - current);
+```
 
-3. Summary
+Invariants:
 
-These two hero paths tie together:
-	•	LUMA identity (nullifier, trustScore, RegionProof),
-	•	VENN’s AI analysis and sentiment mechanics,
-	•	GWC’s UBE, RVU, and Quadratic Funding,
-	•	And the Season 0 data topology & privacy rules.
+- monotonic and bounded in `[0, 2]`
+- one qualifying interaction = one decay step
+- event-level signals are sensitive and not public plaintext
 
-They should be treated as contractual storyboards: if a feature or change breaks one of these loops, it should be considered an architectural regression, not just a UI tweak.
+#### 1.2.4 Synthesis refresh cadence
 
----
+Defaults:
+
+- early accuracy pass: first 5 verified opens can produce critique/refine candidates
+- re-synthesis: every 10 verified comments with >=3 unique verified principals
+- debounce: 30 minutes
+- daily cap: 4/topic
+
+### 1.3 E2E test outline (Civic Dignity)
+
+1. Identity and role gates.
+
+- create a mock identity
+- assert guest cannot write/vote
+- assert verified human can write/vote
+
+2. Feed and story clustering.
+
+- ingest multiple URLs into one story cluster
+- assert one news card renders per cluster
+
+3. Synthesis determinism.
+
+- run candidate quorum path for same topic/epoch
+- assert deterministic accepted synthesis
+
+4. Tri-state stance behavior.
+
+- toggle point `0 -> +1 -> 0 -> -1`
+- assert expected state and weight changes
+
+5. Aggregate privacy boundary.
+
+- inspect public outputs for absence of nullifier + district pair
+- assert only aggregate structures appear publicly
+
+6. Daily boost gate.
+
+- verify one claim/day policy
+- verify trust threshold enforcement
+
+## 2. Hero Path B: Reply-to-Article Loop
+
+User sentence:
+
+"I start with a quick thread reply and seamlessly escalate to longform when the idea needs space."
+
+### 2.1 UX narrative (detailed)
+
+1. I tap reply in thread context.
+
+- Composer is bound to current `threadId` and `topicId`.
+- Input counter shows 240-char max.
+
+2. I exceed 240 chars.
+
+- Send is blocked.
+- I get a `Convert to Article` CTA.
+
+3. I convert to article.
+
+- A docs draft opens prefilled with my text.
+- Draft carries source linkage (`topicId`, `threadId`, optional `parentPostId`).
+- Draft is private-by-default and can be collaborative.
+
+4. I publish article back to topic.
+
+- Article appears in topic feed and forum surface.
+- Comments/votes attach as normal discourse objects.
+- Engagement can trigger nomination policy.
+
+5. Familiar boundaries remain explicit.
+
+- Familiar can propose edits and summarize comments.
+- Familiar cannot publish article without explicit principal approval when configured for high-impact guardrails.
+
+### 2.2 Contract mapping
+
+```ts
+interface ForumPost {
+  id: string;
+  threadId: string;
+  topicId: string;
+  type: 'reply' | 'article';
+  content: string;
+  articleRefId?: string;
+  author: string;
+  via?: 'human' | 'familiar';
+  timestamp: number;
+}
+
+interface DocPublishLink {
+  docId: string;
+  topicId: string;
+  threadId: string;
+  articleId: string;
+  publishedAt: number;
+}
+```
+
+Rules:
+
+- reply hard limit enforced at UI and schema boundaries
+- article must reference a docs artifact
+- published article must preserve topic linkage
+
+### 2.3 E2E test outline (Reply-to-Article)
+
+1. Reply hard cap enforcement.
+
+- enter 241 chars
+- assert send disabled and CTA visible
+
+2. Conversion handoff.
+
+- assert docs draft created with source linkage
+- assert initial content copied correctly
+
+3. Publish and feed/index update.
+
+- publish draft
+- assert article card appears in topic surface
+- assert forum references `articleRefId`
+
+4. Collaboration and offline behavior.
+
+- edit draft offline, reconnect, and sync
+- assert merged content deterministic
+
+## 3. Hero Path C: Governance and Elevation Loop
+
+User sentence:
+
+"This topic matters, so we elevate it into concrete artifacts and forward a coherent packet to representatives."
+
+### 3.1 UX narrative (detailed)
+
+1. I nominate a source object.
+
+- nomination target can be news, topic, or article
+- client shows policy status (remaining threshold)
+
+2. Threshold is crossed.
+
+- system emits elevation job
+- artifacts are generated:
+  - BriefDoc
+  - ProposalScaffold
+  - TalkingPoints
+
+3. I review and edit artifacts.
+
+- packet preview in action center
+- I can modify messaging before forwarding
+
+4. I select representatives.
+
+- rep list derives from my district proof
+- available channels shown (email, phone, share, export, manual)
+
+5. I initiate forwarding.
+
+- I explicitly choose channel
+- system opens native intent
+- on completion/cancel, a local receipt is written
+
+6. Public impact is aggregate-only.
+
+- counter increments by representative
+- no identity linkage leaks in public projections
+
+### 3.2 Contract mapping
+
+```ts
+interface NominationEvent {
+  id: string;
+  topicId: string;
+  sourceType: 'news' | 'topic' | 'article';
+  sourceId: string;
+  nominatorNullifier: string;
+  createdAt: number;
+}
+
+interface ElevationArtifacts {
+  briefDocId: string;
+  proposalScaffoldId: string;
+  talkingPointsId: string;
+  sourceTopicId: string;
+  sourceSynthesisId: string;
+  sourceEpoch: number;
+  generatedAt: number;
+}
+
+interface CivicAction {
+  id: string;
+  author: string;
+  representativeId: string;
+  intent: 'email' | 'phone' | 'share' | 'export' | 'manual';
+  status: 'draft' | 'ready' | 'completed' | 'failed';
+  sourceArtifactId: string;
+  sourceTopicId: string;
+  sourceSynthesisId: string;
+}
+```
+
+Required gates:
+
+- elevation finalize and forwarding require trust `>= 0.7`
+- valid constituency proof required
+- `civic_actions/day` budget enforced per principal
+
+### 3.3 E2E test outline (Governance and Elevation)
+
+1. Nomination threshold behavior.
+
+- simulate multiple nominators
+- assert elevation job only on policy satisfaction
+
+2. Artifact generation integrity.
+
+- assert all three artifacts generated
+- assert references to `topicId/synthesisId/epoch`
+
+3. Representative routing.
+
+- lookup reps by `district_hash`
+- assert matching district behavior
+
+4. Delivery and receipts.
+
+- trigger email/share/export flows
+- assert local receipt for success/failure/cancel
+
+5. Privacy boundary.
+
+- assert public stats contain counts only
+- assert no profile PII in public paths
+
+## 4. Hero Path D: Linked-Social Notification Loop
+
+User sentence:
+
+"I can include social-platform alerts in the same civic feed and pivot quickly into deeper context."
+
+### 4.1 UX narrative (detailed)
+
+1. I connect social account with explicit consent.
+
+- token scope and privacy boundary shown before connect
+- user can revoke at any time
+
+2. Notification card appears in unified feed.
+
+- card includes platform badge and summary
+- I can open for context or dismiss
+
+3. Topic linkage remains consistent.
+
+- notification maps to a `TopicId` of kind `SOCIAL_NOTIFICATION`
+- can enter thread/synthesis context if linked
+
+4. Sensitive data stays protected.
+
+- OAuth tokens are vault-only
+- public projections are sanitized and token-free
+
+### 4.2 Contract mapping
+
+```ts
+interface SocialNotification {
+  id: string;
+  topicId: string;
+  platform: string;
+  summary: string;
+  link?: string;
+  createdAt: number;
+}
+```
+
+Data policy:
+
+- tokens and raw provider secrets are never public
+- card projections must redact sensitive payload fields
+
+### 4.3 E2E test outline (Linked-Social)
+
+1. OAuth consent path shows explicit disclosure.
+2. Tokens are persisted only in vault/local sensitive storage.
+3. Social cards render in feed and filter correctly.
+4. Public object audit confirms token-free projections.
+
+## 5. Cross-Loop Invariants
+
+1. One topic abstraction across all surfaces (`NEWS_STORY`, `USER_TOPIC`, `SOCIAL_NOTIFICATION`).
+2. V2 synthesis linkage by `{topicId, synthesisId, epoch}`.
+3. Event-level identity/sentiment/profile data is sensitive and not public plaintext.
+4. Familiars act on behalf of principals and inherit principal budgets.
+5. High-impact actions require explicit user approval and higher trust threshold.
+
+## 6. Regression Checklist (Developer Use)
+
+Use this checklist before considering a major feed/forum/docs/bridge refactor complete.
+
+1. Feed still supports `All/News/Topics/Social` filtering and canonical sort modes.
+2. Reply hard cap (`240`) still enforced and conversion path still reachable.
+3. Article publication still links docs artifact and returns to topic/feed surfaces.
+4. Nomination thresholding still deterministic under concurrent events.
+5. Artifact generation still emits all required packet artifacts.
+6. Forwarding remains user-initiated with local receipt semantics.
+7. Public projections still pass privacy linting (no nullifier+district linkage).
+8. Trust and budget gates still enforced for familiar and human actions.
+
+## 7. Out of Scope for Season 0
+
+- Autonomous submission to legislative web forms.
+- Public exposure of per-user stance history.
+- Familiar-owned independent influence lanes.
+- Fully on-chain public governance for general users (remains curated/internal in Season 0).

--- a/docs/foundational/LUMA_BriefWhitePaper.md
+++ b/docs/foundational/LUMA_BriefWhitePaper.md
@@ -39,7 +39,7 @@ We assume our adversaries are state-level actors with unlimited compute and phys
 
 2.5 Delegated Agents (Familiars) — Inheritance Rule (Note)
 
-Agents (“familiars”) are delegated sub‑processes of a verified human. They **inherit** the principal’s trust gate and never multiply influence. All agent actions must resolve to a human principal nullifier and are scoped, expiring, and revocable.
+Agents (“familiars”) are delegated sub‑processes of a verified human. They **inherit** the principal’s trust gate and daily participation budgets, never multiply influence, and never create a new influence lane. All agent actions must resolve to a human principal nullifier and are scoped, expiring, and revocable.
 
 3. Technical Architecture: The "Physics of Trust"
 

--- a/docs/foundational/STATUS.md
+++ b/docs/foundational/STATUS.md
@@ -23,6 +23,27 @@
 
 ---
 
+## Product Direction Deltas (A-G)
+
+This section tracks direction-level truth from the V2-first Ship Snapshot against current implementation.
+
+| Direction Delta | Target (Ship Snapshot) | Current Implementation |
+|---|---|---|
+| A. V2-first synthesis | `TopicSynthesisV2` (quorum + epochs + divergence) is canonical | Not implemented end-to-end yet; v1 canonical analysis pipeline still carries runtime load |
+| B. 3-surface feed | Feed mixes `News`, `Topics`, and `Linked-Social Notifications` | Topics + news/thread blend exists; linked-social notifications not implemented |
+| C. Elevation loop | Nomination thresholds produce BriefDoc + ProposalScaffold + TalkingPoints + rep forwarding | Proposal-thread primitives exist; auto-drafted elevation artifacts and forwarding flow are not implemented |
+| D. Thread + longform rules | Reddit-like sorting, 240-char replies, overflow to Docs article | Forum sorting is implemented; reply-to-article conversion path is not yet implemented |
+| E. Collaborative docs | Multi-author encrypted docs, draft-to-publish workflow | Planned only (Sprint 5), no runtime implementation |
+| F. GWC thesis channel | Eye/Lightbulb capture thought-effort; aggregate civic signal drives future REL/AU | Eye/Lightbulb primitives and sentiment flow partially implemented; district aggregate pipeline incomplete |
+| G. Provider switching | Default local WebLLM; remote providers opt-in with cost/privacy clarity | Local default path is wired; provider consent UI and multi-provider switching are not implemented |
+
+Direction boundary:
+
+- `CanonicalAnalysisV1` is legacy compatibility only.
+- New north-star epics are: story clustering, Topic Synthesis V2 epochs/quorum, linked-social notifications, Docs publishing flow, and Civic Action Kit facilitation.
+
+---
+
 ## Recently Completed (Issues #3, #4, #6, #11, #12, #15, #18, #19, #22, #23, #24, #27, #33, #40, #44, #46, #47, #50, #53, #56, #59, #61, #63, #66, #68, #69, #70, #71, #72, #73, #77, #80, #87, #90, #98, #106, #112, #115, #120, #126, #129, #133)
 
 - ✅ **Issue #3** — Chief token smoke test: validated agent loop smoke test infrastructure.
@@ -79,7 +100,14 @@
 
 No active follow-ups.
 
-Next work: planned backlog slices for remaining budget enforcement (moderation, civic_actions). No active issue is currently filed for these items. Budget model defines 8 Season 0 keys; 6 are currently enforced in runtime flows (`shares/day` was the last newly enforced key in #106), with 2 backlog integrations remaining.
+Next work (direction-aligned):
+
+- Implement News Aggregator ingestion and StoryBundle clustering.
+- Implement Topic Synthesis V2 quorum/epoch pipeline and re-synthesis triggers.
+- Add linked-social OAuth + notification cards (vault-only token storage).
+- Ship reply (240 chars) to Docs-backed article conversion flow.
+- Implement elevation artifacts (BriefDoc, ProposalScaffold, TalkingPoints, local Receipt).
+- Add representative directory, native forwarding intents, and receipt tracking.
 
 ---
 
@@ -151,25 +179,25 @@ The following tasks are required to align the codebase with the updated specs (a
 | ✅ ~~Add `proposal?: ProposalExtension` to Thread schema~~ | `spec-hermes-forum-v0.md` §2.1 | Done — `packages/data-model/src/schemas/hermes/forum.ts` (PR #78) |
 | ✅ ~~Unify Feed ↔ Forum: headlines and threads share topicId~~ | `spec-hermes-forum-v0.md` §2.1.1 | Done — `AnalysisFeed.tsx`, `ForumFeed.tsx`, `NewThreadForm.tsx`, forum stores (PR #81) |
 
-### P1 — Canonical Analysis v2 (Quorum Synthesis)
+### P1 — Topic Synthesis V2 (Quorum + Epochs)
 
 | Task | Spec Reference | Files to Modify |
 |------|----------------|-----------------|
-| Define `CandidateAnalysis`, `QuorumMeta`, `CanonicalAnalysisV2` types | `canonical-analysis-v2.md` §3 | `packages/data-model/src/schemas.ts` |
-| Implement candidate gathering (N=5, timeout=24h) | `canonical-analysis-v2.md` §4.1 | `packages/ai-engine/src/analysis.ts` |
-| Add verified-only candidate submission gate | `canonical-analysis-v2.md` §4.1 | `packages/ai-engine/src/analysis.ts` |
-| Implement critique/refine mandate (candidates compare to prior analyses) | `canonical-analysis-v2.md` §4.1 | `packages/ai-engine/src/prompts.ts` |
-| Implement synthesis engine (candidates → synthesis + divergence) | `canonical-analysis-v2.md` §4.2 | New: `packages/ai-engine/src/synthesis.ts` |
+| Define `CandidateSynthesis`, `QuorumMeta`, `TopicSynthesisV2` types | `topic-synthesis-v2.md` §4 | `packages/data-model/src/schemas.ts` |
+| Implement candidate gathering (N=5, timeout=24h) | `topic-synthesis-v2.md` §4.1 | `packages/ai-engine/src/analysis.ts` |
+| Add verified-only candidate submission gate | `topic-synthesis-v2.md` §4.1 | `packages/ai-engine/src/analysis.ts` |
+| Implement critique/refine mandate (candidates compare to prior analyses) | `topic-synthesis-v2.md` §4.1 | `packages/ai-engine/src/prompts.ts` |
+| Implement synthesis engine (candidates → synthesis + divergence) | `topic-synthesis-v2.md` §4.2 | New: `packages/ai-engine/src/synthesis.ts` |
 | ✅ ~~Wire real AI engine (WebLLM) to replace mock default~~ | `AI_ENGINE_CONTRACT.md` | Done — `createDefaultEngine()` returns `LocalMlEngine` in non-E2E mode (#129); remote engine consent flow still pending |
 
 ### P1 — Comment-Driven Re-Synthesis
 
 | Task | Spec Reference | Files to Modify |
 |------|----------------|-----------------|
-| Track verified comment count per topic since last synthesis | `canonical-analysis-v2.md` §4.3 | `apps/web-pwa/src/store/forum/index.ts` |
-| Track unique verified principals per topic | `canonical-analysis-v2.md` §4.3 | `apps/web-pwa/src/store/forum/index.ts` |
-| Implement re-synthesis trigger (N=10 comments, 3 unique principals) | `canonical-analysis-v2.md` §4.3 | New: re-synthesis hook or store action |
-| Implement debounce (30 min) and daily cap (4/topic) | `canonical-analysis-v2.md` §4.3 | Re-synthesis store |
+| Track verified comment count per topic since last synthesis | `topic-synthesis-v2.md` §4.3 | `apps/web-pwa/src/store/forum/index.ts` |
+| Track unique verified principals per topic | `topic-synthesis-v2.md` §4.3 | `apps/web-pwa/src/store/forum/index.ts` |
+| Implement re-synthesis trigger (N=10 comments, 3 unique principals) | `topic-synthesis-v2.md` §4.3 | New: re-synthesis hook or store action |
+| Implement debounce (30 min) and daily cap (4/topic) | `topic-synthesis-v2.md` §4.3 | Re-synthesis store |
 | Generate topic digest for re-analysis input | `Hero_Paths.md` | New: digest builder |
 
 ### P2 — Agentic Guardrails
@@ -348,21 +376,21 @@ const runPipeline = createAnalysisPipeline(createDefaultEngine());
 **First-to-File Limitations (v1 → v2 Direction):**
 - Current (v1): First analysis is immutable, vulnerable to poisoning
 - Risk: Single attacker can publish misleading canonical analysis
-- Planned (v2): Quorum synthesis — first N analyses compared + synthesized
+- Planned (v2): Quorum synthesis - first N candidates compared + synthesized
 - v2 will add challenge/supersession path; v1 records remain immutable
-- Defaults (v2): N=5, timeout=24h, challenge=7d
-- See `docs/specs/canonical-analysis-v2.md` for quorum synthesis contract
+- Defaults (v2): N=5, timeout=24h, debounce=30m, daily cap=4/topic
+- See `docs/specs/topic-synthesis-v2.md` for quorum synthesis contract
 
 **v2 Implementation Gaps:**
 
 | Feature | Spec | Status |
 |---------|------|--------|
-| `CandidateAnalysis` type | `canonical-analysis-v2.md` §3 | ❌ Missing |
-| Candidate gathering (N=5, timeout=24h) | `canonical-analysis-v2.md` §4.1 | ❌ Missing |
-| Verified-only candidate submission | `canonical-analysis-v2.md` §4.1 | ❌ Missing |
-| Critique/refine prior analyses | `canonical-analysis-v2.md` §4.1 | ❌ Missing |
-| Synthesis engine (divergence table) | `canonical-analysis-v2.md` §4.2 | ❌ Missing |
-| Comment-driven re-synthesis | `canonical-analysis-v2.md` §4.3 | ❌ Missing |
+| `CandidateSynthesis` type | `topic-synthesis-v2.md` §4 | ❌ Missing |
+| Candidate gathering (N=5, timeout=24h) | `topic-synthesis-v2.md` §4.1 | ❌ Missing |
+| Verified-only candidate submission | `topic-synthesis-v2.md` §4.1 | ❌ Missing |
+| Critique/refine prior analyses | `topic-synthesis-v2.md` §4.1 | ❌ Missing |
+| Synthesis engine (divergence table) | `topic-synthesis-v2.md` §4.2 | ❌ Missing |
+| Comment-driven re-synthesis | `topic-synthesis-v2.md` §4.3 | ❌ Missing |
 | Per-principal analysis budget (25/day, 5/topic) | `spec-xp-ledger-v0.md` §4 | ✅ Types + runtime utils defined; enforcement wired in `AnalysisFeed.tsx` via check-before/consume-after pattern (PR #67) |
 
 ---
@@ -554,8 +582,8 @@ const runPipeline = createAnalysisPipeline(createDefaultEngine());
 - `docs/foundational/ARCHITECTURE_LOCK.md` — Non-negotiable engineering guardrails (enforced)
 
 ### Canonical Specs
-- `docs/specs/canonical-analysis-v1.md` — Analysis schema contract (implemented)
-- `docs/specs/canonical-analysis-v2.md` — Quorum synthesis contract (planned)
+- `docs/specs/canonical-analysis-v1.md` — Legacy analysis schema (compatibility only)
+- `docs/specs/topic-synthesis-v2.md` — Quorum synthesis contract (planned)
 - `docs/foundational/AI_ENGINE_CONTRACT.md` — AI engine pipeline contract (pipeline exercised end-to-end via `createAnalysisPipeline`; default engine is `LocalMlEngine` (WebLLM) in non-E2E mode, mock in E2E/test — #129)
 - `docs/specs/spec-civic-sentiment.md` — Eye/Lightbulb/Sentiment spec (implemented locally)
 - `docs/specs/spec-xp-ledger-v0.md` — XP ledger spec (fully implemented)

--- a/docs/foundational/System_Architecture.md
+++ b/docs/foundational/System_Architecture.md
@@ -1,583 +1,503 @@
 # BIO-EC OS: Target Architecture
 
-**Codename:** TRINITY (VENN/HERMES x LUMA x GWC)
-**Version:** 0.2.1 (Sprint 4 — Agentic Foundation & Stabilization)
-**Status:** APPROVED FOR EXECUTION
+Codename: TRINITY (VENN/HERMES x LUMA x GWC)  
+Version: 0.4.0 (Season 0 Ship Snapshot, V2-first)  
+Status: Approved target architecture
 
-> ⚠️ **This document describes the target architecture, not current implementation.**
-> For actual implementation status, see `STATUS.md`. For gaps between this document
-> and code reality, see the "Docs vs. Code Alignment" section in `STATUS.md`.
+This document defines target architecture contracts and defaults for Season 0.
+For implementation truth and drift notes, use `docs/foundational/STATUS.md`.
 
------
+## 1. Mission and Prime Directives
 
-## 1. The Mission & Prime Directives
+TRINITY is a local-first civic and economic operating system built around:
 
-TRINITY is a **Parallel Institution**: A self-sovereign Operating System for Identity, Wealth, and Governance. It functions as a digital organism designed to operate without central intermediaries.
+1. LUMA (identity and trust)
+2. GWC (economics and governance rails)
+3. VENN/HERMES (information, discourse, docs, and civic action)
 
-**The Triad:**
+Prime directives:
 
-1.  **LUMA (The Immune System):** Biological reality (Hardware TEE + Biometrics) to filter Sybils.
-2.  **GWC (The Circulatory System):** Resource-backed wealth (ZK-Rollup + Oracles) to distribute value.
-3.  **VENN-HERMES (The Nervous System):** Local-first intent sensing (P2P Mesh + Edge AI) to act on information.
+1. Local is Truth: identity and sensitive civic state stay on-device.
+2. Physics is Trust: attestation-backed identity, not account-credential trust.
+3. Math is Law: deterministic policies, bounded participation, anti-collusion rails.
+4. Shared Reality: Topic Synthesis V2 is selected deterministically per epoch.
+5. Civic Facilitation: forwarding is user-initiated; no default dark automation.
+6. Human Sovereignty: familiars are delegated processes of a principal human.
+7. Strict Discipline: modularity caps (350 LOC) and full coverage gates apply.
 
-**Engineering Prime Directives:**
+## 2. Layered Architecture
 
-1.  **Local is Truth:** Canonical identity and civic state live on the user's device. Mesh and chain hold public or encrypted replicas; untrusted infrastructure sees routing metadata, not raw identity or constituency.
-2.  **Physics is Trust:** Keys are bound to hardware (TEE/Enclave), not passwords.
-3.  **Math is Law:** Governance is receipt-free (MACI) and anti-collusive.
-4.  **Shared Reality:** Analysis is generated at the edge but deduplicated via the "First-to-File" protocol. Canonical analyses may be refreshed in discrete **reanalysis epochs** (e.g., after N trusted discussion additions), with first-to-file applying per epoch window.
-5.  **Civic Facilitation:** We enable verified constituents to speak through user-initiated channels (email/phone/share/export). We do not automate form submission by default.
-6.  **Human Sovereignty (Delegated Agents):** Familiars are delegated sub-processes of a verified human. They never hold independent influence. Every agent action is attributable to a principal nullifier, scoped, expiring, revocable, and budgeted per human.
-7.  **Strict Discipline:** Modularization (350 LOC hard cap) and Testing (100% coverage) are non-negotiable.
+### 2.1 Layer 0: Physics (Root)
 
------
+Role:
 
-## 2. The 4-Layer Architecture
+- hardware root of trust and attestation substrate
 
-### Layer 0: Physics (The Root)
+Functions:
 
-  * **Role:** Hardware Root of Trust.
-  * **Tech:** Secure Enclave (iOS), StrongBox (Android), TPM (Desktop).
-  * **Function:** Generates non-exportable keys. Attests to device integrity (AppAttest/Play Integrity). This layer prevents emulation and virtual machine attacks.
+- key material rooted in secure hardware
+- anti-emulation and integrity signals
 
-### Layer 1: Identity (LUMA - The Synapse)
+### 2.2 Layer 1: Identity (LUMA)
 
-  * **Role:** Sybil resistance, Data Sync, & Recovery.
-  * **Tech:** Rust (Core), GUN (Sync Mesh), Pedersen Commitments, ZK-SNARKs.
-  * **Function:**
-      * **Bio-Tethering:** Liveness checks via TEE-signed biometrics.
-      * **ZK-Residency:** Proof of constituency without doxxing.
-      * **Recovery:** Multi-device linking and Social Recovery (M-of-N guardian signatures) to mitigate device loss.
+Role:
 
-### Layer 2: Economics (GWC - The Ledger)
+- trust scoring
+- nullifier continuity
+- constituency proof path
 
-  * **Role:** Value Transfer & Governance.
-  * **Tech:** EVM (Layer 2 Rollup), Circom (ZK Circuits), MACI.
-  * **Function:**
-      * **RVU:** Real Value Unit (floating purchasing power mirror; not a peg).
-      * **UBE:** Universal Basic Equity distribution.
-      * **Holographic Oracle:** Medianized price feeds from Staked Nodes.
-      * **Governance:** Anti-collusion voting via MACI.
+Functions:
 
-### Layer 3: Application (VENN-HERMES - The Interface)
+- identity session establishment
+- role gating (Guest/Human/Constituent)
+- delegation grants and on-behalf assertions
 
-  * **Role:** User Interaction, Communication, Civic Action (HERMES).
-  * **Tech:** React, Tauri/Capacitor, WebLLM (Edge AI), `@venn-hermes/*`.
-  * **Function:** Canonical News Analysis, E2EE Messaging, Civic Action Kit (facilitation), and proposal-threads (threads elevated with funding metadata).
-  * **Familiar Runtime (Delegated Agents):**
-      * Local-first orchestration; keys never leave device.
-      * **Suggest:** summaries, drafts, triage (low risk).
-      * **Act:** post/comment/thread ops — trust gated + rate limited.
-      * **High-impact:** votes/funding/civic action — explicit human approval + higher trust threshold.
-      * **Defaults:** See `docs/specs/spec-identity-trust-constituency.md` §6 (scopes/tiers) and `docs/specs/spec-xp-ledger-v0.md` §4 (budget caps).
-      * **Execution plan:** See `docs/sprints/04-sprint-agentic-foundation.md`.
+### 2.3 Layer 2: Economics (GWC)
 
------
+Role:
 
-## 3. Unified Tech Stack & Repositories
+- economic and governance rails
 
-The system functions as a Monorepo with polyglot micro-services.
+Functions:
 
-### 3.1 Client-Side (The "Super App")
+- RVU token plumbing
+- UBE daily claim path
+- QF contract flows (curated/internal in Season 0)
+- oracle and future wealth-index progression
 
-  * **Shell:** Tauri (Desktop), Capacitor (Mobile).
-  * **UI Framework:** React 18 + Vite (TypeScript).
-  * **State/Sync:**
-      * *Transient:* Zustand.
-      * *Durable:* `@venn-hermes/gun-client` (Strictly isolated GUN wrapper).
-  * **Edge AI:** **WebLLM (WASM)** running local inference (Llama-3-8B-Quantized or similar) is the target architecture; current implementation status is tracked in `STATUS.md` (mock engine remains active today).
-  * **Automation:** Optional local tooling for user-initiated assist (no default automation).
+### 2.4 Layer 3: Application (VENN/HERMES)
 
-### 3.2 Server-Side (The Untrusted Cloud)
+Role:
 
-  * **Network:** P2P Mesh via Encrypted WebSockets.
-  * **Relays:** Node.js 20 (Stateless). Users are incentivized to run **Home Guardian Nodes** (Raspberry Pi/Mini PC) to decentralize storage and compute.
-  * **Storage:** MinIO (S3 Compatible) for encrypted blobs > 100KB.
-  * **Chain:** Hardhat/Foundry for EVM contracts.
+- user-facing information, discourse, docs, and civic action surfaces
 
-### 3.3 Engineering Constraints
+Functions:
 
-  * **LOC Caps:** Soft: 250 / Hard: 350 lines per file. (Exempt: Tests, Types, ABI bindings).
-  * **Test Coverage:** 100% Line/Branch coverage required.
-  * **Browser Discipline:** No Node.js APIs (`fs`, `crypto`) in Client code.
+- unified feed and topic detail
+- forum and docs publishing
+- nomination/elevation and forwarding flows
 
------
-
-## 4. Core Modules & Implementation Details
-
-### 4.1 LUMA: Bio-Tethering & Recovery
-
-  * **Purpose:** Prevent "Account Renting" and mitigate device loss.
-  * **Mechanism:**
-    1.  **Session Start:** VIO (Visual Inertial Odometry) scan signed by TEE.
-    2.  **Challenge:** Random micro-gesture (e.g., "Tilt left 15°") to prove liveness.
-    3.  **Recovery:** Users designate Guardians or secondary devices. Restoring an identity requires `M-of-N` signatures to rotate the underlying Enclave Key without losing the Identity Nullifier.
+## 3. Product Surfaces (Season 0)
 
-#### 4.1.5 Identity, Trust & Constituency Model
+### 3.1 Unified feed
 
-We unify identity across LUMA, GWC, and VENN-HERMES using three primitives:
+Feed contains three surfaces:
 
-* **TrustScore (0–1):** Device/session trust derived from hardware attestation. On-chain representation: integer 0–10000 (`scaled = Math.round(trustScore * 10000)`, using `TRUST_SCORE_SCALE`). Thresholds (v0): 0.5 for session/UBE/Faucet, 0.7 for QF.
-* **UniquenessNullifier:** Stable per-human key. Off-chain: string. On-chain: `bytes32` hash. Shared across PWA identity, `SentimentSignal.constituency_proof.nullifier`, Region proofs, and UBE/QF attestation.
-* **ConstituencyProof:** Derived from a RegionProof SNARK. Public signals: `[district_hash, nullifier, merkle_root]`. Used to attribute civic signals to a district without exposing raw region codes; `district_hash` is never stored on-chain.
+1. News (clustered stories)
+2. Topics (user-born/evolving discussions)
+3. Linked-social notifications
 
-**Terminology standard:**
-- `principalNullifier` = human’s `UniquenessNullifier`.
-- `familiar` = delegated agent.
-- `DelegationGrant` = scoped, expiring authority.
-- `OnBehalfOfAssertion` = attached to any agent action.
-
-Invariants: same human → same nullifier across all layers; scaled trustScore = `Math.round(trustScore * 10000)`. See `docs/specs/spec-identity-trust-constituency.md` for the canonical contract.
-
-### 4.2 GWC: The Holographic Oracle
-
-  * **Purpose:** Uncensorable pricing for the RVU.
-  * **Mechanism:**
-    1.  **Nodes:** 50+ Staked Economic Nodes.
-    2.  **Privacy:** Price vectors encrypted via Pedersen Commitments.
-    3.  **Calc:** Smart Contract calculates the **Median** homomorphically.
-    4.  **Security:** No single node's specific feed is ever decrypted.
-
-#### 4.2.1 RVU v0: Proto-GWU
-
-Season 0 runs RVU as a standard ERC-20 with `MINTER_ROLE` / `BURNER_ROLE` and no on-chain index logic. It is an inflationary proto-asset with tightly controlled minters, used to harden economic plumbing before activating the full global wealth index.
-
-**Sources (v0):**
-* Bootstrap mint (testnet deploy script).
-* UBE drip (per-human, per-interval).
-* Faucet drip (dev/onboarding; not part of long-term dignity loop).
-
-**Sinks/locks (v0):**
-* QuadraticFunding holds contributions + matching until settlement.
-* No automatic burns; `burn()` exists but is unused in Season 0.
-
-Instrumentation focuses on:
-* `RVU.totalSupply()`.
-* `RVU.balanceOf(QuadraticFunding)`.
-* Aggregate distribution counters (e.g., `UBE.totalDistributed`, `Faucet.totalDripped`, `QuadraticFunding.distributedMatching`) to monitor inflation and governance flow. See `docs/specs/spec-rvu-economics-v0.md` for the canonical Season 0 economic contract.
-
-#### 4.2.2 XP Ledger v0 (Participation Weight)
-
-XP is a per-nullifier, non-transferable, monotonic ledger that prototypes the future participation weight GWC will use for value distribution.
-
-* **Shape (per UniquenessNullifier):**
-  * `civicXP` (news, sentiment, Eye/Lightbulb interactions),
-  * `socialXP` (messaging/HERMES, later),
-  * `projectXP` (proposals, governance/QF actions),
-  * `totalXP = f(civicXP, socialXP, projectXP)` (e.g., weighted sum),
-  * `lastUpdated` (timestamp).
-* **Distribution model (future):** `share_i = totalXP_i^γ / Σ totalXP_j^γ` (γ tunable; α pool fraction tunable when issuing RVU/GWU).
-* **Emission (Season 0 candidates):** first Lightbulb interaction on a topic, subsequent engagements (diminishing), full read sequences, UBE claims ("Daily Boost"), proposal support/creation, REL tasks later.
-* **Invariants:** per-nullifier, non-transferable, monotonic (no negative XP), tracks are stable even if emission coefficients change over time.
-* **Privacy:** XP ledger is sensitive (per-nullifier); stored on-device, optionally encrypted to a trusted node; only safe aggregates (e.g., district averages with cohort thresholds) may leave the device. Never publish `{district_hash, nullifier, XP}` together.
-
-See `docs/specs/spec-xp-ledger-v0.md` for the canonical Season 0 XP ledger contract. For HERMES Messaging/Forum/Project emission rules (amounts, caps, windows), see `docs/sprints/03-sprint-3-the-agora.md` §3.4.
-
-### 4.3 VENN: The Canonical Bias Engine
-
-  * **Purpose:** Shared Analysis without Centralization.
-  * **Mechanism ("First-to-File"):**
-    1.  **Lookup:** User opens URL. App queries Mesh for hash of URL.
-    2.  **Scenario A (Exists):** User downloads shared Analysis. WebLLM (Local) audits it. If valid, User votes.
-    3.  **Scenario B (New):** **WebLLM (Local)** generates Analysis. User signs and publishes it as the **Canonical Record**.
-* **Canonical Record:** For each `urlHash`, at most one `CanonicalAnalysis` (schemaVersion `canonical-analysis-v1`) is stored and reused. Civic signals (votes, decay, messaging threads) key off the canonical `urlHash` and immutable timestamp. v1 is first-to-file; v2 will shift to quorum synthesis (first N candidate analyses → synthesis + divergence). See `docs/specs/canonical-analysis-v1.md`.
-  * **Immutability:** CanonicalAnalysis objects are append-only in v1. Corrections or disputes are modeled as separate signals or future schema versions; they are not edited in place.
-  * **Civic Decay (Asymptotic):**
-          * Formula: $E_{new} = E_{current} + 0.3 * (2.0 - E_{current})$.
-          * Logic: Engagement asymptotically approaches 2.0 to prevent brigading while rewarding depth.
-
-#### 4.3.1 Civic Signals (Eye, Lightbulb, Sentiment)
-
-For each canonical article (topic):
-
-* **Eye (👁 Read Interest):**
-  * For each `topic_id` and user, track a per-topic read score `eye_weight ∈ [0, 2]` updated via Civic Decay on each full read/expand.
-  * The Eye metric displayed for a topic is an aggregate over all users’ `eye_weight` (sum) and may optionally show raw unique reader counts (`eye_weight > 0`).
-  * Repeated reads contribute with diminishing returns and can never exceed 2 units of read interest.
-* **Lightbulb (💡 Engagement Weight):**
-  * Per-user-per-topic engagement weight `weight ∈ [0, 2]`, driven by engagement interactions (table stances, feedback) and independent from Eye read score; repeated reads alone do not change Lightbulb.
-  * Derived from the count of active stances on that topic: first active stance sets weight to `1.0`, each additional active stance applies the Civic Decay step toward `2.0`; clearing stances decrements (all neutral → `0`).
-  * Civic Decay step: `E_new = E_current + 0.3 * (2.0 - E_current)`.
-  * Aggregate Lightbulb per topic is a function of all user weights (sum) stored in `AggregateSentiment`; each user’s contribution is capped at `2`.
-* **Per-point Sentiment:**
-  * For each `(topic_id, point_id)` (bias or counterpoint), each user has `agreement ∈ {-1, 0, +1}` representing Disagree / Neutral / Agree.
-  * UI semantics: each cell has separate `+` / `-` toggles; neutral is implicit. Clicking the same stance again clears it; switching `+`→`-` (or vice-versa) replaces the prior stance.
-  * For aggregation, only committed votes are counted (`+1` or `-1`); neutral (`0`) is tracked per user but does not contribute to per-cell ratios.
-  * Changes in `agreement` plus the user’s current Lightbulb `weight` are emitted as `SentimentSignal` events.
-
-Civic Decay is applied per-user-per-topic. Reads (expanding an analysis) advance the user’s `eye_weight`; engagement interactions (stance changes, feedback) advance the user’s Lightbulb `weight`, each step using `E_new = E_current + 0.3 * (2.0 - E_current)` toward a 2.0 ceiling. This ensures diminishing returns on repeat interactions while rewarding sustained engagement.
-
-*Privacy semantics:* Per-user `SentimentSignal` events are sensitive and MUST NOT be replicated in plaintext on the mesh. Public surfaces and mesh projections use `AggregateSentiment` and per-district aggregates only (counts/ratios/average weights) with no nullifiers; `district_hash` appears only in aggregates, never in individual public events.
-
-#### 4.3.2 AI Engine & Analysis Pipeline
-
-Article analyses are generated via a fixed 5-step pipeline:
-
-1. **Prompt Builder**
-   * `buildPrompt(articleText: string)` constructs the full analysis prompt:
-     * Includes GOALS/GUIDELINES (summary + bias detection),
-     * Specifies the JSON wrapper shape,
-     * Embeds the raw article text between `ARTICLE_START` / `ARTICLE_END`.
-2. **Engine Router (Remote / Local / Hybrid)**
-   * A pluggable engine interface (`JsonCompletionEngine`) abstracts over remote models (gateway API) and local models (WebLLM/MLC in a Worker).
-   * `EngineRouter` selects an engine per `EnginePolicy` (`remote-first`, `local-first`, `remote-only`, `local-only`, `shadow`). Remote vs local is invisible to the rest of the system.
-3. **Parser & Schema Validation**
-   * All engine responses must be valid JSON with shape:
-   ```jsonc
-   {
-     "step_by_step": ["..."],
-     "final_refined": {
-       "summary": "...",
-       "bias_claim_quote": ["..."],
-       "justify_bias_claim": ["..."],
-       "biases": ["..."],
-       "counterpoints": ["..."],
-       "sentimentScore": 0.0,
-       "confidence": 0.0
-     }
-   }
-   ```
-   * The worker extracts the outermost JSON object, unwraps `final_refined` if present, and validates it against `AnalysisResultSchema` (see `canonical-analysis-v1`).
-4. **Hallucination Guardrails**
-   * `validateAnalysisAgainstSource(articleText, analysis)` performs checks:
-     * All `bias_claim_quote` entries must appear in the article text.
-     * Obvious temporal inconsistencies (e.g., years in summary that never appear in the article) are flagged.
-   * Guardrails produce warnings (non-fatal) attached to the canonical record.
-5. **Canonicalization & Storage**
-   * A `CanonicalAnalysisV1` object is built:
-     * `schemaVersion`, `url`, `urlHash`, `timestamp`,
-     * Fields from `AnalysisResult`,
-     * Optional engine provenance `{ id, kind, modelName }`,
-     * Optional `warnings`.
-   * `CanonicalAnalysisSchema.parse(...)` enforces the contract before persistence in the mesh.
+Feed controls:
 
-This pipeline is independent of model choice; swapping remote/local engines only changes the engine implementation/policy, not the canonical analysis contract. See `docs/foundational/AI_ENGINE_CONTRACT.md` for the detailed AI engine contract.
+- filters: `All`, `News`, `Topics`, `Social`
+- sort modes: `Latest`, `Hottest`, `My Activity`
 
-#### 4.3.3 Participation Governors (Anti-Swarm)
+### 3.2 Topic detail (single object, two lenses)
 
-We enforce three distinct governors to prevent agent swarms from overrunning the system:
+Topic detail always presents:
 
-1. **Influence Falloff (Value Share Governor):** Diminishing returns across active projects/topics per principal nullifier.
-2. **Action Budget (Spam Governor):** Posts/votes/moderation actions per time window per principal nullifier.
-3. **Compute/Analysis Budget (Analysis Governor):** Analyses/day plus per-topic throttles per principal nullifier.
+1. Synthesis panel (`TopicSynthesisV2`)
+2. Thread lens (forum)
 
-All governors apply to the **principal**; familiars consume the same budgets and never multiply influence.
+Forum interaction defaults:
 
-### 4.4 HERMES: The Civic Action Kit
+- reply hard limit 240 chars
+- overflow path `Convert to Article`
+- article publishing is docs-backed and topic-linked
 
-  * **Purpose:** Verified constituent voice via user-initiated civic contact.
-  * **Mechanism:**
-    1.  **Aggregate:** Nodes collect proposals via HRW hashing.
-    2.  **Verify:** LUMA attaches **ZK-Proof of Constituency**.
-    3.  **Facilitate (User-Initiated):**
-          * **Desktop/Mobile:** Generate a local report (PDF) and open native actions (`mailto:`, `tel:`, share sheet).
-          * **Fallback:** Always expose representative contact info for manual submission.
-          * **Automation:** Optional, local-only assist may be explored later; no default form submission.
+### 3.3 Action surface
 
------
+High-salience topics can progress through:
 
-### 4.5 Data Topology & Privacy v0
+- nomination events
+- elevation artifacts (`BriefDoc`, `ProposalScaffold`, `TalkingPoints`)
+- representative forwarding (email/phone/share/export/manual)
 
-TRINITY is local-first, not local-only. Devices hold canonical state; mesh and chain hold public or encrypted replicas. We distinguish:
+## 4. Canonical Information Path (V2-first)
 
-* **Public-by-design objects:** shared civic/economic data (public articles, canonical analyses, aggregate sentiment, project funding).
-* **Sensitive objects:** identity, constituency, per-user sentiment, messages, and wallet↔identity mappings.
+### 4.1 Legacy boundary
 
-In Season 0, main objects:
+`CanonicalAnalysisV1` is legacy/compatibility-only.
+New systems should not treat V1 as canonical.
 
-| Object            | On Device                                                        | Mesh / Gun                                     | On-chain                                        | Cloud / MinIO | Class      |
-|-------------------|------------------------------------------------------------------|------------------------------------------------|--------------------------------------------------|--------------|-----------|
-| CanonicalAnalysis | `localStorage: vh_canonical_analyses`, IndexedDB `vh-ai-cache`   | `vh/analyses/<urlHash> = CanonicalAnalysis`    | –                                                | –            | Public    |
-| Sentiment (v0)    | `localStorage: vh_civic_scores_v1` (per item:perspective)        | –                                              | –                                                | –            | Sensitive |
-| Proposals (v0 UI) | React state only                                                 | –                                              | QF `Project` (recipient/amounts, no metadata)    | –            | Public    |
-| Wallet balances   | React state (`balance`, `claimStatus`)                           | –                                              | `RVU.balanceOf`, `UBE.getClaimStatus`, tx log    | –            | Sensitive |
-| IdentityRecord    | IndexedDB `vh-vault` (`vault` store, encrypted with per-device master key) + in-memory provider runtime | `user.devices.<deviceKey> = { linkedAt }`      | `nullifier` + scaled trustScore in UBE/QF/Faucet | –            | Sensitive |
-| RegionProof       | Local-only (per `spec-identity-trust-constituency.md`)           | – (no v0 usage)                                | –                                                | –            | Sensitive |
-| XP Ledger         | `localStorage: vh_xp_ledger` (per nullifier XP tracks)           | – (or encrypted outbox to Guardian node)       | –                                                | –            | Sensitive |
-| Messages (future) | TBD                                                              | `vh/chat/*`, `vh/outbox/*` (guarded; see below)| –                                                | Attachments  | Sensitive |
+### 4.2 Canonical path
 
-Rules:
+1. News Aggregator ingests and clusters sources into `StoryBundle`.
+2. Topic Digest Builder creates rolling digest from verified discourse.
+3. Topic Synthesis V2 runs per epoch from candidate set.
+4. Deterministic selection publishes accepted synthesis for the epoch.
 
-* Only **public** objects may be stored in plaintext under `vh/*` in the mesh.
-* **Sensitive** objects must either remain on-device only, or be sent via encrypted user-scoped channels (e.g., Gun SEA / outbox) to trusted aggregators.
-* CanonicalAnalysis is public content and never includes nullifiers, district hashes, or wallet addresses.
-* Runtime identity reads use the in-memory identity provider: `getPublishedIdentity()` exposes only a public snapshot (`nullifier`, `trustScore`, `scaledTrustScore`), while `getFullIdentity()` is for same-process consumers that require private fields.
-* Legacy key `vh_identity` is migration-only input (read once, then deleted) and is **not** an active persistence layer.
-* `vh:identity-published` is a hydration signal `CustomEvent` with no identity payload.
+### 4.3 Shared reality semantics
 
-See `docs/specs/spec-data-topology-privacy-v0.md` for the canonical Season 0 topology and invariants.
+- key shape: `{topic_id, epoch}` plus accepted `synthesis_id`
+- deterministic candidate ordering and acceptance
+- all peers resolve the same accepted synthesis for the same epoch inputs
 
-## 5. Unified Development Roadmap
+## 5. Core Domain Contracts
 
-This roadmap is the target planning sequence. For actual delivery status and drift notes, use `docs/foundational/STATUS.md`.
+### 5.1 Topic identity
 
-### Sprint 0: The Foundation (Weeks 1–6) [COMPLETE]
+```ts
+type TopicId = string;
 
-**Goal:** Solvency, Identity Root, and Secure Mesh.
-
-  * **Status:** **CLOSED**. Infra live, Core Logic 100% Coverage, E2E Tracer passing.
-
-### Sprint 1: The "Data Dividend" & Civic Beta (Weeks 7–12) [IN PROGRESS]
-
-**Goal:** User Growth & Canonical Analysis.
-
-  * **GWC:** UBE Drip & Basic Quadratic Funding.
-  * **VENN:** Canonical Analysis Protocol & Civic Decay Logic.
-  * **LUMA:** Region Notary (ZK-Residency) & Multi-Device Linking.
-  * **Deliverable:** Public Beta (v0.1). Users verify, earn UBE, and use shared news analysis.
-
-### Sprint 2: The Civic Nervous System (Weeks 13–20) [NEXT]
-
-**Goal:** The Signal (Analysis, Decay, Voting).
-
-  * **VENN:** The Civic Feed (Lazy Load, Z-Index Cards, Lightbulb Metrics).
-  * **GWC:** Quadratic Funding & Proposal Governance.
-  * **Engine:** AI Optimization (<2s) & Persistent Caching.
-  * **Deliverable:** A fully functional "News App" with Governance capabilities.
-
-### Sprint 3: The Agora - Communication (Weeks 21–26)
-
-**Goal:** The Dialogue (Messaging, Forum).
-
-  * **HERMES:** P2P E2EE Messaging (Direct & Group).
-  * **HERMES:** Threaded Civic Forum (Debate & Counterpoints).
-  * **Deliverable:** Beta v0.8 (Secure Communication).
-
-### Sprint 4: Agentic Foundation (Weeks 27–32)
-
-**Goal:** Safety baseline + unified topics + analysis robustness.
-
-  * **LUMA/HERMES:** Delegation grants + familiar runtime (scopes, budgets).
-  * **VENN:** Quorum synthesis + comment-driven re-synthesis flow.
-  * **Interface:** Unified Topics model (analysis + thread).
-  * **Deliverable:** Safe agentic foundation + unified feed.
-
-### Sprint 5: The Agora - Action (Weeks 33–40)
-
-**Goal:** The Bridge (Docs, Civic Action).
-
-  * **HERMES:** Collaborative Documents (CRDTs).
-  * **HERMES:** Civic Action Kit (facilitation: reports + contact channels).
-  * **Deliverable:** Beta v0.9 (Full Feature Set).
-
-### Sprint 6: The Ironclad Hardening (Weeks 41–48)
-
-**Goal:** Sovereignty & Anti-Collusion (Mainnet Prep).
-
-  * **LUMA:** Memory-Hard VDF (to slow Sybil attacks) & Full Social Recovery.
-  * **GWC:** MACI Governance (Mainnet).
-  * **VENN:** Chaos Testing, Audits, & Performance Tuning.
-  * **Deliverable:** Mainnet "Ironclad" Release (v1.0).
-
------
-
-## 6. Data Models
-
-### 6.1 The "Proof of Human" Session
-
-```json
-{
-  "type": "GWC_BioTethered_Session",
-  "version": "3.1",
-  "device_id": "DEVICE_PUBKEY_HASH",
-  "timestamp": 1699982735,
-  "trustScore": 0.95,
-  "scaledTrustScore": 9500,
-  "nullifier": "nullifier-abc123...",
-  "session_token": "session-device-nonce-timestamp",
-  "client_integrity": { "app_attestation": "Apple_AppAttest_v1" },
-  "proof": {
-    "uniqueness_nullifier": "nullifier-abc123...",
-    "vio_integrity_score": 0.99,
-    "tee_signature": "BASE64_SIGNED_BLOB"
-  }
+interface TopicRef {
+  topic_id: TopicId;
+  kind: 'NEWS_STORY' | 'USER_TOPIC' | 'SOCIAL_NOTIFICATION';
 }
 ```
 
-AttestationVerifier derives a stable nullifier from device- or LUMA-bound keys and issues a per-session token. The nullifier is the canonical human key shared with GWC contracts (via UBE/QF attestation) and VENN civic signals; session tokens are per-session.
+Notes:
 
-### 6.2 The Civic Sentiment Signal
+- `topic_id` is not globally equivalent to URL hash.
+- URL hashes may contribute to `NEWS_STORY` derivation.
 
-We distinguish between event-level signals and aggregate sentiment.
+### 5.2 Story clustering
 
-```typescript
-// Event-level: one user, one point, one interaction
-interface SentimentSignal {
-  topic_id: string;       // Hash of Canonical URL
-  analysis_id: string;    // Hash of the Canonical Analysis Object
-  point_id: string;       // ID of the bias/counterpoint/perspective
-  agreement: 1 | 0 | -1;  // 3-state Agree / None / Disagree
-  weight: number;         // User’s per-topic Lightbulb from engagement, in [0, 2]
+```ts
+interface StoryBundle {
+  story_id: string;
+  topic_id: TopicId;
+  headline: string;
+  canonical_window_start: number;
+  canonical_window_end: number;
+  sources: Array<{
+    source_id: string;
+    url: string;
+    publisher: string;
+    published_at: number;
+    url_hash: string;
+  }>;
+  cluster_method: 'semantic+entity+time';
+  provenance_hash: string;
+}
+```
 
-  constituency_proof: {
-      district_hash: string; 
-      nullifier: string;
-      merkle_root: string;
+### 5.3 Topic digest
+
+```ts
+interface TopicDigest {
+  topic_id: TopicId;
+  window_start: number;
+  window_end: number;
+  verified_comment_count: number;
+  unique_verified_principals: number;
+  key_claims: string[];
+  salient_counterclaims: string[];
+  representative_quotes: string[];
+}
+```
+
+### 5.4 Topic synthesis v2
+
+```ts
+interface TopicSynthesisV2 {
+  schemaVersion: 'topic-synthesis-v2';
+  topic_id: TopicId;
+  epoch: number;
+  synthesis_id: string;
+  inputs: {
+    story_bundle_ids?: string[];
+    topic_digest_ids?: string[];
+    topic_seed_id?: string;
   };
-
-  emitted_at: number;     // Unix timestamp
-}
-
-interface PointStats {
-  agree: number;    // distinct users with final agreement = +1
-  disagree: number; // distinct users with final agreement = -1
-}
-
-// Aggregate-level: mesh / ledger projection
-interface AggregateSentiment {
-  topic_id: string;
-  analysis_id: string;
-
-  // Per point: committed votes only (neutral not counted)
-  point_stats: Record<string, PointStats>;
-
-  // Optional convenience: derived dominant stance per point based on point_stats
-  bias_vector: Record<string, 1 | 0 | -1>;
-
-  // Global engagement signal (function of all user Lightbulb weights, e.g. sum)
-  weight: number;          // Aggregate Lightbulb
-  engagementScore: number; // Additional metric if needed (e.g. entropy, variance)
+  facts_summary: string;
+  frames: Array<{ frame: string; reframe: string }>;
+  warnings: string[];
+  divergence_metrics: {
+    disagreement_score: number;
+    source_dispersion: number;
+    candidate_count: number;
+  };
+  quorum: {
+    required: number;
+    received: number;
+    reached_at: number;
+    timed_out: boolean;
+    selection_rule: 'deterministic';
+  };
+  provenance: {
+    candidate_ids: string[];
+    provider_mix: Array<{ provider_id: string; count: number }>;
+  };
+  created_at: number;
 }
 ```
 
-Invariants:
+Canonical wire-shape is owned by `docs/specs/topic-synthesis-v2.md`; this architecture copy should match that spec.
 
-* For any SentimentSignal, `0 ≤ weight ≤ 2`.
-* For any topic and user, Lightbulb `weight` is updated only via the Civic Decay function on engagement interactions.
-* Per-point aggregates ignore neutral (`0`) when computing `point_stats`; `bias_vector` is derived from `point_stats` (e.g., sign of `agree - disagree`).
-* `AggregateSentiment` is a deterministic function of the stream of SentimentSignal events.
-* `constituency_proof` MUST be derived from a valid RegionProof: `district_hash = publicSignals[0]`, `nullifier = publicSignals[1]` (same UniquenessNullifier as identity), `merkle_root = publicSignals[2]`.
+### 5.5 Sentiment identifiers
 
-See `docs/specs/spec-civic-sentiment.md` for the normative contract across client, mesh, and chain.
-
------
-
-### 6.3 Canonical Analysis (v1)
-
-Canonical Analysis is the canonical record of "what this URL means in VENN-world."
-
-**Schema (`canonical-analysis-v1`):**
-
-```typescript
-type BiasEntry = {
-  bias: string;        // Debate-style claim capturing article’s slant
-  quote: string;       // Direct quote from the article supporting the claim
-  explanation: string; // Why this quote evidences the bias (short, academic)
-  counterpoint: string;// Direct rebuttal / alternative framing
-};
-
-interface CanonicalAnalysisV1 {
-  schemaVersion: 'canonical-analysis-v1';
-  url: string;
-  urlHash: string; // Stable hash of normalized URL
-  summary: string; // 4–6 sentence neutral summary
-  bias_claim_quote: string[];
-  justify_bias_claim: string[];
-  biases: string[];
-  counterpoints: string[];
-  perspectives?: Array<{ frame: string; reframe: string }>;
-  sentimentScore: number; // [-1, 1] overall slant
-  confidence?: number;    // [0, 1] model self-confidence
-  timestamp: number;      // ms since epoch (first write)
+```ts
+interface SentimentSignal {
+  topic_id: TopicId;
+  synthesis_id: string;
+  epoch: number;
+  point_id: string;
+  agreement: -1 | 0 | 1;
+  weight: number; // [0,2]
+  constituency_proof: {
+    district_hash: string;
+    nullifier: string;
+    merkle_root: string;
+  };
+  emitted_at: number;
 }
 ```
 
-**Invariants**
+Civic Decay function:
 
-1. `bias_claim_quote.length === justify_bias_claim.length === biases.length === counterpoints.length`.
-2. Summary and all arrays are derived only from the article text (**fact-only rule**).
-3. `schemaVersion` is required and immutable once written.
+```ts
+next = current + 0.3 * (2 - current);
+```
 
-**Fact-only rule**
+## 6. Identity and Trust Model (Cross-Cutting)
 
-Summaries and bias tables MUST NOT introduce information absent from the source article (no new entities, dates, locations, quantities, or motives).
+### 6.1 Identity primitives
 
-**First-to-file semantics (v1)**
+Primary identity primitives:
 
-* Canonical analysis is keyed by `urlHash`.
-* The first successfully validated analysis for a `urlHash` is reused; later writes cannot overwrite it in v1.
-* Corrections/disagreements are separate signals (votes, sentiment, replies), not mutations of the canonical object.
-* Future versions (e.g., `canonical-analysis-v2`) will introduce quorum synthesis and explicit amendment/supersession; v1 treats the record as append-only. See `docs/specs/canonical-analysis-v2.md`.
+- `principalNullifier` (stable per human)
+- `trustScore` (`0..1`) and `scaledTrustScore` (`0..10000`)
+- `ConstituencyProof` from region proof signals
 
-URLs are normalized upstream; the canonical schema enforces `url` as a valid URL (Zod `.url()`), and hashing always uses the normalized form.
+Invariant:
 
-See `docs/specs/canonical-analysis-v1.md` for the precise wire-format contract and validation rules.
+- same human -> same principal nullifier across identity, sentiment, and economic attestations
 
------
+### 6.2 Trust thresholds
 
-### 6.4 UBE v0 (Universal Basic Equity)
+Season 0 defaults:
 
-* **Trust scale:** 0–10000 (`TRUST_SCORE_SCALE`); `minTrustScore = 5000` (0.5).
-* **Cadence:** `claimInterval = 1 day`; `dripAmount` ~25 RVU (Season 0 default).
-* **Eligibility:** Identity exists, `trustScore ≥ minTrustScore`, `expiresAt > now`, cooldown satisfied.
-* **Scope:** Per-human (per nullifier), not region-based in v0; no lifetime cap, bounded by attestation expiry/policy.
-* **UX:** Surfaced as “Daily Boost” to XP; may mint RVU on testnet or simulate XP-only while contracts harden.
-* **Abuse controls:** Attestation expiry, lowering trustScore, modest payout (floor, not upside).
+| Capability | Threshold |
+|------------|-----------|
+| Verified participation (write/vote) | `trustScore >= 0.5` |
+| UBE daily claim | `scaledTrustScore >= 5000` |
+| High-impact forwarding/elevation/QF-ready actions | `trustScore >= 0.7` |
 
-### 6.5 Faucet v0
+### 6.3 Roles and familiar delegation
 
-Mirrors UBE’s trust- and time-gated pattern for dev/onboarding/early tester bonuses. Separate `dripAmount`, cooldown, and `minTrustScore`; mints RVU via `rvu.mint(msg.sender, dripAmount)`. Not part of the long-term dignity loop.
+Roles:
 
-### 6.6 Quadratic Funding v0
+- Guest: read-only or low-impact views
+- Human: verified participant
+- Constituent: verified + district proof
 
-Implements attested participant registration, project registration, quadratic aggregation, matching pool logic, and withdrawals. In Season 0 the contract is exercised by curators/testers with dev accounts; the public governance UI runs off-chain (seeded proposals, local-only votes/voice credits) and does not expose on-chain QF rounds yet.
+Delegation model:
 
-See `docs/specs/spec-rvu-economics-v0.md` for detailed Season 0 economic semantics.
+- familiar grants are scoped, revocable, and expiring
+- familiar actions are attributable to principal
+- familiar never gets independent influence budget
 
-## 7. Risk Register
+## 7. Services and Runtime Components
 
-| ID | Threat | Layer | Mitigation Strategy |
-| :--- | :--- | :--- | :--- |
-| **R-01** | Injection / Emulation | L0 | **Hardware Attestation:** TEE Signatures required. |
-| **R-02** | Account Renting | L1 | **Bio-Tethering:** Random micro-gestures prevent hand-offs. |
-| **R-03** | Reality Fragmentation | L3 | **Canonical Analysis:** First-to-file protocol + AI Audit. |
-| **R-04** | Legislative Blocking | L3 | **Civic Facilitation:** User-initiated contact via reports + native channels; no automated form submission by default. |
-| **R-05** | Device Loss | L1 | **Recovery:** Multi-device linking & Social Recovery. |
-| **R-06** | Malicious Analysis | L3 | **Distributed Moderation:** Local AI audits & community override votes. |
-| **R-07** | Civic Signal Drift (types/math diverge between client, mesh, and chain) | L1/L3 | **Canonical Contract:** Enforce single spec (`docs/specs/spec-civic-sentiment.md`), shared types in `packages/types`, and Zod schemas in `packages/data-model`. CI blocks on schema mismatch. |
-| **R-08** | Identity/Trust Drift | L1/L2/L3 | **Canonical Contract:** Enforce single spec (`spec-identity-trust-constituency.md`), shared types (`TrustScore`, `UniquenessNullifier`, `ConstituencyProof`), and bridge logic. CI blocks on schema mismatch. |
-| **R-09** | AI Contract Drift | L3 | **Canonical Contract:** Enforce `AI_ENGINE_CONTRACT.md`, `canonical-analysis-v1` schema, and worker/schema tests on prompt/parse/validation. |
-| **R-10** | Constituency De-anonymization | L1/L3 | **Aggregation Only:** Keep `SentimentSignal` local/encrypted; publish only per-district aggregates with cohort thresholds; no `district_hash` on-chain; see `docs/specs/spec-data-topology-privacy-v0.md`. |
-| **R-11** | Mesh Metadata Leakage | L1/L3 | **Mesh Hygiene:** Only public objects in plaintext `vh/*`; sensitive data via encrypted outbox; audit Gun paths; feature-flag chat/outbox until E2EE; see `docs/specs/spec-data-topology-privacy-v0.md`. |
+### 7.1 News Aggregator and clustering
 
------
+Responsibilities:
 
-## 8. Developer Quickstart
+- RSS ingest
+- normalization and dedupe
+- clustering into `StoryBundle`
+- provenance capture for all source URLs
+
+### 7.2 Synthesis services
+
+Responsibilities:
+
+- candidate generation and validation
+- quorum synthesis and deterministic acceptance
+- epoch scheduler and debounce/cap enforcement
+
+Default scheduler parameters:
+
+- debounce 30 minutes
+- daily cap 4/topic
+- discussion-trigger threshold 10 verified comments + 3 unique principals
+
+### 7.3 AI engine router
+
+Default path:
+
+- local inference runtime
+
+Optional paths:
+
+- remote providers (`openai`, `google`, `anthropic`, `xai`) with explicit user consent
+- device-local third-party models where available
+
+Provider invariants:
+
+1. provider ID explicit in settings and provenance metadata
+2. consent UI exposes cost and privacy boundary
+3. telemetry excludes source plaintext and identity fields
+
+### 7.4 HERMES forum/docs/publishing
+
+Capabilities:
+
+- public thread discourse
+- reply-to-article conversion
+- docs-based longform collaboration and publishing
+- nomination signals into elevation flow
+
+### 7.5 Civic Action Kit (Bridge)
+
+Capabilities:
+
+1. representative lookup by `district_hash`
+2. artifact packet generation from elevated topics
+3. native user-initiated forwarding channels
+4. local receipts and aggregate-only public counters
+
+## 8. Participation Governors and Defaults
+
+Governors prevent swarm behavior and keep influence bounded.
+
+### 8.1 Governor categories
+
+1. Action Budget Governor: posts/comments/votes/moderation/actions
+2. Compute Governor: analyses/day and per-topic caps
+3. Influence Governor: bounded contribution semantics through caps and decay
+
+### 8.2 Season 0 default budgets (per principal/day)
+
+| Budget Key | Default |
+|------------|---------|
+| `posts` | 20 |
+| `comments` | 50 |
+| `sentiment_votes` | 200 |
+| `governance_votes` | 20 |
+| `analyses` | 25 |
+| `analyses_per_topic` | 5 |
+| `shares` | 10 |
+| `moderation` | 10 |
+| `civic_actions` | 3 |
+
+### 8.3 Governor invariants
+
+- budgets apply to principals; familiars consume same budget pools
+- denied actions must provide explicit reason in UI
+- caps and thresholds are configuration-driven and auditable
+
+## 9. Economics and Governance Rails
+
+### 9.1 RVU v0
+
+Season 0 RVU posture:
+
+- inflationary proto-asset for ecosystem hardening
+- role-gated minting and controlled distribution channels
+- supports UBE/QF rails and test environment validation
+
+### 9.2 UBE (Daily Boost)
+
+Season 0 default semantics:
+
+- trust-scaled gate (`>= 5000`)
+- claim interval 1 day
+- drip amount ~25 RVU
+
+Product framing:
+
+- presented as Daily Boost and XP-friendly UX
+- wallet detail remains advanced/secondary
+
+### 9.3 Quadratic funding
+
+Season 0 posture:
+
+- contracts active and tested for curated/internal rounds
+- public UX remains simulated/off-chain for most users
+- progression path toward broader on-chain participation remains future-sprint work
+
+### 9.4 XP ledger relationship
+
+XP is the Season 0 participation substrate:
+
+- tracks: civic/social/project
+- local-first storage and privacy boundaries
+- no public per-user XP export
+
+## 10. Data Topology and Privacy
+
+### 10.1 Placement matrix
+
+| Object | Device | Mesh public | Mesh encrypted | Chain | Cloud | Class |
+|---|---|---|---|---|---|---|
+| StoryBundle | Cache/index | `vh/news/stories/<storyId>` | - | - | optional blobs | Public |
+| TopicDigest | Cache/index | `vh/topics/<topicId>/digests/<digestId>` | optional | - | - | Public-derived |
+| TopicSynthesisV2 | Cache/index | `vh/topics/<topicId>/epochs/<epoch>/synthesis` | - | optional anchor hash | - | Public |
+| SentimentSignal (event) | Authoritative | forbidden | `~<devicePub>/outbox/sentiment/*` | - | - | Sensitive |
+| AggregateSentiment | Cache | `vh/aggregates/topics/<topicId>/epochs/<epoch>` | - | optional aggregate anchor | - | Public |
+| Linked-social OAuth tokens | Vault only | forbidden | optional encrypted backup | - | - | Secret |
+| Linked-social notifications | Vault/local cache | sanitized card projection only | optional | - | - | Sensitive |
+| Docs drafts | Vault/E2EE stores | forbidden | `~<devicePub>/docs/*` encrypted | - | encrypted attachments | Sensitive |
+| Published articles | Local cache | `vh/topics/<topicId>/articles/<articleId>` | - | optional anchor hash | media blobs | Public |
+| Elevation artifacts | Local authoritative | metadata only | optional encrypted payload | - | optional export blob | Sensitive/Public-mixed |
+| Civic receipts | Local authoritative | aggregate counters only | optional encrypted backup | - | - | Sensitive |
+
+### 10.2 Path and secrecy rules
+
+- Public V2 namespaces:
+  - `vh/news/stories/*`
+  - `vh/topics/*/epochs/*`
+  - `vh/topics/*/digests/*`
+  - `vh/discovery/*`
+  - `vh/forum/*`
+- Vault-only secrets never belong under public `vh/*` paths.
+- No public object may include both district hash and human identifier.
+
+## 11. Sprint Alignment (Direction)
+
+This is target direction; actual progress lives in `STATUS.md`.
+
+### 11.1 Sprint summary map
+
+| Sprint | Intent | Architecture emphasis |
+|--------|--------|-----------------------|
+| 0 | Foundation | monorepo, contracts, baseline runtime |
+| 1 | Core bedrock | identity and analysis baseline |
+| 2 | Civic nervous system | feed quality, sentiment, governance UX scaffolding |
+| 3 | Agora communication | messaging + forum reliability |
+| 4 | Agentic foundation | delegation, budgets, V2 synthesis path |
+| 5 | Bridge/action | docs, reply/article, elevation, forwarding |
+| 6 | Hardening | security, performance, audit readiness |
+
+### 11.2 Near-term implementation priorities
+
+1. News aggregator and story clustering completion
+2. Topic Synthesis V2 quorum and epoch services
+3. Linked-social integration path and privacy boundaries
+4. Docs-backed longform publishing
+5. Elevation artifact generation and policy engine
+6. Representative forwarding and receipt loop
+7. Consent-forward provider switching UI
+
+## 12. Risk Register (Current)
+
+| ID | Threat | Layer | Mitigation |
+|----|--------|-------|------------|
+| R-01 | Identity spoofing / emulation | L0/L1 | attestation hardening + trust gating |
+| R-02 | Swarm amplification by delegated agents | L1/L3 | principal budgets + explicit high-impact approvals |
+| R-03 | Drift between synthesis contracts and UI | L3 | single V2 spec + shared types/tests |
+| R-04 | Public leakage of sensitive civic data | L1/L3 | strict topology rules + schema linting |
+| R-05 | Spam in civic forwarding | L3 | trust >= 0.7 + constituency checks + action budgets |
+| R-06 | Model/provider behavior drift | L3 | explicit provider policy + provenance + consent UI |
+| R-07 | Legacy naming regressions (`analysis_id`) | L3 | V2-first writes, read-only aliases for migration |
+
+## 13. Developer Quickstart (Reference)
 
 ```bash
-# 1. Clone the Monorepo
-git clone git@github.com:trinity-os/core.git
-cd core
-
-# 2. Install Dependencies
+# 1. Clone and install
 pnpm i
 
-# 3. Start Local Universe (Docker: Gun, MinIO, Anvil)
+# 2. Boot local infra
 pnpm vh bootstrap up
 
-# 4. Initialize Keys & Contracts
+# 3. Initialize keys/contracts
 pnpm vh bootstrap init --deploy-contracts
 
-# 5. Run the Client (PWA + Edge AI)
+# 4. Run web app
 pnpm --filter @vh/web-pwa dev
 ```
 
------
-
-## 9. System Prompt for AI Agents
-
-*Paste this context at the start of every AI coding session.*
-
-```text
-You are a Senior Engineer building the TRINITY Bio-Economic OS (GWC x LUMA x VENN).
-
-Core Constraints:
-1.  **Local-First:** User data stays on device. Cloud is for encrypted transport only.
-2.  **Hardware-Rooted:** Critical actions require TEE/Secure Enclave signatures.
-3.  **Shared Reality:** VENN Analysis is generated locally but deduplicated via Mesh.
-4.  **Strict Modularity:** Files MUST NOT exceed 350 LOC. Split logic aggressively.
-5.  **Testing:** 100% Line/Branch coverage required.
-6.  **Stack:** React, Rust (WASM), Solidity, GUN (via wrapper only), WebLLM.
-
-Current Task: [Insert Task]
-```
+Use this architecture as contract guidance; verify code reality and drift in `docs/foundational/STATUS.md`.

--- a/docs/foundational/TRINITY_Season0_SoT.md
+++ b/docs/foundational/TRINITY_Season0_SoT.md
@@ -1,0 +1,166 @@
+# TRINITY (VENN/HERMES × LUMA × GWC) — Season 0 Ship Snapshot (V2‑First)
+
+**Purpose:** one **single tree** that gives **frontend + backend** devs the full picture (UX surfaces + contracts + privacy boundaries + gates).  
+**Stance:** **Design & build for Synthesis V2**. Anything labeled V1 is **legacy/compat only**.  
+**Legend:** ✅ Implemented · 🟡 Partial · 🔴 Stubbed · ⚪ Planned  
+**Last updated:** 2026‑02‑08
+
+---
+
+- **TRINITY Bio‑Economic OS (Season 0)** — UX: “clean news + structured disagreement + legible recognition”; Tech: local‑first identity + edge AI + mesh + economic rails
+  - **Non‑negotiables (Product / UX / Policy)**  
+    - **A — V2‑first synthesis**: quorum + epochs + divergence; V1 is legacy/compat only  
+    - **B — Topics feed has 3 surfaces**: **News**, **Topics/Threads**, **Linked‑Social Notifications**  
+    - **C — Elevation to projects**: News/Topics/Articles can be nominated; thresholds → auto‑draft brief + proposal scaffold; users can forward to reps via email/phone  
+    - **D — Reddit‑like thread mechanics**: sort New/Top; peer‑votes affect visibility; Reply ≤ **240 chars**; overflow → “Convert to Article” (Docs)  
+    - **E — Collaborative docs**: multi‑author E2EE P2P drafting; private iteration → publish to feed  
+    - **F — GWC thesis**: value attention/thought‑effort; redirect value to humans (not advertisers); REL/AU later  
+    - **G — AI provider switching**: default **WebLLM**; allow user‑selected remote providers + local models; explicit opt‑in + cost/privacy clarity
+
+  - **Season 0 defaults (numbers devs should code against unless explicitly changed)**  
+    - **Trust gates:** Human ≥ **0.5** (`scaled ≥ 5000`); QF (future/curated) ≥ **0.7** (`scaled ≥ 7000`)  
+    - **Synthesis epochs:** debounce **30 min**; daily cap **4/topic**  
+    - **Topic re‑synthesis (discussion‑driven):** every **10 verified comments** with **≥3 unique verified principals** since last epoch  
+    - **Early accuracy pass:** first **5 verified opens** produce critique/refine candidates (per topic epoch)  
+    - **Budgets/day (per principal nullifier):** posts=20, comments=50, sentiment_votes=200, governance_votes=20, analyses=25 (max 5/topic), shares=10, moderation=10, civic_actions=3  
+    - **UBE (“Daily Boost”):** 1/day; `minTrustScore=5000`; drip ≈ **25 RVU** (Season 0 default)
+
+  - **Prime Directives (engineering hard constraints)** ✅ (target architecture)
+    - **Local is Truth** ✅ — UX: fast/offline; identity + sensitive civic state on device; mesh/chain only public or encrypted replicas  
+    - **Physics is Trust** 🟡/🔴 — UX: verified humans matter; Tech: hardware attestation intended; current verifier is dev‑stub  
+    - **Math is Law** 🟡 — UX: support becomes legible + anti‑plutocracy later; Tech: QF now, MACI later  
+    - **Shared Reality** 🟡 — UX: same synthesis view for everyone; Tech: deterministic V2 quorum selection per epoch  
+    - **Civic Facilitation (no dark automation)** ⚪ — UX: user‑initiated email/phone/share/export; no default form submission  
+    - **Human Sovereignty (Familiars)** 🟡/⚪ — UX: assistants help but don’t multiply influence; Tech: scoped/expiring/revocable grants; inherit principal budgets  
+    - **Strict Discipline** ✅ — 350 LOC cap (tests/types/ABI exempt) + 100% line/branch coverage gate
+
+  - **Hero loops (what the user experiences)** 🟡
+    - **Civic Dignity Loop** — UX: “I read, I judge; my district signal moves; I’m recognized”
+      - Onboard → (optional) prove district → feed → open topic → stance on frames → see aggregates → claim Daily Boost  
+    - **Governance / Elevation Loop** — UX: “this matters → it becomes a project → support is visible → it reaches reps”
+      - Nominate story/topic/article → threshold → auto‑draft brief + proposal scaffold → simulated QF support → forward‑to‑rep (email/phone)  
+    - **Docs / Longform Loop** — UX: “draft privately → collaborate → publish → discuss → elevate”
+      - E2EE doc draft → publish as topic → thread engagement → auto‑nominate (articles) → elevate
+
+  - **User‑visible UI surfaces (front‑end map)** 🟡
+    - **App Shell / Navigation** ✅ — UX: stable app frame; boot/hydrate before high‑impact actions  
+    - **Unified Topics Feed (3 surfaces)** 🟡 — UX: one stream; filter chips: All / News / Topics / Social; sort: Latest / Hottest / My Activity
+      - **TopicCard (shared)** 🟡 — UX: headline/title + category tags + 👁 Eye + 💡 Lightbulb + comment count  
+      - **NewsCard (clustered story)** ⚪ — UX: **one headline = one story** synthesized across outlets; tap opens TopicDetail  
+      - **TopicCard (user topic/thread)** 🟡 — UX: looks like news once discussion is rich enough (summary + frames + thread)  
+      - **SocialNotificationCard** ⚪ — UX: platform badge; tap expands to embedded platform view; swipe‑left returns & dismisses card  
+    - **Topic Detail (“one object, two lenses”)** 🟡 — UX: synthesis up top; conversation below; stable, readable, non‑churny
+      - **Synthesis Panel (V2)** ⚪/🟡 — UX: “just‑the‑reported‑facts” + Frame/Reframe table; epoch badge; warnings if sources disagree  
+      - **Frame/Reframe Table (stance grid)** 🟡 — UX: per row: Agree (+1) / Neutral (0) / Disagree (‑1); toggles are 3‑state, no spam  
+      - **Thread Lens (Forum)** ✅/🟡 — UX: Reddit‑like; sort New/Top; votes float good replies; stance‑aware threading  
+      - **Reply Composer** ⚪/🟡 — UX: 240‑char hard limit; “Convert to Article” CTA when exceeded  
+      - **Article Viewer / Doc‑backed Post** ⚪ — UX: longform reads like a doc; still has comments + votes underneath  
+      - **Proposal / Support Widget** 🟡 — UX: “Support” amount A → shows **voice credits = A²**; shows estimated match in hypothetical pool  
+    - **Control Panel / Profile** 🟡 — UX: “my score, my boosts, my impact”
+      - **Daily Boost button** 🟡 — UX: claim once/day → XP bump; (optional) testnet RVU mint behind scenes  
+      - **XP Tracks** ✅ — UX: civicXP / socialXP / projectXP (simple bars/number)  
+      - **Wallet (Advanced)** 🟡 — UX: RVU balance + claim status for testers; hidden behind “Advanced”  
+      - **District Dashboard** ⚪/🟡 — UX: per‑district aggregates + comparisons; never shows individual stance  
+    - **Messaging (HERMES)** 🟢 — UX: private chat + group coordination (also where Familiar control lives)  
+      - **Familiar Control Panel** 🟡/⚪ — UX: create/revoke grants; see what the familiar can do; review “high impact” requests  
+    - **Docs (HERMES Docs)** ⚪ — UX: collaborative editor (multi‑author), private by default; publish as Topic/Article  
+    - **Civic Action Kit (Bridge)** ⚪ — UX: “make it real” without creepy automation
+      - **Rep Contact Directory** ⚪ — UX: picks reps for your district; shows public email + phone  
+      - **Export/Share actions** ⚪ — UX: generate brief PDF; open mailto/tel/share‑sheet; store a receipt locally
+
+  - **Core domain objects (shared contracts devs should align on)** 🟡
+    - **Identity (LUMA primitives)** 🟡/🔴 — Tech: gates everything valuable; UX: “verified humans count”
+      - `trustScore: 0..1`, `scaledTrustScore: 0..10000`  
+      - `principalNullifier` (UniquenessNullifier) — invariant across civic signals + XP ledger + economic attestations  
+      - `ConstituencyProof { district_hash, nullifier, merkle_root }` — district attribution without doxxing  
+      - **Roles:** Guest (read‑only) → Human (PoH) → Constituent (PoH + RegionProof)
+    - **Unified Topic (the feed atom)** 🟡 — Tech: one topicId across analysis + thread + metrics; UX: one card type
+      - `topicId` (deterministic)  
+      - `kind: NEWS_STORY | USER_TOPIC | SOCIAL_NOTIFICATION`  
+      - `categories[]` (interest tailoring + discovery)  
+      - `thread` (always present): Thread carries `{ topicId, isHeadline, sourceUrl?, urlHash? }` ✅  
+      - `synthesis` (latest): `{ schemaVersion:'topic-synthesis-v2', epoch, synthesisId }` ⚪  
+      - `metrics`: `{ eye, lightbulb, comments, hotness }` 🟡  
+    - **News story clustering (Aggregator → StoryBundle)** ⚪ — Tech: 1 story = many sources; UX: 1 headline in feed
+      - RSS ingest → normalize → cluster → **StoryBundle** (sources + dedup)  
+      - Synthesis input is **all reporting** on the story (not a single URL)  
+      - Frames/counterframes come from bias/perspective patterns *across outlets* (plus thread digest)
+    - **Topic Synthesis V2 (epochal + quorum)** ⚪/🟡 — UX: stable “versioned” updates, not constant churn
+      - Inputs:
+        - News: `StoryBundle` (+ optional `TopicDigest`)  
+        - User topic: `TopicSeed` + rolling `TopicDigest`  
+      - Per‑epoch pipeline:
+        - gather **N=5** candidate syntheses (verified submission gate)  
+        - candidates must critique/refine prior epoch (“accuracy mandate”)  
+        - quorum synthesizer emits: `factsSummary`, `frames[]`, `warnings[]`, `divergenceMetrics`, `provenance`  
+        - deterministic selection so all peers show the same accepted synthesis
+    - **Civic signals (Eye / Lightbulb / Sentiment)** 🟡 — UX: simple toggles, capped influence
+      - **Civic Decay** ✅ — `next = current + 0.3*(2-current)` (monotonic; bounded [0,2])  
+      - **Eye** 🟡 — per‑user/topic read interest ∈ [0,2]; updated on “full read”; aggregate shown in feed/dashboards  
+      - **Lightbulb** 🟡 — per‑user/topic engagement ∈ [0,2]; updated on stance changes; aggregate shown in feed/dashboards  
+      - **Sentiment** 🟡 — tri‑state per `(topic_id, point_id)` in `{+1,0,-1}`  
+      - **Privacy boundary** ✅:
+        - event‑level `SentimentSignal` is sensitive (device / encrypted channel only)  
+        - public surfaces show aggregates only (`AggregateSentiment`, district rollups)  
+        - never publish `{district_hash, nullifier}` pairs
+    - **Forum (HERMES Forum)** 🟢 — UX: threaded discourse under every topic
+      - Threads/comments are public objects; votes affect visibility (not identity)  
+      - Stance‑aware threading (concur/counter/discuss) ✅/🟡  
+    - **Docs (HERMES Docs)** ⚪ — UX: longform + collaboration
+      - Convert Reply → Article; articles can be co‑authored privately then published  
+    - **Projects / Proposals (proposal‑threads)** 🟡/⚪ — UX: “topics can become funded projects”
+      - Thread has `proposal?: ProposalExtension { fundingRequest, recipient, status, qfProjectId?, ... }` 🟡  
+      - Season 0 public: off‑chain simulated support; internal: curated on‑chain QF rounds  
+    - **Elevation artifacts** ⚪ — UX: “press‑ready” civic packet
+      - `BriefDoc` (communications brief)  
+      - `ProposalScaffold` (project framing + funding request)  
+      - `TalkingPoints[]` (phone script bullets)  
+      - `Receipt` (what was sent, when, to whom — stored locally)
+
+  - **Data topology & privacy (what lives where)** 🟡
+    - **On device (authoritative)** ✅
+      - Identity vault: encrypted IndexedDB `vh-vault` / `vault`  
+      - XP ledger + budgets (per nullifier)  
+      - Raw sentiment events + per‑user stance state  
+      - Linked‑social OAuth tokens + notification objects (sensitive)  
+      - Draft docs (private, E2EE)  
+    - **Mesh / Gun (public)** 🟡
+      - Public topics + threads/comments  
+      - Public syntheses (V2) + public aggregates (no identity leakage)  
+    - **Mesh / Gun (encrypted channels)** 🟢/⚪
+      - E2EE messaging  
+      - Optional encrypted outbox to a Guardian Node (sensitive replication)  
+    - **Chain (EVM contracts)** 🟡
+      - RVU v0, UBE v0, Faucet (dev), QuadraticFunding, MedianOracle  
+      - Season 0: safe defaults; public UX stays “XP‑first”  
+    - **Cloud blob store (MinIO/S3)** ⚪
+      - Encrypted attachments >100KB (docs exports, media), referenced from mesh objects
+
+  - **Engines & services (back‑end / infra pieces)** 🟡
+    - **News Aggregator Service** ⚪ — Tech: RSS ingest → normalize → cluster → StoryBundle; UX: “one story, many sources”
+    - **Synthesis Engine (V2 quorum + epochs)** ⚪ — Tech: candidate gather + critique/refine + synthesize + deterministic accept
+    - **AI Engine Router (model switching)** 🟡
+      - Default: **WebLLM / LocalMlEngine** (edge inference) ✅/🟡  
+      - Optional: Remote providers (OpenAI/Google/Anthropic/xAI) ⚪ — requires explicit opt‑in + cost/privacy disclosure  
+      - Optional: device‑local model (if available) ⚪ — “free but inconsistent”  
+    - **Topic Digest Builder** ⚪ — Tech: rolling digest from comments for re‑synthesis input
+    - **Rep Directory / District mapper** ⚪ — Tech: map `district_hash → reps`; UX: “one‑click email/call”
+    - **Guardian Node (optional)** ⚪/🟡 — Tech: encrypted storage for sensitive outbox; optional aggregate compute; never receives plaintext identity
+    - **Attestor Bridge** 🟡/⚪ — Tech: takes session proofs → registers participants for UBE/QF; Season 0 mostly stubbed
+
+  - **Participation governors (anti‑swarm)** ✅/🟡 — UX: rate limits feel fair; denial explains why
+    - **Action budgets (per nullifier/day)** ✅ — posts, comments, votes, analyses, shares, moderation, civic actions  
+    - **Compute budget** 🟡 — analyses/day + per‑topic cap  
+    - **Familiar inheritance** 🟡 — familiars consume principal budgets; never multiply influence
+
+  - **Implementation reality check (what exists today vs target)** 🟡
+    - **VENN analysis pipeline** 🟡 — end‑to‑end pipeline exists; defaults to WebLLM engine in non‑E2E; remote engines not wired  
+    - **HERMES Messaging** 🟢 — E2EE working  
+    - **HERMES Forum** 🟢 — threads + votes working; unified topics fields landed (`topicId`, `sourceUrl`, `urlHash`, `isHeadline`)  
+    - **HERMES Docs** ⚪ — planned (Sprint 5)  
+    - **Bridge / Civic Action Kit** ⚪ — planned/redesign (Sprint 5)  
+    - **LUMA** 🔴 — attestation + uniqueness mostly stubbed (do not treat as real sybil defense yet)  
+    - **GWC contracts** 🟡 — contracts implemented; public testnet deploy incomplete; Season 0 UX should remain XP‑first
+
+  - **Legacy / migration (explicitly non‑blocking but must be tracked)** 🟡
+    - CanonicalAnalysisV1 exists in code/specs — **do not design new UX around it**; use V2 TopicSynthesis and treat V1 as compat/migration only

--- a/docs/foundational/trinity_project_brief.md
+++ b/docs/foundational/trinity_project_brief.md
@@ -1,326 +1,269 @@
-# TRINITY - VH/LUMA/GWC Project Brief  
-*A parallel operating system for identity, wealth, and governance in the post‑labour era.*
+# TRINITY Project Brief (Season 0, V2-first)
 
----
+A local-first civic-and-economic operating system that turns verified human attention and thought effort into legible civic signal and project momentum.
 
-## 0. One‑paragraph summary
-
-We’re building a **parallel civic-and-economic OS for the post‑labour world**: a news app that turns engagement into real political and economic weight, backed by a cryptographic identity and wealth layer that can eventually track global wealth and pay people for being thoughtful, creative humans.
-
----
-
-## 1. The problem this aims at
-
-### Two big fractures
-
-1. **Labour is decoupling from value.**  
-   AI is steadily eating cognitive work. The old deal—*“work for a wage, earn dignity”*—is breaking. If we don’t redesign how value flows, “human usefulness” becomes a rounding error in GDP.
-
-2. **Reality itself is fracturing.**  
-   News is polluted, feeds are optimized for rage, and we’re atomized into echo chambers. Democratic systems still pretend “the public” is a coherent, well‑informed actor. It isn’t.
-
-### The core bet
-
-- People still **need** challenge, contribution, and belonging.
-- In a world where AI can do the work, the scarce thing is not labour, but **verified human intent**: what we care about, what we judge, what we choose to build together.
-- It is possible to build an infrastructure where:
-  - Information is cleaner,
-  - Human sentiment is trustworthy,
-  - And value flows to people for contributing ideas, coordination, and culture.
-
----
+## 0. One paragraph summary
 
-## 2. The architecture in one diagram (in words)
-
-The system operates three tightly‑coupled layers:
-
-1. **LUMA – Identity / “Proof of Human”**  
-   - Hardware‑attested identity (device secure enclave + biometrics / liveness).  
-   - One real human → one **nullifier** (stable per-human key, reused everywhere).  
-   - Outputs a **trustScore** (0..1) and a **scaledTrustScore** (0..10000) for gating actions (sessions, UBE, QF), with a metadata-minimizing, local-first architecture: sensitive identity and constituency data stays on-device; only aggregated or encrypted signals ever leave.  
-   - Optional region proof → the person becomes a **constituent** in a district, without doxxing their address.
-
-2. **GWC – Global Wealth Chain (Economics)**  
-   - **RVU** (Real Value Unit): the v0 token on an EVM chain, the proto‑version of the future **GWU** that aims to track global wealth.  
-   - **UBE** (Universal Basic Equity): a daily drip of RVU for attested humans (trust‑gated basic income).  
-   - **Quadratic Funding (QF):** an on‑chain engine to route RVU toward public and community projects, amplifying widely supported ideas.  
-   - **Median Oracle:** a commit‑reveal oracle that will eventually be used to tie GWU to a real‑world wealth index (RGU‑Real).
-
-3. **VENN – Interface / Civic Layer**  
-   - A local‑first “super app” that:
-     - Shows a **Topics stream** (external headlines + user threads),  
-     - Generates or fetches **canonical analyses** for articles,  
-     - Lets users vote on biases and counterpoints,  
-     - Hosts discussions and proposals,  
-     - Unifies headlines and threads into a single Topic object (analysis + discussion in one place),  
-     - Exposes a **control panel** for score/wallet and district‑level metrics,  
-     - Includes a **Familiar Control Panel** (in Messaging) to manage delegated agents.
-
-A useful mental model:
-
-> LUMA = the immune system,  
-> GWC = the circulatory system,  
-> VENN = the nervous system.
-
----
-
-## 3. Season 0 product: what users actually experience
+TRINITY Season 0 ships a unified civic product: one feed that blends clustered news stories, user-born topics, and linked-social notifications; one topic detail view that combines deterministic Topic Synthesis V2 with thread discourse; and one elevation path that turns high-salience topics into editable civic artifacts and user-initiated representative forwarding. Identity and trust (LUMA), discourse/docs/action UX (VENN/HERMES), and economic rails (GWC) are designed to work together while preserving strict privacy boundaries.
 
-In **Season 0**, the app is deliberately framed as a **news & participation app with points**, not as a “crypto wallet”.
+## 1. Problem and thesis
 
-### 3.1 The Civic Dignity Loop (news → influence → reward)
+### 1.1 Two fractures we target
 
-1. **Onboard & prove “humanness”**  
-   - The user creates an identity.  
-   - Behind the scenes, LUMA/attestors give them:
-     - A **trust score** (0..1) and **scaledTrustScore** (0..10000),  
-     - A unique **nullifier** (one per human, reused in VENN, GWC, and constituency proofs),  
-   - Optional region proof → they become a constituent of district X.
-   - Optional: configure a **familiar** (delegated agent) to draft/triage; it acts on the user’s behalf, consumes the user’s budgets, and never multiplies influence.
+1. Information fracture.
 
-2. **Scroll a clean Topics stream**  
-   - The stream is a list of **Topics** (external headlines + user threads), not just clickbait headlines.  
-   - Each card has:
-     - Headline,  
-     - Source,  
-     - Two metrics:
-       - an **Eye** (how many humans have really read this),  
-       - a **Lightbulb** (how much engagement/judgement it has attracted).
+- public discourse is fragmented and manipulation-prone
+- users see isolated URLs, not integrated story context
 
-3. **Open canonical analysis instead of raw article**  
-   - Tapping a headline opens a **canonical analysis**, not the original site.  
-   - The view shows:
-     - A **summary** that strips down to verifiable facts,  
-     - A **bias / counterpoint table**:
-       - Each row is a *perspective* → frame + reframe,  
-       - Each cell has its own **+ / –** buttons.
-   - **Early‑open accuracy:** the first **N** verified opens (default 5) each produce a candidate analysis that re‑reads the source and **critiques/refines** prior summaries/tables for maximum accuracy.
-   - **Ongoing refresh:** after every **N verified comments** (default 10, min 3 unique principals), the synthesis is refreshed so the summary and frames evolve with the discussion.
+2. Participation fracture.
 
-4. **Cast nuanced sentiment**  
-   - For each bias or counterpoint, the user can:
-     - Agree (+1),  
-     - Disagree (‑1),  
-     - Or stay neutral (0).  
-   - It’s a tri‑state toggle (no spamming multiple votes).  
-   - Under the hood:
-     - Each cell has its own +/-; clicking the same stance again clears it,  
-     - The first active stance on a topic sets Lightbulb to `1.0`; additional active stances decay toward `2.0`,  
-     - Removing stances steps the engagement back (all neutral → `0`),  
-     - Per‑user, per‑article engagement is capped, so no one can dominate metrics.
+- individual civic effort is often invisible and non-compounding
+- people cannot easily move from discussion to coordinated action
 
-5. **See their voice in a constituent dashboard**  
-   - A dashboard shows:
-     - How **their district** feels about key frames,  
-     - How that compares to global sentiment,  
-     - Which topics are “hot” where they live.  
-   - Anonymous guests see charts, but **only verified humans** move the canonical metrics.
+### 1.2 Core thesis
 
-6. **Get a daily “boost”**  
-   - Once per day, an attested human can claim a **Daily Boost** (backed by UBE).  
-   - Their visible **score** (XP) ticks up.  
-   - Under the hood, that claim can also mint testnet **RVU** to their wallet. Only verified humans above threshold trustScore can claim or vote (QF).
+- verified human intent is scarce and economically/civically meaningful
+- cleaner synthesis + structured disagreement improves civic signal quality
+- participation should remain legible to the user without exposing identity
 
-The loop feels like:
+## 2. Architecture in plain language
 
-> “I see the world more clearly, my judgement affects real metrics for my district, and the system acknowledges my presence and effort.”
-
-### 3.2 The Governance Loop (idea → proposal → support)
-
-For Season 0, the governance loop is **soft‑launched**, with hard economics incubating underneath.
-
-1. **Start from a topic**  
-   - On a topic page (e.g. public transit), there is a **“Related Proposals”** section:
-     - “Community‑owned EV charging,”  
-     - “Civic data trust,” etc.
-
-2. **Explore proposals**  
-   - A proposal card shows:
-     - Title & summary,  
-     - Requested budget (in RVU units),  
-     - Recipient address,  
-     - Current support (For/Against).
-   - **Unified model:** proposals are elevated threads (proposal‑threads) within the Topic, not separate objects.
-
-3. **Support with “weight”**  
-   - The user chooses an amount (in RVU units) to back it with.  
-   - The UI shows **voice credits = amount²** (quadratic feel).  
-   - In Season 0:
-     - For general users: this is tracked in an **off‑chain QF simulation** (and in XP),  
-     - For testers: it can be wired directly to the **QuadraticFunding** contract on testnet.
-
-4. **See hypothetical funding outcomes**  
-   - The user sees:
-     - “Your support: X”,  
-     - “Total support: Σ”,  
-     - “Estimated match: Z if this proposal were in a QF round with pool P”.
+TRINITY combines three systems:
 
-This establishes the mental model:
+1. LUMA (identity and trust)
+2. VENN/HERMES (information, discourse, docs, and action UX)
+3. GWC (economic and governance rails)
 
-> “My engagement and earned weight don’t just stay as stats—they can be pointed at proposals and amplified into actual project funding.”
+### 2.1 LUMA: identity and trust primitives
 
----
-
-## 4. XP, RVU, and “when does this become money?”
-
-### 4.1 XP now, RVU later (by design)
-
-Right now:
+LUMA provides the trust substrate:
 
-- Users see **XP** / a “score”.  
-- Under the hood, the system maintains a multi‑track ledger per human (keyed by nullifier):
-
-  - `civicXP` – news & bias voting, civic actions, sentiment,  
-  - `socialXP` – discussions, contributions in HERMES,  
-  - `projectXP` – concrete proposal/project work.
-
-XP is the **canonical record** of a human’s contribution in Season 0.
-
-RVU exists on‑chain, but:
+- stable principal nullifier
+- trust score (`0..1`) and scaled trust (`0..10000`)
+- optional constituency proof (`district_hash`, `nullifier`, `merkle_root`)
 
-- Primarily for:
-  - UBE pilot,  
-  - Faucet (dev/onboarding),  
-  - Quadratic Funding test rounds.  
-- It is not yet surfaced as “money” to the broad user base.
-- Season 0 RVU is an inflationary proto-asset (no index logic) minted via bootstrap, UBE, and Faucet; GWU mechanics come later.
-
-### 4.2 Future: Global Wealth Unit (GWU) and REL
-
-The long‑term GWC roadmap includes:
-
-- **GWU (Global Wealth Unit)**  
-  - An index‑tracking asset that aims to mirror a regulated benchmark of global wealth (RGU‑Real), not a fiat peg.  
-  - Supply/price governed via:
-    - Primary issuance auctions,  
-    - Arbitrage vaults,  
-    - Bounded open market operations.  
-  - Legally positioned as a **benchmark‑referencing crypto asset**, not a classic “stablecoin”.
-
-- **REL (Resource Exchange Layer)**  
-  - A marketplace where **verified human intent** (Attention Units) is converted into:
-    - Fee credits,  
-    - Compute credits,  
-    - And ultimately GWU/RVU flow, funded by AI labs and other buyers of high‑quality human signal.
-
-Season 0 is about **building the rails and habits**: clean analyses, reliable sentiment, real humans. Once those are hardened and compliant, XP can be mapped into a proper RVU/GWU position and the “XP is just a number” phase naturally evolves into “this is your share of the system”.
-
----
+Role ladder:
 
-## 5. Economic layer v0: what is already real
-
-Under the hood, the contracts are concrete:
-
-- **RVU (Real Value Unit)**  
-  - ERC‑20 with role‑gated minters/burners.  
-  - Currently **inflationary**, via:
-    - Bootstrap mint,  
-    - UBE drip,  
-    - Faucet for dev/test.  
-  - QF uses RVU for contributions and matching pools.
-
-- **UBE (Universal Basic Equity)**  
-  - Attestor‑managed per‑identity record:
-    - `trustScore`, `expiresAt`, `nullifier`, `lastClaimAt`.  
-  - `claim()`:
-    - Enforces trust + expiry + cooldown,  
-    - Mints a fixed RVU amount per interval.  
-  - In the app, this is surfaced as a “Daily Boost” to XP.
-
-- **Faucet**  
-  - Similar pattern to UBE, used for onboarding and dev/testing.
-
-- **QuadraticFunding**  
-  - Attested participants (trust threshold),  
-  - Projects registered by admin/curators,  
-  - Voting in RVU with quadratic aggregation,  
-  - Matching pool and withdrawals.  
-  - Season 0: on-chain rounds are curated/internal; public proposal UI uses local-only voting to test UX before wiring real RVU.
-
-**Privacy stance:** Canonical analyses and aggregate sentiment are public; per-user sentiment, region proofs, and wallet/identity mappings are treated as sensitive and never written to public meshes or chains.
-
-- **MedianOracle**  
-  - Commit–reveal median price oracle, ready to feed into future GWU index logic, not yet wired into RVU directly.
-
-Season 0 provides a **live testbed** for economic research and engineering:
-- Real humans,  
-- Real engagement data,  
-- Real contract flows in a controlled setting,  
-- With the safety of “XP now, money later” for general users.
-
----
-
-## 6. Who this is for and why it matters
-
-### 6.1 For developers
-
-- This is not “just another wallet” or “just another feed”: it is an **OS for a parallel institution**.  
-- Key ingredients:
-  - Local‑first, mesh‑synced app (React + P2P storage + Edge AI),  
-  - EVM contracts (RVU, UBE, Faucet, QF, MedianOracle),  
-  - Hardware‑attested identity with clear Guest vs Human vs Constituent semantics.  
-- Engineering discipline:
-  - Strong modularization and test coverage,  
-  - “Physics is trust, math is law” as an actual design constraint.
-
-### 6.2 For investors & partners
-
-- The **economic engine** targets the post‑labour world:
-  - Long‑term store of value not tied to a single fiat,  
-  - Revenue from AI labs and other buyers of clean human signal (via REL),  
-  - A built‑in **distribution mechanism** (UBE + QF) that routes value to humans who maintain the informational and civic commons.  
-
-- Season 0–2 are:
-  - **Low‑regret** (XP framing, testnets),  
-  - **High‑leverage** (identity, analysis, and governance rails ready for scale).
-
-### 6.3 For politicians & public officials
-
-- The platform gives representatives a **real‑time, verifiable pulse** on their constituents:
-  - Sentiment is:
-    - **Per‑district**, not just “the internet thinks…”,  
-    - **Human‑gated** (Proof of Human),  
-    - **Frame‑aware** (e.g. “how many people agree with *this* framing vs *that* reframe”).  
-- Instead of occasional, expensive polling, they can see:
-  - Which topics are most salient in their district,  
-  - How opinion breaks down across competing narratives,  
-  - How proposals and projects are gaining or losing support over time.  
-
-- Because identity is privacy‑preserving and attested, officials get:
-  - Signals they can trust more than anonymous social media noise,  
-  - A channel for **sending targeted questions** (“what do you think about option A vs B?”) and reading structured responses,  
-  - A way to discover and support **bottom‑up proposals** that already have demonstrated backing from their actual constituents.
-
-In short, it is a tool for moving from noisy outrage to **structured, district‑level input** that can plug directly into legislative and budget decisions.
-
-### 6.4 For journalists & researchers
-
-- A live testbed for:
-  - **Bias-aware, multi‑perspective news consumption**,  
-  - **Constituency‑aware sentiment tracking**,  
-  - **Governance experiments** (QF, PoH‑gated polling, later MACI) in the wild.  
-
-- It enables empirical study of:
-  - How verified humans actually reason and coordinate in the presence of AI,  
-  - How alternative wealth and governance mechanisms might stabilize a turbulent information ecosystem.
-
-### 6.5 For the general public
-
-- Right now:
-  - A cleaner, less manipulative way to read the news,  
-  - A way to see “all the frames at once” instead of falling into one echo chamber,  
-  - A feeling that “my input shows up somewhere real,” not just in a comment abyss.
-
-- Over time:
-  - A place where:
-    - Curiosity,  
-    - Ideas,  
-    - Cultural work,  
-    - Civic projects  
-    actually move resources, not just feed ad networks.
-
----
-
-## 7. One‑line summary
-
-This project quietly wires together a verified‑identity news app, a dignity‑first economic layer, and a governance engine so that when AI has eaten most “jobs”, humans still have a clear way to see reality, express will, and receive a fair, measurable share of the wealth their collective intent creates.
+- Guest: can read
+- Human: verified (`trustScore >= 0.5`), can participate in weighted civic flows
+- Constituent: verified + constituency proof, can contribute to district-level aggregates
+
+### 2.2 VENN/HERMES: product surfaces and interaction loop
+
+VENN/HERMES is the visible product experience:
+
+- one feed with three surfaces:
+  - News
+  - Topics/Threads
+  - Linked-social notifications
+- one topic detail with two lenses:
+  - Synthesis panel (`TopicSynthesisV2`)
+  - Thread/forum lens
+- one longform path:
+  - reply hard cap 240 chars
+  - overflow -> Convert to Article -> Docs draft -> publish back to topic
+
+### 2.3 GWC: economic and governance rails
+
+GWC provides Season 0 rails:
+
+- RVU token infrastructure
+- UBE daily claim path (surfaced as Daily Boost)
+- QF contracts for curated/internal rounds
+- XP-first public UX with governance economics incubating beneath
+
+## 3. Season 0 product contract
+
+### 3.1 Unified feed and discovery
+
+Feed contract:
+
+- cards from three surfaces in one stream
+- filter chips: `All`, `News`, `Topics`, `Social`
+- sort modes: `Latest`, `Hottest`, `My Activity`
+
+News contract:
+
+- one card represents one clustered story, not one URL
+- ingest and clustering produce `StoryBundle` as synthesis input
+
+### 3.2 Topic detail and synthesis
+
+Topic detail contract:
+
+- synthesis + thread always appear as one object
+- synthesis is epochal and deterministic (`TopicSynthesisV2`)
+- warnings/divergence shown when candidate disagreement is meaningful
+
+Synthesis cadence defaults:
+
+- early accuracy pass: first 5 verified opens can generate critique/refine candidates
+- re-synthesis: every 10 verified comments with >=3 unique verified principals
+- debounce: 30 minutes
+- daily cap: 4 per topic
+
+### 3.3 Forum and longform publishing
+
+Forum contract:
+
+- write/vote trust gate at `>= 0.5`
+- sort modes: New/Top/Hot
+- reply hard cap 240 chars
+
+Longform contract:
+
+- overflow reply path to docs-backed article
+- private-first drafting, optional collaboration
+- publish article back into topic/feed and forum context
+
+### 3.4 Civic elevation and representative forwarding
+
+Elevation contract:
+
+- nomination targets: news/topic/article
+- threshold crossing emits artifact generation
+- artifacts:
+  - BriefDoc
+  - ProposalScaffold
+  - TalkingPoints
+
+Forwarding contract:
+
+- rep selection by `district_hash`
+- channels: `mailto`, `tel`, share, export, manual fallback
+- no default automated form submission
+- local receipt authoritative; public counters aggregate-only
+
+## 4. Trust gates, budgets, and safety defaults
+
+### 4.1 Trust thresholds
+
+- Human participation threshold: `trustScore >= 0.5` (`scaled >= 5000`)
+- High-impact (forwarding/elevation finalize/QF-ready) threshold: `trustScore >= 0.7` (`scaled >= 7000`)
+
+### 4.2 Participation budgets (per principal per day)
+
+Season 0 coding defaults:
+
+- posts: 20
+- comments: 50
+- sentiment votes: 200
+- governance votes: 20
+- analyses: 25 (max 5/topic)
+- shares: 10
+- moderation: 10
+- civic actions: 3
+
+Familiars inherit these budgets and consume principal limits.
+
+### 4.3 Familiar boundary
+
+- familiar supports draft/triage/suggest by policy
+- high-impact actions require explicit human approval
+- familiar actions are attributable and revocable
+
+## 5. Civic and economic legibility
+
+### 5.1 XP tracks (public-facing now)
+
+Season 0 participation appears as XP tracks:
+
+- `civicXP` (reading, stance, civic forwarding)
+- `socialXP` (discussion and communication)
+- `projectXP` (proposal/project-oriented work)
+
+XP is local-first and per principal nullifier.
+
+### 5.2 RVU/UBE/QF rails (active but backgrounded)
+
+- UBE is exposed as Daily Boost UX
+- RVU and QF infra exist for internal/curated rounds
+- public Season 0 experience remains XP-first
+
+### 5.3 District dashboard
+
+Dashboard intent:
+
+- show district-level aggregates and trend comparisons
+- avoid individual exposure
+- maintain strict aggregate-only public semantics
+
+## 6. Data topology and privacy posture
+
+### 6.1 Local-first placement
+
+Authoritative on device:
+
+- identity vault data
+- per-user sentiment events
+- profile/contact data for forwarding
+- draft docs and private artifacts
+- XP ledger and budget state
+
+### 6.2 Mesh and chain boundaries
+
+Public mesh/chain should contain:
+
+- public topic/thread/synthesis objects
+- aggregate civic metrics
+- aggregate forwarding counters
+
+Sensitive data must remain:
+
+- local only
+- or encrypted in user-scoped channels
+
+Never public:
+
+- OAuth tokens
+- private keys
+- raw profile/contact PII
+- identity linkage pairs that de-anonymize users
+
+## 7. AI strategy and user control
+
+Default:
+
+- local inference path (WebLLM / local model runtime)
+
+Optional:
+
+- remote providers with explicit user opt-in
+- provider selector must expose cost/privacy boundary
+
+Provider switching is a product feature with clear consent and provenance semantics, not a hidden implementation detail.
+
+## 8. Season 0 north-star epics
+
+1. News aggregator + story clustering
+2. Topic Synthesis V2 quorum/epoch pipeline
+3. Linked-social notifications in unified feed
+4. Reply-to-Article docs publishing flow
+5. Nomination thresholds + elevation artifacts
+6. Representative directory + forwarding + receipts
+7. Provider switching consent UX
+
+## 9. Who this brief serves
+
+### 9.1 Developers
+
+- provides cross-system contracts and defaults to code against
+- clarifies trust/budget/privacy boundaries before implementation
+- anchors migration away from V1 analysis semantics
+
+### 9.2 Partners and operators
+
+- explains why product is XP-first while economic rails mature
+- clarifies governance and compliance boundaries in Season 0
+- details where operational risk controls exist (trust gates, budgets, privacy)
+
+### 9.3 Public stakeholders
+
+- shows how the system converts civic discussion into structured, non-anonymous-but-private aggregate signal
+- explains why representative forwarding is user-initiated, not dark automation
+
+## 10. Legacy boundary and migration note
+
+- `CanonicalAnalysisV1` remains compatibility-only.
+- New specs, UX contracts, and sprint plans should key on V2 (`TopicId`, `StoryBundle`, `TopicSynthesisV2`, `synthesis_id`, `epoch`).
+- Any retained V1 naming should be treated as read-compat aliases only.

--- a/docs/specs/canonical-analysis-v2.md
+++ b/docs/specs/canonical-analysis-v2.md
@@ -1,139 +1,18 @@
-# canonical-analysis-v2 Contract (Quorum Synthesis)
+# canonical-analysis-v2 (Compatibility Alias)
 
-**Status:** Planned (Direction Locked)  
-**Owner:** VENN Engine / Data Model  
-**Reference:** `System_Architecture.md` §6.3, `docs/specs/canonical-analysis-v1.md`
+Status: Compatibility alias
+Owner: VENN Engine / Data Model
 
-## 1. Goals
+This document is retained for backward references.
+Canonical Season 0 V2 behavior is specified in:
 
-- Mitigate first-to-file poisoning by requiring a quorum of candidate analyses.
-- Preserve transparency: show agreement vs. divergence across candidates.
-- Keep canonical analyses public, identity-free, and reproducible from source text.
-- Ensure early candidate analyses explicitly critique and refine summaries/tables against the source text for accuracy.
+- `docs/specs/topic-synthesis-v2.md`
 
-## 2. Default Parameters (v2)
+## Mapping
 
-- `quorumSize`: 5
-- `timeoutMs`: 24h (`86_400_000`)
-- `challengeWindowMs`: 7d (`604_800_000`)
-- `weighting`: `equal` (trust-weighted is optional)
+- `canonical-analysis-v2` canonical object -> `TopicSynthesisV2`
+- `analysis_id` -> `synthesis_id`
+- URL-only input model -> `StoryBundle` / `TopicDigest` / `TopicSeed`
+- first-to-file progression -> epoch + quorum deterministic selection
 
-## 3. Type Definition
-
-> `AnalysisResult` is the same contract as v1 (see `docs/specs/canonical-analysis-v1.md`).
-
-```typescript
-export interface CandidateAnalysis {
-  id: string;              // Hash of candidate payload
-  urlHash: string;
-  analysis: AnalysisResult;
-  engine?: {
-    id: string;            // 'remote-gateway', 'local-mlc', etc.
-    kind: 'remote' | 'local';
-    modelName: string;
-  };
-  warnings?: string[];     // Guardrail warnings (non-fatal)
-  createdAt: number;       // ms since epoch
-}
-
-export interface DivergencePoint {
-  topic: string;           // e.g., "cause", "intent", "impact"
-  positions: Array<{
-    candidateId: string;
-    stance: string;        // Short description of the candidate's position
-  }>;
-}
-
-export interface QuorumMeta {
-  quorumSize: number;      // Default: 5
-  timeoutMs: number;       // Default: 24h
-  reachedAt: number;       // When quorum reached or timeout elapsed
-  candidateCount: number;  // How many candidates were collected
-  weighting: 'equal' | 'trust-weighted';
-}
-
-export interface CanonicalAnalysisV2 {
-  schemaVersion: 'canonical-analysis-v2';
-  url: string;
-  urlHash: string;
-  timestamp: number;       // ms since epoch (canonicalization time)
-
-  // Quorum metadata
-  quorum: QuorumMeta;
-  candidateIds: string[];  // IDs of candidates included in synthesis
-
-  // Canonical synthesis output
-  synthesis: AnalysisResult;
-  divergence: DivergencePoint[];
-
-  // Optional supersession
-  supersedes?: string;     // analysis_id of previous canonical record
-  supersededAt?: number;   // ms since epoch
-}
-```
-
-## 4. Quorum Flow
-
-### 4.1 Candidate Gathering
-
-- The first open of a new `urlHash` creates a **candidate analysis** and writes it to:
-  - `vh/analyses/<urlHash>/candidates/<candidateId>`
-- Subsequent opens continue adding candidates until:
-  - `candidateCount >= quorumSize`, or
-  - `timeoutMs` elapses (default 24h).
-- Candidate submission stops once a canonical v2 record exists.
-- **Verified-only:** candidate submission requires a verified human session (principal nullifier). Familiars may submit only on behalf of a verified principal and consume the same budgets.
-- **Accuracy mandate:** each candidate analysis MUST:
-  - Re-read the original article/post.
-  - Critique and refine prior candidate summaries/bias tables for accuracy.
-  - Preserve the right to disagree; candidates should not be forced to converge.
-
-### 4.2 Synthesis
-
-- When quorum is reached (or timeout triggers):
-  - A synthesis engine compares candidate analyses to the source text.
-  - It produces `synthesis` (an `AnalysisResult`) plus a `divergence` table.
-- Divergence is surfaced as perspectives rather than hidden disagreement.
-
-### 4.3 Periodic Re-Synthesis (Comment-Driven)
-
-- After canonicalization, the analysis is refreshed after every **N verified comments** on the linked thread.
-- Defaults:
-  - `N = 10` verified comments since the last synthesis.
-  - Minimum **3 unique verified principals** since the last synthesis.
-  - Debounce: at most one re-synthesis per **30 minutes**.
-  - Daily cap: **4** re-syntheses per topic.
-- Re-synthesis produces a new canonical record that **supersedes** the prior version.
-
-### 4.4 Canonicalization
-
-- The canonical record is written to:
-  - `vh/analyses/<urlHash>` (schemaVersion `canonical-analysis-v2`).
-- The canonical `analysis_id` remains the hash of the canonical analysis object.
-
-### 4.5 Challenge & Supersession (Planned)
-
-- A challenge window (default 7 days / `604_800_000` ms) allows supersession if new evidence emerges.
-- Superseding records include `supersedes` + `supersededAt` and replace the canonical pointer.
-- Previous canonical records may be archived under:
-  - `vh/analyses/<urlHash>/versions/<analysisId>`
-
-## 5. Invariants
-
-- No identity or constituency fields in candidates or canonical records.
-- `candidateIds.length === quorum.candidateCount`.
-- Canonical synthesis MUST reference the source article only (fact-only rule).
-- Divergence entries MUST reference existing `candidateId`s.
-
-## 6. Privacy & Replication
-
-- Candidate and canonical analyses are public analyses of public articles.
-- Replication to mesh is allowed in plaintext under `vh/analyses/*`.
-- If a user opts out of sharing, candidates may remain local only, but quorum may not be reached.
-
-## 7. Testing Requirements
-
-- Candidate pool: add, dedupe, and stop on quorum/timeout.
-- Synthesis: produces valid `AnalysisResult` + divergence table.
-- Canonicalization: `CanonicalAnalysisV2` validates and is immutable until superseded.
-- Supersession: new canonical replaces pointer and references `supersedes`.
+Any new implementation work should use `topic-synthesis-v2` directly.

--- a/docs/specs/spec-civic-sentiment.md
+++ b/docs/specs/spec-civic-sentiment.md
@@ -1,66 +1,53 @@
-# Civic Sentiment & Engagement Spec
+# Civic Sentiment and Engagement Spec
 
-Version: 0.1  
-Status: Canonical for Sprints 2–3
+Version: 0.2
+Status: Canonical (V2-first)
 
-This document is the normative contract for engagement and sentiment across client, mesh, and chain. All implementations must conform to the types, formulas, and invariants defined here.
+Normative contract for sentiment, Eye, and Lightbulb behavior in Season 0.
 
-## 1. Domain Concepts
+## 1. Core identifiers
 
-- `topic_id` – stable topic key (urlHash for URL topics; deterministic thread-derived hash for native threads).
-- `analysis_id` – stable ID/hash of the canonical analysis object.
-- `point_id` – ID for a bias/counterpoint/perspective cell.
-- `user_id` / `nullifier` – identity linkage via LUMA.
-- `weight` – per-user-per-topic Lightbulb engagement weight in `[0, 2]`.
-- `agreement` – per `(topic_id, point_id)` stance in `{-1, 0, +1}`.
-- `UniquenessNullifier` – stable, pseudonymous human key from LUMA.
-- `district_hash` – hash of a region code (e.g., US-CA-12), used for constituency aggregation.
-- `ConstituencyProof` – `{ district_hash, nullifier, merkle_root }` derived from RegionProof public signals.
+- `topic_id`: `TopicId` for a topic object (`NEWS_STORY`, `USER_TOPIC`, or `SOCIAL_NOTIFICATION`)
+- `synthesis_id`: ID of accepted `TopicSynthesisV2` artifact
+- `epoch`: synthesis epoch number for the topic
+- `point_id`: claim/frame row identifier within synthesis
+- `agreement`: `-1 | 0 | 1`
+- `weight`: per-user Lightbulb contribution in `[0,2]`
 
-**Field naming convention (v0):**
-- Wire/event payloads use `snake_case` fields (`topic_id`, `analysis_id`, `point_id`, `constituency_proof`, `district_hash`) for compatibility with existing stored data and schemas.
-- Application-local variables/hooks may use `camelCase` (`topicId`, `analysisId`, `pointId`) and map to wire fields at emission boundaries.
+Legacy note:
 
-## 2. Event-Level Contract: SentimentSignal
+- `analysis_id` is deprecated for new write paths.
+- Compatibility readers may map `analysis_id` to `synthesis_id` during migration.
+
+## 2. Event-level contract (sensitive)
 
 ```ts
-// One user, one point, one interaction
 interface SentimentSignal {
-  topic_id: string;       // Stable topic key (urlHash or thread-derived)
-  analysis_id: string;    // Hash of the Canonical Analysis Object
-  point_id: string;       // ID of the bias/counterpoint/perspective
-  agreement: 1 | 0 | -1;  // 3-state Agree / None / Disagree
-  weight: number;         // User’s per-topic Lightbulb (engagement), in [0, 2]
+  topic_id: string;
+  synthesis_id: string;
+  epoch: number;
+  point_id: string;
+  agreement: -1 | 0 | 1;
+  weight: number; // [0,2]
 
   constituency_proof: {
     district_hash: string;
-    nullifier: string;     // UniquenessNullifier or its hash
+    nullifier: string;
     merkle_root: string;
   };
 
-  emitted_at: number;     // Unix timestamp
+  emitted_at: number;
 }
 ```
 
-`weight` is the user’s engagement Lightbulb for this topic (from table interactions), not their read score; Eye is derived separately from per-topic read events. Per cell the UI uses `+` / `-` toggles with neutral implicit; clicking the same stance again clears it. `constituency_proof` is derived from a RegionProof as defined in `spec-identity-trust-constituency.md`.
+Rules:
 
-Invariants:
+1. One user has one final stance per `(topic_id, epoch, point_id)`.
+2. `agreement = 0` is neutral and non-counting in point aggregates.
+3. Familiars cannot add separate sentiment identities.
+4. Event-level signals are sensitive and must remain local/encrypted.
 
-- `0 ≤ weight ≤ 2`.
-- For any topic and user, `weight` is updated only via the Civic Decay function on engagement interactions.
-- `agreement` is a 3-state toggle; there is no partial sentiment.
-- `constituency_proof.nullifier` equals the user’s identity nullifier.
-- `district_hash` MUST come from a valid RegionProof (or dev stub shape).
-- Sentiment is per **principal nullifier** only; familiars cannot create additional voters or weight.
-- Optional local-only debug metadata (e.g., `emitted_via_familiar_id`) MAY exist in memory but MUST NOT be published to mesh or chain.
-
-Emission rules:
-
-- Emit on any change to `agreement` for a `(topic_id, point_id)`.
-- Emit when constituency proof changes for the user to preserve rollup integrity.
-- `constituency_proof` is derived from a RegionProof as defined in `spec-identity-trust-constituency.md` (dev stub allowed; field shape must match).
-
-## 3. Aggregate Contract: AggregateSentiment
+## 3. Aggregate contract (public)
 
 ```ts
 interface PointStats {
@@ -70,89 +57,66 @@ interface PointStats {
 
 interface AggregateSentiment {
   topic_id: string;
-  analysis_id: string;
-
-  // Per point: committed votes only (neutral not counted)
+  synthesis_id: string;
+  epoch: number;
   point_stats: Record<string, PointStats>;
-
-  // Optional convenience: dominant stance per point based on point_stats
-  bias_vector: Record<string, 1 | 0 | -1>;
-
-  // Global engagement signal (function of all user weights)
-  weight: number;          // Aggregate Lightbulb (sum)
-  engagementScore: number; // Optional metric (entropy/variance) to show spread
+  bias_vector: Record<string, -1 | 0 | 1>;
+  lightbulb_weight: number;
+  eye_weight: number;
+  engagement_score?: number;
 }
 ```
 
-Computation guidelines:
+Aggregation requirements:
 
-- `point_stats` are unweighted counts of final `agreement = +1` (agree) and `agreement = -1` (disagree); neutral (`0`) is not counted.
-- `bias_vector` is derived from `point_stats` (e.g., sign of `agree - disagree`) or stored distribution.
-- Aggregate Lightbulb should be deterministic (e.g., sum of weights or averaged per unique user) and documented in the consuming service; each user’s contribution is capped at `2`.
+- only aggregate outputs are public
+- no nullifiers in aggregate payloads
+- district dashboards expose aggregate-only slices
 
 ## 4. Civic Decay
 
-Formula: `E_new = E_current + 0.3 * (2.0 - E_current)`.
+Formula:
 
-Pseudocode:
+`E_new = E_current + 0.3 * (2.0 - E_current)`
 
-```ts
-export function calculateDecay(current: number): number {
-  return current + 0.3 * (2.0 - current);
-}
+Properties:
 
-export function applyDecay(current: number): number {
-  return Math.min(2, Math.max(0, calculateDecay(current)));
-}
-```
+- monotonic increase per qualifying interaction
+- bounded to `[0,2]`
+- used for both Eye (reads) and Lightbulb (engagement) with separate state tracks
 
-Example progression (starting at `0.0`): `0.0 → 0.6 → 1.02 → 1.314 → 1.5198 → 1.6639 → …` approaching `2.0`.
+## 5. Eye and Lightbulb semantics
 
-Invariants:
+Eye:
 
-- Monotonic increase per step; cannot exceed `2.0`.
-- Idempotent per interaction: one qualifying interaction = one decay step.
-- Only this function may update `weight`.
-- For Eye: each read (expanding an analysis) applies one decay step to `eye_weight(topic, user)`.
-- For Lightbulb: each engagement interaction (stance change, feedback) applies one decay step to `lightbulb_weight(topic, user)` and drives `SentimentSignal.weight`. Lightbulb is derived from the number of active stances on the topic: first active stance sets weight to `1.0`, each additional active stance applies the decay step toward `2.0`; clearing stances decrements accordingly (all neutral → `0`).
+- tracks read interest per `(topic_id, user)`
+- increments on full read/expand events
+- aggregate Eye is derived from per-user Eye values
 
-## 5. Lifecycle & Storage
+Lightbulb:
 
-- **Client state:** `useSentimentState` stores `agreement` per `(topic_id, point_id)`; `useEngagementState` stores per-topic engagement `weight`; `useReadTracker` (or `useReadState`) stores per-topic `eye_weight` applying decay on each expand/read.
-- **Types:** `packages/types` exports `SentimentSignal` and `AggregateSentiment`.
-- **Schemas:** `packages/data-model` hosts `SentimentSignalSchema` and `AggregateSentimentSchema` (Zod) mirroring the above.
-- **Engine:** `packages/ai-engine/src/decay.ts` implements `calculateDecay` / `applyDecay` using this spec.
-- **Persistence:** Local store → Gun mesh → chain/ledger projections consume the same validated events.
+- tracks engagement per `(topic_id, user)`
+- driven by stance interactions
+- first active stance sets baseline, further active stances decay toward 2.0
 
-## 6. Test Invariants
+## 6. Storage and topology
 
-- All emitted events validate via `SentimentSignalSchema.parse`.
-- Civic Decay tests prove monotonic, bounded progression and clamp behavior at 0 and 2.
-- Eye read scores use the decay function: repeated reads yield monotonic increase in `eye_weight(topic, user)`, bounded in `[0, 2]`.
-- Neutral (`agreement = 0`) is tracked per user but never appears in `point_stats`.
-- Lightbulb uses the decay output on engagement interactions only.
-- UI tests enforce 3-state sentiment toggles and persistence across reloads.
-- Integration tests round-trip: UI interaction → `SentimentSignal` → `AggregateSentiment` projection with deterministic results.
+- `SentimentSignal` event-level records: local or encrypted outbox only
+- public mesh: aggregate-only projections
+- on-chain civic/economic contracts remain aggregate-only with no district-identity linkage
 
-## 7. Eye (Read Interest) Semantics
+## 7. District dashboard privacy rule
 
-- For each `(topic_id, user)` track a per-topic read score `eye_weight ∈ [0, 2]`.
-- On each full read/expand of the analysis, apply `calculateDecay`/`applyDecay` to update `eye_weight`.
-- Aggregated Eye for a topic is a deterministic function of all `eye_weight` values (sum). An optional secondary metric is the count of users with `eye_weight > 0`.
-- Eye reflects reading interest, including repeat visits; it does not use `SentimentSignal` and does not affect Lightbulb `weight`.
+District dashboards must remain aggregate-only:
 
-## 8. Privacy & Topology
+- no per-user lines
+- no joinable `{district_hash, nullifier}` pairs
+- publish only when cohort thresholds are met
 
-Event-level `SentimentSignal` objects are **sensitive**:
+## 8. Testing invariants
 
-- They bind `agreement` and `weight` to a `constituency_proof` (district_hash + nullifier).
-- They MUST NOT be stored in plaintext on the public mesh or chain.
-- They SHOULD remain on-device or be sent via encrypted outbox to a trusted aggregator (e.g., Guardian Node).
-
-Public-facing and mesh-replicated data must use **AggregateSentiment** and similar aggregate structures only:
-
-- No per-user nullifiers.
-- No raw `RegionProof` or `ConstituencyProof`.
-- `district_hash` appears only in per-district aggregates, never joined with individual identifiers.
-
-On-chain contracts (UBE, Faucet, QF) remain region-agnostic; they do not consume `district_hash` or per-user sentiment. See `docs/specs/spec-data-topology-privacy-v0.md` for placement rules.
+1. Signal schema validation for every emitted event.
+2. Decay monotonic/bounded tests for Eye and Lightbulb.
+3. Toggle semantics tests (`+/-` and neutral reset).
+4. Aggregate projection determinism tests by `(topic_id, synthesis_id, epoch)`.
+5. Privacy tests: ensure district dashboard payloads are aggregate-only.

--- a/docs/specs/spec-hermes-messaging-v0.md
+++ b/docs/specs/spec-hermes-messaging-v0.md
@@ -289,7 +289,7 @@ function handleMessage(message: Message) {
 ### 4.1 Session Gating
 
 *   **Requirement:** Messaging requires a valid LUMA session (identity + attestation).
-*   **No Additional Threshold:** HERMES Messaging does not introduce any additional trustScore threshold beyond whatever the session gate uses (per `System_Architecture.md` §4.1.5).
+*   **No Additional Threshold:** HERMES Messaging does not introduce any additional trustScore threshold beyond whatever the global identity/session gate uses (see `docs/foundational/System_Architecture.md` identity and trust model).
 *   **UI Enforcement:** If `useIdentity()` returns no active session, the Messaging UI shows a "Create identity to start messaging" gate.
 
 ---

--- a/docs/specs/spec-linked-socials-v0.md
+++ b/docs/specs/spec-linked-socials-v0.md
@@ -1,0 +1,100 @@
+# Linked Socials Spec (v0)
+
+Version: 0.1
+Status: Canonical for Season 0
+Context: Optional linked-social account connection and notification cards.
+
+## 1. Scope
+
+Provide optional linked-social notifications in the unified feed while keeping OAuth tokens private.
+
+## 2. Connection and auth contract
+
+```ts
+type SocialProviderId = 'x' | 'reddit' | 'youtube' | 'tiktok' | 'instagram' | 'other';
+
+interface LinkedSocialAccount {
+  providerId: SocialProviderId;
+  accountId: string;
+  displayName?: string;
+  connectedAt: number;
+  status: 'connected' | 'revoked' | 'expired';
+}
+
+interface OAuthTokenRecord {
+  providerId: SocialProviderId;
+  accountId: string;
+  accessToken: string;
+  refreshToken?: string;
+  expiresAt?: number;
+  scopes: string[];
+  updatedAt: number;
+}
+```
+
+Storage rule:
+
+- `OAuthTokenRecord` is vault-only and must never appear on public mesh paths.
+
+## 3. Notification object contract
+
+```ts
+interface SocialNotification {
+  id: string;
+  schemaVersion: 'social-notification-v0';
+  topic_id: string;
+  providerId: SocialProviderId;
+  accountId: string;
+  type: 'mention' | 'reply' | 'repost' | 'quote' | 'message' | 'other';
+  title: string;
+  previewText?: string;
+  linkUrl?: string;
+  createdAt: number;
+  seenAt?: number;
+  dismissedAt?: number;
+}
+```
+
+Feed card behavior:
+
+1. render platform badge and summary
+2. allow embedded context view when supported
+3. allow dismiss action that returns user to feed context
+
+## 4. Unified feed integration
+
+- Notifications appear under `Social` surface and optionally `All`.
+- Ranking in `All` is delegated to topic discovery/ranking spec.
+
+## 5. Storage and paths
+
+On-device (authoritative):
+
+- vault: OAuth tokens
+- local cache: notification objects and dismiss state
+
+Optional public projection (sanitized only):
+
+- `vh/social/cards/<cardId>` containing no tokens/account secrets
+
+## 6. Privacy and telemetry
+
+Forbidden in logs/telemetry:
+
+- access tokens
+- refresh tokens
+- provider secrets
+- private message body content
+
+Allowed telemetry:
+
+- provider ID
+- event type
+- seen/dismiss timings
+
+## 7. Tests
+
+1. Vault-only token placement checks.
+2. Notification card render and dismiss flow.
+3. Embedded-view open/close behavior.
+4. Sanitization tests for any public card projection.

--- a/docs/specs/spec-news-aggregator-v0.md
+++ b/docs/specs/spec-news-aggregator-v0.md
@@ -1,0 +1,103 @@
+# News Aggregator Spec (v0)
+
+Version: 0.1
+Status: Canonical for Season 0
+Context: RSS ingest, normalization, clustering, and story bundle publication.
+
+## 1. Scope
+
+Convert many source URLs into one story object for feed consumption and V2 synthesis inputs.
+
+Pipeline:
+
+1. RSS ingest
+2. normalization and dedupe
+3. story clustering
+4. `StoryBundle` publish with provenance
+
+## 2. Inputs and ingest
+
+```ts
+interface FeedSource {
+  id: string;
+  name: string;
+  rssUrl: string;
+  trustTier?: 'primary' | 'secondary';
+  enabled: boolean;
+}
+
+interface RawFeedItem {
+  sourceId: string;
+  url: string;
+  title: string;
+  publishedAt?: number;
+  summary?: string;
+  author?: string;
+}
+```
+
+Normalization requirements:
+
+- canonicalize URLs and hash to `url_hash`
+- strip tracking params
+- dedupe exact URL and near-duplicate title+time windows
+
+## 3. Story clustering contract
+
+```ts
+interface StoryBundle {
+  schemaVersion: 'story-bundle-v0';
+  story_id: string;
+  topic_id: string;
+  headline: string;
+  summary_hint?: string;
+  cluster_window_start: number;
+  cluster_window_end: number;
+  sources: Array<{
+    source_id: string;
+    publisher: string;
+    url: string;
+    url_hash: string;
+    published_at?: number;
+    title: string;
+  }>;
+  cluster_features: {
+    entity_keys: string[];
+    time_bucket: string;
+    semantic_signature: string;
+  };
+  provenance_hash: string;
+  created_at: number;
+}
+```
+
+`story_id` and `topic_id` must be stable for the same cluster window and feature set.
+
+## 4. Provenance requirements
+
+Every story must preserve source-level provenance:
+
+- publisher and source ID
+- canonical URL and URL hash
+- publication time when available
+- deterministic provenance hash over sorted source list
+
+No source URLs should be dropped from provenance if used in clustering/synthesis.
+
+## 5. Mesh/storage paths
+
+- `vh/news/stories/<storyId>`
+- `vh/news/index/latest/<storyId>`
+- optional: `vh/news/source/<sourceId>/<itemId>` for debug snapshots
+
+## 6. Privacy and safety
+
+- News artifacts are public and must not include identity fields.
+- OAuth/social tokens are out-of-scope and forbidden in this subsystem.
+
+## 7. Tests
+
+1. URL normalization and dedupe behavior.
+2. Stable story ID generation for equivalent clusters.
+3. Provenance hash determinism.
+4. Multi-source cluster generation from overlapping feed items.

--- a/docs/specs/spec-topic-discovery-ranking-v0.md
+++ b/docs/specs/spec-topic-discovery-ranking-v0.md
@@ -1,0 +1,89 @@
+# Topic Discovery and Ranking Spec (v0)
+
+Version: 0.1
+Status: Canonical for Season 0
+Context: Unified feed composition across News, Topics, and Social surfaces.
+
+## 1. Scope
+
+Compose and rank one feed from three source surfaces:
+
+1. News (`StoryBundle` backed)
+2. Topics/threads (`TopicSynthesisV2` + forum activity)
+3. Linked-social notifications
+
+## 2. Feed controls
+
+Required controls:
+
+- Filter chips: `All`, `News`, `Topics`, `Social`
+- Sort modes: `Latest`, `Hottest`, `My Activity`
+
+## 3. Discovery item contract
+
+```ts
+type FeedKind = 'NEWS_STORY' | 'USER_TOPIC' | 'SOCIAL_NOTIFICATION';
+
+interface FeedItem {
+  topic_id: string;
+  kind: FeedKind;
+  created_at: number;
+  latest_activity_at: number;
+  hotness: number;
+  eye: number;
+  lightbulb: number;
+  comments: number;
+  my_activity_score?: number;
+}
+```
+
+## 4. Ranking semantics
+
+`Latest`:
+
+- sort by `latest_activity_at` desc
+
+`Hottest`:
+
+- sort by `hotness` desc
+- hotness should combine recency + engagement signals deterministically
+
+`My Activity`:
+
+- sort by user-local activity score (reads, comments, votes, follows)
+- must not expose identity-linked state in public payloads
+
+## 5. Hotness baseline formula
+
+Reference formula (tunable coefficients):
+
+```txt
+hotness =
+  w1 * log1p(eye) +
+  w2 * log1p(lightbulb) +
+  w3 * log1p(comments) +
+  w4 * freshness_decay(latest_activity_at)
+```
+
+All coefficients and decay parameters must be config-driven and versioned.
+
+## 6. Cohort threshold and privacy rules
+
+- District or cohort-specific boosts require minimum cohort sizes before activation.
+- No ranking payload may include person-level identifiers.
+- If cohort requirements are unmet, system falls back to global ranking without district personalization.
+
+## 7. Storage and paths
+
+- `vh/discovery/items/<topicId>`
+- `vh/discovery/index/<filter>/<sort>/<cursor>`
+
+These objects must remain token-free and identity-free.
+
+## 8. Tests
+
+1. Filter correctness for All/News/Topics/Social.
+2. Sort correctness for Latest/Hottest/My Activity.
+3. Deterministic hotness ranking given fixed inputs.
+4. Cohort-threshold fallback behavior.
+5. Privacy checks (no user identifiers in discovery payloads).

--- a/docs/specs/topic-synthesis-v2.md
+++ b/docs/specs/topic-synthesis-v2.md
@@ -1,0 +1,178 @@
+# topic-synthesis-v2 Contract (Canonical)
+
+Status: Canonical for Season 0 Ship Snapshot
+Owner: VENN Engine / Data Model
+References: `docs/foundational/System_Architecture.md`, `docs/foundational/TRINITY_Season0_SoT.md`
+
+## 1. Goals
+
+1. Canonicalize topic understanding from multi-source and discussion inputs.
+2. Replace first-to-file URL ownership with quorum + epoch deterministic selection.
+3. Preserve disagreements with explicit divergence metrics and warnings.
+4. Keep artifacts identity-free on public paths.
+
+## 2. Default parameters
+
+- `quorumSize`: 5 candidates
+- `candidateTimeoutMs`: `86_400_000` (24h)
+- `epochDebounceMs`: `1_800_000` (30m)
+- `dailyEpochCapPerTopic`: 4
+- `resynthesisCommentThreshold`: 10 verified comments
+- `resynthesisUniquePrincipalMin`: 3
+
+## 3. Input contracts
+
+```ts
+type TopicId = string;
+
+interface StoryBundleInput {
+  story_id: string;
+  topic_id: TopicId;
+  sources: Array<{
+    source_id: string;
+    url: string;
+    publisher: string;
+    published_at: number;
+    url_hash: string;
+  }>;
+  normalized_facts_text: string;
+}
+
+interface TopicDigestInput {
+  digest_id: string;
+  topic_id: TopicId;
+  window_start: number;
+  window_end: number;
+  verified_comment_count: number;
+  unique_verified_principals: number;
+  key_claims: string[];
+  salient_counterclaims: string[];
+  representative_quotes: string[];
+}
+
+interface TopicSeedInput {
+  seed_id: string;
+  topic_id: TopicId;
+  title: string;
+  seed_text: string;
+}
+```
+
+Rules:
+
+- News topics require `StoryBundleInput`.
+- User topics require `TopicSeedInput`.
+- `TopicDigestInput` is optional at epoch 0 and expected on later epochs.
+
+## 4. Candidate and synthesis types
+
+```ts
+interface CandidateSynthesis {
+  candidate_id: string;
+  topic_id: TopicId;
+  epoch: number;
+  based_on_prior_epoch?: number;
+  critique_notes: string[];
+  facts_summary: string;
+  frames: Array<{ frame: string; reframe: string }>;
+  warnings: string[];
+  divergence_hints: string[];
+  provider: {
+    provider_id: string;
+    model_id: string;
+    kind: 'local' | 'remote';
+  };
+  created_at: number;
+}
+
+interface TopicSynthesisV2 {
+  schemaVersion: 'topic-synthesis-v2';
+  topic_id: TopicId;
+  epoch: number;
+  synthesis_id: string;
+  inputs: {
+    story_bundle_ids?: string[];
+    topic_digest_ids?: string[];
+    topic_seed_id?: string;
+  };
+  quorum: {
+    required: number;
+    received: number;
+    reached_at: number;
+    timed_out: boolean;
+    selection_rule: 'deterministic';
+  };
+  facts_summary: string;
+  frames: Array<{ frame: string; reframe: string }>;
+  warnings: string[];
+  divergence_metrics: {
+    disagreement_score: number;   // [0,1]
+    source_dispersion: number;    // [0,1]
+    candidate_count: number;
+  };
+  provenance: {
+    candidate_ids: string[];
+    provider_mix: Array<{ provider_id: string; count: number }>;
+  };
+  created_at: number;
+}
+```
+
+## 5. Epoch and quorum flow
+
+### 5.1 Candidate gathering
+
+- Collect candidates until `quorumSize` or timeout.
+- Candidate submission requires verified principal context.
+- Familiars may submit only on-behalf-of a verified principal and consume principal budgets.
+
+### 5.2 Accuracy mandate
+
+Each candidate must:
+
+1. Re-read source inputs (`StoryBundle`/`TopicSeed` + optional `TopicDigest`)
+2. Critique/refine prior epoch output when `epoch > 0`
+3. Preserve disagreement when evidence is unresolved
+
+### 5.3 Deterministic selection
+
+Given same candidate set and input ordering, all peers must select the same synthesis.
+Selection function must be deterministic and versioned.
+
+### 5.4 Comment-driven re-synthesis
+
+New epoch is eligible when both are true since last epoch:
+
+- at least 10 new verified comments
+- at least 3 unique verified principals
+
+Plus scheduler guards:
+
+- debounce 30 minutes
+- max 4 epochs/day/topic
+
+## 6. Storage conventions
+
+Public mesh paths:
+
+- `vh/topics/<topicId>/epochs/<epoch>/candidates/<candidateId>`
+- `vh/topics/<topicId>/epochs/<epoch>/synthesis`
+- `vh/topics/<topicId>/latest` (pointer)
+
+Sensitive material (proofs, tokens, identity) is forbidden in these paths.
+
+## 7. Invariants
+
+1. `synthesis_id` uniquely identifies `{topic_id, epoch, content}`.
+2. `provenance.candidate_ids.length === quorum.received`.
+3. Public synthesis objects contain no `nullifier`, `district_hash`, or OAuth tokens.
+4. `frames` may be empty only when warnings include explicit insufficiency reason.
+
+## 8. Testing requirements
+
+1. Candidate collection stop conditions (quorum vs timeout).
+2. Deterministic selection reproducibility test.
+3. Epoch trigger tests for comment/unique-principal thresholds.
+4. Debounce and daily-cap enforcement tests.
+5. Schema validation tests for synthesis and candidate payloads.
+6. Privacy lint: forbidden sensitive fields in public synthesis paths.

--- a/docs/sprints/02-sprint-2-advanced-features.md
+++ b/docs/sprints/02-sprint-2-advanced-features.md
@@ -6,6 +6,10 @@
 **Goal:** Harden the system for Mainnet, implement full Governance flows, and optimize AI performance within a polished UX.
 **Status:** [ ] In Progress
 
+> Historical note (2026-02-08): This sprint doc captures Sprint 2 execution history.
+> Season 0 forward direction is V2-first (`topic-synthesis-v2`, StoryBundle, TopicDigest, and 3-surface feed).
+> `canonical-analysis-v1` references in this file are legacy context, not current north-star build targets.
+
 ### Guiding Constraints & Quality Gates
 - [ ] **Non-Negotiables:**
     - [ ] **LOC Cap:** Hard limit of **350 lines** per file (tests/types exempt).
@@ -225,7 +229,7 @@
 - [x] **Deterministic JSON:**
     - [x] Stable field set/ordering; snapshot example payload stored in tests.
 - [x] **Docs Wiring:**
-    - [x] `System_Architecture.md` §6.3 and `docs/specs/canonical-analysis-v1.md` are referenced in code comments or README where the schema is consumed.
+    - [x] `docs/foundational/System_Architecture.md` and `docs/specs/canonical-analysis-v1.md` are referenced in code comments or README where the schema is consumed.
 
 ## Phase 2.6 Identity, Trust & Constituency Unification
 

--- a/docs/sprints/03-sprint-3-the-agora.md
+++ b/docs/sprints/03-sprint-3-the-agora.md
@@ -4,6 +4,10 @@
 **Goal:** Implement the "Agora" – the civic dialogue layer. This consists of **HERMES Messaging** (secure, private communication) and **HERMES Forum** (threaded civic discourse).
 **Status:** ✅ **COMPLETE** — All core functionality verified (Dec 6, 2025)
 
+> Historical note (2026-02-08): This sprint doc captures Sprint 3 execution and incident history.
+> For current canonical contracts, use `docs/specs/topic-synthesis-v2.md`, `docs/specs/spec-hermes-forum-v0.md`, and `docs/foundational/System_Architecture.md`.
+> Legacy `sourceAnalysisId` references in this file are historical context.
+
 > ✅ **HERMES Messaging — READY FOR PRODUCTION** (Dec 5, 2025)
 >
 > All unit tests (242+), E2E tests (10), and manual tests passing.
@@ -62,8 +66,8 @@
     - Ensure Gun adapters for HERMES and Forum go through the guarded namespaces, not via raw mesh.
 
 ### 1.4 Identity & Trust Gating
-- [x] **Trust Gating (Forum):** Creating threads/comments and voting in HERMES Forum requires `TrustScore >= 0.5` on the current session, aligned with `System_Architecture.md` §4.1.5 and `spec-hermes-forum-v0.md`.
-- [x] **Session Requirement (Messaging):** HERMES Messaging requires an active session and identity (nullifier). Messaging adds no additional trustScore threshold beyond the session gate defined in `System_Architecture.md` §4.1.5.
+- [x] **Trust Gating (Forum):** Creating threads/comments and voting in HERMES Forum requires `TrustScore >= 0.5` on the current session, aligned with the identity/trust model in `docs/foundational/System_Architecture.md` and `docs/specs/spec-hermes-forum-v0.md`.
+- [x] **Session Requirement (Messaging):** HERMES Messaging requires an active session and identity (nullifier). Messaging adds no additional trustScore threshold beyond the global identity/session gate defined in `docs/foundational/System_Architecture.md`.
 
 ### 1.5 XP & Privacy
 - [x] **XP & Privacy:** Any XP accrual from Messaging/Forum must write only to the on-device XP ledger (`civicXP` / `socialXP` in `spec-xp-ledger-v0.md`), never emitting `{district_hash, nullifier, XP}` off-device.

--- a/docs/sprints/03.5-sprint-3.5-ui-refinement.md
+++ b/docs/sprints/03.5-sprint-3.5-ui-refinement.md
@@ -3,6 +3,9 @@
 **Status:** ✅ COMPLETE | **Dates:** Dec 6-18, 2025
 **Goal:** Polish HERMES Messaging + Forum UI/UX before Sprint 4 (Agentic Foundation)
 
+> Historical note (2026-02-08): This is a closed Sprint 3.5 snapshot.
+> If contract details here differ from current V2 specs (for example stance taxonomy or synthesis naming), treat this file as historical and defer to current specs in `docs/specs/` and `docs/foundational/System_Architecture.md`.
+
 > 📁 **Implementation Details:** [archive/sprints/03.5-implementation-details.md](archive/sprints/03.5-implementation-details.md)
 > 🎨 **Dev Color Panel:** [dev-color-panel.md](dev-color-panel.md)
 

--- a/docs/sprints/04-sprint-agentic-foundation.md
+++ b/docs/sprints/04-sprint-agentic-foundation.md
@@ -1,95 +1,55 @@
-# Sprint 4: Agentic Foundation (Implementation Plan)
+# Sprint 4: Agentic Foundation (Alignment Plan)
 
-**Status:** ⚪ Planning  
-**Predecessor:** Sprint 3.5 (UI Refinement) — ✅ COMPLETE  
-**Context:** Hardening + refactor before scaling agentic features
-
----
+Status: In progress
+Predecessor: Sprint 3.5
+Context: Hardening core contracts before Sprint 5 delivery
 
 ## Goal
 
-Establish a safe foundation for agentic participation, unify the Topics model, and harden analysis workflows before scaling features like Civic Action Kit and Region Proof.
+Establish V2-first foundations so downstream work ships against `TopicSynthesisV2`, not legacy `CanonicalAnalysisV1`.
 
----
+## Direction locks
 
-## Phase 0 — Safety & Integrity Baseline (P0)
+1. `CanonicalAnalysisV1` is compatibility-only.
+2. Canonical synthesis path is StoryBundle + TopicDigest -> TopicSynthesisV2.
+3. Familiars inherit principal budgets/trust and never create separate influence lanes.
 
-### 0.1 Identity Storage Hardening
-- [x] Identity persistence migrated from localStorage to encrypted IndexedDB vault (`vh-vault` / `vault`) (PR #10, commit `813558c`)
-- [ ] Add CSP + secure storage policy
+## Phase 0 - Safety and identity primitives
 
-### 0.2 Delegation Types + OBO Assertions
-- [ ] Implement `FamiliarRecord`, `DelegationGrant`, `OnBehalfOfAssertion`
-- [ ] Enforce tiered scopes (Suggest / Act / High-Impact)
-- [ ] Tier 3 requires explicit human approval at time of action
-- [ ] **E2E mock:** `VITE_E2E_MODE` disables familiar loops and mocks delegation checks
+- [x] Identity vault migration completed
+- [ ] Familiar runtime policy enforcement (suggest/act/high-impact)
+- [ ] Delegation grant lifecycle (create/revoke/expire)
+- [ ] Budget enforcement completion (`moderation/day`, `civic_actions/day`)
 
-### 0.3 Participation Governors
-- [ ] Enforce per-nullifier budgets (posts/comments/votes/analyses/etc.)
-- [ ] Implement local-only “Agent Impact Meter” showing diminishing returns
+## Phase 1 - Story and topic substrate
 
----
+- [ ] Implement News Aggregator ingest + StoryBundle creation
+- [ ] Implement TopicDigest builder from verified thread activity
+- [ ] Define stable TopicId semantics across News/Topics/Social
+- [ ] Add linked-social notification substrate (vault token handling)
 
-## Phase 1 — Unified Topics Model
+## Phase 2 - Topic Synthesis V2 pipeline
 
-### 1.1 Thread Schema & Migration
-- [ ] Add `topicId`, `sourceUrl`, `urlHash`, `isHeadline` to Thread
-- [ ] Add `proposal?: ProposalExtension` to Thread
-- [ ] Add `via?: 'human' | 'familiar'` to Comment
-- [ ] Read-compat migration + schema dual-parse if needed
+- [ ] Candidate collection (quorum size 5, verified-only)
+- [ ] Deterministic synthesis selection and divergence metrics
+- [ ] Epoch scheduler (30m debounce, 4/day cap)
+- [ ] Comment-triggered re-synthesis (10 comments, 3 unique principals)
 
-### 1.2 Topics Stream Integration
-- [ ] Headline ↔ thread ↔ analysis share one `topicId`
-- [ ] Single view for analysis + thread (remove two-graph behavior)
+## Phase 3 - Provider switching and consent
 
----
+- [ ] Provider registry IDs + model metadata
+- [ ] Consent UI for remote providers with cost/privacy labels
+- [ ] Telemetry redaction and policy tests
 
-## Phase 2 — Analysis Robustness
+## Phase 4 - Feed and forum contract alignment
 
-### 2.1 v2 Quorum Synthesis Pipeline
-- [ ] Candidate gather → synthesis → divergence → canonical v2
-- [ ] Verified-only candidate submissions
-- [ ] **Note:** Flow testing only until Phase 3 (real AI)
+- [ ] Unified feed chips/sorts (All/News/Topics/Social + Latest/Hottest/My Activity)
+- [ ] Reply hard limit 240 chars
+- [ ] Convert-to-article routing to Docs draft
+- [ ] Forum references synthesis state by `{topicId, epoch, synthesisId}`
 
-### 2.2 Comment-Driven Re-Synthesis
-- [ ] Trigger after 10 verified comments (min 3 unique verified principals)
-- [ ] Debounce: 30 minutes; Cap: 4 per topic/day
+## Exit criteria
 
----
-
-## Phase 3 — Real AI Engine
-
-- [ ] Wire real engine (local-first)
-- [ ] Remote engine requires explicit opt-in
-- [ ] Preserve validation + guardrails
-
----
-
-## Phase 4 — Civic Action Kit (Facilitation)
-
-- [ ] PDF report generation
-- [ ] Contact directory
-- [ ] Native intents (mail/phone/share)
-
----
-
-## Phase 5 — Region Proof
-
-- [ ] RegionProof pipeline (stubs → real proofs)
-- [ ] Required for district dashboards and verified constituency signals
-
----
-
-## Dependencies
-
-- Sprint 5 (Bridge + Docs) depends on **Phase 0–1** completion.
-
----
-
-## Deliverables
-
-- Secure storage and delegation foundation
-- Enforced participation governors
-- Unified Topics model across feed/forum/analysis
-- Quorum synthesis + re-synthesis flow
-- Real AI engine integration
+1. V2 contracts compile with no `analysis_id` dependency in new paths.
+2. Story clustering + synthesis V2 + linked-social contracts are test-covered.
+3. Sprint 5 can implement Docs and Civic Action Kit without contract churn.

--- a/docs/sprints/MANUAL_TEST_CHECKLIST_SPRINT3.md
+++ b/docs/sprints/MANUAL_TEST_CHECKLIST_SPRINT3.md
@@ -5,6 +5,9 @@
 **Dev Server:** http://localhost:2048
 **Status:** ✅ **SPRINT 3 COMPLETE** — All core functionality verified (Dec 6, 2025)
 
+> Historical note (2026-02-08): This checklist is a Sprint 3 verification artifact.
+> For current canonical V2 contracts and default parameters, use `docs/specs/` plus `docs/foundational/System_Architecture.md`.
+
 ---
 
 ## ✅ RESOLVED GAPS (Phase 1 - Dec 4, 2025)
@@ -456,4 +459,3 @@ tail -f /tmp/vh-pwa-dev.log
 # Run E2E tests (for comparison)
 pnpm test --filter @vh/e2e
 ```
-


### PR DESCRIPTION
## Summary
- align foundational/spec/sprint docs to Season 0 SoT and V2-first contract direction
- restore implementation detail in over-compressed docs while preserving contract intent
- add missing V2 specs for topic synthesis, news aggregation, linked socials, and discovery ranking
- resolve cross-file drift in topology, defaults, and stale references
- mark legacy sprint artifacts as historical context where applicable

## Scope
- docs-only
- 26 files changed
- 5 new docs added

## Key Additions
- `docs/foundational/TRINITY_Season0_SoT.md`
- `docs/specs/topic-synthesis-v2.md`
- `docs/specs/spec-news-aggregator-v0.md`
- `docs/specs/spec-linked-socials-v0.md`
- `docs/specs/spec-topic-discovery-ranking-v0.md`

## Notes
- preserved current-main truth where conflicts existed (`STATUS` recently-completed range includes #133; AI engine runtime note is non-stale)