### PR TITLE
coord: harden Wave-1b CI gates + stability report evidence

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,7 @@ jobs:
   ownership-scope:
     name: Ownership Scope
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v4
@@ -24,9 +25,50 @@ jobs:
       - name: Check ownership scope
         run: node tools/scripts/check-ownership-scope.mjs
 
+  change-detection:
+    name: Change Detection
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      run-e2e: ${{ steps.filter.outputs.run-e2e }}
+      run-bundle: ${{ steps.filter.outputs.run-bundle }}
+      run-lighthouse: ${{ steps.filter.outputs.run-lighthouse }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Detect changed paths
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            run-e2e:
+              - 'apps/web-pwa/**'
+              - 'packages/e2e/**'
+              - 'packages/gun-client/**'
+              - 'packages/ai-engine/**'
+              - 'packages/data-model/**'
+              - 'packages/types/**'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - '.github/workflows/main.yml'
+            run-bundle:
+              - 'apps/web-pwa/**'
+              - 'packages/gun-client/**'
+              - 'packages/ai-engine/**'
+              - 'packages/data-model/**'
+              - 'packages/types/**'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - '.github/workflows/main.yml'
+            run-lighthouse:
+              - 'apps/web-pwa/**'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - '.github/workflows/main.yml'
+
   quality:
     name: Quality Guard
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       
@@ -59,8 +101,11 @@ jobs:
     name: Test & Build
     runs-on: ubuntu-latest
     needs: quality
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -78,33 +123,52 @@ jobs:
       - name: Unit Tests
         run: pnpm test:quick
 
+      - name: Diff-aware Coverage Gate (pull requests only)
+        if: github.event_name == 'pull_request'
+        run: node tools/scripts/check-diff-coverage.mjs
+
       - name: Build
         run: pnpm build
 
   e2e:
     name: E2E Tests
     runs-on: ubuntu-latest
-    needs: test-and-build
+    needs: [test-and-build, change-detection]
+    timeout-minutes: 30
     steps:
+      - name: E2E applicability
+        run: |
+          if [ "${{ needs.change-detection.outputs.run-e2e }}" = "true" ]; then
+            echo "E2E: relevant changes detected; running full E2E suite."
+          else
+            echo "E2E: no relevant file changes detected; passing required check."
+          fi
+
       - uses: actions/checkout@v4
+        if: needs.change-detection.outputs.run-e2e == 'true'
 
       - name: Install pnpm
+        if: needs.change-detection.outputs.run-e2e == 'true'
         uses: pnpm/action-setup@v4
         # Version inferred from packageManager field
 
       - name: Use Node.js 20
+        if: needs.change-detection.outputs.run-e2e == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'pnpm'
 
       - name: Install Dependencies
+        if: needs.change-detection.outputs.run-e2e == 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Install Playwright Browsers
+        if: needs.change-detection.outputs.run-e2e == 'true'
         run: pnpm --filter @vh/e2e exec playwright install --with-deps
 
       - name: Run E2E
+        if: needs.change-detection.outputs.run-e2e == 'true'
         env:
           CI: true
         run: pnpm test:e2e
@@ -112,51 +176,81 @@ jobs:
   bundle-check:
     name: Bundle Size
     runs-on: ubuntu-latest
-    needs: test-and-build
+    needs: [test-and-build, change-detection]
+    timeout-minutes: 20
     steps:
+      - name: Bundle applicability
+        run: |
+          if [ "${{ needs.change-detection.outputs.run-bundle }}" = "true" ]; then
+            echo "Bundle: relevant changes detected; running bundle-size validation."
+          else
+            echo "Bundle: no relevant file changes detected; passing required check."
+          fi
+
       - uses: actions/checkout@v4
+        if: needs.change-detection.outputs.run-bundle == 'true'
 
       - name: Install pnpm
+        if: needs.change-detection.outputs.run-bundle == 'true'
         uses: pnpm/action-setup@v4
         # Version inferred from packageManager field
 
       - name: Use Node.js 20
+        if: needs.change-detection.outputs.run-bundle == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'pnpm'
 
       - name: Install Dependencies
+        if: needs.change-detection.outputs.run-bundle == 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Build PWA
+        if: needs.change-detection.outputs.run-bundle == 'true'
         run: pnpm build
 
       - name: Check Bundle Size (≤ 1 MiB gz)
+        if: needs.change-detection.outputs.run-bundle == 'true'
         run: pnpm bundle:check
 
   lighthouse:
     name: Lighthouse
     runs-on: ubuntu-latest
-    needs: test-and-build
+    needs: [test-and-build, change-detection]
+    timeout-minutes: 15
     steps:
+      - name: Lighthouse applicability
+        run: |
+          if [ "${{ needs.change-detection.outputs.run-lighthouse }}" = "true" ]; then
+            echo "Lighthouse: PWA changes detected; running lighthouse checks."
+          else
+            echo "Lighthouse: no apps/web-pwa changes detected; informational pass."
+          fi
+
       - uses: actions/checkout@v4
+        if: needs.change-detection.outputs.run-lighthouse == 'true'
 
       - name: Install pnpm
+        if: needs.change-detection.outputs.run-lighthouse == 'true'
         uses: pnpm/action-setup@v4
         # Version inferred from packageManager field
 
       - name: Use Node.js 20
+        if: needs.change-detection.outputs.run-lighthouse == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'pnpm'
 
       - name: Install Dependencies
+        if: needs.change-detection.outputs.run-lighthouse == 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Build PWA
+        if: needs.change-detection.outputs.run-lighthouse == 'true'
         run: pnpm build
 
       - name: Run Lighthouse (static dist)
+        if: needs.change-detection.outputs.run-lighthouse == 'true'
         run: npx lhci autorun --collect.staticDistDir=apps/web-pwa/dist --upload.target=filesystem --upload.outputDir=./lhci-report

--- a/tools/scripts/check-diff-coverage.mjs
+++ b/tools/scripts/check-diff-coverage.mjs
@@ -1,0 +1,112 @@
+import { execSync, spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+
+function fail(message) {
+  console.error(`Diff Coverage: FAIL - ${message}`);
+  process.exit(1);
+}
+
+function run(command) {
+  try {
+    return execSync(command, { encoding: 'utf8' }).trim();
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    fail(`unable to execute "${command}": ${msg}`);
+  }
+}
+
+function resolveHeadRef() {
+  const headRef = process.env.GITHUB_HEAD_REF || run('git rev-parse --abbrev-ref HEAD');
+  if (!headRef || headRef === 'HEAD') {
+    fail('unable to resolve git head branch');
+  }
+  return headRef;
+}
+
+function inferBaseRef(headRef) {
+  if (/^team-[a-e]\//.test(headRef)) {
+    return 'integration/wave-1';
+  }
+  return 'main';
+}
+
+function resolveMergeBase() {
+  const headRef = resolveHeadRef();
+  const baseRef = process.env.GITHUB_BASE_REF || inferBaseRef(headRef);
+  const originRef = `origin/${baseRef}`;
+  if (!/^[A-Za-z0-9._/-]+$/.test(baseRef)) {
+    fail(`invalid base ref: ${baseRef}`);
+  }
+  return run(`git merge-base HEAD ${originRef}`);
+}
+
+function changedFilesSince(mergeBase) {
+  const raw = run(`git diff --name-only --diff-filter=ACMRTUXB ${mergeBase}...HEAD`);
+  return raw ? raw.split('\n').map((line) => line.trim()).filter(Boolean) : [];
+}
+
+const COVERAGE_EXCLUDES = [
+  /^apps\/web-pwa\/src\/main\.tsx$/,
+  /^apps\/web-pwa\/src\/App\.tsx$/,
+  /^apps\/web-pwa\/src\/routes\//,
+  /^apps\/web-pwa\/src\/components\//,
+  /^apps\/web-pwa\/src\/store\/chat\//,
+  /^apps\/web-pwa\/src\/store\/forum\//,
+  /^apps\/web-pwa\/src\/store\/index\.ts$/,
+  /^apps\/web-pwa\/src\/hooks\/(useIdentity|useRegion|useFeedStore|useSentimentState)\.ts$/,
+  /^apps\/web-pwa\/src\/utils\/markdown\.ts$/,
+  /^packages\/e2e\//,
+  /^packages\/gun-client\/src\/storage\//,
+  /^packages\/gun-client\/src\/(types|hermesCrypto|topology|auth|chain|hermesAdapters)\.ts$/,
+  /^packages\/gun-client\/src\/sync\/barrier\.ts$/,
+  /^packages\/ai-engine\/src\/(index|schema|useAI|validation|worker|cache|prompts|localMlEngine)\.ts$/,
+  /^packages\/types\/src\/(attestation|identity)\.ts$/,
+  /^packages\/[^/]+\/src\/index\.ts$/
+];
+
+function isEligibleSourceFile(filePath) {
+  if (!/^(packages\/[^/]+\/src\/|apps\/[^/]+\/src\/).+\.(ts|tsx)$/.test(filePath)) {
+    return false;
+  }
+  if (/\.(test|spec)\.(ts|tsx)$/.test(filePath)) {
+    return false;
+  }
+  if (/\.d\.ts$/.test(filePath)) {
+    return false;
+  }
+  if (!existsSync(filePath)) {
+    return false;
+  }
+  return !COVERAGE_EXCLUDES.some((pattern) => pattern.test(filePath));
+}
+
+function main() {
+  const mergeBase = resolveMergeBase();
+  const changedFiles = changedFilesSince(mergeBase);
+  const includedFiles = changedFiles.filter(isEligibleSourceFile);
+
+  if (includedFiles.length === 0) {
+    console.log('Diff Coverage: PASS - no coverage-eligible source files changed.');
+    return;
+  }
+
+  console.log(`Diff Coverage: running coverage for ${includedFiles.length} changed source file(s).`);
+  includedFiles.forEach((filePath) => console.log(`  - ${filePath}`));
+
+  const vitestArgs = ['vitest', 'run', '--coverage', '--coverage.reporter=text-summary'];
+  for (const filePath of includedFiles) {
+    vitestArgs.push(`--coverage.include=${filePath}`);
+  }
+
+  const result = spawnSync('pnpm', vitestArgs, { stdio: 'inherit' });
+  if (result.error) {
+    fail(`failed to execute vitest: ${result.error.message}`);
+  }
+  if ((result.status ?? 1) !== 0) {
+    fail('coverage check failed for changed source files');
+  }
+
+  console.log('Diff Coverage: PASS - changed source files met coverage gate.');
+}
+
+main();

--- a/tools/scripts/check-ownership-scope.mjs
+++ b/tools/scripts/check-ownership-scope.mjs
@@ -57,9 +57,9 @@ function resolveHeadRef() {
 }
 
 function inferBaseRef(headRef) {
-  // Wave-1 team branches and coord branches target integration/wave-1.
-  // Everything else targets main.
-  if (/^team-[a-e]\//.test(headRef) || headRef.startsWith('coord/')) {
+  // Wave-1 team branches target integration/wave-1 by default.
+  // Coordinator or other branches default to main unless GITHUB_BASE_REF is set.
+  if (/^team-[a-e]\//.test(headRef)) {
     return 'integration/wave-1';
   }
   return 'main';


### PR DESCRIPTION
## Summary
- harden Wave-1 CI workflow with explicit job timeouts
- add path-conditional execution for `E2E Tests`, `Bundle Size`, and `Lighthouse` while keeping required jobs green (success, not skipped)
- add diff-aware coverage gate for pull requests (`tools/scripts/check-diff-coverage.mjs`)
- adjust ownership checker base-ref inference so team branches default to `integration/wave-1` and coord branches default to `main`
- correct factual root-cause attribution in first/second stability reports and add evidence appendices with run links and failing log lines

## Why
Implements the accepted Wave-1b stability refinements from the decision record:
- D1 factual corrections + evidence appendix
- D3 timeout/no-manual-cancel guardrail support
- D5 path-conditional CI matrix
- D6 diff-aware coverage enforcement

(OpenClaw agent-contract updates are intentionally out-of-scope for this PR per coordinator instruction.)

## Validation
- `node --check tools/scripts/check-diff-coverage.mjs`
- `node --check tools/scripts/check-ownership-scope.mjs`
- `node tools/scripts/check-ownership-scope.mjs`
- `GITHUB_BASE_REF=integration/wave-1 node tools/scripts/check-diff-coverage.mjs`

## Notes
- `Lighthouse` now behaves as required for PWA changes and informational pass for non-PWA changes, without leaving required checks in skipped/pending states.
