### PR TITLE
feat(docs-keys): document key management — derive, share, encrypt/decrypt (Stage 2 PR 2/3)

### DIFF
--- a/packages/gun-client/src/docsKeyManagement.test.ts
+++ b/packages/gun-client/src/docsKeyManagement.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import SEA from 'gun/sea';
+import {
+  deriveDocumentKey,
+  shareDocumentKey,
+  receiveDocumentKey,
+  encryptDocContent,
+  decryptDocContent,
+  type SEAPair
+} from './docsKeyManagement';
+
+describe('docsKeyManagement', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('deriveDocumentKey', () => {
+    it('derives a deterministic key from docId and owner pair', async () => {
+      const pair = await SEA.pair() as unknown as SEAPair;
+      const key1 = await deriveDocumentKey('doc-1', pair);
+      const key2 = await deriveDocumentKey('doc-1', pair);
+      expect(key1).toBe(key2);
+      expect(typeof key1).toBe('string');
+      expect(key1.length).toBeGreaterThan(0);
+    });
+
+    it('produces different keys for different docIds', async () => {
+      const pair = await SEA.pair() as unknown as SEAPair;
+      const key1 = await deriveDocumentKey('doc-1', pair);
+      const key2 = await deriveDocumentKey('doc-2', pair);
+      expect(key1).not.toBe(key2);
+    });
+
+    it('throws when SEA.work returns falsy', async () => {
+      vi.spyOn(SEA, 'work').mockResolvedValueOnce(undefined as any);
+      const pair = await SEA.pair() as unknown as SEAPair;
+      await expect(deriveDocumentKey('doc-1', pair)).rejects.toThrow(
+        'Failed to derive document key'
+      );
+    });
+  });
+
+  describe('shareDocumentKey + receiveDocumentKey', () => {
+    it('round-trips: owner shares, collaborator receives', async () => {
+      const ownerPair = await SEA.pair() as unknown as SEAPair;
+      const collabPair = await SEA.pair() as unknown as SEAPair;
+      const docKey = await deriveDocumentKey('doc-share', ownerPair);
+
+      const encrypted = await shareDocumentKey(docKey, collabPair.epub, ownerPair);
+      expect(typeof encrypted).toBe('string');
+
+      const decrypted = await receiveDocumentKey(encrypted, ownerPair.epub, collabPair);
+      expect(decrypted).toBe(docKey);
+    });
+
+    it('shareDocumentKey throws when shared secret fails', async () => {
+      vi.spyOn(SEA, 'secret').mockResolvedValueOnce(undefined as any);
+      const pair = await SEA.pair() as unknown as SEAPair;
+      await expect(
+        shareDocumentKey('key', 'bad-epub', pair)
+      ).rejects.toThrow('Failed to derive shared secret for key sharing');
+    });
+
+    it('shareDocumentKey throws when encryption fails', async () => {
+      const ownerPair = await SEA.pair() as unknown as SEAPair;
+      const collabPair = await SEA.pair() as unknown as SEAPair;
+      vi.spyOn(SEA, 'encrypt').mockResolvedValueOnce(null as any);
+      await expect(
+        shareDocumentKey('key', collabPair.epub, ownerPair)
+      ).rejects.toThrow('Failed to encrypt document key');
+    });
+
+    it('shareDocumentKey JSON-stringifies non-string encrypt result', async () => {
+      const ownerPair = await SEA.pair() as unknown as SEAPair;
+      const collabPair = await SEA.pair() as unknown as SEAPair;
+      const objResult = { ct: 'cipher', iv: 'nonce', s: 'salt' };
+      vi.spyOn(SEA, 'encrypt').mockResolvedValueOnce(objResult as any);
+      const result = await shareDocumentKey('key', collabPair.epub, ownerPair);
+      expect(result).toBe(JSON.stringify(objResult));
+    });
+
+    it('receiveDocumentKey JSON-stringifies non-string decrypt result', async () => {
+      const ownerPair = await SEA.pair() as unknown as SEAPair;
+      const collabPair = await SEA.pair() as unknown as SEAPair;
+      const objResult = { nested: 'value' };
+      vi.spyOn(SEA, 'decrypt').mockResolvedValueOnce(objResult as any);
+      const result = await receiveDocumentKey('enc', ownerPair.epub, collabPair);
+      expect(result).toBe(JSON.stringify(objResult));
+    });
+
+    it('receiveDocumentKey throws when shared secret fails', async () => {
+      vi.spyOn(SEA, 'secret').mockResolvedValueOnce(undefined as any);
+      const pair = await SEA.pair() as unknown as SEAPair;
+      await expect(
+        receiveDocumentKey('enc-key', 'bad-epub', pair)
+      ).rejects.toThrow('Failed to derive shared secret for key receiving');
+    });
+
+    it('receiveDocumentKey throws when decryption fails', async () => {
+      const ownerPair = await SEA.pair() as unknown as SEAPair;
+      const collabPair = await SEA.pair() as unknown as SEAPair;
+      vi.spyOn(SEA, 'decrypt').mockResolvedValueOnce(undefined as any);
+      await expect(
+        receiveDocumentKey('bad-data', ownerPair.epub, collabPair)
+      ).rejects.toThrow('Failed to decrypt document key');
+    });
+  });
+
+  describe('encryptDocContent + decryptDocContent', () => {
+    it('round-trips Uint8Array content', async () => {
+      const ownerPair = await SEA.pair() as unknown as SEAPair;
+      const docKey = await deriveDocumentKey('doc-content', ownerPair);
+
+      const original = new Uint8Array([1, 2, 3, 4, 5, 72, 101, 108, 108, 111]);
+      const encrypted = await encryptDocContent(original, docKey);
+      expect(typeof encrypted).toBe('string');
+
+      const decrypted = await decryptDocContent(encrypted, docKey);
+      expect(decrypted).toEqual(original);
+    });
+
+    it('handles empty content', async () => {
+      const ownerPair = await SEA.pair() as unknown as SEAPair;
+      const docKey = await deriveDocumentKey('doc-empty', ownerPair);
+
+      const original = new Uint8Array([]);
+      const encrypted = await encryptDocContent(original, docKey);
+      const decrypted = await decryptDocContent(encrypted, docKey);
+      expect(decrypted).toEqual(original);
+    });
+
+    it('encryptDocContent JSON-stringifies non-string encrypt result', async () => {
+      const objResult = { ct: 'encrypted-state', iv: 'iv', s: 'salt' };
+      vi.spyOn(SEA, 'encrypt').mockResolvedValueOnce(objResult as any);
+      const result = await encryptDocContent(new Uint8Array([1, 2, 3]), 'key');
+      expect(result).toBe(JSON.stringify(objResult));
+    });
+
+    it('encryptDocContent throws when encryption fails', async () => {
+      vi.spyOn(SEA, 'encrypt').mockResolvedValueOnce(null as any);
+      await expect(
+        encryptDocContent(new Uint8Array([1, 2, 3]), 'key')
+      ).rejects.toThrow('Failed to encrypt document content');
+    });
+
+    it('decryptDocContent throws when decryption fails', async () => {
+      vi.spyOn(SEA, 'decrypt').mockResolvedValueOnce(undefined as any);
+      await expect(
+        decryptDocContent('bad-data', 'key')
+      ).rejects.toThrow('Failed to decrypt document content');
+    });
+
+    it('decryptDocContent throws when decrypted value is not a string', async () => {
+      vi.spyOn(SEA, 'decrypt').mockResolvedValueOnce(12345 as any);
+      await expect(
+        decryptDocContent('data', 'key')
+      ).rejects.toThrow('Failed to decrypt document content');
+    });
+  });
+});

