### PR TITLE
Implement item eligibility policy for soak admission

### DIFF
--- a/apps/web-pwa/src/components/feed/newsCardAnalysis.test.ts
+++ b/apps/web-pwa/src/components/feed/newsCardAnalysis.test.ts
@@ -89,6 +89,7 @@ describe('newsCardAnalysis', () => {
   afterEach(() => {
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
   });
 
   it('analyzes at most 3 sources and synthesizes summary + frame rows', async () => {
@@ -233,22 +234,26 @@ describe('newsCardAnalysis', () => {
     expect(input).toContain('FULL ARTICLE TEXT');
   });
 
-  it('falls back to metadata-only input when article fetch fails', async () => {
+  it('skips sources whose article text cannot be fetched', async () => {
+    const baseStory = makeStoryBundle();
     const story = makeStoryBundle({
-      sources: [makeStoryBundle().sources[0]!],
+      sources: [baseStory.sources[0]!, baseStory.sources[1]!],
     });
 
     const analysisInputs: string[] = [];
 
     const result = await synthesizeStoryFromAnalysisPipeline(story, {
-      fetchArticleText: async () => {
-        throw new Error('fetch blocked');
+      fetchArticleText: async (url: string) => {
+        if (url.endsWith('/1')) {
+          throw new Error('fetch blocked');
+        }
+        return 'ARTICLE BODY 2';
       },
       runAnalysis: async (articleText: string) => {
         analysisInputs.push(articleText);
         return {
           analysis: makeAnalysis({
-            summary: 'Metadata fallback still produced analysis.',
+            summary: 'Only fetched article text is analyzed.',
             biases: ['No clear bias detected'],
             counterpoints: ['N/A'],
           }),
@@ -257,37 +262,33 @@ describe('newsCardAnalysis', () => {
     });
 
     expect(analysisInputs).toHaveLength(1);
-    expect(analysisInputs[0]).toContain('ARTICLE BODY: unavailable; analyze available metadata only.');
-    expect(result.summary).toContain('Publisher One: Metadata fallback still produced analysis.');
+    expect(analysisInputs[0]).toContain('ARTICLE BODY 2');
+    expect(result.summary).toContain('Publisher Two: Only fetched article text is analyzed.');
+    expect(result.summary).not.toContain('Publisher One');
   });
 
-  it('skips article fetch entirely when metadata-only analysis is enabled', async () => {
+  it('does not run source analysis when article-text fetching is disabled', async () => {
     vi.stubEnv('VITE_VH_ANALYSIS_SKIP_ARTICLE_TEXT', 'true');
     const story = makeStoryBundle({
       sources: [makeStoryBundle().sources[0]!],
     });
     const fetchArticleText = vi.fn(async () => 'UNUSED ARTICLE TEXT');
-    const analysisInputs: string[] = [];
+    const runAnalysis = vi.fn(async (_articleText: string) => ({
+      analysis: makeAnalysis({
+        summary: 'Should not run.',
+        biases: ['Metadata bias'],
+        counterpoints: ['Metadata counterpoint'],
+      }),
+    }));
 
-    const result = await synthesizeStoryFromAnalysisPipeline(story, {
+    await expect(synthesizeStoryFromAnalysisPipeline(story, {
       fetchArticleText,
-      runAnalysis: async (articleText: string) => {
-        analysisInputs.push(articleText);
-        return {
-          analysis: makeAnalysis({
-            summary: 'Metadata-only analysis completed immediately.',
-            biases: ['Metadata bias'],
-            counterpoints: ['Metadata counterpoint'],
-          }),
-        };
-      },
-    });
+      runAnalysis,
+    })).rejects.toThrow('Analysis pipeline unavailable for all story sources');
 
     expect(newsCardAnalysisInternal.shouldSkipArticleTextFetch()).toBe(true);
     expect(fetchArticleText).not.toHaveBeenCalled();
-    expect(analysisInputs).toHaveLength(1);
-    expect(analysisInputs[0]).toContain('ARTICLE BODY: unavailable; analyze available metadata only.');
-    expect(result.summary).toContain('Publisher One: Metadata-only analysis completed immediately.');
+    expect(runAnalysis).not.toHaveBeenCalled();
   });
 
   it('throws when all source analyses fail', async () => {

--- a/apps/web-pwa/src/components/feed/newsCardAnalysis.ts
+++ b/apps/web-pwa/src/components/feed/newsCardAnalysis.ts
@@ -211,7 +211,7 @@ function selectSourcesForAnalysis(
 function buildAnalysisInput(
   story: StoryBundle,
   source: StoryBundle['sources'][number],
-  articleText: string | null,
+  articleText: string,
 ): string {
   const context = [
     `Publisher: ${source.publisher}`,
@@ -227,19 +227,11 @@ function buildAnalysisInput(
     context.push(`Bundle summary hint: ${story.summary_hint.trim()}`);
   }
 
-  if (articleText && articleText.trim()) {
-    return [
-      context.join('\n'),
-      '',
-      'ARTICLE BODY:',
-      articleText.trim(),
-    ].join('\n');
-  }
-
   return [
     context.join('\n'),
     '',
-    'ARTICLE BODY: unavailable; analyze available metadata only.',
+    'ARTICLE BODY:',
+    articleText.trim(),
   ].join('\n');
 }
 
@@ -307,25 +299,28 @@ async function runSynthesis(
   const skipArticleTextFetch = shouldSkipArticleTextFetch();
 
   for (const source of selectedSources) {
-    try {
-      let articleText: string | null = null;
-      if (!skipArticleTextFetch) {
-        try {
-          articleText = await fetchArticleText(source.url);
-        } catch (error) {
-          console.warn('[vh:news-card-analysis] article fetch failed; using metadata fallback', {
-            sourceId: source.source_id,
-            url: source.url,
-            error,
-          });
-        }
-      }
+    if (skipArticleTextFetch) {
+      console.info('[vh:news-card-analysis] source analysis skipped; article text disabled', {
+        sourceId: source.source_id,
+        url: source.url,
+      });
+      continue;
+    }
 
+    try {
+      const articleText = await fetchArticleText(source.url);
+      if (!articleText.trim()) {
+        console.warn('[vh:news-card-analysis] source analysis skipped; empty article text', {
+          sourceId: source.source_id,
+          url: source.url,
+        });
+        continue;
+      }
       const input = buildAnalysisInput(story, source, articleText);
       const result = await runAnalysis(input);
       analyzed.push(toSourceAnalysis(source, result.analysis));
     } catch (error) {
-      console.warn('[vh:news-card-analysis] source analysis failed', {
+      console.warn('[vh:news-card-analysis] source analysis skipped; article text unavailable', {
         sourceId: source.source_id,
         url: source.url,
         error,

--- a/docs/plans/ITEM_LEVEL_FEED_RELIABILITY_IMPLEMENTATION_PLAN.md
+++ b/docs/plans/ITEM_LEVEL_FEED_RELIABILITY_IMPLEMENTATION_PLAN.md
@@ -3,33 +3,53 @@
 > Status: Implementation Plan
 > Owner: News Aggregator + StoryCluster
 > Branch: `coord/item-reliability-plan`
-> Scope: make item-level disqualification a system rule while keeping soak feeds that are at least 50% article-reliable over an 8-item sample
+> Scope: define the system rule for source reliability and item eligibility without conflating soak evaluation with the product admission contract
 
 ## Goal
 
-Make this an enforced system rule for soak/public-soak work:
+Make this an enforced system rule:
 
-1. A feed stays in the soak surface when its article-candidate links are at least 50% readable/reliable over an 8-item sample.
-2. Specific bad-link articles from otherwise-keep feeds are identified, classified, persisted, and disqualified.
-3. Disqualified article URLs must never be served to end users through article-text, bundle publication, snapshots, or UI-facing latest indexes.
+1. Soak/public-soak evaluation keeps a source when it is at least 50% article-reliable over an 8-item soak sample.
+2. Product admission/readiness keeps a source only when it is at least 66% reliable over a larger rolling sample built from accumulated extraction outcomes.
+3. Articles whose text cannot be extracted must never be treated as analyzed evidence or included in the framing table.
+4. Legitimate source links that fail extraction may still be shown to users as raw related stories.
+5. Truly bad links must be hard-blocked and never shown.
 
 ## Executive Decision
 
-Use a dual-level policy:
+Use two separate policy layers and three item states.
 
-1. Source-level keep/watch/remove remains the authoritative starter-surface policy.
-2. Item-level disqualification becomes a first-class policy underneath it.
+### Reliability layers
 
-This means:
+1. `soak_reliability`
+   - 8-item article-candidate sample
+   - keep at `4/8` or better
+   - only for canary, scout, consumer-smoke, and public-soak evaluation
+2. `product_reliability`
+   - rolling aggregate built from dozens of article extraction outcomes over time
+   - keep at `>= 0.66`
+   - governs real source admission, starter-surface retention, and production readiness
 
-- bad sources can still be removed;
-- good-enough sources are preserved even when some feed entries are junk;
-- bad URLs are quarantined individually instead of poisoning the whole source;
-- publication and serving paths must consult the same canonical disqualification ledger.
+### Item eligibility states
+
+1. `analysis_eligible`
+   - text extraction succeeded
+   - may be used in clustering provenance, synthesis, semantic audit, and framing tables
+2. `link_only`
+   - URL is legitimate and may still be shown to the user as a related story link
+   - text extraction failed or was not good enough for analysis
+   - must not be used in synthesis, framing, or canonical analysis claims
+3. `hard_blocked`
+   - invalid, dead, access-denied, or policy-forbidden URL
+   - must not be analyzed or shown
+
+This is the core design correction.
+
+Do not collapse all extraction failures into a permanent never-serve ledger.
 
 ## Why This Change Is Needed
 
-Current behavior is too blunt.
+Current behavior is too blunt and uses the wrong boundary.
 
 Relevant current code:
 
@@ -38,172 +58,263 @@ Relevant current code:
 - `/Users/bldt/Desktop/VHC/VHC/services/news-aggregator/src/articleTextService.ts`
 - `/Users/bldt/Desktop/VHC/VHC/services/news-aggregator/src/removalLedger.ts`
 - `/Users/bldt/Desktop/VHC/VHC/services/news-aggregator/src/orchestrator.ts`
+- `/Users/bldt/Desktop/VHC/VHC/packages/data-model/src/schemas/hermes/storyBundle.ts`
+- `/Users/bldt/Desktop/VHC/VHC/services/storycluster-engine/src/bundleProjection.ts`
+- `/Users/bldt/Desktop/VHC/VHC/apps/web-pwa/src/components/feed/NewsCard.tsx`
 
 Current gaps:
 
-1. Admission is source-level only.
-   - `sourceAdmissionReport.ts` samples URLs and decides `admitted/rejected/inconclusive` at the source level.
-   - It does not persist bad URLs as a reusable policy artifact.
-2. The extraction layer already knows how to reject removed URLs.
-   - `articleTextService.ts` checks `RemovalLedger` before fetch.
-   - But admission and publication do not systematically write to or consume that policy.
-3. Publication does not filter known-bad URLs before clustering.
-   - `orchestrator.ts` currently does `ingestFeeds -> normalizeAndDedup -> runClusterBatch` with no disqualification filter in between.
-4. The current threshold is not the user’s rule.
-   - admission default is `0.75` in `/Users/bldt/Desktop/VHC/VHC/services/news-aggregator/src/sourceAdmissionReport.ts`
-   - source-health keep default is `1.0` in `/Users/bldt/Desktop/VHC/VHC/services/news-aggregator/src/sourceHealthReport.ts`
+1. Admission is source-level only and has no first-class item eligibility contract.
+2. The extraction layer already supports hard blocks via `RemovalLedger`, but that is too strong a tool for every non-extractable article.
+3. Publication currently has no explicit boundary between:
+   - canonical analyzable sources
+   - raw related links that are display-only
+4. The existing `StoryBundle` contract has no field for “possible sources shown but not analyzed.”
 
-## Rule Definition
+## Correct System Rule
 
 ### Source-level rule
 
-A source is keep-eligible when all of these are true:
+A source decision depends on two different measurements.
 
-1. At least 4 article-candidate samples succeed.
-2. Article-candidate success rate is at least `0.50` over an 8-item sample.
-3. The source is not currently unstable for non-recovered lifecycle reasons.
-4. The source still contributes or corroborates under the existing source-health and contribution gates.
+#### Soak rule
+
+Use this only in soak/public-soak evaluation:
+
+1. sample 8 article-candidate links
+2. keep if at least 4 are extraction-successful
+3. do not let soak math rewrite the canonical product admission thresholds
+
+#### Product rule
+
+Use this for starter-surface admission and production readiness:
+
+1. aggregate extraction outcomes over a much larger rolling sample
+2. keep only when reliable article outcomes are at least `66%`
+3. include historical bad-link pressure in the decision, not just the latest run
 
 ### Item-level rule
 
-An individual URL is disqualified when it is an article candidate and its failure is non-retryable and policy-relevant.
+Each URL must resolve to exactly one item-eligibility state:
 
-Disqualified URLs must:
+1. `analysis_eligible`
+2. `link_only`
+3. `hard_blocked`
 
-1. be persisted by canonical URL hash;
-2. be excluded from future admission scoring as successful candidates;
-3. be dropped before normalize/cluster/publish;
-4. be rejected by article-text fetch;
-5. never appear in user-facing published `StoryBundle.sources`, snapshots, or latest-index-backed UI output.
+### Serving rule
 
-### Counting rule
-
-Count only article-candidate links in the denominator.
-
-Do not count these as article-candidate failures:
-
-- feed-carried video/watch entries already skipped today;
-- explicit non-article hub links caught before extraction;
-- transient 5xx/network/timeout failures that are retryable;
-- links already disqualified and skipped before scoring.
-
-## Sampling Math
-
-The current 4-sample default cannot express the requested soak rule well.
-
-- with `sampleSize = 4`, a single bad link moves the source too aggressively
-- soak work needs a wider sample so mixed-quality feeds can be judged more honestly
-
-### Proposed admission math
-
-Change the admission defaults to:
-
-- `sampleSize = 8`
-- `minimumSuccessCount = 4`
-- `minimumSuccessRate = 0.50`
-
-This makes the rule real:
-
-- `4/8 = 50%` passes
-- `3/8 = 37.5%` fails
-- a single bad link no longer distorts the source-level decision
-
-### Inconclusive floor
-
-If fewer than 4 article-candidate URLs are available after skipping obvious non-article entries, classify the source as `inconclusive`, not `rejected`.
-
-That prevents thin feeds from being misclassified by too little evidence.
+1. `analysis_eligible`
+   - may appear in canonical story provenance and analysis flows
+2. `link_only`
+   - may appear only in a bottom-of-card related stories section
+   - must not be treated as evidence for synthesis or framing
+3. `hard_blocked`
+   - may not be served anywhere
 
 ## Canonical Persistence Decision
 
-Reuse the existing removal ledger instead of inventing a second competing store.
+Keep two policy stores with different semantics.
 
-Canonical policy path:
+### A. Hard-block ledger
+
+Keep using the existing path for true never-serve entries:
 
 - `/Users/bldt/Desktop/VHC/VHC/services/news-aggregator/src/removalLedger.ts`
 - mesh path: `vh/news/removed/<urlHash>`
 
-Why:
+Use this only for `hard_blocked` URLs.
 
-1. `articleTextService.ts` already enforces it.
-2. `packages/gun-client/src/newsAdapters.ts` already understands `vh/news/removed/*`.
-3. Reusing one path keeps extraction, publication, and moderation compatible.
+Examples:
 
-### Ledger semantics
+- invalid URL
+- 404 / 410 dead link
+- access denied
+- explicit publisher/policy removal
+- domain-not-allowed
+- permanent non-article destination
 
-Use `RemovalLedger` as the canonical URL-disqualification ledger for system policy, not just manual moderation.
+### B. Item eligibility store
 
-Add optional metadata fields:
-
-- `sourceId`
-- `reasonCategory`
-- `observedBy`
-- `firstSeenAt`
-- `lastSeenAt`
-- `recoverable`
-- `policyScope`
-
-Keep backward compatibility:
-
-- existing readers must continue accepting the current minimal entry shape;
-- new fields are additive.
-
-## Failure Taxonomy
-
-### Persist as item disqualifications
-
-Persist only non-retryable, policy-significant failures:
-
-- `removed`
-- `access-denied`
-- `domain-not-allowed`
-- `quality-too-low`
-- `invalid-url`
-- `http-404`
-- `http-410`
-- `non_article_destination`
-- `unsupported_link_shape`
-
-### Do not persist as permanent disqualifications
-
-Treat these as transient telemetry:
-
-- timeout
-- 429
-- 5xx upstream failures
-- temporary network failure
-- retryable fetch failure
-
-These should affect observability, but not permanently blacklist the URL.
-
-## Implementation Shape
-
-Create one new policy module and wire it through admission and publication.
-
-### New module
+Add a separate canonical store for `analysis_eligible` vs `link_only` decisions.
 
 Create:
 
-- `/Users/bldt/Desktop/VHC/VHC/services/news-aggregator/src/itemDisqualificationPolicy.ts`
+- `/Users/bldt/Desktop/VHC/VHC/services/news-aggregator/src/itemEligibilityLedger.ts`
 
-Responsibilities:
+Suggested shape:
 
-1. canonicalize URL and compute `urlHash`;
-2. classify article failures into `persistent_disqualification` vs `transient_failure`;
-3. read/write `RemovalLedger` entries with system-policy metadata;
-4. expose helpers to filter raw feed items before normalize/cluster/publish;
-5. expose report helpers for admission and source-health artifacts.
+- key by `urlHash`
+- include:
+  - `canonicalUrl`
+  - `sourceId`
+  - `eligibilityState`
+  - `reason`
+  - `firstSeenAt`
+  - `lastSeenAt`
+  - `observationCount`
+  - `lastObservedOutcome`
+  - `recoverable`
 
-This should be the single policy engine used by:
+Do not overload `vh/news/removed/*` for `link_only` items.
 
-- source admission
-- source health reporting
-- orchestrator/publication filtering
-- optional future moderation tooling
+## Failure Taxonomy
+
+### `analysis_eligible`
+
+Examples:
+
+- article extraction succeeded
+- quality passed
+
+### `link_only`
+
+Examples:
+
+- legitimate article URL but extraction quality too low
+- readable shell but insufficient body text
+- temporary extractor miss on a valid article page
+
+These links may still be shown as related stories.
+
+### `hard_blocked`
+
+Examples:
+
+- invalid URL
+- `http-404`
+- `http-410`
+- `access-denied`
+- `domain-not-allowed`
+- `unsupported_link_shape`
+- `non_article_destination`
+
+These must not be shown.
+
+## Counting and Metrics
+
+### Soak metrics
+
+For soak/public-soak only:
+
+1. denominator is 8 article-candidate URLs
+2. success means `analysis_eligible`
+3. `link_only` counts as non-success for analysis reliability
+4. `hard_blocked` counts as non-success and must be recorded separately
+
+### Product metrics
+
+Do not derive product readiness from soak math.
+
+Product reliability must use accumulated extraction outcomes over time:
+
+1. rolling article attempt count
+2. rolling `analysis_eligible` rate
+3. rolling `link_only` rate
+4. rolling `hard_blocked` rate
+5. source-level trend and contribution evidence
+
+### Historical pressure
+
+Do not let persisted entries disappear from the health picture.
+
+The system needs both:
+
+1. current-run reliability
+2. rolling bad-link pressure
+
+That prevents the source from appearing healthier just because old bad links were already classified once.
+
+## Thin-Feed Rule
+
+The previous draft’s inconclusive floor was too strict.
+
+For specialist or thin feeds:
+
+1. if at least 3 article-candidate URLs exist and all 3 are `analysis_eligible`, allow `provisional_keep_for_soak`
+2. do not automatically promote that into product keep
+3. require larger rolling evidence before product admission uses the source as a true keep
+
+This keeps useful narrow feeds from being stranded forever while preserving a higher production bar.
+
+## Canonical Publication Contract
+
+This is the most important boundary.
+
+### Canonical analysis inputs
+
+Only `analysis_eligible` items may enter:
+
+- `StoryBundle.sources`
+- `StoryBundle.primary_sources`
+- synthesis prompts in `/Users/bldt/Desktop/VHC/VHC/packages/ai-engine/src/bundlePrompts.ts`
+- semantic audit canonical source sets
+- framing table inputs in the UI analysis pipeline
+
+### Raw related-link display
+
+`link_only` items may be shown only through a new display-only field.
+
+Do not overload:
+
+- `sources`
+- `primary_sources`
+- `secondary_assets`
+
+Instead add a distinct field, for example:
+
+- `related_links`
+
+Suggested schema entry:
+
+- `source_id`
+- `publisher`
+- `url`
+- `url_hash`
+- `title`
+- `eligibility_state`
+- `display_reason`
+
+### Hard-blocked items
+
+`hard_blocked` items must appear nowhere in published bundles or UI-facing snapshots.
+
+## Data Model Changes
+
+Update:
+
+- `/Users/bldt/Desktop/VHC/VHC/packages/data-model/src/schemas/hermes/storyBundle.ts`
+
+Add a new optional field:
+
+- `related_links`
+
+This should be display-only, not canonical source provenance.
+
+Do not change the meaning of:
+
+- `sources`
+- `primary_sources`
+- `secondary_assets`
 
 ## File-by-File Implementation Plan
 
-### 1. Admission contract and sampling
+### 1. Item eligibility policy
+
+Create:
+
+- `/Users/bldt/Desktop/VHC/VHC/services/news-aggregator/src/itemEligibilityPolicy.ts`
+
+Responsibilities:
+
+1. classify item outcomes into `analysis_eligible | link_only | hard_blocked`
+2. decide whether a failed extraction is displayable or forbidden
+3. write `hard_blocked` entries to `RemovalLedger`
+4. write `analysis_eligible/link_only` observations to `itemEligibilityLedger`
+5. expose helpers for soak metrics and product metrics
+
+This module must become the single policy engine.
+
+### 2. Soak admission evaluation
 
 Update:
 
@@ -211,31 +322,32 @@ Update:
 
 Changes:
 
-1. Change defaults:
-   - `DEFAULT_SAMPLE_SIZE` from `4` to `8`
-   - `DEFAULT_MIN_SUCCESS_RATE` from `0.75` to `0.50`
-   - `DEFAULT_MIN_SUCCESS_COUNT` from `2` to `4`
-2. Extend `SourceAdmissionSampleResult` with explicit item classification:
+1. add an explicit soak-evaluation mode instead of replacing canonical defaults globally
+2. use:
+   - `sampleSize = 8`
+   - `minimumSuccessCount = 4`
+   - `minimumSuccessRate = 0.50`
+   only when the soak mode is selected
+3. extend `SourceAdmissionSampleResult` to record:
    - `canonicalUrl`
    - `urlHash`
-   - `candidateType: 'article' | 'video' | 'non_article'`
-   - `outcome: 'passed' | 'disqualified' | 'failed_transient' | 'skipped'`
-   - `disqualificationReason`
-   - `persistedDisqualification`
-3. Replace the current binary `passed/failed` sample model with policy-aware classification.
-4. Only count article-candidate URLs in `sampleLinkCount`, `readableSampleCount`, and `readableSampleRate`.
-5. Persist non-retryable bad article links through `itemDisqualificationPolicy.ts`.
-6. Publish an additional artifact in the admission directory:
-   - `disqualified-article-links.json`
+   - `candidateType`
+   - `eligibilityState`
+   - `reason`
+   - `persistedToHardBlockLedger`
+   - `persistedToEligibilityLedger`
+4. allow `3/3` thin-feed provisional soak keep
+5. publish separate soak artifacts for:
+   - `analysis-eligible-links.json`
+   - `link-only-links.json`
+   - `hard-blocked-links.json`
 
-Acceptance for this file:
+Acceptance:
 
-- a source with `4/8` readable article candidates is `admitted`;
-- a source with `3/8` is not;
-- bad non-article links are skipped, not counted as source poison;
-- non-retryable bad article URLs are persisted with URL hash and reason.
+- soak evaluation can keep a source at `4/8`
+- this does not rewrite the repo-wide product default thresholds
 
-### 2. Source-health semantics
+### 3. Product reliability aggregation
 
 Update:
 
@@ -243,21 +355,24 @@ Update:
 
 Changes:
 
-1. Change `keepMinReadableSampleRate` default from `1.0` to `0.50`.
-2. Base keep/watch/remove on article-candidate reliability, not raw mixed feed-link outcomes.
-3. Add observability fields:
-   - `disqualifiedArticleCount`
-   - `transientArticleFailureCount`
-   - `skippedNonArticleCount`
-4. Ensure recovered retries do not count as persistent item disqualifications.
-5. Keep the existing history/release-evidence model, but make it item-aware.
+1. keep the product rule separate from the soak rule
+2. add rolling metrics derived from accumulated item observations:
+   - `analysisEligibleRate`
+   - `linkOnlyRate`
+   - `hardBlockedRate`
+   - `rollingAttemptCount`
+3. make the product keep decision depend on:
+   - `analysisEligibleRate >= 0.66`
+   - enough rolling attempts to be meaningful
+   - existing lifecycle/history gates
+4. add source-health observability for both soak and product measurements
 
-Acceptance for this file:
+Acceptance:
 
-- a source with `>= 0.50` reliable article candidates over the 8-item soak sample can be `keep` if lifecycle and history are otherwise healthy;
-- known disqualified URLs do not force the source to `watch/remove` by themselves.
+- source-health no longer treats the soak threshold as the canonical product threshold
+- product keep remains a higher bar than soak keep
 
-### 3. Canonical URL disqualification ledger
+### 4. Hard-block ledger
 
 Update:
 
@@ -266,98 +381,143 @@ Update:
 
 Changes:
 
-1. Extend ledger entries with additive metadata fields for system-policy disqualifications.
-2. Keep backward compatibility for current readers and tests.
-3. Add convenience helpers for:
-   - `writeSystemDisqualification(url, metadata)`
-   - `readSystemDisqualification(urlHash)`
-4. Do not rename the path in this implementation.
-   - keep `vh/news/removed/<urlHash>` as the canonical wire/storage path
-   - treat naming cleanup as out of scope
+1. keep backward compatibility
+2. use this path only for `hard_blocked`
+3. add optional metadata fields needed for system-policy provenance
 
-Acceptance for this file:
+Acceptance:
 
-- article-text and publication can consult the same persisted URL-hash policy;
-- old entries remain readable.
+- hard-blocked URLs are truly never served
+- `link_only` items are not accidentally swallowed by the removal path
 
-### 4. Article extraction enforcement
+### 5. Item eligibility ledger
 
-Update:
+Create:
 
-- `/Users/bldt/Desktop/VHC/VHC/services/news-aggregator/src/articleTextService.ts`
+- `/Users/bldt/Desktop/VHC/VHC/services/news-aggregator/src/itemEligibilityLedger.ts`
 
 Changes:
 
-1. Keep the current pre-fetch `RemovalLedger` read.
-2. Add richer logging/return context so downstream callers know when a failure came from system disqualification versus live fetch.
-3. Do not make `ArticleTextService` the primary writer for policy in phase 1.
-   - writing should remain centralized in `itemDisqualificationPolicy.ts` and admission/runtime callers
+1. persist `analysis_eligible` and `link_only` observations separately from hard blocks
+2. aggregate repeated observations over time
+3. support rolling product reliability calculations
 
-Acceptance for this file:
+Acceptance:
 
-- disqualified URLs still fail fast with `removed`;
-- callers can surface the disqualification reason cleanly in artifacts.
+- the system can distinguish between “not analyzable” and “must never show”
 
-### 5. Publish-time enforcement before clustering
+### 6. Orchestrator / publication boundary
 
 Update:
 
 - `/Users/bldt/Desktop/VHC/VHC/services/news-aggregator/src/orchestrator.ts`
 - `/Users/bldt/Desktop/VHC/VHC/services/news-aggregator/src/ingest.ts`
-- optional new helper:
+- optional helper:
   - `/Users/bldt/Desktop/VHC/VHC/services/news-aggregator/src/publishableFeedItems.ts`
 
 Changes:
 
-1. After `ingestFeeds`, filter raw items against the canonical disqualification ledger.
-2. Drop disqualified items before `normalizeAndDedup`.
-3. Emit diagnostics for dropped items by source and reason.
-4. Ensure the returned `PipelineResult` includes observability for filtered/disqualified item counts.
+1. after ingest, classify raw items with `itemEligibilityPolicy.ts`
+2. allow only `analysis_eligible` items into normalize/cluster/publish
+3. collect `link_only` items into a sidecar related-links list by story/topic where possible
+4. drop `hard_blocked` items completely
+5. expose diagnostics in `PipelineResult`
 
-This is the critical “never served” enforcement point.
+Acceptance:
 
-Acceptance for this file:
+- canonical story bundles are built only from analyzable evidence
+- legitimate non-extractable links can still be preserved for display
 
-- a URL in `vh/news/removed/<urlHash>` never reaches `normalizeAndDedup`;
-- it cannot appear in `StoryBundle.sources`;
-- it cannot reach latest/hot publication through `writeStoryBundle`.
-
-### 6. Contribution reporting
+### 7. Story bundle contract
 
 Update:
 
-- `/Users/bldt/Desktop/VHC/VHC/services/news-aggregator/src/sourceContributionReport.ts`
+- `/Users/bldt/Desktop/VHC/VHC/packages/data-model/src/schemas/hermes/storyBundle.ts`
+- any dependent type exports in `/Users/bldt/Desktop/VHC/VHC/packages/ai-engine/src/newsTypes.ts`
 
 Changes:
 
-1. Exclude disqualified items from normalized/bundle contribution counts.
-2. Add item-policy observability:
-   - `disqualifiedItemCount`
-   - `transientDroppedItemCount`
-3. Preserve current source contribution semantics while making the item drop behavior visible.
+1. add optional `related_links`
+2. keep `sources` and `primary_sources` as analysis-only
+3. keep `secondary_assets` for its current role, not for extraction-failed article links
 
-Acceptance for this file:
+Acceptance:
 
-- contribution reflects publishable items, not raw feed junk.
+- the data model distinguishes analyzed evidence from raw related links
 
-### 7. Publication/runtime integration
+### 8. StoryCluster projection and runtime
 
 Update:
 
-- `/Users/bldt/Desktop/VHC/VHC/services/news-aggregator/src/daemon.ts`
+- `/Users/bldt/Desktop/VHC/VHC/services/storycluster-engine/src/bundleProjection.ts`
 - `/Users/bldt/Desktop/VHC/VHC/packages/ai-engine/src/newsRuntime.ts`
 
 Changes:
 
-1. Wire the orchestrator’s new filtered-item observability into runtime logs.
-2. Ensure the next runtime tick republishes bundles without disqualified sources.
-3. Do not introduce a second filter after `writeStoryBundle`; keep the enforcement earlier in the pipeline.
+1. preserve canonical-source semantics for `primary_sources`
+2. never widen canonical bundle evidence with `link_only` items
+3. ensure runtime publication carries `related_links` separately if available
 
-Acceptance for this file:
+Acceptance:
 
-- a previously published bad URL disappears on the next clean runtime tick after disqualification.
+- framing and semantic audit continue to rely only on analyzable sources
 
-### 8. Test coverage
+### 9. Analysis and framing boundary
+
+Update:
+
+- `/Users/bldt/Desktop/VHC/VHC/packages/ai-engine/src/bundlePrompts.ts`
+- `/Users/bldt/Desktop/VHC/VHC/apps/web-pwa/src/components/feed/useAnalysis.ts`
+- any news-card analysis helpers under `/Users/bldt/Desktop/VHC/VHC/apps/web-pwa/src/components/feed/`
+
+Changes:
+
+1. ensure synthesis prompts use only canonical analyzable sources
+2. ensure the framing/analysis table never claims coverage from `link_only` URLs
+3. if the UI displays related links, render them separately from analyzed source badges
+
+Acceptance:
+
+- analysis output is honest about what was and was not actually read
+
+### 10. UI related-stories surface
+
+Update:
+
+- `/Users/bldt/Desktop/VHC/VHC/apps/web-pwa/src/components/feed/NewsCard.tsx`
+- `/Users/bldt/Desktop/VHC/VHC/apps/web-pwa/src/components/feed/SourceBadgeRow.tsx`
+- add a new component, for example:
+  - `/Users/bldt/Desktop/VHC/VHC/apps/web-pwa/src/components/feed/RelatedStoriesLinks.tsx`
+
+Changes:
+
+1. keep `SourceBadgeRow` for analyzed canonical sources
+2. add a bottom-of-card related stories section for `related_links`
+3. label the section clearly so it is not mistaken for analysis evidence
+
+Acceptance:
+
+- end users can still see useful raw source links without the app claiming those links informed the analysis
+
+### 11. Immediate scrub semantics
+
+If a URL transitions to `hard_blocked`, the system must scrub already-published surfaces immediately.
+
+Update:
+
+- publication helpers and snapshot builders used by:
+  - `/Users/bldt/Desktop/VHC/VHC/packages/e2e/src/live/daemon-feed-validated-snapshot-server.mjs`
+  - latest published bundle refresh paths
+
+Required behavior:
+
+1. remove hard-blocked URLs from published bundles on the next scrub pass
+2. rebuild latest snapshot artifacts after a hard-block write
+3. do not require waiting for a normal runtime tick to stop serving a hard-blocked URL
+
+This is the real fix for the earlier “never served” gap.
+
+### 12. Tests
 
 Update/create tests in:
 
@@ -366,89 +526,66 @@ Update/create tests in:
 - `/Users/bldt/Desktop/VHC/VHC/services/news-aggregator/src/__tests__/articleTextService.test.ts`
 - `/Users/bldt/Desktop/VHC/VHC/services/news-aggregator/src/__tests__/removalLedger.test.ts`
 - `/Users/bldt/Desktop/VHC/VHC/services/news-aggregator/src/orchestrator.test.ts`
-- `/Users/bldt/Desktop/VHC/VHC/packages/gun-client/src/newsAdapters.test.ts`
+- `/Users/bldt/Desktop/VHC/VHC/packages/data-model/src/schemas/hermes/storyBundle.test.ts`
+- relevant UI tests under `/Users/bldt/Desktop/VHC/VHC/apps/web-pwa/src/components/feed/`
 
 Required new cases:
 
-1. `4/8` source admission passes.
-2. `3/8` source admission fails.
-3. skipped video/non-article URLs do not count against source reliability.
-4. retryable failures are not permanently disqualified.
-5. non-retryable failures are written to the ledger.
-6. orchestrator drops ledgered URLs before normalization.
-7. bundles and latest publication never contain disqualified URLs.
-8. article-text rejects a disqualified URL without hitting the network.
-
-### 9. Docs/spec updates after code lands
-
-Update:
-
-- `/Users/bldt/Desktop/VHC/VHC/docs/ops/NEWS_SOURCE_ADMISSION_RUNBOOK.md`
-- `/Users/bldt/Desktop/VHC/VHC/docs/specs/spec-news-aggregator-v0.md`
-
-Required doc changes:
-
-1. soak source readiness threshold is 50% article-candidate reliability over an 8-item sample, not 100% pristine extraction;
-2. item-level disqualification is now canonical policy;
-3. bad links from otherwise-good sources are quarantined individually;
-4. end-user serving path must exclude disqualified URLs.
+1. soak `4/8` keep passes without changing product defaults
+2. product keep still requires rolling `>= 0.66`
+3. `3/3` thin-feed provisional soak keep works
+4. extraction-failed but legitimate URLs become `link_only`
+5. dead/forbidden URLs become `hard_blocked`
+6. `link_only` URLs do not enter synthesis/framing inputs
+7. `link_only` URLs can still render in the related stories UI section
+8. `hard_blocked` URLs are absent from both analysis and display surfaces
 
 ## Migration / Rollout
 
-### Phase 1: Contract and artifacts
+### Phase 1: Policy separation
 
 Implement:
 
-- `itemDisqualificationPolicy.ts`
-- admission artifact changes
-- ledger metadata extensions
+- `itemEligibilityPolicy.ts`
+- `itemEligibilityLedger.ts`
+- soak vs product rule separation in docs and code
 
 Checkpoint:
 
-- admission artifacts include disqualified-item output;
-- no publication behavior changed yet.
+- no more ambiguity between soak thresholds and product thresholds
 
-### Phase 2: Source-health threshold update
+### Phase 2: Publication boundary
 
 Implement:
 
-- `0.50` keep threshold
-- `8`-sample admission math
-- source-health observability updates
+- analysis-only canonical sources
+- `related_links` sidecar path
+- hard-block filtering
 
 Checkpoint:
 
-- known feeds with up to four bad links out of eight can still remain `keep` if the readable half is healthy and non-retryable bad links are quarantined individually.
+- analysis and framing only use extractable sources
+- related links are display-only
 
-### Phase 3: Publish-time enforcement
+### Phase 3: Safe backfill
 
-Implement:
+Do not backfill from a single latest admission artifact.
 
-- orchestrator disqualification filter
-- runtime logging
-- contribution-report updates
+Instead add a guarded script:
 
-Checkpoint:
+- `/Users/bldt/Desktop/VHC/VHC/tools/scripts/backfill-item-eligibility.mjs`
 
-- a disqualified URL cannot enter a freshly published bundle.
+Rules:
 
-### Phase 4: Migration sweep
-
-Add a one-time backfill script:
-
-- `/Users/bldt/Desktop/VHC/VHC/tools/scripts/backfill-disqualified-article-links.mjs`
-
-Purpose:
-
-1. read latest admission artifacts;
-2. seed the ledger with already-known non-retryable bad URLs;
-3. run a fresh publish tick to republish bundles without those URLs.
+1. only backfill `hard_blocked` from a strict whitelist of reasons
+2. require repeated observation or manual approval for permanent hard-block entries
+3. allow softer historical entries to seed `link_only`, not `hard_blocked`
 
 Checkpoint:
 
-- latest snapshot and canary artifacts no longer contain backfilled disqualified URLs.
+- no one-off noisy run can create a permanent never-serve entry by itself
 
-### Phase 5: Production-readiness confirmation
+### Phase 4: Production-readiness confirmation
 
 Validation commands:
 
@@ -461,50 +598,41 @@ Validation commands:
 
 Checkpoint:
 
-- source health stays `ready/pass` under the new threshold;
-- public soak still passes;
-- no disqualified URL appears in user-facing story sources.
+- source health reports the correct product rule
+- public soak reports the correct soak rule
+- canonical analysis never claims non-extractable URLs as evidence
+- related raw links still show where allowed
 
 ## Acceptance Criteria
 
 We are done when all of these are true:
 
-1. A source with `4/8` readable article candidates is kept when otherwise healthy.
-2. A source with `3/8` readable article candidates is not kept.
-3. Specific bad links from a keep-eligible source are written to the canonical URL-hash disqualification ledger.
-4. `ArticleTextService` rejects those URLs without live fetch.
-5. `orchestrateNewsPipeline()` filters those URLs before normalize/cluster/publish.
-6. Published `StoryBundle.sources` and latest-index-backed consumer artifacts never contain a disqualified URL.
-7. Source-health artifacts expose both source-level and item-level policy outcomes clearly enough for operator review.
+1. Soak/public-soak can keep a source at `4/8` without rewriting the canonical product rule.
+2. Product source-health still requires rolling `>= 0.66` analyzable reliability over a larger sample.
+3. The system distinguishes `analysis_eligible`, `link_only`, and `hard_blocked` item states.
+4. `analysis_eligible` items alone drive synthesis, semantic audit, framing, and canonical source badges.
+5. `link_only` items may appear only in a clearly separate related stories section.
+6. `hard_blocked` items are never shown or analyzed.
+7. Safe backfill rules prevent single noisy runs from creating permanent never-serve entries.
 
 ## Non-Goals
 
 This plan does not:
 
-1. weaken the article-text quality bar;
-2. auto-keep every non-paywalled source regardless of contribution or instability;
-3. rename `vh/news/removed/*` to a different mesh path;
-4. solve all publisher-specific HTML-hub quirks.
-
-## Risks
-
-1. Over-disqualification
-   - If failure classification is too aggressive, we can suppress valid articles.
-   - Mitigation: persist only non-retryable policy failures in phase 1.
-2. Under-filtering
-   - If publication filtering misses a path, bad URLs can still leak to bundles.
-   - Mitigation: enforce before normalization and verify in canary/snapshot tests.
-3. Artifact drift
-   - If admission and source-health compute different denominators, operators will lose trust.
-   - Mitigation: centralize item classification in `itemDisqualificationPolicy.ts`.
+1. lower the canonical product admission bar to the soak threshold;
+2. claim every non-paywalled URL is analyzable;
+3. overload `secondary_assets` with extraction-failed article links;
+4. use a single ledger for both display-only links and hard-blocked links.
 
 ## Recommendation
 
-Implement this as a fix-first systems rule, not as a one-off BBC-style exception.
+Implement this as a contract split, not as a threshold tweak.
 
 The right architecture is:
 
-1. keep good-enough soak sources at `50%+` article reliability across an 8-item sample;
-2. quarantine bad URLs individually;
-3. persist the URL-hash decision once;
-4. enforce it consistently in extraction, publication, and user-facing output.
+1. soak keeps feeds at `50% over 8` for operational evaluation;
+2. product keeps feeds at `66%+` over a larger rolling extraction record;
+3. non-extractable but legitimate links become `link_only`;
+4. truly bad links become `hard_blocked`;
+5. only analyzable links inform analysis and framing;
+6. raw related links can still be shown without misrepresenting them as analyzed evidence.

--- a/docs/plans/ITEM_LEVEL_FEED_RELIABILITY_IMPLEMENTATION_PLAN.md
+++ b/docs/plans/ITEM_LEVEL_FEED_RELIABILITY_IMPLEMENTATION_PLAN.md
@@ -5,6 +5,12 @@
 > Branch: `coord/item-reliability-plan`
 > Scope: define the system rule for source reliability and item eligibility without conflating soak evaluation with the product admission contract
 
+Implementation note:
+
+1. The current implementation sequence lands the eligibility ledger and the analysis/publish boundary first.
+2. The `related_links` data-model and UI rendering work remains a later follow-on slice.
+3. Until that follow-on lands, `link_only` items must stay out of analysis and framing outputs but are not yet rendered in a dedicated bottom-of-card surface.
+
 ## Goal
 
 Make this an enforced system rule:

--- a/services/news-aggregator/src/__tests__/articleTextService.test.ts
+++ b/services/news-aggregator/src/__tests__/articleTextService.test.ts
@@ -13,6 +13,7 @@ import {
   articleTextServiceInternal,
 } from '../articleTextService';
 import { urlHash } from '../normalize';
+import { ItemEligibilityLedger } from '../itemEligibilityLedger';
 import { RemovalLedger } from '../removalLedger';
 import { SourceLifecycleTracker } from '../sourceLifecycle';
 
@@ -220,6 +221,53 @@ describe('ArticleTextService', () => {
     expect(result.extractionMethod).toBe('html-fallback');
     expect(result.title).toBe('Fallback');
     expect(result.cacheHit).toBe('none');
+  });
+
+  it('records item eligibility observations for successful and failed extractions', async () => {
+    const ledger = new ItemEligibilityLedger({ now: () => 77 });
+    const successService = new ArticleTextService({
+      allowlist: new Set(['allowed.com']),
+      itemEligibilityLedger: ledger,
+      fetchFn: vi.fn<typeof fetch>().mockResolvedValue(
+        new Response(makeHtml(makeWords(220), 'Readable Title'), { status: 200 }),
+      ),
+      primaryExtractor: vi.fn().mockResolvedValue({
+        title: 'Readable Title',
+        text: makeWords(220),
+      }),
+      fallbackExtractor: vi.fn().mockReturnValue(null),
+    });
+
+    await successService.extract('https://allowed.com/success');
+    await expect(ledger.readByUrl('https://allowed.com/success')).resolves.toMatchObject({
+      state: 'analysis_eligible',
+      reason: 'analysis_eligible',
+      analysisEligible: true,
+      displayEligible: true,
+      observationCount: 1,
+    });
+
+    const failedService = new ArticleTextService({
+      allowlist: new Set(['allowed.com']),
+      itemEligibilityLedger: ledger,
+      fetchFn: vi.fn<typeof fetch>().mockResolvedValue(
+        new Response(makeHtml('too short'), { status: 200 }),
+      ),
+      primaryExtractor: vi.fn().mockResolvedValue({ title: 'Short', text: 'tiny' }),
+      fallbackExtractor: vi.fn().mockReturnValue({ title: 'Short', text: 'tiny' }),
+    });
+
+    await expect(failedService.extract('https://allowed.com/failure')).rejects.toMatchObject({
+      code: 'quality-too-low',
+      statusCode: 422,
+    });
+    await expect(ledger.readByUrl('https://allowed.com/failure')).resolves.toMatchObject({
+      state: 'link_only',
+      reason: 'quality-too-low',
+      analysisEligible: false,
+      displayEligible: true,
+      observationCount: 1,
+    });
   });
 
   it('raises quality-too-low when both extraction passes fail', async () => {

--- a/services/news-aggregator/src/__tests__/itemEligibilityLedger.test.ts
+++ b/services/news-aggregator/src/__tests__/itemEligibilityLedger.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import {
+  InMemoryItemEligibilityLedgerStore,
+  ItemEligibilityLedger,
+  itemEligibilityLedgerInternal,
+  itemEligibilityLedgerPath,
+} from '../itemEligibilityLedger';
+
+describe('ItemEligibilityLedger', () => {
+  it('writes and reads item eligibility observations by canonical URL', async () => {
+    const ledger = new ItemEligibilityLedger({ now: () => 100 });
+    const hashedUrl = itemEligibilityLedgerInternal.normalizeUrl('https://allowed.com/story')!.hashedUrl;
+
+    const first = await ledger.writeAssessment({
+      canonicalUrl: 'https://allowed.com/story',
+      urlHash: hashedUrl,
+      state: 'link_only',
+      reason: 'quality-too-low',
+      displayEligible: true,
+    });
+
+    expect(first).toMatchObject({
+      urlHash: hashedUrl,
+      canonicalUrl: 'https://allowed.com/story',
+      state: 'link_only',
+      reason: 'quality-too-low',
+      analysisEligible: false,
+      displayEligible: true,
+      recoverable: true,
+      observationCount: 1,
+      firstSeenAt: 100,
+      lastSeenAt: 100,
+    });
+
+    const second = await ledger.writeAssessment({
+      canonicalUrl: 'https://allowed.com/story',
+      urlHash: hashedUrl,
+      state: 'analysis_eligible',
+      reason: 'analysis_eligible',
+      displayEligible: true,
+    });
+
+    expect(second).toMatchObject({
+      state: 'analysis_eligible',
+      reason: 'analysis_eligible',
+      analysisEligible: true,
+      observationCount: 2,
+      firstSeenAt: 100,
+      lastSeenAt: 100,
+    });
+
+    await expect(ledger.readByUrl('https://allowed.com/story')).resolves.toMatchObject({
+      state: 'analysis_eligible',
+      observationCount: 2,
+    });
+  });
+
+  it('returns null for non-canonicalizable assessments', async () => {
+    const ledger = new ItemEligibilityLedger();
+    await expect(ledger.writeAssessment({
+      canonicalUrl: null,
+      urlHash: null,
+      state: 'hard_blocked',
+      reason: 'invalid-url',
+      displayEligible: false,
+    })).resolves.toBeNull();
+  });
+
+  it('exports helpers for pathing and parsing', async () => {
+    expect(itemEligibilityLedgerPath('hash-a')).toBe('vh/news/item-eligibility/hash-a');
+
+    const store = new InMemoryItemEligibilityLedgerStore();
+    await store.put(itemEligibilityLedgerPath('hash-a'), {
+      urlHash: 'hash-a',
+      canonicalUrl: 'https://allowed.com/story',
+      state: 'link_only',
+      reason: 'fetch-failed',
+      analysisEligible: false,
+      displayEligible: true,
+      recoverable: true,
+      observationCount: 1,
+      firstSeenAt: 10,
+      lastSeenAt: 10,
+    });
+
+    const parsed = itemEligibilityLedgerInternal.parseEntry(
+      await store.get(itemEligibilityLedgerPath('hash-a')),
+    );
+    expect(parsed).toMatchObject({
+      canonicalUrl: 'https://allowed.com/story',
+      state: 'link_only',
+      reason: 'fetch-failed',
+    });
+    expect(itemEligibilityLedgerInternal.normalizeUrl('https://allowed.com/story')?.hashedUrl).toBeTruthy();
+  });
+});

--- a/services/news-aggregator/src/articleTextService.ts
+++ b/services/news-aggregator/src/articleTextService.ts
@@ -25,6 +25,11 @@ import {
   getStarterSourceDomainAllowlist,
   isSourceDomainAllowed,
 } from './sourceRegistry';
+import { ItemEligibilityLedger } from './itemEligibilityLedger';
+import {
+  assessItemEligibilityFromError,
+  assessItemEligibilityFromResult,
+} from './itemEligibilityPolicy';
 
 export type ArticleTextQuality = ArticleTextQualityMetrics;
 
@@ -83,6 +88,7 @@ export interface ArticleTextServiceOptions {
   readonly cache?: ArticleTextCache;
   readonly lifecycle?: SourceLifecycleTracker;
   readonly removalLedger?: RemovalLedger;
+  readonly itemEligibilityLedger?: ItemEligibilityLedger;
   readonly primaryExtractor?: (url: string, html: string) => Promise<{ title: string; text: string } | null>;
   readonly fallbackExtractor?: (url: string, html: string) => { title: string; text: string } | null;
 }
@@ -126,6 +132,7 @@ export class ArticleTextService {
   private readonly cache: ArticleTextCache;
   private readonly lifecycle: SourceLifecycleTracker;
   private readonly removalLedger: RemovalLedger;
+  private readonly itemEligibilityLedger: ItemEligibilityLedger;
   private readonly primaryExtractor: (url: string, html: string) => Promise<{ title: string; text: string } | null>;
   private readonly fallbackExtractor: (url: string, html: string) => { title: string; text: string } | null;
 
@@ -143,6 +150,7 @@ export class ArticleTextService {
     this.cache = options.cache ?? new ArticleTextCache();
     this.lifecycle = options.lifecycle ?? new SourceLifecycleTracker();
     this.removalLedger = options.removalLedger ?? new RemovalLedger();
+    this.itemEligibilityLedger = options.itemEligibilityLedger ?? new ItemEligibilityLedger();
     this.primaryExtractor = options.primaryExtractor ?? defaultPrimaryExtractor;
     this.fallbackExtractor = options.fallbackExtractor ?? defaultFallbackExtractor;
   }
@@ -150,17 +158,23 @@ export class ArticleTextService {
   async extract(inputUrl: string): Promise<ArticleTextResult> {
     const canonicalUrl = canonicalizeUrl(inputUrl);
     if (!canonicalUrl) {
-      throw new ArticleTextServiceError('invalid-url', 'Only valid http/https URLs are supported', 400, false);
+      const error = new ArticleTextServiceError('invalid-url', 'Only valid http/https URLs are supported', 400, false);
+      await this.persistEligibilityFromError(inputUrl, error);
+      throw error;
     }
 
     const domain = new URL(canonicalUrl).hostname.toLowerCase();
     if (!isSourceDomainAllowed(domain, this.allowlist)) {
-      throw new ArticleTextServiceError('domain-not-allowed', `Domain is not allowlisted: ${domain}`, 403, false);
+      const error = new ArticleTextServiceError('domain-not-allowed', `Domain is not allowlisted: ${domain}`, 403, false);
+      await this.persistEligibilityFromError(canonicalUrl, error);
+      throw error;
     }
 
     const hashedUrl = urlHash(canonicalUrl);
     if (await this.removalLedger.readByUrlHash(hashedUrl)) {
-      throw new ArticleTextServiceError('removed', 'Article has been removed from extraction', 410, false);
+      const error = new ArticleTextServiceError('removed', 'Article has been removed from extraction', 410, false);
+      await this.persistEligibilityFromError(canonicalUrl, error);
+      throw error;
     }
 
     const directHit = this.cache.get(hashedUrl);
@@ -186,7 +200,7 @@ export class ArticleTextService {
         if (contentHit?.entry.kind === 'success') {
           this.cache.linkUrlToContent(hashedUrl, contentHash);
           this.lifecycle.recordSuccess(domain);
-          return {
+          const result = {
             ...contentHit.entry.value,
             url: canonicalUrl,
             urlHash: hashedUrl,
@@ -194,6 +208,8 @@ export class ArticleTextService {
             cacheHit: 'contentHash',
             attempts: attempt,
           };
+          await this.persistEligibilityFromResult(result);
+          return result;
         }
 
         const extracted = await this.extractWithFallback(canonicalUrl, html);
@@ -212,11 +228,13 @@ export class ArticleTextService {
         this.cache.rememberSuccess(success);
         this.lifecycle.recordSuccess(domain);
 
-        return {
+        const result = {
           ...success,
           cacheHit: 'none',
           attempts: attempt,
         };
+        await this.persistEligibilityFromResult(result);
+        return result;
       } catch (error) {
         const serviceError =
           error instanceof ArticleTextServiceError
@@ -241,7 +259,32 @@ export class ArticleTextService {
       }
     }
 
-    throw terminalError ?? new ArticleTextServiceError('fetch-failed', 'Article extraction failed', 502, true);
+    const finalError =
+      terminalError ?? new ArticleTextServiceError('fetch-failed', 'Article extraction failed', 502, true);
+    await this.persistEligibilityFromError(canonicalUrl, finalError);
+    throw finalError;
+  }
+
+  private async persistEligibilityFromResult(result: ArticleTextResult): Promise<void> {
+    try {
+      await this.itemEligibilityLedger.writeAssessment(
+        assessItemEligibilityFromResult(result),
+        { observedBy: 'article-text-service' },
+      );
+    } catch {
+      // Do not let observability writes break extraction.
+    }
+  }
+
+  private async persistEligibilityFromError(url: string, error: unknown): Promise<void> {
+    try {
+      await this.itemEligibilityLedger.writeAssessment(
+        assessItemEligibilityFromError(url, error),
+        { observedBy: 'article-text-service' },
+      );
+    } catch {
+      // Do not let observability writes break extraction.
+    }
   }
 
   private async extractWithFallback(url: string, html: string): Promise<{

--- a/services/news-aggregator/src/index.ts
+++ b/services/news-aggregator/src/index.ts
@@ -116,6 +116,17 @@ export type {
 } from './removalLedger';
 
 export {
+  InMemoryItemEligibilityLedgerStore,
+  ItemEligibilityLedger,
+  itemEligibilityLedgerPath,
+} from './itemEligibilityLedger';
+export type {
+  ItemEligibilityLedgerEntry,
+  ItemEligibilityLedgerOptions,
+  ItemEligibilityLedgerStore,
+} from './itemEligibilityLedger';
+
+export {
   assessItemEligibilityFromError,
   assessItemEligibilityFromResult,
 } from './itemEligibilityPolicy';

--- a/services/news-aggregator/src/index.ts
+++ b/services/news-aggregator/src/index.ts
@@ -116,6 +116,16 @@ export type {
 } from './removalLedger';
 
 export {
+  assessItemEligibilityFromError,
+  assessItemEligibilityFromResult,
+} from './itemEligibilityPolicy';
+export type {
+  ItemEligibilityAssessment,
+  ItemEligibilityReason,
+  ItemEligibilityState,
+} from './itemEligibilityPolicy';
+
+export {
   STARTER_FEED_URLS,
   STARTER_SOURCE_DOMAINS,
   buildSourceDomainAllowlist,
@@ -137,6 +147,7 @@ export type {
   SourceAdmissionArtifactOptions,
   SourceAdmissionAuditOptions,
   SourceAdmissionCriteria,
+  SourceAdmissionEvaluationMode,
   SourceAdmissionReport,
   SourceAdmissionSampleResult,
   SourceAdmissionSourceReport,

--- a/services/news-aggregator/src/itemEligibilityLedger.ts
+++ b/services/news-aggregator/src/itemEligibilityLedger.ts
@@ -1,0 +1,160 @@
+import { canonicalizeUrl, urlHash } from './normalize';
+import type {
+  ItemEligibilityAssessment,
+  ItemEligibilityReason,
+  ItemEligibilityState,
+} from './itemEligibilityPolicy';
+
+export interface ItemEligibilityLedgerEntry {
+  readonly urlHash: string;
+  readonly canonicalUrl: string;
+  readonly state: ItemEligibilityState;
+  readonly reason: ItemEligibilityReason;
+  readonly analysisEligible: boolean;
+  readonly displayEligible: boolean;
+  readonly recoverable: boolean;
+  readonly observationCount: number;
+  readonly firstSeenAt: number;
+  readonly lastSeenAt: number;
+  readonly observedBy: string | null;
+  readonly note: string | null;
+}
+
+export interface ItemEligibilityLedgerStore {
+  get(path: string): Promise<unknown>;
+  put(path: string, value: unknown): Promise<void>;
+}
+
+export interface ItemEligibilityLedgerOptions {
+  readonly store?: ItemEligibilityLedgerStore;
+  readonly now?: () => number;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object';
+}
+
+function normalizeUrl(inputUrl: string): { canonicalUrl: string; hashedUrl: string } | null {
+  const canonicalUrl = canonicalizeUrl(inputUrl);
+  if (!canonicalUrl) {
+    return null;
+  }
+
+  return {
+    canonicalUrl,
+    hashedUrl: urlHash(canonicalUrl),
+  };
+}
+
+function parseEntry(value: unknown): ItemEligibilityLedgerEntry | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  if (
+    typeof value.urlHash !== 'string'
+    || typeof value.canonicalUrl !== 'string'
+    || typeof value.state !== 'string'
+    || typeof value.reason !== 'string'
+    || typeof value.analysisEligible !== 'boolean'
+    || typeof value.displayEligible !== 'boolean'
+    || typeof value.recoverable !== 'boolean'
+    || typeof value.observationCount !== 'number'
+    || typeof value.firstSeenAt !== 'number'
+    || typeof value.lastSeenAt !== 'number'
+  ) {
+    return null;
+  }
+
+  return {
+    urlHash: value.urlHash,
+    canonicalUrl: value.canonicalUrl,
+    state: value.state as ItemEligibilityState,
+    reason: value.reason as ItemEligibilityReason,
+    analysisEligible: value.analysisEligible,
+    displayEligible: value.displayEligible,
+    recoverable: value.recoverable,
+    observationCount: value.observationCount,
+    firstSeenAt: value.firstSeenAt,
+    lastSeenAt: value.lastSeenAt,
+    observedBy: typeof value.observedBy === 'string' ? value.observedBy : null,
+    note: typeof value.note === 'string' ? value.note : null,
+  };
+}
+
+export function itemEligibilityLedgerPath(urlHashValue: string): string {
+  return `vh/news/item-eligibility/${urlHashValue}`;
+}
+
+export class InMemoryItemEligibilityLedgerStore implements ItemEligibilityLedgerStore {
+  private readonly records = new Map<string, unknown>();
+
+  async get(path: string): Promise<unknown> {
+    return this.records.get(path) ?? null;
+  }
+
+  async put(path: string, value: unknown): Promise<void> {
+    this.records.set(path, value);
+  }
+}
+
+export class ItemEligibilityLedger {
+  private readonly store: ItemEligibilityLedgerStore;
+  private readonly now: () => number;
+
+  constructor(options: ItemEligibilityLedgerOptions = {}) {
+    this.store = options.store ?? new InMemoryItemEligibilityLedgerStore();
+    this.now = options.now ?? Date.now;
+  }
+
+  async writeAssessment(
+    assessment: ItemEligibilityAssessment,
+    metadata: { observedBy?: string; note?: string } = {},
+  ): Promise<ItemEligibilityLedgerEntry | null> {
+    if (!assessment.canonicalUrl || !assessment.urlHash) {
+      return null;
+    }
+
+    const existing = await this.readByUrlHash(assessment.urlHash);
+    const observedAt = this.now();
+    const entry: ItemEligibilityLedgerEntry = {
+      urlHash: assessment.urlHash,
+      canonicalUrl: assessment.canonicalUrl,
+      state: assessment.state,
+      reason: assessment.reason,
+      analysisEligible: assessment.state === 'analysis_eligible',
+      displayEligible: assessment.displayEligible,
+      recoverable: assessment.state === 'link_only',
+      observationCount: (existing?.observationCount ?? 0) + 1,
+      firstSeenAt: existing?.firstSeenAt ?? observedAt,
+      lastSeenAt: observedAt,
+      observedBy: metadata.observedBy?.trim() || null,
+      note: metadata.note?.trim() || null,
+    };
+
+    await this.store.put(itemEligibilityLedgerPath(entry.urlHash), entry);
+    return entry;
+  }
+
+  async readByUrlHash(urlHashValue: string): Promise<ItemEligibilityLedgerEntry | null> {
+    if (!urlHashValue.trim()) {
+      return null;
+    }
+
+    return parseEntry(await this.store.get(itemEligibilityLedgerPath(urlHashValue)));
+  }
+
+  async readByUrl(inputUrl: string): Promise<ItemEligibilityLedgerEntry | null> {
+    const normalized = normalizeUrl(inputUrl);
+    if (!normalized) {
+      return null;
+    }
+
+    return this.readByUrlHash(normalized.hashedUrl);
+  }
+}
+
+export const itemEligibilityLedgerInternal = {
+  normalizeUrl,
+  parseEntry,
+};

--- a/services/news-aggregator/src/itemEligibilityPolicy.test.ts
+++ b/services/news-aggregator/src/itemEligibilityPolicy.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ArticleTextServiceError,
+  type ArticleTextResult,
+} from './articleTextService';
+import {
+  assessItemEligibilityFromError,
+  assessItemEligibilityFromResult,
+} from './itemEligibilityPolicy';
+
+function makeResult(url: string): ArticleTextResult {
+  return {
+    url,
+    urlHash: 'abcd1234',
+    contentHash: 'content',
+    sourceDomain: 'example.com',
+    title: 'Readable article',
+    text: 'Sentence one. Sentence two. Sentence three. Sentence four.',
+    extractionMethod: 'article-extractor',
+    cacheHit: 'none',
+    attempts: 1,
+    fetchedAt: 1,
+    quality: {
+      charCount: 1200,
+      wordCount: 200,
+      sentenceCount: 8,
+      score: 0.95,
+    },
+  };
+}
+
+describe('itemEligibilityPolicy', () => {
+  it('marks readable extraction results as analysis eligible', () => {
+    expect(assessItemEligibilityFromResult(makeResult('https://example.com/a'))).toEqual({
+      url: 'https://example.com/a',
+      canonicalUrl: 'https://example.com/a',
+      urlHash: 'abcd1234',
+      state: 'analysis_eligible',
+      reason: 'analysis_eligible',
+      retryable: false,
+      displayEligible: true,
+    });
+  });
+
+  it('marks quality misses as link-only', () => {
+    const result = assessItemEligibilityFromError(
+      'https://example.com/short',
+      new ArticleTextServiceError('quality-too-low', 'too short', 422, false),
+    );
+
+    expect(result).toMatchObject({
+      state: 'link_only',
+      reason: 'quality-too-low',
+      displayEligible: true,
+    });
+  });
+
+  it('marks access-denied failures as hard blocked', () => {
+    const result = assessItemEligibilityFromError(
+      'https://example.com/blocked',
+      new ArticleTextServiceError('access-denied', 'blocked', 403, false),
+    );
+
+    expect(result).toMatchObject({
+      state: 'hard_blocked',
+      reason: 'access-denied',
+      displayEligible: false,
+    });
+  });
+
+  it('treats fetch failures as link-only rather than hard blocked', () => {
+    const result = assessItemEligibilityFromError(
+      'https://example.com/transient',
+      new ArticleTextServiceError('fetch-failed', 'timeout', 502, true),
+    );
+
+    expect(result).toMatchObject({
+      state: 'link_only',
+      reason: 'fetch-failed',
+      retryable: true,
+      displayEligible: true,
+    });
+  });
+});

--- a/services/news-aggregator/src/itemEligibilityPolicy.ts
+++ b/services/news-aggregator/src/itemEligibilityPolicy.ts
@@ -1,0 +1,117 @@
+import {
+  ArticleTextServiceError,
+  type ArticleTextResult,
+} from './articleTextService';
+import { canonicalizeUrl, urlHash } from './normalize';
+
+export type ItemEligibilityState =
+  | 'analysis_eligible'
+  | 'link_only'
+  | 'hard_blocked';
+
+export type ItemEligibilityReason =
+  | 'analysis_eligible'
+  | 'quality-too-low'
+  | 'fetch-failed'
+  | 'access-denied'
+  | 'domain-not-allowed'
+  | 'invalid-url'
+  | 'removed'
+  | 'unexpected-error';
+
+export interface ItemEligibilityAssessment {
+  readonly url: string;
+  readonly canonicalUrl: string | null;
+  readonly urlHash: string | null;
+  readonly state: ItemEligibilityState;
+  readonly reason: ItemEligibilityReason;
+  readonly retryable: boolean;
+  readonly displayEligible: boolean;
+}
+
+function normalizeUrl(inputUrl: string): {
+  readonly url: string;
+  readonly canonicalUrl: string | null;
+  readonly hashedUrl: string | null;
+} {
+  const canonicalUrl = canonicalizeUrl(inputUrl);
+  return {
+    url: inputUrl,
+    canonicalUrl,
+    hashedUrl: canonicalUrl ? urlHash(canonicalUrl) : null,
+  };
+}
+
+export function assessItemEligibilityFromResult(
+  result: ArticleTextResult,
+): ItemEligibilityAssessment {
+  return {
+    url: result.url,
+    canonicalUrl: result.url,
+    urlHash: result.urlHash,
+    state: 'analysis_eligible',
+    reason: 'analysis_eligible',
+    retryable: false,
+    displayEligible: true,
+  };
+}
+
+export function assessItemEligibilityFromError(
+  inputUrl: string,
+  error: unknown,
+): ItemEligibilityAssessment {
+  const normalized = normalizeUrl(inputUrl);
+
+  if (error instanceof ArticleTextServiceError) {
+    switch (error.code) {
+      case 'access-denied':
+      case 'domain-not-allowed':
+      case 'invalid-url':
+      case 'removed':
+        return {
+          url: normalized.url,
+          canonicalUrl: normalized.canonicalUrl,
+          urlHash: normalized.hashedUrl,
+          state: 'hard_blocked',
+          reason: error.code,
+          retryable: error.retryable,
+          displayEligible: false,
+        };
+      case 'quality-too-low':
+        return {
+          url: normalized.url,
+          canonicalUrl: normalized.canonicalUrl,
+          urlHash: normalized.hashedUrl,
+          state: 'link_only',
+          reason: error.code,
+          retryable: error.retryable,
+          displayEligible: true,
+        };
+      case 'fetch-failed':
+      default:
+        return {
+          url: normalized.url,
+          canonicalUrl: normalized.canonicalUrl,
+          urlHash: normalized.hashedUrl,
+          state: 'link_only',
+          reason: error.code === 'fetch-failed' ? 'fetch-failed' : 'unexpected-error',
+          retryable: error.retryable,
+          displayEligible: true,
+        };
+    }
+  }
+
+  return {
+    url: normalized.url,
+    canonicalUrl: normalized.canonicalUrl,
+    urlHash: normalized.hashedUrl,
+    state: 'link_only',
+    reason: 'unexpected-error',
+    retryable: false,
+    displayEligible: true,
+  };
+}
+
+export const itemEligibilityPolicyInternal = {
+  normalizeUrl,
+};

--- a/services/news-aggregator/src/sourceAdmissionReport.test.ts
+++ b/services/news-aggregator/src/sourceAdmissionReport.test.ts
@@ -11,6 +11,7 @@ import {
   writeSourceAdmissionArtifact,
 } from './sourceAdmissionReport';
 import type { SourceAdmissionCriteria } from './sourceAdmissionReport';
+import { ItemEligibilityLedger } from './itemEligibilityLedger';
 
 function makeResponse(status: number, body: string) {
   return new Response(body, { status });
@@ -537,6 +538,45 @@ describe('sourceAdmissionReport', () => {
     expect(report.reasons).toEqual(['provisional_thin_feed_keep']);
     expect(report.sampleLinkCount).toBe(3);
     expect(report.readableSampleCount).toBe(3);
+  });
+
+  it('persists sampled article eligibility to a provided ledger', async () => {
+    const source = STARTER_FEED_SOURCES[0];
+    const ledger = new ItemEligibilityLedger({ now: () => 123 });
+    const fetchFn = vi.fn(async (input: string | URL) => {
+      const url = String(input);
+      if (url === source.rssUrl) {
+        return makeResponse(
+          200,
+          `<rss><channel>
+             <item><link>https://www.foxnews.com/a</link></item>
+           </channel></rss>`,
+        );
+      }
+      return makeResponse(200, makeReadableHtml('Readable'));
+    }) as typeof fetch;
+
+    const report = await auditFeedSourceAdmission(source, {
+      fetchFn,
+      sampleSize: 1,
+      minimumSuccessCount: 1,
+      minimumSuccessRate: 1,
+      itemEligibilityLedger: ledger,
+      articleTextServiceOptions: {
+        primaryExtractor: async () => ({
+          title: 'Readable',
+          text: makeReadableText(),
+        }),
+        fallbackExtractor: () => null,
+      },
+    });
+
+    expect(report.status).toBe('admitted');
+    await expect(ledger.readByUrl('https://www.foxnews.com/a')).resolves.toMatchObject({
+      state: 'analysis_eligible',
+      reason: 'analysis_eligible',
+      observationCount: 1,
+    });
   });
 
   it('does not count skipped video links against source readability samples', async () => {

--- a/services/news-aggregator/src/sourceAdmissionReport.test.ts
+++ b/services/news-aggregator/src/sourceAdmissionReport.test.ts
@@ -176,6 +176,20 @@ describe('sourceAdmissionReport', () => {
     delete process.env.VH_NEWS_SOURCE_ADMISSION_MIN_SUCCESS_RATE;
   });
 
+  it('uses soak-mode defaults without rewriting product-mode defaults', () => {
+    expect(sourceAdmissionReportInternal.buildCriteria({}, 'product')).toEqual({
+      sampleSize: 4,
+      minimumSuccessCount: 2,
+      minimumSuccessRate: 0.75,
+    });
+
+    expect(sourceAdmissionReportInternal.buildCriteria({ evaluationMode: 'soak' }, 'soak')).toEqual({
+      sampleSize: 8,
+      minimumSuccessCount: 4,
+      minimumSuccessRate: 0.5,
+    });
+  });
+
   it('resolves configured feed sources from env JSON and file overrides', () => {
     vi.stubEnv(
       'VH_NEWS_SOURCE_ADMISSION_SOURCES_JSON',
@@ -394,6 +408,137 @@ describe('sourceAdmissionReport', () => {
     expect(report.skippedVideoUrls).toEqual([]);
   });
 
+  it('admits a source in soak mode when 4 of 8 article candidates are analysis eligible', async () => {
+    const source = STARTER_FEED_SOURCES[0];
+    const readableUrls = new Set([
+      'https://www.foxnews.com/a',
+      'https://www.foxnews.com/b',
+      'https://www.foxnews.com/c',
+      'https://www.foxnews.com/d',
+    ]);
+    const fetchFn = vi.fn(async (input: string | URL) => {
+      const url = String(input);
+      if (url === source.rssUrl) {
+        return makeResponse(
+          200,
+          `<rss><channel>
+             <item><link>https://www.foxnews.com/a</link></item>
+             <item><link>https://www.foxnews.com/b</link></item>
+             <item><link>https://www.foxnews.com/c</link></item>
+             <item><link>https://www.foxnews.com/d</link></item>
+             <item><link>https://www.foxnews.com/e</link></item>
+             <item><link>https://www.foxnews.com/f</link></item>
+             <item><link>https://www.foxnews.com/g</link></item>
+             <item><link>https://www.foxnews.com/h</link></item>
+           </channel></rss>`,
+        );
+      }
+      return makeResponse(200, makeReadableHtml(`Readable ${url}`));
+    }) as typeof fetch;
+
+    const report = await auditFeedSourceAdmission(source, {
+      evaluationMode: 'soak',
+      fetchFn,
+      articleTextServiceOptions: {
+        primaryExtractor: async (url) => (
+          readableUrls.has(url)
+            ? { title: 'Readable', text: makeReadableText() }
+            : { title: 'Too short', text: 'short text' }
+        ),
+        fallbackExtractor: () => null,
+      },
+    });
+
+    expect(report.evaluationMode).toBe('soak');
+    expect(report.status).toBe('admitted');
+    expect(report.sampleLinkCount).toBe(8);
+    expect(report.readableSampleCount).toBe(4);
+    expect(report.readableSampleRate).toBe(0.5);
+    expect(report.samples.filter((sample) => sample.eligibilityState === 'analysis_eligible')).toHaveLength(4);
+    expect(report.samples.filter((sample) => sample.eligibilityState === 'link_only')).toHaveLength(4);
+  });
+
+  it('rejects a source in soak mode when only 3 of 8 article candidates are analysis eligible', async () => {
+    const source = STARTER_FEED_SOURCES[0];
+    const readableUrls = new Set([
+      'https://www.foxnews.com/a',
+      'https://www.foxnews.com/b',
+      'https://www.foxnews.com/c',
+    ]);
+    const fetchFn = vi.fn(async (input: string | URL) => {
+      const url = String(input);
+      if (url === source.rssUrl) {
+        return makeResponse(
+          200,
+          `<rss><channel>
+             <item><link>https://www.foxnews.com/a</link></item>
+             <item><link>https://www.foxnews.com/b</link></item>
+             <item><link>https://www.foxnews.com/c</link></item>
+             <item><link>https://www.foxnews.com/d</link></item>
+             <item><link>https://www.foxnews.com/e</link></item>
+             <item><link>https://www.foxnews.com/f</link></item>
+             <item><link>https://www.foxnews.com/g</link></item>
+             <item><link>https://www.foxnews.com/h</link></item>
+           </channel></rss>`,
+        );
+      }
+      return makeResponse(200, makeReadableHtml(`Readable ${url}`));
+    }) as typeof fetch;
+
+    const report = await auditFeedSourceAdmission(source, {
+      evaluationMode: 'soak',
+      fetchFn,
+      articleTextServiceOptions: {
+        primaryExtractor: async (url) => (
+          readableUrls.has(url)
+            ? { title: 'Readable', text: makeReadableText() }
+            : { title: 'Too short', text: 'short text' }
+        ),
+        fallbackExtractor: () => null,
+      },
+    });
+
+    expect(report.status).toBe('rejected');
+    expect(report.readableSampleCount).toBe(3);
+    expect(report.readableSampleRate).toBe(0.375);
+  });
+
+  it('allows a 3/3 provisional thin-feed keep in soak mode', async () => {
+    const source = STARTER_FEED_SOURCES[0];
+    const fetchFn = vi.fn(async (input: string | URL) => {
+      const url = String(input);
+      if (url === source.rssUrl) {
+        return makeResponse(
+          200,
+          `<rss><channel>
+             <item><link>https://www.foxnews.com/a</link></item>
+             <item><link>https://www.foxnews.com/b</link></item>
+             <item><link>https://www.foxnews.com/c</link></item>
+           </channel></rss>`,
+        );
+      }
+      return makeResponse(200, makeReadableHtml('Readable'));
+    }) as typeof fetch;
+
+    const report = await auditFeedSourceAdmission(source, {
+      evaluationMode: 'soak',
+      fetchFn,
+      articleTextServiceOptions: {
+        primaryExtractor: async () => ({
+          title: 'Readable',
+          text: makeReadableText(),
+        }),
+        fallbackExtractor: () => null,
+      },
+    });
+
+    expect(report.status).toBe('admitted');
+    expect(report.provisionalKeepForSoak).toBe(true);
+    expect(report.reasons).toEqual(['provisional_thin_feed_keep']);
+    expect(report.sampleLinkCount).toBe(3);
+    expect(report.readableSampleCount).toBe(3);
+  });
+
   it('does not count skipped video links against source readability samples', async () => {
     const source = STARTER_FEED_SOURCES.find((entry) => entry.id === 'nbc-politics')!;
     const fetchFn = vi.fn(async (input: string | URL) => {
@@ -529,6 +674,7 @@ describe('sourceAdmissionReport', () => {
     expect(report.samples[0]).toMatchObject({
       outcome: 'failed',
       errorCode: 'access-denied',
+      eligibilityState: 'hard_blocked',
     });
   });
 
@@ -882,6 +1028,7 @@ describe('sourceAdmissionReport', () => {
 
     const report = sourceAdmissionReportInternal.classifySource(
       source,
+      'product',
       criteria,
       {
         ok: true,
@@ -925,6 +1072,7 @@ describe('sourceAdmissionReport', () => {
       outcome: 'failed',
       errorCode: 'unexpected-error',
       errorMessage: 'extractor exploded',
+      eligibilityState: 'link_only',
     });
 
     expect(
@@ -936,6 +1084,7 @@ describe('sourceAdmissionReport', () => {
       outcome: 'failed',
       errorCode: 'unexpected-error',
       errorMessage: 'Unexpected source admission failure',
+      eligibilityState: 'link_only',
     });
   });
 
@@ -949,6 +1098,7 @@ describe('sourceAdmissionReport', () => {
 
     const report = sourceAdmissionReportInternal.classifySource(
       source,
+      'product',
       criteria,
       {
         ok: true,
@@ -1057,6 +1207,9 @@ describe('sourceAdmissionReport', () => {
     expect(reportPath).toBe(path.join(artifactDir, 'source-admission-report.json'));
     expect(report.schemaVersion).toBe(SOURCE_ADMISSION_REPORT_SCHEMA_VERSION);
     expect(readFileSync(reportPath, 'utf8')).toContain('"admittedSourceIds"');
+    expect(readFileSync(path.join(artifactDir, 'analysis-eligible-links.json'), 'utf8')).toContain('analysis_eligible');
+    expect(readFileSync(path.join(artifactDir, 'link-only-links.json'), 'utf8')).toBe('[]\n');
+    expect(readFileSync(path.join(artifactDir, 'hard-blocked-links.json'), 'utf8')).toBe('[]\n');
 
     rmSync(artifactDir, { recursive: true, force: true });
   });

--- a/services/news-aggregator/src/sourceAdmissionReport.ts
+++ b/services/news-aggregator/src/sourceAdmissionReport.ts
@@ -25,6 +25,7 @@ import {
   assessItemEligibilityFromResult,
   type ItemEligibilityState,
 } from './itemEligibilityPolicy';
+import { ItemEligibilityLedger } from './itemEligibilityLedger';
 
 const RSS_ITEM_REGEX = /<item\b[\s\S]*?<\/item>/gi;
 const ATOM_ENTRY_REGEX = /<entry\b[\s\S]*?<\/entry>/gi;
@@ -134,6 +135,7 @@ export interface SourceAdmissionReport {
 export interface SourceAdmissionAuditOptions {
   readonly feedSources?: readonly FeedSource[];
   readonly evaluationMode?: SourceAdmissionEvaluationMode;
+  readonly itemEligibilityLedger?: ItemEligibilityLedger;
   readonly sampleSize?: number;
   readonly minimumSuccessCount?: number;
   readonly minimumSuccessRate?: number;
@@ -910,6 +912,9 @@ export async function auditFeedSourceAdmission(
     fetchFn,
     lifecycle,
     now,
+    itemEligibilityLedger:
+      options.itemEligibilityLedger
+      ?? options.articleTextServiceOptions?.itemEligibilityLedger,
   });
 
   const feedReadResult = await readFeedXml(fetchFn, source, {

--- a/services/news-aggregator/src/sourceAdmissionReport.ts
+++ b/services/news-aggregator/src/sourceAdmissionReport.ts
@@ -20,12 +20,21 @@ import {
   type SourceLifecycleState,
 } from './sourceLifecycle';
 import { buildSourceDomainAllowlist } from './sourceRegistry';
+import {
+  assessItemEligibilityFromError,
+  assessItemEligibilityFromResult,
+  type ItemEligibilityState,
+} from './itemEligibilityPolicy';
 
 const RSS_ITEM_REGEX = /<item\b[\s\S]*?<\/item>/gi;
 const ATOM_ENTRY_REGEX = /<entry\b[\s\S]*?<\/entry>/gi;
 const DEFAULT_SAMPLE_SIZE = 4;
 const DEFAULT_MIN_SUCCESS_COUNT = 2;
 const DEFAULT_MIN_SUCCESS_RATE = 0.75;
+const DEFAULT_SOAK_SAMPLE_SIZE = 8;
+const DEFAULT_SOAK_MIN_SUCCESS_COUNT = 4;
+const DEFAULT_SOAK_MIN_SUCCESS_RATE = 0.5;
+const DEFAULT_SOAK_PROVISIONAL_MIN_SUCCESS_COUNT = 3;
 const REPLACEMENT_SAMPLE_BUFFER = 4;
 const MAX_HTML_FEED_DISCOVERY_DEPTH = 2;
 
@@ -33,6 +42,7 @@ export const SOURCE_ADMISSION_REPORT_SCHEMA_VERSION =
   'news-source-admission-report-v1';
 
 export type SourceAdmissionStatus = 'admitted' | 'rejected' | 'inconclusive';
+export type SourceAdmissionEvaluationMode = 'product' | 'soak';
 
 export interface SourceAdmissionCriteria {
   readonly sampleSize: number;
@@ -43,6 +53,11 @@ export interface SourceAdmissionCriteria {
 export interface SourceAdmissionSampleResult {
   readonly url: string;
   readonly outcome: 'passed' | 'failed';
+  readonly canonicalUrl?: string | null;
+  readonly urlHash?: string | null;
+  readonly eligibilityState?: ItemEligibilityState;
+  readonly eligibilityReason?: string;
+  readonly displayEligible?: boolean;
   readonly title?: string;
   readonly extractionMethod?: ArticleTextResult['extractionMethod'];
   readonly qualityScore?: number;
@@ -79,8 +94,10 @@ export interface SourceAdmissionSourceReport {
   readonly sourceId: string;
   readonly sourceName: string;
   readonly rssUrl: string;
+  readonly evaluationMode: SourceAdmissionEvaluationMode;
   readonly status: SourceAdmissionStatus;
   readonly admitted: boolean;
+  readonly provisionalKeepForSoak?: boolean;
   readonly sampleLinkCount: number;
   readonly readableSampleCount: number;
   readonly readableSampleRate: number | null;
@@ -105,6 +122,7 @@ function countFeedEntryFragments(xml: string): {
 export interface SourceAdmissionReport {
   readonly schemaVersion: typeof SOURCE_ADMISSION_REPORT_SCHEMA_VERSION;
   readonly generatedAt: string;
+  readonly evaluationMode: SourceAdmissionEvaluationMode;
   readonly criteria: SourceAdmissionCriteria;
   readonly sourceCount: number;
   readonly admittedSourceIds: readonly string[];
@@ -115,6 +133,7 @@ export interface SourceAdmissionReport {
 
 export interface SourceAdmissionAuditOptions {
   readonly feedSources?: readonly FeedSource[];
+  readonly evaluationMode?: SourceAdmissionEvaluationMode;
   readonly sampleSize?: number;
   readonly minimumSuccessCount?: number;
   readonly minimumSuccessRate?: number;
@@ -166,6 +185,18 @@ function parseRate(raw: string | undefined, fallback: number): number {
   }
 
   return parsed;
+}
+
+function resolveEvaluationMode(
+  options: Pick<SourceAdmissionAuditOptions, 'evaluationMode'> & Pick<SourceAdmissionArtifactOptions, 'env'> = {},
+): SourceAdmissionEvaluationMode {
+  if (options.evaluationMode) {
+    return options.evaluationMode;
+  }
+
+  const env = options.env ?? process.env;
+  const raw = normalizeNonEmpty(env.VH_NEWS_SOURCE_ADMISSION_MODE)?.toLowerCase();
+  return raw === 'soak' ? 'soak' : 'product';
 }
 
 function normalizeNonEmpty(value: string | undefined): string | null {
@@ -683,33 +714,50 @@ async function readFeedXml(
   };
 }
 
-function buildCriteria(options: SourceAdmissionAuditOptions): SourceAdmissionCriteria {
+function buildCriteria(
+  options: SourceAdmissionAuditOptions & Pick<SourceAdmissionArtifactOptions, 'env'>,
+  evaluationMode: SourceAdmissionEvaluationMode = resolveEvaluationMode(options),
+): SourceAdmissionCriteria {
+  const env = options.env ?? process.env;
+  const defaultSampleSize =
+    evaluationMode === 'soak' ? DEFAULT_SOAK_SAMPLE_SIZE : DEFAULT_SAMPLE_SIZE;
+  const defaultMinSuccessCount =
+    evaluationMode === 'soak' ? DEFAULT_SOAK_MIN_SUCCESS_COUNT : DEFAULT_MIN_SUCCESS_COUNT;
+  const defaultMinSuccessRate =
+    evaluationMode === 'soak' ? DEFAULT_SOAK_MIN_SUCCESS_RATE : DEFAULT_MIN_SUCCESS_RATE;
+
   return {
     sampleSize:
       options.sampleSize
       ?? parsePositiveInt(
-        process.env.VH_NEWS_SOURCE_ADMISSION_SAMPLE_SIZE,
-        DEFAULT_SAMPLE_SIZE,
+        env.VH_NEWS_SOURCE_ADMISSION_SAMPLE_SIZE,
+        defaultSampleSize,
       ),
     minimumSuccessCount:
       options.minimumSuccessCount
       ?? parsePositiveInt(
-        process.env.VH_NEWS_SOURCE_ADMISSION_MIN_SUCCESS_COUNT,
-        DEFAULT_MIN_SUCCESS_COUNT,
+        env.VH_NEWS_SOURCE_ADMISSION_MIN_SUCCESS_COUNT,
+        defaultMinSuccessCount,
       ),
     minimumSuccessRate:
       options.minimumSuccessRate
       ?? parseRate(
-        process.env.VH_NEWS_SOURCE_ADMISSION_MIN_SUCCESS_RATE,
-        DEFAULT_MIN_SUCCESS_RATE,
+        env.VH_NEWS_SOURCE_ADMISSION_MIN_SUCCESS_RATE,
+        defaultMinSuccessRate,
       ),
   };
 }
 
 function passSample(result: ArticleTextResult): SourceAdmissionSampleResult {
+  const assessment = assessItemEligibilityFromResult(result);
   return {
     url: result.url,
     outcome: 'passed',
+    canonicalUrl: assessment.canonicalUrl,
+    urlHash: assessment.urlHash,
+    eligibilityState: assessment.state,
+    eligibilityReason: assessment.reason,
+    displayEligible: assessment.displayEligible,
     title: result.title,
     extractionMethod: result.extractionMethod,
     qualityScore: result.quality.score,
@@ -721,10 +769,16 @@ function failSample(
   url: string,
   error: unknown,
 ): SourceAdmissionSampleResult {
+  const assessment = assessItemEligibilityFromError(url, error);
   if (error instanceof ArticleTextServiceError) {
     return {
       url,
       outcome: 'failed',
+      canonicalUrl: assessment.canonicalUrl,
+      urlHash: assessment.urlHash,
+      eligibilityState: assessment.state,
+      eligibilityReason: assessment.reason,
+      displayEligible: assessment.displayEligible,
       errorCode: error.code,
       errorMessage: error.message,
       retryable: error.retryable,
@@ -734,6 +788,11 @@ function failSample(
   return {
     url,
     outcome: 'failed',
+    canonicalUrl: assessment.canonicalUrl,
+    urlHash: assessment.urlHash,
+    eligibilityState: assessment.state,
+    eligibilityReason: assessment.reason,
+    displayEligible: assessment.displayEligible,
     errorCode: 'unexpected-error',
     errorMessage: error instanceof Error ? error.message : 'Unexpected source admission failure',
     retryable: false,
@@ -755,18 +814,22 @@ function canReplaceSampleFailure(
 function classifySource(
   source: FeedSource,
   criteria: SourceAdmissionCriteria,
+  evaluationMode: SourceAdmissionEvaluationMode,
   feedRead: SourceAdmissionSourceReport['feedRead'],
   sampledUrls: readonly string[],
   skippedVideoUrls: readonly string[],
   samples: readonly SourceAdmissionSampleResult[],
   lifecycle: readonly SourceLifecycleState[],
 ): SourceAdmissionSourceReport {
-  const readableSampleCount = samples.filter((sample) => sample.outcome === 'passed').length;
+  const readableSampleCount = samples.filter(
+    (sample) => sample.eligibilityState === 'analysis_eligible' || sample.outcome === 'passed',
+  ).length;
   const readableSampleRate =
     sampledUrls.length > 0 ? readableSampleCount / sampledUrls.length : null;
 
   const reasons: string[] = [];
   let status: SourceAdmissionStatus = 'rejected';
+  let provisionalKeepForSoak = false;
 
   if (sampledUrls.length === 0) {
     status = 'inconclusive';
@@ -781,6 +844,15 @@ function classifySource(
       }
     }
   } else if (
+    evaluationMode === 'soak'
+    && sampledUrls.length >= DEFAULT_SOAK_PROVISIONAL_MIN_SUCCESS_COUNT
+    && sampledUrls.length < criteria.sampleSize
+    && readableSampleCount === sampledUrls.length
+  ) {
+    status = 'admitted';
+    provisionalKeepForSoak = true;
+    reasons.push('provisional_thin_feed_keep');
+  } else if (
     readableSampleCount >= criteria.minimumSuccessCount &&
     readableSampleCount / sampledUrls.length >= criteria.minimumSuccessRate
   ) {
@@ -789,7 +861,7 @@ function classifySource(
     const failureCodes = new Set(
       samples
         .filter((sample) => sample.outcome === 'failed')
-        .map((sample) => sample.errorCode)
+        .map((sample) => sample.errorCode ?? sample.eligibilityReason)
         .filter((value): value is string => typeof value === 'string' && value.length > 0),
     );
 
@@ -804,8 +876,10 @@ function classifySource(
     sourceId: source.id,
     sourceName: source.name,
     rssUrl: source.rssUrl,
+    evaluationMode,
     status,
     admitted: status === 'admitted',
+    provisionalKeepForSoak,
     sampleLinkCount: sampledUrls.length,
     readableSampleCount,
     readableSampleRate,
@@ -822,7 +896,8 @@ export async function auditFeedSourceAdmission(
   source: FeedSource,
   options: SourceAdmissionAuditOptions = {},
 ): Promise<SourceAdmissionSourceReport> {
-  const criteria = buildCriteria(options);
+  const evaluationMode = resolveEvaluationMode(options);
+  const criteria = buildCriteria(options, evaluationMode);
   const fetchTimeoutMs =
     options.fetchTimeoutMs
     ?? parsePositiveInt(process.env.VH_NEWS_SOURCE_ADMISSION_FETCH_TIMEOUT_MS, 10_000);
@@ -882,6 +957,7 @@ export async function auditFeedSourceAdmission(
   return classifySource(
     source,
     criteria,
+    evaluationMode,
     {
       ...feedReadResult.diagnostics,
       itemFragmentCount: parseResult.itemFragmentCount,
@@ -899,7 +975,8 @@ export async function buildSourceAdmissionReport(
   options: SourceAdmissionAuditOptions & Pick<SourceAdmissionArtifactOptions, 'cwd' | 'env'> = {},
 ): Promise<SourceAdmissionReport> {
   const feedSources = resolveConfiguredFeedSources(options);
-  const criteria = buildCriteria(options);
+  const evaluationMode = resolveEvaluationMode(options);
+  const criteria = buildCriteria(options, evaluationMode);
   const sources: SourceAdmissionSourceReport[] = [];
 
   for (const source of feedSources) {
@@ -909,6 +986,7 @@ export async function buildSourceAdmissionReport(
   return {
     schemaVersion: SOURCE_ADMISSION_REPORT_SCHEMA_VERSION,
     generatedAt: new Date((options.now ?? Date.now)()).toISOString(),
+    evaluationMode,
     criteria,
     sourceCount: sources.length,
     admittedSourceIds: sources.filter((source) => source.status === 'admitted').map((source) => source.sourceId),
@@ -935,6 +1013,33 @@ export async function writeSourceAdmissionArtifact(
   const report = await buildSourceAdmissionReport(options);
   const reportPath = path.join(artifactDir, 'source-admission-report.json');
   writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+  const allSamples = report.sources.flatMap((source) =>
+    source.samples.map((sample) => ({
+      sourceId: source.sourceId,
+      sourceName: source.sourceName,
+      url: sample.url,
+      canonicalUrl: sample.canonicalUrl ?? null,
+      urlHash: sample.urlHash ?? null,
+      eligibilityState: sample.eligibilityState ?? (sample.outcome === 'passed' ? 'analysis_eligible' : 'link_only'),
+      eligibilityReason: sample.eligibilityReason ?? sample.errorCode ?? null,
+      displayEligible: sample.displayEligible ?? sample.outcome === 'passed',
+    })),
+  );
+  writeFileSync(
+    path.join(artifactDir, 'analysis-eligible-links.json'),
+    `${JSON.stringify(allSamples.filter((sample) => sample.eligibilityState === 'analysis_eligible'), null, 2)}\n`,
+    'utf8',
+  );
+  writeFileSync(
+    path.join(artifactDir, 'link-only-links.json'),
+    `${JSON.stringify(allSamples.filter((sample) => sample.eligibilityState === 'link_only'), null, 2)}\n`,
+    'utf8',
+  );
+  writeFileSync(
+    path.join(artifactDir, 'hard-blocked-links.json'),
+    `${JSON.stringify(allSamples.filter((sample) => sample.eligibilityState === 'hard_blocked'), null, 2)}\n`,
+    'utf8',
+  );
   return { artifactDir, reportPath, report };
 }
 
@@ -965,6 +1070,7 @@ if (isDirectExecution()) {
 
 export const sourceAdmissionReportInternal = {
   buildCriteria,
+  resolveEvaluationMode,
   classifySource,
   classifyFeedReadError,
   decodeXmlEntities,


### PR DESCRIPTION
## Summary
- add item-level eligibility classification for analysis-eligible, link-only, and hard-blocked article outcomes
- wire soak-mode source admission to use explicit 8-sample / 4-success thresholds without changing product-mode defaults
- persist admission artifact sidecars for analysis-eligible, link-only, and hard-blocked sampled URLs

## Testing
- pnpm --filter @vh/news-aggregator exec vitest run /Users/bldt/Desktop/VHC/VHC/services/news-aggregator/src/itemEligibilityPolicy.test.ts /Users/bldt/Desktop/VHC/VHC/services/news-aggregator/src/sourceAdmissionReport.test.ts --config /Users/bldt/Desktop/VHC/VHC/services/news-aggregator/vitest.config.ts
- pnpm --filter @vh/news-aggregator exec vitest run /Users/bldt/Desktop/VHC/VHC/services/news-aggregator/src/sourceHealthReport.test.ts --config /Users/bldt/Desktop/VHC/VHC/services/news-aggregator/vitest.config.ts