### PR TITLE
Move related links into publish-time bundle enrichment

### DIFF
--- a/apps/web-pwa/src/components/feed/newsCardAnalysis.test.ts
+++ b/apps/web-pwa/src/components/feed/newsCardAnalysis.test.ts
@@ -266,15 +266,7 @@ describe('newsCardAnalysis', () => {
     expect(analysisInputs[0]).toContain('ARTICLE BODY 2');
     expect(result.summary).toContain('Publisher Two: Only fetched article text is analyzed.');
     expect(result.summary).not.toContain('Publisher One');
-    expect(result.relatedLinks).toEqual([
-      {
-        source_id: 'source-1',
-        publisher: 'Publisher One',
-        url: 'https://example.com/1',
-        url_hash: 'hash-1',
-        title: 'Transit overhaul clears first hurdle',
-      },
-    ]);
+    expect(result.relatedLinks).toEqual([]);
   });
 
   it('does not run source analysis when article-text fetching is disabled', async () => {

--- a/apps/web-pwa/src/components/feed/newsCardAnalysis.ts
+++ b/apps/web-pwa/src/components/feed/newsCardAnalysis.ts
@@ -286,19 +286,6 @@ function toFrameRows(
   }
   return rows.slice(0, MAX_FRAME_ROWS);
 }
-
-function toRelatedLink(
-  source: StoryBundle['sources'][number],
-): NewsCardRelatedLink {
-  return {
-    source_id: source.source_id,
-    publisher: source.publisher,
-    url: source.url,
-    url_hash: source.url_hash,
-    title: source.title,
-  };
-}
-
 function synthesizeSummary(analyses: ReadonlyArray<NewsCardSourceAnalysis>): string {
   const hl = analyses
     .map((sa) => {
@@ -317,7 +304,6 @@ async function runSynthesis(
 ): Promise<NewsCardAnalysisSynthesis> {
   const selectedSources = selectSourcesForAnalysis(story, maxSourceAnalyses);
   const analyzed: NewsCardSourceAnalysis[] = [];
-  const relatedLinks: NewsCardRelatedLink[] = [];
   const skipArticleTextFetch = shouldSkipArticleTextFetch();
 
   for (const source of selectedSources) {
@@ -336,7 +322,6 @@ async function runSynthesis(
           sourceId: source.source_id,
           url: source.url,
         });
-        relatedLinks.push(toRelatedLink(source));
         continue;
       }
       const input = buildAnalysisInput(story, source, articleText);
@@ -356,7 +341,6 @@ async function runSynthesis(
         url: source.url,
         error,
       });
-      relatedLinks.push(toRelatedLink(source));
     }
   }
 
@@ -368,7 +352,7 @@ async function runSynthesis(
     summary: synthesizeSummary(analyzed),
     frames: toFrameRows(analyzed),
     analyses: analyzed,
-    relatedLinks,
+    relatedLinks: [],
   };
 }
 
@@ -429,7 +413,6 @@ export const newsCardAnalysisInternal = {
   shouldSkipArticleTextFetch,
   synthesizeSummary,
   toFrameRows,
-  toRelatedLink,
   toSourceAnalysis,
   toStoryCacheKey,
 };

--- a/packages/ai-engine/src/newsRuntime.storylines.test.ts
+++ b/packages/ai-engine/src/newsRuntime.storylines.test.ts
@@ -154,4 +154,27 @@ describe('newsRuntime storylines', () => {
 
     handle.stop();
   });
+
+  it('skips storylines whose prepared bundles are dropped before publish', async () => {
+    orchestrateNewsPipelineMock.mockResolvedValue(batch([STORY], [STORYLINE]));
+
+    const writeStoryBundle = vi.fn().mockResolvedValue(undefined);
+    const writeStorylineGroup = vi.fn().mockResolvedValue(undefined);
+
+    const handle = startNewsRuntime({
+      ...BASE_CONFIG,
+      prepareStoryBundle: async () => null,
+      writeStoryBundle,
+      writeStorylineGroup,
+      runOnStart: true,
+      pollIntervalMs: 10,
+    });
+
+    await flushTasks();
+
+    expect(writeStorylineGroup).not.toHaveBeenCalled();
+    expect(writeStoryBundle).not.toHaveBeenCalled();
+
+    handle.stop();
+  });
 });