--- a/packages/gun-client/src/docsKeyManagement.ts
+++ b/packages/gun-client/src/docsKeyManagement.ts
@@ -1,0 +1,133 @@
+/**
+ * Document key management for HERMES Docs (spec §4.1–§4.3).
+ *
+ * Provides deterministic key derivation for document owners,
+ * ECDH-based key sharing with collaborators, and content
+ * encryption/decryption for Yjs state snapshots.
+ */
+
+import SEA from 'gun/sea';
+
+/** Minimal SEA key-pair shape for owner/device operations. */
+export interface SEAPair {
+  pub: string;
+  priv: string;
+  epub: string;
+  epriv: string;
+}
+
+/**
+ * Derive a deterministic document key from the document ID
+ * and the owner's device key-pair (spec §4.1).
+ *
+ * Uses SEA.work (PBKDF2) with the docId as salt and
+ * the owner pair as the key material.
+ */
+export async function deriveDocumentKey(
+  docId: string,
+  ownerDevicePair: SEAPair
+): Promise<string> {
+  const key = await SEA.work(docId, ownerDevicePair);
+  if (!key) {
+    throw new Error('Failed to derive document key');
+  }
+  return key;
+}
+
+/**
+ * Encrypt the document key for a collaborator using ECDH (spec §4.2).
+ *
+ * The owner computes a shared secret with the collaborator's epub,
+ * then encrypts the document key with that secret.
+ */
+export async function shareDocumentKey(
+  documentKey: string,
+  collaboratorEpub: string,
+  ownerDevicePair: SEAPair
+): Promise<string> {
+  const sharedSecret = await SEA.secret(collaboratorEpub, ownerDevicePair);
+  if (!sharedSecret) {
+    throw new Error('Failed to derive shared secret for key sharing');
+  }
+  const encrypted = await SEA.encrypt(documentKey, sharedSecret);
+  if (!encrypted) {
+    throw new Error('Failed to encrypt document key');
+  }
+  return typeof encrypted === 'string' ? encrypted : JSON.stringify(encrypted);
+}
+
+/**
+ * Decrypt a document key received from the owner (spec §4.2).
+ *
+ * The collaborator computes the same shared secret using the
+ * owner's epub and their own device pair, then decrypts.
+ */
+export async function receiveDocumentKey(
+  encryptedKey: string,
+  ownerEpub: string,
+  myDevicePair: SEAPair
+): Promise<string> {
+  const sharedSecret = await SEA.secret(ownerEpub, myDevicePair);
+  if (!sharedSecret) {
+    throw new Error('Failed to derive shared secret for key receiving');
+  }
+  const decrypted = await SEA.decrypt(encryptedKey, sharedSecret);
+  if (!decrypted) {
+    throw new Error('Failed to decrypt document key');
+  }
+  return typeof decrypted === 'string' ? decrypted : JSON.stringify(decrypted);
+}
+
+/** Base64 encode Uint8Array (browser-safe). */
+function uint8ToBase64(bytes: Uint8Array): string {
+  let binary = '';
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]!);
+  }
+  return btoa(binary);
+}
+
+/** Base64 decode to Uint8Array (browser-safe). */
+function base64ToUint8(base64: string): Uint8Array {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+/**
+ * Encrypt Yjs document state for storage (spec §4.3).
+ *
+ * Accepts raw Yjs state bytes (from Y.encodeStateAsUpdate),
+ * base64-encodes, then encrypts with the document key.
+ */
+export async function encryptDocContent(
+  stateBytes: Uint8Array,
+  documentKey: string
+): Promise<string> {
+  const base64State = uint8ToBase64(stateBytes);
+  const encrypted = await SEA.encrypt(base64State, documentKey);
+  if (!encrypted) {
+    throw new Error('Failed to encrypt document content');
+  }
+  return typeof encrypted === 'string' ? encrypted : JSON.stringify(encrypted);
+}
+
+/**
+ * Decrypt Yjs document state from storage (spec §4.3).
+ *
+ * Decrypts, then base64-decodes back to Uint8Array for
+ * Y.applyUpdate consumption.
+ */
+export async function decryptDocContent(
+  encryptedContent: string,
+  documentKey: string
+): Promise<Uint8Array> {
+  const decrypted = await SEA.decrypt(encryptedContent, documentKey);
+  if (decrypted === undefined || decrypted === null || typeof decrypted !== 'string') {
+    throw new Error('Failed to decrypt document content');
+  }
+  return base64ToUint8(decrypted);
+}

--- a/packages/gun-client/src/index.ts
+++ b/packages/gun-client/src/index.ts
@@ -153,6 +153,7 @@ export * from './hermesCrypto';
 export * from './forumAdapters';
 export * from './directoryAdapters';
 export * from './docsAdapters';
+export * from './docsKeyManagement';
 export * from './synthesisAdapters';
 export * from './newsAdapters';
 export type { ChainWithGet } from './chain';

--- a/packages/gun-client/src/topology.test.ts
+++ b/packages/gun-client/src/topology.test.ts
@@ -72,4 +72,23 @@ describe('TopologyGuard', () => {
     expect(() => guard.validateWrite('vh/hermes/inbox/device-123', {})).toThrow();
     expect(() => guard.validateWrite('~user/raw/data', {})).toThrow();
   });
+
+  it('allows encrypted writes to hermes docKeys path (sensitive)', () => {
+    const guard = new TopologyGuard();
+    expect(() =>
+      guard.validateWrite('~alice/hermes/docKeys/doc-1', {
+        __encrypted: true,
+        encryptedKey: 'abc123'
+      })
+    ).not.toThrow();
+  });
+
+  it('rejects unencrypted writes to hermes docKeys path', () => {
+    const guard = new TopologyGuard();
+    expect(() =>
+      guard.validateWrite('~alice/hermes/docKeys/doc-1', {
+        encryptedKey: 'abc123'
+      })
+    ).toThrow(/sensitive write without encryption flag/);
+  });
 });

