### PR TITLE
chore(ownership): tighten w2b ownership map for Stage 1

### DIFF
--- a/.github/ownership-map.json
+++ b/.github/ownership-map.json
@@ -70,9 +70,7 @@
     "w2b": {
         "branchPrefix": "w2b/",
         "paths": [
-            "packages/crdt/**",
             "packages/data-model/src/schemas/hermes/docs*.ts",
-            "packages/data-model/src/schemas/hermes/forum*.ts",
             "packages/data-model/src/index*.ts",
             "packages/gun-client/src/docsAdapters*.ts",
             "packages/gun-client/src/index*.ts",


### PR DESCRIPTION
## Summary
Tighten W2-Beta ownership map for Stage 1 dispatch:
- Remove `packages/crdt/**` (Stage 2 scope — CRDT/Yjs collaboration)
- Remove `packages/data-model/src/schemas/hermes/forum*.ts` (no forum schema changes in Stage 1)

## Scope
- [x] No unrelated file changes in this PR.

## Active Wave Branch/Ownership Contract
- [x] Branch name uses allowed prefix: `coord/*`.
- [x] Coordinator rationale: pre-dispatch ownership tightening per CE review.

## Target Branch
- [x] Implementation PR targets `integration/wave-2`.

## Testing
- [x] JSON-only change, no code.

## Coordinator Rationale
CE dual-review (ce-opus HIGH + ce-codex HIGH) identified scope leak: `packages/crdt/**` in W2-Beta Stage 1 ownership when Stage 1 explicitly excludes CRDT work. Tightened to prevent implementation agents from touching Stage 2 scope.