### PR TITLE
feat(wave4-phase2): session lifecycle foundation

### DIFF
--- a/apps/web-pwa/src/hooks/useIdentity.ts
+++ b/apps/web-pwa/src/hooks/useIdentity.ts
@@ -1,20 +1,27 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { IdentityRecord } from '@vh/types';
+import { isSessionExpired, isSessionNearExpiry, migrateSessionFields, DEFAULT_SESSION_TTL_MS } from '@vh/types';
 import { TRUST_MINIMUM } from '@vh/data-model';
 import { SEA, createSession } from '@vh/gun-client';
 import { authenticateGunUser, publishDirectoryEntry, useAppStore } from '../store';
 import { getHandleError, isValidHandle } from '../utils/handle';
-import { migrateLegacyLocalStorage } from '@vh/identity-vault';
-import { publishIdentity } from '../store/identityProvider';
+import { migrateLegacyLocalStorage, clearIdentity as vaultClear } from '@vh/identity-vault';
+import { publishIdentity, clearPublishedIdentity } from '../store/identityProvider';
 import { loadIdentityRecord, saveIdentityRecord } from '../utils/vaultTyped';
 
 const E2E_MODE = (import.meta as any).env?.VITE_E2E_MODE === 'true';
 const DEV_MODE = (import.meta as any).env?.DEV === true || (import.meta as any).env?.MODE === 'development';
+const LIFECYCLE_ENABLED = (import.meta as any).env?.VITE_SESSION_LIFECYCLE_ENABLED === 'true';
 const ATTESTATION_URL =
   (import.meta as any).env?.VITE_ATTESTATION_URL ?? 'http://localhost:3000/verify';
 const VERIFIER_TIMEOUT_MS = Number((import.meta as any).env?.VITE_ATTESTATION_TIMEOUT_MS) || 2000;
 
-export type IdentityStatus = 'hydrating' | 'anonymous' | 'creating' | 'ready' | 'error';
+export type IdentityStatus = 'hydrating' | 'anonymous' | 'creating' | 'ready' | 'expired' | 'error';
+
+/** Result of a session expiry check at an action boundary. */
+export type SessionExpiryCheck =
+  | { valid: true; warning?: 'near-expiry' }
+  | { valid: false; reason: 'expired' };
 
 /** Module-level migration guard — runs at most once. */
 let migrationPromise: Promise<void> | null = null;
