### PR TITLE
fix: glob expansion order in ownership preflight + CE text alignment

### DIFF
--- a/docs/foundational/CE_DUAL_REVIEW_CONTRACTS.md
+++ b/docs/foundational/CE_DUAL_REVIEW_CONTRACTS.md
@@ -36,7 +36,7 @@ Before populating findings, every CE pass must verify the recommendation aligns 
 `docs/foundational/TRINITY_Season0_SoT.md` priorities A–G. If the recommendation
 conflicts with or is silent on a relevant priority, the CE pass must flag it as a
 HIGH finding. This check is recorded in the CE Review Pass output under a new
-`### SoT Alignment` section immediately after `### Findings`.
+`### SoT Alignment` section immediately before `### Findings` (as shown in the schema below).
 
 ### Required input packet
 

--- a/tools/scripts/check-ownership-preflight.mjs
+++ b/tools/scripts/check-ownership-preflight.mjs
@@ -39,9 +39,10 @@ function globToRegExp(glob) {
   const normalized = glob.endsWith('/') ? `${glob}**` : glob;
   const withSentinel = normalized.replace(/\*\*/g, '__DOUBLE_STAR__');
   const escaped = escapeRegex(withSentinel);
-  const wildcardExpanded = escaped
-    .replace(/__DOUBLE_STAR__/g, '.*')
-    .replace(/\*/g, '[^/]*');
+  // Replace single-star BEFORE expanding double-star sentinel,
+  // so the `*` inside the expanded `.*` is not clobbered.
+  const singleExpanded = escaped.replace(/\*/g, '[^/]*');
+  const wildcardExpanded = singleExpanded.replace(/__DOUBLE_STAR__/g, '.*');
   return new RegExp(`^${wildcardExpanded}$`);
 }
 


### PR DESCRIPTION
Follow-up to PR #205 (governance patch set). Two fixes:

1. **HIGH**: `check-ownership-preflight.mjs` glob expansion order was wrong (double-star before single-star). Nested paths like `bridge/deep/x.ts` would incorrectly fail. Now matches the correct pattern from `check-ownership-scope.mjs`.

2. **LOW**: CE contract text said SoT Alignment is 'after Findings' but schema places it before. Text now says 'before Findings' matching the schema.

Made with [Cursor](https://cursor.com)