### PR TITLE
feat(wave4-phase3): constituency proof verification layer

### DIFF
--- a/apps/web-pwa/src/hooks/useIdentity.ts
+++ b/apps/web-pwa/src/hooks/useIdentity.ts
@@ -8,6 +8,7 @@ import { getHandleError, isValidHandle } from '../utils/handle';
 import { migrateLegacyLocalStorage, clearIdentity as vaultClear } from '@vh/identity-vault';
 import { publishIdentity, clearPublishedIdentity } from '../store/identityProvider';
 import { loadIdentityRecord, saveIdentityRecord } from '../utils/vaultTyped';
+import { useSentimentState } from './useSentimentState';
 
 const E2E_MODE = (import.meta as any).env?.VITE_E2E_MODE === 'true';
 const DEV_MODE = (import.meta as any).env?.DEV === true || (import.meta as any).env?.MODE === 'development';
@@ -256,6 +257,8 @@ export function useIdentity() {
     setStatus('anonymous');
     setError(undefined);
     clearPublishedIdentity();
+    // Constituency proof is derived from identity — clearing identity invalidates all proofs (spec §2.1.3)
+    useSentimentState.setState({ signals: [] });
     await vaultClear().catch(() => {});
   }, []);
 

--- a/apps/web-pwa/src/hooks/useRegion.test.ts
+++ b/apps/web-pwa/src/hooks/useRegion.test.ts
@@ -1,0 +1,67 @@
+/* @vitest-environment jsdom */
+
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ConstituencyProof } from '@vh/types';
+
+const useIdentityMock = vi.hoisted(() => vi.fn());
+const getMockConstituencyProofMock = vi.hoisted(() => vi.fn());
+
+vi.mock('./useIdentity', () => ({
+  useIdentity: () => useIdentityMock(),
+}));
+
+vi.mock('../store/bridge/constituencyProof', () => ({
+  getMockConstituencyProof: (...args: unknown[]) =>
+    getMockConstituencyProofMock(...(args as [string, string | undefined])),
+}));
+
+import { useRegion } from './useRegion';
+
+describe('useRegion', () => {
+  beforeEach(() => {
+    useIdentityMock.mockReset();
+    getMockConstituencyProofMock.mockReset();
+    getMockConstituencyProofMock.mockImplementation(
+      (districtHash: string, nullifier?: string): ConstituencyProof => ({
+        district_hash: districtHash,
+        nullifier: nullifier ?? 'mock-nullifier',
+        merkle_root: 'mock-root',
+      }),
+    );
+  });
+
+  it.each([
+    { identity: null },
+    { identity: {} },
+    { identity: { session: {} } },
+  ])('returns null proof when nullifier is unavailable (%j)', ({ identity }) => {
+    useIdentityMock.mockReturnValue({ identity });
+
+    const { result } = renderHook(() => useRegion());
+
+    expect(result.current.proof).toBeNull();
+    expect(getMockConstituencyProofMock).not.toHaveBeenCalled();
+  });
+
+  it('uses centralized proof builder with identity session nullifier', () => {
+    const expectedProof: ConstituencyProof = {
+      district_hash: 'mock-district-hash',
+      nullifier: 'session-nullifier-1',
+      merkle_root: 'mock-root',
+    };
+
+    useIdentityMock.mockReturnValue({
+      identity: { session: { nullifier: 'session-nullifier-1' } },
+    });
+    getMockConstituencyProofMock.mockReturnValue(expectedProof);
+
+    const { result } = renderHook(() => useRegion());
+
+    expect(getMockConstituencyProofMock).toHaveBeenCalledWith(
+      'mock-district-hash',
+      'session-nullifier-1',
+    );
+    expect(result.current.proof).toEqual(expectedProof);
+  });
+});

--- a/apps/web-pwa/src/hooks/useRegion.ts
+++ b/apps/web-pwa/src/hooks/useRegion.ts
@@ -1,6 +1,7 @@
 import { useIdentity } from './useIdentity';
 import type { ConstituencyProof } from '@vh/types';
 import { useMemo } from 'react';
+import { getMockConstituencyProof } from '../store/bridge/constituencyProof';
 
 const MOCK_DISTRICT_HASH = 'mock-district-hash';
 
