### PR TITLE
feat(cak): Phase 3 — bridge UI components, trust enforcement, XP emissions, receipt-in-feed

### DIFF
--- a/apps/web-pwa/src/components/bridge/ActionComposer.test.tsx
+++ b/apps/web-pwa/src/components/bridge/ActionComposer.test.tsx
@@ -1,0 +1,177 @@
+/* @vitest-environment jsdom */
+
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { ActionComposer, validateComposer } from './ActionComposer';
+
+let trustScore = 1;
+let budgetAllowed = true;
+let budgetReason = '';
+
+vi.mock('../../hooks/useIdentity', () => ({
+  useIdentity: () => ({ identity: { session: { trustScore } } }),
+}));
+
+vi.mock('../../store/xpLedger', () => ({
+  useXpLedger: {
+    getState: () => ({
+      canPerformAction: () => ({ allowed: budgetAllowed, reason: budgetReason }),
+      consumeAction: vi.fn(),
+    }),
+  },
+}));
+
+beforeEach(() => {
+  trustScore = 1;
+  budgetAllowed = true;
+  budgetReason = '';
+});
+
+afterEach(() => cleanup());
+
+/* ── validateComposer (pure function) ────────────────────────── */
+
+describe('validateComposer', () => {
+  const valid = { topic: 'Infrastructure', stance: 'support' as const, subject: 'Test subject', body: 'A'.repeat(60), intent: 'email' as const };
+
+  it('returns empty errors for valid input', () => {
+    expect(validateComposer(valid, 'rep-1')).toEqual({});
+  });
+
+  it('requires topic', () => {
+    expect(validateComposer({ ...valid, topic: '' }, 'rep-1').topic).toBe('Topic is required');
+  });
+
+  it('caps topic at 100 chars', () => {
+    expect(validateComposer({ ...valid, topic: 'x'.repeat(101) }, 'rep-1').topic).toContain('≤ 100');
+  });
+
+  it('requires subject', () => {
+    expect(validateComposer({ ...valid, subject: '' }, 'rep-1').subject).toBe('Subject is required');
+  });
+
+  it('caps subject at 200 chars', () => {
+    expect(validateComposer({ ...valid, subject: 'x'.repeat(201) }, 'rep-1').subject).toContain('≤ 200');
+  });
+
+  it('requires body ≥ 50 chars', () => {
+    expect(validateComposer({ ...valid, body: 'short' }, 'rep-1').body).toContain('at least 50');
+  });
+
+  it('caps body at 5000 chars', () => {
+    expect(validateComposer({ ...valid, body: 'x'.repeat(5001) }, 'rep-1').body).toContain('≤ 5000');
+  });
+
+  it('requires repId', () => {
+    expect(validateComposer(valid).repId).toBe('Select a representative first');
+  });
+});
+
+/* ── Component rendering ─────────────────────────────────────── */
+
+describe('ActionComposer', () => {
+  it('renders composer when trust sufficient', () => {
+    render(<ActionComposer selectedRepId="rep-1" />);
+    expect(screen.getByTestId('action-composer')).toBeInTheDocument();
+    expect(screen.getByTestId('composer-topic')).toBeInTheDocument();
+    expect(screen.getByTestId('composer-stance')).toBeInTheDocument();
+    expect(screen.getByTestId('composer-subject')).toBeInTheDocument();
+    expect(screen.getByTestId('composer-body')).toBeInTheDocument();
+    expect(screen.getByTestId('composer-intent')).toBeInTheDocument();
+    expect(screen.getByTestId('composer-send')).toBeInTheDocument();
+  });
+
+  it('shows trust gate when score below 0.5', () => {
+    trustScore = 0.3;
+    render(<ActionComposer />);
+    expect(screen.getByTestId('composer-trust-gate')).toBeInTheDocument();
+  });
+
+  it('shows send trust gate when score between 0.5 and 0.7', () => {
+    trustScore = 0.6;
+    render(<ActionComposer selectedRepId="rep-1" />);
+    expect(screen.getByTestId('send-trust-gate')).toBeInTheDocument();
+    expect(screen.getByText(/0\.60/)).toBeInTheDocument();
+  });
+
+  it('disables send when trust below 0.7', () => {
+    trustScore = 0.6;
+    render(<ActionComposer selectedRepId="rep-1" />);
+    expect(screen.getByTestId('composer-send')).toBeDisabled();
+  });
+
+  it('shows budget exhausted message', () => {
+    budgetAllowed = false;
+    budgetReason = 'Daily limit of 3 reached';
+    render(<ActionComposer selectedRepId="rep-1" />);
+    expect(screen.getByTestId('budget-info').textContent).toContain('Daily limit of 3 reached');
+  });
+
+  it('shows budget available message', () => {
+    render(<ActionComposer selectedRepId="rep-1" />);
+    expect(screen.getByTestId('budget-info').textContent).toContain('Budget available');
+  });
+
+  it('shows rep error when no rep selected', () => {
+    render(<ActionComposer />);
+    expect(screen.getByTestId('error-rep')).toBeInTheDocument();
+  });
+
+  it('shows validation errors for empty fields', () => {
+    render(<ActionComposer selectedRepId="rep-1" />);
+    expect(screen.getByTestId('error-topic')).toBeInTheDocument();
+    expect(screen.getByTestId('error-subject')).toBeInTheDocument();
+    expect(screen.getByTestId('error-body')).toBeInTheDocument();
+  });
+
+  it('updates fields on user input', () => {
+    render(<ActionComposer selectedRepId="rep-1" />);
+    fireEvent.change(screen.getByTestId('composer-topic'), { target: { value: 'Climate' } });
+    fireEvent.change(screen.getByTestId('composer-subject'), { target: { value: 'Subject text' } });
+    fireEvent.change(screen.getByTestId('composer-body'), { target: { value: 'B'.repeat(60) } });
+
+    // After filling valid data, topic error should be gone
+    expect(screen.queryByTestId('error-topic')).not.toBeInTheDocument();
+  });
+
+  it('updates stance selection', () => {
+    render(<ActionComposer selectedRepId="rep-1" />);
+    fireEvent.change(screen.getByTestId('composer-stance'), { target: { value: 'oppose' } });
+    expect((screen.getByTestId('composer-stance') as HTMLSelectElement).value).toBe('oppose');
+  });
+
+  it('updates intent selection', () => {
+    render(<ActionComposer selectedRepId="rep-1" />);
+    fireEvent.change(screen.getByTestId('composer-intent'), { target: { value: 'phone' } });
+    expect((screen.getByTestId('composer-intent') as HTMLSelectElement).value).toBe('phone');
+  });
+
+  it('enables send when all conditions met', () => {
+    trustScore = 0.8;
+    render(<ActionComposer selectedRepId="rep-1" />);
+    fireEvent.change(screen.getByTestId('composer-topic'), { target: { value: 'Topic' } });
+    fireEvent.change(screen.getByTestId('composer-subject'), { target: { value: 'Subject' } });
+    fireEvent.change(screen.getByTestId('composer-body'), { target: { value: 'X'.repeat(60) } });
+
+    expect(screen.getByTestId('composer-send')).not.toBeDisabled();
+  });
+
+  it('disables send when budget exhausted even with valid form', () => {
+    trustScore = 0.8;
+    budgetAllowed = false;
+    budgetReason = 'limit reached';
+    render(<ActionComposer selectedRepId="rep-1" />);
+    fireEvent.change(screen.getByTestId('composer-topic'), { target: { value: 'Topic' } });
+    fireEvent.change(screen.getByTestId('composer-subject'), { target: { value: 'Subject' } });
+    fireEvent.change(screen.getByTestId('composer-body'), { target: { value: 'X'.repeat(60) } });
+
+    expect(screen.getByTestId('composer-send')).toBeDisabled();
+  });
+
+  it('shows body character count', () => {
+    render(<ActionComposer selectedRepId="rep-1" />);
+    expect(screen.getByText('Body (0/5000)')).toBeInTheDocument();
+  });
+});

