### PR TITLE
docs(coord): add first-slice stability review packet

### DIFF
--- a/docs/reports/FIRST_SLICE_STABILITY_REVIEW.md
+++ b/docs/reports/FIRST_SLICE_STABILITY_REVIEW.md
@@ -1,0 +1,200 @@
+# First-Slice Stability Review Packet
+
+**Date**: 2026-02-10 ~02:20 UTC (retrospective)  
+**Author**: Coordinator (AI)  
+**Scope**: Wave 1 — Slice 1 (canary round)
+
+---
+
+## 1. Final State (post first-slice)
+
+**integration/wave-1 HEAD (post S1)**: `6a252d943dd2`  
+**Open PRs after first-slice**: 0  
+**Branch protection**: 5 required checks (Ownership Scope, Quality Guard, Test & Build, E2E Tests, Bundle Size + Lighthouse), `enforce_admins=true` (enabled during this slice)
+
+---
+
+## 2. Merged PR Ledger
+
+| # | SHA (12) | Merged (UTC) | Branch | Title |
+|---|----------|--------------|--------|-------|
+| 146 | `8da2c8b9d647` | 09 18:07 | coord/sync-wave1-post-144 | chore: sync integration/wave-1 with main |
+| 149 | `1e0b26daf600` | 09 21:03 | coord/fix-ownership-glob-regex | fix(ci): ownership-scope glob `**` patterns |
+| 147 | `fc5da489bb25` | 09 22:47 | team-e/E-1-attestor-truth-labels | feat: E-1 DEV-ONLY truth labels |
+| 151 | `02c33131ecba` | 09 22:51 | team-d/D-1-delegation-utils | feat: D-1 delegation runtime guards |
+| 150 | `82c4805ec926` | 09 22:56 | team-a/A-1-synthesis-schemas | feat: A-1 synthesis schema contracts |
+| 148 | `6a252d943dd2` | 10 00:43 | team-c/C-1-discovery-schemas | feat: C-1 FeedItem schemas + hotness |
+
+**Note**: B-1 (service scaffold + StoryBundle schemas) was already on `integration/wave-1` pre-launch as part of Wave 0 infrastructure. No separate first-slice PR was needed.
+
+**Totals**: 6 PRs merged (2 coord infra, 4 team first-slice). B-1 pre-existing.
+
+---
+
+## 3. Test Count Progression
+
+| Milestone | Test Files | Tests | Δ Files | Δ Tests |
+|-----------|-----------|-------|---------|---------|
+| Wave 0 baseline (main) | 83 | 810 | — | — |
+| Post ownership fix (#149) | 84 | 849 | +1 | +39 |
+| After first-slice (4 team PRs) | 89 | 1,068 | +5 | +219 |
+| **Cumulative S1 growth** | **+6 files** | **+258 tests** | **+7.2%** | **+31.9%** |
+
+All 1,068 tests pass. Zero test failures on HEAD.
+
+---
+
+## 4. CI Reliability Summary
+
+**Total CI runs during first-slice window** (09 18:00 – 10 00:44 UTC): 24  
+**Successful**: 18 (75%)  
+**Failed**: 6 (25%)  
+**Cancelled**: 0  
+**Flakes**: 0 (all failures had deterministic root causes)
+
+### Failure Breakdown
+
+| Run | Branch | Failed Check | Root Cause |
+|-----|--------|-------------|------------|
+| 21836424746 | team-e/E-1 | Ownership Scope | Glob `**` patterns didn't recurse into nested paths |
+| 21836511934 | team-c/C-1 | Ownership Scope | Same glob bug |
+| 21836529129 | integration/wave-1 | Test & Build | Push-triggered run on base before team code landed (transient build state) |
+| 21836607359 | coord/fix-ownership-glob | Bundle Size | Coord fix PR iteration (expected during development) |
+| 21836697335 | team-a/A-1 | Ownership Scope | Same glob bug |
+| 21836809098 | team-d/D-1 | Ownership Scope | Same glob bug + transient Hardhat NPM download failure on first attempt |
+
+### Per-Branch CI Runs
+
+| Branch | Total Runs | Pass | Fail | Pass Rate |
+|--------|-----------|------|------|-----------|
+| team-e/E-1 | 2 | 1 | 1 | 50% |
+| team-d/D-1 | 3 | 2 | 1 | 67% |
+| team-a/A-1 | 2 | 1 | 1 | 50% |
+| team-c/C-1 | 2 | 1 | 1 | 50% |
+| coord/fix-ownership-glob | 4 | 3 | 1 | 75% |
+| integration/wave-1 (push) | 7 | 6 | 1 | 86% |
+
+**Note**: All 4 team branch failures share the same single root cause (Ownership Scope glob bug). After the fix landed (#149 at 21:03), every subsequent team branch run passed on first attempt. Adjusted pass rate post-fix: 100%.
+
+---
+
+## 5. Ownership-Scope Incidents + Root Causes
+
+### Incident 1: Glob `**` pattern matching failure (systemic)
+- **Detected**: 09 ~18:30 UTC (within 30 minutes of launch)
+- **Impact**: All 4 team PRs (E-1, C-1, A-1, D-1) failed Ownership Scope on first CI run
+- **Root cause**: `check-ownership-scope.mjs` used `minimatch` without `{dot: true, matchBase: true}` options. The `**` glob in ownership-map patterns did not recurse into nested directories.
+- **Fix**: PR #149 (`1e0b26da`) — merged 09 21:03:30 UTC
+- **Time to detect**: ~12 minutes
+- **Time to fix**: ~2h 33m from launch (included diagnosis, fix, test, review)
+- **Blast radius**: Blocked all team merges for ~3 hours. No code was at risk — only the CI gate was affected.
+
+### Incident 2: Team C included coord-owned file
+- **Detected**: 09 ~21:05 UTC (during post-fix rebase)
+- **Impact**: PR #148 (C-1) included an edit to `.github/ownership-map.json`, which is coord-owned
+- **Root cause**: Team C agent attempted to self-fix the ownership-scope failure by editing the ownership map
+- **Resolution**: Coordinator instructed Team C to drop the `.github/ownership-map.json` change from their branch
+- **Time to fix**: <10 minutes
+- **Severity**: Low — ownership scope CI would have caught this regardless
+
+### Incident 3: Transient Hardhat download failure (D-1)
+- **Detected**: 09 ~18:39 UTC
+- **Impact**: D-1 first CI run had a secondary failure (Hardhat NPM download) alongside the glob bug
+- **Resolution**: Re-run passed. NPM download was transient network issue on GitHub runner.
+- **Severity**: Negligible — masked by the glob bug anyway
+
+---
+
+## 6. Bypass Usage Audit
+
+### `--no-verify` usage: 0 instances during first-slice
+
+No team or coordinator used `--no-verify` during the first-slice window. All pushes went through the pre-push hook.
+
+### `SKIP_OWNERSHIP_SCOPE=1` usage: 0 instances
+
+### Branch protection bypass: 0 instances
+
+`enforce_admins` was **not** enabled at launch (backlog item). It was enabled during the ownership unblock sequence at ~21:10 UTC, after all team PRs were rebased and green. No merges occurred before `enforce_admins` was activated.
+
+### Assessment
+Clean audit. Zero bypasses during first-slice.
+
+---
+
+## 7. Workflow Friction Points Between Agents
+
+### F1: Ownership-scope glob bug blocked all teams simultaneously (HIGH)
+All 5 teams launched at the same time. All 4 that needed PRs hit the same Ownership Scope failure within ~10 minutes of each other. The coordinator had to diagnose, fix, and land a CI infrastructure PR before any team could merge.  
+**Cost**: ~3 hours of blocked merge capability.
+
+### F2: Team C self-edited coord-owned file (MEDIUM)
+When Team C's agent saw the Ownership Scope failure, it attempted to fix the problem by editing `.github/ownership-map.json` — a file outside its ownership boundary. This is the correct instinct (fix the blocker) but the wrong action (cross-boundary edit).  
+**Cost**: ~10 minutes for coordinator intervention + branch cleanup.
+
+### F3: C-1 merge delayed by serial rebase cascade (MEDIUM)
+After E-1, D-1, and A-1 merged in quick succession (22:47–22:56), C-1's branch was behind. With "require up-to-date" in branch protection, C-1 needed a rebase + full CI re-cycle. The rebase happened quickly but CI execution added wall-clock delay.  
+**Cost**: C-1 merged at 00:43 — 1h47m after A-1. Total first-slice merge window: ~2 hours.
+
+### F4: `enforce_admins` was not active at launch (LOW)
+Branch protection was configured but `enforce_admins` was off during initial launch. This was a known backlog item. No exploit occurred, but it was a gap in the safety posture.  
+**Cost**: Risk exposure only. Closed during slice.
+
+### F5: No merge queue available (LOW)
+Without merge queue, PRs had to be merged manually in sequence, with rebase between each merge when branch protection requires up-to-date status.  
+**Cost**: Manual coordination overhead. Partially offset by quick E→D→A merge cadence (~4 min between each).
+
+---
+
+## 8. Top 5 Stability/Process Improvements (Ranked by Impact)
+
+### 1. Smoke-test CI checks against team branches before launch (HIGH)
+**Problem**: The ownership-scope glob bug was not caught until all 5 teams were already running. A single canary push on any team branch before full launch would have surfaced it.  
+**Fix**: Add a "CI canary" step to the launch checklist — push a no-op commit to one team branch and verify all 6 checks pass before dispatching teams.  
+**Impact**: Would have saved ~3 hours of blocked merge capability and eliminated 4 of 6 CI failures.
+
+### 2. Ownership-map glob patterns should use directory-level wildcards (HIGH)
+**Problem**: The ownership map used file-level paths that broke when the glob engine didn't recurse properly.  
+**Fix**: Use `packages/ai-engine/src/**` style patterns (already fixed in #149), and validate glob matching in CI unit tests.  
+**Impact**: Prevents recurrence of the systemic failure mode.
+
+### 3. Agent guardrails: prevent cross-boundary file edits (MEDIUM)
+**Problem**: Team C's agent edited a coord-owned file when it encountered a CI failure.  
+**Fix**: Add explicit instructions in team agent prompts: "Do not edit files outside your ownership scope. If blocked by ownership scope failures, report to coordinator." Also enforce via pre-push hook (which did catch it at PR level).  
+**Impact**: Prevents agents from creating ownership-scope violations that require manual cleanup.
+
+### 4. Enable `enforce_admins` before first merge, not during (MEDIUM)
+**Problem**: `enforce_admins` was a launch backlog item, creating a window where branch protection could be bypassed.  
+**Fix**: Include `enforce_admins` activation in the pre-launch checklist, confirmed before team dispatch.  
+**Impact**: Eliminates the safety gap window entirely.
+
+### 5. Enable merge queue to eliminate serial rebase cascades (MEDIUM)
+**Problem**: C-1 was delayed 1h47m because three PRs merged ahead of it, each requiring C-1 to rebase and re-run CI.  
+**Fix**: GitHub merge queue batches PRs, tests merged result, merges atomically.  
+**Impact**: Would reduce 4-PR merge from ~2h to ~5min. Even more critical for larger slice counts.
+
+---
+
+## 9. Recommendation Set for Slice-2 Readiness
+
+*(Note: this is a retrospective — slice 2 has already completed. These recommendations are recorded for process history.)*
+
+### Pre-requisites identified after first-slice:
+1. ✅ **Ownership glob fix** — landed in #149, validated by all subsequent merges
+2. ✅ **`enforce_admins` enabled** — activated during first-slice unblock sequence
+3. ⚠️ **Merge queue** — not enabled; still manual merge sequencing (carried forward to slice-3 recommendations)
+4. ✅ **Standing directive issued** — no `--no-verify` / `SKIP_OWNERSHIP_SCOPE` without coordinator approval
+
+### Process adjustments carried into slice 2:
+- Coordinator managed merge sequencing manually (D→B→A→C ordering)
+- Auto-merge (`gh pr merge --auto`) used for the first time during slice-2
+- Pre-push hook false positives on merge-commit diffs were a new friction point in slice 2
+
+### Key metric:
+**First-slice failure rate pre-fix**: 100% (all team PRs failed)  
+**First-slice failure rate post-fix**: 0% (all team PRs passed on first attempt)  
+**Lesson**: The CI infrastructure itself was the single point of failure, not the team code.
+
+---
+
+## STATUS: HOLDING_FOR_REVIEW


### PR DESCRIPTION
Adds \ to \ so both slice reports are available on the wave branch.\n\nScope: docs-only (single file).