### PR TITLE
Fix dev CSP relay allowlist and LHCI CLI invocation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -255,4 +255,4 @@ jobs:
 
       - name: Run Lighthouse (static dist)
         if: needs.change-detection.outputs.run-lighthouse == 'true'
-        run: npx lhci autorun --collect.staticDistDir=apps/web-pwa/dist --upload.target=filesystem --upload.outputDir=./lhci-report
+        run: npx @lhci/cli autorun --collect.staticDistDir=apps/web-pwa/dist --upload.target=filesystem --upload.outputDir=./lhci-report

--- a/apps/web-pwa/index.html
+++ b/apps/web-pwa/index.html
@@ -10,7 +10,7 @@
     -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: blob:; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self'"
+      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' http://localhost:7777 ws://localhost:7777 http://100.75.18.26:7777 ws://100.75.18.26:7777; img-src 'self' data: blob:; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self'"
     />
     <title>TRINITY Web PWA</title>
   </head>

--- a/apps/web-pwa/src/csp.test.ts
+++ b/apps/web-pwa/src/csp.test.ts
@@ -60,9 +60,13 @@ describe('index.html content security policy', () => {
 
     expect(directivesWithUnsafeInline).toEqual(['style-src']);
 
-    expect(connectSrc).toBe("'self'");
-    expect(connectSrc).not.toContain('ws:');
+    expect(connectSrc).toContain("'self'");
+    expect(connectSrc).toContain('http://localhost:7777');
+    expect(connectSrc).toContain('ws://localhost:7777');
+    expect(connectSrc).toContain('http://100.75.18.26:7777');
+    expect(connectSrc).toContain('ws://100.75.18.26:7777');
+    expect(connectSrc).not.toContain('*');
+    expect(connectSrc).not.toContain('https:');
     expect(connectSrc).not.toContain('wss:');
-    expect(connectSrc).not.toContain('100.75.18.26');
   });
 });


### PR DESCRIPTION
## Summary
- allow Gun dev relay origins in PWA CSP connect-src for localhost and LAN relay
- update CSP test expectations to enforce explicit relay allowlist
- fix CI Lighthouse command to use @lhci/cli package
- supersedes #256 (same diff, ownership-compliant branch prefix)

## Validation
- pnpm test:quick
- pnpm test:e2e
- pnpm test:coverage (100% across statements/branches/functions/lines)
- pnpm bundle:check
- npx @lhci/cli autorun