### PR TITLE
feat(news-aggregator): B-3 clustering logic + provenance

### DIFF
--- a/services/news-aggregator/src/cluster.test.ts
+++ b/services/news-aggregator/src/cluster.test.ts
@@ -1,0 +1,629 @@
+import { describe, it, expect } from 'vitest';
+import { StoryBundleSchema } from '@vh/data-model';
+import type { FeedSource } from '@vh/data-model';
+import { clusterItems, extractWords } from './cluster';
+import type { NormalizedFeedItem } from './normalize';
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                           */
+/* ------------------------------------------------------------------ */
+
+const FIXED_NOW = 1700000000000;
+const SIX_HOURS = 6 * 60 * 60 * 1000;
+
+function makeItem(overrides: Partial<NormalizedFeedItem> = {}): NormalizedFeedItem {
+  return {
+    sourceId: 'src-1',
+    url: 'https://example.com/article',
+    title: 'Climate Change Summit Results',
+    publishedAt: FIXED_NOW,
+    summary: 'Summary of the article',
+    canonicalUrl: 'https://example.com/article',
+    urlHash: 'aabb1122',
+    ...overrides,
+  };
+}
+
+function makeFeedSources(
+  ...entries: [string, string][]
+): Map<string, FeedSource> {
+  const map = new Map<string, FeedSource>();
+  for (const [id, name] of entries) {
+    map.set(id, {
+      id,
+      name,
+      rssUrl: `https://${id}.example.com/rss`,
+      enabled: true,
+    });
+  }
+  return map;
+}
+
+/* ------------------------------------------------------------------ */
+/*  extractWords                                                      */
+/* ------------------------------------------------------------------ */
+
+describe('extractWords', () => {
+  it('extracts significant words, removing stop words and short words', () => {
+    const words = extractWords('The Climate Change Summit in Paris');
+    expect(words).toEqual(['climate', 'change', 'summit', 'paris']);
+  });
+
+  it('lowercases all words', () => {
+    const words = extractWords('BREAKING NEWS Technology');
+    expect(words).toEqual(['breaking', 'news', 'technology']);
+  });
+
+  it('strips non-alphanumeric characters', () => {
+    const words = extractWords("Biden's $100M Climate-Plan!");
+    expect(words).toEqual(['bidens', '100m', 'climateplan']);
+  });
+
+  it('returns empty for all-stop-word titles', () => {
+    const words = extractWords('the is a an');
+    expect(words).toEqual([]);
+  });
+
+  it('filters words with 2 or fewer chars', () => {
+    const words = extractWords('AI UK EU trade deal');
+    // 'ai' and 'uk' and 'eu' are 2 chars → filtered out
+    expect(words).toEqual(['trade', 'deal']);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  clusterItems — empty input                                        */
+/* ------------------------------------------------------------------ */
+
+describe('clusterItems', () => {
+  const sources = makeFeedSources(
+    ['src-1', 'News Daily'],
+    ['src-2', 'World Report'],
+    ['src-3', 'Tech Journal'],
+  );
+  const nowFn = () => FIXED_NOW;
+
+  it('returns empty array for empty input', () => {
+    const result = clusterItems([], sources, { nowFn });
+    expect(result).toEqual([]);
+  });
+
+  /* ---------------------------------------------------------------- */
+  /*  Single item cluster                                             */
+  /* ---------------------------------------------------------------- */
+
+  it('creates a valid StoryBundle from a single item', () => {
+    const item = makeItem();
+    const bundles = clusterItems([item], sources, { nowFn });
+
+    expect(bundles).toHaveLength(1);
+    const bundle = bundles[0]!;
+
+    // Validate against schema
+    expect(() => StoryBundleSchema.parse(bundle)).not.toThrow();
+
+    expect(bundle.schemaVersion).toBe('story-bundle-v0');
+    expect(bundle.headline).toBe('Climate Change Summit Results');
+    expect(bundle.summary_hint).toBe('Summary of the article');
+    expect(bundle.sources).toHaveLength(1);
+    expect(bundle.sources[0]!.publisher).toBe('News Daily');
+    expect(bundle.sources[0]!.url).toBe('https://example.com/article');
+    expect(bundle.cluster_window_start).toBe(FIXED_NOW);
+    expect(bundle.cluster_window_end).toBe(FIXED_NOW);
+    expect(bundle.created_at).toBe(FIXED_NOW);
+  });
+
+  /* ---------------------------------------------------------------- */
+  /*  Stable IDs                                                      */
+  /* ---------------------------------------------------------------- */
+
+  it('generates stable story_id and topic_id for same input', () => {
+    const items = [makeItem()];
+
+    const bundles1 = clusterItems(items, sources, { nowFn });
+    const bundles2 = clusterItems(items, sources, { nowFn });
+
+    expect(bundles1[0]!.story_id).toBe(bundles2[0]!.story_id);
+    expect(bundles1[0]!.topic_id).toBe(bundles2[0]!.topic_id);
+    expect(bundles1[0]!.story_id).toMatch(/^story-[0-9a-f]{8}$/);
+    expect(bundles1[0]!.topic_id).toMatch(/^topic-[0-9a-f]{8}$/);
+  });
+
+  /* ---------------------------------------------------------------- */
+  /*  Multi-source clustering                                         */
+  /* ---------------------------------------------------------------- */
+
+  it('clusters items with shared entity keys in the same time bucket', () => {
+    const item1 = makeItem({
+      sourceId: 'src-1',
+      title: 'Climate Summit Begins',
+      url: 'https://a.com/1',
+      canonicalUrl: 'https://a.com/1',
+      urlHash: 'hash_a1',
+      publishedAt: FIXED_NOW,
+    });
+    const item2 = makeItem({
+      sourceId: 'src-2',
+      title: 'Climate Summit Day One',
+      url: 'https://b.com/1',
+      canonicalUrl: 'https://b.com/1',
+      urlHash: 'hash_b1',
+      publishedAt: FIXED_NOW + 1000,
+    });
+
+    const bundles = clusterItems([item1, item2], sources, { nowFn });
+
+    // Should be in same cluster (shared "climate", "summit")
+    expect(bundles).toHaveLength(1);
+    expect(bundles[0]!.sources).toHaveLength(2);
+
+    // Validate schema
+    expect(() => StoryBundleSchema.parse(bundles[0]!)).not.toThrow();
+  });
+
+  it('separates items in different time buckets', () => {
+    const item1 = makeItem({
+      sourceId: 'src-1',
+      title: 'Climate Summit Begins',
+      url: 'https://a.com/1',
+      canonicalUrl: 'https://a.com/1',
+      urlHash: 'hash_a1',
+      publishedAt: FIXED_NOW,
+    });
+    const item2 = makeItem({
+      sourceId: 'src-2',
+      title: 'Climate Summit Day Two',
+      url: 'https://b.com/2',
+      canonicalUrl: 'https://b.com/2',
+      urlHash: 'hash_b2',
+      publishedAt: FIXED_NOW + SIX_HOURS + 1, // next bucket
+    });
+
+    const bundles = clusterItems([item1, item2], sources, { nowFn });
+    expect(bundles).toHaveLength(2);
+  });
+
+  it('separates items with no shared entity keys in same bucket', () => {
+    const item1 = makeItem({
+      sourceId: 'src-1',
+      title: 'Climate Summit Begins',
+      url: 'https://a.com/1',
+      canonicalUrl: 'https://a.com/1',
+      urlHash: 'hash_a1',
+      publishedAt: FIXED_NOW,
+    });
+    const item2 = makeItem({
+      sourceId: 'src-2',
+      title: 'Technology Stocks Rally',
+      url: 'https://b.com/1',
+      canonicalUrl: 'https://b.com/1',
+      urlHash: 'hash_b1',
+      publishedAt: FIXED_NOW + 1000,
+    });
+
+    const bundles = clusterItems([item1, item2], sources, { nowFn });
+    expect(bundles).toHaveLength(2);
+  });
+
+  /* ---------------------------------------------------------------- */
+  /*  Provenance                                                      */
+  /* ---------------------------------------------------------------- */
+
+  it('preserves all sources in provenance (no dropped URLs)', () => {
+    const items = [
+      makeItem({
+        sourceId: 'src-1',
+        title: 'Climate Change News',
+        url: 'https://a.com/1',
+        canonicalUrl: 'https://a.com/1',
+        urlHash: 'ha',
+        publishedAt: FIXED_NOW,
+      }),
+      makeItem({
+        sourceId: 'src-2',
+        title: 'Climate Change Update',
+        url: 'https://b.com/1',
+        canonicalUrl: 'https://b.com/1',
+        urlHash: 'hb',
+        publishedAt: FIXED_NOW + 100,
+      }),
+      makeItem({
+        sourceId: 'src-3',
+        title: 'Climate Change Report',
+        url: 'https://c.com/1',
+        canonicalUrl: 'https://c.com/1',
+        urlHash: 'hc',
+        publishedAt: FIXED_NOW + 200,
+      }),
+    ];
+
+    const bundles = clusterItems(items, sources, { nowFn });
+    expect(bundles).toHaveLength(1);
+    expect(bundles[0]!.sources).toHaveLength(3);
+
+    const urls = bundles[0]!.sources.map((s) => s.url).sort();
+    expect(urls).toEqual([
+      'https://a.com/1',
+      'https://b.com/1',
+      'https://c.com/1',
+    ]);
+  });
+
+  it('provenance_hash is deterministic', () => {
+    const items = [
+      makeItem({
+        sourceId: 'src-1',
+        title: 'Climate Summit',
+        url: 'https://a.com/1',
+        canonicalUrl: 'https://a.com/1',
+        urlHash: 'ha',
+      }),
+      makeItem({
+        sourceId: 'src-2',
+        title: 'Climate Summit Update',
+        url: 'https://b.com/1',
+        canonicalUrl: 'https://b.com/1',
+        urlHash: 'hb',
+      }),
+    ];
+
+    const b1 = clusterItems(items, sources, { nowFn });
+    const b2 = clusterItems(items, sources, { nowFn });
+    expect(b1[0]!.provenance_hash).toBe(b2[0]!.provenance_hash);
+    expect(b1[0]!.provenance_hash).toMatch(/^[0-9a-f]{8}$/);
+  });
+
+  /* ---------------------------------------------------------------- */
+  /*  Headline & summary selection                                    */
+  /* ---------------------------------------------------------------- */
+
+  it('selects headline from earliest item by publishedAt', () => {
+    const items = [
+      makeItem({
+        sourceId: 'src-2',
+        title: 'Climate Later',
+        url: 'https://b.com/1',
+        canonicalUrl: 'https://b.com/1',
+        urlHash: 'hb',
+        publishedAt: FIXED_NOW + 5000,
+        summary: 'Later summary',
+      }),
+      makeItem({
+        sourceId: 'src-1',
+        title: 'Climate Earlier',
+        url: 'https://a.com/1',
+        canonicalUrl: 'https://a.com/1',
+        urlHash: 'ha',
+        publishedAt: FIXED_NOW,
+        summary: 'Earlier summary',
+      }),
+    ];
+
+    const bundles = clusterItems(items, sources, { nowFn });
+    expect(bundles).toHaveLength(1);
+    expect(bundles[0]!.headline).toBe('Climate Earlier');
+    expect(bundles[0]!.summary_hint).toBe('Earlier summary');
+  });
+
+  it('uses undefined summary_hint when first item has no summary', () => {
+    const item = makeItem({ summary: undefined });
+    const bundles = clusterItems([item], sources, { nowFn });
+    expect(bundles[0]!.summary_hint).toBeUndefined();
+  });
+
+  /* ---------------------------------------------------------------- */
+  /*  Cluster window                                                  */
+  /* ---------------------------------------------------------------- */
+
+  it('sets cluster_window from min/max publishedAt', () => {
+    const items = [
+      makeItem({
+        sourceId: 'src-1',
+        title: 'Climate Change Alpha',
+        url: 'https://a.com/1',
+        canonicalUrl: 'https://a.com/1',
+        urlHash: 'ha',
+        publishedAt: FIXED_NOW,
+      }),
+      makeItem({
+        sourceId: 'src-2',
+        title: 'Climate Change Beta',
+        url: 'https://b.com/1',
+        canonicalUrl: 'https://b.com/1',
+        urlHash: 'hb',
+        publishedAt: FIXED_NOW + 3000,
+      }),
+    ];
+
+    const bundles = clusterItems(items, sources, { nowFn });
+    expect(bundles[0]!.cluster_window_start).toBe(FIXED_NOW);
+    expect(bundles[0]!.cluster_window_end).toBe(FIXED_NOW + 3000);
+  });
+
+  it('uses nowFn for cluster window when no publishedAt', () => {
+    const items = [
+      makeItem({
+        title: 'Climate Mystery',
+        publishedAt: undefined,
+        url: 'https://a.com/1',
+        canonicalUrl: 'https://a.com/1',
+        urlHash: 'ha',
+      }),
+    ];
+
+    const bundles = clusterItems(items, sources, { nowFn });
+    expect(bundles[0]!.cluster_window_start).toBe(FIXED_NOW);
+    expect(bundles[0]!.cluster_window_end).toBe(FIXED_NOW);
+  });
+
+  /* ---------------------------------------------------------------- */
+  /*  Time bucket features                                            */
+  /* ---------------------------------------------------------------- */
+
+  it('sets time_bucket to tb-unknown when no timestamps', () => {
+    const items = [
+      makeItem({
+        title: 'Climate Mystery',
+        publishedAt: undefined,
+        url: 'https://a.com/1',
+        canonicalUrl: 'https://a.com/1',
+        urlHash: 'ha',
+      }),
+    ];
+
+    const bundles = clusterItems(items, sources, { nowFn });
+    expect(bundles[0]!.cluster_features.time_bucket).toBe('tb-unknown');
+  });
+
+  it('computes time_bucket from earliest timestamp', () => {
+    const items = [makeItem({ publishedAt: FIXED_NOW })];
+    const bundles = clusterItems(items, sources, { nowFn });
+    const expected = `tb-${Math.floor(FIXED_NOW / SIX_HOURS)}`;
+    expect(bundles[0]!.cluster_features.time_bucket).toBe(expected);
+  });
+
+  /* ---------------------------------------------------------------- */
+  /*  Entity keys                                                     */
+  /* ---------------------------------------------------------------- */
+
+  it('limits entity keys to maxEntityKeys', () => {
+    const items = [
+      makeItem({
+        title: 'Alpha Bravo Charlie Delta Echo Foxtrot Golf Hotel India Juliet',
+        url: 'https://a.com/1',
+        canonicalUrl: 'https://a.com/1',
+        urlHash: 'ha',
+      }),
+    ];
+
+    const bundles = clusterItems(items, sources, {
+      nowFn,
+      maxEntityKeys: 3,
+    });
+    expect(bundles[0]!.cluster_features.entity_keys).toHaveLength(3);
+  });
+
+  it('entity_keys are sorted alphabetically', () => {
+    const items = [
+      makeItem({
+        title: 'Zebra Apple Mango',
+        url: 'https://a.com/1',
+        canonicalUrl: 'https://a.com/1',
+        urlHash: 'ha',
+      }),
+    ];
+
+    const bundles = clusterItems(items, sources, { nowFn });
+    const keys = bundles[0]!.cluster_features.entity_keys;
+    expect(keys).toEqual([...keys].sort());
+  });
+
+  /* ---------------------------------------------------------------- */
+  /*  Custom options                                                  */
+  /* ---------------------------------------------------------------- */
+
+  it('respects custom timeBucketMs', () => {
+    const ONE_HOUR = 60 * 60 * 1000;
+    const item1 = makeItem({
+      title: 'Climate Update Alpha',
+      url: 'https://a.com/1',
+      canonicalUrl: 'https://a.com/1',
+      urlHash: 'ha',
+      publishedAt: FIXED_NOW,
+    });
+    const item2 = makeItem({
+      title: 'Climate Update Beta',
+      url: 'https://b.com/1',
+      canonicalUrl: 'https://b.com/1',
+      urlHash: 'hb',
+      publishedAt: FIXED_NOW + ONE_HOUR + 1,
+    });
+
+    // With 1-hour buckets, these should be in different buckets
+    const bundles = clusterItems([item1, item2], sources, {
+      nowFn,
+      timeBucketMs: ONE_HOUR,
+    });
+    expect(bundles).toHaveLength(2);
+  });
+
+  it('defaults nowFn to Date.now when not provided', () => {
+    const item = makeItem({ publishedAt: undefined });
+    const before = Date.now();
+    const bundles = clusterItems([item], sources);
+    const after = Date.now();
+
+    expect(bundles[0]!.created_at).toBeGreaterThanOrEqual(before);
+    expect(bundles[0]!.created_at).toBeLessThanOrEqual(after);
+  });
+
+  /* ---------------------------------------------------------------- */
+  /*  Schema compliance                                               */
+  /* ---------------------------------------------------------------- */
+
+  it('all output bundles pass StoryBundleSchema validation', () => {
+    const items = [
+      makeItem({
+        sourceId: 'src-1',
+        title: 'Economy Growth Report',
+        url: 'https://a.com/1',
+        canonicalUrl: 'https://a.com/1',
+        urlHash: 'h1',
+        publishedAt: FIXED_NOW,
+      }),
+      makeItem({
+        sourceId: 'src-2',
+        title: 'Economy Growth Forecast',
+        url: 'https://b.com/1',
+        canonicalUrl: 'https://b.com/1',
+        urlHash: 'h2',
+        publishedAt: FIXED_NOW + 1000,
+      }),
+      makeItem({
+        sourceId: 'src-3',
+        title: 'Technology Innovation Summit',
+        url: 'https://c.com/1',
+        canonicalUrl: 'https://c.com/1',
+        urlHash: 'h3',
+        publishedAt: FIXED_NOW + 2000,
+      }),
+    ];
+
+    const bundles = clusterItems(items, sources, { nowFn });
+    for (const bundle of bundles) {
+      expect(() => StoryBundleSchema.parse(bundle)).not.toThrow();
+    }
+  });
+
+  /* ---------------------------------------------------------------- */
+  /*  Semantic signature stability                                    */
+  /* ---------------------------------------------------------------- */
+
+  it('semantic_signature is stable for same URLs', () => {
+    const items = [
+      makeItem({
+        title: 'Climate Report',
+        url: 'https://a.com/1',
+        canonicalUrl: 'https://a.com/1',
+        urlHash: 'ha',
+      }),
+    ];
+
+    const b1 = clusterItems(items, sources, { nowFn });
+    const b2 = clusterItems(items, sources, { nowFn });
+    expect(b1[0]!.cluster_features.semantic_signature).toBe(
+      b2[0]!.cluster_features.semantic_signature,
+    );
+  });
+
+  /* ---------------------------------------------------------------- */
+  /*  Items with undefined publishedAt sorting                        */
+  /* ---------------------------------------------------------------- */
+
+  it('items without publishedAt sort after items with publishedAt', () => {
+    const item1 = makeItem({
+      sourceId: 'src-1',
+      title: 'Climate Story Timed',
+      url: 'https://a.com/1',
+      canonicalUrl: 'https://a.com/1',
+      urlHash: 'ha',
+      publishedAt: FIXED_NOW + 5000,
+      summary: 'Timed summary',
+    });
+    const item2 = makeItem({
+      sourceId: 'src-2',
+      title: 'Climate Story Untimed',
+      url: 'https://b.com/1',
+      canonicalUrl: 'https://b.com/1',
+      urlHash: 'hb',
+      publishedAt: undefined,
+      summary: 'Untimed summary',
+    });
+
+    // Both in tb-unknown bucket? No — item1 has publishedAt, item2 does not.
+    // They'll be in different buckets.
+    const bundles = clusterItems([item2, item1], sources, { nowFn });
+    // item1 → specific bucket, item2 → tb-unknown bucket
+    expect(bundles.length).toBeGreaterThanOrEqual(2);
+
+    // Verify the timed one has proper headline
+    const timedBundle = bundles.find((b) =>
+      b.cluster_features.time_bucket !== 'tb-unknown',
+    );
+    expect(timedBundle?.headline).toBe('Climate Story Timed');
+  });
+
+  /* ---------------------------------------------------------------- */
+  /*  Both items without publishedAt in same cluster                  */
+  /* ---------------------------------------------------------------- */
+
+  it('handles multiple items without publishedAt in same cluster', () => {
+    const items = [
+      makeItem({
+        sourceId: 'src-1',
+        title: 'Climate Story Alpha',
+        url: 'https://a.com/1',
+        canonicalUrl: 'https://a.com/1',
+        urlHash: 'ha',
+        publishedAt: undefined,
+        summary: 'Alpha summary',
+      }),
+      makeItem({
+        sourceId: 'src-2',
+        title: 'Climate Story Beta',
+        url: 'https://b.com/1',
+        canonicalUrl: 'https://b.com/1',
+        urlHash: 'hb',
+        publishedAt: undefined,
+        summary: 'Beta summary',
+      }),
+    ];
+
+    const bundles = clusterItems(items, sources, { nowFn });
+    expect(bundles).toHaveLength(1);
+    // Both undefined → array order preserved; first item becomes headline
+    expect(bundles[0]!.headline).toBe('Climate Story Alpha');
+    expect(bundles[0]!.sources).toHaveLength(2);
+    expect(bundles[0]!.cluster_features.time_bucket).toBe('tb-unknown');
+    expect(() => StoryBundleSchema.parse(bundles[0]!)).not.toThrow();
+  });
+
+  /* ---------------------------------------------------------------- */
+  /*  Union-find merging: transitive entity key sharing               */
+  /* ---------------------------------------------------------------- */
+
+  it('merges items transitively through shared entity keys', () => {
+    // A shares "climate" with B, B shares "summit" with C
+    // So A, B, C should all be in one cluster
+    const items = [
+      makeItem({
+        sourceId: 'src-1',
+        title: 'Climate Policy Debate',
+        url: 'https://a.com/1',
+        canonicalUrl: 'https://a.com/1',
+        urlHash: 'ha',
+        publishedAt: FIXED_NOW,
+      }),
+      makeItem({
+        sourceId: 'src-2',
+        title: 'Climate Summit Opening',
+        url: 'https://b.com/1',
+        canonicalUrl: 'https://b.com/1',
+        urlHash: 'hb',
+        publishedAt: FIXED_NOW + 100,
+      }),
+      makeItem({
+        sourceId: 'src-3',
+        title: 'Summit Closing Remarks',
+        url: 'https://c.com/1',
+        canonicalUrl: 'https://c.com/1',
+        urlHash: 'hc',
+        publishedAt: FIXED_NOW + 200,
+      }),
+    ];
+
+    const bundles = clusterItems(items, sources, { nowFn });
+    expect(bundles).toHaveLength(1);
+    expect(bundles[0]!.sources).toHaveLength(3);
+  });
+});

--- a/services/news-aggregator/src/cluster.ts
+++ b/services/news-aggregator/src/cluster.ts
@@ -1,0 +1,349 @@
+/**
+ * Clustering module — groups NormalizedFeedItems into StoryBundles.
+ *
+ * Implements entity-key extraction, time-bucket computation,
+ * semantic signature, and stable story/topic ID generation.
+ *
+ * Pure logic, no I/O.
+ *
+ * @module @vh/news-aggregator/cluster
+ */
+
+import type { FeedSource, StoryBundle } from '@vh/data-model';
+import { STORY_BUNDLE_VERSION } from '@vh/data-model';
+import type { NormalizedFeedItem } from './normalize';
+import { toStoryBundleSource, computeProvenanceHash } from './provenance';
+
+/* ------------------------------------------------------------------ */
+/*  Constants                                                         */
+/* ------------------------------------------------------------------ */
+
+const DEFAULT_TIME_BUCKET_MS = 6 * 60 * 60 * 1000; // 6 hours
+const DEFAULT_MAX_ENTITY_KEYS = 5;
+
+/* prettier-ignore */
+const STOP_WORDS: ReadonlySet<string> = new Set([
+  'a','an','the','is','are','was','were','be','been','being','have','has','had',
+  'do','does','did','will','would','could','should','may','might','shall','can',
+  'to','of','in','for','on','with','at','by','from','as','into','about','after',
+  'before','between','through','during','above','below','and','but','or','nor',
+  'not','so','yet','both','either','neither','each','every','all','any','few',
+  'more','most','other','some','such','no','only','own','same','than','too',
+  'very','just','also','now','then','here','there','when','where','how','what',
+  'which','who','whom','this','that','these','those','it','its','he','she',
+  'they','them','his','her','their','our','your','my','we','you','up','out',
+]);
+
+/* ------------------------------------------------------------------ */
+/*  FNV-1a 32-bit hash                                                */
+/* ------------------------------------------------------------------ */
+
+function fnv1a32(input: string): string {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(16).padStart(8, '0');
+}
+
+/* ------------------------------------------------------------------ */
+/*  Options                                                           */
+/* ------------------------------------------------------------------ */
+
+/** Configuration for the clustering algorithm. */
+export interface ClusterOptions {
+  /** Time bucket size in milliseconds (default: 6 hours). */
+  timeBucketMs?: number;
+  /** Maximum entity keys per cluster (default: 5). */
+  maxEntityKeys?: number;
+  /** Injectable clock for testing (default: Date.now). */
+  nowFn?: () => number;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Entity key extraction                                             */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Extract significant words from a title for entity keying.
+ * Lowercases, strips non-alphanumeric, removes stop words and
+ * short words (≤2 chars).
+ */
+export function extractWords(title: string): string[] {
+  return title
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, '')
+    .split(/\s+/)
+    .filter((w) => w.length > 2 && !STOP_WORDS.has(w));
+}
+
+/**
+ * Compute top-N entity keys from a set of items by word frequency.
+ * Returns sorted keys for determinism.
+ */
+function topEntityKeys(items: NormalizedFeedItem[], max: number): string[] {
+  const freq = new Map<string, number>();
+  for (const item of items) {
+    for (const word of extractWords(item.title)) {
+      freq.set(word, (freq.get(word) ?? 0) + 1);
+    }
+  }
+
+  return [...freq.entries()]
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .slice(0, max)
+    .map(([word]) => word)
+    .sort();
+}
+
+/* ------------------------------------------------------------------ */
+/*  Time bucket                                                       */
+/* ------------------------------------------------------------------ */
+
+function computeTimeBucket(
+  items: NormalizedFeedItem[],
+  bucketMs: number,
+): string {
+  const timestamps = items
+    .map((i) => i.publishedAt)
+    .filter((t): t is number => t !== undefined);
+
+  if (timestamps.length === 0) return 'tb-unknown';
+
+  const min = Math.min(...timestamps);
+  return `tb-${Math.floor(min / bucketMs)}`;
+}
+
+/** Get the time-bucket number for a single item. */
+function itemTimeBucket(
+  publishedAt: number | undefined,
+  bucketMs: number,
+): string {
+  if (publishedAt === undefined) return 'tb-unknown';
+  return `tb-${Math.floor(publishedAt / bucketMs)}`;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Semantic signature                                                */
+/* ------------------------------------------------------------------ */
+
+function computeSemanticSignature(items: NormalizedFeedItem[]): string {
+  const urls = items.map((i) => i.canonicalUrl).sort();
+  return fnv1a32(urls.join('|'));
+}
+
+/* ------------------------------------------------------------------ */
+/*  Stable ID generation                                              */
+/* ------------------------------------------------------------------ */
+
+function generateStoryId(
+  entityKeys: string[],
+  timeBucket: string,
+  semanticSig: string,
+): string {
+  const payload = `${entityKeys.join(',')}|${timeBucket}|${semanticSig}`;
+  return `story-${fnv1a32(payload)}`;
+}
+
+function generateTopicId(entityKeys: string[]): string {
+  return `topic-${fnv1a32(entityKeys.join(','))}`;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Headline / summary selection — sort by publishedAt ascending      */
+/* ------------------------------------------------------------------ */
+function sortByTime(items: NormalizedFeedItem[]): NormalizedFeedItem[] {
+  return [...items].sort((a, b) => {
+    if (a.publishedAt === undefined && b.publishedAt === undefined) return 0;
+    /* v8 ignore next 2: defensive — mixed undefined/defined within a single bucket is prevented by grouping, but kept for safety */
+    if (a.publishedAt === undefined) return 1;
+    if (b.publishedAt === undefined) return -1;
+    return a.publishedAt - b.publishedAt;
+  });
+}
+
+/* ------------------------------------------------------------------ */
+/*  Cluster window                                                    */
+/* ------------------------------------------------------------------ */
+
+function clusterWindow(
+  items: NormalizedFeedItem[],
+  nowFn: () => number,
+): { start: number; end: number } {
+  const timestamps = items
+    .map((i) => i.publishedAt)
+    .filter((t): t is number => t !== undefined);
+
+  if (timestamps.length === 0) {
+    const now = nowFn();
+    return { start: now, end: now };
+  }
+
+  return {
+    start: Math.min(...timestamps),
+    end: Math.max(...timestamps),
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/*  Grouping helpers                                                  */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Group items into clusters by time bucket, then merge within each
+ * bucket by shared entity keys (union-find on overlapping words).
+ */
+function groupItems(
+  items: NormalizedFeedItem[],
+  bucketMs: number,
+): NormalizedFeedItem[][] {
+  // Phase 1: group by time bucket
+  const byBucket = new Map<string, NormalizedFeedItem[]>();
+  for (const item of items) {
+    const bucket = itemTimeBucket(item.publishedAt, bucketMs);
+    const arr = byBucket.get(bucket);
+    if (arr) {
+      arr.push(item);
+    } else {
+      byBucket.set(bucket, [item]);
+    }
+  }
+
+  // Phase 2: within each bucket, merge items sharing ≥1 entity key
+  const clusters: NormalizedFeedItem[][] = [];
+  for (const bucketItems of byBucket.values()) {
+    const merged = mergeBySharedKeys(bucketItems);
+    clusters.push(...merged);
+  }
+
+  return clusters;
+}
+
+/**
+ * Union-find-style merge: items sharing at least one entity key
+ * are grouped together.
+ */
+function mergeBySharedKeys(
+  items: NormalizedFeedItem[],
+): NormalizedFeedItem[][] {
+  // Map each item index to its extracted words
+  const itemWords = items.map((item) => new Set(extractWords(item.title)));
+
+  // Parent array for union-find
+  const parent = items.map((_, i) => i);
+
+  function find(x: number): number {
+    while (parent[x] !== x) {
+      parent[x] = parent[parent[x]!]!; // path compression
+      x = parent[x]!;
+    }
+    return x;
+  }
+
+  function union(a: number, b: number): void {
+    const ra = find(a);
+    const rb = find(b);
+    if (ra !== rb) parent[ra] = rb;
+  }
+
+  // Build word → item indices map
+  const wordToIndices = new Map<string, number[]>();
+  for (let i = 0; i < items.length; i++) {
+    for (const word of itemWords[i]!) {
+      const indices = wordToIndices.get(word);
+      if (indices) {
+        indices.push(i);
+      } else {
+        wordToIndices.set(word, [i]);
+      }
+    }
+  }
+
+  // Union items that share any word
+  for (const indices of wordToIndices.values()) {
+    for (let j = 1; j < indices.length; j++) {
+      union(indices[0]!, indices[j]!);
+    }
+  }
+
+  // Collect groups
+  const groups = new Map<number, NormalizedFeedItem[]>();
+  for (let i = 0; i < items.length; i++) {
+    const root = find(i);
+    const arr = groups.get(root);
+    if (arr) {
+      arr.push(items[i]!);
+    } else {
+      groups.set(root, [items[i]!]);
+    }
+  }
+
+  return [...groups.values()];
+}
+
+/* ------------------------------------------------------------------ */
+/*  Main entry point                                                  */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Cluster normalized feed items into StoryBundles.
+ *
+ * Algorithm:
+ * 1. Group items by time bucket (configurable, default 6h).
+ * 2. Within each bucket, merge items sharing ≥1 entity key.
+ * 3. Build a StoryBundle for each cluster group.
+ *
+ * Single-item clusters are valid (a story with one source).
+ *
+ * @param items - Deduplicated, normalized feed items.
+ * @param feedSources - Map of sourceId → FeedSource for publisher lookup.
+ * @param options - Optional clustering configuration.
+ * @returns Array of StoryBundle objects.
+ */
+export function clusterItems(
+  items: NormalizedFeedItem[],
+  feedSources: Map<string, FeedSource>,
+  options?: ClusterOptions,
+): StoryBundle[] {
+  if (items.length === 0) return [];
+
+  const bucketMs = options?.timeBucketMs ?? DEFAULT_TIME_BUCKET_MS;
+  const maxKeys = options?.maxEntityKeys ?? DEFAULT_MAX_ENTITY_KEYS;
+  const nowFn = options?.nowFn ?? Date.now;
+
+  const groups = groupItems(items, bucketMs);
+
+  return groups.map((group) => {
+    const sorted = sortByTime(group);
+    const first = sorted[0]!;
+
+    const entityKeys = topEntityKeys(group, maxKeys);
+    const timeBucket = computeTimeBucket(group, bucketMs);
+    const semanticSig = computeSemanticSignature(group);
+
+    const sources = group.map((item) =>
+      toStoryBundleSource(item, feedSources),
+    );
+    const provenanceHash = computeProvenanceHash(sources);
+    const window = clusterWindow(group, nowFn);
+
+    return {
+      schemaVersion: STORY_BUNDLE_VERSION,
+      story_id: generateStoryId(entityKeys, timeBucket, semanticSig),
+      topic_id: generateTopicId(entityKeys),
+      headline: first.title,
+      summary_hint: first.summary,
+      cluster_window_start: window.start,
+      cluster_window_end: window.end,
+      sources,
+      cluster_features: {
+        entity_keys: entityKeys,
+        time_bucket: timeBucket,
+        semantic_signature: semanticSig,
+      },
+      provenance_hash: provenanceHash,
+      created_at: nowFn(),
+    };
+  });
+}

--- a/services/news-aggregator/src/index.ts
+++ b/services/news-aggregator/src/index.ts
@@ -41,3 +41,8 @@ export {
   normalizeAndDedup,
 } from './normalize';
 export type { NormalizedFeedItem } from './normalize';
+
+export { toStoryBundleSource, computeProvenanceHash } from './provenance';
+
+export { clusterItems, extractWords } from './cluster';
+export type { ClusterOptions } from './cluster';

--- a/services/news-aggregator/src/provenance.test.ts
+++ b/services/news-aggregator/src/provenance.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect } from 'vitest';
+import type { FeedSource, StoryBundleSource } from '@vh/data-model';
+import { toStoryBundleSource, computeProvenanceHash } from './provenance';
+import type { NormalizedFeedItem } from './normalize';
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                           */
+/* ------------------------------------------------------------------ */
+
+function makeItem(overrides: Partial<NormalizedFeedItem> = {}): NormalizedFeedItem {
+  return {
+    sourceId: 'src-1',
+    url: 'https://example.com/article',
+    title: 'Test Article',
+    publishedAt: 1700000000000,
+    canonicalUrl: 'https://example.com/article',
+    urlHash: 'aabb1122',
+    ...overrides,
+  };
+}
+
+function makeFeedSources(
+  ...entries: [string, string][]
+): Map<string, FeedSource> {
+  const map = new Map<string, FeedSource>();
+  for (const [id, name] of entries) {
+    map.set(id, {
+      id,
+      name,
+      rssUrl: `https://${id}.example.com/rss`,
+      enabled: true,
+    });
+  }
+  return map;
+}
+
+/* ------------------------------------------------------------------ */
+/*  toStoryBundleSource                                               */
+/* ------------------------------------------------------------------ */
+
+describe('toStoryBundleSource', () => {
+  it('maps NormalizedFeedItem to StoryBundleSource with publisher name', () => {
+    const sources = makeFeedSources(['src-1', 'Example News']);
+    const item = makeItem();
+    const result = toStoryBundleSource(item, sources);
+
+    expect(result).toEqual({
+      source_id: 'src-1',
+      publisher: 'Example News',
+      url: 'https://example.com/article',
+      url_hash: 'aabb1122',
+      published_at: 1700000000000,
+      title: 'Test Article',
+    });
+  });
+
+  it('falls back to sourceId when feed source not found', () => {
+    const sources = new Map<string, FeedSource>();
+    const item = makeItem({ sourceId: 'unknown-src' });
+    const result = toStoryBundleSource(item, sources);
+
+    expect(result.publisher).toBe('unknown-src');
+    expect(result.source_id).toBe('unknown-src');
+  });
+
+  it('preserves undefined published_at', () => {
+    const sources = makeFeedSources(['src-1', 'News']);
+    const item = makeItem({ publishedAt: undefined });
+    const result = toStoryBundleSource(item, sources);
+
+    expect(result.published_at).toBeUndefined();
+  });
+
+  it('uses canonicalUrl not original url', () => {
+    const sources = makeFeedSources(['src-1', 'News']);
+    const item = makeItem({
+      url: 'https://example.com/article?utm_source=foo',
+      canonicalUrl: 'https://example.com/article',
+    });
+    const result = toStoryBundleSource(item, sources);
+
+    expect(result.url).toBe('https://example.com/article');
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  computeProvenanceHash                                             */
+/* ------------------------------------------------------------------ */
+
+describe('computeProvenanceHash', () => {
+  it('returns deterministic hash for same sources', () => {
+    const sources: StoryBundleSource[] = [
+      {
+        source_id: 's1',
+        publisher: 'Pub A',
+        url: 'https://a.com/1',
+        url_hash: 'hash_a',
+        title: 'Title A',
+      },
+      {
+        source_id: 's2',
+        publisher: 'Pub B',
+        url: 'https://b.com/1',
+        url_hash: 'hash_b',
+        title: 'Title B',
+      },
+    ];
+
+    const hash1 = computeProvenanceHash(sources);
+    const hash2 = computeProvenanceHash(sources);
+
+    expect(hash1).toBe(hash2);
+    expect(hash1).toMatch(/^[0-9a-f]{8}$/);
+  });
+
+  it('is order-independent (sorts by url_hash)', () => {
+    const s1: StoryBundleSource = {
+      source_id: 's1',
+      publisher: 'A',
+      url: 'https://a.com',
+      url_hash: 'bbb',
+      title: 'A',
+    };
+    const s2: StoryBundleSource = {
+      source_id: 's2',
+      publisher: 'B',
+      url: 'https://b.com',
+      url_hash: 'aaa',
+      title: 'B',
+    };
+
+    expect(computeProvenanceHash([s1, s2])).toBe(
+      computeProvenanceHash([s2, s1]),
+    );
+  });
+
+  it('produces different hashes for different source sets', () => {
+    const s1: StoryBundleSource = {
+      source_id: 's1',
+      publisher: 'A',
+      url: 'https://a.com',
+      url_hash: 'hash1',
+      title: 'A',
+    };
+    const s2: StoryBundleSource = {
+      source_id: 's2',
+      publisher: 'B',
+      url: 'https://b.com',
+      url_hash: 'hash2',
+      title: 'B',
+    };
+    const s3: StoryBundleSource = {
+      source_id: 's3',
+      publisher: 'C',
+      url: 'https://c.com',
+      url_hash: 'hash3',
+      title: 'C',
+    };
+
+    expect(computeProvenanceHash([s1, s2])).not.toBe(
+      computeProvenanceHash([s1, s3]),
+    );
+  });
+
+  it('handles single source', () => {
+    const s: StoryBundleSource = {
+      source_id: 's1',
+      publisher: 'A',
+      url: 'https://a.com',
+      url_hash: 'onlyhash',
+      title: 'A',
+    };
+
+    const hash = computeProvenanceHash([s]);
+    expect(hash).toMatch(/^[0-9a-f]{8}$/);
+  });
+
+  it('does not mutate input array', () => {
+    const sources: StoryBundleSource[] = [
+      {
+        source_id: 's2',
+        publisher: 'B',
+        url: 'https://b.com',
+        url_hash: 'zzz',
+        title: 'B',
+      },
+      {
+        source_id: 's1',
+        publisher: 'A',
+        url: 'https://a.com',
+        url_hash: 'aaa',
+        title: 'A',
+      },
+    ];
+    const original = [...sources];
+    computeProvenanceHash(sources);
+    expect(sources).toEqual(original);
+  });
+});

--- a/services/news-aggregator/src/provenance.ts
+++ b/services/news-aggregator/src/provenance.ts
@@ -1,0 +1,75 @@
+/**
+ * Provenance module — deterministic provenance hash computation
+ * and NormalizedFeedItem → StoryBundleSource mapping.
+ *
+ * Pure logic, no I/O.
+ *
+ * @module @vh/news-aggregator/provenance
+ */
+
+import type { FeedSource, StoryBundleSource } from '@vh/data-model';
+import type { NormalizedFeedItem } from './normalize';
+
+/* ------------------------------------------------------------------ */
+/*  FNV-1a 32-bit hash (same algorithm as normalize.ts)               */
+/* ------------------------------------------------------------------ */
+
+/** FNV-1a 32-bit hash → 8-char hex string. */
+function fnv1a32(input: string): string {
+  let hash = 0x811c9dc5; // FNV offset basis
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193); // FNV prime
+  }
+  return (hash >>> 0).toString(16).padStart(8, '0');
+}
+
+/* ------------------------------------------------------------------ */
+/*  Source mapping                                                    */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Convert a NormalizedFeedItem into a StoryBundleSource entry.
+ *
+ * Uses the feed source name as publisher when available,
+ * falls back to sourceId.
+ *
+ * No source URLs are dropped — every item that enters provenance
+ * is preserved in the output (spec §4).
+ */
+export function toStoryBundleSource(
+  item: NormalizedFeedItem,
+  feedSources: Map<string, FeedSource>,
+): StoryBundleSource {
+  const source = feedSources.get(item.sourceId);
+  return {
+    source_id: item.sourceId,
+    publisher: source?.name ?? item.sourceId,
+    url: item.canonicalUrl,
+    url_hash: item.urlHash,
+    published_at: item.publishedAt,
+    title: item.title,
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/*  Provenance hash                                                   */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Compute a deterministic provenance hash over a list of sources.
+ *
+ * Algorithm (spec §4):
+ * 1. Sort sources by `url_hash` ascending for determinism.
+ * 2. Concatenate sorted url_hashes with '|' separator.
+ * 3. FNV-1a 32-bit hash the concatenation.
+ *
+ * @returns 8-char lowercase hex string.
+ */
+export function computeProvenanceHash(sources: StoryBundleSource[]): string {
+  const sorted = [...sources].sort((a, b) =>
+    a.url_hash.localeCompare(b.url_hash),
+  );
+  const payload = sorted.map((s) => s.url_hash).join('|');
+  return fnv1a32(payload);
+}


### PR DESCRIPTION
## Summary
- [x] Briefly describe what changed and why.

B-3: Clustering logic + provenance for the news-aggregator service.

Implements story clustering (entity-key extraction, time-bucket grouping, union-find merging, semantic signatures, stable story/topic ID generation) and deterministic provenance hashing. All items used in clustering are preserved in provenance (spec §4).

New files:
- `services/news-aggregator/src/cluster.ts` — clustering algorithm
- `services/news-aggregator/src/provenance.ts` — provenance hash + source mapping
- `services/news-aggregator/src/cluster.test.ts` — 28 tests
- `services/news-aggregator/src/provenance.test.ts` — 9 tests

Modified:
- `services/news-aggregator/src/index.ts` — re-exports

## Scope
- [x] No unrelated file changes in this PR.
- [x] This PR stays within one coherent slice.

## Wave 1 Branch/Ownership Contract
- [x] Branch name uses allowed prefix: `team-b/*`.
- [x] Changed files are within owned paths per `.github/ownership-map.json`.
- [x] `Ownership Scope` check is expected to pass for this branch.

## Target Branch
- [x] Wave 1 implementation PR targets `integration/wave-1` (not `main`).

## Feature Flags (if applicable)
N/A — backend service module, no feature flags needed.

## Testing
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test:quick`
- [x] `pnpm test:coverage` — 100% statement, branch, function, and line coverage

All 1244 tests pass globally.