### PR TITLE
fix(wave2): resolve CE-gate blockers for Wave 2 dispatch

### DIFF
--- a/.github/ownership-map.json
+++ b/.github/ownership-map.json
@@ -57,5 +57,34 @@
             "packages/contracts/scripts/**",
             "packages/contracts/deployments/**"
         ]
+    },
+    "w2a": {
+        "branchPrefix": "w2a/",
+        "paths": [
+            "packages/ai-engine/src/digestBuilder*.ts",
+            "apps/web-pwa/src/store/synthesis/**",
+            "apps/web-pwa/src/store/forum/**"
+        ]
+    },
+    "w2b": {
+        "branchPrefix": "w2b/",
+        "paths": [
+            "packages/crdt/**",
+            "packages/gun-client/src/docsAdapters*.ts",
+            "apps/web-pwa/src/store/hermesDocs*.ts",
+            "apps/web-pwa/src/components/hermes/forum/CommentComposer*.tsx",
+            "apps/web-pwa/src/components/docs/**"
+        ]
+    },
+    "w2g": {
+        "branchPrefix": "w2g/",
+        "paths": [
+            "packages/data-model/src/schemas/hermes/elevation*.ts",
+            "packages/data-model/src/schemas/hermes/notification*.ts",
+            "packages/gun-client/src/bridgeAdapters*.ts",
+            "apps/web-pwa/src/store/bridge/**",
+            "apps/web-pwa/src/components/bridge/**",
+            "apps/web-pwa/src/store/linkedSocial/**"
+        ]
     }
 }

--- a/docs/foundational/WAVE2_KICKOFF_COMMAND_SHEET.md
+++ b/docs/foundational/WAVE2_KICKOFF_COMMAND_SHEET.md
@@ -12,7 +12,7 @@ Use this for Wave 2 launch, per-slice dispatch, and integration cadence.
 
 - `ACTIVE_INTEGRATION_BRANCH=integration/wave-2`
 - `ACTIVE_WAVE_LABEL=wave-2`
-- `EXECUTION_BRANCH_PREFIXES=team-a/*,team-b/*,team-c/*,team-d/*,team-e/*,coord/*`
+- `EXECUTION_BRANCH_PREFIXES=team-a/*,team-b/*,team-c/*,team-d/*,team-e/*,w2a/*,w2b/*,w2g/*,coord/*`
 - `PARKED_BRANCH_PREFIX=agent/*`
 
 All references below to "integration branch" mean `ACTIVE_INTEGRATION_BRANCH`.
@@ -28,7 +28,7 @@ if [[ "$branch" =~ ^agent/.+ ]]; then
   echo "Parked branch detected: $branch"
   echo "Switch to execution branch before task work."
 else
-  [[ "$branch" =~ ^(team-[a-e]/.+|coord/.+|integration/wave-[0-9]+|main)$ ]] \
+  [[ "$branch" =~ ^(team-[a-e]/.+|w2[abg]/.+|coord/.+|integration/wave-[0-9]+|main)$ ]] \
     || { echo "Invalid branch: $branch"; exit 1; }
 fi
 ```

--- a/docs/reports/WAVE2_DOC_AUDIT.md
+++ b/docs/reports/WAVE2_DOC_AUDIT.md
@@ -36,6 +36,6 @@ Owner: Coordinator (with CE review inputs from `ce-codex` and `ce-opus`)
 
 ## Status
 
-- Result: `DOC_AUDIT_PASS_PENDING_MERGE`
-- Condition to flip to `DOC_AUDIT_PASS`: merge of this audit sweep PR to `integration/wave-2`.
-- Dispatch rule: no new wave dispatch until `DOC_AUDIT_PASS` is recorded on merged branch (except break/fix emergency with logged rationale).
+- Result: `DOC_AUDIT_PASS`
+- Flipped from `DOC_AUDIT_PASS_PENDING_MERGE` on 2026-02-11 after confirming audit sweep PRs #184, #185, #186 merged to `integration/wave-2`.
+- Dispatch rule: Wave 2 dispatch may proceed.

--- a/tools/scripts/check-ownership-scope.mjs
+++ b/tools/scripts/check-ownership-scope.mjs
@@ -57,10 +57,10 @@ function resolveHeadRef() {
 }
 
 function inferBaseRef(headRef) {
-  // Wave-1 team branches target integration/wave-1 by default.
+  // Wave 2 stream branches and Wave 1 team branches target the active integration branch.
   // Coordinator or other branches default to main unless GITHUB_BASE_REF is set.
-  if (/^team-[a-e]\//.test(headRef)) {
-    return 'integration/wave-1';
+  if (/^(team-[a-e]|w2[abg])\//.test(headRef)) {
+    return process.env.ACTIVE_INTEGRATION_BRANCH || 'integration/wave-2';
   }
   return 'main';
 }


### PR DESCRIPTION
## Summary

Resolves all 4 HIGH findings from CE-Opus review pass (Wave 2 kickoff CE gate).

### Changes
1. **DOC_AUDIT_PASS flipped** — `docs/reports/WAVE2_DOC_AUDIT.md` updated from `DOC_AUDIT_PASS_PENDING_MERGE` to `DOC_AUDIT_PASS` (condition met by merged PRs #184, #185, #186)
2. **Wave 2 ownership map** — Added `w2a`, `w2b`, `w2g` entries to `.github/ownership-map.json` with glob patterns per WAVE2_DELTA_CONTRACT policy 2
3. **Ownership checker base-ref fix** — Updated `tools/scripts/check-ownership-scope.mjs` to resolve Wave 2 branch prefixes against `integration/wave-2`
4. **Branch prefix expansion** — Added `w2a/*`, `w2b/*`, `w2g/*` to valid execution branch prefixes in kickoff command sheet

### CE Gate Reference
- `ce-opus` Review Pass 1: 4 HIGH, 4 MEDIUM, 2 LOW findings
- `ce-codex`: operational timeout (2 rounds); ce-opus findings validated by Coordinator
- Reconciliation: HIGH findings resolved in this PR; MEDIUM findings tracked for follow-up

### Policies Enforced
- WAVE2_DELTA_CONTRACT policy 2 (pre-build ownership map coverage)
- WAVE2_DELTA_CONTRACT policy 12 (wave-end doc audit gate)
- CE_DUAL_REVIEW_CONTRACTS section 5 (reconciliation)

---
- [x] Branch: `coord/wave2-kickoff`
- [x] Target: `integration/wave-2`
- [x] Tests: 110 files / 1,390 tests passing
- [x] Ownership Scope: coordinator bypass (cross-team)