### PR TITLE
feat(cak): Phase 1 — civic action kit data model, Gun adapters, representative directory

### DIFF
--- a/apps/web-pwa/src/store/bridge/index.ts
+++ b/apps/web-pwa/src/store/bridge/index.ts
@@ -13,3 +13,12 @@ export {
   type BudgetPreflightResult,
   type NominationResult,
 } from './nominationFlow';
+
+export {
+  getDirectory,
+  loadDirectory,
+  isNewerVersion,
+  findRepresentatives,
+  findRepresentativesByState,
+  _resetDirectoryForTesting,
+} from './representativeDirectory';

--- a/apps/web-pwa/src/store/bridge/representativeDirectory.test.ts
+++ b/apps/web-pwa/src/store/bridge/representativeDirectory.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import {
+  getDirectory,
+  loadDirectory,
+  isNewerVersion,
+  findRepresentatives,
+  findRepresentativesByState,
+  _resetDirectoryForTesting,
+} from './representativeDirectory';
+import type { Representative } from '@vh/data-model';
+
+const rep1: Representative = {
+  id: 'us-house-ca-11',
+  name: 'Jane Doe',
+  title: 'Representative',
+  office: 'house',
+  country: 'US',
+  state: 'CA',
+  district: '11',
+  districtHash: 'hash-ca-11',
+  contactMethod: 'email',
+  email: 'jane@house.gov',
+  lastVerified: 1_700_000_000_000,
+};
+
+const rep2: Representative = {
+  id: 'us-senate-ca',
+  name: 'John Smith',
+  title: 'Senator',
+  office: 'senate',
+  country: 'US',
+  state: 'CA',
+  districtHash: 'hash-ca-senate',
+  contactMethod: 'both',
+  email: 'john@senate.gov',
+  phone: '+12025559876',
+  lastVerified: 1_700_000_000_000,
+};
+
+const validDirectory = {
+  version: '1.0.0',
+  lastUpdated: 1_700_000_000_000,
+  updateSource: 'test-bundle',
+  representatives: [rep1, rep2],
+  byState: { CA: ['us-house-ca-11', 'us-senate-ca'] },
+  byDistrictHash: {
+    'hash-ca-11': ['us-house-ca-11'],
+    'hash-ca-senate': ['us-senate-ca'],
+  },
+};
+
+beforeEach(() => {
+  _resetDirectoryForTesting();
+});
+
+describe('getDirectory', () => {
+  it('returns empty scaffold by default', () => {
+    const dir = getDirectory();
+    expect(dir.version).toBe('0.0.0');
+    expect(dir.representatives).toEqual([]);
+    expect(dir.byState).toEqual({});
+    expect(dir.byDistrictHash).toEqual({});
+  });
+});
+
+describe('loadDirectory', () => {
+  it('loads a valid directory', () => {
+    const ok = loadDirectory(validDirectory);
+    expect(ok).toBe(true);
+    expect(getDirectory().version).toBe('1.0.0');
+    expect(getDirectory().representatives).toHaveLength(2);
+  });
+
+  it('rejects invalid directory data', () => {
+    const ok = loadDirectory({ version: 123 });
+    expect(ok).toBe(false);
+    expect(getDirectory().version).toBe('0.0.0');
+  });
+
+  it('rejects null', () => {
+    expect(loadDirectory(null)).toBe(false);
+  });
+
+  it('rejects directory with invalid representative', () => {
+    const bad = { ...validDirectory, representatives: [{ id: 'bad' }] };
+    expect(loadDirectory(bad)).toBe(false);
+  });
+
+  it('rejects directory with extra fields (.strict)', () => {
+    const extra = { ...validDirectory, extraField: true };
+    expect(loadDirectory(extra)).toBe(false);
+  });
+});
+
+describe('isNewerVersion', () => {
+  it('returns true when remote is newer', () => {
+    expect(isNewerVersion('1.0.0')).toBe(true);
+  });
+
+  it('returns false when remote is same', () => {
+    expect(isNewerVersion('0.0.0')).toBe(false);
+  });
+
+  it('compares with loaded version', () => {
+    loadDirectory(validDirectory);
+    expect(isNewerVersion('0.9.0')).toBe(false);
+    expect(isNewerVersion('2.0.0')).toBe(true);
+  });
+});
+
+describe('findRepresentatives', () => {
+  beforeEach(() => {
+    loadDirectory(validDirectory);
+  });
+
+  it('finds representatives by district hash', () => {
+    const reps = findRepresentatives('hash-ca-11');
+    expect(reps).toHaveLength(1);
+    expect(reps[0].id).toBe('us-house-ca-11');
+  });
+
+  it('returns empty array for unknown district hash', () => {
+    expect(findRepresentatives('nonexistent')).toEqual([]);
+  });
+
+  it('returns empty array on empty directory', () => {
+    _resetDirectoryForTesting();
+    expect(findRepresentatives('hash-ca-11')).toEqual([]);
+  });
+
+  it('handles dangling ID reference gracefully', () => {
+    const withDangling = {
+      ...validDirectory,
+      byDistrictHash: { 'hash-ca-11': ['nonexistent-id'] },
+    };
+    loadDirectory(withDangling);
+    expect(findRepresentatives('hash-ca-11')).toEqual([]);
+  });
+});
+
+describe('findRepresentativesByState', () => {
+  beforeEach(() => {
+    loadDirectory(validDirectory);
+  });
+
+  it('finds representatives by state', () => {
+    const reps = findRepresentativesByState('CA');
+    expect(reps).toHaveLength(2);
+  });
+
+  it('returns empty array for unknown state', () => {
+    expect(findRepresentativesByState('TX')).toEqual([]);
+  });
+});