--- a/apps/web-pwa/src/components/bridge/ActionComposer.tsx
+++ b/apps/web-pwa/src/components/bridge/ActionComposer.tsx
@@ -1,0 +1,187 @@
+/**
+ * ActionComposer — Draft civic actions per §8.3.
+ *
+ * Fields: topic, stance, subject, body, intent.
+ * Content limits: topic ≤ 100, subject ≤ 200, body 50..5000.
+ * Trust gate: >= 0.5 to draft, >= 0.7 to send.
+ * Budget consumed at send/finalize only.
+ *
+ * Spec: spec-civic-action-kit-v0.md §8.3
+ */
+
+import React, { useState, useMemo } from 'react';
+import type { DeliveryIntent } from '@vh/data-model';
+import { useIdentity } from '../../hooks/useIdentity';
+import { useXpLedger } from '../../store/xpLedger';
+
+export interface ActionComposerProps {
+  readonly selectedRepId?: string;
+}
+
+export interface ComposerFields {
+  topic: string;
+  stance: 'support' | 'oppose' | 'inform';
+  subject: string;
+  body: string;
+  intent: DeliveryIntent;
+}
+
+export interface ValidationErrors {
+  topic?: string;
+  subject?: string;
+  body?: string;
+  repId?: string;
+}
+
+const INTENTS: DeliveryIntent[] = ['email', 'phone', 'share', 'export', 'manual'];
+
+export function validateComposer(fields: ComposerFields, repId?: string): ValidationErrors {
+  const errors: ValidationErrors = {};
+  if (!fields.topic || fields.topic.length > 100) {
+    errors.topic = fields.topic ? 'Topic must be ≤ 100 characters' : 'Topic is required';
+  }
+  if (!fields.subject || fields.subject.length > 200) {
+    errors.subject = fields.subject ? 'Subject must be ≤ 200 characters' : 'Subject is required';
+  }
+  if (!fields.body || fields.body.length < 50) {
+    errors.body = 'Body must be at least 50 characters';
+  } else if (fields.body.length > 5000) {
+    errors.body = 'Body must be ≤ 5000 characters';
+  }
+  if (!repId) {
+    errors.repId = 'Select a representative first';
+  }
+  return errors;
+}
+
+export const ActionComposer: React.FC<ActionComposerProps> = ({ selectedRepId }) => {
+  const { identity } = useIdentity();
+  const trustScore = identity?.session?.trustScore ?? 0;
+
+  const [fields, setFields] = useState<ComposerFields>({
+    topic: '',
+    stance: 'support',
+    subject: '',
+    body: '',
+    intent: 'email',
+  });
+
+  const errors = useMemo(() => validateComposer(fields, selectedRepId), [fields, selectedRepId]);
+  const hasErrors = Object.keys(errors).length > 0;
+
+  const budgetCheck = useXpLedger.getState().canPerformAction('civic_actions/day');
+  const canSend = trustScore >= 0.7 && !hasErrors && budgetCheck.allowed;
+
+  if (trustScore < 0.5) {
+    return (
+      <p data-testid="composer-trust-gate" className="text-sm text-amber-600">
+        Trust score ({trustScore.toFixed(2)}) below 0.50 — verify identity to draft actions.
+      </p>
+    );
+  }
+
+  const update = <K extends keyof ComposerFields>(key: K, value: ComposerFields[K]) => {
+    setFields((prev) => ({ ...prev, [key]: value }));
+  };
+
+  return (
+    <div data-testid="action-composer" className="space-y-3">
+      {/* Topic */}
+      <div>
+        <label className="block text-xs font-medium text-gray-700">Topic</label>
+        <input
+          data-testid="composer-topic"
+          className="mt-1 w-full rounded border px-2 py-1 text-sm"
+          maxLength={100}
+          value={fields.topic}
+          onChange={(e) => update('topic', e.target.value)}
+        />
+        {errors.topic && <p data-testid="error-topic" className="mt-0.5 text-xs text-red-500">{errors.topic}</p>}
+      </div>
+
+      {/* Stance */}
+      <div>
+        <label className="block text-xs font-medium text-gray-700">Stance</label>
+        <select
+          data-testid="composer-stance"
+          className="mt-1 w-full rounded border px-2 py-1 text-sm"
+          value={fields.stance}
+          onChange={(e) => update('stance', e.target.value as ComposerFields['stance'])}
+        >
+          <option value="support">Support</option>
+          <option value="oppose">Oppose</option>
+          <option value="inform">Inform</option>
+        </select>
+      </div>
+
+      {/* Subject */}
+      <div>
+        <label className="block text-xs font-medium text-gray-700">Subject</label>
+        <input
+          data-testid="composer-subject"
+          className="mt-1 w-full rounded border px-2 py-1 text-sm"
+          maxLength={200}
+          value={fields.subject}
+          onChange={(e) => update('subject', e.target.value)}
+        />
+        {errors.subject && <p data-testid="error-subject" className="mt-0.5 text-xs text-red-500">{errors.subject}</p>}
+      </div>
+
+      {/* Body */}
+      <div>
+        <label className="block text-xs font-medium text-gray-700">Body ({fields.body.length}/5000)</label>
+        <textarea
+          data-testid="composer-body"
+          className="mt-1 w-full rounded border px-2 py-1 text-sm"
+          rows={6}
+          maxLength={5000}
+          value={fields.body}
+          onChange={(e) => update('body', e.target.value)}
+        />
+        {errors.body && <p data-testid="error-body" className="mt-0.5 text-xs text-red-500">{errors.body}</p>}
+      </div>
+
+      {/* Intent */}
+      <div>
+        <label className="block text-xs font-medium text-gray-700">Delivery Method</label>
+        <select
+          data-testid="composer-intent"
+          className="mt-1 w-full rounded border px-2 py-1 text-sm"
+          value={fields.intent}
+          onChange={(e) => update('intent', e.target.value as DeliveryIntent)}
+        >
+          {INTENTS.map((i) => (
+            <option key={i} value={i}>{i}</option>
+          ))}
+        </select>
+      </div>
+
+      {/* Budget info */}
+      <div data-testid="budget-info" className="text-xs text-gray-500">
+        {budgetCheck.allowed
+          ? 'Budget available for today.'
+          : `Budget exhausted: ${budgetCheck.reason}`}
+      </div>
+
+      {/* Trust info for send threshold */}
+      {trustScore < 0.7 && (
+        <p data-testid="send-trust-gate" className="text-xs text-amber-600">
+          Trust score ({trustScore.toFixed(2)}) below 0.70 — cannot send actions yet.
+        </p>
+      )}
+
+      {errors.repId && (
+        <p data-testid="error-rep" className="text-xs text-amber-600">{errors.repId}</p>
+      )}
+
+      {/* Send button */}
+      <button
+        data-testid="composer-send"
+        className={`rounded px-4 py-2 text-sm font-medium ${canSend ? 'bg-teal-600 text-white' : 'bg-gray-200 text-gray-400 cursor-not-allowed'}`}
+        disabled={!canSend}
+      >
+        Send Action
+      </button>
+    </div>
+  );
+};

--- a/apps/web-pwa/src/components/bridge/ActionHistory.test.tsx
+++ b/apps/web-pwa/src/components/bridge/ActionHistory.test.tsx
@@ -1,0 +1,100 @@
+/* @vitest-environment jsdom */
+
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { ActionHistory } from './ActionHistory';
+import type { CivicAction } from '@vh/data-model';
+
+const proof = { district_hash: 'h', nullifier: 'n', merkle_root: 'r' };
+
+const actions: CivicAction[] = [
+  {
+    id: 'action-1',
+    schemaVersion: 'hermes-action-v1',
+    author: 'null-1',
+    sourceTopicId: 'topic-1',
+    sourceSynthesisId: 'synth-1',
+    sourceEpoch: 1,
+    sourceArtifactId: 'brief-1',
+    representativeId: 'rep-1',
+    topic: 'Infrastructure',
+    stance: 'support',
+    subject: 'Support bill',
+    body: 'X'.repeat(60),
+    intent: 'email',
+    constituencyProof: proof,
+    status: 'sent',
+    createdAt: 1_700_000_000_000,
+    attempts: 1,
+  },
+  {
+    id: 'action-2',
+    schemaVersion: 'hermes-action-v1',
+    author: 'null-1',
+    sourceTopicId: 'topic-2',
+    sourceSynthesisId: 'synth-2',
+    sourceEpoch: 1,
+    sourceArtifactId: 'brief-2',
+    representativeId: 'rep-2',
+    topic: 'Education',
+    stance: 'oppose',
+    subject: 'Oppose cuts',
+    body: 'Y'.repeat(60),
+    intent: 'phone',
+    constituencyProof: proof,
+    status: 'draft',
+    createdAt: 1_700_001_000_000,
+    attempts: 0,
+  },
+];
+
+vi.mock('../../store/bridge/useBridgeStore', () => ({
+  getAllActions: () => [],
+}));
+
+afterEach(() => cleanup());
+
+describe('ActionHistory', () => {
+  it('shows empty state when no actions', () => {
+    render(<ActionHistory />);
+    expect(screen.getByTestId('history-empty')).toBeInTheDocument();
+  });
+
+  it('renders action items when provided via prop', () => {
+    render(<ActionHistory actions={actions} />);
+    expect(screen.getByTestId('action-history')).toBeInTheDocument();
+    expect(screen.getByTestId('history-item-action-1')).toBeInTheDocument();
+    expect(screen.getByTestId('history-item-action-2')).toBeInTheDocument();
+  });
+
+  it('sorts actions by createdAt descending (newest first)', () => {
+    render(<ActionHistory actions={actions} />);
+    const items = screen.getByTestId('action-history').querySelectorAll('article');
+    expect(items[0].getAttribute('data-testid')).toBe('history-item-action-2');
+    expect(items[1].getAttribute('data-testid')).toBe('history-item-action-1');
+  });
+
+  it('displays topic, status, representative, intent, date', () => {
+    render(<ActionHistory actions={actions} />);
+    expect(screen.getByText('Infrastructure')).toBeInTheDocument();
+    expect(screen.getByTestId('history-status-action-1').textContent).toBe('sent');
+    expect(screen.getByTestId('history-rep-action-1').textContent).toContain('rep-1');
+    expect(screen.getByTestId('history-intent-action-1').textContent).toContain('email');
+    expect(screen.getByTestId('history-date-action-1').textContent).toBeTruthy();
+  });
+
+  it('displays stance and subject in detail line', () => {
+    render(<ActionHistory actions={actions} />);
+    const item = screen.getByTestId('history-item-action-1');
+    expect(item.textContent).toContain('support');
+    expect(item.textContent).toContain('Support bill');
+  });
+
+  it('renders with unknown status gracefully', () => {
+    const custom = [{ ...actions[0], status: 'unknown' as any }];
+    render(<ActionHistory actions={custom} />);
+    expect(screen.getByTestId('history-status-action-1').textContent).toBe('unknown');
+  });
+});

