### PR TITLE
refactor(wave4-phase1b): use TRUST_MINIMUM in gun-client auth guard

### DIFF
--- a/packages/gun-client/src/auth.ts
+++ b/packages/gun-client/src/auth.ts
@@ -1,4 +1,5 @@
 import type { AttestationPayload, SessionResponse } from '@vh/types';
+import { TRUST_MINIMUM } from '@vh/data-model';
 
 export interface Session extends SessionResponse {}
 
@@ -20,7 +21,7 @@ export async function createSession(
   }
 
   const data = (await res.json()) as SessionResponse;
-  if (typeof data.trustScore !== 'number' || data.trustScore < 0.5) {
+  if (typeof data.trustScore !== 'number' || data.trustScore < TRUST_MINIMUM) {
     throw new Error('Security Error: Low Trust Device');
   }
 


### PR DESCRIPTION
Phase-1b follow-up: replace hardcoded 0.5 in `packages/gun-client/src/auth.ts:23` with `TRUST_MINIMUM` from `@vh/data-model`.

Extra site discovered by w1a-chief audit during Phase-1. Approved for immediate Phase-1b scope expansion.

- 1 file, +2/-1 lines
- 2518 tests pass, zero modifications
- No behavior change

Spec: spec-identity-trust-constituency.md §4