### PR TITLE
fix(ownership): expand w2b globs for schema + barrel files

### DIFF
--- a/.github/ownership-map.json
+++ b/.github/ownership-map.json
@@ -71,7 +71,11 @@
         "branchPrefix": "w2b/",
         "paths": [
             "packages/crdt/**",
+            "packages/data-model/src/schemas/hermes/docs*.ts",
+            "packages/data-model/src/schemas/hermes/forum*.ts",
+            "packages/data-model/src/index*.ts",
             "packages/gun-client/src/docsAdapters*.ts",
+            "packages/gun-client/src/index*.ts",
             "apps/web-pwa/src/store/hermesDocs*.ts",
             "apps/web-pwa/src/components/hermes/forum/CommentComposer*.tsx",
             "apps/web-pwa/src/components/docs/**"


### PR DESCRIPTION
## Coordinator Ownership Map Update

**Unblocks:** PR #190 (`w2b/schemas-and-adapters`)

### Changes

Adds missing ownership globs for W2B's schema and barrel files:

| Glob | Purpose |
|------|---------|
| `packages/data-model/src/schemas/hermes/docs*.ts` | ForumPost + HermesDocs schemas + tests |
| `packages/data-model/src/schemas/hermes/forum*.ts` | Forum schemas + tests |
| `packages/data-model/src/index*.ts` | Barrel re-export (additive only) |
| `packages/gun-client/src/index*.ts` | Barrel re-export (additive only) |

### Policy Compliance

- **Policy 2**: Uses `*.ts` glob patterns (not exact single-file paths)
- **Policy 3**: Coordinator-approved shared-file update. Barrel-file globs are for additive re-exports of W2B-owned schemas only. Future non-additive barrel modifications require fresh coordinator approval.

### CE Review

- `ce-opus`: AGREED (round 1) — recommended Option C with coordinator rationale
- `ce-codex`: AGREED (round 1) — recommended `index*.ts` glob over exact path for Policy 2

### Verification

- PR #190 barrel changes confirmed additive-only (single new `export *` line each)
- W2A and W2G do not need barrel globs (their current PRs don't touch barrel files)
- No other teams affected by this change