### PR TITLE
docs: CE closeout SHA alignment + stale PR housekeeping

### DIFF
--- a/docs/reports/BETA_READINESS_MATRIX.md
+++ b/docs/reports/BETA_READINESS_MATRIX.md
@@ -1,0 +1,663 @@
+# Beta Readiness Matrix — Internal Testnet Launch
+
+> **Salvage note (2026-02-15):** This document was salvaged from closed PR #260
+> (`coord/lane-d/readiness-matrix`). The original was assessed against `origin/main`
+> at `09285c9` and is now **stale** — main has advanced to `de322f8`+ with multiple
+> remediation PRs merged (#263–#270). Gate assessments G1–G5 provide useful historical
+> baseline but should not be treated as current status. G6–G9 were never completed.
+
+
+**Generated:** 2026-02-15T10:46Z (rev 3: 10:53Z — G8 CAK update + G9 doc integrity gate)  
+**Branch assessed:** `origin/main` at `09285c9`  
+**Author:** Lane D (Docs agent — subagent)  
+**Status:** G1–G5 assessed; G6–G7 PENDING; G8.2+G8.4 escalated; G9 added
+
+---
+
+## Summary
+
+| Gate | Status | Pass | Fail | Blocked |
+|------|--------|------|------|---------|
+| G1: Identity (LUMA) | **FAIL** | 1/4 | 3/4 | — |
+| G2: Budget Enforcement | **PASS** | 3/3 | — | — |
+| G3: Feature Flags | **FAIL** | 1/3 | 2/3 | — |
+| G4: CI/CD Health | **PASS** | 3/3 | — | — |
+| G5: Security Posture | **FAIL** | 2/3 | 1/3 | — |
+| G6: Invite/Cohort Controls | **PENDING** | — | — | 3/3 |
+| G7: AI Harness | **PENDING** | — | — | 2/2 |
+| G8: Runtime Wiring | **PENDING + ⚠️ ESCALATION** | — | — | 2/4 + 2 SoT conflicts |
+| G9: Documentation Integrity | **⚠️ ESCALATION** | — | — | See below |
+
+**Totals (G1–G5 only):** PASS 10 / FAIL 6 / BLOCKED 0  
+**Overall verdict:** ❌ NOT READY — 6 gate criteria fail across G1, G3, G5 + systemic SoT conflict  
+**Critical blockers:** Missing trust.ts consolidation, session lifecycle module, constituency proof module, session revocation, incomplete feature flag documentation, hardcoded dev secret in storage adapter, **cross-lane SoT integrity conflict (G9)**.
+
+---
+
+## G1: Identity (LUMA)
+
+### G1.1 — Trust constants consolidated in `trust.ts`
+
+| Criterion | Status |
+|-----------|--------|
+| A file named `trust.ts` exists containing consolidated trust constants | **FAIL** |
+
+**Evidence:** `find . -name "trust.ts" -not -path "*/node_modules/*"` returns zero results.
+
+Trust-related constants are scattered:
+- Trust score threshold (`< 0.5` reject) — `apps/web-pwa/src/hooks/useIdentity.ts:112`
+- `scaledTrustScore` clamping (0–10000) — `apps/web-pwa/src/hooks/useIdentity.ts:114,230–234`
+- QF threshold (≥ 0.7) — documented in `docs/specs/spec-identity-trust-constituency.md:37` but not codified as a runtime constant
+- `SEASON_0_BUDGET_DEFAULTS` — `packages/types/src/budget.ts:59–68` (budget layer, not trust layer)
+
+No single `trust.ts` module consolidates these thresholds.
+
+**Verdict:** ❌ **FAIL** — No `trust.ts` exists. Trust constants are dispersed across `useIdentity.ts`, the identity spec, and budget types with no single source of truth.
+
+---
+
+### G1.2 — Session lifecycle working (`session-lifecycle.ts` + tests)
+
+| Criterion | Status |
+|-----------|--------|
+| A `session-lifecycle.ts` module exists with create/hydrate/revoke lifecycle | **FAIL** |
+
+**Evidence:** `find . -name "session-lifecycle*" -not -path "*/node_modules/*"` returns zero results.
+
+Session lifecycle logic is embedded directly in `useIdentity.ts` (React hook):
+- **Create:** `useIdentity.ts:80–129` — `createIdentity()` calls `createSession()` (gun-client), builds `IdentityRecord`, persists to vault
+- **Hydrate:** `useIdentity.ts:59–71` — `loadIdentityFromVault()` on mount
+- **Revoke:** ❌ Not implemented — no `revokeSession` function exists anywhere in the codebase (grep confirms zero matches)
+
+Tests exist in `apps/web-pwa/src/hooks/useIdentity.test.ts` (7 test cases) but they test the React hook, not a standalone module.
+
+**Verdict:** ❌ **FAIL** — No `session-lifecycle.ts` module exists. Lifecycle logic is coupled to the React hook. No revocation capability.
+
+---
+
+### G1.3 — Constituency proof verification (`constituency-verification.ts` + tests)
+
+| Criterion | Status |
+|-----------|--------|
+| A `constituency-verification.ts` module exists with proof verification | **FAIL** |
+
+**Evidence:** `find . -name "constituency*" -not -path "*/node_modules/*"` returns zero results.
+
+The spec (`docs/specs/spec-identity-trust-constituency.md`) defines:
+- `ConstituencyProof`: `{ district_hash, nullifier, merkle_root }` (spec §1)
+- `RegionProof.publicSignals = [district_hash, nullifier, merkle_root]` (spec §4)
+- `decodeRegionProof(publicSignals) -> ConstituencyProof` (spec §4)
+
+None of this is implemented. The `IdentityRecord` type (`packages/types/src/identity.ts`) has no constituency/region fields. STATUS.md confirms LUMA is "🔴 Stubbed" with "No sybil defense" and "No uniqueness checking."
+
+**Verdict:** ❌ **FAIL** — No constituency proof verification code exists. Entirely planned/specced, not implemented.
+
+---
+
+### G1.4 — Session revocation (`useIdentity.ts` `revokeSession`)
+
+| Criterion | Status |
+|-----------|--------|
+| `useIdentity.ts` exports a `revokeSession` (or equivalent revocation) function | **FAIL** |
+
+**Evidence:** `grep -rn "revokeSession\|revoke.*session\|session.*revoke\|logout\|signOut\|clearSession\|destroySession" --include="*.ts" --include="*.tsx"` returns zero matches for any revocation function in `useIdentity.ts`.
+
+The hook exposes: `createIdentity`, `linkDevice`, `startLinkSession`, `completeLinkSession`, `updateHandle`, `validateHandle`. No revocation.
+
+`clearIdentity()` exists in `packages/identity-vault/src/vault.ts:157` (wipes vault data) but is not wired into `useIdentity` as a session revocation flow.
+
+**Verdict:** ❌ **FAIL** — No `revokeSession` or equivalent exists in `useIdentity.ts`. `clearIdentity` in vault is unwired.
+
+---
+
+## G2: Budget Enforcement
+
+### G2.1 — All 8 budget keys active
+
+| Criterion | Status |
+|-----------|--------|
+| All 8 canonical budget action keys are defined AND enforced at runtime | **PASS** |
+
+**Evidence — Definition:** `packages/types/src/budget.ts:4–13` defines the `BudgetActionKey` union type with exactly 8 keys. `BUDGET_ACTION_KEYS` tuple (line 16–25) lists all 8. `SEASON_0_BUDGET_DEFAULTS` (line 59–68) provides limits for all 8.
+
+**Evidence — Runtime enforcement (canPerformAction + consumeAction calls):**
+
+| Key | Enforcement site | File:Line |
+|-----|-----------------|-----------|
+| `posts/day` | `createThread()` | `apps/web-pwa/src/store/forum/index.ts:64,119` |
+| `comments/day` | `createComment()` | `apps/web-pwa/src/store/forum/index.ts:134,183` |
+| `sentiment_votes/day` | `castVote()` | `apps/web-pwa/src/hooks/useSentimentState.ts:87,127` |
+| `governance_votes/day` | `castGovernanceVote()` | `apps/web-pwa/src/hooks/useGovernance.ts:214,245` |
+| `analyses/day` | analysis trigger | `apps/web-pwa/src/routes/AnalysisFeed.tsx:164,179` |
+| `shares/day` | share action | `apps/web-pwa/src/routes/AnalysisFeed.tsx:244,262,268` |
+| `moderation/day` | familiar panel | `apps/web-pwa/src/components/hermes/FamiliarControlPanel.tsx:95` + `xpLedgerBudget.ts:86–104` |
+| `civic_actions/day` | familiar panel | `apps/web-pwa/src/components/hermes/FamiliarControlPanel.tsx:100` + `xpLedgerBudget.ts:108–126` |
+
+**Note:** STATUS.md says "6/8 budget keys active" — this is **stale**. Code review confirms 8/8 are now enforced. The remaining 2 (`moderation/day`, `civic_actions/day`) were wired via `FamiliarControlPanel.tsx` and dedicated entrypoints in `xpLedgerBudget.ts`.
+
+**Test coverage:**
+- `packages/types/src/budget.test.ts` — 8-key validation, Season 0 defaults, schema parse/reject (30+ tests)
+- `packages/types/src/budget-utils.test.ts` — consume/check/rollover logic (30+ tests)
+- `apps/web-pwa/src/store/xpLedgerBudget.test.ts` — moderation & civic action budget helpers (20+ tests)
+- `apps/web-pwa/src/store/xpLedger.test.ts` — store integration, canPerformAction/consumeAction (20+ tests)
+
+**Verdict:** ✅ **PASS** — All 8 budget keys defined, all 8 enforced at runtime with check+consume pattern.
+
+---
+
+### G2.2 — TOCTOU hardening present
+
+| Criterion | Status |
+|-----------|--------|
+| Concurrent budget operations are hardened against TOCTOU races | **PASS** |
+
+**Evidence:**
+
+1. **Forum store TOCTOU documentation:** `apps/web-pwa/src/store/forum/index.ts:115–118` and `179–182` — explicit TOCTOU comments documenting the race window between `canPerformAction` and `consumeAction` (check-then-write to Gun, then consume). Known tradeoff with issue #68 filed for optimistic-consume fix.
+
+2. **Delegation-utils TOCTOU guards:** `packages/types/src/delegation-utils.ts:124,188,205` — three TOCTOU guard checks:
+   - Delegation validation must happen at action time (line 124)
+   - Assertion must be bound to action timestamp (line 188)
+   - High-impact approval must be bound to action timestamp (line 205)
+   
+   Tested: `packages/types/src/delegation-utils.test.ts:202,339,373` — three dedicated TOCTOU test cases.
+
+3. **Vault master key race protection:** `packages/identity-vault/src/vault.ts:52` — insert-only semantics (`IDB add`) to avoid TOCTOU races across tabs. Race test: `vault.master-key-race.test.ts`.
+
+4. **Budget immutability:** `packages/types/src/budget-utils.ts` — all budget functions return new objects (no mutation), verified by `does not mutate original budget` tests in `budget-utils.test.ts`.
+
+**Verdict:** ✅ **PASS** — TOCTOU hardening present at delegation, vault, and budget layers. Forum store documents known TOCTOU window with mitigation plan.
+
+---
+
+### G2.3 — Denial UX functional
+
+| Criterion | Status |
+|-----------|--------|
+| Budget denial produces user-visible messaging at all enforcement points | **PASS** |
+
+**Evidence — Denial messages at each enforcement site:**
+
+| Key | Denial message | File:Line |
+|-----|---------------|-----------|
+| `posts/day` | `"Budget denied: Daily limit of 20 reached for posts/day"` | `forum/index.ts:66` |
+| `comments/day` | `"Budget denied: Daily limit of 50 reached for comments/day"` | `forum/index.ts:136` |
+| `sentiment_votes/day` | `"Daily limit reached for sentiment_votes/day"` (console.warn) | `useSentimentState.ts:89–90` |
+| `governance_votes/day` | `"Governance vote budget exhausted"` (error state) | `useGovernance.ts:216–217` |
+| `analyses/day` | `"Daily limit reached for analyses/day"` (console.warn) | `AnalysisFeed.tsx:166–167` |
+| `shares/day` | `"Daily share limit reached"` (console.warn) | `AnalysisFeed.tsx:246` |
+| `moderation/day` | `"moderation/day budget denied"` | `FamiliarControlPanel.tsx:97` |
+| `civic_actions/day` | `"civic_actions/day budget denied"` | `FamiliarControlPanel.tsx:102` |
+| No nullifier | `"Budget denied: No active nullifier"` | `xpLedger.ts:342` |
+| No nullifier (check) | `"No active nullifier"` | `xpLedger.ts:337` |
+
+All denial paths return structured `BudgetCheckResult` with `{ allowed: false, reason: string }`. Consumer code surfaces the reason string.
+
+**Verdict:** ✅ **PASS** — All 8 budget keys produce denial messages. Null-nullifier edge case also covered.
+
+---
+
+## G3: Feature Flags
+
+### G3.1 — All 10 flags documented in STATUS.md flag table
+
+| Criterion | Status |
+|-----------|--------|
+| STATUS.md flag table lists all feature flags with purpose and default | **FAIL** |
+
+**Evidence:** STATUS.md "Feature Flags (Wave 1)" table lists **3 flags only:**
+1. `VITE_FEED_V2_ENABLED` — default `false`
+2. `VITE_TOPIC_SYNTHESIS_V2_ENABLED` — default `false`
+3. `VITE_REMOTE_ENGINE_URL` — default empty
+
+**Undocumented flags found in codebase:**
+
+| Flag | Source | Purpose |
+|------|--------|---------|
+| `VITE_E2E_MODE` | `env.d.ts:4`, `useIdentity.ts:11` | Gates E2E test mode (mock identity) |
+| `VITE_GUN_PEERS` | `env.d.ts:5` | Gun relay peer list |
+| `VITE_ATTESTATION_URL` | `env.d.ts:6`, `useIdentity.ts:14` | Attestation verifier endpoint |
+| `VITE_ATTESTATION_TIMEOUT_MS` | `env.d.ts:7`, `useIdentity.ts:15` | Verifier timeout |
+| `VITE_RPC_URL` | `env.d.ts:9` | Ethereum RPC endpoint |
+| `VITE_UBE_ADDRESS` | `env.d.ts:10` | UBE contract address |
+| `VITE_RVU_ADDRESS` | `env.d.ts:11` | RVU contract address |
+| `VITE_HERMES_DOCS_ENABLED` | `store/hermesDocs.ts:17` | Gates collaborative docs feature |
+| `VITE_REMOTE_ENGINE_API_KEY` | `ai-engine/src/engines.ts:115` | Remote AI engine API key |
+| `VITE_E2E_MULTI_USER` | `packages/e2e/src/fixtures/multi-user.ts:110` | Multi-user E2E fixture |
+
+Total distinct `VITE_` variables: **13**. Feature-toggle flags (behavioral): **4** (`E2E_MODE`, `FEED_V2`, `SYNTHESIS_V2`, `HERMES_DOCS_ENABLED`). STATUS.md documents **3/13** total, **2/4** behavioral flags.
+
+**Verdict:** ❌ **FAIL** — STATUS.md flag table is incomplete. At minimum `VITE_HERMES_DOCS_ENABLED` and `VITE_E2E_MODE` are missing from documentation.
+
+---
+
+### G3.2 — All flags default false in `.env` files
+
+| Criterion | Status |
+|-----------|--------|
+| Production `.env` sets all feature toggle flags to `false` | **PASS** |
+
+**Evidence:** `apps/web-pwa/.env.production` contents:
+```
+VITE_E2E_MODE=false
+VITE_FEED_V2_ENABLED=false
+VITE_TOPIC_SYNTHESIS_V2_ENABLED=false
+```
+
+All three documented feature flags default to `false`. `VITE_REMOTE_ENGINE_URL` defaults to empty string (disabled). `VITE_HERMES_DOCS_ENABLED` is **not** in `.env.production` but defaults to `false` at runtime (reads `import.meta.env` which is `undefined` → not `'true'`).
+
+**Verdict:** ✅ **PASS** — All feature toggle flags that exist in `.env.production` default to `false`. Undocumented flags also default safely.
+
+---
+
+### G3.3 — ON/OFF behavior verified for each flag
+
+| Criterion | Status |
+|-----------|--------|
+| Test files verify both ON and OFF behavior for each feature flag | **FAIL** |
+
+**Evidence — Flags with ON/OFF tests:**
+
+| Flag | ON test | OFF test | File |
+|------|---------|----------|------|
+| `VITE_FEED_V2_ENABLED` | ✅ `store/discovery/store.test.ts:398` | ✅ `store/discovery/store.test.ts:329`, `useFeedStore.test.ts:6`, `FeedList.test.tsx:15` | Multiple |
+| `VITE_TOPIC_SYNTHESIS_V2_ENABLED` | ✅ `useSynthesis.test.ts:83,114,142`, `commentCounts.test.ts:239` | ✅ `useSynthesis.test.ts:60`, `commentCounts.test.ts:229` | Multiple |
+| `VITE_REMOTE_ENGINE_URL` | ✅ (implicitly via `remoteApiEngine.test.ts`) | ✅ (empty = disabled) | `remoteApiEngine.test.ts` |
+| `VITE_E2E_MODE` | ✅ `useIdentity.test.ts` (loadHook with e2eMode=true) | ✅ `useIdentity.test.ts` (loadHook with e2eMode=false) | `useIdentity.test.ts` |
+| `VITE_HERMES_DOCS_ENABLED` | ❌ No test | ❌ No test | — |
+
+STATUS.md claims "Feature-flag variants ✅ PASS — Both ON/OFF pass all 1390 tests" — this refers to Wave 1 flags only. `VITE_HERMES_DOCS_ENABLED` has no ON/OFF variant test coverage.
+
+**Verdict:** ❌ **FAIL** — 4/5 behavioral flags have ON/OFF tests; `VITE_HERMES_DOCS_ENABLED` lacks any test coverage.
+
+---
+
+## G4: CI/CD Health
+
+### G4.1 — All 7 checks green on main
+
+| Criterion | Status |
+|-----------|--------|
+| CI workflow defines 7 jobs; latest main run all green | **PASS** |
+
+**Evidence:** `.github/workflows/main.yml` defines 7 jobs:
+1. `ownership-scope` (PR-only) — `timeout-minutes: 5`
+2. `change-detection` — `timeout-minutes: 5`
+3. `quality` (lint, build, typecheck, deps:check) — `timeout-minutes: 20`
+4. `test-and-build` (unit tests, diff-coverage, build) — `timeout-minutes: 25`
+5. `e2e` (E2E tests, conditional) — `timeout-minutes: 30`
+6. `bundle-check` (bundle size, conditional) — `timeout-minutes: 20`
+7. `lighthouse` (Lighthouse audit, conditional) — `timeout-minutes: 15`
+
+Latest `main` HEAD: `09285c9` (Merge PR #257 — CSP/LHCI fix). PR #257 merged implies CI passed (branch protection requires checks).
+
+**Note:** Cannot directly verify GitHub Actions run status from this environment. Verdict based on merge-to-main implying required checks passed per branch protection.
+
+**Verdict:** ✅ **PASS** — 7 CI jobs defined; merge to main at `09285c9` implies all required checks passed.
+
+---
+
+### G4.2 — Coverage gate passing
+
+| Criterion | Status |
+|-----------|--------|
+| Coverage gate passes on latest main | **PASS** |
+
+**Evidence:**
+- `tools/scripts/check-diff-coverage.mjs` runs as PR-only gate (`test-and-build` job, line: `if: github.event_name == 'pull_request'`)
+- STATUS.md (verified at `cd22dd0`, Wave 1 integration): 100% statements, branches, functions, lines (4531/4531, 1492/1492, 388/388)
+- `pnpm test:coverage` listed as ✅ PASS in STATUS.md gate table
+- PR #257 merged to main = diff-coverage gate passed
+
+**Verdict:** ✅ **PASS** — Coverage gate passing per merge evidence and STATUS.md verification.
+
+---
+
+### G4.3 — Bundle size within budget
+
+| Criterion | Status |
+|-----------|--------|
+| Bundle size ≤ 1 MiB gzipped | **PASS** |
+
+**Evidence:**
+- `bundle-check` CI job runs `pnpm bundle:check` with limit ≤ 1 MiB gzipped
+- STATUS.md: "180.61 KiB gzipped (< 1 MiB limit)" — ✅ PASS
+- PR #257 merged to main = bundle check passed (conditional on relevant file changes)
+
+**Verdict:** ✅ **PASS** — 180.61 KiB << 1 MiB budget. Well within limits.
+
+---
+
+## G5: Security Posture
+
+### G5.1 — No hardcoded secrets
+
+| Criterion | Status |
+|-----------|--------|
+| No hardcoded secrets, API keys, or private keys in source | **FAIL** |
+
+**Evidence of concerns:**
+
+1. **Hardcoded dev root secret:** `packages/gun-client/src/storage/indexeddb.ts:8`
+   ```ts
+   const DEV_ROOT_SECRET = 'vh-dev-root-secret';
+   ```
+   Used at line 37 to derive the encryption root key for the encrypted IndexedDB adapter. This is a **static, predictable secret** used to encrypt the local Gun graph store. Any attacker with access to the IDB data can derive the same key.
+
+2. **Hardcoded dev root salt:** `packages/gun-client/src/storage/indexeddb.ts:9`
+   ```ts
+   const DEV_ROOT_SALT = 'vh-dev-root-salt';
+   ```
+
+3. **E2E/dev mode fallback tokens:** `apps/web-pwa/src/hooks/useIdentity.ts:93,105–107,241–242` — `mock-session-*`, `dev-session-*`, `mock-device`, `mock-nonce` — these are gated behind `E2E_MODE` and `DEV_MODE` flags, acceptable for dev but the `DEV_MODE` fallback at line 99–109 activates in any development build.
+
+4. **Contract config reads from env (safe pattern):** `packages/contracts/hardhat.config.ts:7,11` — `TESTNET_PRIVATE_KEY` from `process.env`, not hardcoded. ✅
+
+5. **AI engine API key from env (safe pattern):** `packages/ai-engine/src/engines.ts:115` — reads `VITE_REMOTE_ENGINE_API_KEY` from env. ✅
+
+**Primary concern:** The `DEV_ROOT_SECRET` in `indexeddb.ts` is a hardcoded encryption key used in production builds. The encrypted IndexedDB adapter uses it unconditionally — no environment gating.
+
+**Verdict:** ❌ **FAIL** — `DEV_ROOT_SECRET`/`DEV_ROOT_SALT` in `packages/gun-client/src/storage/indexeddb.ts:8–9` are hardcoded static secrets used for encryption key derivation, present in all builds.
+
+---
+
+### G5.2 — CSP enforced
+
+| Criterion | Status |
+|-----------|--------|
+| Content Security Policy is present and enforced in `index.html` | **PASS** |
+
+**Evidence:** `apps/web-pwa/index.html:12–15` — CSP meta tag:
+```html
+<meta http-equiv="Content-Security-Policy"
+  content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline';
+  connect-src 'self'; img-src 'self' data: blob:; worker-src 'self' blob:;
+  object-src 'none'; base-uri 'self'; form-action 'self'" />
+```
+
+**CSP directives verified (9 total):**
+- `default-src 'self'` ✅
+- `script-src 'self'` (no `unsafe-inline`, no `unsafe-eval`) ✅
+- `style-src 'self' 'unsafe-inline'` (acceptable for Tailwind/CSS-in-JS) ✅
+- `connect-src 'self'` (no ws:/wss: — Gun peers must go through self) ✅
+- `img-src 'self' data: blob:` ✅
+- `worker-src 'self' blob:` (for WebLLM worker) ✅
+- `object-src 'none'` ✅
+- `base-uri 'self'` ✅
+- `form-action 'self'` ✅
+
+**Test coverage:** `apps/web-pwa/src/csp.test.ts` — verifies all 9 directives present, `unsafe-inline` only in `style-src`, no `ws:`/`wss:` in `connect-src`.
+
+**Known limitation (documented):** CSP via meta tag; `frame-ancestors`, `report-to`, `sandbox` unsupported. Migration plan referenced at `docs/foundational/CSP_HEADER_MIGRATION.md`.
+
+**Verdict:** ✅ **PASS** — CSP enforced via meta tag with tight policy. Test coverage verifies invariants.
+
+---
+
+### G5.3 — Topology guard active
+
+| Criterion | Status |
+|-----------|--------|
+| `TopologyGuard` validates all Gun writes against classification rules | **PASS** |
+
+**Evidence:** `packages/gun-client/src/topology.ts` implements `TopologyGuard` class:
+- **3 classifications:** `public`, `sensitive`, `local` (line 1)
+- **28 path rules** covering all namespaces: `vh/public/`, `vh/sensitive/`, `vh/local/`, `vh/user/`, `vh/directory/`, `vh/chat/`, `vh/outbox/`, `vh/analyses/`, `vh/aggregates/`, `vh/news/*`, `vh/topics/*`, `vh/discovery/*`, `vh/social/*`, `vh/forum/*`, `vh/civic/*`, `vh/hermes/*`, `~*/hermes/*`, `~*/docs/*` (lines 7–44)
+- **PII guard:** `containsPII()` checks for `nullifier`, `district_hash`, `email`, `wallet`, `address` keys in public paths (lines 46–51)
+- **Encryption guard:** Sensitive paths require `__encrypted` flag on payload (lines 69–72)
+- **Directory exception:** `vh/directory/` allows PII (intentional for public directory entries) (line 63)
+- **Disallowed path rejection:** Unknown paths throw `Topology violation: disallowed path` (line 58)
+
+**Test coverage:** `packages/gun-client/src/topology.test.ts` — 10 test cases:
+- PII blocking in public paths ✅
+- Encryption requirement for sensitive paths ✅
+- Public data without PII allowed ✅
+- Directory PII exception ✅
+- Wave-0 namespace registration ✅
+- Document encryption requirement ✅
+- Invalid prefix rejection ✅
+
+**Verdict:** ✅ **PASS** — TopologyGuard active with comprehensive path rules, PII detection, and encryption enforcement. Well tested.
+
+---
+
+## G6: Invite/Cohort Controls — PENDING
+
+| Sub-gate | Status | Notes |
+|----------|--------|-------|
+| G6.1 Invite gating implemented | **BLOCKED** | Lane C deliverable — not yet assessed |
+| G6.2 Rate limiting present | **BLOCKED** | Lane C deliverable — not yet assessed |
+| G6.3 Kill switch functional | **BLOCKED** | Lane C deliverable — not yet assessed |
+
+**Action:** Await Lane C completion; then verify implementation and update this matrix.
+
+---
+
+## G7: AI Harness — PENDING
+
+| Sub-gate | Status | Notes |
+|----------|--------|-------|
+| G7.1 All 7 adversarial scenarios tested | **BLOCKED** | Lane B deliverable — not yet assessed |
+| G7.2 No critical failures | **BLOCKED** | Lane B deliverable — not yet assessed |
+
+**Action:** Await Lane B results; then incorporate findings and update this matrix.
+
+---
+
+## G8: Runtime Wiring — PARTIAL (2 escalations)
+
+| Sub-gate | Status | Notes |
+|----------|--------|-------|
+| G8.1 Synthesis v2 → feed E2E | **BLOCKED** | Lane A1 deliverable — STATUS.md confirms "Runtime wiring (v2 → UI) ❌ Pending" |
+| G8.2 CollabEditor → ArticleEditor | **⚠️ ESCALATION — SoT conflict** | See detailed analysis below |
+| G8.3 Budget 8/8 | **BLOCKED** | Lane A2 deliverable — NOTE: code review shows 8/8 enforced (see G2.1), but Lane A2 may have additional integration requirements |
+| G8.4 CAK: receipt-in-feed, rep directory, native intents | **⚠️ ESCALATION — SoT conflict** | See detailed analysis below |
+
+### G8.2 Escalation: CollabEditor SoT Integrity Conflict
+
+**Lane A3 reported:** "The ENTIRE CollabEditor stack does NOT exist in the codebase."
+
+**Lane D (Docs) independent verification contradicts this.** The CollabEditor stack **exists and is substantial** on `origin/main` at `09285c9`:
+
+| File | LOC | Content |
+|------|-----|---------|
+| `apps/web-pwa/src/components/docs/CollabEditor.tsx` | 229 | Full TipTap + Yjs binding, awareness, auto-save |
+| `apps/web-pwa/src/components/docs/CollabEditor.test.tsx` | 128 | 5 test cases (render, awareness, defaults) |
+| `apps/web-pwa/src/components/docs/ArticleEditor.tsx` | 275 | Dual-mode shell: textarea (flags off) / CollabEditor (flags on), lazy-loads CollabEditor |
+| `apps/web-pwa/src/components/docs/ArticleEditor.test.tsx` | 288 | Tests for both modes |
+| `apps/web-pwa/src/components/docs/useEditorMode.ts` | 101 | Mode-selection hook (dual flag gate: `VITE_HERMES_DOCS_ENABLED` + `VITE_DOCS_COLLAB_ENABLED`) |
+| `apps/web-pwa/src/components/docs/useEditorMode.test.ts` | 181 | Flag combination tests |
+| `apps/web-pwa/src/components/docs/PresenceBar.tsx` | 66 | Collaborator presence display |
+| `apps/web-pwa/src/components/docs/PresenceBar.test.tsx` | 71 | Presence bar tests |
+| `apps/web-pwa/src/components/docs/ShareModal.tsx` | 262 | Share/access control modal |
+| `apps/web-pwa/src/components/docs/ShareModal.test.tsx` | 200 | Share modal tests |
+| `apps/web-pwa/src/store/hermesDocsCollab.ts` | 222 | Collab store (auto-save timer, key management) |
+| `apps/web-pwa/src/store/hermesDocsCollab.test.ts` | 306 | Collab store tests |
+| `packages/crdt/src/gunYjsProvider.ts` | 187 | GunDB ↔ Yjs sync provider |
+| `packages/crdt/src/gunYjsProvider.test.ts` | 365 | Provider tests |
+| `packages/crdt/src/awareness.ts` | 77 | Awareness adapter |
+| `packages/crdt/src/awareness.test.ts` | 117 | Awareness tests |
+| `packages/crdt/src/mockProvider.ts` | 31 | E2E mock provider |
+| `packages/crdt/src/mockProvider.test.ts` | 40 | Mock provider tests |
+| **Total** | **3,146** | **18 files across 3 packages** |
+
+**Wiring evidence:** `ArticleEditor.tsx` (line 23) lazy-loads `CollabEditor` via `React.lazy()`. `useEditorMode.ts` dual-gates on `VITE_HERMES_DOCS_ENABLED` + `VITE_DOCS_COLLAB_ENABLED`. STATUS.md line 21 confirms "CollabEditor wired into ArticleEditor (flag-gated)." Wave 3 Doc Audit (`WAVE3_DOC_AUDIT.md:20`) confirms PR #230 merged the wiring.
+
+**Possible explanations for Lane A3 discrepancy:**
+1. Lane A3 may be working on a different worktree or stale branch that doesn't have PR #230 changes
+2. Lane A3 may be looking for files with different names/paths than what exists
+3. Lane A3's worktree may not be at `origin/main` HEAD (`09285c9`)
+
+**Recommendation:** Coordinator should verify which commit Lane A3 is assessing. If Lane A3 is on an older branch, this is a worktree sync issue, not a SoT integrity issue. The code exists on `main`.
+
+**Action:** Await coordinator SoT conflict resolution for G8.2.
+
+### G8.4 Escalation: CAK (Receipt-in-Feed, Rep Directory, Native Intents) SoT Conflict
+
+**Lane A4 reported:** "ALL THREE items (receipt-in-feed, rep directory, native intents) have zero runtime code on main. The `store/bridge/` directory, `ACTION_RECEIPT` feed kind, bridge adapters don't exist."
+
+**Lane D (Docs) independent verification contradicts this.** All three subsystems **exist and are substantial** on `origin/main` at `09285c9`:
+
+#### store/bridge/ — 22 files, ~2,500 LOC
+
+| File | LOC | Content |
+|------|-----|---------|
+| `store/bridge/receiptManager.ts` | 82 | Receipt creation, chaining, retry (spec §4.4) |
+| `store/bridge/receiptManager.test.ts` | 141 | Receipt chain + outcome tests |
+| `store/bridge/representativeDirectory.ts` | 80 | Directory scaffold, Zod validation, constituency matching (spec §3.1–3.3) |
+| `store/bridge/representativeDirectory.test.ts` | 154 | Directory load/find/version tests |
+| `store/bridge/intentAdapters.ts` | 110 | Delivery channels: email, phone, share, export, manual (spec §4.3) |
+| `store/bridge/intentAdapters.test.ts` | 189 | Intent dispatch + E2E guard tests |
+| `store/bridge/useBridgeStore.ts` | 185 | Zustand bridge store (actions, receipts, reps) |
+| `store/bridge/useBridgeStore.test.ts` | 222 | Store CRUD + persistence tests |
+| `store/bridge/bridgeStorage.ts` | 160 | Bridge persistence layer |
+| `store/bridge/bridgeStorage.test.ts` | 84 | Storage tests |
+| `store/bridge/constituencyProof.ts` | 24 | Constituency proof utilities |
+| `store/bridge/constituencyProof.test.ts` | 60 | Proof tests |
+| `store/bridge/elevationArtifacts.ts` | 88 | BriefDoc/ProposalScaffold generation |
+| `store/bridge/elevationArtifacts.test.ts` | 97 | Elevation artifact tests |
+| `store/bridge/nominationFlow.ts` | 97 | Nomination threshold flow |
+| `store/bridge/nominationFlow.test.ts` | 166 | Nomination tests |
+| `store/bridge/reportGenerator.ts` | 98 | PDF/HTML civic report generation |
+| `store/bridge/reportGenerator.test.ts` | 126 | Report generation tests |
+| `store/bridge/bridgeXP.ts` | 95 | Bridge XP awards |
+| `store/bridge/bridgeXP.test.ts` | 116 | XP award tests |
+| `store/bridge/index.ts` | 92 | Re-exports |
+| `store/bridge/index.test.ts` | 25 | Import validation |
+
+#### ACTION_RECEIPT in Feed
+
+| File | Line | Evidence |
+|------|------|---------|
+| `packages/data-model/src/schemas/hermes/discovery.ts` | 20 | `'ACTION_RECEIPT'` in DiscoveryItemKind enum |
+| `apps/web-pwa/src/hooks/useFeedStore.ts` | 38, 46 | Description + label for ACTION_RECEIPT |
+| `apps/web-pwa/src/components/feed/FeedShell.tsx` | 124 | Switch case routing ACTION_RECEIPT → ReceiptFeedCard |
+| `apps/web-pwa/src/components/feed/ReceiptFeedCard.tsx` | 59 LOC | Feed card for civic action receipts |
+| `apps/web-pwa/src/components/feed/ReceiptFeedCard.test.tsx` | 86 LOC | Card render tests |
+| `apps/web-pwa/src/components/feed/FeedShell.test.tsx` | 173 | Routes ACTION_RECEIPT to ReceiptFeedCard |
+
+#### Bridge Adapters
+
+| File | LOC | Evidence |
+|------|-----|---------|
+| `packages/gun-client/src/bridgeAdapters.ts` | 200 | Gun bridge adapters — civic action + receipt persistence |
+| `packages/gun-client/src/bridgeAdapters.test.ts` | 316 | Adapter tests |
+
+**Total CAK runtime code:** ~4,500 LOC across 26+ files with tests.
+
+**Possible explanation:** Same as G8.2 — Lane A4 is likely working on a stale worktree/branch that doesn't have the Wave 3 PRs (#229–#242) merged.
+
+**Action:** Await coordinator SoT conflict resolution for G8.4.
+
+---
+
+## G9: Documentation Integrity — ⚠️ ESCALATION (NEW)
+
+This gate was added in response to cross-lane SoT conflict reports. It assesses whether documentation matches codebase reality.
+
+### Systemic Finding: Cross-Lane Phantom Code Claims
+
+Two independent lanes (A3 and A4) reported that significant code subsystems "do not exist" on `main`, while Lane D's independent verification confirms the code is present. This creates a **systemic SoT integrity concern**.
+
+| Lane | Claim | Lane D Verification | Files Found | LOC |
+|------|-------|---------------------|-------------|-----|
+| A3 | "ENTIRE CollabEditor stack does NOT exist" | ❌ **Contradicted** — code exists | 18 files | 3,146 |
+| A4 | "store/bridge/, ACTION_RECEIPT, bridge adapters don't exist" | ❌ **Contradicted** — code exists | 26+ files | ~4,500 |
+
+### Root Cause Hypothesis
+
+The most likely explanation is a **worktree synchronization issue**:
+
+1. The codebase has 4+ waves of merged work. Waves 2–3 added CollabEditor (PR #220, #230) and CAK Phase 3 (PRs #229–#242).
+2. If Lane A3/A4 agents are operating on worktrees checked out at an older commit (pre-Wave 3), they would correctly observe that these files don't exist *on their branch*.
+3. However, on `origin/main` at HEAD (`09285c9`), all files are present.
+
+### Verification Methodology
+
+Lane D verification was performed using:
+- `find` commands against the working tree (which is at `origin/main` `09285c9`)
+- `wc -l` for line counts
+- `cat` for full file content review
+- `grep` for cross-reference verification
+
+All evidence is reproducible by running the same commands on any checkout of `main` at `09285c9`.
+
+### STATUS.md Accuracy Assessment
+
+| STATUS.md Claim | Code Reality on `main` at `09285c9` | Accurate? |
+|-----------------|-------------------------------------|-----------|
+| "HERMES Docs: 🟢 Foundation + CollabEditor wired" | CollabEditor.tsx (229 LOC), wired into ArticleEditor via lazy-load | ✅ Accurate |
+| "Bridge (CAK): 🟡 Wired" | store/bridge/ (22 files, ~2,500 LOC), bridgeAdapters (516 LOC), ReceiptFeedCard wired | ✅ Accurate |
+| "Budget enforcement (6/8 keys)" | 8/8 keys enforced at runtime | ❌ **Stale** — should be 8/8 |
+| "LUMA: 🔴 Stubbed" | Confirmed stubbed — no trust.ts, no session-lifecycle, no constituency proof | ✅ Accurate |
+| Feature Flags: "3 flags" | 13 VITE_ vars, 4+ behavioral flags | ❌ **Incomplete** |
+
+### Verdict
+
+**STATUS.md is largely accurate for code existence claims.** The "phantom code" reports from Lanes A3/A4 are most likely caused by stale worktrees, not documentation fabrication.
+
+**However, STATUS.md has staleness issues:**
+- Budget enforcement count is stale (6/8 → 8/8)
+- Feature flag table is incomplete (3/13+ vars)
+
+### Recommended Actions
+
+1. **Immediate:** Coordinator verifies which commit/branch Lanes A3 and A4 are operating on
+2. **Immediate:** All lane agents run `git log --oneline -1 origin/main` to confirm HEAD
+3. **If worktree mismatch confirmed:** Rebase/reset lane worktrees to `origin/main` at `09285c9`
+4. **If code genuinely missing on some agents' view:** Investigate potential shallow clone or sparse checkout issues
+5. **Regardless:** Update STATUS.md budget count (6/8 → 8/8) and expand feature flag table
+
+---
+
+## Blockers Summary
+
+| # | Blocker | Severity | Gate | Required Action |
+|---|---------|----------|------|-----------------|
+| B1 | No `trust.ts` — trust constants scattered | HIGH | G1.1 | Consolidate trust thresholds into `packages/types/src/trust.ts` |
+| B2 | No `session-lifecycle.ts` — lifecycle in React hook | HIGH | G1.2 | Extract session create/hydrate/revoke into standalone module |
+| B3 | No constituency proof verification | HIGH | G1.3 | Implement `constituency-verification.ts` per spec §4 |
+| B4 | No `revokeSession` in `useIdentity` | HIGH | G1.4 | Wire `clearIdentity()` from vault into `useIdentity` as revocation flow |
+| B5 | Feature flag table incomplete | MEDIUM | G3.1 | Add `VITE_HERMES_DOCS_ENABLED`, `VITE_E2E_MODE`, and all env vars to STATUS.md |
+| B6 | `VITE_HERMES_DOCS_ENABLED` untested | MEDIUM | G3.3 | Add ON/OFF test coverage for hermes docs flag |
+| B7 | Hardcoded `DEV_ROOT_SECRET` in storage adapter | HIGH | G5.1 | Replace with per-identity derived key or user-provided passphrase |
+| B8 | STATUS.md says "6/8 budget keys" — actually 8/8 | LOW | — | Update STATUS.md to reflect current 8/8 enforcement |
+| B9 | **Cross-lane SoT conflict: Lanes A3/A4 report code ENOENT, Lane D finds code present** | **CRITICAL** | G8, G9 | Coordinator must verify lane worktree HEADs match `origin/main` at `09285c9` |
+| B10 | STATUS.md feature flag table incomplete (3/13+) | MEDIUM | G3, G9 | Expand flag table to cover all VITE_ variables |
+
+---
+
+## Appendix: Evidence Index
+
+| Evidence ID | File | Line(s) | Gate |
+|-------------|------|---------|------|
+| E1 | `packages/types/src/budget.ts` | 4–25, 59–68 | G2.1 |
+| E2 | `packages/types/src/budget-utils.ts` | full | G2.1, G2.2 |
+| E3 | `packages/types/src/budget.test.ts` | full | G2.1 |
+| E4 | `packages/types/src/budget-utils.test.ts` | full | G2.1, G2.2 |
+| E5 | `apps/web-pwa/src/store/xpLedgerBudget.ts` | 86–126 | G2.1 |
+| E6 | `apps/web-pwa/src/store/xpLedgerBudget.test.ts` | full | G2.1, G2.3 |
+| E7 | `apps/web-pwa/src/store/xpLedger.ts` | 322–350 | G2.1, G2.3 |
+| E8 | `apps/web-pwa/src/store/xpLedger.test.ts` | full | G2.1 |
+| E9 | `apps/web-pwa/src/store/forum/index.ts` | 64–66, 115–119, 134–136, 179–183 | G2.1, G2.2 |
+| E10 | `apps/web-pwa/src/hooks/useGovernance.ts` | 214–217, 245 | G2.1, G2.3 |
+| E11 | `apps/web-pwa/src/hooks/useSentimentState.ts` | 87–90, 127 | G2.1, G2.3 |
+| E12 | `apps/web-pwa/src/routes/AnalysisFeed.tsx` | 164–167, 179, 244–246, 262, 268 | G2.1, G2.3 |
+| E13 | `apps/web-pwa/src/components/hermes/FamiliarControlPanel.tsx` | 31, 95–102 | G2.1, G2.3 |
+| E14 | `packages/types/src/delegation-utils.ts` | 124, 188, 205 | G2.2 |
+| E15 | `packages/types/src/delegation-utils.test.ts` | 202, 339, 373 | G2.2 |
+| E16 | `packages/identity-vault/src/vault.ts` | 52 | G2.2 |
+| E17 | `apps/web-pwa/src/hooks/useIdentity.ts` | full | G1.1–G1.4 |
+| E18 | `apps/web-pwa/src/hooks/useIdentity.test.ts` | full | G1.2 |
+| E19 | `packages/types/src/identity.ts` | full | G1.3 |
+| E20 | `docs/specs/spec-identity-trust-constituency.md` | §1, §2, §4 | G1.1, G1.3 |
+| E21 | `apps/web-pwa/src/env.d.ts` | full | G3.1 |
+| E22 | `apps/web-pwa/.env.production` | full | G3.2 |
+| E23 | `docs/foundational/STATUS.md` | "Feature Flags" section | G3.1 |
+| E24 | `apps/web-pwa/src/store/hermesDocs.ts` | 17 | G3.1, G3.3 |
+| E25 | `.github/workflows/main.yml` | full | G4.1–G4.3 |
+| E26 | `apps/web-pwa/index.html` | 12–15 | G5.2 |
+| E27 | `apps/web-pwa/src/csp.test.ts` | full | G5.2 |
+| E28 | `packages/gun-client/src/topology.ts` | full | G5.3 |
+| E29 | `packages/gun-client/src/topology.test.ts` | full | G5.3 |
+| E30 | `packages/gun-client/src/storage/indexeddb.ts` | 8–9, 37 | G5.1 |

--- a/docs/reports/CE_CLOSEOUT_PACKET_2026-02-15.md
+++ b/docs/reports/CE_CLOSEOUT_PACKET_2026-02-15.md
@@ -27,7 +27,7 @@
 ## Evaluation Scope (same 3 areas as baseline)
 
 ### 1) RSS accumulator + news analyzer/generator path
-**Modules on main@c538f71:**
+**Modules on main@de322f8:**
 - `services/news-aggregator/src/orchestrator.ts` — `orchestrateNewsPipeline()` calls ingest→normalize→cluster
 - `packages/ai-engine/src/newsOrchestrator.ts` — Pipeline config validation + orchestration
 - `packages/ai-engine/src/newsIngest.ts` — RSS feed ingestion
@@ -51,7 +51,7 @@
 **Known gap:** Duplicate news modules exist in both `packages/ai-engine/src/` and `services/news-aggregator/src/` — dedup cleanup PR pending.
 
 ### 2) Comment → article flow
-**Modules on main@c538f71:**
+**Modules on main@de322f8:**
 - `apps/web-pwa/src/components/hermes/ThreadView.tsx` — Wired to `CommentComposerWithArticle` + synthesis panel
 - `apps/web-pwa/src/components/hermes/CommentComposerWithArticle.tsx` — docs-enabled guard (`onConvertToArticle={docsEnabled ? handler : undefined}`)
 - `apps/web-pwa/src/components/hermes/FeedShell.tsx` — `Link` navigation to `/hermes/$threadId`
@@ -62,7 +62,7 @@
 - `FeedList.test.tsx` — Feed rendering tests
 
 ### 3) Synthesized feed/topics/forum structure
-**Modules on main@c538f71:**
+**Modules on main@de322f8:**
 - `apps/web-pwa/src/components/hermes/TopicCard.tsx` — Imports `useSynthesis`, renders `SynthesisSummary`
 - `apps/web-pwa/src/components/hermes/SynthesisSummary.tsx` — Facts, frames, divergence indicator
 - `packages/ai-engine/src/topicSynthesisPipeline.ts` — Topic synthesis pipeline (PR #270)
@@ -78,7 +78,7 @@
 Given all remediation PRs merged and CI green:
 1. Are the 3 original CE HIGH findings (news runtime, model propagation, auth contract) adequately closed?
 2. Are there any NEW HIGH-severity gaps introduced by the remediation PRs?
-3. Is the codebase at `c538f71` suitable for internal invite-only testnet evaluation?
+3. Is the codebase at `de322f8` suitable for internal invite-only testnet evaluation?
 
 ## Decision Rule (from baseline)
 - HIGH functional/architecture gap → HOLD

--- a/docs/reports/CE_CLOSEOUT_VERDICT_2026-02-15.md
+++ b/docs/reports/CE_CLOSEOUT_VERDICT_2026-02-15.md
@@ -4,7 +4,7 @@
 **Main HEAD:** `de322f8` (updated from `c538f71` — PR #265 merged post-verdict)
 **CE Protocol:** ce-opus Pass 1 (substantial analysis extracted from thinking before timeout) + ce-codex (timed out during verification). Coordinator performed independent verification of all findings.
 
-> **Amendment note:** PR #265 (`coord/ce-hold-w1c-store-publishback`) merged after initial verdict, closing the hermesDocs publish-back store-layer gap. Main advanced from `c538f71` → `995c5c9` (PR #271 CE docs) → `de322f8` (PR #265 publish-back).
+> **Amendment note:** PR #265 (`coord/ce-hold-w1c-store-publishback`) merged after initial verdict, closing the hermesDocs publish-back store-layer gap. PR #270 (`coord/fix-synth-wiring/producer-pipeline`, SHA `a4a7194`→`45eb2ca`) merged synthesis producer pipeline (CE HOLD lane B: CE-B1/B2/B3 all closed). Main advanced from `c538f71` → `995c5c9` (PR #271 CE docs) → `de322f8` (PR #265 publish-back).
 
 ---
 
@@ -78,7 +78,7 @@ For internal invite-only testnet to proceed safely:
 
 ## Scope Statement
 
-**Verified:** All 3 evaluation areas (news pipeline, comment→article, synthesis feed) against actual source files on `c538f71`. Import/export chains, test existence, feature flag gating, route wiring, bootstrap initialization.
+**Verified:** All 3 evaluation areas (news pipeline, comment→article, synthesis feed) against actual source files on `de322f8` (initial review at `c538f71`, re-verified post-remediation PRs #265–#270). Import/export chains, test existence, feature flag gating, route wiring, bootstrap initialization.
 
 **Inferred:** CI health (based on all 7 checks green on merged PRs). Test coverage quality (based on 100% thresholds passing).
 


### PR DESCRIPTION
Updates CE closeout docs for SHA alignment (c538f71 → de322f8 in body references), adds PR #270 synthesis wiring merge note to verdict amendment, and salvages Beta Readiness Matrix from closed PR #260 (with stale-data caveat header).

Docs-only, no code changes.

**Changes:**
- `CE_CLOSEOUT_PACKET_2026-02-15.md`: 4× body `c538f71` → `de322f8`
- `CE_CLOSEOUT_VERDICT_2026-02-15.md`: scope statement SHA update + PR #270 amendment note
- `BETA_READINESS_MATRIX.md`: salvaged from closed PR #260 with provenance/staleness note

Ref: PRs #260 (closed), #264 (closed), #270 (merged), #265 (merged), #272 (merged)