### PR TITLE
Exit cleanly after source health reports

### DIFF
--- a/services/news-aggregator/src/sourceHealthReport.ts
+++ b/services/news-aggregator/src/sourceHealthReport.ts
@@ -1427,7 +1427,13 @@ async function main(): Promise<void> {
 
 /* c8 ignore next 3 */
 if (isDirectExecution()) {
-  await main();
+  try {
+    await main();
+    process.exit(0);
+  } catch (error) {
+    console.error(error);
+    process.exit(1);
+  }
 }
 /* c8 ignore stop */
 


### PR DESCRIPTION
## Summary
- make the source-health CLI exit explicitly after writing artifacts so wrapper commands do not stall after a healthy run

## Validation
- `pnpm --filter @vh/news-aggregator exec vitest run /Users/bldt/Desktop/VHC/VHC/services/news-aggregator/src/sourceHealthReport.test.ts --config /Users/bldt/Desktop/VHC/VHC/services/news-aggregator/vitest.config.ts`
- `time VH_NEWS_SOURCE_ADMISSION_FETCH_TIMEOUT_MS=2000 pnpm report:news-sources:health`
- `VH_NEWS_SOURCE_ADMISSION_FETCH_TIMEOUT_MS=2000 pnpm automation:test:storycluster:publisher-canary`
- `pnpm automation:test:storycluster:consumer-smoke`
- `pnpm automation:test:storycluster:retained-uplift`

## Wave artifacts on this branch
- source health: `/Users/bldt/Desktop/VHC/VHC/services/news-aggregator/.tmp/news-source-admission/1776298514585/source-health-report.json`
- canary: `/Users/bldt/Desktop/VHC/VHC/.tmp/daemon-feed-publisher-canary/1776298587356/publisher-canary-summary.json`
- consumer: `/Users/bldt/Desktop/VHC/VHC/.tmp/daemon-feed-consumer-smoke/1776298657126/consumer-smoke-summary.json`
- retained: `/Users/bldt/Desktop/VHC/VHC/.tmp/daemon-feed-semantic-soak/1776298678203/semantic-soak-summary.json`