### PR TITLE
docs(wave2): add CE review gate and wave-end doc audit sweep

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,15 +5,15 @@
 - [ ] No unrelated file changes in this PR.
 - [ ] This PR stays within one coherent slice.
 
-## Wave 1 Branch/Ownership Contract
+## Active Wave Branch/Ownership Contract
 - [ ] Branch name uses allowed prefix: `team-a/*`, `team-b/*`, `team-c/*`, `team-d/*`, `team-e/*`, or `coord/*`.
 - [ ] If using `coord/*`, coordinator rationale is included below.
 - [ ] Changed files are within owned paths per `.github/ownership-map.json`.
 - [ ] `Ownership Scope` check is expected to pass for this branch.
 
 ## Target Branch
-- [ ] Wave 1 implementation PR targets `integration/wave-1` (not `main`).
-- [ ] If this PR targets `main`, explain why it is not a Wave 1 implementation slice.
+- [ ] Implementation PR targets the active integration branch (`integration/wave-2` for Wave 2), not `main`.
+- [ ] If this PR targets `main`, explain why it is not an implementation slice for the active wave.
 
 ## Feature Flags (if applicable)
 - [ ] New V2 behavior is guarded by required flags:

--- a/docs/foundational/STATUS.md
+++ b/docs/foundational/STATUS.md
@@ -324,6 +324,7 @@ All Wave 1 features are flag-gated. Tests pass in both ON and OFF configurations
 
 ## Next Work (Wave 2 Direction)
 
+- Run Wave 2 via CE dual-review gate (`ce-codex` + `ce-opus`) for all Director-bound execution prompts.
 - Wire synthesis pipeline runtime to discovery feed UI (v2 end-to-end)
 - Feature-flag retirement (Wave 1 flags → permanent on)
 - Implement linked-social OAuth + notification cards
@@ -342,8 +343,18 @@ All Wave 1 features are flag-gated. Tests pass in both ON and OFF configurations
 - `docs/reports/FIRST_SLICE_STABILITY_REVIEW.md` — First slice stability review
 - `docs/reports/SECOND_SLICE_STABILITY_REVIEW.md` — Second slice stability review
 - `docs/foundational/WAVE1_STABILITY_DECISION_RECORD.md` — Stability decision record
-- `docs/foundational/V2_Sprint_Staffing_Plan.md` — Wave 1 staffing plan
+
+### Wave 2 Control Docs
+- `docs/foundational/WAVE2_DELTA_CONTRACT.md` — Binding wave-2 process/policy deltas
+- `docs/foundational/CE_DUAL_REVIEW_CONTRACTS.md` — CE dual-review protocol and escalation flow
+- `docs/foundational/WAVE2_KICKOFF_COMMAND_SHEET.md` — Wave 2 kickoff and execution runbook
+- `docs/reports/WAVE2_DOC_AUDIT.md` — Wave transition document-audit artifact
+
+### Staffing & Operations
+- `docs/foundational/V2_Sprint_Staffing_Plan.md` — Wave staffing baseline (Wave 1 historical + Wave 2 active)
+- `docs/foundational/V2_Sprint_Staffing_Roles.md` — Agent role contracts (with Wave 2 delta override)
 - `docs/foundational/WAVE1_KICKOFF_COMMAND_SHEET.md` — Wave 1 kickoff commands
+- `docs/foundational/WAVE2_KICKOFF_COMMAND_SHEET.md` — Wave 2 kickoff commands
 
 ### Architecture & Specs
 - `System_Architecture.md` — Target architecture

--- a/docs/foundational/V2_Sprint_Staffing_Plan.md
+++ b/docs/foundational/V2_Sprint_Staffing_Plan.md
@@ -727,6 +727,8 @@ Wave 2 runs **3 concurrent workstreams** after Wave 1 exits green.
 
 | Agent ID | Role | Model | Standing? | Reports to |
 | --- | --- | --- | --- | --- |
+| `ce-codex` | CE Technical Review | `codex-5.3-extra-high` | Persistent (cross-wave) | Coordinator |
+| `ce-opus` | CE Governance Review | `opus-4.6` | Persistent (cross-wave) | Coordinator |
 | `w1-spec` | Spec (cross-team) | `opus-4.6` | Full wave | Coordinator |
 | `w1-qa-integ` | QA-Integration | `opus-4.6` | Full wave | Coordinator |
 | `w1-docs` | Docs | `opus-4.6` | Full wave | Coordinator |