--- a/apps/web-pwa/src/store/bridge/representativeDirectory.ts
+++ b/apps/web-pwa/src/store/bridge/representativeDirectory.ts
@@ -1,0 +1,80 @@
+/**
+ * Representative directory — local store for constituency matching.
+ *
+ * Bundles an empty directory scaffold for offline startup.
+ * Validates directory data with Zod before replacing local cache.
+ *
+ * Spec: spec-civic-action-kit-v0.md §3.1, §3.2, §3.3
+ */
+
+import type { Representative, RepresentativeDirectory } from '@vh/data-model';
+import { RepresentativeDirectorySchema } from '@vh/data-model';
+
+/* ── Empty scaffold for offline startup ─────────────────────── */
+
+const EMPTY_DIRECTORY: RepresentativeDirectory = {
+  version: '0.0.0',
+  lastUpdated: 0,
+  updateSource: 'empty-scaffold',
+  representatives: [],
+  byState: {},
+  byDistrictHash: {},
+};
+
+/* ── In-memory store ────────────────────────────────────────── */
+
+let _directory: RepresentativeDirectory = { ...EMPTY_DIRECTORY };
+
+/**
+ * Get the current directory snapshot.
+ */
+export function getDirectory(): RepresentativeDirectory {
+  return _directory;
+}
+
+/**
+ * Load and validate a directory payload, replacing the local cache.
+ * Returns true on success, false if validation fails.
+ * Spec: spec-civic-action-kit-v0.md §3.3
+ */
+export function loadDirectory(data: unknown): boolean {
+  const result = RepresentativeDirectorySchema.safeParse(data);
+  if (!result.success) return false;
+  _directory = result.data;
+  return true;
+}
+
+/**
+ * Check if a remote directory version is newer than local.
+ */
+export function isNewerVersion(remoteVersion: string): boolean {
+  return remoteVersion > _directory.version;
+}
+
+/**
+ * Find representatives matching a district hash.
+ * Spec: spec-civic-action-kit-v0.md §3.2
+ */
+export function findRepresentatives(districtHash: string): Representative[] {
+  const ids = _directory.byDistrictHash[districtHash] ?? [];
+  return ids
+    .map((id) => _directory.representatives.find((rep) => rep.id === id))
+    .filter((rep): rep is Representative => rep !== undefined);
+}
+
+/**
+ * Find representatives by state.
+ */
+export function findRepresentativesByState(state: string): Representative[] {
+  const ids = _directory.byState[state] ?? [];
+  return ids
+    .map((id) => _directory.representatives.find((rep) => rep.id === id))
+    .filter((rep): rep is Representative => rep !== undefined);
+}
+
+/**
+ * Reset directory to empty scaffold. For testing only.
+ */
+export function _resetDirectoryForTesting(): void {
+  _directory = { ...EMPTY_DIRECTORY };
+}

--- a/packages/data-model/src/index.ts
+++ b/packages/data-model/src/index.ts
@@ -16,3 +16,6 @@ export * from './schemas/hermes/notification';
 export * from './schemas/hermes/elevation';
 export * from './schemas/hermes/discovery';
 export * from './schemas/hermes/docs';
+export * from './schemas/hermes/bridgeAction';
+export * from './schemas/hermes/bridgeReceipt';
+export * from './schemas/hermes/bridgeRepresentative';

--- a/packages/data-model/src/schemas/hermes/bridgeAction.test.ts
+++ b/packages/data-model/src/schemas/hermes/bridgeAction.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CivicActionSchema,
+  ConstituencyProofSchema,
+  DeliveryIntentSchema,
+} from './bridgeAction';
+
+const validProof = {
+  district_hash: 'hash-ca-11',
+  nullifier: 'nullifier-abc',
+  merkle_root: 'root-xyz',
+};
+
+const validAction = {
+  id: 'action-1',
+  schemaVersion: 'hermes-action-v1' as const,
+  author: 'nullifier-abc',
+  sourceTopicId: 'topic-42',
+  sourceSynthesisId: 'synth-7',
+  sourceEpoch: 3,
+  sourceArtifactId: 'brief-abc',
+  representativeId: 'us-house-ca-11',
+  topic: 'Infrastructure funding',
+  stance: 'support' as const,
+  subject: 'Support for local bridge repairs',
+  body: 'I am writing to express my support for the proposed infrastructure bill. This is an important initiative for our community and I urge prompt action.',
+  intent: 'email' as const,
+  constituencyProof: validProof,
+  status: 'draft' as const,
+  createdAt: 1_700_000_000_000,
+  attempts: 0,
+};
+
+describe('DeliveryIntentSchema', () => {
+  it.each(['email', 'phone', 'share', 'export', 'manual'] as const)(
+    'accepts valid intent: %s',
+    (intent) => {
+      expect(DeliveryIntentSchema.safeParse(intent).success).toBe(true);
+    },
+  );
+
+  it('rejects invalid intent', () => {
+    expect(DeliveryIntentSchema.safeParse('fax').success).toBe(false);
+  });
+});
+
+describe('ConstituencyProofSchema', () => {
+  it('parses a valid proof', () => {
+    const result = ConstituencyProofSchema.safeParse(validProof);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects unknown keys (.strict)', () => {
+    expect(ConstituencyProofSchema.safeParse({ ...validProof, extra: 1 }).success).toBe(false);
+  });
+
+  it.each(['district_hash', 'nullifier', 'merkle_root'] as const)(
+    'rejects missing field: %s',
+    (field) => {
+      const obj = { ...validProof };
+      delete (obj as Record<string, unknown>)[field];
+      expect(ConstituencyProofSchema.safeParse(obj).success).toBe(false);
+    },
+  );
+
+  it('rejects empty string district_hash', () => {
+    expect(ConstituencyProofSchema.safeParse({ ...validProof, district_hash: '' }).success).toBe(false);
+  });
+});
+
+describe('CivicActionSchema', () => {
+  it('parses a valid action', () => {
+    const result = CivicActionSchema.safeParse(validAction);
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data).toEqual(validAction);
+  });
+
+  it('parses with all optional fields', () => {
+    const full = {
+      ...validAction,
+      sourceDocId: 'doc-1',
+      sourceThreadId: 'thread-1',
+      sentAt: 1_700_000_001_000,
+      lastError: 'timeout',
+      lastErrorCode: 'E_TIMEOUT',
+    };
+    expect(CivicActionSchema.safeParse(full).success).toBe(true);
+  });
+
+  it('rejects unknown keys (.strict)', () => {
+    expect(CivicActionSchema.safeParse({ ...validAction, pii: 'home address' }).success).toBe(false);
+  });
+
+  it('rejects wrong schemaVersion', () => {
+    expect(CivicActionSchema.safeParse({ ...validAction, schemaVersion: 'v2' }).success).toBe(false);
+  });
+
+  it('rejects topic over 100 chars', () => {
+    expect(CivicActionSchema.safeParse({ ...validAction, topic: 'x'.repeat(101) }).success).toBe(false);
+  });
+
+  it('rejects subject over 200 chars', () => {
+    expect(CivicActionSchema.safeParse({ ...validAction, subject: 'x'.repeat(201) }).success).toBe(false);
+  });
+
+  it('rejects body under 50 chars', () => {
+    expect(CivicActionSchema.safeParse({ ...validAction, body: 'too short' }).success).toBe(false);
+  });
+
+  it('rejects body over 5000 chars', () => {
+    expect(CivicActionSchema.safeParse({ ...validAction, body: 'x'.repeat(5001) }).success).toBe(false);
+  });
+
+  it('accepts body at min boundary (50 chars)', () => {
+    expect(CivicActionSchema.safeParse({ ...validAction, body: 'x'.repeat(50) }).success).toBe(true);
+  });
+
+  it('accepts body at max boundary (5000 chars)', () => {
+    expect(CivicActionSchema.safeParse({ ...validAction, body: 'x'.repeat(5000) }).success).toBe(true);
+  });
+
+  it('rejects invalid stance', () => {
+    expect(CivicActionSchema.safeParse({ ...validAction, stance: 'neutral' }).success).toBe(false);
+  });
+
+  it('rejects invalid status', () => {
+    expect(CivicActionSchema.safeParse({ ...validAction, status: 'pending' }).success).toBe(false);
+  });
+
+  it.each([
+    'id', 'schemaVersion', 'author', 'sourceTopicId', 'sourceSynthesisId',
+    'sourceEpoch', 'sourceArtifactId', 'representativeId', 'topic', 'stance',
+    'subject', 'body', 'intent', 'constituencyProof', 'status', 'createdAt', 'attempts',
+  ] as const)(
+    'rejects missing required field: %s',
+    (field) => {
+      const obj = { ...validAction };
+      delete (obj as Record<string, unknown>)[field];
+      expect(CivicActionSchema.safeParse(obj).success).toBe(false);
+    },
+  );
+
+  it('rejects negative sourceEpoch', () => {
+    expect(CivicActionSchema.safeParse({ ...validAction, sourceEpoch: -1 }).success).toBe(false);
+  });
+
+  it('rejects non-integer attempts', () => {
+    expect(CivicActionSchema.safeParse({ ...validAction, attempts: 1.5 }).success).toBe(false);
+  });
+});

