### PR TITLE
docs(wave3): W3-Budget boundary assessment — close out key 8/8

### DIFF
--- a/apps/web-pwa/src/components/hermes/CommunityReactionSummary.tsx
+++ b/apps/web-pwa/src/components/hermes/CommunityReactionSummary.tsx
@@ -153,7 +153,11 @@ const IconAction: React.FC<{ icon: React.ReactNode; label: string; action: Actio
   <button
     className="inline-flex items-center rounded-lg bg-slate-900/40 p-2 text-slate-400 transition hover:text-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-amber-500"
     onClick={() => {
-      // TODO(wave-2): wire checkCivicActionsBudget/consumeCivicActionsBudget when civic actions execute real delivery flows.
+      // W3-Budget assessment (2026-02-14): civic_actions/day budget is now wired in
+      // ActionComposer (W3-CAK Phase 3, PR #236). This IconAction surface triggers
+      // ComingSoonModal — no real delivery flow exists here yet.
+      // Wire budget enforcement when this surface executes real civic action delivery.
+      // See: docs/foundational/WAVE3_BUDGET_BOUNDARY_ASSESSMENT.md
       onOpen(action);
     }}
     aria-describedby={`${action}-coming-soon`}

--- a/apps/web-pwa/src/components/hermes/forum/VoteControl.tsx
+++ b/apps/web-pwa/src/components/hermes/forum/VoteControl.tsx
@@ -29,7 +29,11 @@ export const VoteControl: React.FC<{ commentId: string; score: number }> = ({ co
           }`}
           onClick={(e) => {
             e.stopPropagation();
-            // TODO(wave-2): wire checkModerationBudget/consumeModerationBudget when this surface adds explicit hide/remove moderation actions.
+            // W3-Budget assessment (2026-02-14): moderation/day budget primitives exist
+            // (checkModerationBudget/consumeModerationBudget in xpLedgerBudget.ts) but
+            // VoteControl has no hide/remove moderation surface yet — only up/down votes.
+            // Wire budget enforcement when explicit moderation actions are added.
+            // See: docs/foundational/WAVE3_BUDGET_BOUNDARY_ASSESSMENT.md
             void vote(commentId, current === 'down' ? null : 'down');
           }}
           aria-label="Downvote"

--- a/docs/foundational/WAVE3_BUDGET_BOUNDARY_ASSESSMENT.md
+++ b/docs/foundational/WAVE3_BUDGET_BOUNDARY_ASSESSMENT.md
@@ -1,0 +1,43 @@
+# W3-Budget Boundary Assessment
+
+**Date:** 2026-02-14
+**Author:** Coordinator
+**CE Review:** AGREED (ce-codex + ce-opus, Pass 2)
+**Status:** CLOSED — deferred-until-surface-exists
+
+## Summary
+
+W3-Budget (key 8/8: `moderation/day`) was assessed for wiring readiness. Both CE agents independently concluded this is a boundary-clarification task, not an implementation task.
+
+## Budget Key Status (all 8 keys)
+
+| # | Key | Status | Wired At |
+|---|-----|--------|----------|
+| 1 | `moderation/day` | **Deferred** | No moderation surface exists yet |
+| 2 | `civic_actions/day` | ✅ Wired | `ActionComposer` (PR #236, Phase 3) |
+| 3-8 | (other keys) | ✅ Wired | Various Wave 1-2 PRs |
+
+## Assessment Detail
+
+### `moderation/day` — VoteControl.tsx
+
+The TODO at `VoteControl.tsx` references "when this surface adds explicit hide/remove moderation actions." Current VoteControl only provides up/down voting — no moderation primitives (hide, remove, flag-for-review) exist in the component.
+
+**Budget primitives exist and are tested:**
+- `checkModerationBudget()` in `store/xpLedgerBudget.ts`
+- `consumeModerationBudget()` in `store/xpLedgerBudget.ts`
+- Already enforced in `FamiliarControlPanel` for grant-level moderation
+
+**Decision:** No synthetic wiring. Budget enforcement will be added when the moderation surface materializes. TODO updated with assessment reference.
+
+### `civic_actions/day` — CommunityReactionSummary.tsx
+
+The TODO references "when civic actions execute real delivery flows." This surface currently shows `ComingSoonModal` — no actual delivery occurs.
+
+The civic actions budget IS wired at the real delivery boundary: `ActionComposer.tsx` (Phase 3, PR #236) calls `checkCivicActionsBudget()` before send and `consumeCivicActionsBudget()` at finalize.
+
+**Decision:** Budget correctly wired at real boundary. CommunityReactionSummary TODO updated with assessment reference. Will wire here when this surface executes real delivery.
+
+## Conclusion
+
+All 8 budget keys are either wired at real enforcement boundaries or explicitly deferred-until-surface-exists with documented rationale. W3-Budget workstream is complete.


### PR DESCRIPTION
## Summary

W3-Budget workstream close-out. Both CE agents (Pass 2 AGREED) independently assessed this as a boundary-clarification task, not implementation work.

### Assessment

| Budget Key | Status | Location |
|-----------|--------|----------|
| `moderation/day` | Deferred — no moderation surface exists | VoteControl.tsx |
| `civic_actions/day` | ✅ Wired at ActionComposer (PR #236) | CommunityReactionSummary.tsx |

### Changes
- Updated TODOs in `VoteControl.tsx` and `CommunityReactionSummary.tsx` with explicit assessment notes and doc reference
- Added `docs/foundational/WAVE3_BUDGET_BOUNDARY_ASSESSMENT.md` documenting all 8 budget keys

### Testing
- `pnpm lint` ✅
- `pnpm typecheck` ✅
- `pnpm test:quick` ✅ (2481 tests)