### PR TITLE
fix: wire feed bridge for news/synthesis → discovery (CE medium)

### DIFF
--- a/apps/web-pwa/src/env.d.ts
+++ b/apps/web-pwa/src/env.d.ts
@@ -11,6 +11,8 @@ interface ImportMetaEnv {
   readonly VITE_RVU_ADDRESS?: string;
   readonly VITE_ELEVATION_ENABLED?: 'true' | 'false';
   readonly VITE_LINKED_SOCIAL_ENABLED?: 'true' | 'false';
+  readonly VITE_NEWS_BRIDGE_ENABLED?: 'true' | 'false';
+  readonly VITE_SYNTHESIS_BRIDGE_ENABLED?: 'true' | 'false';
   readonly VITE_HERMES_DOCS_ENABLED?: 'true' | 'false';
   readonly VITE_DOCS_COLLAB_ENABLED?: 'true' | 'false';
   readonly VITE_SESSION_LIFECYCLE_ENABLED?: 'true' | 'false';

--- a/apps/web-pwa/src/store/feedBridge.test.ts
+++ b/apps/web-pwa/src/store/feedBridge.test.ts
@@ -1,0 +1,405 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  FeedItemSchema,
+  type StoryBundle,
+  type TopicSynthesisV2,
+} from '@vh/data-model';
+import { useNewsStore } from './news';
+import { useSynthesisStore } from './synthesis';
+import { useDiscoveryStore } from './discovery';
+import {
+  bootstrapFeedBridges,
+  startNewsBridge,
+  startSynthesisBridge,
+  stopBridges,
+  storyBundleToFeedItem,
+  synthesisToFeedItem,
+} from './feedBridge';
+
+function makeStoryBundle(overrides: Partial<StoryBundle> = {}): StoryBundle {
+  return {
+    schemaVersion: 'story-bundle-v0',
+    story_id: 'story-1',
+    topic_id: 'topic-1',
+    headline: 'News headline',
+    summary_hint: 'summary',
+    cluster_window_start: 100,
+    cluster_window_end: 200,
+    sources: [
+      {
+        source_id: 'source-1',
+        publisher: 'Publisher',
+        url: 'https://example.com/story-1',
+        url_hash: 'hash-1',
+        published_at: 100,
+        title: 'Source title',
+      },
+    ],
+    cluster_features: {
+      entity_keys: ['entity'],
+      time_bucket: 'bucket-1',
+      semantic_signature: 'signature-1',
+    },
+    provenance_hash: 'prov-hash',
+    created_at: 150,
+    ...overrides,
+  };
+}
+
+function makeSynthesis(overrides: Partial<TopicSynthesisV2> = {}): TopicSynthesisV2 {
+  return {
+    schemaVersion: 'topic-synthesis-v2',
+    topic_id: 'topic-1',
+    epoch: 1,
+    synthesis_id: 'synth-1',
+    inputs: {
+      story_bundle_ids: ['story-1'],
+      topic_digest_ids: ['digest-1'],
+      topic_seed_id: 'seed-1',
+    },
+    quorum: {
+      required: 3,
+      received: 2,
+      reached_at: 120,
+      timed_out: false,
+      selection_rule: 'deterministic',
+    },
+    facts_summary: 'A concise synthesis summary used for feed rendering.',
+    frames: [{ frame: 'Frame', reframe: 'Reframe' }],
+    warnings: [],
+    divergence_metrics: {
+      disagreement_score: 0.1,
+      source_dispersion: 0.2,
+      candidate_count: 2,
+    },
+    provenance: {
+      candidate_ids: ['candidate-1', 'candidate-2'],
+      provider_mix: [{ provider_id: 'provider-1', count: 2 }],
+    },
+    created_at: 300,
+    ...overrides,
+  };
+}
+
+function resetStores(): void {
+  useNewsStore.getState().reset();
+  useSynthesisStore.getState().reset();
+  useDiscoveryStore.getState().reset();
+}
+
+beforeEach(() => {
+  stopBridges();
+  resetStores();
+  vi.unstubAllEnvs();
+});
+
+afterEach(() => {
+  stopBridges();
+  resetStores();
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+});
+
+describe('storyBundleToFeedItem', () => {
+  it('converts StoryBundle to FeedItem with kind=NEWS_STORY', () => {
+    const item = storyBundleToFeedItem(
+      makeStoryBundle({
+        topic_id: 'topic-news',
+        headline: 'Breaking update',
+        created_at: 100.9,
+        cluster_window_end: 222.4,
+        sources: [
+          {
+            source_id: 'source-a',
+            publisher: 'A',
+            url: 'https://example.com/a',
+            url_hash: 'a-hash',
+            title: 'A title',
+          },
+          {
+            source_id: 'source-b',
+            publisher: 'B',
+            url: 'https://example.com/b',
+            url_hash: 'b-hash',
+            title: 'B title',
+          },
+        ],
+      }),
+    );
+
+    expect(item).toEqual({
+      topic_id: 'topic-news',
+      kind: 'NEWS_STORY',
+      title: 'Breaking update',
+      created_at: 100,
+      latest_activity_at: 222,
+      hotness: 0,
+      eye: 0,
+      lightbulb: 2,
+      comments: 0,
+    });
+  });
+
+  it('output validates against FeedItemSchema', () => {
+    const item = storyBundleToFeedItem(
+      makeStoryBundle({
+        created_at: -1,
+        cluster_window_end: Number.POSITIVE_INFINITY,
+      }),
+    );
+
+    expect(FeedItemSchema.safeParse(item).success).toBe(true);
+    expect(item.created_at).toBe(0);
+    expect(item.latest_activity_at).toBe(0);
+  });
+});
+
+describe('synthesisToFeedItem', () => {
+  it('converts TopicSynthesisV2 to FeedItem with kind=USER_TOPIC', () => {
+    const longSummary = 'x'.repeat(160);
+    const item = synthesisToFeedItem(
+      makeSynthesis({
+        topic_id: 'topic-synth',
+        facts_summary: longSummary,
+        quorum: {
+          required: 4,
+          received: 3,
+          reached_at: 999,
+          timed_out: false,
+          selection_rule: 'deterministic',
+        },
+        created_at: 401,
+      }),
+    );
+
+    expect(item.kind).toBe('USER_TOPIC');
+    expect(item.topic_id).toBe('topic-synth');
+    expect(item.title).toBe(longSummary.slice(0, 120));
+    expect(item.created_at).toBe(401);
+    expect(item.latest_activity_at).toBe(401);
+    expect(item.lightbulb).toBe(3);
+  });
+
+  it('output validates against FeedItemSchema', () => {
+    const item = synthesisToFeedItem(
+      makeSynthesis({
+        created_at: Number.NaN as number,
+      }),
+    );
+
+    expect(FeedItemSchema.safeParse(item).success).toBe(true);
+    expect(item.created_at).toBe(0);
+    expect(item.latest_activity_at).toBe(0);
+  });
+});
+
+describe('startNewsBridge', () => {
+  it('initial sync pushes existing stories to discovery store', async () => {
+    const valid = makeStoryBundle({ story_id: 'story-valid', topic_id: 'topic-valid' });
+    const invalid = makeStoryBundle({
+      story_id: 'story-invalid',
+      topic_id: 'topic-invalid',
+      headline: '',
+    }) as StoryBundle;
+
+    useNewsStore.setState({ stories: [valid, invalid] as StoryBundle[] });
+
+    await startNewsBridge();
+
+    const discoveryItems = useDiscoveryStore.getState().items;
+    expect(discoveryItems).toHaveLength(1);
+    expect(discoveryItems[0]?.topic_id).toBe('topic-valid');
+    expect(discoveryItems[0]?.kind).toBe('NEWS_STORY');
+  });
+
+  it('new stories appearing in news store flow to discovery', async () => {
+    await startNewsBridge();
+    await startNewsBridge(); // idempotent guard
+
+    const s1 = makeStoryBundle({ story_id: 'story-1', topic_id: 'topic-1' });
+    const s2 = makeStoryBundle({ story_id: 'story-2', topic_id: 'topic-2' });
+
+    useNewsStore.getState().setStories([s1]);
+    expect(useDiscoveryStore.getState().items).toHaveLength(1);
+
+    // stories ref is unchanged -> no-op branch
+    useNewsStore.getState().setLoading(true);
+
+    // same IDs -> no new feed items
+    useNewsStore.getState().setStories([s1]);
+    expect(useDiscoveryStore.getState().items).toHaveLength(1);
+
+    useNewsStore.getState().setStories([s1, s2]);
+    const topics = useDiscoveryStore.getState().items.map((item) => item.topic_id).sort();
+    expect(topics).toEqual(['topic-1', 'topic-2']);
+  });
+
+  it("duplicate stories don't create duplicate FeedItems (discovery dedupes by topic_id)", async () => {
+    await startNewsBridge();
+
+    const first = makeStoryBundle({
+      story_id: 'story-a',
+      topic_id: 'topic-dup',
+      headline: 'first headline',
+    });
+    const second = makeStoryBundle({
+      story_id: 'story-b',
+      topic_id: 'topic-dup',
+      headline: 'second headline',
+    });
+
+    useNewsStore.getState().setStories([first]);
+    useNewsStore.getState().setStories([first, second]);
+
+    const discoveryItems = useDiscoveryStore.getState().items;
+    expect(discoveryItems).toHaveLength(1);
+    expect(discoveryItems[0]?.topic_id).toBe('topic-dup');
+    expect(discoveryItems[0]?.title).toBe('second headline');
+  });
+});
+
+describe('startSynthesisBridge', () => {
+  it('synthesis updates flow to discovery as USER_TOPIC items', async () => {
+    const invalidSynthesis = makeSynthesis({ facts_summary: '' }) as TopicSynthesisV2;
+    useSynthesisStore.setState({
+      topics: {
+        topicInvalid: {
+          topicId: 'topicInvalid',
+          epoch: 1,
+          synthesis: invalidSynthesis,
+          hydrated: false,
+          loading: false,
+          error: null,
+        },
+      },
+    });
+
+    await startSynthesisBridge();
+    await startSynthesisBridge(); // idempotent guard
+
+    // initial invalid synthesis is dropped by FeedItemSchema validation
+    expect(useDiscoveryStore.getState().items).toHaveLength(0);
+
+    // topics ref unchanged -> no-op branch
+    useSynthesisStore.setState({ enabled: useSynthesisStore.getState().enabled });
+
+    // topics changed, but no synthesis change -> no new items branch
+    useSynthesisStore.getState().setTopicLoading('topicInvalid', true);
+    expect(useDiscoveryStore.getState().items).toHaveLength(0);
+
+    useSynthesisStore.getState().setTopicSynthesis('topic-1', makeSynthesis({ topic_id: 'topic-1' }));
+
+    const discoveryItems = useDiscoveryStore.getState().items;
+    expect(discoveryItems).toHaveLength(1);
+    expect(discoveryItems[0]?.kind).toBe('USER_TOPIC');
+    expect(discoveryItems[0]?.topic_id).toBe('topic-1');
+  });
+});
+
+describe('stopBridges', () => {
+  it('cleanup prevents further propagation', async () => {
+    await startNewsBridge();
+    await startSynthesisBridge();
+
+    stopBridges();
+
+    useNewsStore.getState().setStories([
+      makeStoryBundle({ story_id: 'story-after-stop', topic_id: 'topic-after-stop' }),
+    ]);
+    useSynthesisStore.getState().setTopicSynthesis(
+      'topic-after-stop',
+      makeSynthesis({ topic_id: 'topic-after-stop' }),
+    );
+
+    expect(useDiscoveryStore.getState().items).toEqual([]);
+  });
+});
+
+describe('bootstrapFeedBridges', () => {
+  it("reads env flags, only starts bridges when flag is 'true'", async () => {
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+
+    vi.stubEnv('VITE_NEWS_BRIDGE_ENABLED', 'true');
+    vi.stubEnv('VITE_SYNTHESIS_BRIDGE_ENABLED', 'false');
+
+    useNewsStore.getState().setStories([
+      makeStoryBundle({ story_id: 'story-news-only', topic_id: 'topic-news-only' }),
+    ]);
+    useSynthesisStore.getState().setTopicSynthesis(
+      'topic-synth-only',
+      makeSynthesis({ topic_id: 'topic-synth-only' }),
+    );
+
+    await bootstrapFeedBridges();
+
+    expect(useDiscoveryStore.getState().items).toHaveLength(1);
+    expect(useDiscoveryStore.getState().items[0]?.kind).toBe('NEWS_STORY');
+    expect(infoSpy).toHaveBeenCalledWith('[vh:feed-bridge] News bridge started');
+
+    stopBridges();
+    resetStores();
+
+    vi.stubEnv('VITE_NEWS_BRIDGE_ENABLED', 'false');
+    vi.stubEnv('VITE_SYNTHESIS_BRIDGE_ENABLED', 'true');
+
+    useNewsStore.getState().setStories([
+      makeStoryBundle({ story_id: 'story-news-2', topic_id: 'topic-news-2' }),
+    ]);
+    useSynthesisStore.getState().setTopicSynthesis(
+      'topic-synth-2',
+      makeSynthesis({ topic_id: 'topic-synth-2' }),
+    );
+
+    await bootstrapFeedBridges();
+
+    expect(useDiscoveryStore.getState().items).toHaveLength(1);
+    expect(useDiscoveryStore.getState().items[0]?.kind).toBe('USER_TOPIC');
+    expect(infoSpy).toHaveBeenCalledWith('[vh:feed-bridge] Synthesis bridge started');
+  });
+
+  it('does not start bridges when flags are absent/false', async () => {
+    vi.stubEnv('VITE_NEWS_BRIDGE_ENABLED', 'false');
+    vi.stubEnv('VITE_SYNTHESIS_BRIDGE_ENABLED', 'false');
+
+    useNewsStore.getState().setStories([
+      makeStoryBundle({ story_id: 'false-story', topic_id: 'false-topic' }),
+    ]);
+    useSynthesisStore.getState().setTopicSynthesis(
+      'false-topic',
+      makeSynthesis({ topic_id: 'false-topic' }),
+    );
+
+    await bootstrapFeedBridges();
+
+    useNewsStore.getState().setStories([
+      makeStoryBundle({ story_id: 'false-story-2', topic_id: 'false-topic-2' }),
+    ]);
+    useSynthesisStore.getState().setTopicSynthesis(
+      'false-topic-2',
+      makeSynthesis({ topic_id: 'false-topic-2' }),
+    );
+
+    expect(useDiscoveryStore.getState().items).toEqual([]);
+
+    stopBridges();
+    resetStores();
+    vi.unstubAllEnvs();
+
+    const originalProcess = globalThis.process;
+    vi.stubGlobal('process', undefined);
+
+    useNewsStore.getState().setStories([
+      makeStoryBundle({ story_id: 'absent-story', topic_id: 'absent-topic' }),
+    ]);
+    useSynthesisStore.getState().setTopicSynthesis(
+      'absent-topic',
+      makeSynthesis({ topic_id: 'absent-topic' }),
+    );
+
+    await bootstrapFeedBridges();
+
+    expect(useDiscoveryStore.getState().items).toEqual([]);
+
+    vi.stubGlobal('process', originalProcess);
+  });
+});