@@ -736,6 +738,8 @@ Wave 2 runs **3 concurrent workstreams** after Wave 1 exits green.
 ```
 Coordinator (human)
 ├── Coordinator (Wave 0 only)
+├── ce-codex (CE technical review, persistent)
+├── ce-opus (CE governance review, persistent)
 ├── w1-spec (cross-team, standing)
 ├── w1-qa-integ (cross-team, standing)
 ├── w1-docs (cross-team, standing)
@@ -768,10 +772,11 @@ Coordinator (human)
 | Standing impl (pure) | 5 (A x2, B x1, C x2) | `codex-5.3-extra-high` |
 | Standing QA (per-team) | 4 (A/B/C/D) | `codex-5.3-extra-high` |
 | Standing cross-wave | 3 (spec, qa-integ, docs) | `opus-4.6` |
+| CE review (persistent) | 2 (ce-codex, ce-opus) | mixed (`codex-5.3-extra-high` + `opus-4.6`) |
 | Per-PR maint | 4 (A/B/C/D) | `opus-4.6` |
 | Per-issue sidecar | 2 (E impl + qa) | `codex-5.3-extra-high` |
-| **Total agent slots** | **23** | |
-| Standing simultaneously (Wave 1) | **16** (excl. Coordinator which ends after Wave 0; excl. per-PR maint and per-issue sidecar agents) | |
+| **Total agent slots** | **25** | |
+| Standing simultaneously (Wave 2) | **18** (excl. Coordinator which ends after Wave 0; excl. per-PR maint and per-issue sidecar agents) | |
 
 ### Role behavior reference
 
@@ -784,6 +789,7 @@ Coordinator (human)
 | **QA-Integration** | Cross-team smoke at 48h cadence, privacy lint, integration E2E, feature flag validation. Maintains readiness matrix of landed dependencies. | One per wave, not per-team. Owns integration pass gate. |
 | **Maint** | Code quality, LOC compliance, integration review, refactoring suggestions | Per-PR (spun up for reviews). Does not need standing context. |
 | **Docs** | Spec drift detection, doc updates if contracts change during implementation | One per wave, standing across teams. Not per-team. |
+| **CE-Review** | Dual-model review of Director-bound execution prompts. `ce-codex` focuses on technical correctness; `ce-opus` focuses on contract/policy coherence. Uses fixed-schema outputs with 2-round convergence cap. | Persistent cross-wave companion layer. See `docs/foundational/CE_DUAL_REVIEW_CONTRACTS.md`. |
 
 ### Spec agent trigger rule
 

--- a/docs/foundational/V2_Sprint_Staffing_Roles.md
+++ b/docs/foundational/V2_Sprint_Staffing_Roles.md
@@ -3,7 +3,9 @@
 Companion to `docs/foundational/V2_Sprint_Staffing_Plan.md`.
 Defines behavioral contracts for every agent role in the Wave 1 cluster.
 
-Last updated: 2026-02-09
+Last updated: 2026-02-11
+
+Wave 2 execution override: for all wave-specific references in this file, follow `docs/foundational/WAVE2_DELTA_CONTRACT.md`. Where this document says `integration/wave-1`, read `integration/wave-2` during Wave 2 operations.
 
 ---
 
@@ -674,6 +676,10 @@ After each team PR merges to `integration/wave-1`:
 ```
 Coordinator (human)
 │
+├── ce-codex + ce-opus ←── dual-review all Director-bound execution prompts
+│    (fixed-schema passes, 2-round cap, escalate to CEO if unresolved)
+│    See: docs/foundational/CE_DUAL_REVIEW_CONTRACTS.md
+│
 ├── w1-spec ←── Chiefs invoke for risky slices
 │                (mandatory for cross-module, schema, security, policy, ambiguity)
 │
@@ -695,17 +701,20 @@ Coordinator (human)
     │    └──► if security-sensitive + specialists unavailable:
     │         Maint + w1-spec + Chief fallback review
     │
