### PR TITLE
docs: rename w0-chief references to Coordinator

### DIFF
--- a/docs/foundational/V2_Sprint_Staffing_Plan.md
+++ b/docs/foundational/V2_Sprint_Staffing_Plan.md
@@ -672,7 +672,7 @@ Wave 2 runs **3 concurrent workstreams** after Wave 1 exits green.
 
 | Agent ID | Role | Model | Standing? | Reports to |
 | --- | --- | --- | --- | --- |
-| `w0-chief` | Wave 0 Chief | `opus-4.6` | Duration of Wave 0 | Coordinator |
+| `Coordinator` | Wave 0 Coordinator | `opus-4.6` | Duration of Wave 0 | Coordinator |
 
 ### Wave 1 Team A agents (Topic Synthesis V2)
 
@@ -730,7 +730,7 @@ Wave 2 runs **3 concurrent workstreams** after Wave 1 exits green.
 
 ```
 Coordinator (human)
-├── w0-chief (Wave 0 only)
+├── Coordinator (Wave 0 only)
 ├── w1-spec (cross-team, standing)
 ├── w1-qa-integ (cross-team, standing)
 ├── w1-docs (cross-team, standing)
@@ -758,7 +758,7 @@ Coordinator (human)
 
 | Category | Count | Model |
 | --- | --- | --- |
-| Standing chiefs (pure) | 4 (w0, A, B, C) | `opus-4.6` |
+| Standing chiefs (pure) | 4 (Coordinator, A, B, C) | `opus-4.6` |
 | Standing chief+impl (hybrid) | 1 (D) | `codex-5.3-extra-high` |
 | Standing impl (pure) | 5 (A x2, B x1, C x2) | `codex-5.3-extra-high` |
 | Standing QA (per-team) | 4 (A/B/C/D) | `codex-5.3-extra-high` |
@@ -766,7 +766,7 @@ Coordinator (human)
 | Per-PR maint | 4 (A/B/C/D) | `opus-4.6` |
 | Per-issue sidecar | 2 (E impl + qa) | `codex-5.3-extra-high` |
 | **Total agent slots** | **23** | |
-| Standing simultaneously (Wave 1) | **16** (excl. w0-chief which ends after Wave 0; excl. per-PR maint and per-issue sidecar agents) | |
+| Standing simultaneously (Wave 1) | **16** (excl. Coordinator which ends after Wave 0; excl. per-PR maint and per-issue sidecar agents) | |
 
 ### Role behavior reference
 

--- a/docs/foundational/V2_Sprint_Staffing_Roles.md
+++ b/docs/foundational/V2_Sprint_Staffing_Roles.md
@@ -98,7 +98,7 @@ Load on every spawn:
   - `w1-spec`: `docs/foundational/ARCHITECTURE_LOCK.md` + all Wave 1 canonical specs listed in Docs section below
   - `w1-qa-integ`: `docs/foundational/ARCHITECTURE_LOCK.md` + full `docs/foundational/V2_Sprint_Staffing_Plan.md` + `docs/foundational/STATUS.md`
   - `w1-docs`: `docs/foundational/ARCHITECTURE_LOCK.md` + `docs/foundational/STATUS.md` + `docs/foundational/System_Architecture.md` + canonical specs
-  - `w0-chief`: `docs/foundational/ARCHITECTURE_LOCK.md` + Wave 0/Coordinator sections of `docs/foundational/V2_Sprint_Staffing_Plan.md`
+  - `Coordinator`: `docs/foundational/ARCHITECTURE_LOCK.md` + Wave 0/Coordinator sections of `docs/foundational/V2_Sprint_Staffing_Plan.md`
 
 ### Tier 2 (situational context)
 
@@ -128,9 +128,9 @@ If a standing agent nears context limits mid-wave:
 
 ### Identity
 
-Agent IDs: `w0-chief`, `w1a-chief`, `w1b-chief`, `w1c-chief`, `w1d-chief-impl`
+Agent IDs: `Coordinator`, `w1a-chief`, `w1b-chief`, `w1c-chief`, `w1d-chief-impl`
 
-`w0-chief` is Wave 0 only and operates on `main` during contract lockdown. Wave 1 chiefs operate on `integration/wave-1`.
+`Coordinator` is Wave 0 only and operates on `main` during contract lockdown. Wave 1 chiefs operate on `integration/wave-1`.
 
 ### Role
 
@@ -183,7 +183,7 @@ If a merged PR breaks CI on `integration/wave-1` and the team cannot fix within 
 
 #### Phase -1: Preflight sync and baseline
 
-1. Fetch and fast-forward the active target branch (`main` for `w0-chief` in Wave 0; `integration/wave-1` for Wave 1 chiefs).
+1. Fetch and fast-forward the active target branch (`main` for `Coordinator` in Wave 0; `integration/wave-1` for Wave 1 chiefs).
 2. Record baseline SHA.
 3. Verify no conflicting open PRs touching the same files.
 4. Confirm in-scope and out-of-scope issue IDs before coding.


### PR DESCRIPTION
Renames remaining Wave 0 role references from w0-chief to Coordinator in foundational staffing docs.

## Updated files
- docs/foundational/V2_Sprint_Staffing_Plan.md
- docs/foundational/V2_Sprint_Staffing_Roles.md

## Scope
- Documentation-only rename
- No behavioral code changes