### PR TITLE
fix(ownership): add commentTracker glob to w2a paths

### DIFF
--- a/.github/ownership-map.json
+++ b/.github/ownership-map.json
@@ -61,6 +61,7 @@
     "w2a": {
         "branchPrefix": "w2a/",
         "paths": [
+            "packages/ai-engine/src/commentTracker*.ts",
             "packages/ai-engine/src/digestBuilder*.ts",
             "apps/web-pwa/src/store/synthesis/**",
             "apps/web-pwa/src/store/forum/**"


### PR DESCRIPTION
## Summary
- [x] Add `packages/ai-engine/src/commentTracker*.ts` glob to w2a ownership paths.

## Scope
- [x] No unrelated file changes in this PR.
- [x] This PR stays within one coherent slice.

## Active Wave Branch/Ownership Contract
- [x] Branch name uses allowed prefix: `coord/*`.
- [x] Coordinator rationale is included below.
- [x] Changed files are within owned paths per `.github/ownership-map.json`.
- [x] `Ownership Scope` check is expected to pass (coordinator bypass).

## Target Branch
- [x] Implementation PR targets `integration/wave-2`.

## Feature Flags (if applicable)
- N/A — ownership map only.

## Testing
- N/A — JSON config change only.

## Coordinator Rationale (required for `coord/*` branches)
The w2a scope lock (`docs/wave2/w2a-scope-lock.md`) defines PR 1 as `commentTracker.ts` + test.
The ownership map was missing this glob — only `digestBuilder*.ts` was pre-registered during
Wave 2 kickoff. Per WAVE2_DELTA_CONTRACT policy #2 (pre-build ownership map coverage),
adding the glob now to unblock w2a PR 1 dispatch.