### PR TITLE
CE HOLD Lane C: UI/LENS remediation (thread composer + lens + nav wiring)

### DIFF
--- a/apps/web-pwa/src/components/docs/ArticleFeedCard.test.tsx
+++ b/apps/web-pwa/src/components/docs/ArticleFeedCard.test.tsx
@@ -100,6 +100,16 @@ describe('ArticleFeedCard', () => {
     expect(screen.getByTestId('article-card-date-article-1')).toHaveTextContent('unknown');
   });
 
+  it('links to thread detail route using topic_id by default', () => {
+    render(<ArticleFeedCard item={makeArticleItem({ topic_id: 'custom-id' })} />);
+    expect(screen.getByTestId('article-card-open-thread-custom-id')).toHaveAttribute('href', '/hermes/custom-id');
+  });
+
+  it('uses explicit threadId when provided', () => {
+    render(<ArticleFeedCard item={makeArticleItem()} threadId="thread-99" />);
+    expect(screen.getByTestId('article-card-open-thread-article-1')).toHaveAttribute('href', '/hermes/thread-99');
+  });
+
   it('renders with different topic_id', () => {
     render(<ArticleFeedCard item={makeArticleItem({ topic_id: 'custom-id' })} />);
     expect(screen.getByTestId('article-card-custom-id')).toBeInTheDocument();

--- a/apps/web-pwa/src/components/docs/ArticleFeedCard.tsx
+++ b/apps/web-pwa/src/components/docs/ArticleFeedCard.tsx
@@ -11,6 +11,8 @@ import type { FeedItem } from '@vh/data-model';
 export interface ArticleFeedCardProps {
   /** Discovery feed item; expected kind: ARTICLE. */
   readonly item: FeedItem;
+  /** Optional thread route target; defaults to item.topic_id. */
+  readonly threadId?: string;
 }
 
 function formatTimestamp(timestampMs: number): string {
@@ -20,12 +22,20 @@ function formatTimestamp(timestampMs: number): string {
   return new Date(timestampMs).toLocaleDateString();
 }
 
+function buildThreadHref(threadId: string): string {
+  return `/hermes/${encodeURIComponent(threadId)}`;
+}
+
 /**
  * Article card for discovery feed ARTICLE items.
  * Rendered in the discovery feed (V2 feed is now the permanent path).
  */
-export const ArticleFeedCard: React.FC<ArticleFeedCardProps> = ({ item }) => {
+export const ArticleFeedCard: React.FC<ArticleFeedCardProps> = ({
+  item,
+  threadId,
+}) => {
   const publishedDate = formatTimestamp(item.created_at);
+  const resolvedThreadId = threadId?.trim() || item.topic_id;
 
   return (
     <article
@@ -62,6 +72,14 @@ export const ArticleFeedCard: React.FC<ArticleFeedCardProps> = ({ item }) => {
           💬 {item.comments}
         </span>
       </div>
+
+      <a
+        href={buildThreadHref(resolvedThreadId)}
+        className="mt-3 inline-flex text-xs font-medium text-teal-700 hover:underline"
+        data-testid={`article-card-open-thread-${item.topic_id}`}
+      >
+        Open thread →
+      </a>
     </article>
   );
 };

--- a/apps/web-pwa/src/components/feed/FeedShell.test.tsx
+++ b/apps/web-pwa/src/components/feed/FeedShell.test.tsx
@@ -155,7 +155,7 @@ describe('FeedShell', () => {
     expect(within(socialRow).getByText('Linked social mention')).toBeInTheDocument();
   });
 
-  it('routes ARTICLE kind to ArticleFeedCard', () => {
+  it('routes ARTICLE kind to ArticleFeedCard with thread route link', () => {
     const items = [
       makeFeedItem({
         topic_id: 'article-1',
@@ -168,6 +168,7 @@ describe('FeedShell', () => {
 
     expect(screen.getByTestId('article-card-article-1')).toBeInTheDocument();
     expect(screen.getByText('My Published Article')).toBeInTheDocument();
+    expect(screen.getByTestId('article-card-open-thread-article-1')).toHaveAttribute('href', '/hermes/article-1');
   });
 
   it('routes ACTION_RECEIPT kind to ReceiptFeedCard', () => {

--- a/apps/web-pwa/src/components/feed/FeedShell.tsx
+++ b/apps/web-pwa/src/components/feed/FeedShell.tsx
@@ -120,7 +120,7 @@ const FeedItemCard: React.FC<FeedItemCardProps> = ({ item }) => {
     case 'SOCIAL_NOTIFICATION':
       return <SocialNotificationCard item={item} />;
     case 'ARTICLE':
-      return <ArticleFeedCard item={item} />;
+      return <ArticleFeedCard item={item} threadId={item.topic_id} />;
     case 'ACTION_RECEIPT':
       return <ReceiptFeedCard item={item} />;
     default:

--- a/apps/web-pwa/src/components/feed/TopicCard.test.tsx
+++ b/apps/web-pwa/src/components/feed/TopicCard.test.tsx
@@ -103,6 +103,11 @@ describe('TopicCard', () => {
     expect(screen.getByTestId('topic-card-comments-topic-42')).toHaveTextContent('12');
   });
 
+  it('links to thread detail route for the topic', () => {
+    render(<TopicCard item={makeTopicItem()} />);
+    expect(screen.getByTestId('topic-card-open-thread-topic-42')).toHaveAttribute('href', '/hermes/topic-42');
+  });
+
   it('formats my_activity_score with one decimal place', () => {
     render(<TopicCard item={makeTopicItem()} />);
     expect(screen.getByTestId('topic-card-activity-topic-42')).toHaveTextContent('My activity 4.3');

--- a/apps/web-pwa/src/components/feed/TopicCard.tsx
+++ b/apps/web-pwa/src/components/feed/TopicCard.tsx
@@ -16,6 +16,10 @@ function formatActivityScore(score: number | undefined): string {
   return score.toFixed(1);
 }
 
+function buildThreadHref(threadId: string): string {
+  return `/hermes/${encodeURIComponent(threadId)}`;
+}
+
 /**
  * User topic/thread card for discovery feed USER_TOPIC items.
  *
@@ -62,6 +66,14 @@ export const TopicCard: React.FC<TopicCardProps> = ({ item }) => {
         <span data-testid={`topic-card-lightbulb-${item.topic_id}`}>💡 {item.lightbulb}</span>
         <span data-testid={`topic-card-comments-${item.topic_id}`}>💬 {item.comments}</span>
       </div>
+
+      <a
+        href={buildThreadHref(item.topic_id)}
+        className="mt-3 inline-flex text-xs font-medium text-emerald-700 hover:underline"
+        data-testid={`topic-card-open-thread-${item.topic_id}`}
+      >
+        Open thread →
+      </a>
     </article>
   );
 };

--- a/apps/web-pwa/src/components/hermes/forum/CommentComposerWithArticle.tsx
+++ b/apps/web-pwa/src/components/hermes/forum/CommentComposerWithArticle.tsx
@@ -8,7 +8,7 @@
 import React, { useCallback, useState } from 'react';
 import { CommentComposer } from './CommentComposer';
 import { ArticleEditor } from '../../docs/ArticleEditor';
-import type { SourceContext } from '../../../store/hermesDocs';
+import { useDocsStore, type SourceContext } from '../../../store/hermesDocs';
 
 export interface CommentComposerWithArticleProps {
   threadId: string;
@@ -22,15 +22,17 @@ export interface CommentComposerWithArticleProps {
 export const CommentComposerWithArticle: React.FC<
   CommentComposerWithArticleProps
 > = ({ threadId, parentId, isThreadCreation, onSubmit, sourceContext }) => {
+  const docsEnabled = useDocsStore((state) => state.enabled);
   const [editorOpen, setEditorOpen] = useState(false);
   const [draftContent, setDraftContent] = useState('');
 
   const handleConvertToArticle = useCallback(
     (text: string) => {
+      if (!docsEnabled) return;
       setDraftContent(text);
       setEditorOpen(true);
     },
-    [],
+    [docsEnabled],
   );
 
   const handleEditorComplete = useCallback(() => {
@@ -76,7 +78,7 @@ export const CommentComposerWithArticle: React.FC<
       parentId={parentId}
       isThreadCreation={isThreadCreation}
       onSubmit={onSubmit}
-      onConvertToArticle={handleConvertToArticle}
+      onConvertToArticle={docsEnabled ? handleConvertToArticle : undefined}
     />
   );
 };


### PR DESCRIPTION
## CE HOLD Lane C remediation — UI/LENS lane

Implements the UI/flow/nav remediations requested for Lane C:

1. Replaced root reply composer in `ThreadView` with `CommentComposerWithArticle` and passed `sourceContext` (`sourceThreadId`).
2. Enforced docs enabled/disabled behavior in `CommentComposerWithArticle` by wiring `onConvertToArticle` only when docs are enabled, preserving existing `Coming soon` fallback when disabled.
3. Wired discovery card navigation links to thread detail route (`/hermes/$threadId`) for relevant cards:
   - `TopicCard`
   - `ArticleFeedCard` (wired where rendered via `FeedShell`)
4. Added unified thread lens in thread detail view with synthesis context panel using existing `useSynthesis` + `SynthesisSummary` path, with loading/error/empty states.
5. Kept touched source files below 350 LOC.

## Tests
- Updated tests for composer wiring and docs enabled/disabled behavior.
- Updated tests for discovery navigation links.
- Added thread lens rendering coverage in `ThreadView` tests.

### Commands run
- `pnpm lint` ✅
- `pnpm typecheck` ⚠️ fails in pre-existing workspace package (`packages/crdt`) due missing `yjs`/`y-protocols` type resolution
- Targeted vitest (touched files) ✅

Please review in context of CE HOLD Lane C.