### PR TITLE
feat(ux): wire comment→article flow, feed nav, synthesis panel (Lane C remediation)

### DIFF
--- a/apps/web-pwa/src/components/FeedList.test.tsx
+++ b/apps/web-pwa/src/components/FeedList.test.tsx
@@ -1,9 +1,21 @@
 /* @vitest-environment jsdom */
 
+import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import FeedList from './FeedList';
+
+// Mock @tanstack/react-router Link to avoid needing full router context
+vi.mock('@tanstack/react-router', () => ({
+  Link: React.forwardRef<HTMLAnchorElement, any>(
+    ({ children, to, params, ...rest }, ref) => (
+      <a ref={ref} href={typeof to === 'string' ? to : '#'} {...rest}>
+        {children}
+      </a>
+    ),
+  ),
+}));
 
 vi.mock('../hooks/useDiscoveryFeed', () => ({
   useDiscoveryFeed: vi.fn(() => ({

--- a/apps/web-pwa/src/components/feed/FeedShell.test.tsx
+++ b/apps/web-pwa/src/components/feed/FeedShell.test.tsx
@@ -3,9 +3,21 @@
 import { render, screen, cleanup, within, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 import { describe, expect, it, afterEach, vi } from 'vitest';
+import React from 'react';
 import { FeedShell } from './FeedShell';
 import type { UseDiscoveryFeedResult } from '../../hooks/useDiscoveryFeed';
 import type { FeedItem } from '@vh/data-model';
+
+// Mock @tanstack/react-router Link to avoid needing full router context
+vi.mock('@tanstack/react-router', () => ({
+  Link: React.forwardRef<HTMLAnchorElement, any>(
+    ({ children, to, params, ...rest }, ref) => (
+      <a ref={ref} href={typeof to === 'string' ? to : '#'} {...rest}>
+        {children}
+      </a>
+    ),
+  ),
+}));
 
 // ---- Helpers ----
 

--- a/apps/web-pwa/src/components/feed/FeedShell.tsx
+++ b/apps/web-pwa/src/components/feed/FeedShell.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from '@tanstack/react-router';
 import type { FeedItem } from '@vh/data-model';
 import type { UseDiscoveryFeedResult } from '../../hooks/useDiscoveryFeed';
 import { FilterChips } from './FilterChips';
@@ -102,7 +103,14 @@ interface FeedItemRowProps {
 const FeedItemRow: React.FC<FeedItemRowProps> = ({ item }) => {
   return (
     <li data-testid={`feed-item-${item.topic_id}`}>
-      <FeedItemCard item={item} />
+      <Link
+        to="/hermes/$threadId"
+        params={{ threadId: item.topic_id }}
+        className="block no-underline"
+        data-testid={`feed-link-${item.topic_id}`}
+      >
+        <FeedItemCard item={item} />
+      </Link>
     </li>
   );
 };

--- a/apps/web-pwa/src/components/hermes/forum/CommentComposerWithArticle.tsx
+++ b/apps/web-pwa/src/components/hermes/forum/CommentComposerWithArticle.tsx
@@ -8,7 +8,7 @@
 import React, { useCallback, useState } from 'react';
 import { CommentComposer } from './CommentComposer';
 import { ArticleEditor } from '../../docs/ArticleEditor';
-import type { SourceContext } from '../../../store/hermesDocs';
+import { useDocsStore, type SourceContext } from '../../../store/hermesDocs';
 
 export interface CommentComposerWithArticleProps {
   threadId: string;
@@ -24,6 +24,7 @@ export const CommentComposerWithArticle: React.FC<
 > = ({ threadId, parentId, isThreadCreation, onSubmit, sourceContext }) => {
   const [editorOpen, setEditorOpen] = useState(false);
   const [draftContent, setDraftContent] = useState('');
+  const docsEnabled = useDocsStore((s) => s.enabled);
 
   const handleConvertToArticle = useCallback(
     (text: string) => {
@@ -76,7 +77,7 @@ export const CommentComposerWithArticle: React.FC<
       parentId={parentId}
       isThreadCreation={isThreadCreation}
       onSubmit={onSubmit}
-      onConvertToArticle={handleConvertToArticle}
+      onConvertToArticle={docsEnabled ? handleConvertToArticle : undefined}
     />
   );
 };


### PR DESCRIPTION
## Lane C Remediation — Comment→Article + Feed/Forum UX

Coordinator execution (w1c-chief subagents A4-blocked on read-only).

### Changes
1. **ThreadView** — Replace `CommentComposer` with `CommentComposerWithArticle` + add synthesis panel (`useSynthesis` + `SynthesisSummary`)
2. **CommentComposerWithArticle** — Gate `onConvertToArticle` behind `useDocsStore.enabled` flag
3. **FeedShell** — Wrap `FeedItemRow` in `Link` to `/hermes/$threadId` for card navigation
4. **Test fixes** — Mock `@tanstack/react-router` `Link` in FeedShell + FeedList tests

### Evidence
- 2689 tests passing, 0 failures
- Typecheck clean
- All files under 350 LOC cap (ThreadView: 231, FeedShell: 146, CommentComposerWithArticle: 83)

### Refs
- `docs/foundational/Hero_Paths.md` §unified-lens
- `docs/foundational/TRINITY_Season0_SoT.md`
- w1c-impl-ui analysis (session `a88daa46`)