### PR TITLE
Implement item eligibility boundary groundwork

### DIFF
--- a/apps/web-pwa/src/components/feed/NewsCard.sharedTopicIsolation.test.tsx
+++ b/apps/web-pwa/src/components/feed/NewsCard.sharedTopicIsolation.test.tsx
@@ -96,6 +96,7 @@ const SYNTHESIS_RESULT: NewsCardAnalysisSynthesis = {
       model_id: 'gpt-4o-mini',
     },
   ],
+  relatedLinks: [],
 };
 
 describe('NewsCard shared-topic isolation', () => {

--- a/apps/web-pwa/src/components/feed/NewsCard.test.tsx
+++ b/apps/web-pwa/src/components/feed/NewsCard.test.tsx
@@ -135,6 +135,7 @@ describe('NewsCard', () => {
           model_id: 'gpt-4o-mini',
         },
       ],
+      relatedLinks: [],
     });
   });
   afterEach(() => {
@@ -273,6 +274,65 @@ describe('NewsCard', () => {
     expect(screen.getByTestId('news-card-headline-news-1')).toBeInTheDocument();
     expect(mockSynthesizeStoryFromAnalysisPipeline).toHaveBeenCalledTimes(1);
   });
+  it('renders related links separately from canonical source badges', async () => {
+    vi.stubEnv('VITE_VH_ANALYSIS_PIPELINE', 'false');
+    useNewsStore.getState().setStories([
+      makeStoryBundle({
+        sources: [
+          {
+            source_id: 'src-1',
+            publisher: 'Local Paper',
+            url: 'https://example.com/news-1',
+            url_hash: 'hash-1',
+            published_at: NOW - 3_600_000,
+            title: 'City council votes on transit plan',
+          },
+          {
+            source_id: 'src-2',
+            publisher: 'Difficult Extractor',
+            url: 'https://example.com/related-link',
+            url_hash: 'hash-2',
+            published_at: NOW - 3_000_000,
+            title: 'Transit debate follow-up',
+          },
+        ],
+        primary_sources: [
+          {
+            source_id: 'src-1',
+            publisher: 'Local Paper',
+            url: 'https://example.com/news-1',
+            url_hash: 'hash-1',
+            published_at: NOW - 3_600_000,
+            title: 'City council votes on transit plan',
+          },
+        ],
+        related_links: [
+          {
+            source_id: 'src-2',
+            publisher: 'Difficult Extractor',
+            url: 'https://example.com/related-link',
+            url_hash: 'hash-2',
+            published_at: NOW - 3_000_000,
+            title: 'Transit debate follow-up',
+          },
+        ],
+      }),
+    ]);
+    useSynthesisStore
+      .getState()
+      .setTopicSynthesis('news-1', makeSynthesis());
+
+    render(<NewsCard item={makeNewsItem()} />);
+
+    expect(screen.getByTestId('source-badge-src-1')).toBeInTheDocument();
+    expect(screen.queryByTestId('source-badge-src-2')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('news-card-headline-news-1'));
+
+    expect(await screen.findByTestId('news-card-related-links-news-1')).toHaveTextContent(
+      'Difficult Extractor: Transit debate follow-up',
+    );
+  });
   it('uses provider_id provenance when model metadata is unavailable', async () => {
     vi.stubEnv('VITE_VH_ANALYSIS_PIPELINE', 'true');
     mockSynthesizeStoryFromAnalysisPipeline.mockResolvedValueOnce({
@@ -291,6 +351,7 @@ describe('NewsCard', () => {
           provider_id: 'openai',
         },
       ],
+      relatedLinks: [],
     });
     useNewsStore.getState().setStories([makeStoryBundle()]);
     useSynthesisStore.getState().setTopicSynthesis('news-1', makeSynthesis({ frames: [] }));
@@ -318,6 +379,7 @@ describe('NewsCard', () => {
           justifyBiasClaims: [],
         },
       ],
+      relatedLinks: [],
     });
     useNewsStore.getState().setStories([makeStoryBundle()]);
     render(<NewsCard item={makeNewsItem()} />);
@@ -331,6 +393,7 @@ describe('NewsCard', () => {
       summary: 'Summary with no per-source analyses.',
       frames: [],
       analyses: [],
+      relatedLinks: [],
     });
     useNewsStore.getState().setStories([makeStoryBundle()]);
     render(<NewsCard item={makeNewsItem()} />);

--- a/apps/web-pwa/src/components/feed/NewsCard.tsx
+++ b/apps/web-pwa/src/components/feed/NewsCard.tsx
@@ -90,6 +90,46 @@ export function resolveAnalysisProviderModel(
   return withProvider?.provider_id ?? null;
 }
 
+function resolveDisplaySources(
+  story: StoryBundle | null,
+): ReadonlyArray<StoryBundle['sources'][number]> {
+  if (!story) {
+    return [];
+  }
+
+  return story.primary_sources ?? story.sources;
+}
+
+function mergeRelatedLinks(
+  story: StoryBundle | null,
+  analysis: ReturnType<typeof useAnalysis>['analysis'],
+): ReadonlyArray<{
+  source_id: string;
+  publisher: string;
+  title: string;
+  url: string;
+}> {
+  const entries = [
+    ...(story?.related_links ?? []),
+    ...(analysis?.relatedLinks ?? []),
+  ];
+  const deduped = new Map<string, {
+    source_id: string;
+    publisher: string;
+    title: string;
+    url: string;
+  }>();
+
+  for (const entry of entries) {
+    const key = `${entry.source_id}|${entry.url}`;
+    if (!deduped.has(key)) {
+      deduped.set(key, entry);
+    }
+  }
+
+  return [...deduped.values()];
+}
+
 export const NewsCard: React.FC<NewsCardProps> = ({ item }) => {
   const stories = useStore(useNewsStore, (state) => state.stories);
   const storylinesById = useStore(useNewsStore, (state) => state.storylinesById);
@@ -127,6 +167,10 @@ export const NewsCard: React.FC<NewsCardProps> = ({ item }) => {
   const singletonVideoSource = useMemo(
     () => resolveSingletonVideoSource(analysisStory),
     [analysisStory],
+  );
+  const displaySources = useMemo(
+    () => resolveDisplaySources(story),
+    [story],
   );
   const {
     analysis,
@@ -173,6 +217,10 @@ export const NewsCard: React.FC<NewsCardProps> = ({ item }) => {
     analysisPipelineEnabled && analysisStatus === 'success' && analysis
       ? analysis.analyses.filter((e) => e.summary.trim().length > 0)
       : [];
+  const relatedLinks = useMemo(
+    () => mergeRelatedLinks(story, analysis),
+    [story, analysis],
+  );
   const frontRegionId = `news-card-front-${item.topic_id}`;
   const backRegionId = `news-card-back-region-${item.topic_id}`;
 
@@ -301,9 +349,9 @@ export const NewsCard: React.FC<NewsCardProps> = ({ item }) => {
             >
               {item.title}
             </button>
-            {story && story.sources.length > 0 && (
+            {displaySources.length > 0 && (
               <SourceBadgeRow
-                sources={story.sources.map((source) => ({
+                sources={displaySources.map((source) => ({
                   source_id: source.source_id,
                   publisher: source.publisher,
                   url: source.url,
@@ -348,6 +396,7 @@ export const NewsCard: React.FC<NewsCardProps> = ({ item }) => {
                 analysisProvider={analysisProvider}
                 perSourceSummaries={perSourceSummaries}
                 relatedCoverage={storyline?.related_coverage ?? []}
+                relatedLinks={relatedLinks}
                 storylineHeadline={storylineHeadline}
                 storylineStoryCount={storylineStoryCount}
                 analysisFeedbackStatus={analysisFeedbackStatus}

--- a/apps/web-pwa/src/components/feed/NewsCardBack.storyline.test.tsx
+++ b/apps/web-pwa/src/components/feed/NewsCardBack.storyline.test.tsx
@@ -16,6 +16,7 @@ function renderBack(
       frameRows={[]}
       analysisProvider={null}
       perSourceSummaries={[]}
+      relatedLinks={[]}
       relatedCoverage={[
         {
           source_id: 'related-1',

--- a/apps/web-pwa/src/components/feed/NewsCardBack.tsx
+++ b/apps/web-pwa/src/components/feed/NewsCardBack.tsx
@@ -21,6 +21,12 @@ export interface NewsCardBackProps {
     title: string;
     url: string;
   }>;
+  readonly relatedLinks: ReadonlyArray<{
+    source_id: string;
+    publisher: string;
+    title: string;
+    url: string;
+  }>;
   readonly storylineHeadline: string | null;
   readonly storylineStoryCount: number;
   readonly analysisFeedbackStatus:
@@ -56,6 +62,7 @@ export const NewsCardBack: React.FC<NewsCardBackProps> = ({
   analysisProvider,
   perSourceSummaries,
   relatedCoverage,
+  relatedLinks,
   storylineHeadline,
   storylineStoryCount,
   analysisFeedbackStatus,
@@ -168,6 +175,35 @@ export const NewsCardBack: React.FC<NewsCardBackProps> = ({
                     </li>
                   ))}
                 </ul>
+              )}
+
+              {relatedLinks.length > 0 && (
+                <div
+                  className="space-y-2 rounded-xl border border-amber-200 bg-amber-50 p-3"
+                  data-testid={`news-card-related-links-${topicId}`}
+                >
+                  <h4 className="text-xs font-semibold uppercase tracking-wide text-amber-700">
+                    Related stories
+                  </h4>
+                  <p className="text-xs text-amber-700/80">
+                    These links were not used in the framing table or analysis summary.
+                  </p>
+                  <ul className="space-y-1 text-xs text-amber-800">
+                    {relatedLinks.map((entry) => (
+                      <li key={`${entry.source_id}|${entry.url}`}>
+                        <span className="font-medium">{entry.publisher}:</span>{' '}
+                        <a
+                          className="underline decoration-amber-300 underline-offset-2 hover:text-amber-950"
+                          href={entry.url}
+                          target="_blank"
+                          rel="noreferrer"
+                        >
+                          {entry.title}
+                        </a>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
               )}
 
               {relatedCoverage.length > 0 && (

--- a/apps/web-pwa/src/components/feed/newsCardAnalysis.test.ts
+++ b/apps/web-pwa/src/components/feed/newsCardAnalysis.test.ts
@@ -159,6 +159,7 @@ describe('newsCardAnalysis', () => {
     expect(result.summary).toContain('Publisher One: Publisher One says rollout should move fast.');
     expect(result.summary).toContain('Publisher Two: Publisher Two focuses on budget risk.');
     expect(result.summary).toContain('Publisher Three: Publisher Three emphasizes implementation details.');
+    expect(result.relatedLinks).toEqual([]);
 
     expect(result.frames).toEqual([
       {
@@ -265,6 +266,15 @@ describe('newsCardAnalysis', () => {
     expect(analysisInputs[0]).toContain('ARTICLE BODY 2');
     expect(result.summary).toContain('Publisher Two: Only fetched article text is analyzed.');
     expect(result.summary).not.toContain('Publisher One');
+    expect(result.relatedLinks).toEqual([
+      {
+        source_id: 'source-1',
+        publisher: 'Publisher One',
+        url: 'https://example.com/1',
+        url_hash: 'hash-1',
+        title: 'Transit overhaul clears first hurdle',
+      },
+    ]);
   });
 
   it('does not run source analysis when article-text fetching is disabled', async () => {

--- a/apps/web-pwa/src/components/feed/newsCardAnalysis.test.ts
+++ b/apps/web-pwa/src/components/feed/newsCardAnalysis.test.ts
@@ -89,6 +89,7 @@ describe('newsCardAnalysis', () => {
   afterEach(() => {
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
   });
 
   it('analyzes at most 3 sources and synthesizes summary + frame rows', async () => {
@@ -233,22 +234,26 @@ describe('newsCardAnalysis', () => {
     expect(input).toContain('FULL ARTICLE TEXT');
   });
 
-  it('falls back to metadata-only input when article fetch fails', async () => {
+  it('skips sources whose article text cannot be fetched', async () => {
+    const baseStory = makeStoryBundle();
     const story = makeStoryBundle({
-      sources: [makeStoryBundle().sources[0]!],
+      sources: [baseStory.sources[0]!, baseStory.sources[1]!],
     });
 
     const analysisInputs: string[] = [];
 
     const result = await synthesizeStoryFromAnalysisPipeline(story, {
-      fetchArticleText: async () => {
-        throw new Error('fetch blocked');
+      fetchArticleText: async (url: string) => {
+        if (url.endsWith('/1')) {
+          throw new Error('fetch blocked');
+        }
+        return 'ARTICLE BODY 2';
       },
       runAnalysis: async (articleText: string) => {
         analysisInputs.push(articleText);
         return {
           analysis: makeAnalysis({
-            summary: 'Metadata fallback still produced analysis.',
+            summary: 'Only fetched article text is analyzed.',
             biases: ['No clear bias detected'],
             counterpoints: ['N/A'],
           }),
@@ -257,37 +262,33 @@ describe('newsCardAnalysis', () => {
     });
 
     expect(analysisInputs).toHaveLength(1);
-    expect(analysisInputs[0]).toContain('ARTICLE BODY: unavailable; analyze available metadata only.');
-    expect(result.summary).toContain('Publisher One: Metadata fallback still produced analysis.');
+    expect(analysisInputs[0]).toContain('ARTICLE BODY 2');
+    expect(result.summary).toContain('Publisher Two: Only fetched article text is analyzed.');
+    expect(result.summary).not.toContain('Publisher One');
   });
 
-  it('skips article fetch entirely when metadata-only analysis is enabled', async () => {
+  it('does not run source analysis when article-text fetching is disabled', async () => {
     vi.stubEnv('VITE_VH_ANALYSIS_SKIP_ARTICLE_TEXT', 'true');
     const story = makeStoryBundle({
       sources: [makeStoryBundle().sources[0]!],
     });
     const fetchArticleText = vi.fn(async () => 'UNUSED ARTICLE TEXT');
-    const analysisInputs: string[] = [];
+    const runAnalysis = vi.fn(async (_articleText: string) => ({
+      analysis: makeAnalysis({
+        summary: 'Should not run.',
+        biases: ['Metadata bias'],
+        counterpoints: ['Metadata counterpoint'],
+      }),
+    }));
 
-    const result = await synthesizeStoryFromAnalysisPipeline(story, {
+    await expect(synthesizeStoryFromAnalysisPipeline(story, {
       fetchArticleText,
-      runAnalysis: async (articleText: string) => {
-        analysisInputs.push(articleText);
-        return {
-          analysis: makeAnalysis({
-            summary: 'Metadata-only analysis completed immediately.',
-            biases: ['Metadata bias'],
-            counterpoints: ['Metadata counterpoint'],
-          }),
-        };
-      },
-    });
+      runAnalysis,
+    })).rejects.toThrow('Analysis pipeline unavailable for all story sources');
 
     expect(newsCardAnalysisInternal.shouldSkipArticleTextFetch()).toBe(true);
     expect(fetchArticleText).not.toHaveBeenCalled();
-    expect(analysisInputs).toHaveLength(1);
-    expect(analysisInputs[0]).toContain('ARTICLE BODY: unavailable; analyze available metadata only.');
-    expect(result.summary).toContain('Publisher One: Metadata-only analysis completed immediately.');
+    expect(runAnalysis).not.toHaveBeenCalled();
   });
 
   it('throws when all source analyses fail', async () => {

--- a/apps/web-pwa/src/components/feed/newsCardAnalysis.ts
+++ b/apps/web-pwa/src/components/feed/newsCardAnalysis.ts
@@ -22,10 +22,19 @@ export interface NewsCardSourceAnalysis {
   readonly model_id?: string;
 }
 
+export interface NewsCardRelatedLink {
+  readonly source_id: string;
+  readonly publisher: string;
+  readonly url: string;
+  readonly url_hash: string;
+  readonly title: string;
+}
+
 export interface NewsCardAnalysisSynthesis {
   readonly summary: string;
   readonly frames: ReadonlyArray<{ frame: string; reframe: string }>;
   readonly analyses: ReadonlyArray<NewsCardSourceAnalysis>;
+  readonly relatedLinks: ReadonlyArray<NewsCardRelatedLink>;
 }
 
 interface NewsCardAnalysisOptions {
@@ -278,6 +287,18 @@ function toFrameRows(
   return rows.slice(0, MAX_FRAME_ROWS);
 }
 
+function toRelatedLink(
+  source: StoryBundle['sources'][number],
+): NewsCardRelatedLink {
+  return {
+    source_id: source.source_id,
+    publisher: source.publisher,
+    url: source.url,
+    url_hash: source.url_hash,
+    title: source.title,
+  };
+}
+
 function synthesizeSummary(analyses: ReadonlyArray<NewsCardSourceAnalysis>): string {
   const hl = analyses
     .map((sa) => {
@@ -296,6 +317,7 @@ async function runSynthesis(
 ): Promise<NewsCardAnalysisSynthesis> {
   const selectedSources = selectSourcesForAnalysis(story, maxSourceAnalyses);
   const analyzed: NewsCardSourceAnalysis[] = [];
+  const relatedLinks: NewsCardRelatedLink[] = [];
   const skipArticleTextFetch = shouldSkipArticleTextFetch();
 
   for (const source of selectedSources) {
@@ -314,17 +336,27 @@ async function runSynthesis(
           sourceId: source.source_id,
           url: source.url,
         });
+        relatedLinks.push(toRelatedLink(source));
         continue;
       }
       const input = buildAnalysisInput(story, source, articleText);
-      const result = await runAnalysis(input);
-      analyzed.push(toSourceAnalysis(source, result.analysis));
+      try {
+        const result = await runAnalysis(input);
+        analyzed.push(toSourceAnalysis(source, result.analysis));
+      } catch (error) {
+        console.warn('[vh:news-card-analysis] source analysis skipped; analysis unavailable', {
+          sourceId: source.source_id,
+          url: source.url,
+          error,
+        });
+      }
     } catch (error) {
       console.warn('[vh:news-card-analysis] source analysis skipped; article text unavailable', {
         sourceId: source.source_id,
         url: source.url,
         error,
       });
+      relatedLinks.push(toRelatedLink(source));
     }
   }
 
@@ -336,6 +368,7 @@ async function runSynthesis(
     summary: synthesizeSummary(analyzed),
     frames: toFrameRows(analyzed),
     analyses: analyzed,
+    relatedLinks,
   };
 }
 
@@ -396,6 +429,7 @@ export const newsCardAnalysisInternal = {
   shouldSkipArticleTextFetch,
   synthesizeSummary,
   toFrameRows,
+  toRelatedLink,
   toSourceAnalysis,
   toStoryCacheKey,
 };

--- a/apps/web-pwa/src/components/feed/newsCardAnalysis.ts
+++ b/apps/web-pwa/src/components/feed/newsCardAnalysis.ts
@@ -211,7 +211,7 @@ function selectSourcesForAnalysis(
 function buildAnalysisInput(
   story: StoryBundle,
   source: StoryBundle['sources'][number],
-  articleText: string | null,
+  articleText: string,
 ): string {
   const context = [
     `Publisher: ${source.publisher}`,
@@ -227,19 +227,11 @@ function buildAnalysisInput(
     context.push(`Bundle summary hint: ${story.summary_hint.trim()}`);
   }
 
-  if (articleText && articleText.trim()) {
-    return [
-      context.join('\n'),
-      '',
-      'ARTICLE BODY:',
-      articleText.trim(),
-    ].join('\n');
-  }
-
   return [
     context.join('\n'),
     '',
-    'ARTICLE BODY: unavailable; analyze available metadata only.',
+    'ARTICLE BODY:',
+    articleText.trim(),
   ].join('\n');
 }
 
@@ -307,25 +299,28 @@ async function runSynthesis(
   const skipArticleTextFetch = shouldSkipArticleTextFetch();
 
   for (const source of selectedSources) {
-    try {
-      let articleText: string | null = null;
-      if (!skipArticleTextFetch) {
-        try {
-          articleText = await fetchArticleText(source.url);
-        } catch (error) {
-          console.warn('[vh:news-card-analysis] article fetch failed; using metadata fallback', {
-            sourceId: source.source_id,
-            url: source.url,
-            error,
-          });
-        }
-      }
+    if (skipArticleTextFetch) {
+      console.info('[vh:news-card-analysis] source analysis skipped; article text disabled', {
+        sourceId: source.source_id,
+        url: source.url,
+      });
+      continue;
+    }
 
+    try {
+      const articleText = await fetchArticleText(source.url);
+      if (!articleText.trim()) {
+        console.warn('[vh:news-card-analysis] source analysis skipped; empty article text', {
+          sourceId: source.source_id,
+          url: source.url,
+        });
+        continue;
+      }
       const input = buildAnalysisInput(story, source, articleText);
       const result = await runAnalysis(input);
       analyzed.push(toSourceAnalysis(source, result.analysis));
     } catch (error) {
-      console.warn('[vh:news-card-analysis] source analysis failed', {
+      console.warn('[vh:news-card-analysis] source analysis skipped; article text unavailable', {
         sourceId: source.source_id,
         url: source.url,
         error,

--- a/apps/web-pwa/src/components/feed/useAnalysis.test.ts
+++ b/apps/web-pwa/src/components/feed/useAnalysis.test.ts
@@ -97,6 +97,7 @@ function makeAnalysis(overrides: Partial<NewsCardAnalysisSynthesis> = {}): NewsC
         model_id: 'gpt-4o-mini',
       },
     ],
+    relatedLinks: [],
     ...overrides,
   };
 }

--- a/apps/web-pwa/src/components/feed/useAnalysisMesh.test.ts
+++ b/apps/web-pwa/src/components/feed/useAnalysisMesh.test.ts
@@ -80,6 +80,7 @@ function makeSynthesis(overrides: Partial<NewsCardAnalysisSynthesis> = {}): News
         model_id: 'gpt-5.3-codex',
       },
     ],
+    relatedLinks: [],
     ...overrides,
   };
 }
@@ -150,6 +151,7 @@ describe('useAnalysisMesh', () => {
           model_id: 'gpt-5.3-codex',
         },
       ],
+      relatedLinks: [],
     });
 
     expect(mockReadAnalysis).toHaveBeenCalledTimes(1);
@@ -285,6 +287,7 @@ describe('useAnalysisMesh', () => {
       summary: 'Mismatch provenance',
       frames: [{ frame: 'f', reframe: 'r' }],
       analyses: [],
+      relatedLinks: [],
     });
 
     expect(infoSpy).toHaveBeenCalledWith(
@@ -322,6 +325,7 @@ describe('useAnalysisMesh', () => {
       summary: 'Mismatch model',
       frames: [{ frame: 'f', reframe: 'r' }],
       analyses: [],
+      relatedLinks: [],
     });
 
     expect(infoSpy).toHaveBeenCalledWith(

--- a/apps/web-pwa/src/components/feed/useAnalysisMesh.ts
+++ b/apps/web-pwa/src/components/feed/useAnalysisMesh.ts
@@ -256,6 +256,13 @@ function toSynthesis(artifact: StoryAnalysisArtifact): NewsCardAnalysisSynthesis
       provider_id: entry.provider_id,
       model_id: entry.model_id,
     })),
+    relatedLinks: (artifact.relatedLinks ?? []).map((entry) => ({
+      source_id: entry.source_id,
+      publisher: entry.publisher,
+      url: entry.url,
+      url_hash: entry.url_hash,
+      title: entry.title,
+    })),
   };
 }
 
@@ -307,6 +314,13 @@ async function toArtifact(
         .filter((value) => value.length > 0),
       provider_id: entry.provider_id?.trim() || undefined,
       model_id: entry.model_id?.trim() || undefined,
+    })),
+    relatedLinks: synthesis.relatedLinks.map((entry) => ({
+      source_id: ensureNonEmpty(entry.source_id, story.story_id),
+      publisher: ensureNonEmpty(entry.publisher, 'Unknown publisher'),
+      url: ensureNonEmpty(entry.url, 'https://example.invalid/related'),
+      url_hash: ensureNonEmpty(entry.url_hash, `${story.story_id}-related`),
+      title: ensureNonEmpty(entry.title, 'Related story'),
     })),
     provider: {
       provider_id: ensureNonEmpty(firstProvider?.provider_id, 'unknown-provider'),

--- a/apps/web-pwa/tsconfig.json
+++ b/apps/web-pwa/tsconfig.json
@@ -13,6 +13,8 @@
     "baseUrl": "./",
     "paths": {
       "@/*": ["./src/*"],
+      "@vh/data-model": ["../../packages/data-model/src/index.ts"],
+      "@vh/data-model/*": ["../../packages/data-model/src/*"],
       "@vh/ai-engine": ["../../packages/ai-engine/src/index.ts"],
       "@vh/ai-engine/*": ["../../packages/ai-engine/src/*"]
     }

--- a/docs/plans/ITEM_LEVEL_FEED_RELIABILITY_IMPLEMENTATION_PLAN.md
+++ b/docs/plans/ITEM_LEVEL_FEED_RELIABILITY_IMPLEMENTATION_PLAN.md
@@ -5,6 +5,12 @@
 > Branch: `coord/item-reliability-plan`
 > Scope: define the system rule for source reliability and item eligibility without conflating soak evaluation with the product admission contract
 
+Implementation note:
+
+1. The current implementation sequence lands the eligibility ledger and the analysis/publish boundary first.
+2. The `related_links` data-model and UI rendering work remains a later follow-on slice.
+3. Until that follow-on lands, `link_only` items must stay out of analysis and framing outputs but are not yet rendered in a dedicated bottom-of-card surface.
+
 ## Goal
 
 Make this an enforced system rule:

--- a/docs/plans/ITEM_LEVEL_FEED_RELIABILITY_IMPLEMENTATION_PLAN.md
+++ b/docs/plans/ITEM_LEVEL_FEED_RELIABILITY_IMPLEMENTATION_PLAN.md
@@ -7,9 +7,9 @@
 
 Implementation note:
 
-1. The current implementation sequence lands the eligibility ledger and the analysis/publish boundary first.
-2. The `related_links` data-model and UI rendering work remains a later follow-on slice.
-3. Until that follow-on lands, `link_only` items must stay out of analysis and framing outputs but are not yet rendered in a dedicated bottom-of-card surface.
+1. The current implementation sequence lands the eligibility ledger and the analysis boundary first.
+2. `related_links` is now implemented as a data-model field plus a UI/runtime sidecar surfaced from article-text failures.
+3. Publish-time bundle enrichment from the eligibility ledger is still a follow-on slice; until that lands, runtime-discovered `related_links` are display-only and must not widen canonical analyzed-source semantics.
 
 ## Goal
 

--- a/docs/plans/ITEM_LEVEL_FEED_RELIABILITY_IMPLEMENTATION_PLAN.md
+++ b/docs/plans/ITEM_LEVEL_FEED_RELIABILITY_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,638 @@
+# Item-Level Feed Reliability Implementation Plan
+
+> Status: Implementation Plan
+> Owner: News Aggregator + StoryCluster
+> Branch: `coord/item-reliability-plan`
+> Scope: define the system rule for source reliability and item eligibility without conflating soak evaluation with the product admission contract
+
+## Goal
+
+Make this an enforced system rule:
+
+1. Soak/public-soak evaluation keeps a source when it is at least 50% article-reliable over an 8-item soak sample.
+2. Product admission/readiness keeps a source only when it is at least 66% reliable over a larger rolling sample built from accumulated extraction outcomes.
+3. Articles whose text cannot be extracted must never be treated as analyzed evidence or included in the framing table.
+4. Legitimate source links that fail extraction may still be shown to users as raw related stories.
+5. Truly bad links must be hard-blocked and never shown.
+
+## Executive Decision
+
+Use two separate policy layers and three item states.
+
+### Reliability layers
+
+1. `soak_reliability`
+   - 8-item article-candidate sample
+   - keep at `4/8` or better
+   - only for canary, scout, consumer-smoke, and public-soak evaluation
+2. `product_reliability`
+   - rolling aggregate built from dozens of article extraction outcomes over time
+   - keep at `>= 0.66`
+   - governs real source admission, starter-surface retention, and production readiness
+
+### Item eligibility states
+
+1. `analysis_eligible`
+   - text extraction succeeded
+   - may be used in clustering provenance, synthesis, semantic audit, and framing tables
+2. `link_only`
+   - URL is legitimate and may still be shown to the user as a related story link
+   - text extraction failed or was not good enough for analysis
+   - must not be used in synthesis, framing, or canonical analysis claims
+3. `hard_blocked`
+   - invalid, dead, access-denied, or policy-forbidden URL
+   - must not be analyzed or shown
+
+This is the core design correction.
+
+Do not collapse all extraction failures into a permanent never-serve ledger.
+
+## Why This Change Is Needed
+
+Current behavior is too blunt and uses the wrong boundary.
+
+Relevant current code:
+
+- `/Users/bldt/Desktop/VHC/VHC/services/news-aggregator/src/sourceAdmissionReport.ts`
+- `/Users/bldt/Desktop/VHC/VHC/services/news-aggregator/src/sourceHealthReport.ts`
+- `/Users/bldt/Desktop/VHC/VHC/services/news-aggregator/src/articleTextService.ts`
+- `/Users/bldt/Desktop/VHC/VHC/services/news-aggregator/src/removalLedger.ts`
+- `/Users/bldt/Desktop/VHC/VHC/services/news-aggregator/src/orchestrator.ts`
+- `/Users/bldt/Desktop/VHC/VHC/packages/data-model/src/schemas/hermes/storyBundle.ts`
+- `/Users/bldt/Desktop/VHC/VHC/services/storycluster-engine/src/bundleProjection.ts`
+- `/Users/bldt/Desktop/VHC/VHC/apps/web-pwa/src/components/feed/NewsCard.tsx`
+
+Current gaps:
+
+1. Admission is source-level only and has no first-class item eligibility contract.
+2. The extraction layer already supports hard blocks via `RemovalLedger`, but that is too strong a tool for every non-extractable article.
+3. Publication currently has no explicit boundary between:
+   - canonical analyzable sources
+   - raw related links that are display-only
+4. The existing `StoryBundle` contract has no field for “possible sources shown but not analyzed.”
+
+## Correct System Rule
+
+### Source-level rule
+
+A source decision depends on two different measurements.
+
+#### Soak rule
+
+Use this only in soak/public-soak evaluation:
+
+1. sample 8 article-candidate links
+2. keep if at least 4 are extraction-successful
+3. do not let soak math rewrite the canonical product admission thresholds
+
+#### Product rule
+
+Use this for starter-surface admission and production readiness:
+
+1. aggregate extraction outcomes over a much larger rolling sample
+2. keep only when reliable article outcomes are at least `66%`
+3. include historical bad-link pressure in the decision, not just the latest run
+
+### Item-level rule
+
+Each URL must resolve to exactly one item-eligibility state:
+
+1. `analysis_eligible`
+2. `link_only`
+3. `hard_blocked`
+
+### Serving rule
+
+1. `analysis_eligible`
+   - may appear in canonical story provenance and analysis flows
+2. `link_only`
+   - may appear only in a bottom-of-card related stories section
+   - must not be treated as evidence for synthesis or framing
+3. `hard_blocked`
+   - may not be served anywhere
+
+## Canonical Persistence Decision
+
+Keep two policy stores with different semantics.
+
+### A. Hard-block ledger
+
+Keep using the existing path for true never-serve entries:
+
+- `/Users/bldt/Desktop/VHC/VHC/services/news-aggregator/src/removalLedger.ts`
+- mesh path: `vh/news/removed/<urlHash>`
+
+Use this only for `hard_blocked` URLs.
+
+Examples:
+
+- invalid URL
+- 404 / 410 dead link
+- access denied
+- explicit publisher/policy removal
+- domain-not-allowed
+- permanent non-article destination
+
+### B. Item eligibility store
+
+Add a separate canonical store for `analysis_eligible` vs `link_only` decisions.
+
+Create:
+
+- `/Users/bldt/Desktop/VHC/VHC/services/news-aggregator/src/itemEligibilityLedger.ts`
+
+Suggested shape:
+
+- key by `urlHash`
+- include:
+  - `canonicalUrl`
+  - `sourceId`
+  - `eligibilityState`
+  - `reason`
+  - `firstSeenAt`
+  - `lastSeenAt`
+  - `observationCount`
+  - `lastObservedOutcome`
+  - `recoverable`
+
+Do not overload `vh/news/removed/*` for `link_only` items.
+
+## Failure Taxonomy
+
+### `analysis_eligible`
+
+Examples:
+
+- article extraction succeeded
+- quality passed
+
+### `link_only`
+
+Examples:
+
+- legitimate article URL but extraction quality too low
+- readable shell but insufficient body text
+- temporary extractor miss on a valid article page
+
+These links may still be shown as related stories.
+
+### `hard_blocked`
+
+Examples:
+
+- invalid URL
+- `http-404`
+- `http-410`
+- `access-denied`
+- `domain-not-allowed`
+- `unsupported_link_shape`
+- `non_article_destination`
+
+These must not be shown.
+
+## Counting and Metrics
+
+### Soak metrics
+
+For soak/public-soak only:
+
+1. denominator is 8 article-candidate URLs
+2. success means `analysis_eligible`
+3. `link_only` counts as non-success for analysis reliability
+4. `hard_blocked` counts as non-success and must be recorded separately
+
+### Product metrics
+
+Do not derive product readiness from soak math.
+
+Product reliability must use accumulated extraction outcomes over time:
+
+1. rolling article attempt count
+2. rolling `analysis_eligible` rate
+3. rolling `link_only` rate
+4. rolling `hard_blocked` rate
+5. source-level trend and contribution evidence
+
+### Historical pressure
+
+Do not let persisted entries disappear from the health picture.
+
+The system needs both:
+
+1. current-run reliability
+2. rolling bad-link pressure
+
+That prevents the source from appearing healthier just because old bad links were already classified once.
+
+## Thin-Feed Rule
+
+The previous draft’s inconclusive floor was too strict.
+
+For specialist or thin feeds:
+
+1. if at least 3 article-candidate URLs exist and all 3 are `analysis_eligible`, allow `provisional_keep_for_soak`
+2. do not automatically promote that into product keep
+3. require larger rolling evidence before product admission uses the source as a true keep
+
+This keeps useful narrow feeds from being stranded forever while preserving a higher production bar.
+
+## Canonical Publication Contract
+
+This is the most important boundary.
+
+### Canonical analysis inputs
+
+Only `analysis_eligible` items may enter:
+
+- `StoryBundle.sources`
+- `StoryBundle.primary_sources`
+- synthesis prompts in `/Users/bldt/Desktop/VHC/VHC/packages/ai-engine/src/bundlePrompts.ts`
+- semantic audit canonical source sets
+- framing table inputs in the UI analysis pipeline
+
+### Raw related-link display
+
+`link_only` items may be shown only through a new display-only field.
+
+Do not overload:
+
+- `sources`
+- `primary_sources`
+- `secondary_assets`
+
+Instead add a distinct field, for example:
+
+- `related_links`
+
+Suggested schema entry:
+
+- `source_id`
+- `publisher`
+- `url`
+- `url_hash`
+- `title`
+- `eligibility_state`
+- `display_reason`
+
+### Hard-blocked items
+
+`hard_blocked` items must appear nowhere in published bundles or UI-facing snapshots.
+
+## Data Model Changes
+
+Update:
+
+- `/Users/bldt/Desktop/VHC/VHC/packages/data-model/src/schemas/hermes/storyBundle.ts`
+
+Add a new optional field:
+
+- `related_links`
+
+This should be display-only, not canonical source provenance.
+
+Do not change the meaning of:
+
+- `sources`
+- `primary_sources`
+- `secondary_assets`
+
+## File-by-File Implementation Plan
+
+### 1. Item eligibility policy
+
+Create:
+
+- `/Users/bldt/Desktop/VHC/VHC/services/news-aggregator/src/itemEligibilityPolicy.ts`
+
+Responsibilities:
+
+1. classify item outcomes into `analysis_eligible | link_only | hard_blocked`
+2. decide whether a failed extraction is displayable or forbidden
+3. write `hard_blocked` entries to `RemovalLedger`
+4. write `analysis_eligible/link_only` observations to `itemEligibilityLedger`
+5. expose helpers for soak metrics and product metrics
+
+This module must become the single policy engine.
+
+### 2. Soak admission evaluation
+
+Update:
+
+- `/Users/bldt/Desktop/VHC/VHC/services/news-aggregator/src/sourceAdmissionReport.ts`
+
+Changes:
+
+1. add an explicit soak-evaluation mode instead of replacing canonical defaults globally
+2. use:
+   - `sampleSize = 8`
+   - `minimumSuccessCount = 4`
+   - `minimumSuccessRate = 0.50`
+   only when the soak mode is selected
+3. extend `SourceAdmissionSampleResult` to record:
+   - `canonicalUrl`
+   - `urlHash`
+   - `candidateType`
+   - `eligibilityState`
+   - `reason`
+   - `persistedToHardBlockLedger`
+   - `persistedToEligibilityLedger`
+4. allow `3/3` thin-feed provisional soak keep
+5. publish separate soak artifacts for:
+   - `analysis-eligible-links.json`
+   - `link-only-links.json`
+   - `hard-blocked-links.json`
+
+Acceptance:
+
+- soak evaluation can keep a source at `4/8`
+- this does not rewrite the repo-wide product default thresholds
+
+### 3. Product reliability aggregation
+
+Update:
+
+- `/Users/bldt/Desktop/VHC/VHC/services/news-aggregator/src/sourceHealthReport.ts`
+
+Changes:
+
+1. keep the product rule separate from the soak rule
+2. add rolling metrics derived from accumulated item observations:
+   - `analysisEligibleRate`
+   - `linkOnlyRate`
+   - `hardBlockedRate`
+   - `rollingAttemptCount`
+3. make the product keep decision depend on:
+   - `analysisEligibleRate >= 0.66`
+   - enough rolling attempts to be meaningful
+   - existing lifecycle/history gates
+4. add source-health observability for both soak and product measurements
+
+Acceptance:
+
+- source-health no longer treats the soak threshold as the canonical product threshold
+- product keep remains a higher bar than soak keep
+
+### 4. Hard-block ledger
+
+Update:
+
+- `/Users/bldt/Desktop/VHC/VHC/services/news-aggregator/src/removalLedger.ts`
+- `/Users/bldt/Desktop/VHC/VHC/packages/gun-client/src/newsAdapters.ts`
+
+Changes:
+
+1. keep backward compatibility
+2. use this path only for `hard_blocked`
+3. add optional metadata fields needed for system-policy provenance
+
+Acceptance:
+
+- hard-blocked URLs are truly never served
+- `link_only` items are not accidentally swallowed by the removal path
+
+### 5. Item eligibility ledger
+
+Create:
+
+- `/Users/bldt/Desktop/VHC/VHC/services/news-aggregator/src/itemEligibilityLedger.ts`
+
+Changes:
+
+1. persist `analysis_eligible` and `link_only` observations separately from hard blocks
+2. aggregate repeated observations over time
+3. support rolling product reliability calculations
+
+Acceptance:
+
+- the system can distinguish between “not analyzable” and “must never show”
+
+### 6. Orchestrator / publication boundary
+
+Update:
+
+- `/Users/bldt/Desktop/VHC/VHC/services/news-aggregator/src/orchestrator.ts`
+- `/Users/bldt/Desktop/VHC/VHC/services/news-aggregator/src/ingest.ts`
+- optional helper:
+  - `/Users/bldt/Desktop/VHC/VHC/services/news-aggregator/src/publishableFeedItems.ts`
+
+Changes:
+
+1. after ingest, classify raw items with `itemEligibilityPolicy.ts`
+2. allow only `analysis_eligible` items into normalize/cluster/publish
+3. collect `link_only` items into a sidecar related-links list by story/topic where possible
+4. drop `hard_blocked` items completely
+5. expose diagnostics in `PipelineResult`
+
+Acceptance:
+
+- canonical story bundles are built only from analyzable evidence
+- legitimate non-extractable links can still be preserved for display
+
+### 7. Story bundle contract
+
+Update:
+
+- `/Users/bldt/Desktop/VHC/VHC/packages/data-model/src/schemas/hermes/storyBundle.ts`
+- any dependent type exports in `/Users/bldt/Desktop/VHC/VHC/packages/ai-engine/src/newsTypes.ts`
+
+Changes:
+
+1. add optional `related_links`
+2. keep `sources` and `primary_sources` as analysis-only
+3. keep `secondary_assets` for its current role, not for extraction-failed article links
+
+Acceptance:
+
+- the data model distinguishes analyzed evidence from raw related links
+
+### 8. StoryCluster projection and runtime
+
+Update:
+
+- `/Users/bldt/Desktop/VHC/VHC/services/storycluster-engine/src/bundleProjection.ts`
+- `/Users/bldt/Desktop/VHC/VHC/packages/ai-engine/src/newsRuntime.ts`
+
+Changes:
+
+1. preserve canonical-source semantics for `primary_sources`
+2. never widen canonical bundle evidence with `link_only` items
+3. ensure runtime publication carries `related_links` separately if available
+
+Acceptance:
+
+- framing and semantic audit continue to rely only on analyzable sources
+
+### 9. Analysis and framing boundary
+
+Update:
+
+- `/Users/bldt/Desktop/VHC/VHC/packages/ai-engine/src/bundlePrompts.ts`
+- `/Users/bldt/Desktop/VHC/VHC/apps/web-pwa/src/components/feed/useAnalysis.ts`
+- any news-card analysis helpers under `/Users/bldt/Desktop/VHC/VHC/apps/web-pwa/src/components/feed/`
+
+Changes:
+
+1. ensure synthesis prompts use only canonical analyzable sources
+2. ensure the framing/analysis table never claims coverage from `link_only` URLs
+3. if the UI displays related links, render them separately from analyzed source badges
+
+Acceptance:
+
+- analysis output is honest about what was and was not actually read
+
+### 10. UI related-stories surface
+
+Update:
+
+- `/Users/bldt/Desktop/VHC/VHC/apps/web-pwa/src/components/feed/NewsCard.tsx`
+- `/Users/bldt/Desktop/VHC/VHC/apps/web-pwa/src/components/feed/SourceBadgeRow.tsx`
+- add a new component, for example:
+  - `/Users/bldt/Desktop/VHC/VHC/apps/web-pwa/src/components/feed/RelatedStoriesLinks.tsx`
+
+Changes:
+
+1. keep `SourceBadgeRow` for analyzed canonical sources
+2. add a bottom-of-card related stories section for `related_links`
+3. label the section clearly so it is not mistaken for analysis evidence
+
+Acceptance:
+
+- end users can still see useful raw source links without the app claiming those links informed the analysis
+
+### 11. Immediate scrub semantics
+
+If a URL transitions to `hard_blocked`, the system must scrub already-published surfaces immediately.
+
+Update:
+
+- publication helpers and snapshot builders used by:
+  - `/Users/bldt/Desktop/VHC/VHC/packages/e2e/src/live/daemon-feed-validated-snapshot-server.mjs`
+  - latest published bundle refresh paths
+
+Required behavior:
+
+1. remove hard-blocked URLs from published bundles on the next scrub pass
+2. rebuild latest snapshot artifacts after a hard-block write
+3. do not require waiting for a normal runtime tick to stop serving a hard-blocked URL
+
+This is the real fix for the earlier “never served” gap.
+
+### 12. Tests
+
+Update/create tests in:
+
+- `/Users/bldt/Desktop/VHC/VHC/services/news-aggregator/src/sourceAdmissionReport.test.ts`
+- `/Users/bldt/Desktop/VHC/VHC/services/news-aggregator/src/sourceHealthReport.test.ts`
+- `/Users/bldt/Desktop/VHC/VHC/services/news-aggregator/src/__tests__/articleTextService.test.ts`
+- `/Users/bldt/Desktop/VHC/VHC/services/news-aggregator/src/__tests__/removalLedger.test.ts`
+- `/Users/bldt/Desktop/VHC/VHC/services/news-aggregator/src/orchestrator.test.ts`
+- `/Users/bldt/Desktop/VHC/VHC/packages/data-model/src/schemas/hermes/storyBundle.test.ts`
+- relevant UI tests under `/Users/bldt/Desktop/VHC/VHC/apps/web-pwa/src/components/feed/`
+
+Required new cases:
+
+1. soak `4/8` keep passes without changing product defaults
+2. product keep still requires rolling `>= 0.66`
+3. `3/3` thin-feed provisional soak keep works
+4. extraction-failed but legitimate URLs become `link_only`
+5. dead/forbidden URLs become `hard_blocked`
+6. `link_only` URLs do not enter synthesis/framing inputs
+7. `link_only` URLs can still render in the related stories UI section
+8. `hard_blocked` URLs are absent from both analysis and display surfaces
+
+## Migration / Rollout
+
+### Phase 1: Policy separation
+
+Implement:
+
+- `itemEligibilityPolicy.ts`
+- `itemEligibilityLedger.ts`
+- soak vs product rule separation in docs and code
+
+Checkpoint:
+
+- no more ambiguity between soak thresholds and product thresholds
+
+### Phase 2: Publication boundary
+
+Implement:
+
+- analysis-only canonical sources
+- `related_links` sidecar path
+- hard-block filtering
+
+Checkpoint:
+
+- analysis and framing only use extractable sources
+- related links are display-only
+
+### Phase 3: Safe backfill
+
+Do not backfill from a single latest admission artifact.
+
+Instead add a guarded script:
+
+- `/Users/bldt/Desktop/VHC/VHC/tools/scripts/backfill-item-eligibility.mjs`
+
+Rules:
+
+1. only backfill `hard_blocked` from a strict whitelist of reasons
+2. require repeated observation or manual approval for permanent hard-block entries
+3. allow softer historical entries to seed `link_only`, not `hard_blocked`
+
+Checkpoint:
+
+- no one-off noisy run can create a permanent never-serve entry by itself
+
+### Phase 4: Production-readiness confirmation
+
+Validation commands:
+
+1. `pnpm report:news-sources:admission`
+2. `pnpm report:news-sources:health`
+3. `pnpm test:storycluster:publisher-canary`
+4. `pnpm test:storycluster:consumer-smoke`
+5. `pnpm check:storycluster:correctness`
+6. `pnpm check:storycluster:production-readiness`
+
+Checkpoint:
+
+- source health reports the correct product rule
+- public soak reports the correct soak rule
+- canonical analysis never claims non-extractable URLs as evidence
+- related raw links still show where allowed
+
+## Acceptance Criteria
+
+We are done when all of these are true:
+
+1. Soak/public-soak can keep a source at `4/8` without rewriting the canonical product rule.
+2. Product source-health still requires rolling `>= 0.66` analyzable reliability over a larger sample.
+3. The system distinguishes `analysis_eligible`, `link_only`, and `hard_blocked` item states.
+4. `analysis_eligible` items alone drive synthesis, semantic audit, framing, and canonical source badges.
+5. `link_only` items may appear only in a clearly separate related stories section.
+6. `hard_blocked` items are never shown or analyzed.
+7. Safe backfill rules prevent single noisy runs from creating permanent never-serve entries.
+
+## Non-Goals
+
+This plan does not:
+
+1. lower the canonical product admission bar to the soak threshold;
+2. claim every non-paywalled URL is analyzable;
+3. overload `secondary_assets` with extraction-failed article links;
+4. use a single ledger for both display-only links and hard-blocked links.
+
+## Recommendation
+
+Implement this as a contract split, not as a threshold tweak.
+
+The right architecture is:
+
+1. soak keeps feeds at `50% over 8` for operational evaluation;
+2. product keeps feeds at `66%+` over a larger rolling extraction record;
+3. non-extractable but legitimate links become `link_only`;
+4. truly bad links become `hard_blocked`;
+5. only analyzable links inform analysis and framing;
+6. raw related links can still be shown without misrepresenting them as analyzed evidence.

--- a/packages/ai-engine/src/__tests__/newsTypes.test.ts
+++ b/packages/ai-engine/src/__tests__/newsTypes.test.ts
@@ -128,6 +128,15 @@ describe('newsTypes', () => {
             title: 'Story title',
           },
         ],
+        related_links: [
+          {
+            source_id: 'src-2',
+            publisher: 'src-2',
+            url: 'https://example.com/story-2',
+            url_hash: 'deadbeef-2',
+            title: 'Related story title',
+          },
+        ],
         secondary_assets: [
           {
             source_id: 'src-video',
@@ -192,6 +201,15 @@ describe('newsTypes', () => {
           url: 'https://example.com/story',
           url_hash: 'hash-1',
           title: 'Title',
+        },
+      ],
+      related_links: [
+        {
+          source_id: 'src-2',
+          publisher: 'src-2',
+          url: 'https://example.com/related',
+          url_hash: 'hash-2',
+          title: 'Related',
         },
       ],
       cluster_features: {

--- a/packages/ai-engine/src/newsTypes.ts
+++ b/packages/ai-engine/src/newsTypes.ts
@@ -102,6 +102,7 @@ export const StoryBundleSchema = z
     sources: z.array(StoryBundleSourceSchema).min(1),
     primary_sources: z.array(StoryBundleSourceSchema).min(1).optional(),
     secondary_assets: z.array(StoryBundleSourceSchema).optional(),
+    related_links: z.array(StoryBundleSourceSchema).optional(),
     cluster_features: z
       .object({
         entity_keys: z.array(z.string().min(1)).min(1),

--- a/packages/data-model/src/schemas/hermes/sentiment.test.ts
+++ b/packages/data-model/src/schemas/hermes/sentiment.test.ts
@@ -42,6 +42,15 @@ const validArtifact = {
       model_id: 'model-y',
     },
   ],
+  relatedLinks: [
+    {
+      source_id: 'src-2',
+      publisher: 'Related Source',
+      url: 'https://example.com/related',
+      url_hash: 'related-hash',
+      title: 'Related coverage',
+    },
+  ],
   provider: {
     provider_id: 'provider-x',
     model: 'model-y',

--- a/packages/data-model/src/schemas/hermes/sentiment.ts
+++ b/packages/data-model/src/schemas/hermes/sentiment.ts
@@ -27,6 +27,16 @@ export const StoryAnalysisSourceSchema = z
   })
   .strict();
 
+export const StoryAnalysisRelatedLinkSchema = z
+  .object({
+    source_id: NonEmptyString,
+    publisher: NonEmptyString,
+    url: z.string().url(),
+    url_hash: NonEmptyString,
+    title: NonEmptyString,
+  })
+  .strict();
+
 export const StoryAnalysisProviderSchema = z
   .object({
     provider_id: NonEmptyString,
@@ -51,6 +61,7 @@ export const StoryAnalysisArtifactSchema = z
     summary: NonEmptyString,
     frames: z.array(StoryAnalysisFrameSchema),
     analyses: z.array(StoryAnalysisSourceSchema),
+    relatedLinks: z.array(StoryAnalysisRelatedLinkSchema).optional(),
     provider: StoryAnalysisProviderSchema,
     created_at: NonEmptyString,
   })
@@ -156,6 +167,7 @@ export const PointAggregateSnapshotV1Schema = z
 
 export type StoryAnalysisFrame = z.infer<typeof StoryAnalysisFrameSchema>;
 export type StoryAnalysisSource = z.infer<typeof StoryAnalysisSourceSchema>;
+export type StoryAnalysisRelatedLink = z.infer<typeof StoryAnalysisRelatedLinkSchema>;
 export type StoryAnalysisProvider = z.infer<typeof StoryAnalysisProviderSchema>;
 export type StoryAnalysisArtifact = z.infer<typeof StoryAnalysisArtifactSchema>;
 export type StoryAnalysisLatestPointer = z.infer<typeof StoryAnalysisLatestPointerSchema>;

--- a/packages/data-model/src/schemas/hermes/storyBundle.test.ts
+++ b/packages/data-model/src/schemas/hermes/storyBundle.test.ts
@@ -62,6 +62,7 @@ const validStoryBundle = {
   sources: [validBundleSource],
   primary_sources: [validBundleSource],
   secondary_assets: [{ ...validBundleSource, source_id: 'src-video', title: 'Video: markets rise' }],
+  related_links: [{ ...validBundleSource, source_id: 'src-related', title: 'Related: markets reaction' }],
   cluster_features: validClusterFeatures,
   provenance_hash: 'prov-hash-xyz',
   created_at: 1700003600001,

--- a/packages/data-model/src/schemas/hermes/storyBundle.ts
+++ b/packages/data-model/src/schemas/hermes/storyBundle.ts
@@ -91,6 +91,7 @@ export const StoryBundleSchema = z.object({
   sources: z.array(StoryBundleSourceSchema).min(1),
   primary_sources: z.array(StoryBundleSourceSchema).min(1).optional(),
   secondary_assets: z.array(StoryBundleSourceSchema).optional(),
+  related_links: z.array(StoryBundleSourceSchema).optional(),
   cluster_features: ClusterFeaturesSchema,
   provenance_hash: z.string().min(1),
   created_at: z.number(),

--- a/services/news-aggregator/src/__tests__/articleTextService.test.ts
+++ b/services/news-aggregator/src/__tests__/articleTextService.test.ts
@@ -13,6 +13,7 @@ import {
   articleTextServiceInternal,
 } from '../articleTextService';
 import { urlHash } from '../normalize';
+import { ItemEligibilityLedger } from '../itemEligibilityLedger';
 import { RemovalLedger } from '../removalLedger';
 import { SourceLifecycleTracker } from '../sourceLifecycle';
 
@@ -220,6 +221,53 @@ describe('ArticleTextService', () => {
     expect(result.extractionMethod).toBe('html-fallback');
     expect(result.title).toBe('Fallback');
     expect(result.cacheHit).toBe('none');
+  });
+
+  it('records item eligibility observations for successful and failed extractions', async () => {
+    const ledger = new ItemEligibilityLedger({ now: () => 77 });
+    const successService = new ArticleTextService({
+      allowlist: new Set(['allowed.com']),
+      itemEligibilityLedger: ledger,
+      fetchFn: vi.fn<typeof fetch>().mockResolvedValue(
+        new Response(makeHtml(makeWords(220), 'Readable Title'), { status: 200 }),
+      ),
+      primaryExtractor: vi.fn().mockResolvedValue({
+        title: 'Readable Title',
+        text: makeWords(220),
+      }),
+      fallbackExtractor: vi.fn().mockReturnValue(null),
+    });
+
+    await successService.extract('https://allowed.com/success');
+    await expect(ledger.readByUrl('https://allowed.com/success')).resolves.toMatchObject({
+      state: 'analysis_eligible',
+      reason: 'analysis_eligible',
+      analysisEligible: true,
+      displayEligible: true,
+      observationCount: 1,
+    });
+
+    const failedService = new ArticleTextService({
+      allowlist: new Set(['allowed.com']),
+      itemEligibilityLedger: ledger,
+      fetchFn: vi.fn<typeof fetch>().mockResolvedValue(
+        new Response(makeHtml('too short'), { status: 200 }),
+      ),
+      primaryExtractor: vi.fn().mockResolvedValue({ title: 'Short', text: 'tiny' }),
+      fallbackExtractor: vi.fn().mockReturnValue({ title: 'Short', text: 'tiny' }),
+    });
+
+    await expect(failedService.extract('https://allowed.com/failure')).rejects.toMatchObject({
+      code: 'quality-too-low',
+      statusCode: 422,
+    });
+    await expect(ledger.readByUrl('https://allowed.com/failure')).resolves.toMatchObject({
+      state: 'link_only',
+      reason: 'quality-too-low',
+      analysisEligible: false,
+      displayEligible: true,
+      observationCount: 1,
+    });
   });
 
   it('raises quality-too-low when both extraction passes fail', async () => {

--- a/services/news-aggregator/src/__tests__/itemEligibilityLedger.test.ts
+++ b/services/news-aggregator/src/__tests__/itemEligibilityLedger.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import {
+  InMemoryItemEligibilityLedgerStore,
+  ItemEligibilityLedger,
+  itemEligibilityLedgerInternal,
+  itemEligibilityLedgerPath,
+} from '../itemEligibilityLedger';
+
+describe('ItemEligibilityLedger', () => {
+  it('writes and reads item eligibility observations by canonical URL', async () => {
+    const ledger = new ItemEligibilityLedger({ now: () => 100 });
+    const hashedUrl = itemEligibilityLedgerInternal.normalizeUrl('https://allowed.com/story')!.hashedUrl;
+
+    const first = await ledger.writeAssessment({
+      canonicalUrl: 'https://allowed.com/story',
+      urlHash: hashedUrl,
+      state: 'link_only',
+      reason: 'quality-too-low',
+      displayEligible: true,
+    });
+
+    expect(first).toMatchObject({
+      urlHash: hashedUrl,
+      canonicalUrl: 'https://allowed.com/story',
+      state: 'link_only',
+      reason: 'quality-too-low',
+      analysisEligible: false,
+      displayEligible: true,
+      recoverable: true,
+      observationCount: 1,
+      firstSeenAt: 100,
+      lastSeenAt: 100,
+    });
+
+    const second = await ledger.writeAssessment({
+      canonicalUrl: 'https://allowed.com/story',
+      urlHash: hashedUrl,
+      state: 'analysis_eligible',
+      reason: 'analysis_eligible',
+      displayEligible: true,
+    });
+
+    expect(second).toMatchObject({
+      state: 'analysis_eligible',
+      reason: 'analysis_eligible',
+      analysisEligible: true,
+      observationCount: 2,
+      firstSeenAt: 100,
+      lastSeenAt: 100,
+    });
+
+    await expect(ledger.readByUrl('https://allowed.com/story')).resolves.toMatchObject({
+      state: 'analysis_eligible',
+      observationCount: 2,
+    });
+  });
+
+  it('returns null for non-canonicalizable assessments', async () => {
+    const ledger = new ItemEligibilityLedger();
+    await expect(ledger.writeAssessment({
+      canonicalUrl: null,
+      urlHash: null,
+      state: 'hard_blocked',
+      reason: 'invalid-url',
+      displayEligible: false,
+    })).resolves.toBeNull();
+  });
+
+  it('exports helpers for pathing and parsing', async () => {
+    expect(itemEligibilityLedgerPath('hash-a')).toBe('vh/news/item-eligibility/hash-a');
+
+    const store = new InMemoryItemEligibilityLedgerStore();
+    await store.put(itemEligibilityLedgerPath('hash-a'), {
+      urlHash: 'hash-a',
+      canonicalUrl: 'https://allowed.com/story',
+      state: 'link_only',
+      reason: 'fetch-failed',
+      analysisEligible: false,
+      displayEligible: true,
+      recoverable: true,
+      observationCount: 1,
+      firstSeenAt: 10,
+      lastSeenAt: 10,
+    });
+
+    const parsed = itemEligibilityLedgerInternal.parseEntry(
+      await store.get(itemEligibilityLedgerPath('hash-a')),
+    );
+    expect(parsed).toMatchObject({
+      canonicalUrl: 'https://allowed.com/story',
+      state: 'link_only',
+      reason: 'fetch-failed',
+    });
+    expect(itemEligibilityLedgerInternal.normalizeUrl('https://allowed.com/story')?.hashedUrl).toBeTruthy();
+  });
+});

--- a/services/news-aggregator/src/articleTextService.ts
+++ b/services/news-aggregator/src/articleTextService.ts
@@ -179,7 +179,7 @@ export class ArticleTextService {
 
     const directHit = this.cache.get(hashedUrl);
     if (directHit?.entry.kind === 'success') {
-      return { ...directHit.entry.value, cacheHit: 'urlHash', attempts: 0 };
+      return { ...directHit.entry.value, cacheHit: 'urlHash', attempts: 0 } satisfies ArticleTextResult;
     }
 
     if (directHit?.entry.kind === 'failure') {
@@ -200,7 +200,7 @@ export class ArticleTextService {
         if (contentHit?.entry.kind === 'success') {
           this.cache.linkUrlToContent(hashedUrl, contentHash);
           this.lifecycle.recordSuccess(domain);
-          const result = {
+          const result: ArticleTextResult = {
             ...contentHit.entry.value,
             url: canonicalUrl,
             urlHash: hashedUrl,
@@ -228,7 +228,7 @@ export class ArticleTextService {
         this.cache.rememberSuccess(success);
         this.lifecycle.recordSuccess(domain);
 
-        const result = {
+        const result: ArticleTextResult = {
           ...success,
           cacheHit: 'none',
           attempts: attempt,

--- a/services/news-aggregator/src/articleTextService.ts
+++ b/services/news-aggregator/src/articleTextService.ts
@@ -25,6 +25,11 @@ import {
   getStarterSourceDomainAllowlist,
   isSourceDomainAllowed,
 } from './sourceRegistry';
+import { ItemEligibilityLedger } from './itemEligibilityLedger';
+import {
+  assessItemEligibilityFromError,
+  assessItemEligibilityFromResult,
+} from './itemEligibilityPolicy';
 
 export type ArticleTextQuality = ArticleTextQualityMetrics;
 
@@ -83,6 +88,7 @@ export interface ArticleTextServiceOptions {
   readonly cache?: ArticleTextCache;
   readonly lifecycle?: SourceLifecycleTracker;
   readonly removalLedger?: RemovalLedger;
+  readonly itemEligibilityLedger?: ItemEligibilityLedger;
   readonly primaryExtractor?: (url: string, html: string) => Promise<{ title: string; text: string } | null>;
   readonly fallbackExtractor?: (url: string, html: string) => { title: string; text: string } | null;
 }
@@ -126,6 +132,7 @@ export class ArticleTextService {
   private readonly cache: ArticleTextCache;
   private readonly lifecycle: SourceLifecycleTracker;
   private readonly removalLedger: RemovalLedger;
+  private readonly itemEligibilityLedger: ItemEligibilityLedger;
   private readonly primaryExtractor: (url: string, html: string) => Promise<{ title: string; text: string } | null>;
   private readonly fallbackExtractor: (url: string, html: string) => { title: string; text: string } | null;
 
@@ -143,6 +150,7 @@ export class ArticleTextService {
     this.cache = options.cache ?? new ArticleTextCache();
     this.lifecycle = options.lifecycle ?? new SourceLifecycleTracker();
     this.removalLedger = options.removalLedger ?? new RemovalLedger();
+    this.itemEligibilityLedger = options.itemEligibilityLedger ?? new ItemEligibilityLedger();
     this.primaryExtractor = options.primaryExtractor ?? defaultPrimaryExtractor;
     this.fallbackExtractor = options.fallbackExtractor ?? defaultFallbackExtractor;
   }
@@ -150,17 +158,23 @@ export class ArticleTextService {
   async extract(inputUrl: string): Promise<ArticleTextResult> {
     const canonicalUrl = canonicalizeUrl(inputUrl);
     if (!canonicalUrl) {
-      throw new ArticleTextServiceError('invalid-url', 'Only valid http/https URLs are supported', 400, false);
+      const error = new ArticleTextServiceError('invalid-url', 'Only valid http/https URLs are supported', 400, false);
+      await this.persistEligibilityFromError(inputUrl, error);
+      throw error;
     }
 
     const domain = new URL(canonicalUrl).hostname.toLowerCase();
     if (!isSourceDomainAllowed(domain, this.allowlist)) {
-      throw new ArticleTextServiceError('domain-not-allowed', `Domain is not allowlisted: ${domain}`, 403, false);
+      const error = new ArticleTextServiceError('domain-not-allowed', `Domain is not allowlisted: ${domain}`, 403, false);
+      await this.persistEligibilityFromError(canonicalUrl, error);
+      throw error;
     }
 
     const hashedUrl = urlHash(canonicalUrl);
     if (await this.removalLedger.readByUrlHash(hashedUrl)) {
-      throw new ArticleTextServiceError('removed', 'Article has been removed from extraction', 410, false);
+      const error = new ArticleTextServiceError('removed', 'Article has been removed from extraction', 410, false);
+      await this.persistEligibilityFromError(canonicalUrl, error);
+      throw error;
     }
 
     const directHit = this.cache.get(hashedUrl);
@@ -186,7 +200,7 @@ export class ArticleTextService {
         if (contentHit?.entry.kind === 'success') {
           this.cache.linkUrlToContent(hashedUrl, contentHash);
           this.lifecycle.recordSuccess(domain);
-          return {
+          const result = {
             ...contentHit.entry.value,
             url: canonicalUrl,
             urlHash: hashedUrl,
@@ -194,6 +208,8 @@ export class ArticleTextService {
             cacheHit: 'contentHash',
             attempts: attempt,
           };
+          await this.persistEligibilityFromResult(result);
+          return result;
         }
 
         const extracted = await this.extractWithFallback(canonicalUrl, html);
@@ -212,11 +228,13 @@ export class ArticleTextService {
         this.cache.rememberSuccess(success);
         this.lifecycle.recordSuccess(domain);
 
-        return {
+        const result = {
           ...success,
           cacheHit: 'none',
           attempts: attempt,
         };
+        await this.persistEligibilityFromResult(result);
+        return result;
       } catch (error) {
         const serviceError =
           error instanceof ArticleTextServiceError
@@ -241,7 +259,32 @@ export class ArticleTextService {
       }
     }
 
-    throw terminalError ?? new ArticleTextServiceError('fetch-failed', 'Article extraction failed', 502, true);
+    const finalError =
+      terminalError ?? new ArticleTextServiceError('fetch-failed', 'Article extraction failed', 502, true);
+    await this.persistEligibilityFromError(canonicalUrl, finalError);
+    throw finalError;
+  }
+
+  private async persistEligibilityFromResult(result: ArticleTextResult): Promise<void> {
+    try {
+      await this.itemEligibilityLedger.writeAssessment(
+        assessItemEligibilityFromResult(result),
+        { observedBy: 'article-text-service' },
+      );
+    } catch {
+      // Do not let observability writes break extraction.
+    }
+  }
+
+  private async persistEligibilityFromError(url: string, error: unknown): Promise<void> {
+    try {
+      await this.itemEligibilityLedger.writeAssessment(
+        assessItemEligibilityFromError(url, error),
+        { observedBy: 'article-text-service' },
+      );
+    } catch {
+      // Do not let observability writes break extraction.
+    }
   }
 
   private async extractWithFallback(url: string, html: string): Promise<{

--- a/services/news-aggregator/src/index.ts
+++ b/services/news-aggregator/src/index.ts
@@ -116,6 +116,17 @@ export type {
 } from './removalLedger';
 
 export {
+  InMemoryItemEligibilityLedgerStore,
+  ItemEligibilityLedger,
+  itemEligibilityLedgerPath,
+} from './itemEligibilityLedger';
+export type {
+  ItemEligibilityLedgerEntry,
+  ItemEligibilityLedgerOptions,
+  ItemEligibilityLedgerStore,
+} from './itemEligibilityLedger';
+
+export {
   assessItemEligibilityFromError,
   assessItemEligibilityFromResult,
 } from './itemEligibilityPolicy';

--- a/services/news-aggregator/src/index.ts
+++ b/services/news-aggregator/src/index.ts
@@ -116,6 +116,16 @@ export type {
 } from './removalLedger';
 
 export {
+  assessItemEligibilityFromError,
+  assessItemEligibilityFromResult,
+} from './itemEligibilityPolicy';
+export type {
+  ItemEligibilityAssessment,
+  ItemEligibilityReason,
+  ItemEligibilityState,
+} from './itemEligibilityPolicy';
+
+export {
   STARTER_FEED_URLS,
   STARTER_SOURCE_DOMAINS,
   buildSourceDomainAllowlist,
@@ -137,6 +147,7 @@ export type {
   SourceAdmissionArtifactOptions,
   SourceAdmissionAuditOptions,
   SourceAdmissionCriteria,
+  SourceAdmissionEvaluationMode,
   SourceAdmissionReport,
   SourceAdmissionSampleResult,
   SourceAdmissionSourceReport,

--- a/services/news-aggregator/src/itemEligibilityLedger.ts
+++ b/services/news-aggregator/src/itemEligibilityLedger.ts
@@ -1,0 +1,160 @@
+import { canonicalizeUrl, urlHash } from './normalize';
+import type {
+  ItemEligibilityAssessment,
+  ItemEligibilityReason,
+  ItemEligibilityState,
+} from './itemEligibilityPolicy';
+
+export interface ItemEligibilityLedgerEntry {
+  readonly urlHash: string;
+  readonly canonicalUrl: string;
+  readonly state: ItemEligibilityState;
+  readonly reason: ItemEligibilityReason;
+  readonly analysisEligible: boolean;
+  readonly displayEligible: boolean;
+  readonly recoverable: boolean;
+  readonly observationCount: number;
+  readonly firstSeenAt: number;
+  readonly lastSeenAt: number;
+  readonly observedBy: string | null;
+  readonly note: string | null;
+}
+
+export interface ItemEligibilityLedgerStore {
+  get(path: string): Promise<unknown>;
+  put(path: string, value: unknown): Promise<void>;
+}
+
+export interface ItemEligibilityLedgerOptions {
+  readonly store?: ItemEligibilityLedgerStore;
+  readonly now?: () => number;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object';
+}
+
+function normalizeUrl(inputUrl: string): { canonicalUrl: string; hashedUrl: string } | null {
+  const canonicalUrl = canonicalizeUrl(inputUrl);
+  if (!canonicalUrl) {
+    return null;
+  }
+
+  return {
+    canonicalUrl,
+    hashedUrl: urlHash(canonicalUrl),
+  };
+}
+
+function parseEntry(value: unknown): ItemEligibilityLedgerEntry | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  if (
+    typeof value.urlHash !== 'string'
+    || typeof value.canonicalUrl !== 'string'
+    || typeof value.state !== 'string'
+    || typeof value.reason !== 'string'
+    || typeof value.analysisEligible !== 'boolean'
+    || typeof value.displayEligible !== 'boolean'
+    || typeof value.recoverable !== 'boolean'
+    || typeof value.observationCount !== 'number'
+    || typeof value.firstSeenAt !== 'number'
+    || typeof value.lastSeenAt !== 'number'
+  ) {
+    return null;
+  }
+
+  return {
+    urlHash: value.urlHash,
+    canonicalUrl: value.canonicalUrl,
+    state: value.state as ItemEligibilityState,
+    reason: value.reason as ItemEligibilityReason,
+    analysisEligible: value.analysisEligible,
+    displayEligible: value.displayEligible,
+    recoverable: value.recoverable,
+    observationCount: value.observationCount,
+    firstSeenAt: value.firstSeenAt,
+    lastSeenAt: value.lastSeenAt,
+    observedBy: typeof value.observedBy === 'string' ? value.observedBy : null,
+    note: typeof value.note === 'string' ? value.note : null,
+  };
+}
+
+export function itemEligibilityLedgerPath(urlHashValue: string): string {
+  return `vh/news/item-eligibility/${urlHashValue}`;
+}
+
+export class InMemoryItemEligibilityLedgerStore implements ItemEligibilityLedgerStore {
+  private readonly records = new Map<string, unknown>();
+
+  async get(path: string): Promise<unknown> {
+    return this.records.get(path) ?? null;
+  }
+
+  async put(path: string, value: unknown): Promise<void> {
+    this.records.set(path, value);
+  }
+}
+
+export class ItemEligibilityLedger {
+  private readonly store: ItemEligibilityLedgerStore;
+  private readonly now: () => number;
+
+  constructor(options: ItemEligibilityLedgerOptions = {}) {
+    this.store = options.store ?? new InMemoryItemEligibilityLedgerStore();
+    this.now = options.now ?? Date.now;
+  }
+
+  async writeAssessment(
+    assessment: ItemEligibilityAssessment,
+    metadata: { observedBy?: string; note?: string } = {},
+  ): Promise<ItemEligibilityLedgerEntry | null> {
+    if (!assessment.canonicalUrl || !assessment.urlHash) {
+      return null;
+    }
+
+    const existing = await this.readByUrlHash(assessment.urlHash);
+    const observedAt = this.now();
+    const entry: ItemEligibilityLedgerEntry = {
+      urlHash: assessment.urlHash,
+      canonicalUrl: assessment.canonicalUrl,
+      state: assessment.state,
+      reason: assessment.reason,
+      analysisEligible: assessment.state === 'analysis_eligible',
+      displayEligible: assessment.displayEligible,
+      recoverable: assessment.state === 'link_only',
+      observationCount: (existing?.observationCount ?? 0) + 1,
+      firstSeenAt: existing?.firstSeenAt ?? observedAt,
+      lastSeenAt: observedAt,
+      observedBy: metadata.observedBy?.trim() || null,
+      note: metadata.note?.trim() || null,
+    };
+
+    await this.store.put(itemEligibilityLedgerPath(entry.urlHash), entry);
+    return entry;
+  }
+
+  async readByUrlHash(urlHashValue: string): Promise<ItemEligibilityLedgerEntry | null> {
+    if (!urlHashValue.trim()) {
+      return null;
+    }
+
+    return parseEntry(await this.store.get(itemEligibilityLedgerPath(urlHashValue)));
+  }
+
+  async readByUrl(inputUrl: string): Promise<ItemEligibilityLedgerEntry | null> {
+    const normalized = normalizeUrl(inputUrl);
+    if (!normalized) {
+      return null;
+    }
+
+    return this.readByUrlHash(normalized.hashedUrl);
+  }
+}
+
+export const itemEligibilityLedgerInternal = {
+  normalizeUrl,
+  parseEntry,
+};

--- a/services/news-aggregator/src/itemEligibilityPolicy.test.ts
+++ b/services/news-aggregator/src/itemEligibilityPolicy.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ArticleTextServiceError,
+  type ArticleTextResult,
+} from './articleTextService';
+import {
+  assessItemEligibilityFromError,
+  assessItemEligibilityFromResult,
+} from './itemEligibilityPolicy';
+
+function makeResult(url: string): ArticleTextResult {
+  return {
+    url,
+    urlHash: 'abcd1234',
+    contentHash: 'content',
+    sourceDomain: 'example.com',
+    title: 'Readable article',
+    text: 'Sentence one. Sentence two. Sentence three. Sentence four.',
+    extractionMethod: 'article-extractor',
+    cacheHit: 'none',
+    attempts: 1,
+    fetchedAt: 1,
+    quality: {
+      charCount: 1200,
+      wordCount: 200,
+      sentenceCount: 8,
+      score: 0.95,
+    },
+  };
+}
+
+describe('itemEligibilityPolicy', () => {
+  it('marks readable extraction results as analysis eligible', () => {
+    expect(assessItemEligibilityFromResult(makeResult('https://example.com/a'))).toEqual({
+      url: 'https://example.com/a',
+      canonicalUrl: 'https://example.com/a',
+      urlHash: 'abcd1234',
+      state: 'analysis_eligible',
+      reason: 'analysis_eligible',
+      retryable: false,
+      displayEligible: true,
+    });
+  });
+
+  it('marks quality misses as link-only', () => {
+    const result = assessItemEligibilityFromError(
+      'https://example.com/short',
+      new ArticleTextServiceError('quality-too-low', 'too short', 422, false),
+    );
+
+    expect(result).toMatchObject({
+      state: 'link_only',
+      reason: 'quality-too-low',
+      displayEligible: true,
+    });
+  });
+
+  it('marks access-denied failures as hard blocked', () => {
+    const result = assessItemEligibilityFromError(
+      'https://example.com/blocked',
+      new ArticleTextServiceError('access-denied', 'blocked', 403, false),
+    );
+
+    expect(result).toMatchObject({
+      state: 'hard_blocked',
+      reason: 'access-denied',
+      displayEligible: false,
+    });
+  });
+
+  it('treats fetch failures as link-only rather than hard blocked', () => {
+    const result = assessItemEligibilityFromError(
+      'https://example.com/transient',
+      new ArticleTextServiceError('fetch-failed', 'timeout', 502, true),
+    );
+
+    expect(result).toMatchObject({
+      state: 'link_only',
+      reason: 'fetch-failed',
+      retryable: true,
+      displayEligible: true,
+    });
+  });
+});

--- a/services/news-aggregator/src/itemEligibilityPolicy.ts
+++ b/services/news-aggregator/src/itemEligibilityPolicy.ts
@@ -1,7 +1,3 @@
-import {
-  ArticleTextServiceError,
-  type ArticleTextResult,
-} from './articleTextService';
 import { canonicalizeUrl, urlHash } from './normalize';
 
 export type ItemEligibilityState =
@@ -29,6 +25,16 @@ export interface ItemEligibilityAssessment {
   readonly displayEligible: boolean;
 }
 
+interface ArticleTextResultLike {
+  readonly url: string;
+  readonly urlHash: string;
+}
+
+interface ArticleTextServiceErrorLike {
+  readonly code: string;
+  readonly retryable: boolean;
+}
+
 function normalizeUrl(inputUrl: string): {
   readonly url: string;
   readonly canonicalUrl: string | null;
@@ -43,7 +49,7 @@ function normalizeUrl(inputUrl: string): {
 }
 
 export function assessItemEligibilityFromResult(
-  result: ArticleTextResult,
+  result: ArticleTextResultLike,
 ): ItemEligibilityAssessment {
   return {
     url: result.url,
@@ -56,13 +62,24 @@ export function assessItemEligibilityFromResult(
   };
 }
 
+function isArticleTextServiceErrorLike(
+  error: unknown,
+): error is ArticleTextServiceErrorLike {
+  return Boolean(
+    error
+    && typeof error === 'object'
+    && typeof (error as { code?: unknown }).code === 'string'
+    && typeof (error as { retryable?: unknown }).retryable === 'boolean',
+  );
+}
+
 export function assessItemEligibilityFromError(
   inputUrl: string,
   error: unknown,
 ): ItemEligibilityAssessment {
   const normalized = normalizeUrl(inputUrl);
 
-  if (error instanceof ArticleTextServiceError) {
+  if (isArticleTextServiceErrorLike(error)) {
     switch (error.code) {
       case 'access-denied':
       case 'domain-not-allowed':

--- a/services/news-aggregator/src/itemEligibilityPolicy.ts
+++ b/services/news-aggregator/src/itemEligibilityPolicy.ts
@@ -1,0 +1,117 @@
+import {
+  ArticleTextServiceError,
+  type ArticleTextResult,
+} from './articleTextService';
+import { canonicalizeUrl, urlHash } from './normalize';
+
+export type ItemEligibilityState =
+  | 'analysis_eligible'
+  | 'link_only'
+  | 'hard_blocked';
+
+export type ItemEligibilityReason =
+  | 'analysis_eligible'
+  | 'quality-too-low'
+  | 'fetch-failed'
+  | 'access-denied'
+  | 'domain-not-allowed'
+  | 'invalid-url'
+  | 'removed'
+  | 'unexpected-error';
+
+export interface ItemEligibilityAssessment {
+  readonly url: string;
+  readonly canonicalUrl: string | null;
+  readonly urlHash: string | null;
+  readonly state: ItemEligibilityState;
+  readonly reason: ItemEligibilityReason;
+  readonly retryable: boolean;
+  readonly displayEligible: boolean;
+}
+
+function normalizeUrl(inputUrl: string): {
+  readonly url: string;
+  readonly canonicalUrl: string | null;
+  readonly hashedUrl: string | null;
+} {
+  const canonicalUrl = canonicalizeUrl(inputUrl);
+  return {
+    url: inputUrl,
+    canonicalUrl,
+    hashedUrl: canonicalUrl ? urlHash(canonicalUrl) : null,
+  };
+}
+
+export function assessItemEligibilityFromResult(
+  result: ArticleTextResult,
+): ItemEligibilityAssessment {
+  return {
+    url: result.url,
+    canonicalUrl: result.url,
+    urlHash: result.urlHash,
+    state: 'analysis_eligible',
+    reason: 'analysis_eligible',
+    retryable: false,
+    displayEligible: true,
+  };
+}
+
+export function assessItemEligibilityFromError(
+  inputUrl: string,
+  error: unknown,
+): ItemEligibilityAssessment {
+  const normalized = normalizeUrl(inputUrl);
+
+  if (error instanceof ArticleTextServiceError) {
+    switch (error.code) {
+      case 'access-denied':
+      case 'domain-not-allowed':
+      case 'invalid-url':
+      case 'removed':
+        return {
+          url: normalized.url,
+          canonicalUrl: normalized.canonicalUrl,
+          urlHash: normalized.hashedUrl,
+          state: 'hard_blocked',
+          reason: error.code,
+          retryable: error.retryable,
+          displayEligible: false,
+        };
+      case 'quality-too-low':
+        return {
+          url: normalized.url,
+          canonicalUrl: normalized.canonicalUrl,
+          urlHash: normalized.hashedUrl,
+          state: 'link_only',
+          reason: error.code,
+          retryable: error.retryable,
+          displayEligible: true,
+        };
+      case 'fetch-failed':
+      default:
+        return {
+          url: normalized.url,
+          canonicalUrl: normalized.canonicalUrl,
+          urlHash: normalized.hashedUrl,
+          state: 'link_only',
+          reason: error.code === 'fetch-failed' ? 'fetch-failed' : 'unexpected-error',
+          retryable: error.retryable,
+          displayEligible: true,
+        };
+    }
+  }
+
+  return {
+    url: normalized.url,
+    canonicalUrl: normalized.canonicalUrl,
+    urlHash: normalized.hashedUrl,
+    state: 'link_only',
+    reason: 'unexpected-error',
+    retryable: false,
+    displayEligible: true,
+  };
+}
+
+export const itemEligibilityPolicyInternal = {
+  normalizeUrl,
+};

--- a/services/news-aggregator/src/sourceAdmissionReport.test.ts
+++ b/services/news-aggregator/src/sourceAdmissionReport.test.ts
@@ -11,6 +11,7 @@ import {
   writeSourceAdmissionArtifact,
 } from './sourceAdmissionReport';
 import type { SourceAdmissionCriteria } from './sourceAdmissionReport';
+import { ItemEligibilityLedger } from './itemEligibilityLedger';
 
 function makeResponse(status: number, body: string) {
   return new Response(body, { status });
@@ -537,6 +538,45 @@ describe('sourceAdmissionReport', () => {
     expect(report.reasons).toEqual(['provisional_thin_feed_keep']);
     expect(report.sampleLinkCount).toBe(3);
     expect(report.readableSampleCount).toBe(3);
+  });
+
+  it('persists sampled article eligibility to a provided ledger', async () => {
+    const source = STARTER_FEED_SOURCES[0];
+    const ledger = new ItemEligibilityLedger({ now: () => 123 });
+    const fetchFn = vi.fn(async (input: string | URL) => {
+      const url = String(input);
+      if (url === source.rssUrl) {
+        return makeResponse(
+          200,
+          `<rss><channel>
+             <item><link>https://www.foxnews.com/a</link></item>
+           </channel></rss>`,
+        );
+      }
+      return makeResponse(200, makeReadableHtml('Readable'));
+    }) as typeof fetch;
+
+    const report = await auditFeedSourceAdmission(source, {
+      fetchFn,
+      sampleSize: 1,
+      minimumSuccessCount: 1,
+      minimumSuccessRate: 1,
+      itemEligibilityLedger: ledger,
+      articleTextServiceOptions: {
+        primaryExtractor: async () => ({
+          title: 'Readable',
+          text: makeReadableText(),
+        }),
+        fallbackExtractor: () => null,
+      },
+    });
+
+    expect(report.status).toBe('admitted');
+    await expect(ledger.readByUrl('https://www.foxnews.com/a')).resolves.toMatchObject({
+      state: 'analysis_eligible',
+      reason: 'analysis_eligible',
+      observationCount: 1,
+    });
   });
 
   it('does not count skipped video links against source readability samples', async () => {

--- a/services/news-aggregator/src/sourceAdmissionReport.test.ts
+++ b/services/news-aggregator/src/sourceAdmissionReport.test.ts
@@ -176,6 +176,20 @@ describe('sourceAdmissionReport', () => {
     delete process.env.VH_NEWS_SOURCE_ADMISSION_MIN_SUCCESS_RATE;
   });
 
+  it('uses soak-mode defaults without rewriting product-mode defaults', () => {
+    expect(sourceAdmissionReportInternal.buildCriteria({}, 'product')).toEqual({
+      sampleSize: 4,
+      minimumSuccessCount: 2,
+      minimumSuccessRate: 0.75,
+    });
+
+    expect(sourceAdmissionReportInternal.buildCriteria({ evaluationMode: 'soak' }, 'soak')).toEqual({
+      sampleSize: 8,
+      minimumSuccessCount: 4,
+      minimumSuccessRate: 0.5,
+    });
+  });
+
   it('resolves configured feed sources from env JSON and file overrides', () => {
     vi.stubEnv(
       'VH_NEWS_SOURCE_ADMISSION_SOURCES_JSON',
@@ -394,6 +408,137 @@ describe('sourceAdmissionReport', () => {
     expect(report.skippedVideoUrls).toEqual([]);
   });
 
+  it('admits a source in soak mode when 4 of 8 article candidates are analysis eligible', async () => {
+    const source = STARTER_FEED_SOURCES[0];
+    const readableUrls = new Set([
+      'https://www.foxnews.com/a',
+      'https://www.foxnews.com/b',
+      'https://www.foxnews.com/c',
+      'https://www.foxnews.com/d',
+    ]);
+    const fetchFn = vi.fn(async (input: string | URL) => {
+      const url = String(input);
+      if (url === source.rssUrl) {
+        return makeResponse(
+          200,
+          `<rss><channel>
+             <item><link>https://www.foxnews.com/a</link></item>
+             <item><link>https://www.foxnews.com/b</link></item>
+             <item><link>https://www.foxnews.com/c</link></item>
+             <item><link>https://www.foxnews.com/d</link></item>
+             <item><link>https://www.foxnews.com/e</link></item>
+             <item><link>https://www.foxnews.com/f</link></item>
+             <item><link>https://www.foxnews.com/g</link></item>
+             <item><link>https://www.foxnews.com/h</link></item>
+           </channel></rss>`,
+        );
+      }
+      return makeResponse(200, makeReadableHtml(`Readable ${url}`));
+    }) as typeof fetch;
+
+    const report = await auditFeedSourceAdmission(source, {
+      evaluationMode: 'soak',
+      fetchFn,
+      articleTextServiceOptions: {
+        primaryExtractor: async (url) => (
+          readableUrls.has(url)
+            ? { title: 'Readable', text: makeReadableText() }
+            : { title: 'Too short', text: 'short text' }
+        ),
+        fallbackExtractor: () => null,
+      },
+    });
+
+    expect(report.evaluationMode).toBe('soak');
+    expect(report.status).toBe('admitted');
+    expect(report.sampleLinkCount).toBe(8);
+    expect(report.readableSampleCount).toBe(4);
+    expect(report.readableSampleRate).toBe(0.5);
+    expect(report.samples.filter((sample) => sample.eligibilityState === 'analysis_eligible')).toHaveLength(4);
+    expect(report.samples.filter((sample) => sample.eligibilityState === 'link_only')).toHaveLength(4);
+  });
+
+  it('rejects a source in soak mode when only 3 of 8 article candidates are analysis eligible', async () => {
+    const source = STARTER_FEED_SOURCES[0];
+    const readableUrls = new Set([
+      'https://www.foxnews.com/a',
+      'https://www.foxnews.com/b',
+      'https://www.foxnews.com/c',
+    ]);
+    const fetchFn = vi.fn(async (input: string | URL) => {
+      const url = String(input);
+      if (url === source.rssUrl) {
+        return makeResponse(
+          200,
+          `<rss><channel>
+             <item><link>https://www.foxnews.com/a</link></item>
+             <item><link>https://www.foxnews.com/b</link></item>
+             <item><link>https://www.foxnews.com/c</link></item>
+             <item><link>https://www.foxnews.com/d</link></item>
+             <item><link>https://www.foxnews.com/e</link></item>
+             <item><link>https://www.foxnews.com/f</link></item>
+             <item><link>https://www.foxnews.com/g</link></item>
+             <item><link>https://www.foxnews.com/h</link></item>
+           </channel></rss>`,
+        );
+      }
+      return makeResponse(200, makeReadableHtml(`Readable ${url}`));
+    }) as typeof fetch;
+
+    const report = await auditFeedSourceAdmission(source, {
+      evaluationMode: 'soak',
+      fetchFn,
+      articleTextServiceOptions: {
+        primaryExtractor: async (url) => (
+          readableUrls.has(url)
+            ? { title: 'Readable', text: makeReadableText() }
+            : { title: 'Too short', text: 'short text' }
+        ),
+        fallbackExtractor: () => null,
+      },
+    });
+
+    expect(report.status).toBe('rejected');
+    expect(report.readableSampleCount).toBe(3);
+    expect(report.readableSampleRate).toBe(0.375);
+  });
+
+  it('allows a 3/3 provisional thin-feed keep in soak mode', async () => {
+    const source = STARTER_FEED_SOURCES[0];
+    const fetchFn = vi.fn(async (input: string | URL) => {
+      const url = String(input);
+      if (url === source.rssUrl) {
+        return makeResponse(
+          200,
+          `<rss><channel>
+             <item><link>https://www.foxnews.com/a</link></item>
+             <item><link>https://www.foxnews.com/b</link></item>
+             <item><link>https://www.foxnews.com/c</link></item>
+           </channel></rss>`,
+        );
+      }
+      return makeResponse(200, makeReadableHtml('Readable'));
+    }) as typeof fetch;
+
+    const report = await auditFeedSourceAdmission(source, {
+      evaluationMode: 'soak',
+      fetchFn,
+      articleTextServiceOptions: {
+        primaryExtractor: async () => ({
+          title: 'Readable',
+          text: makeReadableText(),
+        }),
+        fallbackExtractor: () => null,
+      },
+    });
+
+    expect(report.status).toBe('admitted');
+    expect(report.provisionalKeepForSoak).toBe(true);
+    expect(report.reasons).toEqual(['provisional_thin_feed_keep']);
+    expect(report.sampleLinkCount).toBe(3);
+    expect(report.readableSampleCount).toBe(3);
+  });
+
   it('does not count skipped video links against source readability samples', async () => {
     const source = STARTER_FEED_SOURCES.find((entry) => entry.id === 'nbc-politics')!;
     const fetchFn = vi.fn(async (input: string | URL) => {
@@ -529,6 +674,7 @@ describe('sourceAdmissionReport', () => {
     expect(report.samples[0]).toMatchObject({
       outcome: 'failed',
       errorCode: 'access-denied',
+      eligibilityState: 'hard_blocked',
     });
   });
 
@@ -882,6 +1028,7 @@ describe('sourceAdmissionReport', () => {
 
     const report = sourceAdmissionReportInternal.classifySource(
       source,
+      'product',
       criteria,
       {
         ok: true,
@@ -925,6 +1072,7 @@ describe('sourceAdmissionReport', () => {
       outcome: 'failed',
       errorCode: 'unexpected-error',
       errorMessage: 'extractor exploded',
+      eligibilityState: 'link_only',
     });
 
     expect(
@@ -936,6 +1084,7 @@ describe('sourceAdmissionReport', () => {
       outcome: 'failed',
       errorCode: 'unexpected-error',
       errorMessage: 'Unexpected source admission failure',
+      eligibilityState: 'link_only',
     });
   });
 
@@ -949,6 +1098,7 @@ describe('sourceAdmissionReport', () => {
 
     const report = sourceAdmissionReportInternal.classifySource(
       source,
+      'product',
       criteria,
       {
         ok: true,
@@ -1057,6 +1207,9 @@ describe('sourceAdmissionReport', () => {
     expect(reportPath).toBe(path.join(artifactDir, 'source-admission-report.json'));
     expect(report.schemaVersion).toBe(SOURCE_ADMISSION_REPORT_SCHEMA_VERSION);
     expect(readFileSync(reportPath, 'utf8')).toContain('"admittedSourceIds"');
+    expect(readFileSync(path.join(artifactDir, 'analysis-eligible-links.json'), 'utf8')).toContain('analysis_eligible');
+    expect(readFileSync(path.join(artifactDir, 'link-only-links.json'), 'utf8')).toBe('[]\n');
+    expect(readFileSync(path.join(artifactDir, 'hard-blocked-links.json'), 'utf8')).toBe('[]\n');
 
     rmSync(artifactDir, { recursive: true, force: true });
   });

--- a/services/news-aggregator/src/sourceAdmissionReport.ts
+++ b/services/news-aggregator/src/sourceAdmissionReport.ts
@@ -25,6 +25,7 @@ import {
   assessItemEligibilityFromResult,
   type ItemEligibilityState,
 } from './itemEligibilityPolicy';
+import { ItemEligibilityLedger } from './itemEligibilityLedger';
 
 const RSS_ITEM_REGEX = /<item\b[\s\S]*?<\/item>/gi;
 const ATOM_ENTRY_REGEX = /<entry\b[\s\S]*?<\/entry>/gi;
@@ -134,6 +135,7 @@ export interface SourceAdmissionReport {
 export interface SourceAdmissionAuditOptions {
   readonly feedSources?: readonly FeedSource[];
   readonly evaluationMode?: SourceAdmissionEvaluationMode;
+  readonly itemEligibilityLedger?: ItemEligibilityLedger;
   readonly sampleSize?: number;
   readonly minimumSuccessCount?: number;
   readonly minimumSuccessRate?: number;
@@ -910,6 +912,9 @@ export async function auditFeedSourceAdmission(
     fetchFn,
     lifecycle,
     now,
+    itemEligibilityLedger:
+      options.itemEligibilityLedger
+      ?? options.articleTextServiceOptions?.itemEligibilityLedger,
   });
 
   const feedReadResult = await readFeedXml(fetchFn, source, {

--- a/services/news-aggregator/src/sourceAdmissionReport.ts
+++ b/services/news-aggregator/src/sourceAdmissionReport.ts
@@ -20,12 +20,21 @@ import {
   type SourceLifecycleState,
 } from './sourceLifecycle';
 import { buildSourceDomainAllowlist } from './sourceRegistry';
+import {
+  assessItemEligibilityFromError,
+  assessItemEligibilityFromResult,
+  type ItemEligibilityState,
+} from './itemEligibilityPolicy';
 
 const RSS_ITEM_REGEX = /<item\b[\s\S]*?<\/item>/gi;
 const ATOM_ENTRY_REGEX = /<entry\b[\s\S]*?<\/entry>/gi;
 const DEFAULT_SAMPLE_SIZE = 4;
 const DEFAULT_MIN_SUCCESS_COUNT = 2;
 const DEFAULT_MIN_SUCCESS_RATE = 0.75;
+const DEFAULT_SOAK_SAMPLE_SIZE = 8;
+const DEFAULT_SOAK_MIN_SUCCESS_COUNT = 4;
+const DEFAULT_SOAK_MIN_SUCCESS_RATE = 0.5;
+const DEFAULT_SOAK_PROVISIONAL_MIN_SUCCESS_COUNT = 3;
 const REPLACEMENT_SAMPLE_BUFFER = 4;
 const MAX_HTML_FEED_DISCOVERY_DEPTH = 2;
 
@@ -33,6 +42,7 @@ export const SOURCE_ADMISSION_REPORT_SCHEMA_VERSION =
   'news-source-admission-report-v1';
 
 export type SourceAdmissionStatus = 'admitted' | 'rejected' | 'inconclusive';
+export type SourceAdmissionEvaluationMode = 'product' | 'soak';
 
 export interface SourceAdmissionCriteria {
   readonly sampleSize: number;
@@ -43,6 +53,11 @@ export interface SourceAdmissionCriteria {
 export interface SourceAdmissionSampleResult {
   readonly url: string;
   readonly outcome: 'passed' | 'failed';
+  readonly canonicalUrl?: string | null;
+  readonly urlHash?: string | null;
+  readonly eligibilityState?: ItemEligibilityState;
+  readonly eligibilityReason?: string;
+  readonly displayEligible?: boolean;
   readonly title?: string;
   readonly extractionMethod?: ArticleTextResult['extractionMethod'];
   readonly qualityScore?: number;
@@ -79,8 +94,10 @@ export interface SourceAdmissionSourceReport {
   readonly sourceId: string;
   readonly sourceName: string;
   readonly rssUrl: string;
+  readonly evaluationMode: SourceAdmissionEvaluationMode;
   readonly status: SourceAdmissionStatus;
   readonly admitted: boolean;
+  readonly provisionalKeepForSoak?: boolean;
   readonly sampleLinkCount: number;
   readonly readableSampleCount: number;
   readonly readableSampleRate: number | null;
@@ -105,6 +122,7 @@ function countFeedEntryFragments(xml: string): {
 export interface SourceAdmissionReport {
   readonly schemaVersion: typeof SOURCE_ADMISSION_REPORT_SCHEMA_VERSION;
   readonly generatedAt: string;
+  readonly evaluationMode: SourceAdmissionEvaluationMode;
   readonly criteria: SourceAdmissionCriteria;
   readonly sourceCount: number;
   readonly admittedSourceIds: readonly string[];
@@ -115,6 +133,7 @@ export interface SourceAdmissionReport {
 
 export interface SourceAdmissionAuditOptions {
   readonly feedSources?: readonly FeedSource[];
+  readonly evaluationMode?: SourceAdmissionEvaluationMode;
   readonly sampleSize?: number;
   readonly minimumSuccessCount?: number;
   readonly minimumSuccessRate?: number;
@@ -166,6 +185,18 @@ function parseRate(raw: string | undefined, fallback: number): number {
   }
 
   return parsed;
+}
+
+function resolveEvaluationMode(
+  options: Pick<SourceAdmissionAuditOptions, 'evaluationMode'> & Pick<SourceAdmissionArtifactOptions, 'env'> = {},
+): SourceAdmissionEvaluationMode {
+  if (options.evaluationMode) {
+    return options.evaluationMode;
+  }
+
+  const env = options.env ?? process.env;
+  const raw = normalizeNonEmpty(env.VH_NEWS_SOURCE_ADMISSION_MODE)?.toLowerCase();
+  return raw === 'soak' ? 'soak' : 'product';
 }
 
 function normalizeNonEmpty(value: string | undefined): string | null {
@@ -683,33 +714,50 @@ async function readFeedXml(
   };
 }
 
-function buildCriteria(options: SourceAdmissionAuditOptions): SourceAdmissionCriteria {
+function buildCriteria(
+  options: SourceAdmissionAuditOptions & Pick<SourceAdmissionArtifactOptions, 'env'>,
+  evaluationMode: SourceAdmissionEvaluationMode = resolveEvaluationMode(options),
+): SourceAdmissionCriteria {
+  const env = options.env ?? process.env;
+  const defaultSampleSize =
+    evaluationMode === 'soak' ? DEFAULT_SOAK_SAMPLE_SIZE : DEFAULT_SAMPLE_SIZE;
+  const defaultMinSuccessCount =
+    evaluationMode === 'soak' ? DEFAULT_SOAK_MIN_SUCCESS_COUNT : DEFAULT_MIN_SUCCESS_COUNT;
+  const defaultMinSuccessRate =
+    evaluationMode === 'soak' ? DEFAULT_SOAK_MIN_SUCCESS_RATE : DEFAULT_MIN_SUCCESS_RATE;
+
   return {
     sampleSize:
       options.sampleSize
       ?? parsePositiveInt(
-        process.env.VH_NEWS_SOURCE_ADMISSION_SAMPLE_SIZE,
-        DEFAULT_SAMPLE_SIZE,
+        env.VH_NEWS_SOURCE_ADMISSION_SAMPLE_SIZE,
+        defaultSampleSize,
       ),
     minimumSuccessCount:
       options.minimumSuccessCount
       ?? parsePositiveInt(
-        process.env.VH_NEWS_SOURCE_ADMISSION_MIN_SUCCESS_COUNT,
-        DEFAULT_MIN_SUCCESS_COUNT,
+        env.VH_NEWS_SOURCE_ADMISSION_MIN_SUCCESS_COUNT,
+        defaultMinSuccessCount,
       ),
     minimumSuccessRate:
       options.minimumSuccessRate
       ?? parseRate(
-        process.env.VH_NEWS_SOURCE_ADMISSION_MIN_SUCCESS_RATE,
-        DEFAULT_MIN_SUCCESS_RATE,
+        env.VH_NEWS_SOURCE_ADMISSION_MIN_SUCCESS_RATE,
+        defaultMinSuccessRate,
       ),
   };
 }
 
 function passSample(result: ArticleTextResult): SourceAdmissionSampleResult {
+  const assessment = assessItemEligibilityFromResult(result);
   return {
     url: result.url,
     outcome: 'passed',
+    canonicalUrl: assessment.canonicalUrl,
+    urlHash: assessment.urlHash,
+    eligibilityState: assessment.state,
+    eligibilityReason: assessment.reason,
+    displayEligible: assessment.displayEligible,
     title: result.title,
     extractionMethod: result.extractionMethod,
     qualityScore: result.quality.score,
@@ -721,10 +769,16 @@ function failSample(
   url: string,
   error: unknown,
 ): SourceAdmissionSampleResult {
+  const assessment = assessItemEligibilityFromError(url, error);
   if (error instanceof ArticleTextServiceError) {
     return {
       url,
       outcome: 'failed',
+      canonicalUrl: assessment.canonicalUrl,
+      urlHash: assessment.urlHash,
+      eligibilityState: assessment.state,
+      eligibilityReason: assessment.reason,
+      displayEligible: assessment.displayEligible,
       errorCode: error.code,
       errorMessage: error.message,
       retryable: error.retryable,
@@ -734,6 +788,11 @@ function failSample(
   return {
     url,
     outcome: 'failed',
+    canonicalUrl: assessment.canonicalUrl,
+    urlHash: assessment.urlHash,
+    eligibilityState: assessment.state,
+    eligibilityReason: assessment.reason,
+    displayEligible: assessment.displayEligible,
     errorCode: 'unexpected-error',
     errorMessage: error instanceof Error ? error.message : 'Unexpected source admission failure',
     retryable: false,
@@ -755,18 +814,22 @@ function canReplaceSampleFailure(
 function classifySource(
   source: FeedSource,
   criteria: SourceAdmissionCriteria,
+  evaluationMode: SourceAdmissionEvaluationMode,
   feedRead: SourceAdmissionSourceReport['feedRead'],
   sampledUrls: readonly string[],
   skippedVideoUrls: readonly string[],
   samples: readonly SourceAdmissionSampleResult[],
   lifecycle: readonly SourceLifecycleState[],
 ): SourceAdmissionSourceReport {
-  const readableSampleCount = samples.filter((sample) => sample.outcome === 'passed').length;
+  const readableSampleCount = samples.filter(
+    (sample) => sample.eligibilityState === 'analysis_eligible' || sample.outcome === 'passed',
+  ).length;
   const readableSampleRate =
     sampledUrls.length > 0 ? readableSampleCount / sampledUrls.length : null;
 
   const reasons: string[] = [];
   let status: SourceAdmissionStatus = 'rejected';
+  let provisionalKeepForSoak = false;
 
   if (sampledUrls.length === 0) {
     status = 'inconclusive';
@@ -781,6 +844,15 @@ function classifySource(
       }
     }
   } else if (
+    evaluationMode === 'soak'
+    && sampledUrls.length >= DEFAULT_SOAK_PROVISIONAL_MIN_SUCCESS_COUNT
+    && sampledUrls.length < criteria.sampleSize
+    && readableSampleCount === sampledUrls.length
+  ) {
+    status = 'admitted';
+    provisionalKeepForSoak = true;
+    reasons.push('provisional_thin_feed_keep');
+  } else if (
     readableSampleCount >= criteria.minimumSuccessCount &&
     readableSampleCount / sampledUrls.length >= criteria.minimumSuccessRate
   ) {
@@ -789,7 +861,7 @@ function classifySource(
     const failureCodes = new Set(
       samples
         .filter((sample) => sample.outcome === 'failed')
-        .map((sample) => sample.errorCode)
+        .map((sample) => sample.errorCode ?? sample.eligibilityReason)
         .filter((value): value is string => typeof value === 'string' && value.length > 0),
     );
 
@@ -804,8 +876,10 @@ function classifySource(
     sourceId: source.id,
     sourceName: source.name,
     rssUrl: source.rssUrl,
+    evaluationMode,
     status,
     admitted: status === 'admitted',
+    provisionalKeepForSoak,
     sampleLinkCount: sampledUrls.length,
     readableSampleCount,
     readableSampleRate,
@@ -822,7 +896,8 @@ export async function auditFeedSourceAdmission(
   source: FeedSource,
   options: SourceAdmissionAuditOptions = {},
 ): Promise<SourceAdmissionSourceReport> {
-  const criteria = buildCriteria(options);
+  const evaluationMode = resolveEvaluationMode(options);
+  const criteria = buildCriteria(options, evaluationMode);
   const fetchTimeoutMs =
     options.fetchTimeoutMs
     ?? parsePositiveInt(process.env.VH_NEWS_SOURCE_ADMISSION_FETCH_TIMEOUT_MS, 10_000);
@@ -882,6 +957,7 @@ export async function auditFeedSourceAdmission(
   return classifySource(
     source,
     criteria,
+    evaluationMode,
     {
       ...feedReadResult.diagnostics,
       itemFragmentCount: parseResult.itemFragmentCount,
@@ -899,7 +975,8 @@ export async function buildSourceAdmissionReport(
   options: SourceAdmissionAuditOptions & Pick<SourceAdmissionArtifactOptions, 'cwd' | 'env'> = {},
 ): Promise<SourceAdmissionReport> {
   const feedSources = resolveConfiguredFeedSources(options);
-  const criteria = buildCriteria(options);
+  const evaluationMode = resolveEvaluationMode(options);
+  const criteria = buildCriteria(options, evaluationMode);
   const sources: SourceAdmissionSourceReport[] = [];
 
   for (const source of feedSources) {
@@ -909,6 +986,7 @@ export async function buildSourceAdmissionReport(
   return {
     schemaVersion: SOURCE_ADMISSION_REPORT_SCHEMA_VERSION,
     generatedAt: new Date((options.now ?? Date.now)()).toISOString(),
+    evaluationMode,
     criteria,
     sourceCount: sources.length,
     admittedSourceIds: sources.filter((source) => source.status === 'admitted').map((source) => source.sourceId),
@@ -935,6 +1013,33 @@ export async function writeSourceAdmissionArtifact(
   const report = await buildSourceAdmissionReport(options);
   const reportPath = path.join(artifactDir, 'source-admission-report.json');
   writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+  const allSamples = report.sources.flatMap((source) =>
+    source.samples.map((sample) => ({
+      sourceId: source.sourceId,
+      sourceName: source.sourceName,
+      url: sample.url,
+      canonicalUrl: sample.canonicalUrl ?? null,
+      urlHash: sample.urlHash ?? null,
+      eligibilityState: sample.eligibilityState ?? (sample.outcome === 'passed' ? 'analysis_eligible' : 'link_only'),
+      eligibilityReason: sample.eligibilityReason ?? sample.errorCode ?? null,
+      displayEligible: sample.displayEligible ?? sample.outcome === 'passed',
+    })),
+  );
+  writeFileSync(
+    path.join(artifactDir, 'analysis-eligible-links.json'),
+    `${JSON.stringify(allSamples.filter((sample) => sample.eligibilityState === 'analysis_eligible'), null, 2)}\n`,
+    'utf8',
+  );
+  writeFileSync(
+    path.join(artifactDir, 'link-only-links.json'),
+    `${JSON.stringify(allSamples.filter((sample) => sample.eligibilityState === 'link_only'), null, 2)}\n`,
+    'utf8',
+  );
+  writeFileSync(
+    path.join(artifactDir, 'hard-blocked-links.json'),
+    `${JSON.stringify(allSamples.filter((sample) => sample.eligibilityState === 'hard_blocked'), null, 2)}\n`,
+    'utf8',
+  );
   return { artifactDir, reportPath, report };
 }
 
@@ -965,6 +1070,7 @@ if (isDirectExecution()) {
 
 export const sourceAdmissionReportInternal = {
   buildCriteria,
+  resolveEvaluationMode,
   classifySource,
   classifyFeedReadError,
   decodeXmlEntities,


### PR DESCRIPTION
## Summary
- add the item-level reliability plan on main with the corrected soak/product split
- add item eligibility classification and ledger persistence for article extraction outcomes
- enforce the analysis boundary so failed article-text fetches do not enter framing/analysis outputs

## Testing
- pnpm --filter @vh/news-aggregator exec vitest run /Users/bldt/Desktop/VHC/VHC/services/news-aggregator/src/itemEligibilityPolicy.test.ts /Users/bldt/Desktop/VHC/VHC/services/news-aggregator/src/__tests__/itemEligibilityLedger.test.ts /Users/bldt/Desktop/VHC/VHC/services/news-aggregator/src/__tests__/articleTextService.test.ts /Users/bldt/Desktop/VHC/VHC/services/news-aggregator/src/sourceAdmissionReport.test.ts /Users/bldt/Desktop/VHC/VHC/services/news-aggregator/src/sourceHealthReport.test.ts /Users/bldt/Desktop/VHC/VHC/services/news-aggregator/src/__tests__/server.test.ts --config /Users/bldt/Desktop/VHC/VHC/services/news-aggregator/vitest.config.ts
- pnpm exec vitest run /Users/bldt/Desktop/VHC/VHC/apps/web-pwa/src/components/feed/newsCardAnalysis.test.ts --config /Users/bldt/Desktop/VHC/VHC/vitest.config.ts
- pnpm docs:check