### PR TITLE
docs/ci: apply post-review polish nits

### DIFF
--- a/docs/reports/FIRST_SLICE_STABILITY_REVIEW.md
+++ b/docs/reports/FIRST_SLICE_STABILITY_REVIEW.md
@@ -10,7 +10,7 @@
 
 **integration/wave-1 HEAD (post S1)**: `6a252d943dd2`  
 **Open PRs after first-slice**: 0  
-**Branch protection**: 5 required checks (Ownership Scope, Quality Guard, Test & Build, E2E Tests, Bundle Size), `enforce_admins=true` (enabled during this slice). Lighthouse ran as an additional CI job.
+**Branch protection**: 5 required checks (Ownership Scope, Quality Guard, Test & Build, E2E Tests, Bundle Size), `enforce_admins=true` (enabled during this slice). Lighthouse is path-conditional (required for `apps/web-pwa/**`, informational otherwise).
 
 ---
 

--- a/tools/scripts/check-diff-coverage.mjs
+++ b/tools/scripts/check-diff-coverage.mjs
@@ -45,6 +45,8 @@ function changedFilesSince(mergeBase) {
   return raw ? raw.split('\n').map((line) => line.trim()).filter(Boolean) : [];
 }
 
+// Keep this deny-list intentionally small and shrinking over time.
+// Any new exclusion should require explicit coordinator approval.
 const COVERAGE_EXCLUDES = [
   /^apps\/web-pwa\/src\/main\.tsx$/,
   /^apps\/web-pwa\/src\/App\.tsx$/,


### PR DESCRIPTION
## Summary
- clarify first-slice branch-protection wording to explicitly call Lighthouse path-conditional behavior
- add maintenance note to `COVERAGE_EXCLUDES` in `check-diff-coverage.mjs` (deny-list should shrink; additions require coordinator approval)

## Why
Applies the two low-severity follow-up nits from review, without changing runtime behavior.

## Validation
- `node --check tools/scripts/check-diff-coverage.mjs`
