### PR TITLE
fix(wave2): align notification schema with spec + patch delta contract prefixes

### DIFF
--- a/docs/foundational/WAVE2_DELTA_CONTRACT.md
+++ b/docs/foundational/WAVE2_DELTA_CONTRACT.md
@@ -24,7 +24,7 @@ This delta captures what changed for Wave 2 and why, based on concrete Wave 1 in
 
 - ACTIVE_INTEGRATION_BRANCH=integration/wave-2
 - ACTIVE_WAVE_LABEL=wave-2
-- EXECUTION_BRANCH_PREFIXES=team-a/*,team-b/*,team-c/*,team-d/*,team-e/*,coord/*
+- EXECUTION_BRANCH_PREFIXES=team-a/*,team-b/*,team-c/*,team-d/*,team-e/*,w2a/*,w2b/*,w2g/*,coord/*
 - PARKED_BRANCH_PREFIX=agent/*
 
 All references in this sheet to "integration branch" mean $ACTIVE_INTEGRATION_BRANCH.

--- a/packages/data-model/src/schemas/hermes/notification.ts
+++ b/packages/data-model/src/schemas/hermes/notification.ts
@@ -2,8 +2,28 @@ import { z } from 'zod';
 
 // ── Shared primitives ──────────────────────────────────────────────
 
-const SocialPlatform = z.enum(['bluesky', 'mastodon', 'nostr']);
-const NotificationType = z.enum(['mention', 'reply', 'repost', 'follow']);
+/**
+ * Canonical platform set from spec-linked-socials-v0.md §2.
+ * The 'other' variant is a catch-all for platforms not yet listed.
+ */
+const SocialProviderId = z.enum([
+  'x',
+  'reddit',
+  'youtube',
+  'tiktok',
+  'instagram',
+  'other',
+]);
+
+const NotificationType = z.enum([
+  'mention',
+  'reply',
+  'repost',
+  'quote',
+  'message',
+  'other',
+]);
+
 const PositiveTimestamp = z.number().int().nonnegative();
 
 // ── Social Notification ────────────────────────────────────────────
@@ -13,7 +33,7 @@ export const SocialNotificationSchema = z
     id: z.string().min(1),
     schemaVersion: z.literal('hermes-notification-v0'),
     accountId: z.string().min(1),
-    platform: SocialPlatform,
+    providerId: SocialProviderId,
     type: NotificationType,
     message: z.string().min(1),
     url: z.string().url().optional(),
@@ -28,11 +48,11 @@ export const LinkedSocialAccountSchema = z
   .object({
     id: z.string().min(1),
     schemaVersion: z.literal('hermes-linked-social-v0'),
-    platform: SocialPlatform,
-    handle: z.string().min(1),
-    verified: z.boolean().optional(),
+    providerId: SocialProviderId,
+    accountId: z.string().min(1),
+    displayName: z.string().optional(),
     connectedAt: PositiveTimestamp,
-    lastSyncAt: PositiveTimestamp.optional(),
+    status: z.enum(['connected', 'revoked', 'expired']).default('connected'),
   })
   .strict();
 


### PR DESCRIPTION
## Summary
- Reconcile SocialPlatform enum with canonical spec-linked-socials-v0.md §2
- Rename `platform` field to `providerId` per spec contract
- Align LinkedSocialAccount with spec shape (accountId, displayName, status)
- Align NotificationType with spec (add quote/message/other variants)
- Update delta contract EXECUTION_BRANCH_PREFIXES to include w2a/w2b/w2g

## Scope
- [x] No unrelated file changes in this PR.
- [x] This PR stays within one coherent slice.

## Active Wave Branch/Ownership Contract
- [x] Branch name uses allowed prefix: `coord/*`.
- [x] Coordinator rationale: cross-team schema alignment required before W2-Gamma dispatch. CE dual-review AGREED (ce-opus + ce-codex, round 2).
- [x] Changed files are within owned paths per `.github/ownership-map.json`.
- [x] `Ownership Scope` check is expected to pass for this branch.

## Target Branch
- [x] Implementation PR targets the active integration branch (`integration/wave-2`).

## Testing
- [x] `pnpm typecheck` ✅
- [x] `pnpm lint` ✅
- [x] `pnpm test:quick` ✅ (1543 tests)
- [x] `pnpm test:coverage` ✅ (100% all metrics)

## Coordinator Rationale
Platform enum mismatch between spec (x/reddit/youtube/tiktok/instagram/other) and implementation (bluesky/mastodon/nostr) identified by CE dual-review as HIGH severity blocker for W2-Gamma dispatch. Spec is canonical (Status: Canonical for Season 0). Also patches stale branch prefix list in delta contract (MEDIUM).