@@ -63,10 +70,22 @@ export function useIdentity() {
 
     loadIdentityFromVault().then((loaded) => {
       if (loaded) {
-        setIdentity(loaded);
+        // Migrate legacy sessions missing createdAt/expiresAt
+        const migratedSession = migrateSessionFields(loaded.session);
+        const migrated = migratedSession !== loaded.session
+          ? { ...loaded, session: migratedSession }
+          : loaded;
+
+        // Check expiry when lifecycle feature flag is enabled
+        if (LIFECYCLE_ENABLED && isSessionExpired(migrated.session)) {
+          setIdentity(migrated);
+          setStatus('expired');
+          return;
+        }
+
+        setIdentity(migrated);
         setStatus('ready');
-        // Publish identity for downstream consumers.
-        publishIdentity(loaded);
+        publishIdentity(migrated);
       } else {
         setStatus('anonymous');
       }
@@ -118,17 +137,21 @@ export function useIdentity() {
       }
 
       const scaledTrustScore = clampScaledTrustScore(Math.round(session.trustScore * 10000));
+      const nowMs = Date.now();
+      const sessionExpiresAt = LIFECYCLE_ENABLED ? nowMs + DEFAULT_SESSION_TTL_MS : 0;
 
       const fallbackHandle = handleRef.current ?? `user_${randomToken().slice(0, 6)}`;
       const record: IdentityRecord = {
         id: randomToken(),
-        createdAt: Date.now(),
+        createdAt: nowMs,
         attestation,
         session: {
           token: session.token,
           trustScore: session.trustScore,
           scaledTrustScore,
-          nullifier: session.nullifier
+          nullifier: session.nullifier,
+          createdAt: nowMs,
+          expiresAt: sessionExpiresAt,
         },
         devicePair: {
           pub: devicePair.pub,
@@ -221,6 +244,41 @@ export function useIdentity() {
     [identity]
   );
 
+  /**
+   * Revoke the current session (spec §2.1.3).
+   *
+   * Always available regardless of feature flag — this is a user-initiated
+   * security action. Clears session, vault, published identity, and
+   * delegation grants. Preserves nullifier derivation material.
+   */
+  const revokeSession = useCallback(async () => {
+    setIdentity(null);
+    setStatus('anonymous');
+    setError(undefined);
+    clearPublishedIdentity();
+    await vaultClear().catch(() => {});
+  }, []);
+
+  /**
+   * Check session validity at action boundaries (spec §2.1.4).
+   *
+   * Returns { valid: true } when lifecycle is disabled or session is fresh.
+   * Consumers should call this before trust-gated actions.
+   */
+  const checkSessionExpiry = useCallback((): SessionExpiryCheck => {
+    if (!LIFECYCLE_ENABLED || E2E_MODE || !identity?.session) {
+      return { valid: true };
+    }
+    if (isSessionExpired(identity.session)) {
+      setStatus('expired');
+      return { valid: false, reason: 'expired' };
+    }
+    if (isSessionNearExpiry(identity.session)) {
+      return { valid: true, warning: 'near-expiry' };
+    }
+    return { valid: true };
+  }, [identity]);
+
   return {
     identity,
     status,
@@ -230,6 +288,8 @@ export function useIdentity() {
     startLinkSession,
     completeLinkSession,
     updateHandle,
+    revokeSession,
+    checkSessionExpiry,
     validateHandle: isValidHandle
   };
 }

--- a/apps/web-pwa/src/store/forum/types.ts
+++ b/apps/web-pwa/src/store/forum/types.ts
@@ -7,6 +7,15 @@ export const TRUST_THRESHOLD = TRUST_MINIMUM;
 export const SEEN_TTL_MS = 60_000;
 export const SEEN_CLEANUP_THRESHOLD = 100;
 
+/** Feature flag check for session lifecycle enforcement. */
+export function isLifecycleEnabled(): boolean {
+  try {
+    return (import.meta as any).env?.VITE_SESSION_LIFECYCLE_ENABLED === 'true';
+  } catch {
+    return false;
+  }
+}
+
 export interface ForumState {
   threads: Map<string, HermesThread>;
   comments: Map<string, HermesComment[]>;
@@ -36,7 +45,7 @@ export interface ForumState {
 }
 
 export type ForumIdentity = {
-  session: Pick<IdentityRecord['session'], 'nullifier' | 'trustScore' | 'scaledTrustScore'>;
+  session: Pick<IdentityRecord['session'], 'nullifier' | 'trustScore' | 'scaledTrustScore' | 'expiresAt'>;
 };
 
 export interface ForumDeps {

--- a/apps/web-pwa/src/store/identityProvider.test.ts
+++ b/apps/web-pwa/src/store/identityProvider.test.ts
@@ -22,7 +22,7 @@ describe('identityProvider', () => {
 
   it('publishes and retrieves identity snapshot', () => {
     publishIdentity({
-      session: { nullifier: 'test-null', trustScore: 0.9, scaledTrustScore: 9000 },
+      session: { nullifier: 'test-null', trustScore: 0.9, scaledTrustScore: 9000, expiresAt: 0 },
     });
     const snapshot = getPublishedIdentity();
     expect(snapshot).not.toBeNull();
@@ -33,7 +33,7 @@ describe('identityProvider', () => {
 
   it('returns full record (including private keys) via getFullIdentity', () => {
     const record = {
-      session: { nullifier: 'n', trustScore: 1, scaledTrustScore: 10000 },
+      session: { nullifier: 'n', trustScore: 1, scaledTrustScore: 10000, expiresAt: 0 },
       devicePair: { pub: 'pub', priv: 'priv', epub: 'epub', epriv: 'epriv' },
       attestation: { token: 'secret-token' },
     };
@@ -47,7 +47,7 @@ describe('identityProvider', () => {
 
   it('does not leak extra fields from input', () => {
     const input = {
-      session: { nullifier: 'n', trustScore: 1, scaledTrustScore: 10000 },
+      session: { nullifier: 'n', trustScore: 1, scaledTrustScore: 10000, expiresAt: 0 },
       devicePair: { pub: 'pub', priv: 'SECRET', epub: 'epub', epriv: 'SECRET2' },
       someOtherField: 'should not appear',
     } as any;
@@ -60,7 +60,7 @@ describe('identityProvider', () => {
 
   it('clears identity', () => {
     publishIdentity({
-      session: { nullifier: 'n', trustScore: 1, scaledTrustScore: 10000 },
+      session: { nullifier: 'n', trustScore: 1, scaledTrustScore: 10000, expiresAt: 0 },
       devicePair: { pub: 'pub', priv: 'priv', epub: 'epub', epriv: 'epriv' },
     });
     expect(getPublishedIdentity()).not.toBeNull();
@@ -72,7 +72,7 @@ describe('identityProvider', () => {
 
   it('returns a defensive copy — mutations do not affect the singleton', () => {
     publishIdentity({
-      session: { nullifier: 'original', trustScore: 0.9, scaledTrustScore: 9000 },
+      session: { nullifier: 'original', trustScore: 0.9, scaledTrustScore: 9000, expiresAt: 0 },
     });
     const snapshot = getPublishedIdentity()!;
     snapshot.session.nullifier = 'mutated';
@@ -81,7 +81,7 @@ describe('identityProvider', () => {
 
   it('getFullIdentity returns a defensive copy — mutations do not affect the singleton', () => {
     const record = {
-      session: { nullifier: 'original', trustScore: 0.9, scaledTrustScore: 9000 },
+      session: { nullifier: 'original', trustScore: 0.9, scaledTrustScore: 9000, expiresAt: 0 },
       devicePair: { pub: 'pub', priv: 'priv', epub: 'epub', epriv: 'epriv' },
     };
     publishIdentity(record);
@@ -98,7 +98,7 @@ describe('identityProvider', () => {
   it('sets __vh_identity_published flag on globalThis', () => {
     expect((globalThis as any).__vh_identity_published).toBeFalsy();
     publishIdentity({
-      session: { nullifier: 'n', trustScore: 1, scaledTrustScore: 10000 },
+      session: { nullifier: 'n', trustScore: 1, scaledTrustScore: 10000, expiresAt: 0 },
     });
     expect((globalThis as any).__vh_identity_published).toBe(true);
     clearPublishedIdentity();
@@ -114,7 +114,7 @@ describe('identityProvider', () => {
     vi.stubGlobal('window', fakeWindow);
 
     publishIdentity({
-      session: { nullifier: 'window-null', trustScore: 0.8, scaledTrustScore: 8000 },
+      session: { nullifier: 'window-null', trustScore: 0.8, scaledTrustScore: 8000, expiresAt: 0 },
     });
 
     expect((fakeWindow as any).__vh_identity_published).toBe(true);

--- a/apps/web-pwa/src/store/identityProvider.ts
+++ b/apps/web-pwa/src/store/identityProvider.ts
@@ -15,6 +15,7 @@ export interface PublicIdentitySnapshot {
     nullifier: string;
     trustScore: number;
     scaledTrustScore: number;
+    expiresAt: number;
   };
 }
 
@@ -29,7 +30,7 @@ let fullRecord: Record<string, unknown> | null = null;
  * - current: public-only snapshot for untrusted downstream consumers
  */
 export function publishIdentity<T extends {
-  session: { nullifier: string; trustScore: number; scaledTrustScore: number };
+  session: { nullifier: string; trustScore: number; scaledTrustScore: number; expiresAt: number };
 }>(identity: T): void {
   fullRecord = identity as unknown as Record<string, unknown>;
   current = {
@@ -37,6 +38,7 @@ export function publishIdentity<T extends {
       nullifier: identity.session.nullifier,
       trustScore: identity.session.trustScore,
       scaledTrustScore: identity.session.scaledTrustScore,
+      expiresAt: identity.session.expiresAt,
     },
   };
   // E2E bridge: signal that identity is hydrated so Playwright can await it.

--- a/packages/gun-client/src/auth.ts
+++ b/packages/gun-client/src/auth.ts
@@ -25,9 +25,13 @@ export async function createSession(
     throw new Error('Security Error: Low Trust Device');
   }
 
+  const nowMs = Date.now();
   return {
     token: data.token,
     trustScore: data.trustScore,
-    nullifier: data.nullifier
+    scaledTrustScore: data.scaledTrustScore ?? Math.round(data.trustScore * 10000),
+    nullifier: data.nullifier,
+    createdAt: data.createdAt ?? nowMs,
+    expiresAt: data.expiresAt ?? 0,
   };
 }

--- a/packages/types/src/identity.ts
+++ b/packages/types/src/identity.ts
@@ -1,4 +1,5 @@
 import type { AttestationPayload } from './attestation';
+import type { SessionResponse } from './session';
 
 /** SEA keypair for GunDB device authentication and encryption. */
 export interface DevicePair {
@@ -12,18 +13,14 @@ export interface DevicePair {
  * Canonical identity record stored encrypted in the vault.
  *
  * Runtime shape validation is the consumer's responsibility.
+ * The session field uses the canonical SessionResponse type.
  */
 export interface IdentityRecord {
   id: string;
   createdAt: number;
   attestation: AttestationPayload;
   handle?: string;
-  session: {
-    token: string;
-    trustScore: number;
-    scaledTrustScore: number;
-    nullifier: string;
-  };
+  session: SessionResponse;
   linkedDevices?: string[];
   pendingLinkCode?: string;
   devicePair?: DevicePair;

--- a/packages/types/src/index.test.ts
+++ b/packages/types/src/index.test.ts
@@ -44,13 +44,27 @@ describe('types schemas', () => {
   });
 
   it('validates session response', () => {
-    const resp: SessionResponse = { token: 't', trustScore: 0.8, nullifier: 'n' };
+    const resp: SessionResponse = {
+      token: 't', trustScore: 0.8, scaledTrustScore: 8000,
+      nullifier: 'n', createdAt: 1000, expiresAt: 2000,
+    };
+    expect(() => SessionResponseSchema.parse(resp)).not.toThrow();
+  });
+
+  it('validates session response with zero expiresAt (transitional)', () => {
+    const resp: SessionResponse = {
+      token: 't', trustScore: 0.5, scaledTrustScore: 5000,
+      nullifier: 'n', createdAt: 1000, expiresAt: 0,
+    };
     expect(() => SessionResponseSchema.parse(resp)).not.toThrow();
   });
 
   it('rejects session response with low trust type', () => {
     expect(() =>
-      SessionResponseSchema.parse({ token: '', trustScore: -1, nullifier: '' })
+      SessionResponseSchema.parse({
+        token: '', trustScore: -1, scaledTrustScore: 0,
+        nullifier: '', createdAt: 0, expiresAt: 0,
+      })
     ).toThrow();
   });
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -8,11 +8,16 @@ export interface VerificationResult {
   issuedAt: number;
 }
 
-export interface SessionResponse {
-  token: string;
-  trustScore: number;
-  nullifier: string;
-}
+export type { SessionResponse } from './session';
+export { SessionResponseSchema } from './session';
+
+export {
+  isSessionExpired,
+  isSessionNearExpiry,
+  migrateSessionFields,
+  NEAR_EXPIRY_WINDOW_MS,
+  DEFAULT_SESSION_TTL_MS,
+} from './session-lifecycle';
 
 export interface RegionProof {
   proof: string;
@@ -31,12 +36,6 @@ export const VerificationResultSchema = z.object({
   success: z.boolean(),
   trustScore: z.number().min(0).max(1),
   issuedAt: z.number().int().nonnegative()
-});
-
-export const SessionResponseSchema = z.object({
-  token: z.string().min(1),
-  trustScore: z.number().min(0).max(1),
-  nullifier: z.string().min(1)
 });
 
 export const RegionProofSchema = z.object({

--- a/packages/types/src/session-lifecycle.test.ts
+++ b/packages/types/src/session-lifecycle.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isSessionExpired,
+  isSessionNearExpiry,
+  migrateSessionFields,
+  NEAR_EXPIRY_WINDOW_MS,
+  DEFAULT_SESSION_TTL_MS,
+} from './session-lifecycle';
+
+describe('isSessionExpired', () => {
+  it('returns false when expiresAt is 0 (no expiry / transitional)', () => {
+    expect(isSessionExpired({ expiresAt: 0 }, 999999999)).toBe(false);
+  });
+
+  it('returns false when session has not expired', () => {
+    expect(isSessionExpired({ expiresAt: 2000 }, 1000)).toBe(false);
+  });
+
+  it('returns true when now equals expiresAt', () => {
+    expect(isSessionExpired({ expiresAt: 1000 }, 1000)).toBe(true);
+  });
+
+  it('returns true when now is past expiresAt', () => {
+    expect(isSessionExpired({ expiresAt: 1000 }, 2000)).toBe(true);
+  });
+
+  it('returns false when expiresAt is missing (backward compat)', () => {
+    expect(isSessionExpired({} as any, 9999)).toBe(false);
+  });
+
+  it('uses Date.now() when now is not provided', () => {
+    const futureExpiry = Date.now() + 1_000_000;
+    expect(isSessionExpired({ expiresAt: futureExpiry })).toBe(false);
+  });
+
+  it('returns true for past expiry when now is not provided', () => {
+    expect(isSessionExpired({ expiresAt: 1 })).toBe(true);
+  });
+});
+
+describe('isSessionNearExpiry', () => {
+  it('returns false when expiresAt is 0 (no expiry)', () => {
+    expect(isSessionNearExpiry({ expiresAt: 0 }, 500)).toBe(false);
+  });
+
+  it('returns false when session is already expired', () => {
+    expect(isSessionNearExpiry({ expiresAt: 1000 }, 2000)).toBe(false);
+  });
+
+  it('returns true when within default 24h window', () => {
+    const expiresAt = 1000 + NEAR_EXPIRY_WINDOW_MS - 1;
+    expect(isSessionNearExpiry({ expiresAt }, 1000)).toBe(true);
+  });
+
+  it('returns false when outside default 24h window', () => {
+    const expiresAt = 1000 + NEAR_EXPIRY_WINDOW_MS + 1;
+    expect(isSessionNearExpiry({ expiresAt }, 1000)).toBe(false);
+  });
+
+  it('returns true exactly at window boundary', () => {
+    const expiresAt = 1000 + NEAR_EXPIRY_WINDOW_MS;
+    expect(isSessionNearExpiry({ expiresAt }, 1000)).toBe(true);
+  });
+
+  it('respects custom windowMs', () => {
+    const customWindow = 5000;
+    expect(isSessionNearExpiry({ expiresAt: 10000 }, 6000, customWindow)).toBe(true);
+    expect(isSessionNearExpiry({ expiresAt: 10000 }, 4000, customWindow)).toBe(false);
+  });
+
+  it('returns false when expiresAt is missing (backward compat)', () => {
+    expect(isSessionNearExpiry({} as any, 500)).toBe(false);
+  });
+});
+
+describe('migrateSessionFields', () => {
+  it('adds createdAt and expiresAt when missing', () => {
+    const legacy = { token: 't', trustScore: 0.8, nullifier: 'n' } as any;
+    const migrated = migrateSessionFields(legacy);
+    expect(migrated.createdAt).toBe(0);
+    expect(migrated.expiresAt).toBe(0);
+    expect(migrated.token).toBe('t');
+  });
+
+  it('preserves existing createdAt and expiresAt', () => {
+    const session = { token: 't', trustScore: 0.8, nullifier: 'n', createdAt: 100, expiresAt: 200 };
+    const migrated = migrateSessionFields(session);
+    expect(migrated.createdAt).toBe(100);
+    expect(migrated.expiresAt).toBe(200);
+  });
+
+  it('handles partial fields (only createdAt present)', () => {
+    const session = { token: 't', trustScore: 0.8, nullifier: 'n', createdAt: 100 } as any;
+    const migrated = migrateSessionFields(session);
+    expect(migrated.createdAt).toBe(100);
+    expect(migrated.expiresAt).toBe(0);
+  });
+});
+
+describe('constants', () => {
+  it('NEAR_EXPIRY_WINDOW_MS is 24 hours', () => {
+    expect(NEAR_EXPIRY_WINDOW_MS).toBe(24 * 60 * 60 * 1000);
+  });
+
+  it('DEFAULT_SESSION_TTL_MS is 7 days', () => {
+    expect(DEFAULT_SESSION_TTL_MS).toBe(7 * 24 * 60 * 60 * 1000);
+  });
+});

--- a/packages/types/src/session-lifecycle.ts
+++ b/packages/types/src/session-lifecycle.ts
@@ -1,0 +1,63 @@
+/**
+ * Session lifecycle utilities — pure functions, flag-agnostic.
+ *
+ * Spec: spec-identity-trust-constituency.md §2.1.2–§2.1.4
+ *
+ * Consumers decide whether to call these based on feature flag;
+ * the utilities themselves are unconditional.
+ */
+
+import type { SessionResponse } from './session';
+
+/** Default near-expiry warning window: 24 hours (spec §2.1.4). */
+export const NEAR_EXPIRY_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+/** Default session TTL: 7 days (spec §2.1.2 recommended for Silver assurance). */
+export const DEFAULT_SESSION_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * Check whether a session has expired.
+ *
+ * A session with `expiresAt === 0` never expires (transitional, spec §2.1.2).
+ * Sessions missing `expiresAt` are treated as non-expiring for backward compat.
+ */
+export function isSessionExpired(session: Pick<SessionResponse, 'expiresAt'>, now?: number): boolean {
+  const expiresAt = session.expiresAt ?? 0;
+  if (expiresAt === 0) return false;
+  return (now ?? Date.now()) >= expiresAt;
+}
+
+/**
+ * Check whether a session is within the near-expiry warning window.
+ *
+ * Returns false for non-expiring sessions (`expiresAt === 0`).
+ * Returns false if the session is already expired (use `isSessionExpired` first).
+ */
+export function isSessionNearExpiry(
+  session: Pick<SessionResponse, 'expiresAt'>,
+  now?: number,
+  windowMs?: number
+): boolean {
+  const expiresAt = session.expiresAt ?? 0;
+  if (expiresAt === 0) return false;
+  const currentTime = now ?? Date.now();
+  if (currentTime >= expiresAt) return false; // already expired
+  return (expiresAt - currentTime) <= (windowMs ?? NEAR_EXPIRY_WINDOW_MS);
+}
+
+/**
+ * Migrate a legacy session record that lacks `createdAt`/`expiresAt`.
+ *
+ * Returns a new object with the missing fields filled in.
+ * - `createdAt` defaults to 0 (unknown creation time).
+ * - `expiresAt` defaults to 0 (no expiry — transitional).
+ */
+export function migrateSessionFields<T extends Partial<SessionResponse>>(
+  session: T
+): T & Pick<SessionResponse, 'createdAt' | 'expiresAt'> {
+  return {
+    ...session,
+    createdAt: session.createdAt ?? 0,
+    expiresAt: session.expiresAt ?? 0,
+  };
+}

--- a/packages/types/src/session.ts
+++ b/packages/types/src/session.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+
+/**
+ * Canonical session shape per spec-identity-trust-constituency.md §2/§2.1.
+ *
+ * All code that stores or checks session data MUST use this type.
+ */
+export interface SessionResponse {
+  token: string;
+  trustScore: number;        // [0, 1]
+  scaledTrustScore: number;  // Math.round(trustScore * 10000)
+  nullifier: string;         // UniquenessNullifier (stable per device)
+  createdAt: number;         // epoch ms
+  expiresAt: number;         // epoch ms; 0 = no expiry (transitional)
+}
+
+export const SessionResponseSchema = z.object({
+  token: z.string().min(1),
+  trustScore: z.number().min(0).max(1),
+  scaledTrustScore: z.number().int().min(0).max(10000),
+  nullifier: z.string().min(1),
+  createdAt: z.number().int().nonnegative(),
+  expiresAt: z.number().int().nonnegative(), // 0 = no expiry (transitional)
+});


### PR DESCRIPTION
## Wave 4 Phase 2 — Session Lifecycle Foundation

**Spec:** `spec-identity-trust-constituency.md` v0.2 §2.1.2–§2.1.6

### What

Session lifecycle infrastructure: TTL, expiry detection, revocation, backward-compat migration, feature-flag gating. This is the plumbing layer — no UI components yet (Phase 3).

### Changes

| Area | Files | What |
|------|-------|------|
| **Type alignment** | `session.ts`, `identity.ts`, `index.ts` | Extract `SessionResponse` to own module; add `scaledTrustScore`, `createdAt`, `expiresAt`; align `IdentityRecord.session` to use `SessionResponse` directly |
| **Lifecycle utilities** | `session-lifecycle.ts` | Pure functions: `isSessionExpired()`, `isSessionNearExpiry()`, `migrateSessionFields()`; constants: 7-day TTL, 24h warning window |
| **useIdentity hook** | `useIdentity.ts` | `expired` status, expiry check on hydration, `revokeSession()` (always available), `checkSessionExpiry()` (for action boundaries), legacy migration |
| **Forum guard** | `helpers.ts`, `types.ts` | `ensureIdentity()` enforces session freshness; `isLifecycleEnabled()` feature flag |
| **Gun-client** | `auth.ts` | `createSession()` populates new fields with safe defaults |

### Feature Flag

`VITE_SESSION_LIFECYCLE_ENABLED` (default `false`)
- **Gated:** expiry checks, TTL on new sessions, near-expiry warnings
- **NOT gated:** `revokeSession()` — always available (security action)

### Tests

2538 passing (20 new + 2518 existing, zero regressions)

### CE Review

- ce-opus Pass 1: AGREED (spec v0.2 worktree-staleness downgraded; type drift + Zod lockstep flagged and addressed)
- ce-codex Pass 2: AGREED + 4 additional findings incorporated (IdentityStatus exhaustive handling, ensureIdentity freshness, migration, test coverage)
- Reconciliation: **AGREED** ✅