### PR TITLE
infra(wave3): guardrails + discovery spec sync

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -14,10 +14,11 @@ if [[ "$branch" == "HEAD" ]]; then
 fi
 
 # Allow direct pushes only to coordination branches and team branches.
-allowed_branch_regex='^(team-[a-e]/|w2[abg]/|coord/|main$|integration/wave-)'
+# Wave 1: team-[a-e]/*  Wave 2: w2[abg]/*  Wave 3: w3[cbfl]/*
+allowed_branch_regex='^(team-[a-e]/|w2[abg]/|w3[cbfl]/|coord/|main$|integration/wave-)'
 if [[ ! "$branch" =~ $allowed_branch_regex ]]; then
   echo "[pre-push] Branch '$branch' is not allowed for agent workflow."
-  echo "[pre-push] Use one of: team-[a-e]/*, w2a/*, w2b/*, w2g/*, coord/*"
+  echo "[pre-push] Use one of: team-[a-e]/*, w2[abg]/*, w3[cbfl]/*, coord/*"
   echo "[pre-push] Set SKIP_OWNERSHIP_SCOPE=1 only for explicit emergency override."
   exit 1
 fi

--- a/docs/specs/spec-topic-discovery-ranking-v0.md
+++ b/docs/specs/spec-topic-discovery-ranking-v0.md
@@ -1,32 +1,42 @@
 # Topic Discovery and Ranking Spec (v0)
 
-Version: 0.1
+Version: 0.3
 Status: Canonical for Season 0
-Context: Unified feed composition across News, Topics, and Social surfaces.
+Context: Unified feed composition across News, Topics, Social, Articles, and Civic Action surfaces.
 
 ## 1. Scope
 
-Compose and rank one feed from three source surfaces:
+Compose and rank one feed from five source surfaces:
 
 1. News (`StoryBundle` backed)
 2. Topics/threads (`TopicSynthesisV2` + forum activity)
 3. Linked-social notifications
+4. Articles (long-form content, added Wave 2)
+5. Civic Action Receipts (bridge action confirmations, added Wave 3)
 
 ## 2. Feed controls
 
 Required controls:
 
-- Filter chips: `All`, `News`, `Topics`, `Social`
+- Filter chips: `All`, `News`, `Topics`, `Social`, `Articles`
 - Sort modes: `Latest`, `Hottest`, `My Activity`
+
+Note: `ACTION_RECEIPT` items appear under `All` only — no dedicated filter chip for Season 0.
 
 ## 3. Discovery item contract
 
 ```ts
-type FeedKind = 'NEWS_STORY' | 'USER_TOPIC' | 'SOCIAL_NOTIFICATION';
+type FeedKind =
+  | 'NEWS_STORY'
+  | 'USER_TOPIC'
+  | 'SOCIAL_NOTIFICATION'
+  | 'ARTICLE'           // Wave 2: long-form content
+  | 'ACTION_RECEIPT';   // Wave 3: civic action confirmations
 
 interface FeedItem {
   topic_id: string;
   kind: FeedKind;
+  title: string;
   created_at: number;
   latest_activity_at: number;
   hotness: number;
@@ -36,6 +46,18 @@ interface FeedItem {
   my_activity_score?: number;
 }
 ```
+
+### 3.1 Filter-to-kind mapping
+
+| Filter chip | Included kinds |
+|-------------|---------------|
+| `ALL` | All 5 kinds |
+| `NEWS` | `NEWS_STORY` |
+| `TOPICS` | `USER_TOPIC` |
+| `SOCIAL` | `SOCIAL_NOTIFICATION` |
+| `ARTICLES` | `ARTICLE` |
+
+`ACTION_RECEIPT` is intentionally excluded from dedicated filter chips for Season 0. It surfaces only under `ALL`.
 
 ## 4. Ranking semantics
 
@@ -82,8 +104,17 @@ These objects must remain token-free and identity-free.
 
 ## 8. Tests
 
-1. Filter correctness for All/News/Topics/Social.
+1. Filter correctness for All/News/Topics/Social/Articles (including ACTION_RECEIPT under All only).
 2. Sort correctness for Latest/Hottest/My Activity.
 3. Deterministic hotness ranking given fixed inputs.
 4. Cohort-threshold fallback behavior.
 5. Privacy checks (no user identifiers in discovery payloads).
+6. FeedItem schema validation: `title` required, `kind` must be one of the 5 defined kinds.
+
+## 9. Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 0.1 | Wave 1 | Initial spec: 3 FeedKinds, 4 filter chips |
+| 0.2 | Wave 2 | Added `ARTICLE` kind, `ARTICLES` filter chip, `title` field on FeedItem |
+| 0.3 | Wave 3 | Added `ACTION_RECEIPT` kind (All filter only), documented filter-to-kind mapping |

--- a/tools/scripts/check-ownership-scope.mjs
+++ b/tools/scripts/check-ownership-scope.mjs
@@ -57,10 +57,10 @@ function resolveHeadRef() {
 }
 
 function inferBaseRef(headRef) {
-  // Wave 2 stream branches and Wave 1 team branches target the active integration branch.
+  // Wave 1-3 stream branches target the active integration branch.
   // Coordinator or other branches default to main unless GITHUB_BASE_REF is set.
-  if (/^(team-[a-e]|w2[abg])\//.test(headRef)) {
-    return process.env.ACTIVE_INTEGRATION_BRANCH || 'integration/wave-2';
+  if (/^(team-[a-e]|w2[abg]|w3[cbfl])\//.test(headRef)) {
+    return process.env.ACTIVE_INTEGRATION_BRANCH || 'integration/wave-3';
   }
   return 'main';
 }


### PR DESCRIPTION
## Summary

Closes both HIGH findings from CE dual-review Pass 2 (ce-codex + ce-opus AGREED):

### 1. Pre-push hook + ownership-scope guardrails (Action 1b)
- `.githooks/pre-push`: Added Wave 3 branch prefixes (`w3c/*`, `w3b/*`, `w3f/*`, `w3l/*`) to allowlist
- `tools/scripts/check-ownership-scope.mjs`: Updated `inferBaseRef()` to recognize Wave 3 prefixes and default to `integration/wave-3`
- **Impact**: Impl agents can now push Wave 3 branches without `SKIP_OWNERSHIP_SCOPE=1` workaround

### 2. Discovery spec drift closure (Action 1)
Syncs `spec-topic-discovery-ranking-v0.md` from v0.1 → v0.3 to match code reality:
- **FeedKind union**: 3 → 5 members (`ARTICLE` from Wave 2, `ACTION_RECEIPT` from Wave 3)
- **FeedItem**: Added `title: string` field (present in code since Wave 2)
- **Filter chips**: Added `Articles` chip, documented `ACTION_RECEIPT` under `All` only
- **§3.1**: New filter-to-kind mapping table
- **§9**: Added changelog tracking spec versions

### CE Review
Both `ce-codex` and `ce-opus` reached AGREED on Pass 2. No CE review required for coordinator infra/docs-only work per CE contracts.

### Testing
- `pnpm lint` ✅
- `pnpm typecheck` ✅  
- `pnpm test:quick` ✅ (162 files, 2481 tests)