--- a/packages/data-model/src/schemas/hermes/bridgeAction.ts
+++ b/packages/data-model/src/schemas/hermes/bridgeAction.ts
@@ -1,0 +1,76 @@
+import { z } from 'zod';
+
+/**
+ * Delivery intent — channel used for civic action delivery.
+ * Spec: spec-civic-action-kit-v0.md §2.3
+ */
+export const DeliveryIntentSchema = z.enum([
+  'email',
+  'phone',
+  'share',
+  'export',
+  'manual',
+]);
+
+export type DeliveryIntent = z.infer<typeof DeliveryIntentSchema>;
+
+/**
+ * Constituency proof — cryptographic proof of district membership.
+ * Spec: spec-civic-action-kit-v0.md §2.3
+ */
+export const ConstituencyProofSchema = z
+  .object({
+    district_hash: z.string().min(1),
+    nullifier: z.string().min(1),
+    merkle_root: z.string().min(1),
+  })
+  .strict();
+
+export type ConstituencyProof = z.infer<typeof ConstituencyProofSchema>;
+
+/**
+ * Civic action — user-initiated outreach record to a representative.
+ * Spec: spec-civic-action-kit-v0.md §2.3, §2.5
+ */
+export const CivicActionSchema = z
+  .object({
+    id: z.string().min(1),
+    schemaVersion: z.literal('hermes-action-v1'),
+
+    // author
+    author: z.string().min(1),
+
+    // source
+    sourceTopicId: z.string().min(1),
+    sourceSynthesisId: z.string().min(1),
+    sourceEpoch: z.number().int().nonnegative(),
+    sourceArtifactId: z.string().min(1),
+    sourceDocId: z.string().optional(),
+    sourceThreadId: z.string().optional(),
+
+    // target
+    representativeId: z.string().min(1),
+
+    // content (per §2.5 limits)
+    topic: z.string().min(1).max(100),
+    stance: z.enum(['support', 'oppose', 'inform']),
+    subject: z.string().min(1).max(200),
+    body: z.string().min(50).max(5000),
+    intent: DeliveryIntentSchema,
+
+    // verification
+    constituencyProof: ConstituencyProofSchema,
+
+    // state
+    status: z.enum(['draft', 'ready', 'completed', 'failed']),
+    createdAt: z.number().int().nonnegative(),
+    sentAt: z.number().int().nonnegative().optional(),
+
+    // retries / diagnostics
+    attempts: z.number().int().nonnegative(),
+    lastError: z.string().optional(),
+    lastErrorCode: z.string().optional(),
+  })
+  .strict();
+
+export type CivicAction = z.infer<typeof CivicActionSchema>;

