### PR TITLE
fix(ownership): expand w2b globs for Stage 2 CRDT/Yjs collab hardening

### DIFF
--- a/.github/ownership-map.json
+++ b/.github/ownership-map.json
@@ -71,11 +71,16 @@
     },
     "w2b": {
         "branchPrefix": "w2b/",
+        "_note_stage2": "packages/crdt/** and docsKeyManagement added for Stage 2 CRDT/Yjs collab hardening per coordinator pre-approval (Policy 3). packages/gun-client/src/topology*.ts shared-file access for docKeys path rule.",
         "paths": [
             "packages/data-model/src/schemas/hermes/docs*.ts",
             "packages/data-model/src/index*.ts",
             "packages/gun-client/src/docsAdapters*.ts",
+            "packages/gun-client/src/docsKeyManagement*.ts",
+            "packages/gun-client/src/topology*.ts",
             "packages/gun-client/src/index*.ts",
+            "packages/crdt/src/**",
+            "packages/crdt/package.json",
             "apps/web-pwa/src/store/hermesDocs*.ts",
             "apps/web-pwa/src/components/hermes/forum/CommentComposer*.tsx",
             "apps/web-pwa/src/components/docs/**"


### PR DESCRIPTION
## Summary
Expand w2b ownership map for Stage 2 CRDT/Yjs collaborative editing hardening.

### Paths Added
- `packages/crdt/src/**` — Yjs provider, awareness adapter, dedup module
- `packages/crdt/package.json` — yjs + y-protocols dependencies
- `packages/gun-client/src/docsKeyManagement*.ts` — key derivation/sharing helpers
- `packages/gun-client/src/topology*.ts` — shared-file access for docKeys topology rule

### Policy Compliance
- **Policy 3 (Shared-file protocol)**: topology*.ts is a shared file; coordinator pre-approval granted here
- **Policy 16 (Ownership preflight)**: Must land before w2b-chief Stage 2 dispatch
- **CE dual-review**: ce-opus AGREED, ce-codex concerns incorporated

### Context
Stage 2 covers spec-hermes-docs-v0.md §3-§7 (CRDT architecture, encryption, access control, editor UI).
`packages/crdt/**` was explicitly removed from Stage 1 ownership per previous CE review; now correctly re-added for Stage 2.