### PR TITLE
fix: stabilize source-health gating for retained uplift

### DIFF
--- a/services/news-aggregator/src/sourceHealthReport.test.ts
+++ b/services/news-aggregator/src/sourceHealthReport.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { STARTER_FEED_SOURCES } from '@vh/ai-engine';
 import type { SourceAdmissionReport, SourceAdmissionSourceReport } from './sourceAdmissionReport';
 import {
+  SOURCE_HEALTH_POLICY_VERSION,
   SOURCE_HEALTH_REPORT_SCHEMA_VERSION,
   SOURCE_HEALTH_TREND_INDEX_SCHEMA_VERSION,
   buildSourceHealthReport,
@@ -71,6 +72,7 @@ function writeHistoricalSourceHealthReport(
   runId: string,
   report: {
     readonly generatedAt: string;
+    readonly policyVersion?: string;
     readonly readinessStatus?: 'ready' | 'review' | 'blocked';
     readonly runAssessment?: {
       readonly globalFeedStageFailure: boolean;
@@ -88,6 +90,7 @@ function writeHistoricalSourceHealthReport(
     path.join(runDir, 'source-health-report.json'),
     `${JSON.stringify({
       schemaVersion: SOURCE_HEALTH_REPORT_SCHEMA_VERSION,
+      policyVersion: report.policyVersion ?? SOURCE_HEALTH_POLICY_VERSION,
       generatedAt: report.generatedAt,
       readinessStatus: report.readinessStatus,
       runAssessment: report.runAssessment,
@@ -162,7 +165,7 @@ describe('sourceHealthReport', () => {
     expect(decision.unstableLifecycleDomains).toEqual(['www.theguardian.com']);
   });
 
-  it('keeps admitted sources when prior failures fully recovered without retries', () => {
+  it('keeps admitted sources when prior failures fully recovered after retries', () => {
     const source = makeAdmissionSource({
       sourceId: 'guardian-us',
       lifecycle: [
@@ -173,11 +176,11 @@ describe('sourceHealthReport', () => {
           totalSuccesses: 4,
           totalFailures: 1,
           consecutiveFailures: 0,
-          retryCount: 0,
+          retryCount: 1,
           lastAttemptAt: 5,
           lastSuccessAt: 5,
           lastFailureAt: 1,
-          lastRetryAt: null,
+          lastRetryAt: 2,
           nextRetryAt: null,
           lastBackoffMs: null,
           lastErrorMessage: null,
@@ -262,6 +265,7 @@ describe('sourceHealthReport', () => {
     );
 
     expect(report.schemaVersion).toBe(SOURCE_HEALTH_REPORT_SCHEMA_VERSION);
+    expect(report.policyVersion).toBe(SOURCE_HEALTH_POLICY_VERSION);
     expect(report.readinessStatus).toBe('blocked');
     expect(report.recommendedAction).toBe('prune_remove_candidates');
     expect(report.keepSourceIds).toEqual(['fox-latest']);
@@ -518,6 +522,83 @@ describe('sourceHealthReport', () => {
     expect(report.sources[0]?.baseDecision).toBe('keep');
     expect(report.sources[0]?.decision).toBe('watch');
     expect(report.sources[0]?.reasons).toContain('pending_readmission_stability_window');
+
+    rmSync(artifactRoot, { recursive: true, force: true });
+  });
+
+  it('clears pending readmission for a clean corroborating source', () => {
+    const artifactRoot = mkdtempSync(path.join(os.tmpdir(), 'vh-source-health-history-readmit-corroborated-'));
+    writeHistoricalSourceHealthReport(artifactRoot, 'run-1', {
+      generatedAt: '2026-03-15T00:00:00.000Z',
+      sources: [
+        {
+          sourceId: 'bbc-general',
+          baseDecision: 'remove',
+          decision: 'remove',
+        },
+      ],
+    });
+    writeHistoricalSourceHealthReport(artifactRoot, 'run-2', {
+      generatedAt: '2026-03-16T00:00:00.000Z',
+      sources: [
+        {
+          sourceId: 'bbc-general',
+          baseDecision: 'watch',
+          decision: 'watch',
+        },
+      ],
+    });
+
+    const report = buildSourceHealthReport(
+      makeAdmissionReport([
+        makeAdmissionSource({ sourceId: 'bbc-general' }),
+      ]),
+      {
+        artifactDir: path.join(artifactRoot, 'run-3'),
+        thresholds: {
+          readmissionKeepRunCount: 3,
+          minContributingSourceCount: 0,
+        },
+        feedContribution: {
+          schemaVersion: 'news-source-feed-contribution-report-v1',
+          generatedAt: '2026-03-16T12:00:00.000Z',
+          snapshotMode: 'heuristic_live_feed_snapshot',
+          sourceCount: 1,
+          totalIngestedItemCount: 8,
+          totalNormalizedItemCount: 8,
+          totalBundleCount: 4,
+          totalSingletonBundleCount: 1,
+          totalCorroboratedBundleCount: 3,
+          contributingSourceIds: ['bbc-general'],
+          corroboratingSourceIds: ['bbc-general'],
+          zeroContributionSourceIds: [],
+          sources: [
+            {
+              sourceId: 'bbc-general',
+              sourceName: 'BBC News',
+              rssUrl: 'https://feeds.bbci.co.uk/news/rss.xml',
+              ingestErrorCount: 0,
+              ingestErrors: [],
+              ingestedItemCount: 8,
+              normalizedItemCount: 8,
+              dedupDroppedItemCount: 0,
+              bundleAppearanceCount: 4,
+              singletonBundleCount: 1,
+              corroboratedBundleCount: 3,
+              contributionStatus: 'corroborated',
+            },
+          ],
+        },
+        now: () => 1_700_000_000_000,
+      },
+    );
+
+    expect(report.keepSourceIds).toEqual(['bbc-general']);
+    expect(report.watchSourceIds).toEqual([]);
+    expect(report.historySummary.pendingReadmissionSourceIds).toEqual([]);
+    expect(report.observability.pendingReadmissionSourceCount).toBe(0);
+    expect(report.sources[0]?.history.pendingReadmission).toBe(false);
+    expect(report.sources[0]?.reasons).not.toContain('pending_readmission_stability_window');
 
     rmSync(artifactRoot, { recursive: true, force: true });
   });
@@ -892,6 +973,51 @@ describe('sourceHealthReport', () => {
           sourceId: 'cbs-politics',
           baseDecision: 'remove',
           decision: 'remove',
+        },
+      ],
+    });
+
+    const report = buildSourceHealthReport(
+      makeAdmissionReport([
+        makeAdmissionSource({ sourceId: 'fox-latest' }),
+      ]),
+      {
+        artifactDir: path.join(artifactRoot, 'run-2'),
+        thresholds: {
+          minContributingSourceCount: 0,
+        },
+        now: () => Date.parse('2026-03-20T12:00:00.000Z'),
+      },
+    );
+
+    expect(report.historySummary.priorReportCount).toBe(0);
+    expect(report.sources[0]?.history.priorReportCount).toBe(0);
+    expect(report.releaseEvidence).toEqual({
+      status: 'pass',
+      recommendedAction: 'release_ready',
+      reasons: [],
+      recentWindowRunCount: 1,
+      recentReadyRunCount: 1,
+      recentReviewRunCount: 0,
+      recentBlockedRunCount: 0,
+      latestNewWatchSourceIds: [],
+      latestNewRemoveSourceIds: [],
+    });
+
+    rmSync(artifactRoot, { recursive: true, force: true });
+  });
+
+  it('resets history and release evidence when the source-health policy version changes', () => {
+    const artifactRoot = mkdtempSync(path.join(os.tmpdir(), 'vh-source-health-policy-reset-'));
+    writeHistoricalSourceHealthReport(artifactRoot, 'run-1', {
+      generatedAt: '2026-03-20T00:00:00.000Z',
+      policyVersion: 'legacy',
+      readinessStatus: 'review',
+      sources: [
+        {
+          sourceId: 'fox-latest',
+          baseDecision: 'watch',
+          decision: 'watch',
         },
       ],
     });

--- a/services/news-aggregator/src/sourceHealthReport.ts
+++ b/services/news-aggregator/src/sourceHealthReport.ts
@@ -15,11 +15,14 @@ import {
   type SourceFeedContributionReport,
   type SourceFeedContributionSourceReport,
 } from './sourceContributionReport';
+import type { SourceLifecycleState } from './sourceLifecycle';
 
 export const SOURCE_HEALTH_REPORT_SCHEMA_VERSION =
   'news-source-health-report-v1';
 export const SOURCE_HEALTH_TREND_INDEX_SCHEMA_VERSION =
   'news-source-health-trend-v1';
+export const SOURCE_HEALTH_POLICY_VERSION =
+  'news-source-health-policy-v2';
 
 const FEED_STAGE_BLOCKING_REASONS = new Set([
   'feed_links_unavailable',
@@ -156,6 +159,7 @@ export interface SourceHealthRunAssessment {
 
 export interface SourceHealthReport {
   readonly schemaVersion: typeof SOURCE_HEALTH_REPORT_SCHEMA_VERSION;
+  readonly policyVersion: typeof SOURCE_HEALTH_POLICY_VERSION;
   readonly generatedAt: string;
   readonly readinessStatus: SourceHealthReadinessStatus;
   readonly recommendedAction:
@@ -196,6 +200,7 @@ export interface SourceHealthArtifactOptions extends SourceAdmissionArtifactOpti
 interface HistoricalSourceHealthRecord {
   readonly generatedAtMs: number;
   readonly generatedAt: string;
+  readonly policyVersion: string;
   readonly globalFeedStageFailure: boolean;
   readonly readinessStatus: SourceHealthReadinessStatus;
   readonly enabledSourceCount: number;
@@ -378,6 +383,10 @@ function parseHistoricalSourceHealthRecord(
   return {
     generatedAtMs: generatedAt,
     generatedAt: new Date(generatedAt).toISOString(),
+    policyVersion:
+      typeof record.policyVersion === 'string' && record.policyVersion.trim().length > 0
+        ? record.policyVersion.trim()
+        : 'legacy',
     globalFeedStageFailure:
       typeof (record.runAssessment as Record<string, unknown> | undefined)?.globalFeedStageFailure === 'boolean'
         ? (record.runAssessment as Record<string, boolean>).globalFeedStageFailure ?? false
@@ -514,19 +523,26 @@ function buildSourceSlateKey(sourceIds: readonly string[]): string {
 function filterComparableHistoricalReports(
   currentSourceIds: readonly string[],
   historicalReports: readonly HistoricalSourceHealthRecord[],
+  currentPolicyVersion: string,
 ): HistoricalSourceHealthRecord[] {
   const currentSourceSlateKey = buildSourceSlateKey(currentSourceIds);
   return historicalReports.filter((report) => (
+    report.policyVersion === currentPolicyVersion
+    && (
     buildSourceSlateKey(report.sources.map((source) => source.sourceId)) === currentSourceSlateKey
+    )
   ));
+}
+
+function isLifecycleCurrentlyUnstable(
+  state: Pick<SourceLifecycleState, 'status' | 'consecutiveFailures'>,
+): boolean {
+  return state.status !== 'healthy' || state.consecutiveFailures > 0;
 }
 
 function hasLifecycleInstability(source: SourceAdmissionSourceReport): boolean {
   return source.lifecycle.some(
-    (state) =>
-      state.status !== 'healthy'
-      || state.retryCount > 0
-      || state.consecutiveFailures > 0,
+    (state) => isLifecycleCurrentlyUnstable(state),
   );
 }
 
@@ -536,10 +552,7 @@ function buildDecision(
 ): SourceHealthSourceReport {
   const unstableLifecycleDomains = source.lifecycle
     .filter(
-      (state) =>
-        state.status !== 'healthy'
-        || state.retryCount > 0
-        || state.consecutiveFailures > 0,
+      (state) => isLifecycleCurrentlyUnstable(state),
     )
     .map((state) => state.sourceDomain);
 
@@ -644,6 +657,9 @@ function buildSourceHistory(
   historicalReports: readonly HistoricalSourceHealthRecord[],
   thresholds: SourceHealthThresholds,
   baseDecision: SourceHealthDecision,
+  options: {
+    readonly bypassPendingReadmission?: boolean;
+  } = {},
 ): SourceHealthSourceHistory {
   const priorRecords = historicalReports
     .map((report) => report.sources.find((source) => source.sourceId === sourceId) ?? null)
@@ -665,6 +681,7 @@ function buildSourceHistory(
   const priorRemovalSeen = priorEffectiveDecisions.includes('remove');
   const pendingReadmission =
     baseDecision === 'keep'
+    && !options.bypassPendingReadmission
     && priorRemovalSeen
     && consecutiveBaseKeepRuns + 1 < thresholds.readmissionKeepRunCount;
   const escalatedToRemove =
@@ -971,17 +988,25 @@ export function buildSourceHealthReport(
   const comparableHistoricalReports = filterComparableHistoricalReports(
     admissionReport.sources.map((source) => source.sourceId),
     historicalReports,
+    SOURCE_HEALTH_POLICY_VERSION,
   );
   const sources = admissionReport.sources.map((source) => {
     const baseDecision = buildDecision(source, thresholds);
+    const contribution =
+      feedContribution.sources.find((entry) => entry.sourceId === source.sourceId) ?? null;
     const history = buildSourceHistory(
       baseDecision.sourceId,
       comparableHistoricalReports,
       thresholds,
       baseDecision.baseDecision,
+      {
+        bypassPendingReadmission:
+          baseDecision.baseDecision === 'keep'
+          && baseDecision.reasons.length === 0
+          && baseDecision.unstableLifecycleDomains.length === 0
+          && contribution?.contributionStatus === 'corroborated',
+      },
     );
-    const contribution =
-      feedContribution.sources.find((entry) => entry.sourceId === source.sourceId) ?? null;
     return {
       ...applyHistoricalDecisionPolicy(baseDecision, history),
       feedContribution: contribution,
@@ -1062,6 +1087,7 @@ export function buildSourceHealthReport(
 
   return {
     schemaVersion: SOURCE_HEALTH_REPORT_SCHEMA_VERSION,
+    policyVersion: SOURCE_HEALTH_POLICY_VERSION,
     generatedAt,
     readinessStatus,
     recommendedAction:
@@ -1208,9 +1234,14 @@ export async function writeSourceHealthArtifact(
     admissionArtifact.artifactDir,
     sourceHealthReport.thresholds.historyLookbackRunCount,
   );
+  const comparableHistoricalReports = filterComparableHistoricalReports(
+    admissionArtifact.report.sources.map((source) => source.sourceId),
+    historicalReports,
+    SOURCE_HEALTH_POLICY_VERSION,
+  );
   const sourceHealthTrendIndex = buildSourceHealthTrendIndex(
     sourceHealthReport,
-    historicalReports,
+    comparableHistoricalReports,
   );
 
   writeFileSync(


### PR DESCRIPTION
## Summary
- stop treating recovered lifecycle retries as active source-health instability
- let strongly corroborating clean sources clear pending readmission immediately
- reset source-health trend comparability when the policy version changes
- keep written trend artifacts aligned with the filtered comparable-history set

## Validation
- `pnpm --filter @vh/news-aggregator exec vitest run /Users/bldt/Desktop/VHC/VHC/services/news-aggregator/src/sourceHealthReport.test.ts --config /Users/bldt/Desktop/VHC/VHC/services/news-aggregator/vitest.config.ts`
- `VH_NEWS_SOURCE_ADMISSION_FETCH_TIMEOUT_MS=2000 pnpm report:news-sources:health`
- forced wave on the fresh `ready/pass` source-health artifact:
  - publisher canary pass
  - consumer smoke pass
  - retained semantic soak ran and passed

## Notes
- I also updated the local Codex automation prompts for `Retained Uplift` and `Findings Triage` under `~/.codex/automations/` so retained uses the effective preserved starter surface on transient feed-stage outages and triage judges the daily wave by the four-part success rule. Those automation prompt changes are local scheduler config, not repo files.