### PR TITLE
docs(wave2): codify context-rotation guard for CE and standing agents

### DIFF
--- a/docs/foundational/CE_DUAL_REVIEW_CONTRACTS.md
+++ b/docs/foundational/CE_DUAL_REVIEW_CONTRACTS.md
@@ -34,6 +34,7 @@ These two agents are review/planning authorities only. They do not execute imple
 Every CE pass must start from a packet containing:
 - Director report (latest)
 - current branch/PR/check status
+- current context usage snapshot for Coordinator and both CE sessions
 - relevant source docs/specs for the decision
 - explicit question to resolve
 
@@ -53,14 +54,28 @@ Every CE pass must use this exact structure:
 ### Recommended next prompt
 - [exact prompt text or "approve partner draft as-is"]
 
+### Context Guard
+- coordinator_context: [percent]
+- ce_context: [percent]
+- rotation_required: [yes/no]
+
 ### Status
-- NEEDS_PARTNER_REVIEW | AGREED | ESCALATE_TO_CEO
+- NEEDS_PARTNER_REVIEW | AGREED | ESCALATE_TO_CEO | HOLDING_FOR_ROTATION
 ```
 
 ### Convergence cap
 
 - Maximum: 2 rounds per CE agent per decision.
 - If unresolved after round 2, escalate to CEO with option tradeoffs.
+
+### Session context thresholds (mandatory)
+
+- Warning: >=70% context usage
+- Mandatory rotate before new Director-bound dispatch: >=80%
+- Freeze new work (handoff-only): >=90%
+
+These thresholds are enforced by CE gate for Coordinator and CE agents only.
+Chiefs are responsible for monitoring their standing impl/chief agents and rotating before the 80% threshold.
 
 ### Escalation trigger
 
@@ -158,9 +173,10 @@ Keep execution aligned with canonical contracts and prevent procedural drift bet
 ## 5) Reconciliation Rules
 
 1. `ce-codex` and `ce-opus` each publish pass output using the fixed schema.
-2. If both statuses are `AGREED`, issue single final prompt to Director.
-3. If one is `NEEDS_PARTNER_REVIEW`, run one additional pass.
-4. If still unresolved after second pass, issue CEO escalation packet.
+2. If either pass marks `rotation_required=yes`, status is `HOLDING_FOR_ROTATION` and no Director-bound prompt may be issued.
+3. If both statuses are `AGREED`, issue single final prompt to Director.
+4. If one is `NEEDS_PARTNER_REVIEW`, run one additional pass.
+5. If still unresolved after second pass, issue CEO escalation packet.
 
 No free-form debate transcripts in final handoff.
 

--- a/docs/foundational/WAVE2_DELTA_CONTRACT.md
+++ b/docs/foundational/WAVE2_DELTA_CONTRACT.md
@@ -84,6 +84,14 @@ Rationale: Wave 1 manual relay of dual-review was effective but added latency an
 Policy: before declaring wave closeout or dispatching the next wave, run a formal doc audit (`ce-opus` for contract/policy coherence, `ce-codex` for execution fidelity) producing `docs/reports/WAVE<n>_DOC_AUDIT.md` with findings, drift matrix, fix list, and pass/fail status; no dispatch until `DOC_AUDIT_PASS`.
 Rationale: Wave 1 closeout revealed stale STATUS entries, missing doc artifacts on main, and branch-protection drift. A formal audit gate prevents recurrence.
 
+13. Session-context rotation guard is mandatory for standing agents.
+Policy: enforce context thresholds as hard guardrails:
+- Coordinator and CE agents: warning at >=70% context, mandatory rotation at >=80% before any new Director-bound prompt/dispatch, freeze new work at >=90% (handoff-only until respawn).
+- Standing impl/chief agents: same thresholds apply, but monitoring and enforcement are owned by the team Chief.
+- Per-PR agents (maint, per-issue QA/sidecars): exempt by design.
+Rationale: Wave 1 had multiple high-context failures and timeout/no-output runs that were operational, not technical, defects.
+Enforcement split: CE gate enforces thresholds for Coordinator/CE agents only. Chiefs are responsible for monitoring their standing impl agents' context usage and rotating before the 80% threshold.
+
 ---
 
 ## Exception Handling


### PR DESCRIPTION
## Summary
- add Wave 2 Binding Policy 13 for session-context rotation guardrails
- codify threshold ownership split:
  - CE gate enforces Coordinator/CE context thresholds
  - Chiefs enforce standing impl/chief thresholds
  - per-PR agents exempt
- update CE review schema to require a `Context Guard` block and allow `HOLDING_FOR_ROTATION`
- update CE reconciliation rules to block Director-bound prompts when rotation is required

## Why
Wave 1 showed repeated high-context and timeout/no-output failure modes. This makes rotation a formal gate rather than a best practice.

## Scope
- docs-only