--- a/packages/data-model/src/schemas/hermes/bridgeReceipt.test.ts
+++ b/packages/data-model/src/schemas/hermes/bridgeReceipt.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import { DeliveryReceiptSchema } from './bridgeReceipt';
+
+const validReceipt = {
+  id: 'receipt-1',
+  schemaVersion: 'hermes-receipt-v1' as const,
+  actionId: 'action-1',
+  representativeId: 'us-house-ca-11',
+  status: 'success' as const,
+  timestamp: 1_700_000_000_000,
+  intent: 'email' as const,
+  userAttested: true,
+  retryCount: 0,
+};
+
+describe('DeliveryReceiptSchema', () => {
+  it('parses a valid receipt', () => {
+    const result = DeliveryReceiptSchema.safeParse(validReceipt);
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data).toEqual(validReceipt);
+  });
+
+  it('parses with all optional fields', () => {
+    const full = {
+      ...validReceipt,
+      errorMessage: 'connection refused',
+      errorCode: 'E_CONNREFUSED',
+      previousReceiptId: 'receipt-0',
+    };
+    expect(DeliveryReceiptSchema.safeParse(full).success).toBe(true);
+  });
+
+  it('accepts all status values', () => {
+    for (const status of ['success', 'failed', 'user-cancelled'] as const) {
+      expect(DeliveryReceiptSchema.safeParse({ ...validReceipt, status }).success).toBe(true);
+    }
+  });
+
+  it('accepts all intent values', () => {
+    for (const intent of ['email', 'phone', 'share', 'export', 'manual'] as const) {
+      expect(DeliveryReceiptSchema.safeParse({ ...validReceipt, intent }).success).toBe(true);
+    }
+  });
+
+  it('rejects unknown keys (.strict)', () => {
+    expect(DeliveryReceiptSchema.safeParse({ ...validReceipt, extra: 1 }).success).toBe(false);
+  });
+
+  it('rejects wrong schemaVersion', () => {
+    expect(DeliveryReceiptSchema.safeParse({ ...validReceipt, schemaVersion: 'v2' }).success).toBe(false);
+  });
+
+  it('rejects invalid status', () => {
+    expect(DeliveryReceiptSchema.safeParse({ ...validReceipt, status: 'pending' }).success).toBe(false);
+  });
+
+  it('rejects non-boolean userAttested', () => {
+    expect(DeliveryReceiptSchema.safeParse({ ...validReceipt, userAttested: 'yes' }).success).toBe(false);
+  });
+
+  it('rejects negative retryCount', () => {
+    expect(DeliveryReceiptSchema.safeParse({ ...validReceipt, retryCount: -1 }).success).toBe(false);
+  });
+
+  it('rejects non-integer timestamp', () => {
+    expect(DeliveryReceiptSchema.safeParse({ ...validReceipt, timestamp: 1.5 }).success).toBe(false);
+  });
+
+  it.each([
+    'id', 'schemaVersion', 'actionId', 'representativeId',
+    'status', 'timestamp', 'intent', 'userAttested', 'retryCount',
+  ] as const)(
+    'rejects missing required field: %s',
+    (field) => {
+      const obj = { ...validReceipt };
+      delete (obj as Record<string, unknown>)[field];
+      expect(DeliveryReceiptSchema.safeParse(obj).success).toBe(false);
+    },
+  );
+});

--- a/packages/data-model/src/schemas/hermes/bridgeReceipt.ts
+++ b/packages/data-model/src/schemas/hermes/bridgeReceipt.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod';
+import { DeliveryIntentSchema } from './bridgeAction';
+
+/**
+ * Delivery receipt — user-attested record of civic action outcome.
+ * Spec: spec-civic-action-kit-v0.md §2.4
+ */
+export const DeliveryReceiptSchema = z
+  .object({
+    id: z.string().min(1),
+    schemaVersion: z.literal('hermes-receipt-v1'),
+
+    actionId: z.string().min(1),
+    representativeId: z.string().min(1),
+
+    status: z.enum(['success', 'failed', 'user-cancelled']),
+    timestamp: z.number().int().nonnegative(),
+    intent: DeliveryIntentSchema,
+
+    userAttested: z.boolean(),
+
+    errorMessage: z.string().optional(),
+    errorCode: z.string().optional(),
+
+    retryCount: z.number().int().nonnegative(),
+    previousReceiptId: z.string().optional(),
+  })
+  .strict();
+
+export type DeliveryReceipt = z.infer<typeof DeliveryReceiptSchema>;

