### PR TITLE
fix(ownership): add resynthesisWiring glob to w2a paths

### DIFF
--- a/.github/ownership-map.json
+++ b/.github/ownership-map.json
@@ -64,6 +64,7 @@
         "paths": [
             "packages/ai-engine/src/commentTracker*.ts",
             "packages/ai-engine/src/digestBuilder*.ts",
+            "packages/ai-engine/src/resynthesisWiring*.ts",
             "apps/web-pwa/src/store/synthesis/**",
             "apps/web-pwa/src/store/forum/**"
         ]


### PR DESCRIPTION
Adds `packages/ai-engine/src/resynthesisWiring*.ts` to the w2a ownership map entry.

Required for PR #202 (w2a/resynthesis-wiring) to pass the Ownership Scope check.

## Coordinator Rationale
Ownership map is a shared governance file. W2-Alpha PR 3 introduced `resynthesisWiring.ts` which needs to be registered in the w2a scope. This coord PR adds the glob so PR #202 can pass CI after rebasing.