--- a/apps/web-pwa/src/components/bridge/ActionHistory.tsx
+++ b/apps/web-pwa/src/components/bridge/ActionHistory.tsx
@@ -1,0 +1,73 @@
+/**
+ * ActionHistory — List past civic actions per §8.1.
+ *
+ * Shows status, target representative, intent used, timestamps.
+ *
+ * Spec: spec-civic-action-kit-v0.md §8.1
+ */
+
+import React from 'react';
+import type { CivicAction } from '@vh/data-model';
+import { getAllActions } from '../../store/bridge/useBridgeStore';
+
+const STATUS_STYLES: Record<string, string> = {
+  draft: 'bg-gray-100 text-gray-600',
+  ready: 'bg-blue-100 text-blue-700',
+  sent: 'bg-teal-100 text-teal-700',
+  failed: 'bg-red-100 text-red-700',
+};
+
+function formatTs(ts: number): string {
+  return new Date(ts).toLocaleString();
+}
+
+export interface ActionHistoryProps {
+  /** Override actions list for testing */
+  readonly actions?: CivicAction[];
+}
+
+export const ActionHistory: React.FC<ActionHistoryProps> = ({ actions: overrideActions }) => {
+  const actions = overrideActions ?? getAllActions();
+
+  if (actions.length === 0) {
+    return (
+      <p data-testid="history-empty" className="text-sm text-gray-500">
+        No civic actions yet. Compose your first action to get started.
+      </p>
+    );
+  }
+
+  const sorted = [...actions].sort((a, b) => b.createdAt - a.createdAt);
+
+  return (
+    <div data-testid="action-history" className="space-y-2">
+      {sorted.map((action) => (
+        <article
+          key={action.id}
+          data-testid={`history-item-${action.id}`}
+          className="rounded border border-gray-200 p-3"
+        >
+          <div className="flex items-baseline justify-between">
+            <span className="text-sm font-medium">{action.topic}</span>
+            <span
+              data-testid={`history-status-${action.id}`}
+              className={`rounded px-1.5 py-0.5 text-xs ${STATUS_STYLES[action.status] ?? 'bg-gray-100 text-gray-600'}`}
+            >
+              {action.status}
+            </span>
+          </div>
+          <div className="mt-1 text-xs text-gray-500">
+            <span data-testid={`history-rep-${action.id}`}>Rep: {action.representativeId}</span>
+            <span className="mx-1">·</span>
+            <span data-testid={`history-intent-${action.id}`}>Via: {action.intent}</span>
+            <span className="mx-1">·</span>
+            <span data-testid={`history-date-${action.id}`}>{formatTs(action.createdAt)}</span>
+          </div>
+          <p className="mt-1 text-xs text-gray-400">
+            {action.stance} · {action.subject}
+          </p>
+        </article>
+      ))}
+    </div>
+  );
+};

--- a/apps/web-pwa/src/components/bridge/BridgeLayout.test.tsx
+++ b/apps/web-pwa/src/components/bridge/BridgeLayout.test.tsx
@@ -1,0 +1,93 @@
+/* @vitest-environment jsdom */
+
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { BridgeLayout } from './BridgeLayout';
+
+let trustScore = 1;
+
+vi.mock('../../hooks/useIdentity', () => ({
+  useIdentity: () => ({ identity: { session: { trustScore } } }),
+}));
+
+vi.mock('./RepresentativeSelector', () => ({
+  RepresentativeSelector: ({ onSelect }: any) => (
+    <div data-testid="rep-selector-mock">
+      <button data-testid="select-rep-btn" onClick={() => onSelect('rep-1')}>Select</button>
+    </div>
+  ),
+}));
+
+vi.mock('./ActionComposer', () => ({
+  ActionComposer: ({ selectedRepId }: any) => (
+    <div data-testid="action-composer-mock">Rep: {selectedRepId ?? 'none'}</div>
+  ),
+}));
+
+vi.mock('./ActionHistory', () => ({
+  ActionHistory: () => <div data-testid="action-history-mock">History</div>,
+}));
+
+beforeEach(() => {
+  trustScore = 1;
+  vi.stubEnv('VITE_ELEVATION_ENABLED', 'true');
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllEnvs();
+});
+
+describe('BridgeLayout', () => {
+  it('renders layout when enabled and trust sufficient', () => {
+    render(<BridgeLayout />);
+    expect(screen.getByTestId('bridge-layout')).toBeInTheDocument();
+    expect(screen.getByTestId('bridge-nav')).toBeInTheDocument();
+  });
+
+  it('shows disabled message when feature flag off', () => {
+    vi.stubEnv('VITE_ELEVATION_ENABLED', 'false');
+    render(<BridgeLayout />);
+    expect(screen.getByTestId('bridge-disabled')).toBeInTheDocument();
+  });
+
+  it('shows trust gate when score below 0.5', () => {
+    trustScore = 0.3;
+    render(<BridgeLayout />);
+    expect(screen.getByTestId('bridge-trust-gate')).toBeInTheDocument();
+    expect(screen.getByText(/0\.30/)).toBeInTheDocument();
+  });
+
+  it('navigates sections via nav buttons', () => {
+    render(<BridgeLayout />);
+
+    // Default: representatives
+    expect(screen.getByTestId('rep-selector-mock')).toBeInTheDocument();
+
+    // Click compose
+    fireEvent.click(screen.getByTestId('bridge-nav-compose'));
+    expect(screen.getByTestId('action-composer-mock')).toBeInTheDocument();
+
+    // Click history
+    fireEvent.click(screen.getByTestId('bridge-nav-history'));
+    expect(screen.getByTestId('action-history-mock')).toBeInTheDocument();
+
+    // Back to representatives
+    fireEvent.click(screen.getByTestId('bridge-nav-representatives'));
+    expect(screen.getByTestId('rep-selector-mock')).toBeInTheDocument();
+  });
+
+  it('selecting a rep navigates to compose with repId', () => {
+    render(<BridgeLayout />);
+    fireEvent.click(screen.getByTestId('select-rep-btn'));
+    expect(screen.getByTestId('action-composer-mock')).toBeInTheDocument();
+    expect(screen.getByText('Rep: rep-1')).toBeInTheDocument();
+  });
+
+  it('renders with initialSection prop', () => {
+    render(<BridgeLayout initialSection="history" />);
+    expect(screen.getByTestId('action-history-mock')).toBeInTheDocument();
+  });
+});