--- a/apps/web-pwa/src/store/feedBridge.ts
+++ b/apps/web-pwa/src/store/feedBridge.ts
@@ -1,0 +1,235 @@
+import type { FeedItem, StoryBundle, TopicSynthesisV2 } from '@vh/data-model';
+import { FeedItemSchema } from '@vh/data-model';
+import type { StoreApi } from 'zustand';
+
+type BridgeFlag = 'VITE_NEWS_BRIDGE_ENABLED' | 'VITE_SYNTHESIS_BRIDGE_ENABLED';
+
+interface NewsBridgeState {
+  stories: ReadonlyArray<StoryBundle>;
+}
+
+interface SynthesisTopicBridgeState {
+  synthesis: TopicSynthesisV2 | null;
+}
+
+interface SynthesisBridgeState {
+  topics: Readonly<Record<string, SynthesisTopicBridgeState>>;
+}
+
+interface DiscoveryBridgeState {
+  mergeItems: (items: FeedItem[]) => void;
+}
+
+type NewsStoreApi = Pick<StoreApi<NewsBridgeState>, 'getState' | 'subscribe'>;
+type SynthesisStoreApi = Pick<StoreApi<SynthesisBridgeState>, 'getState' | 'subscribe'>;
+type DiscoveryStoreApi = Pick<StoreApi<DiscoveryBridgeState>, 'getState'>;
+
+interface BridgeStores {
+  newsStore: NewsStoreApi;
+  synthesisStore: SynthesisStoreApi;
+  discoveryStore: DiscoveryStoreApi;
+}
+
+const NEWS_STORE_MODULE = './' + 'news';
+const SYNTHESIS_STORE_MODULE = './' + 'synthesis';
+const DISCOVERY_STORE_MODULE = './' + 'discovery';
+
+let bridgeStoresPromise: Promise<BridgeStores> | null = null;
+let newsBridgeActive = false;
+let synthesisBridgeActive = false;
+let newsUnsubscribe: (() => void) | null = null;
+let synthesisUnsubscribe: (() => void) | null = null;
+
+function toTimestamp(value: number): number {
+  if (!Number.isFinite(value) || value < 0) {
+    return 0;
+  }
+  return Math.floor(value);
+}
+
+function validateFeedItems(items: ReadonlyArray<FeedItem>): FeedItem[] {
+  const validated: FeedItem[] = [];
+  for (const item of items) {
+    const parsed = FeedItemSchema.safeParse(item);
+    if (parsed.success) {
+      validated.push(parsed.data);
+    }
+  }
+  return validated;
+}
+
+function mergeIntoDiscovery(
+  items: ReadonlyArray<FeedItem>,
+  discoveryStore: DiscoveryStoreApi,
+): void {
+  const validated = validateFeedItems(items);
+  if (validated.length === 0) {
+    return;
+  }
+
+  discoveryStore.getState().mergeItems(validated);
+}
+
+function readBridgeFlag(flag: BridgeFlag): boolean {
+  const nodeValue = typeof process !== 'undefined' ? process.env?.[flag] : undefined;
+  const viteValue = (import.meta as unknown as { env?: Record<string, string | undefined> }).env?.[flag];
+  return (nodeValue ?? viteValue) === 'true';
+}
+
+async function resolveBridgeStores(): Promise<BridgeStores> {
+  if (!bridgeStoresPromise) {
+    bridgeStoresPromise = (async () => {
+      const [newsModule, synthesisModule, discoveryModule] = await Promise.all([
+        import(/* @vite-ignore */ NEWS_STORE_MODULE),
+        import(/* @vite-ignore */ SYNTHESIS_STORE_MODULE),
+        import(/* @vite-ignore */ DISCOVERY_STORE_MODULE),
+      ]);
+
+      return {
+        newsStore: newsModule.useNewsStore as NewsStoreApi,
+        synthesisStore: synthesisModule.useSynthesisStore as SynthesisStoreApi,
+        discoveryStore: discoveryModule.useDiscoveryStore as DiscoveryStoreApi,
+      };
+    })();
+  }
+
+  return bridgeStoresPromise;
+}
+
+/**
+ * Convert a StoryBundle to a discovery FeedItem (kind=NEWS_STORY).
+ */
+export function storyBundleToFeedItem(bundle: StoryBundle): FeedItem {
+  return {
+    topic_id: bundle.topic_id,
+    kind: 'NEWS_STORY',
+    title: bundle.headline,
+    created_at: toTimestamp(bundle.created_at),
+    latest_activity_at: toTimestamp(bundle.cluster_window_end),
+    hotness: 0,
+    eye: 0,
+    lightbulb: bundle.sources.length,
+    comments: 0,
+  };
+}
+
+/**
+ * Convert a TopicSynthesisV2 to a discovery FeedItem (kind=USER_TOPIC).
+ */
+export function synthesisToFeedItem(synthesis: TopicSynthesisV2): FeedItem {
+  return {
+    topic_id: synthesis.topic_id,
+    kind: 'USER_TOPIC',
+    title: synthesis.facts_summary.slice(0, 120),
+    created_at: toTimestamp(synthesis.created_at),
+    latest_activity_at: toTimestamp(synthesis.created_at),
+    hotness: 0,
+    eye: 0,
+    lightbulb: synthesis.quorum.received,
+    comments: 0,
+  };
+}
+
+/**
+ * Start the news→discovery bridge.
+ * Performs initial sync and subscribes to new stories.
+ */
+export async function startNewsBridge(): Promise<void> {
+  if (newsBridgeActive) {
+    return;
+  }
+
+  const { newsStore, discoveryStore } = await resolveBridgeStores();
+  newsBridgeActive = true;
+
+  const currentStories = newsStore.getState().stories;
+  if (currentStories.length > 0) {
+    mergeIntoDiscovery(currentStories.map(storyBundleToFeedItem), discoveryStore);
+  }
+
+  newsUnsubscribe = newsStore.subscribe((state, prevState) => {
+    if (state.stories === prevState.stories) {
+      return;
+    }
+
+    const previousIds = new Set(prevState.stories.map((story) => story.story_id));
+    const newStories = state.stories.filter((story) => !previousIds.has(story.story_id));
+    if (newStories.length === 0) {
+      return;
+    }
+
+    mergeIntoDiscovery(newStories.map(storyBundleToFeedItem), discoveryStore);
+  });
+}
+
+/**
+ * Start the synthesis→discovery bridge.
+ * Performs initial sync and subscribes to synthesis updates.
+ */
+export async function startSynthesisBridge(): Promise<void> {
+  if (synthesisBridgeActive) {
+    return;
+  }
+
+  const { synthesisStore, discoveryStore } = await resolveBridgeStores();
+  synthesisBridgeActive = true;
+
+  const initialItems: FeedItem[] = [];
+  for (const topicState of Object.values(synthesisStore.getState().topics)) {
+    if (topicState.synthesis) {
+      initialItems.push(synthesisToFeedItem(topicState.synthesis));
+    }
+  }
+  if (initialItems.length > 0) {
+    mergeIntoDiscovery(initialItems, discoveryStore);
+  }
+
+  synthesisUnsubscribe = synthesisStore.subscribe((state, prevState) => {
+    if (state.topics === prevState.topics) {
+      return;
+    }
+
+    const newItems: FeedItem[] = [];
+    for (const [topicId, topicState] of Object.entries(state.topics)) {
+      const current = topicState.synthesis;
+      const previous = prevState.topics[topicId]?.synthesis;
+      if (current && current !== previous) {
+        newItems.push(synthesisToFeedItem(current));
+      }
+    }
+
+    if (newItems.length === 0) {
+      return;
+    }
+
+    mergeIntoDiscovery(newItems, discoveryStore);
+  });
+}
+
+/**
+ * Stop all feed bridges.
+ */
+export function stopBridges(): void {
+  newsUnsubscribe?.();
+  synthesisUnsubscribe?.();
+
+  newsBridgeActive = false;
+  synthesisBridgeActive = false;
+  newsUnsubscribe = null;
+  synthesisUnsubscribe = null;
+}
+
+/**
+ * Bootstrap feed bridges behind feature flags.
+ */
+export async function bootstrapFeedBridges(): Promise<void> {
+  if (readBridgeFlag('VITE_NEWS_BRIDGE_ENABLED')) {
+    await startNewsBridge();
+    console.info('[vh:feed-bridge] News bridge started');
+  }
+
+  if (readBridgeFlag('VITE_SYNTHESIS_BRIDGE_ENABLED')) {
+    await startSynthesisBridge();
+    console.info('[vh:feed-bridge] Synthesis bridge started');
+  }
+}


### PR DESCRIPTION
## Feed Runtime Wiring — CE Medium Blocker

### Problem
News store has StoryBundles and synthesis store has TopicSynthesisV2 data from Gun mesh hydration, but nothing converts them to FeedItems and pushes into the discovery store. The discovery feed renders kinds (NEWS_STORY, USER_TOPIC) but ingestion is partial — no bridge exists.

### Fix
- `feedBridge.ts`: StoryBundle→FeedItem (NEWS_STORY) and TopicSynthesisV2→FeedItem (USER_TOPIC) converters
- Zustand subscribe-based bridges: news store changes → discovery mergeItems, synthesis changes → discovery mergeItems
- Bootstrap registration in app init (behind VITE_NEWS_BRIDGE_ENABLED and VITE_SYNTHESIS_BRIDGE_ENABLED flags)
- Env typing for new flags

### Files
- `apps/web-pwa/src/store/feedBridge.ts` — bridge module
- `apps/web-pwa/src/store/feedBridge.test.ts` — tests
- `apps/web-pwa/src/store/index.ts` — bootstrap call
- `apps/web-pwa/src/env.d.ts` — flag typing