### PR TITLE
fix(infra): w4l ownership map branchPrefix + Phase-3 globs

### DIFF
--- a/.github/ownership-map.json
+++ b/.github/ownership-map.json
@@ -142,12 +142,17 @@
     "source": [
       "packages/data-model/src/constants/**",
       "apps/web-pwa/src/hooks/useIdentity*",
-      "apps/web-pwa/src/store/bridge/constituencyProof*"
+      "apps/web-pwa/src/store/bridge/constituencyProof*",
+      "packages/types/src/constituency-verification*",
+      "apps/web-pwa/src/hooks/useRegion*"
     ],
     "test": [
       "packages/data-model/src/constants/**/*.test.*",
       "apps/web-pwa/src/hooks/useIdentity*.test.*",
-      "apps/web-pwa/src/store/bridge/constituencyProof*.test.*"
-    ]
+      "apps/web-pwa/src/store/bridge/constituencyProof*.test.*",
+      "packages/types/src/constituency-verification*.test.*",
+      "apps/web-pwa/src/hooks/useRegion*.test.*"
+    ],
+    "branchPrefix": "w4l/"
   }
 }


### PR DESCRIPTION
Adds missing `branchPrefix: 'w4l/'` to the w4l ownership entry and expands source/test globs to cover Phase-3 artifacts (constituency-verification, useRegion).

Without this, `w4l/*` branches fail the pre-push ownership scope check.

Ref: spec-identity-trust-constituency.md v0.2 §4.1–§4.4