### PR TITLE
feat(discovery): add ACTION_RECEIPT FeedKind + ReceiptFeedCard placeholder

### DIFF
--- a/apps/web-pwa/src/components/feed/FeedShell.test.tsx
+++ b/apps/web-pwa/src/components/feed/FeedShell.test.tsx
@@ -170,6 +170,21 @@ describe('FeedShell', () => {
     expect(screen.getByText('My Published Article')).toBeInTheDocument();
   });
 
+  it('routes ACTION_RECEIPT kind to ReceiptFeedCard', () => {
+    const items = [
+      makeFeedItem({
+        topic_id: 'receipt-1',
+        title: 'Letter to Rep. Smith',
+        kind: 'ACTION_RECEIPT',
+      }),
+    ];
+
+    render(<FeedShell feedResult={makeFeedResult({ feed: items })} />);
+
+    expect(screen.getByTestId('feed-receipt-receipt-1')).toBeInTheDocument();
+    expect(screen.getByText('Letter to Rep. Smith')).toBeInTheDocument();
+  });
+
   // ---- Filter and sort interaction ----
 
   it('passes active filter to FilterChips', () => {

--- a/apps/web-pwa/src/components/feed/FeedShell.tsx
+++ b/apps/web-pwa/src/components/feed/FeedShell.tsx
@@ -7,6 +7,7 @@ import { NewsCard } from './NewsCard';
 import { TopicCard } from './TopicCard';
 import { SocialNotificationCard } from './SocialNotificationCard';
 import { ArticleFeedCard } from '../docs/ArticleFeedCard';
+import { ReceiptFeedCard } from './ReceiptFeedCard';
 
 export interface FeedShellProps {
   /** Discovery feed hook result (injected for testability). */
@@ -120,6 +121,8 @@ const FeedItemCard: React.FC<FeedItemCardProps> = ({ item }) => {
       return <SocialNotificationCard item={item} />;
     case 'ARTICLE':
       return <ArticleFeedCard item={item} />;
+    case 'ACTION_RECEIPT':
+      return <ReceiptFeedCard item={item} />;
     default:
       return (
         <article

--- a/apps/web-pwa/src/components/feed/ReceiptFeedCard.test.tsx
+++ b/apps/web-pwa/src/components/feed/ReceiptFeedCard.test.tsx
@@ -1,0 +1,48 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { ReceiptFeedCard } from './ReceiptFeedCard';
+import type { FeedItem } from '@vh/data-model';
+
+const now = Date.now();
+
+const receiptItem: FeedItem = {
+  topic_id: 'receipt-abc-123',
+  kind: 'ACTION_RECEIPT',
+  title: 'Letter to Rep. Smith',
+  created_at: now - 3_600_000,
+  latest_activity_at: now,
+  hotness: 0,
+  eye: 0,
+  lightbulb: 0,
+  comments: 0,
+};
+
+describe('ReceiptFeedCard', () => {
+  afterEach(() => cleanup());
+
+  it('renders receipt title', () => {
+    render(<ReceiptFeedCard item={receiptItem} />);
+    expect(screen.getByText('Letter to Rep. Smith')).toBeDefined();
+  });
+
+  it('renders with correct test id', () => {
+    render(<ReceiptFeedCard item={receiptItem} />);
+    expect(screen.getByTestId('feed-receipt-receipt-abc-123')).toBeDefined();
+  });
+
+  it('displays civic action receipt label', () => {
+    render(<ReceiptFeedCard item={receiptItem} />);
+    const el = screen.getByTestId('feed-receipt-receipt-abc-123');
+    expect(el.textContent).toContain('Civic action receipt');
+  });
+
+  it('displays formatted date', () => {
+    render(<ReceiptFeedCard item={receiptItem} />);
+    const el = screen.getByTestId('feed-receipt-receipt-abc-123');
+    // Date should be rendered (exact format varies by locale)
+    expect(el.textContent).toContain('/');
+  });
+});

--- a/apps/web-pwa/src/components/feed/ReceiptFeedCard.tsx
+++ b/apps/web-pwa/src/components/feed/ReceiptFeedCard.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import type { FeedItem } from '@vh/data-model';
+
+export interface ReceiptFeedCardProps {
+  readonly item: FeedItem;
+}
+
+/**
+ * Placeholder card for ACTION_RECEIPT feed items.
+ * Full receipt card UI will be implemented in W3-CAK Phase 3.
+ *
+ * Spec: docs/specs/spec-civic-action-kit-v0.md §8.4
+ */
+export const ReceiptFeedCard: React.FC<ReceiptFeedCardProps> = ({ item }) => {
+  return (
+    <article
+      data-testid={`feed-receipt-${item.topic_id}`}
+      className="rounded border border-teal-200 bg-teal-50 p-3 text-sm text-teal-900"
+    >
+      <h3 className="font-medium">{item.title}</h3>
+      <p className="mt-1 text-xs text-teal-600">
+        Civic action receipt · {new Date(item.latest_activity_at).toLocaleDateString()}
+      </p>
+    </article>
+  );
+};

--- a/apps/web-pwa/src/hooks/useFeedStore.ts
+++ b/apps/web-pwa/src/hooks/useFeedStore.ts
@@ -34,14 +34,16 @@ const DISCOVERY_SUMMARY_BY_KIND: Record<FeedKind, string> = {
   NEWS_STORY: 'Trending in discovery feed.',
   USER_TOPIC: 'Community topic update.',
   SOCIAL_NOTIFICATION: 'Social activity update.',
-  ARTICLE: 'Published community article.'
+  ARTICLE: 'Published community article.',
+  ACTION_RECEIPT: 'Civic action receipt.'
 };
 
 const DISCOVERY_SOURCE_BY_KIND: Record<FeedKind, string> = {
   NEWS_STORY: 'Discovery · News',
   USER_TOPIC: 'Discovery · Topics',
   SOCIAL_NOTIFICATION: 'Discovery · Social',
-  ARTICLE: 'Discovery · Articles'
+  ARTICLE: 'Discovery · Articles',
+  ACTION_RECEIPT: 'Bridge · Actions'
 };
 
 function normalizeTimestamp(value: number): number {

--- a/packages/data-model/src/schemas/hermes/discovery.ts
+++ b/packages/data-model/src/schemas/hermes/discovery.ts
@@ -17,6 +17,7 @@ export const FEED_KINDS = [
   'USER_TOPIC',
   'SOCIAL_NOTIFICATION',
   'ARTICLE',
+  'ACTION_RECEIPT',
 ] as const;
 
 export const FeedKindSchema = z.enum(FEED_KINDS);


### PR DESCRIPTION
## Pre-dispatch coordinator PR for W3-CAK Phase 3

Resolves ownership boundary for Phase 3 receipt-in-feed integration.

### Changes
- **`packages/data-model/src/schemas/hermes/discovery.ts`**: Add `ACTION_RECEIPT` to `FEED_KINDS` enum. `FILTER_TO_KINDS['ALL']` picks it up automatically via `FEED_KINDS` reference. No new filter chip — receipts show under ALL only for now.
- **`apps/web-pwa/src/components/feed/FeedShell.tsx`**: Add `ACTION_RECEIPT` case to FeedItemCard switch, routing to `ReceiptFeedCard`.
- **`apps/web-pwa/src/components/feed/ReceiptFeedCard.tsx`**: Placeholder receipt card — Phase 3 will replace with full receipt UI.
- **`apps/web-pwa/src/hooks/useFeedStore.ts`**: Add `ACTION_RECEIPT` entries to summary/source kind maps.
- **Tests**: 4 new ReceiptFeedCard tests + 1 new FeedShell routing test.

### CE Review
Both `ce-codex` and `ce-opus` flagged this as HIGH — `discovery.ts` is not in `w3c` scope (`bridge*` glob doesn't match). Both AGREED the correct fix is a coordinator `coord/*` PR (this PR).

### Gate Compliance
- All files ≤ 350 LOC
- Typecheck clean
- 89 tests passing (discovery + FeedShell + ReceiptFeedCard + useFeedStore)
- No `node:*` imports
- Additive only — no breaking changes to existing feed behavior