### PR TITLE
chore: add feed component paths to w2g ownership map (Policy 3 pre-approval)

### DIFF
--- a/.github/ownership-map.json
+++ b/.github/ownership-map.json
@@ -83,7 +83,7 @@
     },
     "w2g": {
         "branchPrefix": "w2g/",
-        "_note_shared": "apps/web-pwa/src/env.d.ts added per coordinator shared-file pre-approval (Policy 3) for VITE_ELEVATION_ENABLED typing",
+        "_note_shared": "apps/web-pwa/src/env.d.ts added per coordinator shared-file pre-approval (Policy 3) for VITE_ELEVATION_ENABLED typing. apps/web-pwa/src/components/feed/** added per coordinator shared-file pre-approval (Policy 3) for Phase 3 feed integration wiring — shared with team-c.",
         "paths": [
             "packages/data-model/src/schemas/hermes/elevation*.ts",
             "packages/data-model/src/schemas/hermes/notification*.ts",
@@ -91,6 +91,7 @@
             "apps/web-pwa/src/store/bridge/**",
             "apps/web-pwa/src/components/bridge/**",
             "apps/web-pwa/src/store/linkedSocial/**",
+            "apps/web-pwa/src/components/feed/**",
             "apps/web-pwa/src/env.d.ts"
         ]
     }


### PR DESCRIPTION
## Ownership Map Update — W2-Gamma Phase 3 Pre-Dispatch

Adds `apps/web-pwa/src/components/feed/**` to w2g ownership paths per shared-file protocol (Policy 3) with coordinator pre-approval.

**Context:** Phase 3 feed integration wiring requires w2g to modify existing feed components (SocialNotificationCard, FeedShell, FilterChips) originally owned by team-c.

**Dual ownership:** team-c retains ownership of these paths. This is cross-team integration scope approved by coordinator.

**Blocks:** W2-Gamma Phase 3 dispatch (cannot pass Ownership Scope CI without this).