### PR TITLE
fix(types): break circular dependency in constituency-verification

### DIFF
--- a/packages/types/src/constituency-proof.ts
+++ b/packages/types/src/constituency-proof.ts
@@ -1,0 +1,12 @@
+/**
+ * Canonical constituency proof shape.
+ * Spec: spec-identity-trust-constituency.md v0.2 §4.1
+ *
+ * Extracted to its own module to avoid circular imports
+ * between the barrel (index.ts) and constituency-verification.ts.
+ */
+export interface ConstituencyProof {
+  district_hash: string;
+  nullifier: string;
+  merkle_root: string;
+}

--- a/packages/types/src/constituency-verification.ts
+++ b/packages/types/src/constituency-verification.ts
@@ -1,6 +1,6 @@
 // Spec: spec-identity-trust-constituency.md v0.2 §4.2
 
-import type { ConstituencyProof } from './index';
+import type { ConstituencyProof } from './constituency-proof';
 
 export type ProofVerificationError =
   | 'nullifier_mismatch'

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -66,11 +66,11 @@ export interface SentimentSignal {
 
 export type RegionProofTuple = [string, string, string]; // [district_hash, nullifier, merkle_root]
 
-export interface ConstituencyProof {
-  district_hash: string;
-  nullifier: string;
-  merkle_root: string;
-}
+import type { ConstituencyProof as _ConstituencyProof } from './constituency-proof';
+// Re-export the extracted type (avoids circular dep with constituency-verification.ts)
+export type { ConstituencyProof } from './constituency-proof';
+// Local alias for use within this file
+type ConstituencyProof = _ConstituencyProof;
 
 export const ConstituencyProofSchema = z.object({
   district_hash: z.string().min(1),


### PR DESCRIPTION
Extracts `ConstituencyProof` interface to `packages/types/src/constituency-proof.ts` to break the circular dependency between `index.ts` and `constituency-verification.ts` that was causing Quality Guard CI failure.

- `constituency-verification.ts` now imports from `./constituency-proof` (not `./index`)
- `index.ts` re-exports from `./constituency-proof` with local alias for internal use
- `madge --circular`: zero circular dependencies ✅
- All 20 types tests pass ✅

Ref: spec-identity-trust-constituency.md v0.2 §4.1