--- a/packages/ai-engine/src/newsRuntime.test.ts
+++ b/packages/ai-engine/src/newsRuntime.test.ts
@@ -186,6 +186,58 @@ describe('newsRuntime', () => {
     handle.stop();
   });
 
+  it('prepares bundles before publish and synthesis hooks run', async () => {
+    orchestrateNewsPipelineMock.mockResolvedValue(batch([STORY_BUNDLE]));
+
+    const preparedBundle: StoryBundle = {
+      ...STORY_BUNDLE,
+      sources: [
+        {
+          ...STORY_BUNDLE.sources[0]!,
+          title: 'Prepared source title',
+        },
+      ],
+      related_links: [
+        {
+          source_id: 'src-related',
+          publisher: 'Related Publisher',
+          url: 'https://example.com/related-story',
+          url_hash: 'related-hash',
+          title: 'Related story',
+        },
+      ],
+      provenance_hash: 'prepared-provhash',
+    };
+
+    const writeStoryBundle = vi.fn().mockResolvedValue(undefined);
+    const onSynthesisCandidate = vi.fn();
+    const prepareStoryBundle = vi.fn(async () => preparedBundle);
+
+    const handle = startNewsRuntime({
+      ...BASE_CONFIG,
+      prepareStoryBundle,
+      writeStoryBundle,
+      onSynthesisCandidate,
+      pollIntervalMs: 10,
+      runOnStart: true,
+    });
+
+    await flushTasks();
+
+    expect(prepareStoryBundle).toHaveBeenCalledWith(STORY_BUNDLE);
+    expect(writeStoryBundle).toHaveBeenCalledWith(BASE_CONFIG.gunClient, preparedBundle);
+    expect(onSynthesisCandidate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        story_id: 'story-1',
+        advanced_artifact: expect.objectContaining({
+          story_id: 'story-1',
+        }),
+      }),
+    );
+
+    handle.stop();
+  });
+
   it('runs periodic ticks, publishes bundles, and updates lastRun', async () => {
     orchestrateNewsPipelineMock.mockResolvedValue(batch([STORY_BUNDLE]));
 

--- a/packages/ai-engine/src/newsRuntime.ts
+++ b/packages/ai-engine/src/newsRuntime.ts
@@ -40,6 +40,7 @@ export interface NewsRuntimeConfig {
   pollIntervalMs?: number;
   runOnStart?: boolean;
   enabled?: boolean;
+  prepareStoryBundle?: (bundle: StoryBundle) => Promise<StoryBundle | null> | StoryBundle | null;
   writeStoryBundle?: (client: unknown, bundle: StoryBundle) => Promise<unknown>;
   removeStoryBundle?: (client: unknown, storyId: string) => Promise<unknown>;
   writeStorylineGroup?: (client: unknown, storyline: StorylineGroup) => Promise<unknown>;
@@ -149,6 +150,7 @@ export function startNewsRuntime(config: NewsRuntimeConfig): NewsRuntimeHandle {
         storyline_count: storylines.length,
       });
 
+      const prepareStoryBundle = config.prepareStoryBundle;
       const writeStoryBundle = config.writeStoryBundle;
       if (!writeStoryBundle) {
         throw new Error('writeStoryBundle adapter is required');
@@ -163,16 +165,50 @@ export function startNewsRuntime(config: NewsRuntimeConfig): NewsRuntimeHandle {
 
       const nextPublishedStoryIds = new Set<string>();
       const nextPublishedStorylineIds = new Set<string>();
+      const preparedBundles: StoryBundle[] = [];
+      const preparedStoryIds = new Set<string>();
+
+      for (const bundle of bundles) {
+        const preparedBundle = prepareStoryBundle
+          ? await prepareStoryBundle(bundle)
+          : bundle;
+        if (!preparedBundle) {
+          runtimeTrace('bundle_skipped', {
+            story_id: bundle.story_id,
+            reason: 'prepareStoryBundle',
+          });
+          continue;
+        }
+        preparedBundles.push(preparedBundle);
+        preparedStoryIds.add(preparedBundle.story_id);
+      }
+
+      const preparedStorylines = storylines
+        .map((storyline) => {
+          const nextStoryIds = storyline.story_ids.filter((storyId) => preparedStoryIds.has(storyId));
+          if (nextStoryIds.length === 0) {
+            return null;
+          }
+
+          return {
+            ...storyline,
+            story_ids: nextStoryIds,
+            canonical_story_id: nextStoryIds.includes(storyline.canonical_story_id)
+              ? storyline.canonical_story_id
+              : nextStoryIds[0]!,
+          };
+        })
+        .filter((storyline): storyline is StorylineGroup => storyline !== null);
 
       if (writeStorylineGroup) {
-        for (const storyline of storylines) {
+        for (const storyline of preparedStorylines) {
           await writeStorylineGroup(config.gunClient, storyline);
           nextPublishedStorylineIds.add(storyline.storyline_id);
           publishedStorylineIds.add(storyline.storyline_id);
         }
       }
 
-      for (const bundle of bundles) {
+      for (const bundle of preparedBundles) {
         const request = buildRemoteRequest(createPrompt(bundle));
         const workItems = buildEnrichmentWorkItems(bundle);
 
@@ -217,7 +253,7 @@ export function startNewsRuntime(config: NewsRuntimeConfig): NewsRuntimeHandle {
         }
       }
 
-      if (removeStoryBundle && nextPublishedStoryIds.size > 0) {
+      if (removeStoryBundle && bundles.length > 0) {
         const staleStoryIds = [...publishedStoryIds]
           .filter((storyId) => !nextPublishedStoryIds.has(storyId))
           .sort();

--- a/services/news-aggregator/src/daemon.test.ts
+++ b/services/news-aggregator/src/daemon.test.ts
@@ -346,6 +346,68 @@ describe('news aggregator daemon', () => {
     await daemon.stop();
   });
 
+  it('prepares story bundles through the daemon publish enricher before mesh writes', async () => {
+    const logger = makeLogger();
+    const runtimeHandle = makeRuntimeHandle();
+    const timers = makeTimerControls();
+
+    const heldLease = makeLease();
+    const startRuntime = vi.fn(() => runtimeHandle);
+    const readLease = vi.fn().mockResolvedValueOnce(null).mockResolvedValueOnce(heldLease);
+    const writeLease = vi.fn(async () => heldLease);
+    const writeBundle = vi.fn().mockResolvedValue(undefined);
+    const storyBundleEnricher = vi.fn(async (bundle: any) => ({
+      ...bundle,
+      related_links: [
+        {
+          source_id: 'source-related',
+          publisher: 'Related Publisher',
+          url: 'https://example.com/related',
+          url_hash: 'related-hash',
+          title: 'Related link',
+        },
+      ],
+    }));
+
+    const daemon = createNewsAggregatorDaemon({
+      client: { id: 'client-enrich' } as VennClient,
+      feedSources: [...FEED_SOURCES],
+      topicMapping: { ...TOPIC_MAPPING },
+      startRuntime,
+      readLease,
+      writeLease,
+      writeBundle,
+      storyBundleEnricher,
+      logger,
+      setIntervalFn: timers.setIntervalFn,
+      clearIntervalFn: timers.clearIntervalFn,
+      leaseHolderId: 'vh-news-daemon:test',
+    });
+
+    await daemon.start();
+
+    const runtimeConfig = startRuntime.mock.calls[0]?.[0] as NewsRuntimeConfig;
+    const preparedBundle = await runtimeConfig.prepareStoryBundle?.({
+      story_id: 'story-1',
+      sources: [],
+    } as any);
+    await runtimeConfig.writeStoryBundle?.({ id: 'client-enrich' }, preparedBundle as any);
+
+    expect(storyBundleEnricher).toHaveBeenCalledWith(expect.objectContaining({ story_id: 'story-1' }));
+    expect(writeBundle).toHaveBeenCalledWith(
+      { id: 'client-enrich' },
+      expect.objectContaining({
+        related_links: [
+          expect.objectContaining({
+            source_id: 'source-related',
+          }),
+        ],
+      }),
+    );
+
+    await daemon.stop();
+  });
+
   it('renews lease on heartbeat ticks while running', async () => {
     const logger = makeLogger();
     const runtimeHandle = makeRuntimeHandle();

--- a/services/news-aggregator/src/daemon.ts
+++ b/services/news-aggregator/src/daemon.ts
@@ -6,6 +6,12 @@ import {
   type NewsRuntimeHandle,
   type TopicMapping,
 } from '@vh/ai-engine';
+import { ArticleTextService } from './articleTextService';
+import { ItemEligibilityLedger } from './itemEligibilityLedger';
+import {
+  createStoryBundleEligibilityEnricher,
+  type StoryBundleEligibilityEnricher,
+} from './storyBundleEligibilityEnrichment';
 import {
   createNodeMeshClient,
   readNewsIngestionLease,
@@ -51,6 +57,9 @@ export interface NewsAggregatorDaemonConfig {
   writeBundle?: (client: VennClient, bundle: unknown) => Promise<unknown>;
   removeBundle?: (client: VennClient, storyId: string) => Promise<unknown>;
   enrichmentWorker?: EnrichmentWorker;
+  storyBundleEnricher?: StoryBundleEligibilityEnricher;
+  articleTextService?: Pick<ArticleTextService, 'extract'>;
+  itemEligibilityLedger?: ItemEligibilityLedger;
   runtimeOrchestratorOptions?: NewsRuntimeConfig['orchestratorOptions'];
   now?: () => number;
   random?: () => number;
@@ -82,6 +91,12 @@ export function createNewsAggregatorDaemon(config: NewsAggregatorDaemonConfig): 
   const leaseVerificationWindowMs = Math.max(500, Math.min(5_000, Math.floor(leaseTtlMs / 6)));
   const holderId = resolveLeaseHolderId(config.leaseHolderId);
   const queue = createAsyncEnrichmentQueue(config.enrichmentWorker ?? (() => undefined), logger);
+  const itemEligibilityLedger = config.itemEligibilityLedger ?? new ItemEligibilityLedger();
+  const storyBundleEnricher = config.storyBundleEnricher ?? createStoryBundleEligibilityEnricher({
+    itemEligibilityLedger,
+    articleTextService: config.articleTextService ?? new ArticleTextService({ itemEligibilityLedger }),
+    logger,
+  });
   const clusterCaptureRecorder = createDaemonFeedClusterCaptureRecorder(
     readEnvVar('VH_DAEMON_FEED_RUN_ID'),
   );
@@ -119,6 +134,10 @@ export function createNewsAggregatorDaemon(config: NewsAggregatorDaemonConfig): 
       topicMapping: config.topicMapping,
       gunClient: config.client,
       pollIntervalMs: config.pollIntervalMs,
+      prepareStoryBundle: async (bundle) => {
+        await leaseGuard.assertHeld(nowFn());
+        return storyBundleEnricher(bundle);
+      },
       writeStoryBundle: async (runtimeClient: unknown, bundle: unknown) => {
         await leaseGuard.assertHeld(nowFn());
         return writeBundle(runtimeClient as VennClient, bundle);

--- a/services/news-aggregator/src/index.ts
+++ b/services/news-aggregator/src/index.ts
@@ -214,6 +214,13 @@ export type {
 
 export { SOURCE_SCOUT_CANDIDATE_FEED_SOURCES } from './sourceScoutCandidates';
 
+
+export {
+  createStoryBundleEligibilityEnricher,
+  enrichStoryBundleWithEligibility,
+} from './storyBundleEligibilityEnrichment';
+export type { StoryBundleEligibilityEnricher } from './storyBundleEligibilityEnrichment';
+
 export {
   createArticleTextServer,
   startArticleTextServer,

--- a/services/news-aggregator/src/storyBundleEligibilityEnrichment.test.ts
+++ b/services/news-aggregator/src/storyBundleEligibilityEnrichment.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { StoryBundle, StoryBundleSource } from '@vh/data-model';
+import { InMemoryItemEligibilityLedgerStore, ItemEligibilityLedger } from './itemEligibilityLedger';
+import { createStoryBundleEligibilityEnricher, enrichStoryBundleWithEligibility } from './storyBundleEligibilityEnrichment';
+
+function makeSource(overrides: Partial<StoryBundleSource> = {}): StoryBundleSource {
+  return {
+    source_id: 'source-1',
+    publisher: 'Publisher One',
+    url: 'https://example.com/story-1',
+    url_hash: 'hash-1',
+    title: 'Headline One',
+    published_at: 1_700_000_000_000,
+    ...overrides,
+  };
+}
+
+function makeBundle(overrides: Partial<StoryBundle> = {}): StoryBundle {
+  const sources = [
+    makeSource(),
+    makeSource({
+      source_id: 'source-2',
+      publisher: 'Publisher Two',
+      url: 'https://example.com/story-2',
+      url_hash: 'hash-2',
+      title: 'Headline Two',
+    }),
+    makeSource({
+      source_id: 'source-3',
+      publisher: 'Publisher Three',
+      url: 'https://example.com/story-3',
+      url_hash: 'hash-3',
+      title: 'Headline Three',
+    }),
+  ];
+
+  return {
+    schemaVersion: 'story-bundle-v0',
+    story_id: 'story-1',
+    topic_id: 'topic-1',
+    storyline_id: 'storyline-1',
+    headline: 'Headline',
+    summary_hint: 'Summary',
+    cluster_window_start: 1,
+    cluster_window_end: 2,
+    sources,
+    primary_sources: sources.slice(0, 2),
+    cluster_features: {
+      entity_keys: ['topic'],
+      time_bucket: '2026-04-13T10',
+      semantic_signature: 'sig-1',
+    },
+    provenance_hash: 'old-prov',
+    created_at: 3,
+    ...overrides,
+  };
+}
+
+describe('storyBundleEligibilityEnrichment', () => {
+  it('partitions canonical sources and related links at publish time', async () => {
+    const store = new InMemoryItemEligibilityLedgerStore();
+    const ledger = new ItemEligibilityLedger({ store, now: () => 100 });
+    await ledger.writeAssessment({
+      canonicalUrl: 'https://example.com/story-1',
+      urlHash: 'hash-1',
+      state: 'analysis_eligible',
+      reason: 'analysis_eligible',
+      displayEligible: true,
+    });
+    await ledger.writeAssessment({
+      canonicalUrl: 'https://example.com/story-2',
+      urlHash: 'hash-2',
+      state: 'link_only',
+      reason: 'quality-too-low',
+      displayEligible: true,
+    });
+    await ledger.writeAssessment({
+      canonicalUrl: 'https://example.com/story-3',
+      urlHash: 'hash-3',
+      state: 'hard_blocked',
+      reason: 'removed',
+      displayEligible: false,
+    });
+
+    const bundle = makeBundle();
+    const result = await enrichStoryBundleWithEligibility(bundle, {
+      itemEligibilityLedger: ledger,
+      articleTextService: { extract: vi.fn() as any },
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.sources).toEqual([bundle.sources[0]!]);
+    expect(result?.primary_sources).toEqual([bundle.primary_sources?.[0]!]);
+    expect(result?.related_links).toEqual([bundle.sources[1]!]);
+    expect(result?.provenance_hash).not.toBe('old-prov');
+  });
+
+  it('assesses missing sources through article extraction before publishing', async () => {
+    const ledger = new ItemEligibilityLedger({ now: () => 200 });
+    const extract = vi.fn(async (url: string) => {
+      if (url.endsWith('story-1')) {
+        return {
+          url,
+          urlHash: 'hash-1',
+          contentHash: 'content-1',
+          sourceDomain: 'example.com',
+          title: 'Headline One',
+          text: 'Long enough article text to qualify for analysis.',
+          extractionMethod: 'article-extractor' as const,
+          cacheHit: 'none' as const,
+          attempts: 1,
+          fetchedAt: 200,
+          quality: {
+            charCount: 900,
+            wordCount: 180,
+            sentenceCount: 5,
+            score: 0.9,
+          },
+        };
+      }
+      throw Object.assign(new Error('too short'), {
+        code: 'quality-too-low',
+        retryable: false,
+      });
+    });
+
+    const bundle = makeBundle({
+      sources: [makeSource(), makeSource({ source_id: 'source-2', url: 'https://example.com/story-2', url_hash: 'hash-2' })],
+      primary_sources: [makeSource(), makeSource({ source_id: 'source-2', url: 'https://example.com/story-2', url_hash: 'hash-2' })],
+    });
+
+    const result = await enrichStoryBundleWithEligibility(bundle, {
+      itemEligibilityLedger: ledger,
+      articleTextService: { extract },
+    });
+
+    expect(extract).toHaveBeenCalledTimes(2);
+    expect(result?.sources).toEqual([bundle.sources[0]!]);
+    expect(result?.related_links).toEqual([bundle.sources[1]!]);
+  });
+
+  it('returns null when no sources remain analysis-eligible', async () => {
+    const ledger = new ItemEligibilityLedger({ now: () => 300 });
+    const logger = { warn: vi.fn() };
+    const bundle = makeBundle({
+      sources: [makeSource()],
+      primary_sources: [makeSource()],
+    });
+
+    const result = await enrichStoryBundleWithEligibility(bundle, {
+      itemEligibilityLedger: ledger,
+      articleTextService: {
+        extract: vi.fn(async () => {
+          throw Object.assign(new Error('gone'), {
+            code: 'removed',
+            retryable: false,
+          });
+        }),
+      },
+      logger,
+    });
+
+    expect(result).toBeNull();
+    expect(logger.warn).toHaveBeenCalledWith(
+      '[vh:news-daemon] skipping bundle with no analysis-eligible sources',
+      expect.objectContaining({ story_id: 'story-1', source_count: 1 }),
+    );
+  });
+
+  it('creates a reusable enricher closure', async () => {
+    const store = new InMemoryItemEligibilityLedgerStore();
+    const ledger = new ItemEligibilityLedger({ store, now: () => 400 });
+    await ledger.writeAssessment({
+      canonicalUrl: 'https://example.com/story-1',
+      urlHash: 'hash-1',
+      state: 'analysis_eligible',
+      reason: 'analysis_eligible',
+      displayEligible: true,
+    });
+
+    const enricher = createStoryBundleEligibilityEnricher({
+      itemEligibilityLedger: ledger,
+      articleTextService: { extract: vi.fn() as any },
+    });
+
+    const result = await enricher(makeBundle({
+      sources: [makeSource()],
+      primary_sources: [makeSource()],
+    }));
+    expect(result?.sources).toEqual([makeSource()]);
+  });
+});

--- a/services/news-aggregator/src/storyBundleEligibilityEnrichment.ts
+++ b/services/news-aggregator/src/storyBundleEligibilityEnrichment.ts
@@ -1,0 +1,150 @@
+import type { StoryBundle, StoryBundleSource } from '@vh/data-model';
+import { ArticleTextService, type ArticleTextResult } from './articleTextService';
+import { ItemEligibilityLedger, type ItemEligibilityLedgerEntry } from './itemEligibilityLedger';
+import {
+  assessItemEligibilityFromError,
+  assessItemEligibilityFromResult,
+  type ItemEligibilityAssessment,
+} from './itemEligibilityPolicy';
+import { computeProvenanceHash } from './provenance';
+
+export interface StoryBundleEligibilityEnrichmentOptions {
+  readonly articleTextService?: Pick<ArticleTextService, 'extract'>;
+  readonly itemEligibilityLedger?: Pick<ItemEligibilityLedger, 'readByUrlHash'>;
+  readonly logger?: Pick<Console, 'warn'>;
+}
+
+export type StoryBundleEligibilityEnricher = (
+  bundle: StoryBundle,
+) => Promise<StoryBundle | null>;
+
+function sourceKey(source: StoryBundleSource): string {
+  return `${source.source_id}|${source.url_hash}`;
+}
+
+function dedupeSources(sources: readonly StoryBundleSource[]): StoryBundleSource[] {
+  const deduped = new Map<string, StoryBundleSource>();
+  for (const source of sources) {
+    const key = sourceKey(source);
+    if (!deduped.has(key)) {
+      deduped.set(key, source);
+    }
+  }
+  return [...deduped.values()];
+}
+
+function toAssessmentFromLedgerEntry(entry: ItemEligibilityLedgerEntry): ItemEligibilityAssessment {
+  return {
+    url: entry.canonicalUrl,
+    canonicalUrl: entry.canonicalUrl,
+    urlHash: entry.urlHash,
+    state: entry.state,
+    reason: entry.reason,
+    retryable: entry.recoverable,
+    displayEligible: entry.displayEligible,
+  };
+}
+
+async function assessSourceEligibility(
+  source: StoryBundleSource,
+  articleTextService: Pick<ArticleTextService, 'extract'>,
+  itemEligibilityLedger: Pick<ItemEligibilityLedger, 'readByUrlHash'>,
+): Promise<ItemEligibilityAssessment> {
+  const existing = await itemEligibilityLedger.readByUrlHash(source.url_hash);
+  if (existing) {
+    return toAssessmentFromLedgerEntry(existing);
+  }
+
+  try {
+    const result: ArticleTextResult = await articleTextService.extract(source.url);
+    return assessItemEligibilityFromResult(result);
+  } catch (error) {
+    return assessItemEligibilityFromError(source.url, error);
+  }
+}
+
+function filterPrimarySources(
+  primarySources: readonly StoryBundleSource[] | undefined,
+  canonicalKeys: ReadonlySet<string>,
+): StoryBundleSource[] | undefined {
+  if (!primarySources || primarySources.length === 0) {
+    return undefined;
+  }
+
+  const filtered = primarySources.filter((source) => canonicalKeys.has(sourceKey(source)));
+  return filtered.length > 0 ? filtered : undefined;
+}
+
+function mergeRelatedLinks(
+  bundle: StoryBundle,
+  relatedSources: readonly StoryBundleSource[],
+  canonicalKeys: ReadonlySet<string>,
+): StoryBundleSource[] | undefined {
+  const merged = dedupeSources([
+    ...relatedSources,
+    ...(bundle.related_links ?? []),
+  ]).filter((source) => !canonicalKeys.has(sourceKey(source)));
+
+  return merged.length > 0 ? merged : undefined;
+}
+
+export async function enrichStoryBundleWithEligibility(
+  bundle: StoryBundle,
+  options: StoryBundleEligibilityEnrichmentOptions = {},
+): Promise<StoryBundle | null> {
+  const articleTextService = options.articleTextService ?? new ArticleTextService();
+  const itemEligibilityLedger = options.itemEligibilityLedger ?? new ItemEligibilityLedger();
+  const logger = options.logger ?? console;
+
+  const canonicalSources: StoryBundleSource[] = [];
+  const relatedSources: StoryBundleSource[] = [];
+
+  for (const source of bundle.sources) {
+    const assessment = await assessSourceEligibility(source, articleTextService, itemEligibilityLedger);
+    if (assessment.state === 'analysis_eligible') {
+      canonicalSources.push(source);
+      continue;
+    }
+
+    if (assessment.displayEligible) {
+      relatedSources.push(source);
+    }
+  }
+
+  const dedupedCanonicalSources = dedupeSources(canonicalSources);
+  if (dedupedCanonicalSources.length === 0) {
+    logger.warn('[vh:news-daemon] skipping bundle with no analysis-eligible sources', {
+      story_id: bundle.story_id,
+      source_count: bundle.sources.length,
+    });
+    return null;
+  }
+
+  const canonicalKeys = new Set(dedupedCanonicalSources.map((source) => sourceKey(source)));
+  const primarySources = filterPrimarySources(bundle.primary_sources, canonicalKeys);
+  const relatedLinks = mergeRelatedLinks(bundle, relatedSources, canonicalKeys);
+
+  const nextProvenanceHash = computeProvenanceHash(dedupedCanonicalSources);
+
+  return {
+    ...bundle,
+    sources: dedupedCanonicalSources,
+    primary_sources: primarySources,
+    related_links: relatedLinks,
+    provenance_hash: nextProvenanceHash,
+  };
+}
+
+export function createStoryBundleEligibilityEnricher(
+  options: StoryBundleEligibilityEnrichmentOptions = {},
+): StoryBundleEligibilityEnricher {
+  return async (bundle: StoryBundle) => enrichStoryBundleWithEligibility(bundle, options);
+}
+
+export const storyBundleEligibilityEnrichmentInternal = {
+  dedupeSources,
+  filterPrimarySources,
+  mergeRelatedLinks,
+  sourceKey,
+  toAssessmentFromLedgerEntry,
+};


### PR DESCRIPTION
## Summary
- enrich story bundles at publish time using item eligibility so link-only sources become `related_links` before snapshots and downstream consumers read them
- add a runtime prepare hook so dropped bundles/storylines are filtered consistently before publish/removal bookkeeping
- stop generating `relatedLinks` inside the card-open analysis pass so related-link ownership stays with publish-time enrichment

## Validation
- `pnpm --filter @vh/news-aggregator exec vitest run /Users/bldt/Desktop/VHC/VHC/services/news-aggregator/src/storyBundleEligibilityEnrichment.test.ts /Users/bldt/Desktop/VHC/VHC/services/news-aggregator/src/daemon.test.ts --config /Users/bldt/Desktop/VHC/VHC/services/news-aggregator/vitest.config.ts`
- `pnpm exec vitest run packages/ai-engine/src/newsRuntime.test.ts packages/ai-engine/src/newsRuntime.storylines.test.ts apps/web-pwa/src/components/feed/newsCardAnalysis.test.ts --config /Users/bldt/Desktop/VHC/VHC/vitest.config.ts`
- `pnpm typecheck`