### PR TITLE
feat(feed): C-3 FeedShell + FilterChips + SortControls

### DIFF
--- a/apps/web-pwa/src/components/feed/FeedShell.test.tsx
+++ b/apps/web-pwa/src/components/feed/FeedShell.test.tsx
@@ -1,0 +1,195 @@
+/* @vitest-environment jsdom */
+
+import { render, screen, cleanup, within, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { describe, expect, it, afterEach, vi } from 'vitest';
+import { FeedShell } from './FeedShell';
+import type { UseDiscoveryFeedResult } from '../../hooks/useDiscoveryFeed';
+import type { FeedItem } from '@vh/data-model';
+
+// ---- Helpers ----
+
+const NOW = 1_700_000_000_000;
+const HOUR_MS = 3_600_000;
+
+function makeFeedItem(overrides: Partial<FeedItem> = {}): FeedItem {
+  return {
+    topic_id: 'topic-1',
+    kind: 'NEWS_STORY',
+    title: 'Test headline',
+    created_at: NOW - 2 * HOUR_MS,
+    latest_activity_at: NOW - HOUR_MS,
+    hotness: 5.0,
+    eye: 10,
+    lightbulb: 5,
+    comments: 3,
+    ...overrides,
+  };
+}
+
+function makeFeedResult(
+  overrides: Partial<UseDiscoveryFeedResult> = {},
+): UseDiscoveryFeedResult {
+  return {
+    feed: [],
+    filter: 'ALL',
+    sortMode: 'LATEST',
+    loading: false,
+    error: null,
+    setFilter: vi.fn(),
+    setSortMode: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('FeedShell', () => {
+  afterEach(() => cleanup());
+
+  // ---- Rendering structure ----
+
+  it('renders the shell container', () => {
+    render(<FeedShell feedResult={makeFeedResult()} />);
+    expect(screen.getByTestId('feed-shell')).toBeInTheDocument();
+  });
+
+  it('renders FilterChips component', () => {
+    render(<FeedShell feedResult={makeFeedResult()} />);
+    expect(screen.getByTestId('filter-chips')).toBeInTheDocument();
+  });
+
+  it('renders SortControls component', () => {
+    render(<FeedShell feedResult={makeFeedResult()} />);
+    expect(screen.getByTestId('sort-controls')).toBeInTheDocument();
+  });
+
+  // ---- Empty state ----
+
+  it('shows empty state when feed is empty', () => {
+    render(<FeedShell feedResult={makeFeedResult({ feed: [] })} />);
+    expect(screen.getByTestId('feed-empty')).toBeInTheDocument();
+    expect(screen.getByText('No items to show.')).toBeInTheDocument();
+  });
+
+  // ---- Loading state ----
+
+  it('shows loading state when loading is true', () => {
+    render(<FeedShell feedResult={makeFeedResult({ loading: true })} />);
+    expect(screen.getByTestId('feed-loading')).toBeInTheDocument();
+    expect(screen.getByText('Loading feed…')).toBeInTheDocument();
+  });
+
+  it('does not show feed list while loading', () => {
+    render(<FeedShell feedResult={makeFeedResult({ loading: true })} />);
+    expect(screen.queryByTestId('feed-list')).not.toBeInTheDocument();
+  });
+
+  // ---- Error state ----
+
+  it('shows error state when error is set', () => {
+    render(
+      <FeedShell feedResult={makeFeedResult({ error: 'Network error' })} />,
+    );
+    expect(screen.getByTestId('feed-error')).toBeInTheDocument();
+    expect(screen.getByText('Network error')).toBeInTheDocument();
+  });
+
+  it('error has role=alert for accessibility', () => {
+    render(
+      <FeedShell feedResult={makeFeedResult({ error: 'Bad request' })} />,
+    );
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+  });
+
+  it('error takes precedence over loading', () => {
+    render(
+      <FeedShell
+        feedResult={makeFeedResult({ error: 'Err', loading: true })}
+      />,
+    );
+    expect(screen.getByTestId('feed-error')).toBeInTheDocument();
+    expect(screen.queryByTestId('feed-loading')).not.toBeInTheDocument();
+  });
+
+  it('error takes precedence over feed items', () => {
+    const items = [makeFeedItem({ topic_id: 'a' })];
+    render(
+      <FeedShell
+        feedResult={makeFeedResult({ error: 'Err', feed: items })}
+      />,
+    );
+    expect(screen.getByTestId('feed-error')).toBeInTheDocument();
+    expect(screen.queryByTestId('feed-list')).not.toBeInTheDocument();
+  });
+
+  // ---- Feed items ----
+
+  it('renders feed items when available', () => {
+    const items = [
+      makeFeedItem({ topic_id: 'item-1', title: 'First' }),
+      makeFeedItem({ topic_id: 'item-2', title: 'Second' }),
+    ];
+    render(<FeedShell feedResult={makeFeedResult({ feed: items })} />);
+    expect(screen.getByTestId('feed-list')).toBeInTheDocument();
+    expect(screen.getByTestId('feed-item-item-1')).toBeInTheDocument();
+    expect(screen.getByTestId('feed-item-item-2')).toBeInTheDocument();
+  });
+
+  it('renders item title and kind', () => {
+    const items = [
+      makeFeedItem({ topic_id: 'x', title: 'Hot news', kind: 'NEWS_STORY' }),
+    ];
+    render(<FeedShell feedResult={makeFeedResult({ feed: items })} />);
+    const row = screen.getByTestId('feed-item-x');
+    expect(within(row).getByText('Hot news')).toBeInTheDocument();
+    expect(within(row).getByText('NEWS_STORY')).toBeInTheDocument();
+  });
+
+  // ---- Filter and sort interaction ----
+
+  it('passes active filter to FilterChips', () => {
+    render(<FeedShell feedResult={makeFeedResult({ filter: 'TOPICS' })} />);
+    expect(screen.getByTestId('filter-chip-TOPICS')).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+  });
+
+  it('passes active sortMode to SortControls', () => {
+    render(
+      <FeedShell feedResult={makeFeedResult({ sortMode: 'HOTTEST' })} />,
+    );
+    expect(screen.getByTestId('sort-mode-HOTTEST')).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+  });
+
+  it('calls setFilter when a filter chip is clicked', () => {
+    const setFilter = vi.fn();
+    render(<FeedShell feedResult={makeFeedResult({ setFilter })} />);
+
+    fireEvent.click(screen.getByTestId('filter-chip-NEWS'));
+    expect(setFilter).toHaveBeenCalledWith('NEWS');
+  });
+
+  it('calls setSortMode when a sort button is clicked', () => {
+    const setSortMode = vi.fn();
+    render(<FeedShell feedResult={makeFeedResult({ setSortMode })} />);
+
+    fireEvent.click(screen.getByTestId('sort-mode-MY_ACTIVITY'));
+    expect(setSortMode).toHaveBeenCalledWith('MY_ACTIVITY');
+  });
+
+  // ---- Multiple items render ----
+
+  it('renders correct number of items', () => {
+    const items = [
+      makeFeedItem({ topic_id: 'a' }),
+      makeFeedItem({ topic_id: 'b' }),
+      makeFeedItem({ topic_id: 'c' }),
+    ];
+    render(<FeedShell feedResult={makeFeedResult({ feed: items })} />);
+    const list = screen.getByTestId('feed-list');
+    expect(list.querySelectorAll('li')).toHaveLength(3);
+  });
+});

--- a/apps/web-pwa/src/components/feed/FeedShell.tsx
+++ b/apps/web-pwa/src/components/feed/FeedShell.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import type { FeedItem } from '@vh/data-model';
+import type { UseDiscoveryFeedResult } from '../../hooks/useDiscoveryFeed';
+import { FilterChips } from './FilterChips';
+import { SortControls } from './SortControls';
+
+export interface FeedShellProps {
+  /** Discovery feed hook result (injected for testability). */
+  readonly feedResult: UseDiscoveryFeedResult;
+}
+
+/**
+ * Shell container for the V2 discovery feed.
+ * Composes FilterChips + SortControls + feed item list.
+ *
+ * This component is mounted only when VITE_FEED_V2_ENABLED is on (C-5).
+ * It does NOT gate itself — the flag guard lives in the page/route layer.
+ *
+ * Spec: docs/specs/spec-topic-discovery-ranking-v0.md §2
+ */
+export const FeedShell: React.FC<FeedShellProps> = ({ feedResult }) => {
+  const { feed, filter, sortMode, loading, error, setFilter, setSortMode } =
+    feedResult;
+
+  return (
+    <div className="flex flex-col gap-4" data-testid="feed-shell">
+      {/* Controls row */}
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <FilterChips active={filter} onSelect={setFilter} />
+        <SortControls active={sortMode} onSelect={setSortMode} />
+      </div>
+
+      {/* Feed content area */}
+      <FeedContent feed={feed} loading={loading} error={error} />
+    </div>
+  );
+};
+
+// ---- Internal sub-components ----
+
+interface FeedContentProps {
+  readonly feed: ReadonlyArray<FeedItem>;
+  readonly loading: boolean;
+  readonly error: string | null;
+}
+
+const FeedContent: React.FC<FeedContentProps> = ({ feed, loading, error }) => {
+  if (error) {
+    return (
+      <div
+        role="alert"
+        data-testid="feed-error"
+        className="rounded bg-red-50 p-3 text-sm text-red-700"
+      >
+        {error}
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div
+        data-testid="feed-loading"
+        className="py-8 text-center text-sm text-slate-400"
+      >
+        Loading feed…
+      </div>
+    );
+  }
+
+  if (feed.length === 0) {
+    return (
+      <div
+        data-testid="feed-empty"
+        className="py-8 text-center text-sm text-slate-400"
+      >
+        No items to show.
+      </div>
+    );
+  }
+
+  return (
+    <ul data-testid="feed-list" className="space-y-3">
+      {feed.map((item) => (
+        <FeedItemRow key={item.topic_id} item={item} />
+      ))}
+    </ul>
+  );
+};
+
+// ---- Placeholder item row (C-4 will replace with real cards) ----
+
+interface FeedItemRowProps {
+  readonly item: FeedItem;
+}
+
+const FeedItemRow: React.FC<FeedItemRowProps> = ({ item }) => {
+  return (
+    <li
+      data-testid={`feed-item-${item.topic_id}`}
+      className="rounded border border-slate-200 p-3"
+    >
+      <span className="text-sm font-medium">{item.title}</span>
+      <span className="ml-2 text-xs text-slate-400">{item.kind}</span>
+    </li>
+  );
+};
+
+export default FeedShell;

--- a/apps/web-pwa/src/components/feed/FilterChips.test.tsx
+++ b/apps/web-pwa/src/components/feed/FilterChips.test.tsx
@@ -1,0 +1,104 @@
+/* @vitest-environment jsdom */
+
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { describe, expect, it, afterEach, vi } from 'vitest';
+import { FilterChips } from './FilterChips';
+import type { FilterChip } from '@vh/data-model';
+
+describe('FilterChips', () => {
+  afterEach(() => cleanup());
+
+  it('renders all four filter chips', () => {
+    render(<FilterChips active="ALL" onSelect={vi.fn()} />);
+    expect(screen.getByTestId('filter-chip-ALL')).toBeInTheDocument();
+    expect(screen.getByTestId('filter-chip-NEWS')).toBeInTheDocument();
+    expect(screen.getByTestId('filter-chip-TOPICS')).toBeInTheDocument();
+    expect(screen.getByTestId('filter-chip-SOCIAL')).toBeInTheDocument();
+  });
+
+  it('displays correct labels', () => {
+    render(<FilterChips active="ALL" onSelect={vi.fn()} />);
+    expect(screen.getByText('All')).toBeInTheDocument();
+    expect(screen.getByText('News')).toBeInTheDocument();
+    expect(screen.getByText('Topics')).toBeInTheDocument();
+    expect(screen.getByText('Social')).toBeInTheDocument();
+  });
+
+  it('marks the active chip with aria-pressed=true', () => {
+    render(<FilterChips active="NEWS" onSelect={vi.fn()} />);
+    expect(screen.getByTestId('filter-chip-NEWS')).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+    expect(screen.getByTestId('filter-chip-ALL')).toHaveAttribute(
+      'aria-pressed',
+      'false',
+    );
+    expect(screen.getByTestId('filter-chip-TOPICS')).toHaveAttribute(
+      'aria-pressed',
+      'false',
+    );
+    expect(screen.getByTestId('filter-chip-SOCIAL')).toHaveAttribute(
+      'aria-pressed',
+      'false',
+    );
+  });
+
+  it('calls onSelect with the correct chip when clicked', () => {
+    const onSelect = vi.fn<(chip: FilterChip) => void>();
+    render(<FilterChips active="ALL" onSelect={onSelect} />);
+
+    fireEvent.click(screen.getByTestId('filter-chip-TOPICS'));
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith('TOPICS');
+  });
+
+  it('calls onSelect for each chip type', () => {
+    const onSelect = vi.fn<(chip: FilterChip) => void>();
+    render(<FilterChips active="ALL" onSelect={onSelect} />);
+
+    fireEvent.click(screen.getByTestId('filter-chip-NEWS'));
+    expect(onSelect).toHaveBeenCalledWith('NEWS');
+
+    fireEvent.click(screen.getByTestId('filter-chip-SOCIAL'));
+    expect(onSelect).toHaveBeenCalledWith('SOCIAL');
+
+    fireEvent.click(screen.getByTestId('filter-chip-ALL'));
+    expect(onSelect).toHaveBeenCalledWith('ALL');
+
+    expect(onSelect).toHaveBeenCalledTimes(3);
+  });
+
+  it('applies active styling to the selected chip', () => {
+    render(<FilterChips active="SOCIAL" onSelect={vi.fn()} />);
+    const activeChip = screen.getByTestId('filter-chip-SOCIAL');
+    expect(activeChip.className).toContain('bg-blue-600');
+    expect(activeChip.className).toContain('text-white');
+  });
+
+  it('applies inactive styling to non-selected chips', () => {
+    render(<FilterChips active="SOCIAL" onSelect={vi.fn()} />);
+    const inactiveChip = screen.getByTestId('filter-chip-ALL');
+    expect(inactiveChip.className).toContain('bg-slate-200');
+    expect(inactiveChip.className).toContain('text-slate-700');
+  });
+
+  it('has a group role with accessible label', () => {
+    render(<FilterChips active="ALL" onSelect={vi.fn()} />);
+    const group = screen.getByTestId('filter-chips');
+    expect(group).toHaveAttribute('role', 'group');
+    expect(group).toHaveAttribute('aria-label', 'Feed filter');
+  });
+
+  it('renders chips in spec order: ALL, NEWS, TOPICS, SOCIAL', () => {
+    render(<FilterChips active="ALL" onSelect={vi.fn()} />);
+    const group = screen.getByTestId('filter-chips');
+    const buttons = group.querySelectorAll('button');
+    expect(buttons).toHaveLength(4);
+    expect(buttons[0]).toHaveAttribute('data-testid', 'filter-chip-ALL');
+    expect(buttons[1]).toHaveAttribute('data-testid', 'filter-chip-NEWS');
+    expect(buttons[2]).toHaveAttribute('data-testid', 'filter-chip-TOPICS');
+    expect(buttons[3]).toHaveAttribute('data-testid', 'filter-chip-SOCIAL');
+  });
+});

--- a/apps/web-pwa/src/components/feed/FilterChips.tsx
+++ b/apps/web-pwa/src/components/feed/FilterChips.tsx
@@ -1,0 +1,85 @@
+import React, { useCallback } from 'react';
+import { FILTER_CHIPS, type FilterChip } from '@vh/data-model';
+
+/**
+ * Filter chip labels for display.
+ * Spec: docs/specs/spec-topic-discovery-ranking-v0.md §2
+ */
+const CHIP_LABELS: Record<FilterChip, string> = {
+  ALL: 'All',
+  NEWS: 'News',
+  TOPICS: 'Topics',
+  SOCIAL: 'Social',
+};
+
+export interface FilterChipsProps {
+  /** Currently active filter chip. */
+  readonly active: FilterChip;
+  /** Called when a chip is clicked. */
+  readonly onSelect: (chip: FilterChip) => void;
+}
+
+/**
+ * Horizontal chip bar for filtering the discovery feed by kind.
+ * Renders one chip per FILTER_CHIPS value; highlights the active chip.
+ *
+ * Spec: docs/specs/spec-topic-discovery-ranking-v0.md §2
+ */
+export const FilterChips: React.FC<FilterChipsProps> = ({ active, onSelect }) => {
+  return (
+    <div
+      className="flex gap-2"
+      role="group"
+      aria-label="Feed filter"
+      data-testid="filter-chips"
+    >
+      {FILTER_CHIPS.map((chip) => (
+        <FilterChipButton
+          key={chip}
+          chip={chip}
+          label={CHIP_LABELS[chip]}
+          isActive={chip === active}
+          onSelect={onSelect}
+        />
+      ))}
+    </div>
+  );
+};
+
+// ---- Internal chip button ----
+
+interface FilterChipButtonProps {
+  readonly chip: FilterChip;
+  readonly label: string;
+  readonly isActive: boolean;
+  readonly onSelect: (chip: FilterChip) => void;
+}
+
+const FilterChipButton: React.FC<FilterChipButtonProps> = ({
+  chip,
+  label,
+  isActive,
+  onSelect,
+}) => {
+  const handleClick = useCallback(() => {
+    onSelect(chip);
+  }, [chip, onSelect]);
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      aria-pressed={isActive}
+      data-testid={`filter-chip-${chip}`}
+      className={
+        isActive
+          ? 'rounded-full bg-blue-600 px-3 py-1 text-sm font-medium text-white'
+          : 'rounded-full bg-slate-200 px-3 py-1 text-sm font-medium text-slate-700'
+      }
+    >
+      {label}
+    </button>
+  );
+};
+
+export default FilterChips;

--- a/apps/web-pwa/src/components/feed/SortControls.test.tsx
+++ b/apps/web-pwa/src/components/feed/SortControls.test.tsx
@@ -1,0 +1,94 @@
+/* @vitest-environment jsdom */
+
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { describe, expect, it, afterEach, vi } from 'vitest';
+import { SortControls } from './SortControls';
+import type { SortMode } from '@vh/data-model';
+
+describe('SortControls', () => {
+  afterEach(() => cleanup());
+
+  it('renders all three sort mode buttons', () => {
+    render(<SortControls active="LATEST" onSelect={vi.fn()} />);
+    expect(screen.getByTestId('sort-mode-LATEST')).toBeInTheDocument();
+    expect(screen.getByTestId('sort-mode-HOTTEST')).toBeInTheDocument();
+    expect(screen.getByTestId('sort-mode-MY_ACTIVITY')).toBeInTheDocument();
+  });
+
+  it('displays correct labels', () => {
+    render(<SortControls active="LATEST" onSelect={vi.fn()} />);
+    expect(screen.getByText('Latest')).toBeInTheDocument();
+    expect(screen.getByText('Hottest')).toBeInTheDocument();
+    expect(screen.getByText('My Activity')).toBeInTheDocument();
+  });
+
+  it('marks the active mode with aria-pressed=true', () => {
+    render(<SortControls active="HOTTEST" onSelect={vi.fn()} />);
+    expect(screen.getByTestId('sort-mode-HOTTEST')).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+    expect(screen.getByTestId('sort-mode-LATEST')).toHaveAttribute(
+      'aria-pressed',
+      'false',
+    );
+    expect(screen.getByTestId('sort-mode-MY_ACTIVITY')).toHaveAttribute(
+      'aria-pressed',
+      'false',
+    );
+  });
+
+  it('calls onSelect with the correct mode when clicked', () => {
+    const onSelect = vi.fn<(mode: SortMode) => void>();
+    render(<SortControls active="LATEST" onSelect={onSelect} />);
+
+    fireEvent.click(screen.getByTestId('sort-mode-HOTTEST'));
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith('HOTTEST');
+  });
+
+  it('calls onSelect for each mode type', () => {
+    const onSelect = vi.fn<(mode: SortMode) => void>();
+    render(<SortControls active="LATEST" onSelect={onSelect} />);
+
+    fireEvent.click(screen.getByTestId('sort-mode-LATEST'));
+    expect(onSelect).toHaveBeenCalledWith('LATEST');
+
+    fireEvent.click(screen.getByTestId('sort-mode-MY_ACTIVITY'));
+    expect(onSelect).toHaveBeenCalledWith('MY_ACTIVITY');
+
+    expect(onSelect).toHaveBeenCalledTimes(2);
+  });
+
+  it('applies active styling to the selected mode', () => {
+    render(<SortControls active="MY_ACTIVITY" onSelect={vi.fn()} />);
+    const active = screen.getByTestId('sort-mode-MY_ACTIVITY');
+    expect(active.className).toContain('bg-blue-600');
+    expect(active.className).toContain('text-white');
+  });
+
+  it('applies inactive styling to non-selected modes', () => {
+    render(<SortControls active="MY_ACTIVITY" onSelect={vi.fn()} />);
+    const inactive = screen.getByTestId('sort-mode-LATEST');
+    expect(inactive.className).toContain('bg-slate-200');
+    expect(inactive.className).toContain('text-slate-700');
+  });
+
+  it('has a group role with accessible label', () => {
+    render(<SortControls active="LATEST" onSelect={vi.fn()} />);
+    const group = screen.getByTestId('sort-controls');
+    expect(group).toHaveAttribute('role', 'group');
+    expect(group).toHaveAttribute('aria-label', 'Feed sort');
+  });
+
+  it('renders modes in spec order: LATEST, HOTTEST, MY_ACTIVITY', () => {
+    render(<SortControls active="LATEST" onSelect={vi.fn()} />);
+    const group = screen.getByTestId('sort-controls');
+    const buttons = group.querySelectorAll('button');
+    expect(buttons).toHaveLength(3);
+    expect(buttons[0]).toHaveAttribute('data-testid', 'sort-mode-LATEST');
+    expect(buttons[1]).toHaveAttribute('data-testid', 'sort-mode-HOTTEST');
+    expect(buttons[2]).toHaveAttribute('data-testid', 'sort-mode-MY_ACTIVITY');
+  });
+});

--- a/apps/web-pwa/src/components/feed/SortControls.tsx
+++ b/apps/web-pwa/src/components/feed/SortControls.tsx
@@ -1,0 +1,87 @@
+import React, { useCallback } from 'react';
+import { SORT_MODES, type SortMode } from '@vh/data-model';
+
+/**
+ * Sort mode labels for display.
+ * Spec: docs/specs/spec-topic-discovery-ranking-v0.md §2
+ */
+const SORT_LABELS: Record<SortMode, string> = {
+  LATEST: 'Latest',
+  HOTTEST: 'Hottest',
+  MY_ACTIVITY: 'My Activity',
+};
+
+export interface SortControlsProps {
+  /** Currently active sort mode. */
+  readonly active: SortMode;
+  /** Called when a sort mode is selected. */
+  readonly onSelect: (mode: SortMode) => void;
+}
+
+/**
+ * Sort mode selector for the discovery feed.
+ * Renders one button per SORT_MODES value; highlights the active mode.
+ *
+ * Spec: docs/specs/spec-topic-discovery-ranking-v0.md §2
+ */
+export const SortControls: React.FC<SortControlsProps> = ({
+  active,
+  onSelect,
+}) => {
+  return (
+    <div
+      className="flex gap-2"
+      role="group"
+      aria-label="Feed sort"
+      data-testid="sort-controls"
+    >
+      {SORT_MODES.map((mode) => (
+        <SortButton
+          key={mode}
+          mode={mode}
+          label={SORT_LABELS[mode]}
+          isActive={mode === active}
+          onSelect={onSelect}
+        />
+      ))}
+    </div>
+  );
+};
+
+// ---- Internal sort button ----
+
+interface SortButtonProps {
+  readonly mode: SortMode;
+  readonly label: string;
+  readonly isActive: boolean;
+  readonly onSelect: (mode: SortMode) => void;
+}
+
+const SortButton: React.FC<SortButtonProps> = ({
+  mode,
+  label,
+  isActive,
+  onSelect,
+}) => {
+  const handleClick = useCallback(() => {
+    onSelect(mode);
+  }, [mode, onSelect]);
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      aria-pressed={isActive}
+      data-testid={`sort-mode-${mode}`}
+      className={
+        isActive
+          ? 'rounded bg-blue-600 px-3 py-1 text-sm font-medium text-white'
+          : 'rounded bg-slate-200 px-3 py-1 text-sm font-medium text-slate-700'
+      }
+    >
+      {label}
+    </button>
+  );
+};
+
+export default SortControls;


### PR DESCRIPTION
## Summary
- [x] C-3: FeedShell + FilterChips + SortControls for V2 discovery feed

Three new UI components under `apps/web-pwa/src/components/feed/`:
- **FilterChips** — Horizontal chip bar rendering All/News/Topics/Social filter options with active state highlighting and onSelect callback
- **SortControls** — Sort mode selector rendering Latest/Hottest/My Activity with active state and onSelect callback
- **FeedShell** — Container component orchestrating FilterChips + SortControls + feed item list with loading/error/empty states

## Scope
- [x] No unrelated file changes in this PR.
- [x] This PR stays within one coherent slice.

## Wave 1 Branch/Ownership Contract
- [x] Branch name uses allowed prefix: `team-c/*`.
- [ ] If using `coord/*`, coordinator rationale is included below.
- [x] Changed files are within owned paths per `.github/ownership-map.json`.
- [x] `Ownership Scope` check is expected to pass for this branch.

## Target Branch
- [x] Wave 1 implementation PR targets `integration/wave-1` (not `main`).
- [ ] If this PR targets `main`, explain why it is not a Wave 1 implementation slice.

## Feature Flags (if applicable)
- [x] New V2 behavior is guarded by required flags:
  - Components are standalone modules — flag gating (`VITE_FEED_V2_ENABLED`) is wired in C-5
- [x] Existing behavior remains intact when flags are `false`.

## Testing
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test:quick` — 99 files, 1279 tests pass (35 new)
- [x] 100% line+branch coverage for all new files

## Design Notes
- FeedShell accepts `feedResult: UseDiscoveryFeedResult` as a prop (injected) for full testability
- Placeholder `FeedItemRow` renders title + kind; C-4 will replace with real card components
- All components use Tailwind CSS classes consistent with existing codebase patterns
- Accessible: role="group" with aria-label, aria-pressed on active buttons, role="alert" on errors

Spec: `docs/specs/spec-topic-discovery-ranking-v0.md` §2