--- a/packages/gun-client/src/topology.ts
+++ b/packages/gun-client/src/topology.ts
@@ -37,6 +37,7 @@ const DEFAULT_RULES: TopologyRule[] = [
   { pathPrefix: '~*/docs/*', classification: 'sensitive' },
   { pathPrefix: '~*/hermes/docs/*', classification: 'sensitive' },
   { pathPrefix: '~*/hermes/bridge/*', classification: 'sensitive' },
+  { pathPrefix: '~*/hermes/docKeys/*', classification: 'sensitive' },
   // Forum
   { pathPrefix: 'vh/forum/threads/', classification: 'public' },
   { pathPrefix: 'vh/forum/indexes/', classification: 'public' }


### PR DESCRIPTION
## Summary
Implements spec-hermes-docs-v0 §4.1-§4.3 for document key management.

### Changes
- **docsKeyManagement.ts** (133 LOC): Key derivation via SEA.work, ECDH key sharing, content encrypt/decrypt with browser-safe base64
- **topology.ts**: Added `~*/hermes/docKeys/*` as sensitive path rule
- **index.ts**: Barrel export for docsKeyManagement

### Coverage
135 LOC tests covering derive, share, encrypt/decrypt round-trips, error paths.

### Spec References
- spec-hermes-docs-v0 §4.1 (Key Derivation)
- spec-hermes-docs-v0 §4.2 (Key Sharing)
- spec-hermes-docs-v0 §4.3 (Content Encryption)

### Stage 2 PR Chain
- PR 1/3: #214 (Yjs provider) ✅ MERGED
- **PR 2/3: This PR (doc key management)**
- PR 3/3: Collab editor (pending)