### PR TITLE
chore: add env.d.ts to w2g ownership map (Policy 3 pre-approval)

### DIFF
--- a/.github/ownership-map.json
+++ b/.github/ownership-map.json
@@ -83,13 +83,15 @@
     },
     "w2g": {
         "branchPrefix": "w2g/",
+        "_note_shared": "apps/web-pwa/src/env.d.ts added per coordinator shared-file pre-approval (Policy 3) for VITE_ELEVATION_ENABLED typing",
         "paths": [
             "packages/data-model/src/schemas/hermes/elevation*.ts",
             "packages/data-model/src/schemas/hermes/notification*.ts",
             "packages/gun-client/src/bridgeAdapters*.ts",
             "apps/web-pwa/src/store/bridge/**",
             "apps/web-pwa/src/components/bridge/**",
-            "apps/web-pwa/src/store/linkedSocial/**"
+            "apps/web-pwa/src/store/linkedSocial/**",
+            "apps/web-pwa/src/env.d.ts"
         ]
     }
 }


### PR DESCRIPTION
## Summary

Adds `apps/web-pwa/src/env.d.ts` to w2g ownership paths.

**Rationale:** Coordinator pre-approved under shared-file protocol (Delta Contract Policy 3) for `VITE_ELEVATION_ENABLED` typing addition in the Phase 2 elevation artifacts PR.

## Changed Files
- `.github/ownership-map.json`: add env.d.ts to w2g paths with note

## Risk
Zero functional risk — ownership map metadata change only.