### PR TITLE
C-4: add NewsCard, TopicCard, and SocialNotificationCard

### DIFF
--- a/apps/web-pwa/src/components/feed/FeedShell.test.tsx
+++ b/apps/web-pwa/src/components/feed/FeedShell.test.tsx
@@ -134,14 +134,25 @@ describe('FeedShell', () => {
     expect(screen.getByTestId('feed-item-item-2')).toBeInTheDocument();
   });
 
-  it('renders item title and kind', () => {
+  it('routes each feed kind to the matching card component', () => {
     const items = [
-      makeFeedItem({ topic_id: 'x', title: 'Hot news', kind: 'NEWS_STORY' }),
+      makeFeedItem({ topic_id: 'news', title: 'Hot news', kind: 'NEWS_STORY' }),
+      makeFeedItem({ topic_id: 'topic', title: 'Community topic', kind: 'USER_TOPIC' }),
+      makeFeedItem({
+        topic_id: 'social',
+        title: 'Linked social mention',
+        kind: 'SOCIAL_NOTIFICATION',
+      }),
     ];
+
     render(<FeedShell feedResult={makeFeedResult({ feed: items })} />);
-    const row = screen.getByTestId('feed-item-x');
-    expect(within(row).getByText('Hot news')).toBeInTheDocument();
-    expect(within(row).getByText('NEWS_STORY')).toBeInTheDocument();
+
+    expect(screen.getByTestId('news-card-news')).toBeInTheDocument();
+    expect(screen.getByTestId('topic-card-topic')).toBeInTheDocument();
+    expect(screen.getByTestId('social-card-social')).toBeInTheDocument();
+
+    const socialRow = screen.getByTestId('feed-item-social');
+    expect(within(socialRow).getByText('Linked social mention')).toBeInTheDocument();
   });
 
   // ---- Filter and sort interaction ----

--- a/apps/web-pwa/src/components/feed/FeedShell.tsx
+++ b/apps/web-pwa/src/components/feed/FeedShell.tsx
@@ -3,6 +3,9 @@ import type { FeedItem } from '@vh/data-model';
 import type { UseDiscoveryFeedResult } from '../../hooks/useDiscoveryFeed';
 import { FilterChips } from './FilterChips';
 import { SortControls } from './SortControls';
+import { NewsCard } from './NewsCard';
+import { TopicCard } from './TopicCard';
+import { SocialNotificationCard } from './SocialNotificationCard';
 
 export interface FeedShellProps {
   /** Discovery feed hook result (injected for testability). */
@@ -88,7 +91,7 @@ const FeedContent: React.FC<FeedContentProps> = ({ feed, loading, error }) => {
   );
 };
 
-// ---- Placeholder item row (C-4 will replace with real cards) ----
+// ---- Feed item renderer ----
 
 interface FeedItemRowProps {
   readonly item: FeedItem;
@@ -96,14 +99,34 @@ interface FeedItemRowProps {
 
 const FeedItemRow: React.FC<FeedItemRowProps> = ({ item }) => {
   return (
-    <li
-      data-testid={`feed-item-${item.topic_id}`}
-      className="rounded border border-slate-200 p-3"
-    >
-      <span className="text-sm font-medium">{item.title}</span>
-      <span className="ml-2 text-xs text-slate-400">{item.kind}</span>
+    <li data-testid={`feed-item-${item.topic_id}`}>
+      <FeedItemCard item={item} />
     </li>
   );
+};
+
+interface FeedItemCardProps {
+  readonly item: FeedItem;
+}
+
+const FeedItemCard: React.FC<FeedItemCardProps> = ({ item }) => {
+  switch (item.kind) {
+    case 'NEWS_STORY':
+      return <NewsCard item={item} />;
+    case 'USER_TOPIC':
+      return <TopicCard item={item} />;
+    case 'SOCIAL_NOTIFICATION':
+      return <SocialNotificationCard item={item} />;
+    default:
+      return (
+        <article
+          data-testid={`feed-item-unknown-${item.topic_id}`}
+          className="rounded border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900"
+        >
+          Unsupported feed item kind.
+        </article>
+      );
+  }
 };
 
 export default FeedShell;

--- a/apps/web-pwa/src/components/feed/NewsCard.test.tsx
+++ b/apps/web-pwa/src/components/feed/NewsCard.test.tsx
@@ -1,0 +1,77 @@
+/* @vitest-environment jsdom */
+
+import { render, screen, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { describe, expect, it, afterEach } from 'vitest';
+import type { FeedItem } from '@vh/data-model';
+import { NewsCard } from './NewsCard';
+
+const NOW = 1_700_000_000_000;
+
+function makeNewsItem(overrides: Partial<FeedItem> = {}): FeedItem {
+  return {
+    topic_id: 'news-1',
+    kind: 'NEWS_STORY',
+    title: 'City council votes on transit plan',
+    created_at: NOW - 3_600_000,
+    latest_activity_at: NOW,
+    hotness: 7.1234,
+    eye: 22,
+    lightbulb: 8,
+    comments: 5,
+    ...overrides,
+  };
+}
+
+describe('NewsCard', () => {
+  afterEach(() => cleanup());
+
+  it('renders title and news badge', () => {
+    render(<NewsCard item={makeNewsItem()} />);
+
+    expect(screen.getByTestId('news-card-news-1')).toBeInTheDocument();
+    expect(screen.getByText('News')).toBeInTheDocument();
+    expect(
+      screen.getByText('City council votes on transit plan'),
+    ).toBeInTheDocument();
+  });
+
+  it('renders created/updated timestamps as ISO strings', () => {
+    const item = makeNewsItem();
+    render(<NewsCard item={item} />);
+
+    expect(
+      screen.getByText(
+        `Created ${new Date(item.created_at).toISOString()} • Updated ${new Date(item.latest_activity_at).toISOString()}`,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('renders engagement stats and hotness with fixed precision', () => {
+    render(<NewsCard item={makeNewsItem()} />);
+
+    expect(screen.getByTestId('news-card-eye-news-1')).toHaveTextContent('22');
+    expect(screen.getByTestId('news-card-lightbulb-news-1')).toHaveTextContent('8');
+    expect(screen.getByTestId('news-card-comments-news-1')).toHaveTextContent('5');
+    expect(screen.getByTestId('news-card-hotness-news-1')).toHaveTextContent(
+      'Hotness 7.12',
+    );
+  });
+
+  it('falls back to unknown timestamp and hotness 0.00 for invalid numeric values', () => {
+    const malformed = makeNewsItem({
+      created_at: -1,
+      latest_activity_at: Number.NaN,
+      hotness: Number.POSITIVE_INFINITY,
+    } as Partial<FeedItem>);
+
+    render(<NewsCard item={malformed} />);
+
+    expect(
+      screen.getByText('Created unknown • Updated unknown'),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('news-card-hotness-news-1')).toHaveTextContent(
+      'Hotness 0.00',
+    );
+  });
+});

--- a/apps/web-pwa/src/components/feed/NewsCard.tsx
+++ b/apps/web-pwa/src/components/feed/NewsCard.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import type { FeedItem } from '@vh/data-model';
+
+export interface NewsCardProps {
+  /** Discovery feed item; expected kind: NEWS_STORY. */
+  readonly item: FeedItem;
+}
+
+function formatIsoTimestamp(timestampMs: number): string {
+  if (!Number.isFinite(timestampMs) || timestampMs < 0) {
+    return 'unknown';
+  }
+  return new Date(timestampMs).toISOString();
+}
+
+function formatHotness(hotness: number): string {
+  if (!Number.isFinite(hotness)) {
+    return '0.00';
+  }
+  return hotness.toFixed(2);
+}
+
+/**
+ * Clustered story card for discovery feed NEWS_STORY items.
+ *
+ * Spec context: docs/specs/spec-topic-discovery-ranking-v0.md
+ */
+export const NewsCard: React.FC<NewsCardProps> = ({ item }) => {
+  const latestActivity = formatIsoTimestamp(item.latest_activity_at);
+  const createdAt = formatIsoTimestamp(item.created_at);
+
+  return (
+    <article
+      data-testid={`news-card-${item.topic_id}`}
+      className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm"
+      aria-label="News story"
+    >
+      <header className="mb-2 flex items-center justify-between gap-2">
+        <span className="rounded-full bg-blue-100 px-2 py-0.5 text-xs font-semibold text-blue-700">
+          News
+        </span>
+        <span className="text-xs text-slate-500" data-testid={`news-card-hotness-${item.topic_id}`}>
+          Hotness {formatHotness(item.hotness)}
+        </span>
+      </header>
+
+      <h3 className="text-base font-semibold text-slate-900">{item.title}</h3>
+
+      <p className="mt-1 text-xs text-slate-500">
+        Created {createdAt} • Updated {latestActivity}
+      </p>
+
+      <div className="mt-3 flex flex-wrap gap-2 text-xs text-slate-700">
+        <span data-testid={`news-card-eye-${item.topic_id}`}>👁️ {item.eye}</span>
+        <span data-testid={`news-card-lightbulb-${item.topic_id}`}>💡 {item.lightbulb}</span>
+        <span data-testid={`news-card-comments-${item.topic_id}`}>💬 {item.comments}</span>
+      </div>
+    </article>
+  );
+};
+
+export default NewsCard;

--- a/apps/web-pwa/src/components/feed/SocialNotificationCard.test.tsx
+++ b/apps/web-pwa/src/components/feed/SocialNotificationCard.test.tsx
@@ -1,0 +1,81 @@
+/* @vitest-environment jsdom */
+
+import { render, screen, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { describe, expect, it, afterEach } from 'vitest';
+import type { FeedItem } from '@vh/data-model';
+import {
+  SocialNotificationCard,
+  pickMockPlatform,
+  createMockHandle,
+} from './SocialNotificationCard';
+
+const NOW = 1_700_000_000_000;
+
+function makeSocialItem(overrides: Partial<FeedItem> = {}): FeedItem {
+  return {
+    topic_id: 'social-topic-7',
+    kind: 'SOCIAL_NOTIFICATION',
+    title: '3 people quoted this thread in external discussion.',
+    created_at: NOW - 10_000,
+    latest_activity_at: NOW,
+    hotness: 2.2,
+    eye: 11,
+    lightbulb: 4,
+    comments: 6,
+    ...overrides,
+  };
+}
+
+describe('SocialNotificationCard', () => {
+  afterEach(() => cleanup());
+
+  it('renders platform badge, title, and mock handle preview', () => {
+    render(<SocialNotificationCard item={makeSocialItem()} />);
+
+    expect(screen.getByTestId('social-card-social-topic-7')).toBeInTheDocument();
+    expect(screen.getByTestId('social-card-platform-social-topic-7')).toBeInTheDocument();
+    expect(
+      screen.getByText('3 people quoted this thread in external discussion.'),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('social-card-handle-social-topic-7')).toHaveTextContent(
+      '@socialtopic7 mentioned this topic.',
+    );
+  });
+
+  it('renders engagement stats', () => {
+    render(<SocialNotificationCard item={makeSocialItem()} />);
+
+    expect(screen.getByTestId('social-card-eye-social-topic-7')).toHaveTextContent(
+      '11',
+    );
+    expect(
+      screen.getByTestId('social-card-lightbulb-social-topic-7'),
+    ).toHaveTextContent('4');
+    expect(
+      screen.getByTestId('social-card-comments-social-topic-7'),
+    ).toHaveTextContent('6');
+  });
+
+  it('pickMockPlatform is deterministic for the same topic id', () => {
+    const first = pickMockPlatform('same-topic-id');
+    const second = pickMockPlatform('same-topic-id');
+
+    expect(first.label).toBe(second.label);
+    expect(first.icon).toBe(second.icon);
+  });
+
+  it('pickMockPlatform falls back to first platform when topic id is empty', () => {
+    const platform = pickMockPlatform('');
+    expect(platform.label).toBe('Bluesky');
+    expect(platform.icon).toBe('🦋');
+  });
+
+  it('createMockHandle sanitizes and truncates topic id', () => {
+    expect(createMockHandle('SOCIAL-TOPIC-1234567890')).toBe('@socialtopic1');
+  });
+
+  it('createMockHandle falls back when topic id has no alphanumerics', () => {
+    expect(createMockHandle('---___***')).toBe('@community');
+  });
+});

--- a/apps/web-pwa/src/components/feed/SocialNotificationCard.tsx
+++ b/apps/web-pwa/src/components/feed/SocialNotificationCard.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import type { FeedItem } from '@vh/data-model';
+
+export interface SocialNotificationCardProps {
+  /** Discovery feed item; expected kind: SOCIAL_NOTIFICATION. */
+  readonly item: FeedItem;
+}
+
+const PLATFORM_MOCKS = [
+  { label: 'Bluesky', icon: '🦋', badgeClass: 'bg-sky-100 text-sky-700' },
+  { label: 'Mastodon', icon: '🐘', badgeClass: 'bg-indigo-100 text-indigo-700' },
+  { label: 'Nostr', icon: '⚡', badgeClass: 'bg-violet-100 text-violet-700' },
+] as const;
+
+function stableHash(value: string): number {
+  let hash = 0;
+  for (let i = 0; i < value.length; i += 1) {
+    hash = (hash * 31 + value.charCodeAt(i)) >>> 0;
+  }
+  return hash;
+}
+
+export function pickMockPlatform(topicId: string): (typeof PLATFORM_MOCKS)[number] {
+  if (!topicId) {
+    return PLATFORM_MOCKS[0];
+  }
+  const index = stableHash(topicId) % PLATFORM_MOCKS.length;
+  return PLATFORM_MOCKS[index as 0 | 1 | 2];
+}
+
+export function createMockHandle(topicId: string): string {
+  const sanitized = topicId.toLowerCase().replace(/[^a-z0-9]/g, '');
+  if (sanitized.length === 0) {
+    return '@community';
+  }
+  return `@${sanitized.slice(0, 12)}`;
+}
+
+/**
+ * Social notification shell card.
+ * Wave 1 boundary: mock presentation only, no OAuth/token or live ingestion.
+ */
+export const SocialNotificationCard: React.FC<SocialNotificationCardProps> = ({
+  item,
+}) => {
+  const platform = pickMockPlatform(item.topic_id);
+  const handle = createMockHandle(item.topic_id);
+
+  return (
+    <article
+      data-testid={`social-card-${item.topic_id}`}
+      className="rounded-xl border border-violet-200 bg-violet-50 p-4 shadow-sm"
+      aria-label="Social notification"
+    >
+      <header className="mb-2 flex items-center justify-between gap-2">
+        <span
+          data-testid={`social-card-platform-${item.topic_id}`}
+          className={`rounded-full px-2 py-0.5 text-xs font-semibold ${platform.badgeClass}`}
+        >
+          {platform.icon} {platform.label}
+        </span>
+        <span className="text-xs text-violet-800">Mock social preview</span>
+      </header>
+
+      <h3 className="text-base font-semibold text-slate-900">{item.title}</h3>
+
+      <p className="mt-1 text-xs text-slate-600" data-testid={`social-card-handle-${item.topic_id}`}>
+        {handle} mentioned this topic.
+      </p>
+
+      <div className="mt-3 flex flex-wrap gap-2 text-xs text-slate-700">
+        <span data-testid={`social-card-eye-${item.topic_id}`}>👁️ {item.eye}</span>
+        <span data-testid={`social-card-lightbulb-${item.topic_id}`}>💡 {item.lightbulb}</span>
+        <span data-testid={`social-card-comments-${item.topic_id}`}>💬 {item.comments}</span>
+      </div>
+    </article>
+  );
+};
+
+export default SocialNotificationCard;

--- a/apps/web-pwa/src/components/feed/TopicCard.test.tsx
+++ b/apps/web-pwa/src/components/feed/TopicCard.test.tsx
@@ -1,0 +1,76 @@
+/* @vitest-environment jsdom */
+
+import { render, screen, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { describe, expect, it, afterEach } from 'vitest';
+import type { FeedItem } from '@vh/data-model';
+import { TopicCard } from './TopicCard';
+
+const NOW = 1_700_000_000_000;
+
+function makeTopicItem(overrides: Partial<FeedItem> = {}): FeedItem {
+  return {
+    topic_id: 'topic-42',
+    kind: 'USER_TOPIC',
+    title: 'Should the district pilot free transit weekends?',
+    created_at: NOW - 7_200_000,
+    latest_activity_at: NOW,
+    hotness: 3.5,
+    eye: 14,
+    lightbulb: 9,
+    comments: 12,
+    my_activity_score: 4.25,
+    ...overrides,
+  };
+}
+
+describe('TopicCard', () => {
+  afterEach(() => cleanup());
+
+  it('renders topic badge, title, and stats', () => {
+    render(<TopicCard item={makeTopicItem()} />);
+
+    expect(screen.getByTestId('topic-card-topic-42')).toBeInTheDocument();
+    expect(screen.getByText('Topic')).toBeInTheDocument();
+    expect(
+      screen.getByText('Should the district pilot free transit weekends?'),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('topic-card-eye-topic-42')).toHaveTextContent(
+      '14',
+    );
+    expect(
+      screen.getByTestId('topic-card-lightbulb-topic-42'),
+    ).toHaveTextContent('9');
+    expect(screen.getByTestId('topic-card-comments-topic-42')).toHaveTextContent(
+      '12',
+    );
+  });
+
+  it('formats my_activity_score with one decimal place', () => {
+    render(<TopicCard item={makeTopicItem()} />);
+
+    expect(
+      screen.getByTestId('topic-card-activity-topic-42'),
+    ).toHaveTextContent('My activity 4.3');
+  });
+
+  it('uses 0.0 when my_activity_score is missing', () => {
+    render(<TopicCard item={makeTopicItem({ my_activity_score: undefined })} />);
+
+    expect(
+      screen.getByTestId('topic-card-activity-topic-42'),
+    ).toHaveTextContent('My activity 0.0');
+  });
+
+  it('uses 0.0 when my_activity_score is invalid', () => {
+    render(
+      <TopicCard
+        item={makeTopicItem({ my_activity_score: Number.NEGATIVE_INFINITY })}
+      />,
+    );
+
+    expect(
+      screen.getByTestId('topic-card-activity-topic-42'),
+    ).toHaveTextContent('My activity 0.0');
+  });
+});

--- a/apps/web-pwa/src/components/feed/TopicCard.tsx
+++ b/apps/web-pwa/src/components/feed/TopicCard.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import type { FeedItem } from '@vh/data-model';
+
+export interface TopicCardProps {
+  /** Discovery feed item; expected kind: USER_TOPIC. */
+  readonly item: FeedItem;
+}
+
+function formatActivityScore(score: number | undefined): string {
+  if (typeof score !== 'number' || !Number.isFinite(score) || score < 0) {
+    return '0.0';
+  }
+  return score.toFixed(1);
+}
+
+/**
+ * User topic/thread card for discovery feed USER_TOPIC items.
+ */
+export const TopicCard: React.FC<TopicCardProps> = ({ item }) => {
+  const myActivity = formatActivityScore(item.my_activity_score);
+
+  return (
+    <article
+      data-testid={`topic-card-${item.topic_id}`}
+      className="rounded-xl border border-emerald-200 bg-emerald-50 p-4 shadow-sm"
+      aria-label="User topic"
+    >
+      <header className="mb-2 flex items-center justify-between gap-2">
+        <span className="rounded-full bg-emerald-200 px-2 py-0.5 text-xs font-semibold text-emerald-800">
+          Topic
+        </span>
+        <span className="text-xs text-emerald-900" data-testid={`topic-card-activity-${item.topic_id}`}>
+          My activity {myActivity}
+        </span>
+      </header>
+
+      <h3 className="text-base font-semibold text-slate-900">{item.title}</h3>
+
+      <p className="mt-1 text-xs text-slate-600">Active thread with community responses.</p>
+
+      <div className="mt-3 flex flex-wrap gap-2 text-xs text-slate-700">
+        <span data-testid={`topic-card-eye-${item.topic_id}`}>👁️ {item.eye}</span>
+        <span data-testid={`topic-card-lightbulb-${item.topic_id}`}>💡 {item.lightbulb}</span>
+        <span data-testid={`topic-card-comments-${item.topic_id}`}>💬 {item.comments}</span>
+      </div>
+    </article>
+  );
+};
+
+export default TopicCard;


### PR DESCRIPTION
## Summary
- [x] Added Team C C-4 feed card components: `NewsCard`, `TopicCard`, and `SocialNotificationCard`.
- [x] Updated `FeedShell` to render card-by-kind (`NEWS_STORY`, `USER_TOPIC`, `SOCIAL_NOTIFICATION`) instead of placeholder rows.
- [x] Added component render tests and deterministic mock-social tests.

## Scope
- [x] No unrelated file changes in this PR.
- [x] This PR stays within one coherent slice.

## Wave 1 Branch/Ownership Contract
- [x] Branch name uses allowed prefix: `team-a/*`, `team-b/*`, `team-c/*`, `team-d/*`, `team-e/*`, or `coord/*`.
- [x] If using `coord/*`, coordinator rationale is included below.
- [x] Changed files are within owned paths per `.github/ownership-map.json`.
- [x] `Ownership Scope` check is expected to pass for this branch.

## Target Branch
- [x] Wave 1 implementation PR targets `integration/wave-1` (not `main`).
- [x] If this PR targets `main`, explain why it is not a Wave 1 implementation slice.

## Feature Flags (if applicable)
- [x] New V2 behavior is guarded by required flags:
  - `VITE_TOPIC_SYNTHESIS_V2_ENABLED`
  - `VITE_FEED_V2_ENABLED`
- [x] Existing behavior remains intact when flags are `false`.

## Testing
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test:quick`
- [x] `pnpm test:coverage` (or justified exception)

Coverage verification for new C-4 files (targeted run) is 100% statements/branches/functions/lines for:
- `apps/web-pwa/src/components/feed/NewsCard.tsx`
- `apps/web-pwa/src/components/feed/TopicCard.tsx`
- `apps/web-pwa/src/components/feed/SocialNotificationCard.tsx`

## Coordinator Rationale (required for `coord/*` branches)
N/A (team-owned branch).
