### PR TITLE
fix(ci): scope Bundle Size and Lighthouse builds to @vh/web-pwa only

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -208,7 +208,7 @@ jobs:
 
       - name: Build PWA
         if: needs.change-detection.outputs.run-bundle == 'true'
-        run: pnpm build
+        run: pnpm --filter @vh/web-pwa build
 
       - name: Check Bundle Size (≤ 1 MiB gz)
         if: needs.change-detection.outputs.run-bundle == 'true'
@@ -249,7 +249,7 @@ jobs:
 
       - name: Build PWA
         if: needs.change-detection.outputs.run-lighthouse == 'true'
-        run: pnpm build
+        run: pnpm --filter @vh/web-pwa build
 
       - name: Run Lighthouse (static dist)
         if: needs.change-detection.outputs.run-lighthouse == 'true'


### PR DESCRIPTION
## Summary
Scopes the `Build PWA` step in Bundle Size and Lighthouse CI jobs to `pnpm --filter @vh/web-pwa build` instead of workspace-wide `pnpm build`.

## Problem
Bundle Size and Lighthouse jobs triggered full workspace build including `@vh/contracts` Hardhat compile, causing:
- Transient HH501 failures (Hardhat compiler download timeouts)
- Unnecessary build time for non-PWA packages

## Changes
- `.github/workflows/main.yml`: Bundle Size job `Build PWA` step: `pnpm build` → `pnpm --filter @vh/web-pwa build`
- `.github/workflows/main.yml`: Lighthouse job `Build PWA` step: `pnpm build` → `pnpm --filter @vh/web-pwa build`

## Not changed
- Check names (Bundle Size, Lighthouse)
- Applicability patterns / path filters
- Quality Guard or Test & Build jobs (remain workspace-wide)

## Acceptance
- [ ] Required checks pass
- [ ] Bundle/Lighthouse logs show PWA-only build path
- [ ] No `@vh/contracts` / `hardhat compile` in Bundle/Lighthouse execution