-    Chief ──► merge to integration/wave-1 (if all gates pass)
+    Chief ──► merge via merge queue (if all gates pass)
     │
     Chief ──► notify w1-docs for drift check
     │
     Chief ──► completion report
 ```
 
+All execution prompts from Coordinator to Director must pass through the CE dual-review loop before dispatch. Direct Coordinator-to-Director prompts without CE review are allowed only for break/fix emergencies with logged rationale. See `docs/foundational/CE_DUAL_REVIEW_CONTRACTS.md` for protocol details.
+
 ---
 
 ## Revision History
 
+- 2026-02-11: Added Wave 2 delta-override banner and CE dual-review handoff gate in role interaction flow.
 - 2026-02-09: Clarified branch lifecycle policy: `agent/*` is parked-context-only, while `team-*`/`coord/*` are execution branches required for coding, push, and PR. Added explicit parked->execution task-start transition in preflight.
 - 2026-02-09: Added deterministic spawn preflight commands, tiered context-loading contract (Tier 0/1/2), cross-wave baseline context requirements, standing-agent handoff protocol, and AGENTS.md rollout scope notes for per-team vs cross-wave agents.
 - 2026-02-08: Initial version. Adapted from existing agent contracts for Wave 1 multi-team context. Incorporates ownership scope enforcement, feature flag discipline, branch naming contract, integration merge ordering, rollback protocol, spec trigger rule, specialist fallback, drift SLA, and QA-Integration readiness matrix.

--- a/docs/foundational/WAVE1_KICKOFF_COMMAND_SHEET.md
+++ b/docs/foundational/WAVE1_KICKOFF_COMMAND_SHEET.md
@@ -1,5 +1,7 @@
 # Wave 1 Kickoff Command Sheet
 
+Historical status: frozen for Wave 1 closeout. Do not reuse for Wave 2+ dispatch. Use `docs/foundational/WAVE2_KICKOFF_COMMAND_SHEET.md` for active execution.
+
 Companion to:
 - `docs/foundational/V2_Sprint_Staffing_Plan.md`
 - `docs/foundational/V2_Sprint_Staffing_Roles.md`

--- a/docs/foundational/WAVE2_DELTA_CONTRACT.md
+++ b/docs/foundational/WAVE2_DELTA_CONTRACT.md
@@ -76,6 +76,14 @@ Rationale: Wave 1 merge-to-main exposed branch-protection and Ownership Scope mi
 Policy: one subagent spawn per phase; no spawn may include instructions for subsequent phases; next phase starts only after prior phase artifact is verified.
 Rationale: Wave 1 multi-phase batching hit context limits and produced partial/no-output runs.
 
+11. CE dual-review is mandatory for Director-bound prompts.
+Policy: all execution prompts from Coordinator to Director must pass through `ce-codex` and `ce-opus` review using the fixed-schema CE Review Pass protocol before dispatch; direct prompts to Director without CE review are allowed only for break/fix emergencies with explicit logged rationale.
+Rationale: Wave 1 manual relay of dual-review was effective but added latency and risked dropped context; formalizing it as an agent loop removes relay friction.
+
+12. Wave-end documentation audit is required before next-wave dispatch.
+Policy: before declaring wave closeout or dispatching the next wave, run a formal doc audit (`ce-opus` for contract/policy coherence, `ce-codex` for execution fidelity) producing `docs/reports/WAVE<n>_DOC_AUDIT.md` with findings, drift matrix, fix list, and pass/fail status; no dispatch until `DOC_AUDIT_PASS`.
+Rationale: Wave 1 closeout revealed stale STATUS entries, missing doc artifacts on main, and branch-protection drift. A formal audit gate prevents recurrence.
+
 ---
 
 ## Exception Handling

--- a/docs/foundational/WAVE2_KICKOFF_COMMAND_SHEET.md
+++ b/docs/foundational/WAVE2_KICKOFF_COMMAND_SHEET.md
@@ -1,0 +1,124 @@
+# Wave 2 Kickoff Command Sheet
+
+Companion to:
+- `docs/foundational/V2_Sprint_Staffing_Plan.md`
+- `docs/foundational/V2_Sprint_Staffing_Roles.md`
+- `docs/foundational/WAVE2_DELTA_CONTRACT.md`
+- `docs/foundational/CE_DUAL_REVIEW_CONTRACTS.md`
+
+Use this for Wave 2 launch, per-slice dispatch, and integration cadence.
+
+## Wave 2 Runtime Constants
+
+- `ACTIVE_INTEGRATION_BRANCH=integration/wave-2`
+- `ACTIVE_WAVE_LABEL=wave-2`
+- `EXECUTION_BRANCH_PREFIXES=team-a/*,team-b/*,team-c/*,team-d/*,team-e/*,coord/*`
+- `PARKED_BRANCH_PREFIX=agent/*`
+
+All references below to "integration branch" mean `ACTIVE_INTEGRATION_BRANCH`.
+
+## 0) One-time bootstrap (per worktree / agent)
+
+```bash
+pnpm install --frozen-lockfile
+pnpm hooks:install
+
+branch="$(git rev-parse --abbrev-ref HEAD)"
+if [[ "$branch" =~ ^agent/.+ ]]; then
+  echo "Parked branch detected: $branch"
+  echo "Switch to execution branch before task work."
+else
+  [[ "$branch" =~ ^(team-[a-e]/.+|coord/.+|integration/wave-[0-9]+|main)$ ]] \
+    || { echo "Invalid branch: $branch"; exit 1; }
+fi
+```
+
+## 1) Coordinator pre-dispatch checks
+
+```bash
+git fetch origin
+git checkout "$ACTIVE_INTEGRATION_BRANCH"
+git pull --ff-only origin "$ACTIVE_INTEGRATION_BRANCH"
+
+REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
+gh api "repos/$REPO/branches/$ACTIVE_INTEGRATION_BRANCH/protection" \
+  --jq '{enforce_admins: .enforce_admins.enabled, required: [.required_status_checks.checks[].context]}'
+```
+
+Expected required checks on integration branch:
+- `Ownership Scope`
+- `Quality Guard`
+- `Test & Build`
+- `E2E Tests`
+- `Bundle Size`
+
+## 2) CE dual-review gate (mandatory before Director dispatch)
+
+1. Coordinator prepares packet (latest Director report + branch/PR/check state + explicit decision question).
+2. Send packet to both `ce-codex` and `ce-opus`.
+3. Each returns fixed-schema `CE Review Pass`.
+4. Reconcile per `CE_DUAL_REVIEW_CONTRACTS.md` section 5:
+   - both `AGREED` -> dispatch one prompt to Director
+   - one `NEEDS_PARTNER_REVIEW` -> one additional round
+   - unresolved after round 2 -> CEO escalation packet
+
+Direct Coordinator-to-Director prompts without CE review are allowed only for break/fix emergencies with logged rationale.
+
+## 3) Team execution branch start + PR creation
+
+```bash
+# Example for Team A; substitute team letter and ticket slug.
+git fetch origin
+git checkout -b team-a/<ticket>-<slug> "origin/$ACTIVE_INTEGRATION_BRANCH"
+
+pnpm typecheck
+pnpm lint
+pnpm test:quick
+pnpm test:coverage
+node tools/scripts/check-ownership-scope.mjs
+
+cp .github/pull_request_template.md /tmp/w2-pr-body.md
+"${EDITOR:-vi}" /tmp/w2-pr-body.md
+
+git push -u origin team-a/<ticket>-<slug>
+PR_URL=$(gh pr create \
+  --base "$ACTIVE_INTEGRATION_BRANCH" \
+  --head team-a/<ticket>-<slug> \
+  --title "<slice-title>" \
+  --body-file /tmp/w2-pr-body.md)
+PR_NUM=$(echo "$PR_URL" | sed -E 's#.*/pull/([0-9]+).*#\1#')
+```
+
+## 4) Chief gate + merge queue flow
+
+```bash
+PR=<number>
+gh pr checks "$PR"
+gh pr view "$PR" --json baseRefName,headRefName,mergeStateStatus,isDraft,autoMergeRequest \
+  --jq '{base: .baseRefName, head: .headRefName, merge: .mergeStateStatus, draft: .isDraft, autoMerge: .autoMergeRequest}'
+```
+
+Chief confirms:
+- PR base is `ACTIVE_INTEGRATION_BRANCH`
+- head prefix is valid (`team-*` or approved `coord/*`)
+- all required checks green (or queued under merge queue)
+- ownership scope clean
+- dependency ordering respected
+
+Then set auto-merge if missing:
+
+```bash
+gh pr merge "$PR" --merge --auto
+```
+
+Do not manually cancel CI jobs. Use job `timeout-minutes`; only cancel with deterministic proof of a code-level failure.
+
+## 5) Wave-end doc audit gate (required before next-wave dispatch)
+
+Produce `docs/reports/WAVE2_DOC_AUDIT.md` with:
+- findings by severity
+- doc drift matrix
+- fix list
+- pass/fail status
+
+No next-wave dispatch until `DOC_AUDIT_PASS` (except break/fix emergency with logged rationale).

--- a/docs/reports/WAVE2_DOC_AUDIT.md
+++ b/docs/reports/WAVE2_DOC_AUDIT.md
@@ -1,0 +1,41 @@
+# Wave 2 Document Audit
+
+Date: 2026-02-11  
+Scope: Wave 1 -> Wave 2 transition controls and operational docs  
+Owner: Coordinator (with CE review inputs from `ce-codex` and `ce-opus`)
+
+## Findings (by severity)
+
+- HIGH: Core staffing/process docs did not explicitly include the CE dual-review loop, creating execution ambiguity for Director-bound prompts.
+- HIGH: Wave kickoff runbook remained Wave-1-specific; no dedicated Wave 2 runbook existed.
+- MEDIUM: PR template still referenced `integration/wave-1`, increasing risk of target-branch mistakes.
+- MEDIUM: Wave 1 kickoff document was still treated as active without freeze guidance.
+- MEDIUM: No mandatory wave-end doc-audit artifact was defined in binding policy.
+
+## Drift Matrix
+
+| Area | Expected for Wave 2 | Observed before audit | Remediation |
+| --- | --- | --- | --- |
+| Staffing roster | CE agents listed in operating cluster docs | CE agents only defined in standalone companion doc | Add CE entries to staffing plan roster/hierarchy/counts |
+| Role contracts | CE review loop documented before Director dispatch | Roles doc had no CE gate reference | Add CE gate in interaction summary + explicit dispatch rule |
+| Delta policy | Binding policies include CE gate + doc-audit gate | Policies ended at 10; no CE/doc-audit requirement | Add policy 11 and 12 |
+| PR controls | Active-wave target branch language | Template hardcoded Wave 1 branch | Update to active-wave target (`integration/wave-2`) |
+| Kickoff runbook | Dedicated Wave 2 sheet with runtime constants | Only Wave 1 kickoff sheet existed | Add `WAVE2_KICKOFF_COMMAND_SHEET.md` |
+| Historical docs | Wave 1 runbook frozen | Wave 1 sheet appeared active | Add freeze banner to Wave 1 kickoff sheet |
+| Status references | Wave 2 control docs listed | CE/W2 control docs absent from refs | Add Wave 2 control-doc references to `STATUS.md` |
+
+## Fix List
+
+1. Update `docs/foundational/V2_Sprint_Staffing_Plan.md` for CE roster/hierarchy/counts and role behavior reference.
+2. Update `docs/foundational/V2_Sprint_Staffing_Roles.md` with Wave 2 override banner and CE dual-review flow in Role Interaction Summary.
+3. Update `docs/foundational/WAVE2_DELTA_CONTRACT.md` with binding policy 11 (CE gate) and 12 (wave-end doc audit gate).
+4. Update `.github/pull_request_template.md` to active-wave target branch language.
+5. Update `docs/foundational/STATUS.md` with Wave 2 control-doc references and CE gate mention.
+6. Add `docs/foundational/WAVE2_KICKOFF_COMMAND_SHEET.md` as dedicated Wave 2 runbook.
+7. Mark `docs/foundational/WAVE1_KICKOFF_COMMAND_SHEET.md` as historical/frozen.
+
+## Status
+
+- Result: `DOC_AUDIT_PASS_PENDING_MERGE`
+- Condition to flip to `DOC_AUDIT_PASS`: merge of this audit sweep PR to `integration/wave-2`.
+- Dispatch rule: no new wave dispatch until `DOC_AUDIT_PASS` is recorded on merged branch (except break/fix emergency with logged rationale).


### PR DESCRIPTION
## Summary
- add CE review layer to Wave 2 staffing/roles references
- add Wave 2 doc-audit gate as binding policy
- update PR template to active-wave branch language
- add dedicated Wave 2 kickoff command sheet
- freeze Wave 1 kickoff sheet as historical
- add Wave 2 doc-audit artifact with drift matrix/fix list

## Files
- docs/foundational/V2_Sprint_Staffing_Plan.md
- docs/foundational/V2_Sprint_Staffing_Roles.md
- docs/foundational/WAVE2_DELTA_CONTRACT.md
- .github/pull_request_template.md
- docs/foundational/STATUS.md
- docs/foundational/WAVE2_KICKOFF_COMMAND_SHEET.md
- docs/foundational/WAVE1_KICKOFF_COMMAND_SHEET.md
- docs/reports/WAVE2_DOC_AUDIT.md

## Why
Wave 2 dispatch baseline needed a complete document-coherence sweep so CE dual-review and wave-end doc audit are explicit in plan/roles/runbook/policy surfaces.

## Scope
- docs-only
- no runtime or CI logic changes
