### PR TITLE
feat(ai-engine): add commentTracker module (W2A PR 1/3)

### DIFF
--- a/packages/ai-engine/src/commentTracker.test.ts
+++ b/packages/ai-engine/src/commentTracker.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CommentActivityEntrySchema,
+  CommentTrackerStateSchema,
+  getActivitySince,
+  meetsResynthesisThreshold,
+  recordComment,
+  resetForEpoch,
+  type CommentTrackerState,
+} from './commentTracker';
+
+function emptyState(): CommentTrackerState {
+  return { topics: new Map() };
+}
+
+// ── Schemas ────────────────────────────────────────────────────────
+
+describe('CommentActivityEntrySchema', () => {
+  it('accepts runtime Set input and keeps it as a Set', () => {
+    const parsed = CommentActivityEntrySchema.parse({
+      verified_comment_count: 2,
+      unique_principals: new Set(['p-1', 'p-2']),
+    });
+
+    expect(parsed.verified_comment_count).toBe(2);
+    expect(parsed.unique_principals).toBeInstanceOf(Set);
+    expect(parsed.unique_principals.size).toBe(2);
+  });
+
+  it('accepts array input and de-duplicates principals during conversion', () => {
+    const parsed = CommentActivityEntrySchema.parse({
+      verified_comment_count: 3,
+      unique_principals: ['p-1', 'p-1', 'p-2'],
+    });
+
+    expect([...parsed.unique_principals]).toEqual(['p-1', 'p-2']);
+  });
+
+  it('rejects negative verified_comment_count', () => {
+    expect(
+      CommentActivityEntrySchema.safeParse({
+        verified_comment_count: -1,
+        unique_principals: ['p-1'],
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe('CommentTrackerStateSchema', () => {
+  it('accepts runtime Map state and converts nested sets', () => {
+    const parsed = CommentTrackerStateSchema.parse({
+      topics: new Map([
+        [
+          'topic-1',
+          {
+            verified_comment_count: 1,
+            unique_principals: new Set(['p-1']),
+          },
+        ],
+      ]),
+    });
+
+    expect(parsed.topics).toBeInstanceOf(Map);
+    expect(parsed.topics.get('topic-1')?.verified_comment_count).toBe(1);
+    expect(parsed.topics.get('topic-1')?.unique_principals).toBeInstanceOf(Set);
+  });
+
+  it('accepts serializable tuple-array state', () => {
+    const parsed = CommentTrackerStateSchema.parse({
+      topics: [
+        [
+          'topic-1',
+          {
+            verified_comment_count: 2,
+            unique_principals: ['p-1', 'p-2'],
+          },
+        ],
+      ],
+    });
+
+    expect(parsed.topics.get('topic-1')?.unique_principals.size).toBe(2);
+  });
+
+  it('rejects empty topic ids', () => {
+    expect(
+      CommentTrackerStateSchema.safeParse({
+        topics: [
+          [
+            '',
+            {
+              verified_comment_count: 1,
+              unique_principals: ['p-1'],
+            },
+          ],
+        ],
+      }).success,
+    ).toBe(false);
+  });
+});
+
+// ── recordComment + getActivitySince ──────────────────────────────
+
+describe('recordComment / getActivitySince', () => {
+  it('records first comment for a topic without mutating prior state', () => {
+    const state0 = emptyState();
+    const state1 = recordComment(state0, 'topic-1', 'p-1');
+
+    expect(state0.topics.size).toBe(0);
+    expect(state1.topics.size).toBe(1);
+    expect(getActivitySince(state1, 'topic-1')).toEqual({
+      verified_comment_count: 1,
+      unique_principal_count: 1,
+    });
+  });
+
+  it('increments count and unique principal count for new principals', () => {
+    const state1 = recordComment(emptyState(), 'topic-1', 'p-1');
+    const state2 = recordComment(state1, 'topic-1', 'p-2');
+
+    expect(getActivitySince(state1, 'topic-1')).toEqual({
+      verified_comment_count: 1,
+      unique_principal_count: 1,
+    });
+    expect(getActivitySince(state2, 'topic-1')).toEqual({
+      verified_comment_count: 2,
+      unique_principal_count: 2,
+    });
+  });
+
+  it('increments only verified comment count for repeat principal', () => {
+    const state1 = recordComment(emptyState(), 'topic-1', 'p-1');
+    const state2 = recordComment(state1, 'topic-1', 'p-1');
+
+    expect(getActivitySince(state2, 'topic-1')).toEqual({
+      verified_comment_count: 2,
+      unique_principal_count: 1,
+    });
+  });
+
+  it('returns zero activity for topics with no tracked comments', () => {
+    const state = recordComment(emptyState(), 'topic-1', 'p-1');
+
+    expect(getActivitySince(state, 'topic-2')).toEqual({
+      verified_comment_count: 0,
+      unique_principal_count: 0,
+    });
+  });
+
+  it('throws for empty ids', () => {
+    expect(() => recordComment(emptyState(), '', 'p-1')).toThrow();
+    expect(() => recordComment(emptyState(), 'topic-1', '')).toThrow();
+    expect(() => getActivitySince(emptyState(), '')).toThrow();
+  });
+});
+
+// ── resetForEpoch ─────────────────────────────────────────────────
+
+describe('resetForEpoch', () => {
+  it('removes tracked activity for the specified topic only', () => {
+    const state1 = recordComment(emptyState(), 'topic-1', 'p-1');
+    const state2 = recordComment(state1, 'topic-2', 'p-2');
+    const state3 = resetForEpoch(state2, 'topic-1');
+
+    expect(getActivitySince(state3, 'topic-1')).toEqual({
+      verified_comment_count: 0,
+      unique_principal_count: 0,
+    });
+    expect(getActivitySince(state3, 'topic-2')).toEqual({
+      verified_comment_count: 1,
+      unique_principal_count: 1,
+    });
+  });
+
+  it('is a safe no-op when topic was never tracked', () => {
+    const state1 = recordComment(emptyState(), 'topic-1', 'p-1');
+    const state2 = resetForEpoch(state1, 'missing-topic');
+
+    expect(state2).not.toBe(state1);
+    expect(getActivitySince(state2, 'topic-1')).toEqual({
+      verified_comment_count: 1,
+      unique_principal_count: 1,
+    });
+  });
+});
+
+// ── meetsResynthesisThreshold ──────────────────────────────────────
+
+describe('meetsResynthesisThreshold', () => {
+  it('passes at exact default thresholds (10 comments, 3 unique)', () => {
+    expect(
+      meetsResynthesisThreshold({
+        verified_comment_count: 10,
+        unique_principal_count: 3,
+      }),
+    ).toBe(true);
+  });
+
+  it('fails when verified comment threshold is not met', () => {
+    expect(
+      meetsResynthesisThreshold({
+        verified_comment_count: 9,
+        unique_principal_count: 3,
+      }),
+    ).toBe(false);
+  });
+
+  it('fails when unique principal minimum is not met', () => {
+    expect(
+      meetsResynthesisThreshold({
+        verified_comment_count: 10,
+        unique_principal_count: 2,
+      }),
+    ).toBe(false);
+  });
+
+  it('respects config overrides', () => {
+    expect(
+      meetsResynthesisThreshold(
+        {
+          verified_comment_count: 2,
+          unique_principal_count: 2,
+        },
+        {
+          resynthesis_comment_threshold: 2,
+          resynthesis_unique_principal_min: 2,
+        },
+      ),
+    ).toBe(true);
+  });
+
+  it('throws for invalid activity shape', () => {
+    expect(() =>
+      meetsResynthesisThreshold({
+        verified_comment_count: -1,
+        unique_principal_count: 2,
+      }),
+    ).toThrow();
+  });
+});

--- a/packages/ai-engine/src/commentTracker.ts
+++ b/packages/ai-engine/src/commentTracker.ts
@@ -1,0 +1,145 @@
+/**
+ * Per-topic verified comment activity tracking for synthesis V2.
+ *
+ * Pure computation — no I/O. Tracks verified comments and unique principals
+ * per topic since the last synthesis epoch.
+ *
+ * @module commentTracker
+ */
+
+import { z } from 'zod';
+import {
+  type SynthesisPipelineConfig,
+  SynthesisPipelineConfigSchema,
+} from './synthesisTypes';
+
+const TopicIdSchema = z.string().min(1);
+const PrincipalIdSchema = z.string().min(1);
+
+const UniquePrincipalsInputSchema = z.preprocess(
+  (value) => (value instanceof Set ? [...value] : value),
+  z.array(PrincipalIdSchema),
+);
+
+// ── Types + schemas ───────────────────────────────────────────────
+
+export interface CommentActivityEntry {
+  readonly verified_comment_count: number;
+  readonly unique_principals: ReadonlySet<string>;
+}
+
+export const CommentActivityEntrySchema = z
+  .object({
+    verified_comment_count: z.number().int().nonnegative(),
+    unique_principals: UniquePrincipalsInputSchema,
+  })
+  .transform(
+    (entry): CommentActivityEntry => ({
+      verified_comment_count: entry.verified_comment_count,
+      unique_principals: new Set(entry.unique_principals),
+    }),
+  );
+
+const TopicEntriesInputSchema = z.preprocess(
+  (value) => (value instanceof Map ? [...value.entries()] : value),
+  z.array(z.tuple([TopicIdSchema, CommentActivityEntrySchema])),
+);
+
+export interface CommentTrackerState {
+  readonly topics: ReadonlyMap<string, CommentActivityEntry>;
+}
+
+export const CommentTrackerStateSchema = z
+  .object({
+    topics: TopicEntriesInputSchema,
+  })
+  .transform(
+    (state): CommentTrackerState => ({
+      topics: new Map(state.topics),
+    }),
+  );
+
+export const CommentActivitySinceSchema = z.object({
+  verified_comment_count: z.number().int().nonnegative(),
+  unique_principal_count: z.number().int().nonnegative(),
+});
+
+export type CommentActivitySince = z.infer<typeof CommentActivitySinceSchema>;
+
+// ── Pure operations ───────────────────────────────────────────────
+
+/** Record one verified comment for a topic+principal. */
+export function recordComment(
+  state: CommentTrackerState,
+  topicId: string,
+  principalId: string,
+): CommentTrackerState {
+  const parsedState = CommentTrackerStateSchema.parse(state);
+  const parsedTopicId = TopicIdSchema.parse(topicId);
+  const parsedPrincipalId = PrincipalIdSchema.parse(principalId);
+
+  const previousEntry = parsedState.topics.get(parsedTopicId);
+  const nextPrincipals = new Set(previousEntry?.unique_principals ?? []);
+  nextPrincipals.add(parsedPrincipalId);
+
+  const nextEntry: CommentActivityEntry = {
+    verified_comment_count: (previousEntry?.verified_comment_count ?? 0) + 1,
+    unique_principals: nextPrincipals,
+  };
+
+  const nextTopics = new Map(parsedState.topics);
+  nextTopics.set(parsedTopicId, nextEntry);
+
+  return { topics: nextTopics };
+}
+
+/** Get verified comment + unique principal activity for a topic. */
+export function getActivitySince(
+  state: CommentTrackerState,
+  topicId: string,
+): CommentActivitySince {
+  const parsedState = CommentTrackerStateSchema.parse(state);
+  const parsedTopicId = TopicIdSchema.parse(topicId);
+
+  const entry = parsedState.topics.get(parsedTopicId);
+  return {
+    verified_comment_count: entry?.verified_comment_count ?? 0,
+    unique_principal_count: entry?.unique_principals.size ?? 0,
+  };
+}
+
+/** Reset per-topic activity after an epoch trigger. */
+export function resetForEpoch(
+  state: CommentTrackerState,
+  topicId: string,
+): CommentTrackerState {
+  const parsedState = CommentTrackerStateSchema.parse(state);
+  const parsedTopicId = TopicIdSchema.parse(topicId);
+
+  const nextTopics = new Map(parsedState.topics);
+  nextTopics.delete(parsedTopicId);
+
+  return { topics: nextTopics };
+}
+
+/**
+ * Check whether topic activity meets re-synthesis thresholds.
+ *
+ * Defaults come from SynthesisPipelineConfigSchema:
+ * - verified comments >= 10
+ * - unique principals >= 3
+ */
+export function meetsResynthesisThreshold(
+  activity: CommentActivitySince,
+  configOverrides?: Partial<SynthesisPipelineConfig>,
+): boolean {
+  const parsedActivity = CommentActivitySinceSchema.parse(activity);
+  const config = SynthesisPipelineConfigSchema.parse(configOverrides ?? {});
+
+  return (
+    parsedActivity.verified_comment_count >=
+      config.resynthesis_comment_threshold &&
+    parsedActivity.unique_principal_count >=
+      config.resynthesis_unique_principal_min
+  );
+}


### PR DESCRIPTION
## Summary
- [x] Pure computation module for per-topic verified comment tracking.
- [x] Tracks verified_comment_count and unique_principals since last epoch.
- [x] Exposes recordComment, getActivitySince, resetForEpoch, meetsResynthesisThreshold.
- [x] 100% line + branch coverage.

## Scope
- [x] No unrelated file changes in this PR.
- [x] This PR stays within one coherent slice.

## Active Wave Branch/Ownership Contract
- [x] Branch name uses allowed prefix: w2a/*.
- [x] Changed files are within owned paths per .github/ownership-map.json.
- [x] Ownership Scope check is expected to pass for this branch.

## Target Branch
- [x] Implementation PR targets integration/wave-2.

## Feature Flags (if applicable)
- N/A — pure computation module with no UI or store integration.

## Testing
- [x] pnpm typecheck
- [x] pnpm lint
- [x] pnpm test:quick
- [x] pnpm test:coverage

Part of W2-Alpha comment-driven re-synthesis pipeline.
PR chain: **PR 1/3** (comment tracker) → PR 2 (digest builder) → PR 3 (store bridge).