### PR TITLE
fix(governance): add Wave 2 branch prefixes to PR template + resolve ownership overlap

### DIFF
--- a/.github/ownership-map.json
+++ b/.github/ownership-map.json
@@ -1,6 +1,7 @@
 {
     "team-a": {
         "branchPrefix": "team-a/",
+        "_note": "apps/web-pwa/src/store/synthesis/** transferred to w2a for Wave 2; team-a retains ai-engine + data-model ownership",
         "paths": [
             "packages/ai-engine/src/synthesis*.ts",
             "packages/ai-engine/src/candidateGatherer*.ts",
@@ -9,7 +10,6 @@
             "packages/ai-engine/src/topicSynthesisPipeline*.ts",
             "packages/data-model/src/schemas/hermes/synthesis*.ts",
             "packages/gun-client/src/synthesisAdapters*.ts",
-            "apps/web-pwa/src/store/synthesis/**",
             "apps/web-pwa/src/hooks/useSynthesis*.ts",
             "apps/web-pwa/src/components/synthesis/**"
         ]
@@ -60,6 +60,7 @@
     },
     "w2a": {
         "branchPrefix": "w2a/",
+        "_note": "apps/web-pwa/src/store/synthesis/** ownership transferred from team-a to w2a for Wave 2 execution",
         "paths": [
             "packages/ai-engine/src/commentTracker*.ts",
             "packages/ai-engine/src/digestBuilder*.ts",

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@
 - [ ] This PR stays within one coherent slice.
 
 ## Active Wave Branch/Ownership Contract
-- [ ] Branch name uses allowed prefix: `team-a/*`, `team-b/*`, `team-c/*`, `team-d/*`, `team-e/*`, or `coord/*`.
+- [ ] Branch name uses allowed prefix: `team-a/*`, `team-b/*`, `team-c/*`, `team-d/*`, `team-e/*`, `w2a/*`, `w2b/*`, `w2g/*`, or `coord/*`.
 - [ ] If using `coord/*`, coordinator rationale is included below.
 - [ ] Changed files are within owned paths per `.github/ownership-map.json`.
 - [ ] `Ownership Scope` check is expected to pass for this branch.


### PR DESCRIPTION
## Summary
- PR template now lists `w2a/*`, `w2b/*`, `w2g/*` as allowed branch prefixes alongside the existing `team-a/*`...`team-e/*` and `coord/*`.
- Resolved `apps/web-pwa/src/store/synthesis/**` ownership overlap between `team-a` and `w2a` by removing it from `team-a` (transferred to `w2a` for Wave 2 execution).
- Added `_note` annotations documenting the transfer.

## Scope
- [x] No unrelated file changes.
- [x] Stays within one coherent slice.

## Active Wave Branch/Ownership Contract
- [x] Branch name uses allowed prefix: `coord/*`.
- [x] Coordinator rationale included below.
- [x] Changed files are within owned paths (`.github/` governance files).
- [x] `Ownership Scope` check passes (coordinator bypass).

## Target Branch
- [x] Targets `integration/wave-2`.

## Testing
- [x] `pnpm typecheck` — pass
- [x] JSON validity verified

## Coordinator Rationale
CE dual-review (ce-opus + ce-codex) both flagged:
1. Branch prefixes `w2a/*`, `w2b/*`, `w2g/*` missing from PR template allowlist (governance drift).
2. Ownership overlap on `store/synthesis/**` between `team-a` and `w2a` creating merge/review ambiguity.

This is a cross-team governance fix required before dispatching W2-Alpha PR 3.