### PR TITLE
refactor(wave4-phase1): extract TRUST_THRESHOLDS to canonical module

### DIFF
--- a/apps/web-pwa/src/components/bridge/ActionComposer.tsx
+++ b/apps/web-pwa/src/components/bridge/ActionComposer.tsx
@@ -11,6 +11,7 @@
 
 import React, { useState, useMemo } from 'react';
 import type { DeliveryIntent } from '@vh/data-model';
+import { TRUST_MINIMUM, TRUST_ELEVATED } from '@vh/data-model';
 import { useIdentity } from '../../hooks/useIdentity';
 import { useXpLedger } from '../../store/xpLedger';
 
@@ -70,9 +71,9 @@ export const ActionComposer: React.FC<ActionComposerProps> = ({ selectedRepId })
   const hasErrors = Object.keys(errors).length > 0;
 
   const budgetCheck = useXpLedger.getState().canPerformAction('civic_actions/day');
-  const canSend = trustScore >= 0.7 && !hasErrors && budgetCheck.allowed;
+  const canSend = trustScore >= TRUST_ELEVATED && !hasErrors && budgetCheck.allowed;
 
-  if (trustScore < 0.5) {
+  if (trustScore < TRUST_MINIMUM) {
     return (
       <p data-testid="composer-trust-gate" className="text-sm text-amber-600">
         Trust score ({trustScore.toFixed(2)}) below 0.50 — verify identity to draft actions.
@@ -164,7 +165,7 @@ export const ActionComposer: React.FC<ActionComposerProps> = ({ selectedRepId })
       </div>
 
       {/* Trust info for send threshold */}
-      {trustScore < 0.7 && (
+      {trustScore < TRUST_ELEVATED && (
         <p data-testid="send-trust-gate" className="text-xs text-amber-600">
           Trust score ({trustScore.toFixed(2)}) below 0.70 — cannot send actions yet.
         </p>

--- a/apps/web-pwa/src/components/bridge/BridgeLayout.tsx
+++ b/apps/web-pwa/src/components/bridge/BridgeLayout.tsx
@@ -8,6 +8,7 @@
  */
 
 import React, { useState } from 'react';
+import { TRUST_MINIMUM } from '@vh/data-model';
 import { useIdentity } from '../../hooks/useIdentity';
 import { RepresentativeSelector } from './RepresentativeSelector';
 import { ActionComposer } from './ActionComposer';
@@ -46,7 +47,7 @@ export const BridgeLayout: React.FC<BridgeLayoutProps> = ({ initialSection = 're
     );
   }
 
-  if (trustScore < 0.5) {
+  if (trustScore < TRUST_MINIMUM) {
     return (
       <div data-testid="bridge-trust-gate" className="p-4">
         <p className="text-sm text-amber-600">

--- a/apps/web-pwa/src/components/bridge/RepresentativeSelector.tsx
+++ b/apps/web-pwa/src/components/bridge/RepresentativeSelector.tsx
@@ -9,6 +9,7 @@
 
 import React from 'react';
 import type { Representative } from '@vh/data-model';
+import { TRUST_MINIMUM } from '@vh/data-model';
 import { useIdentity } from '../../hooks/useIdentity';
 import { findRepresentatives } from '../../store/bridge/representativeDirectory';
 
@@ -33,7 +34,7 @@ export const RepresentativeSelector: React.FC<RepresentativeSelectorProps> = ({ 
   const { identity } = useIdentity();
   const trustScore = identity?.session?.trustScore ?? 0;
 
-  if (trustScore < 0.5) {
+  if (trustScore < TRUST_MINIMUM) {
     return (
       <p data-testid="rep-trust-gate" className="text-sm text-amber-600">
         Trust score ({trustScore.toFixed(2)}) below 0.50 — verify identity to view representatives.

--- a/apps/web-pwa/src/components/docs/ShareModal.tsx
+++ b/apps/web-pwa/src/components/docs/ShareModal.tsx
@@ -11,6 +11,7 @@
  */
 
 import React, { useCallback, useState } from 'react';
+import { TRUST_MINIMUM } from '@vh/data-model';
 
 // ── Types ─────────────────────────────────────────────────────────────
 
@@ -43,7 +44,7 @@ export interface ShareModalProps {
 
 // ── Constants ─────────────────────────────────────────────────────────
 
-const DEFAULT_TRUST_THRESHOLD = 0.5;
+const DEFAULT_TRUST_THRESHOLD = TRUST_MINIMUM;
 const MAX_COLLABORATORS = 10;
 
 // ── Component ─────────────────────────────────────────────────────────

--- a/apps/web-pwa/src/components/hermes/forum/TrustGate.tsx
+++ b/apps/web-pwa/src/components/hermes/forum/TrustGate.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { TRUST_MINIMUM } from '@vh/data-model';
 import { useIdentity } from '../../../hooks/useIdentity';
 
 interface Props {
@@ -9,7 +10,7 @@ interface Props {
 export const TrustGate: React.FC<Props> = ({ children, fallback }) => {
   const { identity } = useIdentity();
   const trustScore = identity?.session?.trustScore ?? 0;
-  if (trustScore < 0.5) {
+  if (trustScore < TRUST_MINIMUM) {
     return (
       <>
         {fallback ?? (

--- a/apps/web-pwa/src/hooks/useGovernance.ts
+++ b/apps/web-pwa/src/hooks/useGovernance.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { create } from 'zustand';
-import { CURATED_PROJECTS } from '@vh/data-model';
+import { CURATED_PROJECTS, TRUST_ELEVATED } from '@vh/data-model';
 import { isE2EMode } from '../store';
 import { useXpLedger } from '../store/xpLedger';
 
@@ -27,7 +27,7 @@ type StoredVote = { amount: number; direction: 'for' | 'against' };
 type StoredVotes = Record<string, StoredVote>;
 
 const VOTE_STORAGE_KEY = 'vh_governance_votes';
-export const MIN_TRUST_TO_VOTE = 0.7;
+export const MIN_TRUST_TO_VOTE = TRUST_ELEVATED;
 
 const seedProposals: Proposal[] = [
   {

--- a/apps/web-pwa/src/hooks/useIdentity.ts
+++ b/apps/web-pwa/src/hooks/useIdentity.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { IdentityRecord } from '@vh/types';
+import { TRUST_MINIMUM } from '@vh/data-model';
 import { SEA, createSession } from '@vh/gun-client';
 import { authenticateGunUser, publishDirectoryEntry, useAppStore } from '../store';
 import { getHandleError, isValidHandle } from '../utils/handle';
@@ -112,7 +113,7 @@ export function useIdentity() {
         }
       }
 
-      if (session.trustScore < 0.5) {
+      if (session.trustScore < TRUST_MINIMUM) {
         throw new Error('Security Error: Low Trust Device');
       }
 

--- a/apps/web-pwa/src/routes/WalletPanel.tsx
+++ b/apps/web-pwa/src/routes/WalletPanel.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useState, useEffect } from 'react';
 import { Button } from '@vh/ui';
+import { TRUST_MINIMUM } from '@vh/data-model';
 import { useWallet } from '../hooks/useWallet';
 import { useIdentity } from '../hooks/useIdentity';
 import { useXpLedger } from '../store/xpLedger';
@@ -67,7 +68,7 @@ export const WalletPanel: React.FC = () => {
     identity?.session?.trustScore ??
     (identity?.session?.scaledTrustScore != null ? identity.session.scaledTrustScore / 10000 : undefined);
   const eligibleLocal =
-    trustScoreFloat != null && trustScoreFloat >= 0.5 && (localNextClaimAt === 0 || localNextClaimAt * 1000 <= Date.now());
+    trustScoreFloat != null && trustScoreFloat >= TRUST_MINIMUM && (localNextClaimAt === 0 || localNextClaimAt * 1000 <= Date.now());
   const nextClaimLabel = useMemo(() => formatNextClaimLabel(claimStatus), [claimStatus]);
   // Prefer local identity trust score, fallback to wallet/chain trust score
   const trustLabel = useMemo(() => {

--- a/apps/web-pwa/src/routes/dashboardContent.tsx
+++ b/apps/web-pwa/src/routes/dashboardContent.tsx
@@ -1,5 +1,6 @@
 import React, { Suspense, lazy, useEffect, useState } from 'react';
 import { Button } from '@vh/ui';
+import { TRUST_MINIMUM, TRUST_ELEVATED } from '@vh/data-model';
 import { useAI, type AnalysisResult } from '@vh/ai-engine';
 import { useAppStore } from '../store';
 import { useIdentity } from '../hooks/useIdentity';
@@ -175,17 +176,17 @@ export const DashboardContent: React.FC = () => {
         <div className="space-y-3">
           <div className="flex flex-wrap items-center gap-3 text-sm text-slate-600">
             <span className="rounded-full bg-emerald-100 px-3 py-1 text-emerald-700">Connected to mesh</span>
-            {identity?.session?.trustScore != null && identity.session.trustScore >= 0.7 && (
+            {identity?.session?.trustScore != null && identity.session.trustScore >= TRUST_ELEVATED && (
               <span className="rounded-full bg-emerald-100 px-3 py-1 text-emerald-700" data-testid="identity-badge">
                 Verified
               </span>
             )}
-            {identity?.session?.trustScore != null && identity.session.trustScore >= 0.5 && identity.session.trustScore < 0.7 && (
+            {identity?.session?.trustScore != null && identity.session.trustScore >= TRUST_MINIMUM && identity.session.trustScore < TRUST_ELEVATED && (
               <span className="rounded-full bg-amber-100 px-3 py-1 text-amber-700" data-testid="identity-badge">
                 Attested
               </span>
             )}
-            {identity?.session?.trustScore != null && identity.session.trustScore < 0.5 && (
+            {identity?.session?.trustScore != null && identity.session.trustScore < TRUST_MINIMUM && (
               <span className="rounded-full bg-slate-100 px-3 py-1 text-slate-600" data-testid="identity-badge">
                 Limited
               </span>

--- a/apps/web-pwa/src/store/forum/types.ts
+++ b/apps/web-pwa/src/store/forum/types.ts
@@ -1,8 +1,9 @@
 import type { HermesComment, HermesThread, IdentityRecord } from '@vh/types';
 import type { VennClient } from '@vh/gun-client';
+import { TRUST_MINIMUM } from '@vh/data-model';
 
 export const VOTES_KEY_PREFIX = 'vh_forum_votes:';
-export const TRUST_THRESHOLD = 0.5;
+export const TRUST_THRESHOLD = TRUST_MINIMUM;
 export const SEEN_TTL_MS = 60_000;
 export const SEEN_CLEANUP_THRESHOLD = 100;
 

--- a/apps/web-pwa/src/store/xpLedger.ts
+++ b/apps/web-pwa/src/store/xpLedger.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import type { BudgetActionKey, BudgetCheckResult, NullifierBudget } from '@vh/types';
+import { TRUST_MINIMUM } from '@vh/data-model';
 import { getPublishedIdentity } from './identityProvider';
 import { safeGetItem, safeSetItem } from '../utils/safeStorage';
 import { checkBudget, consumeFromBudget, ensureBudget, todayISO, validateBudgetOrNull } from './xpLedgerBudget';
@@ -316,7 +317,7 @@ export const useXpLedger = create<XpLedgerState>((set, get) => ({
     return clampRvu(get().totalXP * (scaled / 10000));
   },
   claimDailyBoost(trustScore) {
-    if (clampTrust(trustScore) < 0.5) return 0;
+    if (clampTrust(trustScore) < TRUST_MINIMUM) return 0;
     const rvMint = DAILY_BOOST_RVU;
     get().addXp('civic', rvMint);
     return rvMint;

--- a/packages/data-model/src/constants/trust.test.ts
+++ b/packages/data-model/src/constants/trust.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import {
+  TRUST_MINIMUM,
+  TRUST_ELEVATED,
+  TRUST_MINIMUM_SCALED,
+  TRUST_ELEVATED_SCALED,
+} from './trust';
+
+describe('trust constants', () => {
+  it('TRUST_MINIMUM is 0.5', () => {
+    expect(TRUST_MINIMUM).toBe(0.5);
+  });
+
+  it('TRUST_ELEVATED is 0.7', () => {
+    expect(TRUST_ELEVATED).toBe(0.7);
+  });
+
+  it('TRUST_MINIMUM_SCALED is 5000', () => {
+    expect(TRUST_MINIMUM_SCALED).toBe(5000);
+  });
+
+  it('TRUST_ELEVATED_SCALED is 7000', () => {
+    expect(TRUST_ELEVATED_SCALED).toBe(7000);
+  });
+
+  it('scaled values are 10000× float values', () => {
+    expect(TRUST_MINIMUM_SCALED).toBe(TRUST_MINIMUM * 10000);
+    expect(TRUST_ELEVATED_SCALED).toBe(TRUST_ELEVATED * 10000);
+  });
+
+  it('TRUST_MINIMUM < TRUST_ELEVATED', () => {
+    expect(TRUST_MINIMUM).toBeLessThan(TRUST_ELEVATED);
+  });
+
+  it('all values are finite numbers', () => {
+    for (const v of [TRUST_MINIMUM, TRUST_ELEVATED, TRUST_MINIMUM_SCALED, TRUST_ELEVATED_SCALED]) {
+      expect(Number.isFinite(v)).toBe(true);
+    }
+  });
+});

--- a/packages/data-model/src/constants/trust.ts
+++ b/packages/data-model/src/constants/trust.ts
@@ -1,0 +1,18 @@
+/**
+ * Canonical trust thresholds for Season 0.
+ *
+ * Spec: spec-identity-trust-constituency.md §4 (Trust Tiers)
+ *
+ * ALL gated surfaces MUST import from this module.
+ * Do NOT hardcode trust threshold values elsewhere.
+ */
+
+/** Minimum trust score (0–1) for session creation, forum access, bridge access, UBE/faucet, rep browsing, draft civic actions. */
+export const TRUST_MINIMUM = 0.5;
+
+/** Elevated trust score (0–1) for governance votes, civic action send/finalize, and verified tier display. */
+export const TRUST_ELEVATED = 0.7;
+
+/** Scaled equivalents (trustScore × 10 000) for on-chain / integer comparisons. */
+export const TRUST_MINIMUM_SCALED = 5000;
+export const TRUST_ELEVATED_SCALED = 7000;

--- a/packages/data-model/src/index.ts
+++ b/packages/data-model/src/index.ts
@@ -1,4 +1,5 @@
 export * from './schemas';
+export * from './constants/trust';
 export type Profile = import('zod').infer<typeof import('./schemas').ProfileSchema>;
 export type Message = import('zod').infer<typeof import('./schemas').MessageSchema>;
 export type Analysis = import('zod').infer<typeof import('./schemas').AnalysisSchema>;


### PR DESCRIPTION
## Wave-4 Phase-1: TRUST_THRESHOLDS Consolidation

### Objective
Extract all hardcoded trust threshold references into a single canonical module at `packages/data-model/src/constants/trust.ts` and replace all call sites with imports from the new module.

### Contract
- **NO BEHAVIOR CHANGE** — pure mechanical refactor
- All 2518 tests pass (7 new + 2511 existing)
- Zero test modifications required

### New Module
| Constant | Value | Usage |
|----------|-------|-------|
| TRUST_MINIMUM | 0.5 | Session creation, forum, bridge, UBE, rep browsing |
| TRUST_ELEVATED | 0.7 | Governance votes, civic action send, verified tier |
| TRUST_MINIMUM_SCALED | 5000 | On-chain / integer comparisons |
| TRUST_ELEVATED_SCALED | 7000 | On-chain / integer comparisons |

### Migration Manifest (11 call sites — ALL COMPLETE)
- [x] useIdentity.ts:115
- [x] TrustGate.tsx:12
- [x] BridgeLayout.tsx:49
- [x] RepresentativeSelector.tsx:36
- [x] ActionComposer.tsx:73,75,167
- [x] ShareModal.tsx:46
- [x] WalletPanel.tsx:70
- [x] forum/types.ts:5
- [x] xpLedger.ts:319
- [x] useGovernance.ts:30
- [x] dashboardContent.tsx:178-188

### Additional Site Discovered (NOT modified per stop conditions)
packages/gun-client/src/auth.ts:23 — data.trustScore < 0.5. Outside manifest. Requires coordinator approval.

### Spec: spec-identity-trust-constituency.md §4 (Trust Tiers)
### CE: dual-review AGREED (ce-codex + ce-opus)