@@ -9,11 +10,7 @@ export function useRegion(): { proof: ConstituencyProof | null } {
 
   const proof = useMemo(() => {
     if (!identity?.session?.nullifier) return null;
-    return {
-      district_hash: MOCK_DISTRICT_HASH,
-      nullifier: identity.session.nullifier,
-      merkle_root: 'mock-root'
-    };
+    return getMockConstituencyProof(MOCK_DISTRICT_HASH, identity.session.nullifier);
   }, [identity?.session?.nullifier]);
 
   return { proof };

--- a/apps/web-pwa/src/store/bridge/constituencyProof.test.ts
+++ b/apps/web-pwa/src/store/bridge/constituencyProof.test.ts
@@ -1,22 +1,60 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ConstituencyProofSchema } from '@vh/data-model';
-import { getMockConstituencyProof } from './constituencyProof';
+
+async function loadModule() {
+  vi.resetModules();
+  return import('./constituencyProof');
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
 
 describe('getMockConstituencyProof', () => {
-  it('returns a valid ConstituencyProof', () => {
+  it('returns a valid ConstituencyProof', async () => {
+    const { getMockConstituencyProof } = await loadModule();
     const proof = getMockConstituencyProof('hash-ca-11');
     const parsed = ConstituencyProofSchema.safeParse(proof);
+
     expect(parsed.success).toBe(true);
   });
 
-  it('uses the provided districtHash', () => {
-    const proof = getMockConstituencyProof('my-hash');
+  it('uses provided districtHash and nullifier', async () => {
+    const { getMockConstituencyProof } = await loadModule();
+    const proof = getMockConstituencyProof('my-hash', 'my-nullifier');
+
     expect(proof.district_hash).toBe('my-hash');
+    expect(proof.nullifier).toBe('my-nullifier');
+    expect(proof.merkle_root).toBe('mock-root');
   });
 
-  it('returns deterministic mock fields', () => {
+  it('keeps backward compatibility when nullifier is omitted', async () => {
+    const { getMockConstituencyProof } = await loadModule();
     const proof = getMockConstituencyProof('h');
+
     expect(proof.nullifier).toBe('mock-nullifier');
     expect(proof.merkle_root).toBe('mock-root');
+  });
+});
+
+describe('isProofVerificationEnabled', () => {
+  it('returns true when VITE_CONSTITUENCY_PROOF_REAL is true', async () => {
+    vi.stubEnv('VITE_CONSTITUENCY_PROOF_REAL', 'true');
+    const { isProofVerificationEnabled } = await loadModule();
+
+    expect(isProofVerificationEnabled()).toBe(true);
+  });
+
+  it('returns false when VITE_CONSTITUENCY_PROOF_REAL is false', async () => {
+    vi.stubEnv('VITE_CONSTITUENCY_PROOF_REAL', 'false');
+    const { isProofVerificationEnabled } = await loadModule();
+
+    expect(isProofVerificationEnabled()).toBe(false);
+  });
+
+  it('returns false when VITE_CONSTITUENCY_PROOF_REAL is missing', async () => {
+    const { isProofVerificationEnabled } = await loadModule();
+
+    expect(isProofVerificationEnabled()).toBe(false);
   });
 });

--- a/apps/web-pwa/src/store/bridge/constituencyProof.ts
+++ b/apps/web-pwa/src/store/bridge/constituencyProof.ts
@@ -1,20 +1,22 @@
-/**
- * Constituency proof — stub for Phase 3 development.
- *
- * Real proof acquisition deferred to W3-LUMA identity hardening workstream.
- * Spec: spec-civic-action-kit-v0.md §7.2
- */
-
 import type { ConstituencyProof } from '@vh/data-model';
 
-/**
- * Return a mock constituency proof for development/testing.
- * The district_hash matches the provided value to satisfy Zod validation.
- */
-export function getMockConstituencyProof(districtHash: string): ConstituencyProof {
+export function isProofVerificationEnabled(): boolean {
+  try {
+    const importMetaEnv = (import.meta as any).env;
+    const processEnv = (globalThis as any).process?.env;
+    return (importMetaEnv?.VITE_CONSTITUENCY_PROOF_REAL ?? processEnv?.VITE_CONSTITUENCY_PROOF_REAL) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+export function getMockConstituencyProof(
+  districtHash: string,
+  nullifier?: string,
+): ConstituencyProof {
   return {
     district_hash: districtHash,
-    nullifier: 'mock-nullifier',
+    nullifier: nullifier ?? 'mock-nullifier',
     merkle_root: 'mock-root',
   };
 }

--- a/packages/types/src/constituency-verification.test.ts
+++ b/packages/types/src/constituency-verification.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from 'vitest';
+import type { ConstituencyProof } from './index';
+import {
+  type ProofVerificationError,
+  type ProofVerificationResult,
+  verifyConstituencyProof,
+} from './constituency-verification';
+import {
+  verifyConstituencyProof as verifyConstituencyProofFromIndex,
+  type ProofVerificationError as ProofVerificationErrorFromIndex,
+  type ProofVerificationResult as ProofVerificationResultFromIndex,
+} from './index';
+
+const EXPECTED_NULLIFIER = 'nullifier-1';
+const EXPECTED_DISTRICT = 'district-1';
+
+function makeProof(overrides: Partial<ConstituencyProof> = {}): ConstituencyProof {
+  return {
+    district_hash: EXPECTED_DISTRICT,
+    nullifier: EXPECTED_NULLIFIER,
+    merkle_root: 'root-1',
+    ...overrides,
+  };
+}
+
+describe('verifyConstituencyProof', () => {
+  it('returns valid=true for a matching and fresh proof', () => {
+    const result = verifyConstituencyProof(
+      makeProof(),
+      EXPECTED_NULLIFIER,
+      EXPECTED_DISTRICT,
+    );
+
+    expect(result).toEqual({ valid: true });
+  });
+
+  it('returns nullifier_mismatch when proof nullifier differs', () => {
+    const result = verifyConstituencyProof(
+      makeProof({ nullifier: 'other-nullifier' }),
+      EXPECTED_NULLIFIER,
+      EXPECTED_DISTRICT,
+    );
+
+    expect(result).toEqual({ valid: false, error: 'nullifier_mismatch' });
+  });
+
+  it('returns district_mismatch when proof district differs', () => {
+    const result = verifyConstituencyProof(
+      makeProof({ district_hash: 'other-district' }),
+      EXPECTED_NULLIFIER,
+      EXPECTED_DISTRICT,
+    );
+
+    expect(result).toEqual({ valid: false, error: 'district_mismatch' });
+  });
+
+  it.each(['', '   \n\t'])(
+    'returns stale_proof when merkle_root is blank (%j)',
+    (merkleRoot) => {
+      const result = verifyConstituencyProof(
+        makeProof({ merkle_root: merkleRoot }),
+        EXPECTED_NULLIFIER,
+        EXPECTED_DISTRICT,
+      );
+
+      expect(result).toEqual({ valid: false, error: 'stale_proof' });
+    },
+  );
+
+  it('returns malformed_proof for null/undefined proof', () => {
+    expect(
+      verifyConstituencyProof(null, EXPECTED_NULLIFIER, EXPECTED_DISTRICT),
+    ).toEqual({ valid: false, error: 'malformed_proof' });
+
+    expect(
+      verifyConstituencyProof(undefined, EXPECTED_NULLIFIER, EXPECTED_DISTRICT),
+    ).toEqual({ valid: false, error: 'malformed_proof' });
+  });
+
+  it('returns malformed_proof for missing required fields', () => {
+    const missingDistrict = {
+      nullifier: EXPECTED_NULLIFIER,
+      merkle_root: 'root-1',
+    } as ConstituencyProof;
+
+    const missingNullifier = {
+      district_hash: EXPECTED_DISTRICT,
+      merkle_root: 'root-1',
+    } as ConstituencyProof;
+
+    const missingMerkleRoot = {
+      district_hash: EXPECTED_DISTRICT,
+      nullifier: EXPECTED_NULLIFIER,
+    } as ConstituencyProof;
+
+    expect(
+      verifyConstituencyProof(
+        missingDistrict,
+        EXPECTED_NULLIFIER,
+        EXPECTED_DISTRICT,
+      ),
+    ).toEqual({ valid: false, error: 'malformed_proof' });
+
+    expect(
+      verifyConstituencyProof(
+        missingNullifier,
+        EXPECTED_NULLIFIER,
+        EXPECTED_DISTRICT,
+      ),
+    ).toEqual({ valid: false, error: 'malformed_proof' });
+
+    expect(
+      verifyConstituencyProof(
+        missingMerkleRoot,
+        EXPECTED_NULLIFIER,
+        EXPECTED_DISTRICT,
+      ),
+    ).toEqual({ valid: false, error: 'malformed_proof' });
+  });
+
+  it('returns malformed_proof for empty required fields', () => {
+    expect(
+      verifyConstituencyProof(
+        makeProof({ district_hash: '' }),
+        EXPECTED_NULLIFIER,
+        EXPECTED_DISTRICT,
+      ),
+    ).toEqual({ valid: false, error: 'malformed_proof' });
+
+    expect(
+      verifyConstituencyProof(
+        makeProof({ nullifier: '' }),
+        EXPECTED_NULLIFIER,
+        EXPECTED_DISTRICT,
+      ),
+    ).toEqual({ valid: false, error: 'malformed_proof' });
+  });
+
+  it('treats null merkle_root as malformed_proof', () => {
+    const result = verifyConstituencyProof(
+      makeProof({ merkle_root: null as unknown as string }),
+      EXPECTED_NULLIFIER,
+      EXPECTED_DISTRICT,
+    );
+
+    expect(result).toEqual({ valid: false, error: 'malformed_proof' });
+  });
+});
+
+describe('constituency verification re-exports', () => {
+  it('re-exports runtime and types from index', () => {
+    const errorFromIndex: ProofVerificationErrorFromIndex = 'stale_proof';
+    const resultFromIndex: ProofVerificationResultFromIndex = {
+      valid: false,
+      error: errorFromIndex,
+    };
+
+    const errorLocal: ProofVerificationError = errorFromIndex;
+    const resultLocal: ProofVerificationResult = resultFromIndex;
+
+    expect(errorLocal).toBe('stale_proof');
+    expect(resultLocal).toEqual({ valid: false, error: 'stale_proof' });
+    expect(verifyConstituencyProofFromIndex).toBe(verifyConstituencyProof);
+  });
+});

--- a/packages/types/src/constituency-verification.ts
+++ b/packages/types/src/constituency-verification.ts
@@ -1,0 +1,48 @@
+// Spec: spec-identity-trust-constituency.md v0.2 §4.2
+
+import type { ConstituencyProof } from './index';
+
+export type ProofVerificationError =
+  | 'nullifier_mismatch'
+  | 'district_mismatch'
+  | 'stale_proof'
+  | 'malformed_proof';
+
+export interface ProofVerificationResult {
+  valid: boolean;
+  error?: ProofVerificationError;
+}
+
+export function verifyConstituencyProof(
+  proof: ConstituencyProof | null | undefined,
+  expectedNullifier: string,
+  expectedDistrictHash: string,
+): ProofVerificationResult {
+  // 1. Malformed check
+  if (
+    !proof ||
+    !proof.district_hash ||
+    !proof.nullifier ||
+    proof.merkle_root === undefined ||
+    proof.merkle_root === null
+  ) {
+    return { valid: false, error: 'malformed_proof' };
+  }
+
+  // 2. Nullifier match
+  if (proof.nullifier !== expectedNullifier) {
+    return { valid: false, error: 'nullifier_mismatch' };
+  }
+
+  // 3. District match
+  if (proof.district_hash !== expectedDistrictHash) {
+    return { valid: false, error: 'district_mismatch' };
+  }
+
+  // 4. Freshness — Season 0 no-op (empty root only fails)
+  if (!proof.merkle_root.trim()) {
+    return { valid: false, error: 'stale_proof' };
+  }
+
+  return { valid: true };
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -19,6 +19,12 @@ export {
   DEFAULT_SESSION_TTL_MS,
 } from './session-lifecycle';
 
+export {
+  type ProofVerificationError,
+  type ProofVerificationResult,
+  verifyConstituencyProof,
+} from './constituency-verification';
+
 export interface RegionProof {
   proof: string;
   publicSignals: string[];


### PR DESCRIPTION
## Summary
- implement constituency proof verification runtime in `@vh/types`
- add exhaustive tests for proof verification outcomes (success, malformed, nullifier mismatch, district mismatch, stale)
- centralize web-pwa mock constituency proof generation and add env-driven verification flag helper
- refactor `useRegion` to consume centralized proof helper and add dedicated hook tests
- document revocation behavior in `useIdentity` and clear in-memory sentiment signals on session revoke

## Spec reference
Implements `spec-identity-trust-constituency.md v0.2 §4.1–§4.4`.

## Validation
- `pnpm typecheck` ✅
- `pnpm test` ⚠️ fails in pre-existing `apps/web-pwa/src/secure-storage-audit.test.ts` path-resolution checks when run via `@vh/identity-vault` workspace script (ENOENT from package cwd)
- targeted tests for this slice passed:
  - `pnpm exec vitest run packages/types/src/constituency-verification.test.ts apps/web-pwa/src/store/bridge/constituencyProof.test.ts apps/web-pwa/src/hooks/useRegion.test.ts`
