### PR TITLE
fix(coord): ownership-map glob sweep + base-ref fallback for wave-1

### DIFF
--- a/.github/ownership-map.json
+++ b/.github/ownership-map.json
@@ -3,14 +3,14 @@
     "branchPrefix": "team-a/",
     "paths": [
       "packages/ai-engine/src/synthesis*.ts",
-      "packages/ai-engine/src/candidateGatherer.ts",
-      "packages/ai-engine/src/epochScheduler.ts",
-      "packages/ai-engine/src/quorum.ts",
-      "packages/ai-engine/src/topicSynthesisPipeline.ts",
+      "packages/ai-engine/src/candidateGatherer*.ts",
+      "packages/ai-engine/src/epochScheduler*.ts",
+      "packages/ai-engine/src/quorum*.ts",
+      "packages/ai-engine/src/topicSynthesisPipeline*.ts",
       "packages/data-model/src/schemas/hermes/synthesis*.ts",
-      "packages/gun-client/src/synthesisAdapters.ts",
+      "packages/gun-client/src/synthesisAdapters*.ts",
       "apps/web-pwa/src/store/synthesis/**",
-      "apps/web-pwa/src/hooks/useSynthesis.ts",
+      "apps/web-pwa/src/hooks/useSynthesis*.ts",
       "apps/web-pwa/src/components/synthesis/**"
     ]
   },
@@ -19,7 +19,7 @@
     "paths": [
       "services/news-aggregator/**",
       "packages/data-model/src/schemas/hermes/storyBundle*.ts",
-      "packages/gun-client/src/newsAdapters.ts",
+      "packages/gun-client/src/newsAdapters*.ts",
       "apps/web-pwa/src/store/news/**"
     ]
   },
@@ -28,7 +28,7 @@
     "paths": [
       "packages/data-model/src/schemas/hermes/discovery*.ts",
       "apps/web-pwa/src/store/discovery/**",
-      "apps/web-pwa/src/hooks/useDiscoveryFeed.ts",
+      "apps/web-pwa/src/hooks/useDiscoveryFeed*.ts",
       "apps/web-pwa/src/components/feed/**"
     ]
   },
@@ -36,10 +36,10 @@
     "branchPrefix": "team-d/",
     "paths": [
       "packages/types/src/delegation*.ts",
-      "packages/types/src/index.ts",
+      "packages/types/src/index*.ts",
       "apps/web-pwa/src/store/delegation/**",
-      "apps/web-pwa/src/hooks/useFamiliar.ts",
-      "apps/web-pwa/src/components/hermes/FamiliarControlPanel.tsx"
+      "apps/web-pwa/src/hooks/useFamiliar*.ts",
+      "apps/web-pwa/src/components/hermes/FamiliarControlPanel*.tsx"
     ]
   },
   "team-e": {

--- a/tools/scripts/check-ownership-scope.mjs
+++ b/tools/scripts/check-ownership-scope.mjs
@@ -56,8 +56,18 @@ function resolveHeadRef() {
   return headRef;
 }
 
+function inferBaseRef(headRef) {
+  // Wave-1 team branches and coord branches target integration/wave-1.
+  // Everything else targets main.
+  if (/^team-[a-e]\//.test(headRef) || headRef.startsWith('coord/')) {
+    return 'integration/wave-1';
+  }
+  return 'main';
+}
+
 function resolveMergeBase() {
-  const baseRef = process.env.GITHUB_BASE_REF || 'main';
+  const headRef = process.env.GITHUB_HEAD_REF || run('git rev-parse --abbrev-ref HEAD');
+  const baseRef = process.env.GITHUB_BASE_REF || inferBaseRef(headRef);
   if (!/^[A-Za-z0-9._/-]+$/.test(baseRef)) {
     fail(`invalid base ref: ${baseRef}`);
   }


### PR DESCRIPTION
## Summary
Ownership hardening for second-slice closeout:

1. **Glob sweep on ownership-map.json**: All exact `.ts`/`.tsx` file paths converted to wildcard patterns (e.g. `candidateGatherer.ts` → `candidateGatherer*.ts`) so co-located `.test.ts` files are automatically covered. Directory globs (`**`) unchanged.

2. **Base-ref fallback in check-ownership-scope.mjs**: Added `inferBaseRef()` so `team-*/` and `coord/` branches default to `integration/wave-1` (not `main`) when `GITHUB_BASE_REF` is unset. Fixes local pre-push hook failures.

## Root cause
PR #153 (A-2) failed Ownership Scope because `candidateGatherer.test.ts` and `quorum.test.ts` had no matching glob in the ownership map.

## Scope
- [x] No unrelated file changes.
- [x] Coordinator branch (`coord/`).
- [x] Only coordinator-owned files changed.

## Testing
- Pre-push hook passes (coord bypass).
- CI will validate on this PR.