--- a/apps/web-pwa/src/components/bridge/BridgeLayout.tsx
+++ b/apps/web-pwa/src/components/bridge/BridgeLayout.tsx
@@ -1,0 +1,91 @@
+/**
+ * BridgeLayout — Container/routing for the civic action center.
+ *
+ * Gates entire component behind VITE_ELEVATION_ENABLED.
+ * Shows trust gating reason if below threshold.
+ *
+ * Spec: spec-civic-action-kit-v0.md §8
+ */
+
+import React, { useState } from 'react';
+import { useIdentity } from '../../hooks/useIdentity';
+import { RepresentativeSelector } from './RepresentativeSelector';
+import { ActionComposer } from './ActionComposer';
+import { ActionHistory } from './ActionHistory';
+
+/* ── Feature flag ────────────────────────────────────────────── */
+
+function isEnabled(): boolean {
+  /* v8 ignore next 2 -- browser env resolves import.meta differently */
+  const viteValue = (import.meta as unknown as { env?: Record<string, string> }).env
+    ?.VITE_ELEVATION_ENABLED;
+  /* v8 ignore next 3 -- browser runtime may not expose process */
+  const nodeValue =
+    typeof process !== 'undefined' ? process.env?.VITE_ELEVATION_ENABLED : undefined;
+  /* v8 ignore next 1 -- ?? fallback only reachable in-browser */
+  return (nodeValue ?? viteValue) === 'true';
+}
+
+export type BridgeSection = 'representatives' | 'compose' | 'history';
+
+export interface BridgeLayoutProps {
+  readonly initialSection?: BridgeSection;
+}
+
+export const BridgeLayout: React.FC<BridgeLayoutProps> = ({ initialSection = 'representatives' }) => {
+  const { identity } = useIdentity();
+  const trustScore = identity?.session?.trustScore ?? 0;
+  const [section, setSection] = useState<BridgeSection>(initialSection);
+  const [selectedRepId, setSelectedRepId] = useState<string | undefined>();
+
+  if (!isEnabled()) {
+    return (
+      <div data-testid="bridge-disabled" className="p-4 text-sm text-gray-500">
+        Civic Action Center is not enabled.
+      </div>
+    );
+  }
+
+  if (trustScore < 0.5) {
+    return (
+      <div data-testid="bridge-trust-gate" className="p-4">
+        <p className="text-sm text-amber-600">
+          Your trust score ({trustScore.toFixed(2)}) is below the 0.50 threshold required
+          to access the Civic Action Center. Complete identity verification to increase your score.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div data-testid="bridge-layout" className="space-y-4 p-4">
+      <nav className="flex gap-2" data-testid="bridge-nav">
+        {(['representatives', 'compose', 'history'] as const).map((s) => (
+          <button
+            key={s}
+            data-testid={`bridge-nav-${s}`}
+            className={`rounded px-3 py-1 text-sm ${section === s ? 'bg-teal-600 text-white' : 'bg-gray-100 text-gray-700'}`}
+            onClick={() => setSection(s)}
+          >
+            {s === 'representatives' ? 'Representatives' : s === 'compose' ? 'Compose Action' : 'History'}
+          </button>
+        ))}
+      </nav>
+
+      {section === 'representatives' && (
+        <RepresentativeSelector
+          onSelect={(repId) => {
+            setSelectedRepId(repId);
+            setSection('compose');
+          }}
+        />
+      )}
+
+      {section === 'compose' && (
+        <ActionComposer selectedRepId={selectedRepId} />
+      )}
+
+      {section === 'history' && <ActionHistory />}
+    </div>
+  );
+};

--- a/apps/web-pwa/src/components/bridge/ReceiptViewer.test.tsx
+++ b/apps/web-pwa/src/components/bridge/ReceiptViewer.test.tsx
@@ -1,0 +1,160 @@
+/* @vitest-environment jsdom */
+
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { ReceiptViewer, buildRetryChain } from './ReceiptViewer';
+import type { DeliveryReceipt } from '@vh/data-model';
+
+/* ── Mock bridge store ───────────────────────────────────────── */
+
+const receiptStore = new Map<string, DeliveryReceipt>();
+const actionReceipts = new Map<string, DeliveryReceipt[]>();
+
+vi.mock('../../store/bridge/useBridgeStore', () => ({
+  getReceipt: (id: string) => receiptStore.get(id) ?? undefined,
+  getReceiptsForAction: (actionId: string) => actionReceipts.get(actionId) ?? [],
+}));
+
+const baseReceipt: DeliveryReceipt = {
+  id: 'receipt-1',
+  schemaVersion: 'hermes-receipt-v1',
+  actionId: 'action-1',
+  representativeId: 'rep-1',
+  status: 'success',
+  timestamp: 1_700_000_000_000,
+  intent: 'email',
+  userAttested: true,
+  retryCount: 0,
+};
+
+const failedReceipt: DeliveryReceipt = {
+  id: 'receipt-0',
+  schemaVersion: 'hermes-receipt-v1',
+  actionId: 'action-1',
+  representativeId: 'rep-1',
+  status: 'failed',
+  timestamp: 1_699_999_000_000,
+  intent: 'email',
+  userAttested: true,
+  retryCount: 0,
+  errorMessage: 'connection refused',
+};
+
+const retriedReceipt: DeliveryReceipt = {
+  ...baseReceipt,
+  id: 'receipt-1',
+  retryCount: 1,
+  previousReceiptId: 'receipt-0',
+};
+
+beforeEach(() => {
+  receiptStore.clear();
+  actionReceipts.clear();
+});
+
+afterEach(() => cleanup());
+
+/* ── buildRetryChain ─────────────────────────────────────────── */
+
+describe('buildRetryChain', () => {
+  it('returns single-item chain for receipt without previous', () => {
+    const chain = buildRetryChain(baseReceipt);
+    expect(chain).toHaveLength(1);
+    expect(chain[0].id).toBe('receipt-1');
+  });
+
+  it('builds chain from previousReceiptId', () => {
+    receiptStore.set('receipt-0', failedReceipt);
+    const chain = buildRetryChain(retriedReceipt);
+    expect(chain).toHaveLength(2);
+    expect(chain[0].id).toBe('receipt-0'); // oldest first
+    expect(chain[1].id).toBe('receipt-1');
+  });
+
+  it('handles circular references gracefully', () => {
+    const circular: DeliveryReceipt = { ...baseReceipt, previousReceiptId: 'receipt-1' };
+    receiptStore.set('receipt-1', circular);
+    const chain = buildRetryChain(circular);
+    expect(chain).toHaveLength(1); // Does not loop
+  });
+
+  it('handles missing previous receipt', () => {
+    const chain = buildRetryChain(retriedReceipt);
+    expect(chain).toHaveLength(1); // receipt-0 not in store
+  });
+});
+
+/* ── ReceiptViewer component ─────────────────────────────────── */
+
+describe('ReceiptViewer', () => {
+  it('shows empty state when no receipts for action', () => {
+    render(<ReceiptViewer actionId="no-such-action" />);
+    expect(screen.getByTestId('receipt-empty')).toBeInTheDocument();
+  });
+
+  it('renders receipt detail', () => {
+    actionReceipts.set('action-1', [baseReceipt]);
+    render(<ReceiptViewer actionId="action-1" />);
+    expect(screen.getByTestId('receipt-viewer')).toBeInTheDocument();
+    expect(screen.getByTestId('receipt-detail')).toBeInTheDocument();
+    expect(screen.getByTestId('receipt-rep').textContent).toBe('rep-1');
+    expect(screen.getByTestId('receipt-intent').textContent).toBe('email');
+    expect(screen.getByTestId('receipt-time').textContent).toBeTruthy();
+  });
+
+  it('shows success status icon', () => {
+    actionReceipts.set('action-1', [baseReceipt]);
+    render(<ReceiptViewer actionId="action-1" />);
+    expect(screen.getByTestId('receipt-viewer').textContent).toContain('✅');
+  });
+
+  it('shows failed status icon', () => {
+    actionReceipts.set('action-1', [failedReceipt]);
+    render(<ReceiptViewer actionId="action-1" />);
+    expect(screen.getByTestId('receipt-viewer').textContent).toContain('❌');
+  });
+
+  it('shows error message for failed receipt', () => {
+    actionReceipts.set('action-1', [failedReceipt]);
+    render(<ReceiptViewer actionId="action-1" />);
+    expect(screen.getByTestId('receipt-viewer').textContent).toContain('connection refused');
+  });
+
+  it('shows user-cancelled status', () => {
+    const cancelled: DeliveryReceipt = { ...baseReceipt, status: 'user-cancelled' };
+    actionReceipts.set('action-1', [cancelled]);
+    render(<ReceiptViewer actionId="action-1" />);
+    expect(screen.getByTestId('receipt-viewer').textContent).toContain('🚫');
+  });
+
+  it('renders retry chain when present', () => {
+    receiptStore.set('receipt-0', failedReceipt);
+    actionReceipts.set('action-1', [failedReceipt, retriedReceipt]);
+    render(<ReceiptViewer actionId="action-1" />);
+    expect(screen.getByTestId('receipt-chain')).toBeInTheDocument();
+    expect(screen.getByTestId('chain-item-0')).toBeInTheDocument();
+    expect(screen.getByTestId('chain-item-1')).toBeInTheDocument();
+  });
+
+  it('does not show chain section for single receipt', () => {
+    actionReceipts.set('action-1', [baseReceipt]);
+    render(<ReceiptViewer actionId="action-1" />);
+    expect(screen.queryByTestId('receipt-chain')).not.toBeInTheDocument();
+  });
+
+  it('shows chain error messages', () => {
+    receiptStore.set('receipt-0', failedReceipt);
+    actionReceipts.set('action-1', [failedReceipt, retriedReceipt]);
+    render(<ReceiptViewer actionId="action-1" />);
+    expect(screen.getByTestId('receipt-chain').textContent).toContain('connection refused');
+  });
+
+  it('shows unknown status icon for unrecognized status', () => {
+    const unknown: DeliveryReceipt = { ...baseReceipt, status: 'pending' as any };
+    actionReceipts.set('action-1', [unknown]);
+    render(<ReceiptViewer actionId="action-1" />);
+    expect(screen.getByTestId('receipt-viewer').textContent).toContain('❓');
+  });
+});

--- a/apps/web-pwa/src/components/bridge/ReceiptViewer.tsx
+++ b/apps/web-pwa/src/components/bridge/ReceiptViewer.tsx
@@ -1,0 +1,106 @@
+/**
+ * ReceiptViewer — Receipt detail with retry chain per §8.4.
+ *
+ * Shows target representative, intent, timestamp, status.
+ * Traverses previousReceiptId for retry chain history.
+ *
+ * Spec: spec-civic-action-kit-v0.md §8.4
+ */
+
+import React from 'react';
+import type { DeliveryReceipt } from '@vh/data-model';
+import { getReceipt, getReceiptsForAction } from '../../store/bridge/useBridgeStore';
+
+const STATUS_ICONS: Record<string, string> = {
+  success: '✅',
+  failed: '❌',
+  'user-cancelled': '🚫',
+};
+
+function formatTs(ts: number): string {
+  return new Date(ts).toLocaleString();
+}
+
+/**
+ * Build the retry chain by walking previousReceiptId backwards.
+ */
+export function buildRetryChain(receipt: DeliveryReceipt): DeliveryReceipt[] {
+  const chain: DeliveryReceipt[] = [receipt];
+  let current = receipt;
+  const seen = new Set<string>([current.id]);
+
+  while (current.previousReceiptId) {
+    const prev = getReceipt(current.previousReceiptId);
+    if (!prev || seen.has(prev.id)) break;
+    seen.add(prev.id);
+    chain.push(prev);
+    current = prev;
+  }
+
+  return chain.reverse(); // oldest first
+}
+
+export interface ReceiptViewerProps {
+  readonly actionId: string;
+}
+
+export const ReceiptViewer: React.FC<ReceiptViewerProps> = ({ actionId }) => {
+  const receipts = getReceiptsForAction(actionId);
+
+  if (receipts.length === 0) {
+    return (
+      <p data-testid="receipt-empty" className="text-sm text-gray-500">
+        No delivery receipts for this action.
+      </p>
+    );
+  }
+
+  // Show the latest receipt with its chain
+  const lastReceipt = receipts[receipts.length - 1];
+  if (!lastReceipt) {
+    return <p data-testid="receipt-empty" className="text-xs text-gray-400">No receipts available.</p>;
+  }
+  const latest = lastReceipt;
+  const chain = buildRetryChain(latest);
+
+  return (
+    <div data-testid="receipt-viewer" className="space-y-2">
+      <h3 className="text-sm font-medium">
+        Delivery Receipt · {STATUS_ICONS[latest.status] ?? '❓'} {latest.status}
+      </h3>
+
+      <div data-testid="receipt-detail" className="rounded border border-gray-200 p-3">
+        <div className="text-xs text-gray-600">
+          <p>Representative: <span data-testid="receipt-rep">{latest.representativeId}</span></p>
+          <p>Intent: <span data-testid="receipt-intent">{latest.intent}</span></p>
+          <p>Time: <span data-testid="receipt-time">{formatTs(latest.timestamp)}</span></p>
+          <p>Attested: {latest.userAttested ? 'Yes' : 'No'}</p>
+          {latest.errorMessage && (
+            <p className="text-red-500">Error: {latest.errorMessage}</p>
+          )}
+        </div>
+      </div>
+
+      {chain.length > 1 && (
+        <div data-testid="receipt-chain">
+          <h4 className="text-xs font-medium text-gray-500">Retry History ({chain.length} attempts)</h4>
+          <div className="mt-1 space-y-1">
+            {chain.map((r, i) => (
+              <div
+                key={r.id}
+                data-testid={`chain-item-${i}`}
+                className="flex items-center gap-2 text-xs text-gray-500"
+              >
+                <span>{STATUS_ICONS[r.status] ?? '❓'}</span>
+                <span>Attempt {i + 1}</span>
+                <span>· {r.intent}</span>
+                <span>· {formatTs(r.timestamp)}</span>
+                {r.errorMessage && <span className="text-red-400">({r.errorMessage})</span>}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/apps/web-pwa/src/components/bridge/RepresentativeSelector.test.tsx
+++ b/apps/web-pwa/src/components/bridge/RepresentativeSelector.test.tsx
@@ -1,0 +1,142 @@
+/* @vitest-environment jsdom */
+
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { RepresentativeSelector } from './RepresentativeSelector';
+import type { Representative } from '@vh/data-model';
+
+let trustScore = 1;
+const onSelectMock = vi.fn();
+
+vi.mock('../../hooks/useIdentity', () => ({
+  useIdentity: () => ({ identity: { session: { trustScore } } }),
+}));
+
+const mockReps: Representative[] = [
+  {
+    id: 'us-house-ca-11',
+    name: 'Jane Doe',
+    title: 'Representative',
+    office: 'house',
+    country: 'US',
+    state: 'CA',
+    district: '11',
+    districtHash: 'hash-ca-11',
+    contactMethod: 'both',
+    email: 'jane@house.gov',
+    phone: '+12025551234',
+    contactUrl: 'https://house.gov/contact',
+    lastVerified: 1_700_000_000_000,
+    party: 'Independent',
+  },
+  {
+    id: 'us-senate-ca-1',
+    name: 'John Smith',
+    title: 'Senator',
+    office: 'senate',
+    country: 'US',
+    state: 'CA',
+    districtHash: 'hash-ca-s1',
+    contactMethod: 'email',
+    email: 'john@senate.gov',
+    lastVerified: 1_700_000_000_000,
+  },
+];
+
+let mockRepsList: Representative[] = mockReps;
+
+vi.mock('../../store/bridge/representativeDirectory', () => ({
+  findRepresentatives: () => mockRepsList,
+}));
+
+beforeEach(() => {
+  trustScore = 1;
+  mockRepsList = mockReps;
+  onSelectMock.mockClear();
+});
+
+afterEach(() => cleanup());
+
+describe('RepresentativeSelector', () => {
+  it('renders rep cards when trust sufficient', () => {
+    render(<RepresentativeSelector onSelect={onSelectMock} />);
+    expect(screen.getByTestId('rep-selector')).toBeInTheDocument();
+    expect(screen.getByTestId('rep-card-us-house-ca-11')).toBeInTheDocument();
+    expect(screen.getByTestId('rep-card-us-senate-ca-1')).toBeInTheDocument();
+  });
+
+  it('shows trust gate when score below 0.5', () => {
+    trustScore = 0.3;
+    render(<RepresentativeSelector onSelect={onSelectMock} />);
+    expect(screen.getByTestId('rep-trust-gate')).toBeInTheDocument();
+    expect(screen.getByText(/0\.30/)).toBeInTheDocument();
+  });
+
+  it('renders rep details: name, title, office, party, district, state', () => {
+    render(<RepresentativeSelector onSelect={onSelectMock} />);
+    expect(screen.getByText('Jane Doe')).toBeInTheDocument();
+    const card = screen.getByTestId('rep-card-us-house-ca-11');
+    expect(card.textContent).toContain('Representative');
+    expect(card.textContent).toContain('house');
+    expect(card.textContent).toContain('Independent');
+    expect(card.textContent).toContain('District 11');
+    expect(card.textContent).toContain('CA');
+  });
+
+  it('renders channel badges', () => {
+    render(<RepresentativeSelector onSelect={onSelectMock} />);
+    // Jane has email + phone + contactUrl
+    const card = screen.getByTestId('rep-card-us-house-ca-11');
+    expect(card.textContent).toContain('email');
+    expect(card.textContent).toContain('phone');
+    expect(card.textContent).toContain('web');
+  });
+
+  it('shows manual badge when no channels available', () => {
+    mockRepsList = [{
+      id: 'rep-no-contact',
+      name: 'No Contact',
+      title: 'Rep',
+      office: 'house',
+      country: 'US',
+      districtHash: 'h',
+      contactMethod: 'manual',
+      lastVerified: Date.now(),
+    }];
+    render(<RepresentativeSelector onSelect={onSelectMock} />);
+    const card = screen.getByTestId('rep-card-rep-no-contact');
+    expect(card.textContent).toContain('manual');
+  });
+
+  it('calls onSelect with rep id when clicked', () => {
+    render(<RepresentativeSelector onSelect={onSelectMock} />);
+    fireEvent.click(screen.getByTestId('rep-card-us-house-ca-11'));
+    expect(onSelectMock).toHaveBeenCalledWith('us-house-ca-11');
+  });
+
+  it('shows empty state when no reps loaded', () => {
+    mockRepsList = [];
+    render(<RepresentativeSelector onSelect={onSelectMock} />);
+    expect(screen.getByTestId('rep-empty')).toBeInTheDocument();
+  });
+
+  it('displays Verified date', () => {
+    render(<RepresentativeSelector onSelect={onSelectMock} />);
+    const card = screen.getByTestId('rep-card-us-house-ca-11');
+    expect(card.textContent).toContain('Verified');
+  });
+
+  it('omits party when absent', () => {
+    render(<RepresentativeSelector onSelect={onSelectMock} />);
+    const card = screen.getByTestId('rep-card-us-senate-ca-1');
+    expect(card.textContent).not.toContain('Independent');
+  });
+
+  it('omits district when absent', () => {
+    render(<RepresentativeSelector onSelect={onSelectMock} />);
+    const card = screen.getByTestId('rep-card-us-senate-ca-1');
+    expect(card.textContent).not.toContain('District');
+  });
+});

--- a/apps/web-pwa/src/components/bridge/RepresentativeSelector.tsx
+++ b/apps/web-pwa/src/components/bridge/RepresentativeSelector.tsx
@@ -1,0 +1,88 @@
+/**
+ * RepresentativeSelector — Representative cards per §8.2.
+ *
+ * Renders name, title, party, office, district, channels, lastVerified.
+ * Trust gate: >= 0.5 to view rep list.
+ *
+ * Spec: spec-civic-action-kit-v0.md §8.2
+ */
+
+import React from 'react';
+import type { Representative } from '@vh/data-model';
+import { useIdentity } from '../../hooks/useIdentity';
+import { findRepresentatives } from '../../store/bridge/representativeDirectory';
+
+export interface RepresentativeSelectorProps {
+  readonly onSelect: (repId: string) => void;
+}
+
+function channelBadges(rep: Representative): string[] {
+  const channels: string[] = [];
+  if (rep.email) channels.push('email');
+  if (rep.phone) channels.push('phone');
+  if (rep.contactUrl) channels.push('web');
+  if (channels.length === 0) channels.push('manual');
+  return channels;
+}
+
+function formatDate(ts: number): string {
+  return new Date(ts).toLocaleDateString();
+}
+
+export const RepresentativeSelector: React.FC<RepresentativeSelectorProps> = ({ onSelect }) => {
+  const { identity } = useIdentity();
+  const trustScore = identity?.session?.trustScore ?? 0;
+
+  if (trustScore < 0.5) {
+    return (
+      <p data-testid="rep-trust-gate" className="text-sm text-amber-600">
+        Trust score ({trustScore.toFixed(2)}) below 0.50 — verify identity to view representatives.
+      </p>
+    );
+  }
+
+  const reps = findRepresentatives('');
+
+  if (reps.length === 0) {
+    return (
+      <p data-testid="rep-empty" className="text-sm text-gray-500">
+        No representatives loaded. Directory will sync when available.
+      </p>
+    );
+  }
+
+  return (
+    <div data-testid="rep-selector" className="space-y-2">
+      {reps.map((rep) => (
+        <button
+          key={rep.id}
+          data-testid={`rep-card-${rep.id}`}
+          className="w-full rounded border border-gray-200 p-3 text-left hover:border-teal-400"
+          onClick={() => onSelect(rep.id)}
+        >
+          <div className="flex items-baseline justify-between">
+            <span className="font-medium">{rep.name}</span>
+            <span className="text-xs text-gray-400">Verified {formatDate(rep.lastVerified)}</span>
+          </div>
+          <div className="mt-1 text-xs text-gray-600">
+            {rep.title} · {rep.office}
+            {rep.party && ` · ${rep.party}`}
+            {rep.district && ` · District ${rep.district}`}
+            {rep.state && ` · ${rep.state}`}
+          </div>
+          <div className="mt-1 flex gap-1">
+            {channelBadges(rep).map((ch) => (
+              <span
+                key={ch}
+                data-testid={`rep-channel-${ch}`}
+                className="rounded bg-gray-100 px-1.5 py-0.5 text-xs text-gray-600"
+              >
+                {ch}
+              </span>
+            ))}
+          </div>
+        </button>
+      ))}
+    </div>
+  );
+};

--- a/apps/web-pwa/src/components/bridge/index.test.ts
+++ b/apps/web-pwa/src/components/bridge/index.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// Mock dependencies to avoid React/hook imports during barrel test
+vi.mock('../../hooks/useIdentity', () => ({ useIdentity: () => ({}) }));
+vi.mock('../../store/xpLedger', () => ({
+  useXpLedger: { getState: () => ({ canPerformAction: () => ({ allowed: true }), addXp: vi.fn() }) },
+}));
+vi.mock('../../store/bridge/representativeDirectory', () => ({ findRepresentatives: () => [] }));
+vi.mock('../../store/bridge/useBridgeStore', () => ({
+  getAllActions: () => [],
+  getReceipt: () => undefined,
+  getReceiptsForAction: () => [],
+}));
+
+describe('components/bridge barrel', () => {
+  it('re-exports all component modules', async () => {
+    const barrel = await import('./index');
+    expect(barrel.BridgeLayout).toBeDefined();
+    expect(barrel.RepresentativeSelector).toBeDefined();
+    expect(barrel.ActionComposer).toBeDefined();
+    expect(barrel.validateComposer).toBeDefined();
+    expect(barrel.ActionHistory).toBeDefined();
+    expect(barrel.ReceiptViewer).toBeDefined();
+    expect(barrel.buildRetryChain).toBeDefined();
+  });
+});

--- a/apps/web-pwa/src/components/bridge/index.ts
+++ b/apps/web-pwa/src/components/bridge/index.ts
@@ -1,0 +1,5 @@
+export { BridgeLayout, type BridgeLayoutProps, type BridgeSection } from './BridgeLayout';
+export { RepresentativeSelector, type RepresentativeSelectorProps } from './RepresentativeSelector';
+export { ActionComposer, validateComposer, type ActionComposerProps, type ComposerFields, type ValidationErrors } from './ActionComposer';
+export { ActionHistory, type ActionHistoryProps } from './ActionHistory';
+export { ReceiptViewer, buildRetryChain, type ReceiptViewerProps } from './ReceiptViewer';

--- a/apps/web-pwa/src/components/feed/ReceiptFeedCard.test.tsx
+++ b/apps/web-pwa/src/components/feed/ReceiptFeedCard.test.tsx
@@ -45,4 +45,42 @@ describe('ReceiptFeedCard', () => {
     // Date should be rendered (exact format varies by locale)
     expect(el.textContent).toContain('/');
   });
+
+  it('shows status badge when meta is present', () => {
+    const withMeta = { ...receiptItem, meta: { status: 'success', intent: 'email' } } as any;
+    render(<ReceiptFeedCard item={withMeta} />);
+    expect(screen.getByTestId('receipt-status').textContent).toContain('Delivered');
+    expect(screen.getByTestId('receipt-status').textContent).toContain('✅');
+  });
+
+  it('shows failed status', () => {
+    const withMeta = { ...receiptItem, meta: { status: 'failed', intent: 'phone' } } as any;
+    render(<ReceiptFeedCard item={withMeta} />);
+    expect(screen.getByTestId('receipt-status').textContent).toContain('Failed');
+  });
+
+  it('shows cancelled status', () => {
+    const withMeta = { ...receiptItem, meta: { status: 'user-cancelled' } } as any;
+    render(<ReceiptFeedCard item={withMeta} />);
+    expect(screen.getByTestId('receipt-status').textContent).toContain('Cancelled');
+  });
+
+  it('shows intent in description when meta present', () => {
+    const withMeta = { ...receiptItem, meta: { status: 'success', intent: 'email' } } as any;
+    render(<ReceiptFeedCard item={withMeta} />);
+    const el = screen.getByTestId('feed-receipt-receipt-abc-123');
+    expect(el.textContent).toContain('via email');
+  });
+
+  it('handles meta with invalid status gracefully', () => {
+    const withMeta = { ...receiptItem, meta: { status: 'unknown-status' } } as any;
+    render(<ReceiptFeedCard item={withMeta} />);
+    // Falls back to success label
+    expect(screen.getByTestId('receipt-status').textContent).toContain('Delivered');
+  });
+
+  it('renders without status badge when no meta', () => {
+    render(<ReceiptFeedCard item={receiptItem} />);
+    expect(screen.queryByTestId('receipt-status')).toBeNull();
+  });
 });

--- a/apps/web-pwa/src/components/feed/ReceiptFeedCard.tsx
+++ b/apps/web-pwa/src/components/feed/ReceiptFeedCard.tsx
@@ -1,3 +1,13 @@
+/**
+ * ReceiptFeedCard — Feed card for ACTION_RECEIPT items.
+ *
+ * Displays receipt summary inline in the feed.
+ * topic_id = receipt.actionId, title = action.topic.
+ * Appears under ALL filter only.
+ *
+ * Spec: spec-civic-action-kit-v0.md §8.4
+ */
+
 import React from 'react';
 import type { FeedItem } from '@vh/data-model';
 
@@ -5,21 +15,44 @@ export interface ReceiptFeedCardProps {
   readonly item: FeedItem;
 }
 
-/**
- * Placeholder card for ACTION_RECEIPT feed items.
- * Full receipt card UI will be implemented in W3-CAK Phase 3.
- *
- * Spec: docs/specs/spec-civic-action-kit-v0.md §8.4
- */
+const STATUS_LABELS: Record<string, { icon: string; label: string; color: string }> = {
+  success: { icon: '✅', label: 'Delivered', color: 'text-teal-700' },
+  failed: { icon: '❌', label: 'Failed', color: 'text-red-600' },
+  'user-cancelled': { icon: '🚫', label: 'Cancelled', color: 'text-gray-500' },
+};
+
+function getReceiptMeta(item: FeedItem): { status: string; intent: string } | null {
+  const meta = (item as Record<string, unknown>).meta;
+  if (meta && typeof meta === 'object') {
+    const m = meta as Record<string, unknown>;
+    return {
+      status: typeof m.status === 'string' ? m.status : 'success',
+      intent: typeof m.intent === 'string' ? m.intent : '',
+    };
+  }
+  return null;
+}
+
 export const ReceiptFeedCard: React.FC<ReceiptFeedCardProps> = ({ item }) => {
+  const meta = getReceiptMeta(item);
+  const statusInfo = STATUS_LABELS[meta?.status ?? ''] ?? STATUS_LABELS['success'];
+
   return (
     <article
       data-testid={`feed-receipt-${item.topic_id}`}
       className="rounded border border-teal-200 bg-teal-50 p-3 text-sm text-teal-900"
     >
-      <h3 className="font-medium">{item.title}</h3>
+      <div className="flex items-baseline justify-between">
+        <h3 className="font-medium">{item.title}</h3>
+        {meta && statusInfo && (
+          <span data-testid="receipt-status" className={`text-xs font-medium ${statusInfo.color}`}>
+            {statusInfo.icon} {statusInfo.label}
+          </span>
+        )}
+      </div>
       <p className="mt-1 text-xs text-teal-600">
         Civic action receipt · {new Date(item.latest_activity_at).toLocaleDateString()}
+        {meta?.intent && ` · via ${meta.intent}`}
       </p>
     </article>
   );

--- a/apps/web-pwa/src/store/bridge/bridgeXP.test.ts
+++ b/apps/web-pwa/src/store/bridge/bridgeXP.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, beforeEach, vi, afterEach } from 'vitest';
+import {
+  emitActionCompleted,
+  emitElevationForwarded,
+  pruneStaleEntries,
+  XP_FIRST_ACTION,
+  XP_SUBSEQUENT_ACTION,
+  XP_ELEVATION_FORWARDED,
+  _resetXPForTesting,
+  _getRepWeekSetSize,
+} from './bridgeXP';
+
+/* ── Mock xpLedger ───────────────────────────────────────────── */
+
+const addXpMock = vi.fn();
+
+vi.mock('../../store/xpLedger', () => ({
+  useXpLedger: {
+    getState: () => ({ addXp: addXpMock }),
+  },
+}));
+
+beforeEach(() => {
+  _resetXPForTesting();
+  addXpMock.mockClear();
+});
+
+/* ── emitActionCompleted ─────────────────────────────────────── */
+
+describe('emitActionCompleted', () => {
+  it('emits XP_FIRST_ACTION for first action per rep/week', () => {
+    const amount = emitActionCompleted('rep-1');
+    expect(amount).toBe(XP_FIRST_ACTION);
+    expect(addXpMock).toHaveBeenCalledWith('civic', XP_FIRST_ACTION);
+  });
+
+  it('emits XP_SUBSEQUENT_ACTION for same rep in same week', () => {
+    const now = Date.now();
+    emitActionCompleted('rep-1', now);
+    const amount = emitActionCompleted('rep-1', now + 1000);
+    expect(amount).toBe(XP_SUBSEQUENT_ACTION);
+    expect(addXpMock).toHaveBeenLastCalledWith('civic', XP_SUBSEQUENT_ACTION);
+  });
+
+  it('emits XP_FIRST_ACTION for different rep in same week', () => {
+    const now = Date.now();
+    emitActionCompleted('rep-1', now);
+    const amount = emitActionCompleted('rep-2', now);
+    expect(amount).toBe(XP_FIRST_ACTION);
+  });
+
+  it('emits XP_FIRST_ACTION for same rep in different week', () => {
+    const now = Date.now();
+    emitActionCompleted('rep-1', now);
+    const nextWeek = now + 8 * 24 * 60 * 60 * 1000;
+    const amount = emitActionCompleted('rep-1', nextWeek);
+    expect(amount).toBe(XP_FIRST_ACTION);
+  });
+
+  it('uses Date.now() by default', () => {
+    const amount = emitActionCompleted('rep-x');
+    expect(amount).toBe(XP_FIRST_ACTION);
+    expect(addXpMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+/* ── emitElevationForwarded ──────────────────────────────────── */
+
+describe('emitElevationForwarded', () => {
+  it('emits XP_ELEVATION_FORWARDED', () => {
+    const amount = emitElevationForwarded();
+    expect(amount).toBe(XP_ELEVATION_FORWARDED);
+    expect(addXpMock).toHaveBeenCalledWith('civic', XP_ELEVATION_FORWARDED);
+  });
+});
+
+/* ── pruneStaleEntries ───────────────────────────────────────── */
+
+describe('pruneStaleEntries', () => {
+  it('prunes entries older than 2 weeks', () => {
+    const twoWeeksAgo = Date.now() - 15 * 24 * 60 * 60 * 1000;
+    emitActionCompleted('rep-old', twoWeeksAgo);
+    emitActionCompleted('rep-new', Date.now());
+    expect(_getRepWeekSetSize()).toBe(2);
+
+    const pruned = pruneStaleEntries();
+    expect(pruned).toBe(1);
+    expect(_getRepWeekSetSize()).toBe(1);
+  });
+
+  it('returns 0 when nothing to prune', () => {
+    emitActionCompleted('rep-1');
+    expect(pruneStaleEntries()).toBe(0);
+  });
+
+  it('handles empty state', () => {
+    expect(pruneStaleEntries()).toBe(0);
+  });
+
+  it('uses Date.now() by default', () => {
+    const pruned = pruneStaleEntries();
+    expect(pruned).toBe(0);
+  });
+});
+
+/* ── Reset utility ───────────────────────────────────────────── */
+
+describe('_resetXPForTesting', () => {
+  it('clears all rep/week state', () => {
+    emitActionCompleted('rep-1');
+    emitActionCompleted('rep-2');
+    expect(_getRepWeekSetSize()).toBe(2);
+    _resetXPForTesting();
+    expect(_getRepWeekSetSize()).toBe(0);
+  });
+});

--- a/apps/web-pwa/src/store/bridge/bridgeXP.ts
+++ b/apps/web-pwa/src/store/bridge/bridgeXP.ts
@@ -1,0 +1,95 @@
+/**
+ * Bridge XP emissions — civic action rewards.
+ *
+ * Emission amounts per spec §9.1:
+ * - action_completed (first per rep/week): +3 civicXP
+ * - action_completed (subsequent same rep/week): +1 civicXP
+ * - elevation_forwarded: +1 civicXP
+ *
+ * All emissions bounded by weekly cap (enforced by xpLedger).
+ *
+ * Spec: spec-civic-action-kit-v0.md §9
+ */
+
+import { useXpLedger } from '../../store/xpLedger';
+
+/* ── Constants ───────────────────────────────────────────────── */
+
+export const XP_FIRST_ACTION = 3;
+export const XP_SUBSEQUENT_ACTION = 1;
+export const XP_ELEVATION_FORWARDED = 1;
+
+const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+
+/* ── State: rep/week dedup ───────────────────────────────────── */
+
+/** Track which reps received their first action this week. Key: `{repId}:{weekStart}` */
+const repWeekSet = new Set<string>();
+
+function weekStart(now: number): number {
+  const d = new Date(now);
+  d.setUTCHours(0, 0, 0, 0);
+  d.setUTCDate(d.getUTCDate() - d.getUTCDay()); // Sunday start
+  return d.getTime();
+}
+
+function repWeekKey(repId: string, now: number): string {
+  return `${repId}:${weekStart(now)}`;
+}
+
+/* ── Emitters ────────────────────────────────────────────────── */
+
+/**
+ * Emit XP for completing a civic action.
+ * First action per representative per week earns +3, subsequent earn +1.
+ */
+export function emitActionCompleted(representativeId: string, now?: number): number {
+  const ts = now ?? Date.now();
+  const key = repWeekKey(representativeId, ts);
+  const isFirst = !repWeekSet.has(key);
+  const amount = isFirst ? XP_FIRST_ACTION : XP_SUBSEQUENT_ACTION;
+
+  if (isFirst) repWeekSet.add(key);
+  useXpLedger.getState().addXp('civic', amount);
+  return amount;
+}
+
+/**
+ * Emit XP for forwarding an elevation artifact.
+ */
+export function emitElevationForwarded(): number {
+  useXpLedger.getState().addXp('civic', XP_ELEVATION_FORWARDED);
+  return XP_ELEVATION_FORWARDED;
+}
+
+/* ── Pruning (GC old week entries) ───────────────────────────── */
+
+/**
+ * Prune rep/week entries older than 2 weeks.
+ * Called periodically or at hydration.
+ */
+export function pruneStaleEntries(now?: number): number {
+  const ts = now ?? Date.now();
+  const cutoff = ts - 2 * WEEK_MS;
+  let pruned = 0;
+  for (const key of repWeekSet) {
+    const weekTs = Number(key.split(':').pop());
+    if (weekTs < cutoff) {
+      repWeekSet.delete(key);
+      pruned++;
+    }
+  }
+  return pruned;
+}
+
+/* ── Test utilities ──────────────────────────────────────────── */
+
+/** @internal */
+export function _resetXPForTesting(): void {
+  repWeekSet.clear();
+}
+
+/** @internal — expose for testing */
+export function _getRepWeekSetSize(): number {
+  return repWeekSet.size;
+}

--- a/apps/web-pwa/src/store/bridge/constituencyProof.test.ts
+++ b/apps/web-pwa/src/store/bridge/constituencyProof.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { ConstituencyProofSchema } from '@vh/data-model';
+import { getMockConstituencyProof } from './constituencyProof';
+
+describe('getMockConstituencyProof', () => {
+  it('returns a valid ConstituencyProof', () => {
+    const proof = getMockConstituencyProof('hash-ca-11');
+    const parsed = ConstituencyProofSchema.safeParse(proof);
+    expect(parsed.success).toBe(true);
+  });
+
+  it('uses the provided districtHash', () => {
+    const proof = getMockConstituencyProof('my-hash');
+    expect(proof.district_hash).toBe('my-hash');
+  });
+
+  it('returns deterministic mock fields', () => {
+    const proof = getMockConstituencyProof('h');
+    expect(proof.nullifier).toBe('mock-nullifier');
+    expect(proof.merkle_root).toBe('mock-root');
+  });
+});

--- a/apps/web-pwa/src/store/bridge/constituencyProof.ts
+++ b/apps/web-pwa/src/store/bridge/constituencyProof.ts
@@ -1,0 +1,20 @@
+/**
+ * Constituency proof — stub for Phase 3 development.
+ *
+ * Real proof acquisition deferred to W3-LUMA identity hardening workstream.
+ * Spec: spec-civic-action-kit-v0.md §7.2
+ */
+
+import type { ConstituencyProof } from '@vh/data-model';
+
+/**
+ * Return a mock constituency proof for development/testing.
+ * The district_hash matches the provided value to satisfy Zod validation.
+ */
+export function getMockConstituencyProof(districtHash: string): ConstituencyProof {
+  return {
+    district_hash: districtHash,
+    nullifier: 'mock-nullifier',
+    merkle_root: 'mock-root',
+  };
+}

--- a/apps/web-pwa/src/store/bridge/index.ts
+++ b/apps/web-pwa/src/store/bridge/index.ts
@@ -77,3 +77,16 @@ export {
   retryReceipt,
   type ReceiptOutcome,
 } from './receiptManager';
+
+export { getMockConstituencyProof } from './constituencyProof';
+
+export {
+  emitActionCompleted,
+  emitElevationForwarded,
+  pruneStaleEntries,
+  XP_FIRST_ACTION,
+  XP_SUBSEQUENT_ACTION,
+  XP_ELEVATION_FORWARDED,
+  _resetXPForTesting,
+  _getRepWeekSetSize,
+} from './bridgeXP';


### PR DESCRIPTION
## W3-CAK Phase 3 — UI + Trust + XP + Receipt-in-Feed

Builds on Phase 1 (data model, #231), Phase 2 (store/delivery, #234), and coordinator pre-dispatch (#235 — ACTION_RECEIPT FeedKind).

### Deliverables

| Module | LOC | Purpose |
|--------|-----|---------|
| `BridgeLayout.tsx` | 91 | Container/routing, VITE_ELEVATION_ENABLED gate, trust-gated sections |
| `RepresentativeSelector.tsx` | 88 | Rep cards (name/title/party/channels/lastVerified), trust >= 0.5 |
| `ActionComposer.tsx` | 187 | Draft form (topic/stance/subject/body/intent), content limits, budget display |
| `ActionHistory.tsx` | 73 | Past actions list with status/rep/intent/timestamps |
| `ReceiptViewer.tsx` | 102 | Receipt detail with retry chain history |
| `bridgeXP.ts` | 95 | XP emissions via useXpLedger (+3/+1 civicXP per spec §9.1) |
| `constituencyProof.ts` | 20 | Mock proof stub (real proof deferred to W3-LUMA) |
| `ReceiptFeedCard.tsx` | 59 | Full receipt card (upgraded from placeholder) |
| `index.ts` (barrel) | 5 | Re-exports for bridge components |

### Trust Enforcement (spec §7.1)
- `useIdentity()` hook, pattern from `TrustGate.tsx`
- >= 0.5: view rep list, draft action
- >= 0.7: generate report, send/finalize
- Clear gating UI with reason text

### Budget Enforcement
- `civic_actions/day` via `useXpLedger.canPerformAction()` / `consumeAction()`
- Informational display during compose, consumed at send/finalize only

### XP Emissions (spec §9)
- Uses existing `useXpLedger.addXp('civic', amount)`
- +3 first per rep/week, +1 subsequent, +1 elevation_forwarded

### Explicit Deferrals
- §8.5 templates → Phase 4
- §7.2 real constituency proof → W3-LUMA

### CE Review
CE dual-review AGREED (ce-codex Pass 2 + ce-opus Pass 2). All amendments incorporated.

### Gates
- 83 tests, all new/touched modules covered
- All source files ≤ 187 LOC (well under 350 cap)
- Typecheck clean (pre-existing CRDT/yjs errors only)
- All paths within w3c ownership scope
- No node:* imports