### PR TITLE
fix: recover source health from stale retries

### DIFF
--- a/packages/ai-engine/src/feedRegistry.test.ts
+++ b/packages/ai-engine/src/feedRegistry.test.ts
@@ -9,7 +9,7 @@ import { FeedSourceSchema, type FeedSource } from './newsTypes';
 describe('feedRegistry', () => {
   describe('STARTER_FEED_SOURCES', () => {
     it('contains the baseline starter surface and evidence-admitted additions', () => {
-      expect(STARTER_FEED_SOURCES.length).toBeGreaterThanOrEqual(29);
+      expect(STARTER_FEED_SOURCES.length).toBeGreaterThanOrEqual(28);
     });
 
     it('all sources pass FeedSourceSchema validation', () => {
@@ -42,7 +42,7 @@ describe('feedRegistry', () => {
       const wire = STARTER_FEED_SOURCES.filter(
         (s) => s.perspectiveTag === 'international-wire',
       );
-      expect(wire.length).toBeGreaterThanOrEqual(6);
+      expect(wire.length).toBeGreaterThanOrEqual(5);
     });
 
     it('includes the highest-confidence statehouse and specialist additions', () => {
@@ -261,9 +261,9 @@ describe('feedRegistry', () => {
     });
 
     it('returns metadata for international-wire source', () => {
-      const meta = getSourceMetadata('bbc-general');
+      const meta = getSourceMetadata('bbc-us-canada');
       expect(meta).toEqual({
-        displayName: 'BBC News',
+        displayName: 'BBC',
         perspectiveTag: 'international-wire',
         iconKey: 'bbc',
       });

--- a/packages/ai-engine/src/feedRegistry.ts
+++ b/packages/ai-engine/src/feedRegistry.ts
@@ -122,15 +122,6 @@ export const STARTER_FEED_SOURCES: readonly FeedSource[] = Object.freeze([
   }),
   // International wire (3)
   FeedSourceSchema.parse({
-    id: 'bbc-general',
-    name: 'BBC News',
-    displayName: 'BBC News',
-    rssUrl: 'https://feeds.bbci.co.uk/news/rss.xml',
-    perspectiveTag: 'international-wire',
-    iconKey: 'bbc',
-    enabled: true,
-  }),
-  FeedSourceSchema.parse({
     id: 'bbc-us-canada',
     name: 'BBC US & Canada',
     displayName: 'BBC',

--- a/services/news-aggregator/src/sourceHealthReport.test.ts
+++ b/services/news-aggregator/src/sourceHealthReport.test.ts
@@ -195,6 +195,39 @@ describe('sourceHealthReport', () => {
     expect(decision.unstableLifecycleDomains).toEqual([]);
   });
 
+  it('keeps admitted sources when retrying fully recovered before the final sample', () => {
+    const source = makeAdmissionSource({
+      sourceId: 'fedsmith-news',
+      lifecycle: [
+        {
+          sourceDomain: 'www.fedsmith.com',
+          status: 'healthy',
+          totalAttempts: 5,
+          totalSuccesses: 4,
+          totalFailures: 0,
+          consecutiveFailures: 0,
+          retryCount: 1,
+          lastAttemptAt: 5,
+          lastSuccessAt: 5,
+          lastFailureAt: null,
+          lastRetryAt: 4,
+          nextRetryAt: null,
+          lastBackoffMs: null,
+          lastErrorMessage: null,
+        },
+      ],
+    });
+
+    const decision = sourceHealthReportInternal.buildDecision(
+      source,
+      buildSourceHealthThresholds(),
+    );
+
+    expect(decision.decision).toBe('keep');
+    expect(decision.reasons).toEqual([]);
+    expect(decision.unstableLifecycleDomains).toEqual([]);
+  });
+
   it('marks rejected non-feed-outage sources for removal', () => {
     const source = makeAdmissionSource({
       sourceId: 'cbs-politics',
@@ -216,7 +249,7 @@ describe('sourceHealthReport', () => {
 
   it('keeps feed-link outages on the manual-review watchlist', () => {
     const source = makeAdmissionSource({
-      sourceId: 'bbc-general',
+      sourceId: 'bbc-us-canada',
       status: 'inconclusive',
       admitted: false,
       sampleLinkCount: 0,

--- a/services/news-aggregator/src/sourceHealthReport.ts
+++ b/services/news-aggregator/src/sourceHealthReport.ts
@@ -521,13 +521,21 @@ function filterComparableHistoricalReports(
   ));
 }
 
+function isLifecycleStateUnstable(state: SourceAdmissionSourceReport['lifecycle'][number]): boolean {
+  if (state.status !== 'healthy' || state.consecutiveFailures > 0) {
+    return true;
+  }
+  if (state.retryCount <= 0 || state.lastRetryAt === null) {
+    return false;
+  }
+  if (state.lastSuccessAt === null) {
+    return true;
+  }
+  return state.lastSuccessAt < state.lastRetryAt;
+}
+
 function hasLifecycleInstability(source: SourceAdmissionSourceReport): boolean {
-  return source.lifecycle.some(
-    (state) =>
-      state.status !== 'healthy'
-      || state.retryCount > 0
-      || state.consecutiveFailures > 0,
-  );
+  return source.lifecycle.some((state) => isLifecycleStateUnstable(state));
 }
 
 function buildDecision(
@@ -535,12 +543,7 @@ function buildDecision(
   thresholds: SourceHealthThresholds,
 ): SourceHealthSourceReport {
   const unstableLifecycleDomains = source.lifecycle
-    .filter(
-      (state) =>
-        state.status !== 'healthy'
-        || state.retryCount > 0
-        || state.consecutiveFailures > 0,
-    )
+    .filter((state) => isLifecycleStateUnstable(state))
     .map((state) => state.sourceDomain);
 
   if (source.status === 'admitted') {
@@ -1338,6 +1341,7 @@ export const sourceHealthReportInternal = {
   countConsecutiveDecisions,
   filterComparableHistoricalReports,
   hasLifecycleInstability,
+  isLifecycleStateUnstable,
   isDirectExecution,
   isFeedStageFailureSource,
   parseBoolean,


### PR DESCRIPTION
## Summary
- stop treating fully recovered lifecycle retries as permanent source-health instability
- remove the unstable  generic BBC feed from the starter surface and rely on 
- keep the source-health gate aligned with the corrected 28-source starter slate

## Validation
- pnpm exec vitest run /Users/bldt/Desktop/VHC/VHC/packages/ai-engine/src/feedRegistry.test.ts --config /Users/bldt/Desktop/VHC/VHC/vitest.config.ts
- pnpm --filter @vh/news-aggregator exec vitest run /Users/bldt/Desktop/VHC/VHC/services/news-aggregator/src/sourceHealthReport.test.ts --config /Users/bldt/Desktop/VHC/VHC/services/news-aggregator/vitest.config.ts
- pnpm report:news-sources:health
- ready/pass artifact: /Users/bldt/Desktop/VHC/VHC/services/news-aggregator/.tmp/news-source-admission/1776041840714/source-health-report.json
- ready/pass artifact after slate correction: /Users/bldt/Desktop/VHC/VHC/services/news-aggregator/.tmp/news-source-admission/1776041766209/source-health-report.json