--- a/packages/data-model/src/schemas/hermes/bridgeRepresentative.test.ts
+++ b/packages/data-model/src/schemas/hermes/bridgeRepresentative.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest';
+import {
+  RepresentativeSchema,
+  RepresentativeDirectorySchema,
+} from './bridgeRepresentative';
+
+const validRep = {
+  id: 'us-house-ca-11',
+  name: 'Jane Doe',
+  title: 'Representative',
+  office: 'house' as const,
+  country: 'US',
+  state: 'CA',
+  district: '11',
+  districtHash: 'abc123hash',
+  contactMethod: 'email' as const,
+  email: 'jane@house.gov',
+  lastVerified: 1_700_000_000_000,
+};
+
+const validDirectory = {
+  version: '1.0.0',
+  lastUpdated: 1_700_000_000_000,
+  updateSource: 'bundled-v1',
+  representatives: [validRep],
+  byState: { CA: ['us-house-ca-11'] },
+  byDistrictHash: { abc123hash: ['us-house-ca-11'] },
+};
+
+describe('RepresentativeSchema', () => {
+  it('parses a valid representative', () => {
+    const result = RepresentativeSchema.safeParse(validRep);
+    expect(result.success).toBe(true);
+  });
+
+  it('parses with all optional fields', () => {
+    const full = {
+      ...validRep,
+      party: 'Independent',
+      contactUrl: 'https://house.gov/contact',
+      phone: '+12025551234',
+      website: 'https://janedoe.house.gov',
+      photoUrl: 'https://house.gov/photo.jpg',
+      socialHandles: { x: '@janedoe' },
+    };
+    const result = RepresentativeSchema.safeParse(full);
+    expect(result.success).toBe(true);
+  });
+
+  it('parses without optional fields', () => {
+    const minimal = {
+      id: 'local-1',
+      name: 'John Smith',
+      title: 'Councilmember',
+      office: 'local' as const,
+      country: 'US',
+      districtHash: 'hash1',
+      contactMethod: 'manual' as const,
+      lastVerified: Date.now(),
+    };
+    const result = RepresentativeSchema.safeParse(minimal);
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts all office values', () => {
+    for (const office of ['senate', 'house', 'state', 'local'] as const) {
+      const result = RepresentativeSchema.safeParse({ ...validRep, office });
+      expect(result.success).toBe(true);
+    }
+  });
+
+  it('accepts all contactMethod values', () => {
+    for (const cm of ['email', 'phone', 'both', 'manual'] as const) {
+      const result = RepresentativeSchema.safeParse({ ...validRep, contactMethod: cm });
+      expect(result.success).toBe(true);
+    }
+  });
+
+  it('rejects unknown keys (.strict)', () => {
+    const result = RepresentativeSchema.safeParse({ ...validRep, extraField: 'no' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects invalid office', () => {
+    const result = RepresentativeSchema.safeParse({ ...validRep, office: 'federal' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects invalid email', () => {
+    const result = RepresentativeSchema.safeParse({ ...validRep, email: 'not-email' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects invalid contactUrl', () => {
+    const result = RepresentativeSchema.safeParse({ ...validRep, contactUrl: 'nope' });
+    expect(result.success).toBe(false);
+  });
+
+  it.each(['id', 'name', 'title', 'office', 'country', 'districtHash', 'contactMethod', 'lastVerified'] as const)(
+    'rejects missing required field: %s',
+    (field) => {
+      const obj = { ...validRep };
+      delete (obj as Record<string, unknown>)[field];
+      expect(RepresentativeSchema.safeParse(obj).success).toBe(false);
+    },
+  );
+});
+
+describe('RepresentativeDirectorySchema', () => {
+  it('parses a valid directory', () => {
+    const result = RepresentativeDirectorySchema.safeParse(validDirectory);
+    expect(result.success).toBe(true);
+  });
+
+  it('parses an empty directory', () => {
+    const empty = {
+      version: '0.0.1',
+      lastUpdated: 0,
+      updateSource: 'empty',
+      representatives: [],
+      byState: {},
+      byDistrictHash: {},
+    };
+    const result = RepresentativeDirectorySchema.safeParse(empty);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects unknown keys (.strict)', () => {
+    const result = RepresentativeDirectorySchema.safeParse({ ...validDirectory, extra: true });
+    expect(result.success).toBe(false);
+  });
+
+  it.each(['version', 'lastUpdated', 'updateSource', 'representatives', 'byState', 'byDistrictHash'] as const)(
+    'rejects missing required field: %s',
+    (field) => {
+      const obj = { ...validDirectory };
+      delete (obj as Record<string, unknown>)[field];
+      expect(RepresentativeDirectorySchema.safeParse(obj).success).toBe(false);
+    },
+  );
+
+  it('rejects directory with invalid representative entry', () => {
+    const bad = { ...validDirectory, representatives: [{ id: 'bad' }] };
+    expect(RepresentativeDirectorySchema.safeParse(bad).success).toBe(false);
+  });
+});

--- a/packages/data-model/src/schemas/hermes/bridgeRepresentative.ts
+++ b/packages/data-model/src/schemas/hermes/bridgeRepresentative.ts
@@ -1,0 +1,55 @@
+import { z } from 'zod';
+
+/**
+ * Representative schema — elected officials and contacts for civic outreach.
+ * Spec: spec-civic-action-kit-v0.md §2.2
+ */
+export const RepresentativeSchema = z
+  .object({
+    id: z.string().min(1),
+
+    // identity
+    name: z.string().min(1),
+    title: z.string().min(1),
+    party: z.string().optional(),
+
+    // jurisdiction
+    office: z.enum(['senate', 'house', 'state', 'local']),
+    country: z.string().min(2).max(3),
+    state: z.string().min(2).max(2).optional(),
+    district: z.string().optional(),
+    districtHash: z.string().min(1),
+
+    // contact
+    contactMethod: z.enum(['email', 'phone', 'both', 'manual']),
+    contactUrl: z.string().url().optional(),
+    email: z.string().email().optional(),
+    phone: z.string().optional(),
+    website: z.string().url().optional(),
+
+    // metadata
+    photoUrl: z.string().url().optional(),
+    socialHandles: z.record(z.string(), z.string()).optional(),
+    lastVerified: z.number().int().nonnegative(),
+  })
+  .strict();
+
+/**
+ * Representative directory — bundled snapshot for offline startup.
+ * Spec: spec-civic-action-kit-v0.md §3.1
+ */
+export const RepresentativeDirectorySchema = z
+  .object({
+    version: z.string().min(1),
+    lastUpdated: z.number().int().nonnegative(),
+    updateSource: z.string().min(1),
+
+    representatives: z.array(RepresentativeSchema),
+
+    byState: z.record(z.string(), z.array(z.string())),
+    byDistrictHash: z.record(z.string(), z.array(z.string())),
+  })
+  .strict();
+
+export type Representative = z.infer<typeof RepresentativeSchema>;
+export type RepresentativeDirectory = z.infer<typeof RepresentativeDirectorySchema>;

--- a/packages/gun-client/src/bridgeAdapters.test.ts
+++ b/packages/gun-client/src/bridgeAdapters.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import {
+  findForbiddenKey,
+  stripUndefined,
+  getUserActionsChain,
+  getUserReceiptsChain,
+  getRepStatsChain,
+  saveAction,
+  saveReceipt,
+  incrementRepStats,
+} from './bridgeAdapters';
+import type { CivicAction, DeliveryReceipt } from '@vh/data-model';
+
+/* ── Mock Gun client ─────────────────────────────────────────── */
+
+function mockChain(data?: any) {
+  const chain = {
+    get: vi.fn().mockReturnThis(),
+    put: vi.fn((_val: any, cb?: any) => {
+      if (cb) cb(undefined); // success ack
+    }),
+    once: vi.fn((cb: any) => cb(data ?? null)),
+  };
+  return chain;
+}
+
+function mockClient(chainData?: any) {
+  const chain = mockChain(chainData);
+  return {
+    client: {
+      gun: {
+        user: () => chain,
+        get: (_key: string) => chain,
+      },
+    } as any,
+    chain,
+  };
+}
+
+/* ── Test data ───────────────────────────────────────────────── */
+
+const validProof = {
+  district_hash: 'hash-ca-11',
+  nullifier: 'nullifier-abc',
+  merkle_root: 'root-xyz',
+};
+
+const validAction: CivicAction = {
+  id: 'action-1',
+  schemaVersion: 'hermes-action-v1',
+  author: 'nullifier-abc',
+  sourceTopicId: 'topic-42',
+  sourceSynthesisId: 'synth-7',
+  sourceEpoch: 3,
+  sourceArtifactId: 'brief-abc',
+  representativeId: 'us-house-ca-11',
+  topic: 'Infrastructure funding',
+  stance: 'support',
+  subject: 'Support for local bridge repairs',
+  body: 'I am writing to express my support for the proposed infrastructure bill. This is an important initiative for our community and I urge prompt action.',
+  intent: 'email',
+  constituencyProof: validProof,
+  status: 'draft',
+  createdAt: 1_700_000_000_000,
+  attempts: 0,
+};
+
+const validReceipt: DeliveryReceipt = {
+  id: 'receipt-1',
+  schemaVersion: 'hermes-receipt-v1',
+  actionId: 'action-1',
+  representativeId: 'us-house-ca-11',
+  status: 'success',
+  timestamp: 1_700_000_000_000,
+  intent: 'email',
+  userAttested: true,
+  retryCount: 0,
+};
+
+/* ── findForbiddenKey ────────────────────────────────────────── */
+
+describe('findForbiddenKey', () => {
+  it('returns null for clean objects', () => {
+    expect(findForbiddenKey({ name: 'Jane', id: '123' })).toBeNull();
+  });
+
+  it('detects accessToken', () => {
+    expect(findForbiddenKey({ accessToken: 'secret' })).toBe('accessToken');
+  });
+
+  it('detects access_token (case-insensitive)', () => {
+    expect(findForbiddenKey({ Access_Token: 'val' })).toBe('Access_Token');
+  });
+
+  it('detects nested forbidden keys', () => {
+    expect(findForbiddenKey({ nested: { refreshToken: 'x' } })).toBe('refreshToken');
+  });
+
+  it('handles circular references safely', () => {
+    const obj: any = { a: 1 };
+    obj.self = obj;
+    expect(findForbiddenKey(obj)).toBeNull();
+  });
+
+  it('returns null for null/undefined/primitives', () => {
+    expect(findForbiddenKey(null)).toBeNull();
+    expect(findForbiddenKey(undefined)).toBeNull();
+    expect(findForbiddenKey(42)).toBeNull();
+    expect(findForbiddenKey('string')).toBeNull();
+  });
+
+  it('detects token field', () => {
+    expect(findForbiddenKey({ token: 'bearer-xyz' })).toBe('token');
+  });
+
+  it('detects secret field', () => {
+    expect(findForbiddenKey({ secret: 'shhh' })).toBe('secret');
+  });
+});
+
+/* ── stripUndefined ──────────────────────────────────────────── */
+
+describe('stripUndefined', () => {
+  it('removes undefined values', () => {
+    const result = stripUndefined({ a: 1, b: undefined, c: 'yes' });
+    expect(result).toEqual({ a: 1, c: 'yes' });
+    expect('b' in result).toBe(false);
+  });
+
+  it('preserves null values', () => {
+    const result = stripUndefined({ a: null, b: 0, c: '' });
+    expect(result).toEqual({ a: null, b: 0, c: '' });
+  });
+
+  it('handles empty object', () => {
+    expect(stripUndefined({})).toEqual({});
+  });
+});
+
+/* ── Chain accessors ─────────────────────────────────────────── */
+
+describe('chain accessors', () => {
+  it('getUserActionsChain navigates user graph', () => {
+    const { client, chain } = mockClient();
+    getUserActionsChain(client, 'act-1');
+    expect(chain.get).toHaveBeenCalledWith('hermes');
+    expect(chain.get).toHaveBeenCalledWith('bridge');
+    expect(chain.get).toHaveBeenCalledWith('actions');
+    expect(chain.get).toHaveBeenCalledWith('act-1');
+  });
+
+  it('getUserReceiptsChain navigates user graph', () => {
+    const { client, chain } = mockClient();
+    getUserReceiptsChain(client, 'rec-1');
+    expect(chain.get).toHaveBeenCalledWith('hermes');
+    expect(chain.get).toHaveBeenCalledWith('bridge');
+    expect(chain.get).toHaveBeenCalledWith('receipts');
+    expect(chain.get).toHaveBeenCalledWith('rec-1');
+  });
+
+  it('getRepStatsChain navigates public graph', () => {
+    const gunGet = vi.fn().mockReturnValue(mockChain());
+    const client = { gun: { get: gunGet } } as any;
+    getRepStatsChain(client, 'rep-1');
+    expect(gunGet).toHaveBeenCalledWith('vh');
+  });
+});
+
+/* ── saveAction ──────────────────────────────────────────────── */
+
+describe('saveAction', () => {
+  it('saves a valid action via put', async () => {
+    const { client, chain } = mockClient();
+    await saveAction(client, validAction);
+    expect(chain.put).toHaveBeenCalled();
+  });
+
+  it('rejects invalid action (Zod validation)', async () => {
+    const { client } = mockClient();
+    const bad = { ...validAction, schemaVersion: 'wrong' } as any;
+    await expect(saveAction(client, bad)).rejects.toThrow();
+  });
+
+  it('rejects action with PII fields', async () => {
+    const { client } = mockClient();
+    const withPii = { ...validAction, accessToken: 'secret' } as any;
+    // Zod .strict() will reject unknown fields first
+    await expect(saveAction(client, withPii)).rejects.toThrow();
+  });
+
+  it('propagates Gun put errors', async () => {
+    const chain = mockChain();
+    chain.put = vi.fn((_val: any, cb: any) => cb({ err: 'write failed' }));
+    const client = { gun: { user: () => chain, get: () => chain } } as any;
+    await expect(saveAction(client, validAction)).rejects.toThrow('write failed');
+  });
+});
+
+/* ── saveReceipt ─────────────────────────────────────────────── */
+
+describe('saveReceipt', () => {
+  it('saves a valid receipt via put', async () => {
+    const { client, chain } = mockClient();
+    await saveReceipt(client, validReceipt);
+    expect(chain.put).toHaveBeenCalled();
+  });
+
+  it('rejects invalid receipt (Zod validation)', async () => {
+    const { client } = mockClient();
+    const bad = { ...validReceipt, schemaVersion: 'wrong' } as any;
+    await expect(saveReceipt(client, bad)).rejects.toThrow();
+  });
+
+  it('propagates Gun put errors', async () => {
+    const chain = mockChain();
+    chain.put = vi.fn((_val: any, cb: any) => cb({ err: 'write failed' }));
+    const client = { gun: { user: () => chain, get: () => chain } } as any;
+    await expect(saveReceipt(client, validReceipt)).rejects.toThrow('write failed');
+  });
+});
+
+/* ── incrementRepStats ───────────────────────────────────────── */
+
+describe('incrementRepStats', () => {
+  it('increments count from zero', async () => {
+    const chain = mockChain(null);
+    const client = { gun: { get: () => chain } } as any;
+    await incrementRepStats(client, 'rep-1');
+    expect(chain.put).toHaveBeenCalledWith(
+      expect.objectContaining({ count: 1 }),
+      expect.any(Function),
+    );
+  });
+
+  it('increments existing count', async () => {
+    const chain = mockChain({ count: 5, lastActivity: 100 });
+    const client = { gun: { get: () => chain } } as any;
+    await incrementRepStats(client, 'rep-1');
+    expect(chain.put).toHaveBeenCalledWith(
+      expect.objectContaining({ count: 6 }),
+      expect.any(Function),
+    );
+  });
+
+  it('propagates Gun put errors', async () => {
+    const chain = mockChain(null);
+    chain.put = vi.fn((_val: any, cb: any) => cb({ err: 'stats write failed' }));
+    const client = { gun: { get: () => chain } } as any;
+    await expect(incrementRepStats(client, 'rep-1')).rejects.toThrow('stats write failed');
+  });
+});

--- a/packages/gun-client/src/bridgeAdapters.ts
+++ b/packages/gun-client/src/bridgeAdapters.ts
@@ -1,0 +1,156 @@
+/**
+ * Gun bridge adapters — civic action + receipt persistence and aggregate stats.
+ *
+ * Write paths:
+ * - Auth: ~<devicePub>/hermes/bridge/actions/<actionId>
+ * - Auth: ~<devicePub>/hermes/bridge/receipts/<receiptId>
+ * - Public: vh/bridge/stats/<repId>
+ *
+ * Spec: spec-civic-action-kit-v0.md §5.2, §5.3
+ */
+
+import type { CivicAction, DeliveryReceipt } from '@vh/data-model';
+import { CivicActionSchema, DeliveryReceiptSchema } from '@vh/data-model';
+import type { VennClient } from './types';
+
+/* ── PII strip filter ───────────────────────────────────────── */
+
+/**
+ * Fields that must never appear in stored records.
+ * Matches FORBIDDEN_PUBLIC_FIELDS from accountStore.
+ */
+const FORBIDDEN_KEYS = new Set([
+  'accesstoken', 'access_token',
+  'refreshtoken', 'refresh_token',
+  'bearer', 'bearertoken', 'bearer_token',
+  'providersecret', 'provider_secret', 'secret',
+  'privatemessagebody', 'private_message_body',
+  'token',
+]);
+
+/**
+ * Check if an object contains any forbidden PII keys (recursive).
+ * Returns the first forbidden key found, or null if clean.
+ */
+export function findForbiddenKey(
+  obj: unknown,
+  visited = new WeakSet<object>(),
+): string | null {
+  if (obj === null || obj === undefined || typeof obj !== 'object') return null;
+  const target = obj as Record<string, unknown>;
+  if (visited.has(target)) return null;
+  visited.add(target);
+
+  for (const key of Object.keys(target)) {
+    if (FORBIDDEN_KEYS.has(key.toLowerCase())) return key;
+    const value = target[key];
+    if (typeof value === 'object' && value !== null) {
+      const found = findForbiddenKey(value, visited);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+
+/**
+ * Strip undefined values from an object (Gun rejects undefined in puts).
+ */
+export function stripUndefined<T extends Record<string, unknown>>(obj: T): T {
+  const result = {} as Record<string, unknown>;
+  for (const [key, value] of Object.entries(obj)) {
+    if (value !== undefined) {
+      result[key] = value;
+    }
+  }
+  return result as T;
+}
+
+/* ── Chain accessors ────────────────────────────────────────── */
+
+export function getUserActionsChain(client: VennClient, actionId: string) {
+  return (client.gun.user() as any).get('hermes').get('bridge').get('actions').get(actionId);
+}
+
+export function getUserReceiptsChain(client: VennClient, receiptId: string) {
+  return (client.gun.user() as any).get('hermes').get('bridge').get('receipts').get(receiptId);
+}
+
+export function getRepStatsChain(client: VennClient, repId: string) {
+  return client.gun.get('vh').get('bridge').get('stats').get(repId);
+}
+
+/* ── Write operations ───────────────────────────────────────── */
+
+/**
+ * Save a civic action to the authenticated user graph.
+ * Validates with Zod, strips PII, rejects forbidden fields.
+ * Spec: spec-civic-action-kit-v0.md §5.2
+ */
+export async function saveAction(
+  client: VennClient,
+  action: CivicAction,
+): Promise<void> {
+  const parsed = CivicActionSchema.parse(action);
+  const forbidden = findForbiddenKey(parsed);
+  /* v8 ignore next 3 -- defense-in-depth; strict Zod rejects unknown keys first */
+  if (forbidden) {
+    throw new Error(`PII field rejected: ${forbidden}`);
+  }
+  const clean = stripUndefined(parsed as unknown as Record<string, unknown>);
+  const chain = getUserActionsChain(client, parsed.id);
+  return new Promise<void>((resolve, reject) => {
+    chain.put(clean, ((ack: { err?: string } | undefined) => {
+      if (ack?.err) reject(new Error(ack.err));
+      else resolve();
+    }) as any);
+  });
+}
+
+/**
+ * Save a delivery receipt to the authenticated user graph.
+ * Validates with Zod, strips PII, rejects forbidden fields.
+ * Spec: spec-civic-action-kit-v0.md §5.2
+ */
+export async function saveReceipt(
+  client: VennClient,
+  receipt: DeliveryReceipt,
+): Promise<void> {
+  const parsed = DeliveryReceiptSchema.parse(receipt);
+  const forbidden = findForbiddenKey(parsed);
+  /* v8 ignore next 3 -- defense-in-depth; strict Zod rejects unknown keys first */
+  if (forbidden) {
+    throw new Error(`PII field rejected: ${forbidden}`);
+  }
+  const clean = stripUndefined(parsed as unknown as Record<string, unknown>);
+  const chain = getUserReceiptsChain(client, parsed.id);
+  return new Promise<void>((resolve, reject) => {
+    chain.put(clean, ((ack: { err?: string } | undefined) => {
+      if (ack?.err) reject(new Error(ack.err));
+      else resolve();
+    }) as any);
+  });
+}
+
+/**
+ * Increment anonymous aggregate stats for a representative.
+ * Public path: vh/bridge/stats/<repId>
+ * Spec: spec-civic-action-kit-v0.md §5.3
+ */
+export async function incrementRepStats(
+  client: VennClient,
+  repId: string,
+): Promise<void> {
+  const chain = getRepStatsChain(client, repId);
+
+  // Read current count, increment, write back
+  return new Promise<void>((resolve, reject) => {
+    chain.once((data: any) => {
+      const currentCount = typeof data?.count === 'number' ? data.count : 0;
+      const update = { count: currentCount + 1, lastActivity: Date.now() };
+      chain.put(update, ((ack: { err?: string } | undefined) => {
+        if (ack?.err) reject(new Error(ack.err));
+        else resolve();
+      }) as any);
+    });
+  });
+}

--- a/packages/gun-client/src/index.ts
+++ b/packages/gun-client/src/index.ts
@@ -156,5 +156,6 @@ export * from './docsAdapters';
 export * from './docsKeyManagement';
 export * from './synthesisAdapters';
 export * from './newsAdapters';
+export * from './bridgeAdapters';
 export type { ChainWithGet } from './chain';
 export { default as SEA } from 'gun/sea';


### PR DESCRIPTION
## Summary

W3-CAK Phase 1: Zod schemas, Gun bridge adapters, and representative directory store for the Civic Action Kit data layer.

## Deliverables

### 1. Zod Schemas (`packages/data-model/src/schemas/hermes/`)

| File | Exports | Spec |
|------|---------|------|
| `bridgeAction.ts` | `CivicActionSchema`, `ConstituencyProofSchema`, `DeliveryIntentSchema` | §2.3, §2.5 |
| `bridgeReceipt.ts` | `DeliveryReceiptSchema` | §2.4 |
| `bridgeRepresentative.ts` | `RepresentativeSchema`, `RepresentativeDirectorySchema` | §2.2, §3.1 |

All schemas use `.strict()` — no passthrough. Content limits enforced per §2.5:
- `topic ≤ 100`, `subject ≤ 200`, `body = 50..5000`
- All re-exported from `packages/data-model/src/index.ts`

### 2. Gun Bridge Adapters (`packages/gun-client/src/bridgeAdapters.ts`)

- `saveAction`: persist CivicAction to `~*/hermes/bridge/actions/<actionId>` (§5.2)
- `saveReceipt`: persist DeliveryReceipt to `~*/hermes/bridge/receipts/<receiptId>` (§5.2)
- `incrementRepStats`: anonymous aggregate counter at `vh/bridge/stats/<repId>` (§5.3)
- `findForbiddenKey`: PII strip filter (defense-in-depth behind strict Zod)
- `stripUndefined`: Gun-compatible write helper
- Re-exported from `packages/gun-client/src/index.ts`

### 3. Representative Directory (`apps/web-pwa/src/store/bridge/representativeDirectory.ts`)

- `loadDirectory(data)`: validate + replace local cache (§3.3)
- `findRepresentatives(districtHash)`: constituency lookup (§3.2)
- `findRepresentativesByState(state)`: state-level lookup
- `isNewerVersion(remoteVersion)`: version comparison for updates
- Empty scaffold for offline startup
- Re-exported from `store/bridge/index.ts` barrel

### 4. Barrel Exports

- `packages/data-model/src/index.ts`: +3 bridge schema re-exports
- `packages/gun-client/src/index.ts`: +bridgeAdapters re-export
- `apps/web-pwa/src/store/bridge/index.ts`: +representativeDirectory re-exports
- No regressions on existing exports (notification, elevation, discovery, etc.)
- Note: `notificationToken.ts` is not exported from data-model barrel (pre-existing gap, not w3c scope)

## Changed Files

| File | LOC | Change |
|------|-----|--------|
| `bridgeAction.ts` | 76 | NEW — schema |
| `bridgeReceipt.ts` | 30 | NEW — schema |
| `bridgeRepresentative.ts` | 55 | NEW — schema |
| `bridgeAdapters.ts` | 156 | NEW — Gun adapters |
| `representativeDirectory.ts` | 80 | NEW — directory store |
| `data-model/index.ts` | +3 | barrel exports |
| `gun-client/index.ts` | +1 | barrel export |
| `store/bridge/index.ts` | +9 | barrel exports |

All source files under 350 LOC cap ✅

## Tests & Coverage

- **128 new tests** (89 schema + 24 adapter + 15 directory)
- `bridgeAction.ts`: 100% / 100% / 100% / 100%
- `bridgeReceipt.ts`: 100% / 100% / 100% / 100%
- `bridgeRepresentative.ts`: 100% / 100% / 100% / 100%
- `bridgeAdapters.ts`: 100% / 100% / 100% / 100%
- `representativeDirectory.ts`: 100% / 100% / 100% / 100%
- Full suite: 2253 tests pass, 5 pre-existing crdt/CollabEditor failures (yjs dependency)

## Ownership Scope

All 13 changed files match w3c ownership globs ✅
(Local pre-push hook defaults to wave-2 base for `w3c/` prefix; CI `GITHUB_BASE_REF` resolves correctly)

## Not Included (explicit)

- ACTION_RECEIPT FeedKind — deferred to CAK Phase 3
- notificationToken barrel export — pre-existing gap, not w3c scope

## Phase 4 Blockers (elevation receipt-in-feed)

> - Missing DeliveryReceipt → FeedItem adapter + FeedKind extension
> - Discovery schema changes require Team C ownership coordination
> - Receipt card render contract undefined

## Spec Reference

spec-civic-action-kit-v0.md (Canonical v0.3)