### PR TITLE
Require frame/reframe perspectives in analysis prompts

### DIFF
--- a/apps/web-pwa/src/components/feed/NewsCard.tsx
+++ b/apps/web-pwa/src/components/feed/NewsCard.tsx
@@ -154,6 +154,12 @@ export const NewsCard: React.FC<NewsCardProps> = ({ item }) => {
   const useAnalysisFrames = synthesisFrameRows.length === 0 && analysisFrameRows.length > 0;
   const frameRows = synthesisFrameRows.length > 0 ? synthesisFrameRows : analysisFrameRows;
   const frameAnalysis = useAnalysisFrames ? analysis : null;
+  const analysisNeedsRegeneration =
+    analysisPipelineEnabled
+    && analysisStatus === 'success'
+    && !!analysis
+    && synthesisFrameRows.length === 0
+    && analysisFrameRows.length === 0;
   const analyzedSourceCount = analysis?.analyses.length ?? 0;
   const expectedSourceCount = displaySources.length || story?.sources.length || 0;
   const summaryBasisLabel = hasSynthesisSummary
@@ -322,6 +328,7 @@ export const NewsCard: React.FC<NewsCardProps> = ({ item }) => {
               analysisFeedbackStatus={analysisFeedbackStatus}
               analysisError={analysisError}
               retryAnalysis={retryAnalysis}
+              analysisNeedsRegeneration={analysisNeedsRegeneration}
               synthesisLoading={synthesisLoading}
               synthesisError={synthesisError}
               analysis={frameAnalysis}

--- a/apps/web-pwa/src/components/feed/NewsCardBack.storyline.test.tsx
+++ b/apps/web-pwa/src/components/feed/NewsCardBack.storyline.test.tsx
@@ -83,4 +83,12 @@ describe('NewsCardBack storyline presentation', () => {
       'https://example.com/gallery-1.jpg',
     );
   });
+
+  it('shows regeneration copy when cached analysis lacks usable frame rows', () => {
+    renderBack({ analysisNeedsRegeneration: true });
+
+    expect(screen.getByTestId('news-card-analysis-regeneration-news-1')).toHaveTextContent(
+      'Analysis needs regeneration to produce frame/reframe rows.',
+    );
+  });
 });

--- a/apps/web-pwa/src/components/feed/NewsCardBack.tsx
+++ b/apps/web-pwa/src/components/feed/NewsCardBack.tsx
@@ -46,6 +46,7 @@ export interface NewsCardBackProps {
     | null;
   readonly analysisError: string | null;
   readonly retryAnalysis: () => void;
+  readonly analysisNeedsRegeneration?: boolean;
   readonly synthesisLoading: boolean;
   readonly synthesisError: string | null;
   readonly analysis: NewsCardAnalysisSynthesis | null;
@@ -89,6 +90,7 @@ export const NewsCardBack: React.FC<NewsCardBackProps> = ({
   analysisFeedbackStatus,
   analysisError,
   retryAnalysis,
+  analysisNeedsRegeneration = false,
   synthesisLoading,
   synthesisError,
   analysis,
@@ -304,13 +306,22 @@ export const NewsCardBack: React.FC<NewsCardBackProps> = ({
           </p>
         )}
 
+        {analysisNeedsRegeneration && !synthesisLoading && (
+          <p
+            className="mt-2 text-xs text-amber-700"
+            data-testid={`news-card-analysis-regeneration-${topicId}`}
+          >
+            Analysis needs regeneration to produce frame/reframe rows.
+          </p>
+        )}
+
         <div className="mt-2">
-            <BiasTable
-              analyses={analysis?.analyses ?? []}
-              frames={frameRows}
-              providerLabel={analysisProvider ?? undefined}
-              basisLabel={frameBasisLabel}
-              loading={synthesisLoading && frameRows.length === 0}
+          <BiasTable
+            analyses={analysis?.analyses ?? []}
+            frames={frameRows}
+            providerLabel={analysisProvider ?? undefined}
+            basisLabel={frameBasisLabel}
+            loading={synthesisLoading && frameRows.length === 0}
             topicId={topicId}
             analysisId={analysisId ?? undefined}
             synthesisId={synthesisId ?? undefined}

--- a/apps/web-pwa/src/components/feed/newsCardAnalysis.test.ts
+++ b/apps/web-pwa/src/components/feed/newsCardAnalysis.test.ts
@@ -68,6 +68,7 @@ function makeAnalysis(overrides: Partial<{
   summary: string;
   biases: string[];
   counterpoints: string[];
+  perspectives: Array<{ frame: string; reframe: string }>;
 }> = {}) {
   return {
     summary: 'A concise factual summary. Another sentence.',
@@ -75,6 +76,7 @@ function makeAnalysis(overrides: Partial<{
     justify_bias_claim: ['justification'],
     biases: ['Bias statement'],
     counterpoints: ['Counterpoint statement'],
+    perspectives: [],
     sentimentScore: 0.1,
     confidence: 0.8,
     ...overrides,
@@ -377,6 +379,66 @@ describe('newsCardAnalysis', () => {
     expect(result.analyses[0]!.justifyBiasClaims).toEqual(['justification']);
   });
 
+  it('prefers explicit perspective rows over legacy bias fallback rows', () => {
+    const rows = newsCardAnalysisInternal.toFrameRows([
+      {
+        source_id: 'source-1',
+        publisher: 'Publisher One',
+        url: 'https://example.com/1',
+        summary: 'Summary.',
+        biases: ['No clear bias detected'],
+        counterpoints: ['N/A'],
+        biasClaimQuotes: ['N/A'],
+        justifyBiasClaims: ['N/A'],
+        perspectives: [
+          {
+            frame: 'Public safety requires faster intervention.',
+            reframe: 'Civil liberties require stricter limits on intervention.',
+          },
+          {
+            frame: 'Institutional accountability depends on transparent enforcement.',
+            reframe: 'Operational flexibility depends on limiting premature disclosure.',
+          },
+        ],
+      },
+    ]);
+
+    expect(rows).toEqual([
+      {
+        frame: 'Public safety requires faster intervention.',
+        reframe: 'Civil liberties require stricter limits on intervention.',
+      },
+      {
+        frame: 'Institutional accountability depends on transparent enforcement.',
+        reframe: 'Operational flexibility depends on limiting premature disclosure.',
+      },
+    ]);
+    expect(rows[0]!.frame).not.toContain('Publisher One');
+    expect(rows[0]!.frame).not.toContain('No clear bias detected');
+  });
+
+  it('falls back to legacy bias rows when explicit perspectives are unavailable', () => {
+    const rows = newsCardAnalysisInternal.toFrameRows([
+      {
+        source_id: 'source-1',
+        publisher: 'Publisher One',
+        url: 'https://example.com/1',
+        summary: 'Summary.',
+        biases: ['Urgency justifies immediate action.'],
+        counterpoints: ['Verification should precede irreversible action.'],
+        biasClaimQuotes: ['quote'],
+        justifyBiasClaims: ['reason'],
+      },
+    ]);
+
+    expect(rows).toEqual([
+      {
+        frame: 'Publisher One: Urgency justifies immediate action.',
+        reframe: 'Verification should precede irreversible action.',
+      },
+    ]);
+  });
+
   it('toSourceAnalysis maps bias_claim_quote and justify_bias_claim', () => {
     const source = makeStoryBundle().sources[0]!;
     const analysis: AnalysisResult = {
@@ -385,6 +447,7 @@ describe('newsCardAnalysis', () => {
       justify_bias_claim: ['just-1'],
       biases: ['B1'],
       counterpoints: ['C1'],
+      perspectives: [{ frame: 'F1', reframe: 'R1' }],
     };
 
     const mapped = newsCardAnalysisInternal.toSourceAnalysis(source, analysis);
@@ -392,6 +455,7 @@ describe('newsCardAnalysis', () => {
     expect(mapped.justifyBiasClaims).toEqual(['just-1']);
     expect(mapped.biases).toEqual(['B1']);
     expect(mapped.counterpoints).toEqual(['C1']);
+    expect(mapped.perspectives).toEqual([{ frame: 'F1', reframe: 'R1' }]);
   });
 
   describe('runAnalysisViaRelay model threading', () => {

--- a/apps/web-pwa/src/components/feed/newsCardAnalysis.test.ts
+++ b/apps/web-pwa/src/components/feed/newsCardAnalysis.test.ts
@@ -439,6 +439,33 @@ describe('newsCardAnalysis', () => {
     ]);
   });
 
+  it('does not render legacy placeholder bias rows as frame/reframe UI', () => {
+    const rows = newsCardAnalysisInternal.toFrameRows([
+      {
+        source_id: 'source-1',
+        publisher: 'Publisher One',
+        url: 'https://example.com/1',
+        summary: 'Summary.',
+        biases: ['No clear bias detected'],
+        counterpoints: ['N/A'],
+        biasClaimQuotes: ['N/A'],
+        justifyBiasClaims: ['N/A'],
+      },
+      {
+        source_id: 'source-2',
+        publisher: 'Publisher Two',
+        url: 'https://example.com/2',
+        summary: 'Summary.',
+        biases: ['  '],
+        counterpoints: ['not applicable'],
+        biasClaimQuotes: [],
+        justifyBiasClaims: [],
+      },
+    ]);
+
+    expect(rows).toEqual([]);
+  });
+
   it('toSourceAnalysis maps bias_claim_quote and justify_bias_claim', () => {
     const source = makeStoryBundle().sources[0]!;
     const analysis: AnalysisResult = {

--- a/apps/web-pwa/src/components/feed/newsCardAnalysis.ts
+++ b/apps/web-pwa/src/components/feed/newsCardAnalysis.ts
@@ -18,6 +18,7 @@ export interface NewsCardSourceAnalysis {
   readonly counterpoints: ReadonlyArray<string>;
   readonly biasClaimQuotes: ReadonlyArray<string>;
   readonly justifyBiasClaims: ReadonlyArray<string>;
+  readonly perspectives?: ReadonlyArray<{ frame: string; reframe: string }>;
   readonly provider_id?: string;
   readonly model_id?: string;
 }
@@ -302,6 +303,22 @@ function normalizeOptionalString(value: unknown): string | undefined {
   return n.length > 0 ? n : undefined;
 }
 
+function normalizePerspectiveRows(
+  rows: ReadonlyArray<{ frame: string; reframe: string }> | undefined,
+): ReadonlyArray<{ frame: string; reframe: string }> {
+  if (!rows) return [];
+  const normalized: Array<{ frame: string; reframe: string }> = [];
+  for (const row of rows) {
+    const frame = row.frame.trim();
+    const reframe = row.reframe.trim();
+    if (!frame || !reframe) continue;
+    if (/^(?:n\/a|no clear bias detected)$/i.test(frame)) continue;
+    if (/^(?:n\/a|no clear bias detected)$/i.test(reframe)) continue;
+    normalized.push({ frame, reframe });
+  }
+  return normalized;
+}
+
 function toSourceAnalysis(
   source: StoryBundle['sources'][number],
   analysis: AnalysisResult,
@@ -315,6 +332,7 @@ function toSourceAnalysis(
     counterpoints: analysis.counterpoints,
     biasClaimQuotes: analysis.bias_claim_quote,
     justifyBiasClaims: analysis.justify_bias_claim,
+    perspectives: normalizePerspectiveRows(analysis.perspectives),
     provider_id:
       normalizeOptionalString(analysis.provider_id) ??
       normalizeOptionalString(analysis.provider?.provider_id),
@@ -329,6 +347,12 @@ function toFrameRows(
 ): ReadonlyArray<{ frame: string; reframe: string }> {
   const rows: Array<{ frame: string; reframe: string }> = [];
   for (const sa of analyses) {
+    const perspectiveRows = normalizePerspectiveRows(sa.perspectives);
+    if (perspectiveRows.length > 0) {
+      rows.push(...perspectiveRows);
+      continue;
+    }
+
     const count = Math.max(sa.biases.length, sa.counterpoints.length);
     for (let i = 0; i < count; i++) {
       const bias = sa.biases[i]?.trim() || 'No clear bias detected';

--- a/apps/web-pwa/src/components/feed/newsCardAnalysis.ts
+++ b/apps/web-pwa/src/components/feed/newsCardAnalysis.ts
@@ -1,7 +1,7 @@
 import type { StoryBundle } from '@vh/data-model';
 import { createRemoteEngine } from '../../../../../packages/ai-engine/src/engines';
 import { createAnalysisPipeline, type PipelineResult } from '../../../../../packages/ai-engine/src/pipeline';
-import type { AnalysisResult } from '../../../../../packages/ai-engine/src/schema';
+import { isPlaceholderPerspectiveText, type AnalysisResult } from '../../../../../packages/ai-engine/src/schema';
 import { getDevModelOverride } from '../dev/DevModelPicker';
 
 const MAX_SOURCE_ANALYSES = 3;
@@ -312,8 +312,8 @@ function normalizePerspectiveRows(
     const frame = row.frame.trim();
     const reframe = row.reframe.trim();
     if (!frame || !reframe) continue;
-    if (/^(?:n\/a|no clear bias detected)$/i.test(frame)) continue;
-    if (/^(?:n\/a|no clear bias detected)$/i.test(reframe)) continue;
+    if (isPlaceholderPerspectiveText(frame)) continue;
+    if (isPlaceholderPerspectiveText(reframe)) continue;
     normalized.push({ frame, reframe });
   }
   return normalized;
@@ -357,6 +357,9 @@ function toFrameRows(
     for (let i = 0; i < count; i++) {
       const bias = sa.biases[i]?.trim() || 'No clear bias detected';
       const cp = sa.counterpoints[i]?.trim() || 'N/A';
+      if (isPlaceholderPerspectiveText(bias) || isPlaceholderPerspectiveText(cp)) {
+        continue;
+      }
       rows.push({ frame: `${sa.publisher}: ${bias}`, reframe: cp });
     }
   }

--- a/apps/web-pwa/src/server/analysisRelay.budgetAndErrors.test.ts
+++ b/apps/web-pwa/src/server/analysisRelay.budgetAndErrors.test.ts
@@ -33,6 +33,7 @@ function validAnalysisContent(summary = 'Summary text'): string {
       justify_bias_claim: ['reason'],
       biases: ['bias'],
       counterpoints: ['counter'],
+      perspectives: [{ frame: 'Public safety requires faster action.', reframe: 'Civil liberties require stricter limits.' }],
     },
   });
 }
@@ -176,7 +177,7 @@ describe('analysisRelay budget + error paths', () => {
 
   it('handles parse failures that throw non-Error values', async () => {
     const parseSpy = vi
-      .spyOn(schemaModule, 'parseAnalysisResponse')
+      .spyOn(schemaModule, 'parseGeneratedAnalysisResponse')
       .mockImplementation(() => {
         throw 'non-error-parse';
       });

--- a/apps/web-pwa/src/server/analysisRelay.test.ts
+++ b/apps/web-pwa/src/server/analysisRelay.test.ts
@@ -26,6 +26,7 @@ function validAnalysisContent(summary = 'Summary text'): string {
       justify_bias_claim: ['reason'],
       biases: ['bias'],
       counterpoints: ['counter'],
+      perspectives: [{ frame: 'Public safety requires faster action.', reframe: 'Civil liberties require stricter limits.' }],
     },
   });
 }
@@ -376,6 +377,65 @@ describe('analysisRelay config + success paths', () => {
     expect(body.messages[1].role).toBe('user');
     expect(body.messages[1].content).toContain('--- ARTICLE START ---');
     expect(body).not.toHaveProperty('prompt');
+  });
+
+  it('rejects article analysis output that omits generated perspectives', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      okResponse({
+        choices: [{
+          message: {
+            content: JSON.stringify({
+              final_refined: {
+                summary: 'Article summary',
+                bias_claim_quote: ['quote'],
+                justify_bias_claim: ['reason'],
+                biases: ['No clear bias detected'],
+                counterpoints: ['N/A'],
+              },
+            }),
+          },
+        }],
+      }),
+    );
+
+    const result = await relayAnalysis(
+      { articleText: 'Topic ID: topic-derived\nBody paragraph' },
+      { env: BASE_ENV, fetchImpl: fetchMock },
+    );
+
+    expect(result.status).toBe(502);
+    expect(result.payload).toMatchObject({
+      error: 'Relay could not parse analysis output',
+      details: 'SCHEMA_VALIDATION_ERROR',
+    });
+  });
+
+  it('rejects article analysis output with placeholder frame/reframe rows', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      okResponse({
+        content: JSON.stringify({
+          final_refined: {
+            summary: 'Article summary',
+            bias_claim_quote: ['quote'],
+            justify_bias_claim: ['reason'],
+            biases: ['No clear bias detected'],
+            counterpoints: ['N/A'],
+            perspectives: [{ frame: 'No clear bias detected', reframe: 'N/A' }],
+          },
+        }),
+      }),
+    );
+
+    const result = await relayAnalysis(
+      { articleText: 'Topic ID: topic-derived\nBody paragraph' },
+      { env: BASE_ENV, fetchImpl: fetchMock },
+    );
+
+    expect(result.status).toBe(502);
+    expect(result.payload).toMatchObject({
+      error: 'Relay could not parse analysis output',
+      details: 'SCHEMA_VALIDATION_ERROR',
+    });
   });
 
   it('uses explicit topicId for article requests when provided', async () => {

--- a/apps/web-pwa/src/server/analysisRelay.ts
+++ b/apps/web-pwa/src/server/analysisRelay.ts
@@ -1,5 +1,5 @@
 import { buildRemoteRequest } from '../../../../packages/ai-engine/src/modelConfig';
-import { parseAnalysisResponse, type AnalysisResult } from '../../../../packages/ai-engine/src/schema';
+import { parseGeneratedAnalysisResponse, type AnalysisResult } from '../../../../packages/ai-engine/src/schema';
 import { buildLegacyVhcArticlePrompt } from './legacyPrompt';
 
 const DEFAULT_ANALYSES_LIMIT = 25;
@@ -418,7 +418,7 @@ export async function relayAnalysis(
         let analysis: AnalysisResult | undefined;
         if (articleRequest) {
           try {
-            analysis = { ...parseAnalysisResponse(content), provider };
+            analysis = { ...parseGeneratedAnalysisResponse(content), provider };
           } catch (error) {
             return {
               status: 502,

--- a/docs/foundational/STATUS.md
+++ b/docs/foundational/STATUS.md
@@ -152,6 +152,9 @@ Current truth for the news bundler and feed hardening lane:
   - sorted `source_article_ids`
   - source count and cluster window
   - latest-analysis reuse is exact-revision only, so regenerated bundles do not overwrite or silently reuse stale analysis records.
+- Generated article and bundle analyses must emit non-empty frame/reframe rows:
+  - bias arrays may use the explicit `No clear bias detected` / `N/A` fallback when source bias is sparse;
+  - frame/reframe rows must instead become terse debate-style issue-side claims and counterclaims grounded in public/political/stakeholder disagreements around the summarized issue.
 - The fixture-backed daemon-first release gates are green on `main` after the latest semantic-fixture expansion:
   - `pnpm --filter @vh/e2e test:live:daemon-feed:integrity-gate`
   - `pnpm --filter @vh/e2e test:live:daemon-feed:semantic-gate`

--- a/docs/specs/spec-news-aggregator-v0.md
+++ b/docs/specs/spec-news-aggregator-v0.md
@@ -175,6 +175,12 @@ Analysis persistence identity:
 - `source_article_ids` are stable `source_id:url_hash` identifiers sorted across the accepted source set;
 - latest-analysis pointers must not be reused across bundle revision/source-set drift; old artifacts remain readable by their exact analysis key, and regenerated bundles must create a fresh analysis rather than overwriting or silently reusing stale analysis.
 
+Analysis frame/reframe output contract:
+- generated article and bundle analyses must emit non-empty frame/reframe rows for every eligible analysis artifact;
+- bias arrays may use the explicit `No clear bias detected` / `N/A` fallback when the article is straight reporting, but frame/reframe rows must not use those placeholders;
+- when explicit outlet bias is sparse, frame/reframe rows must be inferred as terse debate-style issue-side claims and counterclaims grounded in the story subject: public opinion splits, political divides, stakeholder tradeoffs, legal/institutional tensions, cost/risk disputes, rights/safety debates, or accountability arguments;
+- frame/reframe rows are issue-side claims, not publication-by-publication summaries, and should not prefix publisher names unless the publisher itself is materially part of the dispute.
+
 ## 5. Mesh/storage paths
 
 - `vh/news/stories/<storyId>`

--- a/packages/ai-engine/src/__tests__/schema.test.ts
+++ b/packages/ai-engine/src/__tests__/schema.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import {
   AnalysisParseError,
+  GeneratedAnalysisResultSchema,
   AnalysisResultSchema,
   parseAnalysisResponse,
+  parseGeneratedAnalysisResponse,
 } from '../schema';
 
 const BASE_ANALYSIS = {
@@ -12,6 +14,10 @@ const BASE_ANALYSIS = {
   biases: ['bias'],
   counterpoints: ['counterpoint'],
 };
+
+const GENERATED_PERSPECTIVES = [
+  { frame: 'Public safety requires faster action.', reframe: 'Civil liberties require stricter limits.' },
+];
 
 describe('AnalysisResultSchema', () => {
   it('allows missing sentimentScore', () => {
@@ -70,6 +76,33 @@ describe('AnalysisResultSchema', () => {
       model_id: 'gpt-5.2',
       kind: 'remote',
     });
+  });
+
+  it('keeps stored legacy payloads backward-compatible while strict generated parsing requires perspectives', () => {
+    expect(AnalysisResultSchema.parse(BASE_ANALYSIS).perspectives).toBeUndefined();
+
+    expect(() => GeneratedAnalysisResultSchema.parse(BASE_ANALYSIS)).toThrow();
+    expect(() => parseGeneratedAnalysisResponse(JSON.stringify(BASE_ANALYSIS))).toThrow(
+      AnalysisParseError.SCHEMA_VALIDATION_ERROR,
+    );
+
+    const parsed = parseGeneratedAnalysisResponse(JSON.stringify({
+      ...BASE_ANALYSIS,
+      perspectives: GENERATED_PERSPECTIVES,
+    }));
+
+    expect(parsed.perspectives).toEqual(GENERATED_PERSPECTIVES);
+  });
+
+  it('rejects placeholder generated frame/reframe rows', () => {
+    const placeholderPayload = {
+      ...BASE_ANALYSIS,
+      perspectives: [{ frame: 'No clear bias detected', reframe: 'N/A' }],
+    };
+
+    expect(() => parseGeneratedAnalysisResponse(JSON.stringify(placeholderPayload))).toThrow(
+      AnalysisParseError.SCHEMA_VALIDATION_ERROR,
+    );
   });
 
   it('throws parse errors for invalid payloads', () => {

--- a/packages/ai-engine/src/bundlePrompts.test.ts
+++ b/packages/ai-engine/src/bundlePrompts.test.ts
@@ -112,6 +112,14 @@ describe('bundlePrompts', () => {
       const prompt = generateBundleSynthesisPrompt(sampleBundle);
       expect(prompt).toContain('GOALS AND GUIDELINES');
     });
+
+    it('requires issue-side frame rows even when explicit source disagreement is sparse', () => {
+      const prompt = generateBundleSynthesisPrompt(sampleBundle);
+      expect(prompt).toContain('Never return an empty frames array');
+      expect(prompt).toContain('standalone, affirmative, debate-style claim');
+      expect(prompt).toContain('If explicit outlet bias or source disagreement is sparse');
+      expect(prompt).toContain('Never use "N/A" or "No clear bias detected"');
+    });
   });
 
   describe('buildBundlePrompt', () => {

--- a/packages/ai-engine/src/bundlePrompts.ts
+++ b/packages/ai-engine/src/bundlePrompts.ts
@@ -42,8 +42,12 @@ Return exactly one JSON object with these keys and no extraneous text:
 
 Rules:
 - "summary" must be 2-4 sentences, neutral, factual, covering what all sources agree on.
-- "frames" must have 2-4 entries. Each frame states a perspective found in the coverage; each reframe provides a direct counter-perspective.
-- Use terse, debate-style language for frames and reframes.
+- "frames" must have 2-4 entries. Never return an empty frames array.
+- Each frame must be a standalone, affirmative, debate-style claim from one public, political, institutional, or stakeholder side of the story.
+- Each reframe must be a direct, standalone, affirmative counterclaim that challenges the paired frame.
+- If explicit outlet bias or source disagreement is sparse, infer common sides around the issue: political divides, public opinion splits, stakeholder tradeoffs, rights/safety tensions, cost/risk disputes, or accountability arguments.
+- Frames are issue-side claims, not publication summaries. Do not prefix frames with publisher names unless the publisher itself is materially part of the dispute.
+- Never use "N/A" or "No clear bias detected" as a frame or reframe.
 - Do NOT insert opinions or emotive language in the summary.
 - Explicitly note where sources disagree in the frames section.
 `.trim();

--- a/packages/ai-engine/src/engines.ts
+++ b/packages/ai-engine/src/engines.ts
@@ -70,6 +70,7 @@ export function createMockEngine(): JsonCompletionEngine {
           justify_bias_claim: ['justification'],
           biases: ['bias'],
           counterpoints: ['counter'],
+          perspectives: [{ frame: 'Mock frame', reframe: 'Mock reframe' }],
           confidence: 0.9
         }
       });

--- a/packages/ai-engine/src/pipeline.test.ts
+++ b/packages/ai-engine/src/pipeline.test.ts
@@ -23,6 +23,7 @@ function validWrappedResult(summary = 'Source summary') {
       justify_bias_claim: ['justification'],
       biases: ['bias'],
       counterpoints: ['counterpoint'],
+      perspectives: [{ frame: 'Frame claim', reframe: 'Reframe claim' }],
       confidence: 0.9
     }
   });
@@ -94,6 +95,28 @@ describe('createAnalysisPipeline', () => {
             justify_bias_claim: ['justification'],
             biases: ['bias'],
             counterpoints: ['counterpoint']
+          }
+        })
+      )
+    };
+
+    const pipeline = createAnalysisPipeline(engine);
+
+    await expect(pipeline('article text')).rejects.toThrow(AnalysisParseError.SCHEMA_VALIDATION_ERROR);
+  });
+
+  it('throws schema validation error when generated output omits perspectives', async () => {
+    const engine: JsonCompletionEngine = {
+      name: 'missing-perspectives-engine',
+      kind: 'local',
+      generate: vi.fn().mockResolvedValue(
+        JSON.stringify({
+          final_refined: {
+            summary: 'Summary',
+            bias_claim_quote: ['quote'],
+            justify_bias_claim: ['justification'],
+            biases: ['No clear bias detected'],
+            counterpoints: ['N/A']
           }
         })
       )

--- a/packages/ai-engine/src/pipeline.ts
+++ b/packages/ai-engine/src/pipeline.ts
@@ -1,5 +1,5 @@
 import { buildPrompt } from './prompts';
-import { parseAnalysisResponse, type AnalysisResult } from './schema';
+import { parseGeneratedAnalysisResponse, type AnalysisResult } from './schema';
 import { validateAnalysisAgainstSource } from './validation';
 import {
   createDefaultEngine,
@@ -77,7 +77,7 @@ export function createAnalysisPipeline(
   return async (articleText: string): Promise<PipelineResult> => {
     const prompt = buildPrompt(articleText);
     const { text, engine } = await runtime.router.generate(prompt);
-    const analysis = parseAnalysisResponse(text);
+    const analysis = parseGeneratedAnalysisResponse(text);
     const warnings = validateAnalysisAgainstSource(articleText, analysis).map((warning) => warning.message);
     const successfulEngine = runtime.candidates.find((candidate) => candidate.name === engine);
     /* v8 ignore next 3 -- defensive guard: router always returns a candidate name */

--- a/packages/ai-engine/src/prompts.test.ts
+++ b/packages/ai-engine/src/prompts.test.ts
@@ -17,6 +17,10 @@ describe('prompts', () => {
     const prompt = generateAnalysisPrompt({ articleText: 'Hello world' });
     expect(prompt).toContain('GOALS AND GUIDELINES');
     expect(prompt).toContain('Hello world');
+    expect(prompt).toContain('"perspectives"');
+    expect(prompt).toContain('Always Produce Debate Rows');
+    expect(prompt).toContain('Never leave perspectives empty');
+    expect(prompt).toContain('commonly held disagreements around the issue');
     expect(prompt).not.toContain('SINGLE PREV PASS');
   });
 
@@ -49,6 +53,8 @@ describe('prompts', () => {
     expect(prompt).toContain('Frame and Reframe');
     expect(prompt).toContain('"frame"');
     expect(prompt).toContain('"reframe"');
+    expect(prompt).toContain('Produce 2-4 frame/reframe pairs');
+    expect(prompt).toContain('Never return N/A');
     expect(prompt).toContain(text);
   });
 });

--- a/packages/ai-engine/src/prompts.ts
+++ b/packages/ai-engine/src/prompts.ts
@@ -42,7 +42,22 @@ GOALS AND GUIDELINES FOR BIAS DETECTION & COUNTERPOINT GENERATION:
     - These may also be used to identify biases/counterpoints.
 6. **No Redundancy**: Ensure each bias and its corresponding counterpoint address unique aspects of the article's slant.
     - Focus on different elements of the text (e.g., language, sourcing, framing) to avoid overlap in the issues or evidence presented.
-7. **Bias Absence**: *THIS IS IMPORTANT*: If no clear bias is detected, you must include a single entry in the biases list stating "No clear bias detected" with a corresponding counterpoint of "N/A".
+7. **Bias Absence**: *THIS IS IMPORTANT*: If no clear article-level bias is detected, you may include a single entry in the biases list stating "No clear bias detected" with a corresponding counterpoint of "N/A"; however, you must still produce frame/reframe perspectives under the perspective requirements below.
+
+GOALS AND GUIDELINES FOR FRAME/REFRAME PERSPECTIVES:
+1. **Always Produce Debate Rows**:
+    - You must produce 2-4 frame/reframe perspective pairs for the issue or event being summarized.
+    - Never leave perspectives empty. Never use "N/A" or "No clear bias detected" as a frame or reframe.
+2. **Frames Are Issue Sides, Not Publication Summaries**:
+    - A frame is the strongest concise claim a reasonable advocate for one public, political, institutional, or stakeholder interpretation would make.
+    - A reframe is the strongest concise counterclaim that directly challenges the frame.
+    - Do not write frames as outlet-by-outlet summaries. Do not prefix frames with publisher names unless the publisher itself is materially part of the dispute.
+3. **When Bias Is Sparse, Infer Common Public Disagreements**:
+    - If the article is straight reporting and no clear bias can be extracted, generate frames from commonly held disagreements around the issue: political divides, stakeholder tradeoffs, public opinion splits, legal/institutional tensions, cost/risk disputes, rights/safety debates, or governance accountability arguments.
+    - Keep these frames anchored to the article's subject matter. Do not invent facts, actors, dates, or outcomes not present in the article.
+4. **Claim Styling Is Mandatory**:
+    - Each frame and reframe must be a standalone, affirmative, debate-style claim.
+    - Avoid labels, questions, hedges, process notes, and vague formulations such as "Some people think..." or "There are concerns about...".
 
 GOALS AND GUIDELINES FOR VOICE AND STYLE:
 1. **Formulate Biases in the Voice of an Authoritative Advocate for the Article's Slant**:
@@ -91,6 +106,17 @@ export const PRIMARY_OUTPUT_FORMAT_REQ = `
     "[A counterpoint challenging the first bias, written as a direct, debate-style counterclaim that challenges the corresponding bias (see examples from GOALS AND GUIDELINES FOR VOICE AND STYLE)]",
     "[A counterpoint challenging the second bias, written as a direct, debate-style counterclaim that challenges the corresponding bias (see examples from GOALS AND GUIDELINES FOR VOICE AND STYLE)]",
     "[A counterpoint challenging the third bias, written as a direct, debate-style counterclaim that challenges the corresponding bias (see examples from GOALS AND GUIDELINES FOR VOICE AND STYLE)]",
+    ...
+  ],
+  "perspectives": [
+    {
+      "frame": "[A standalone, affirmative, debate-style claim representing one public/political/stakeholder side of the article's issue]",
+      "reframe": "[A direct, standalone, affirmative counterclaim that challenges the frame]"
+    },
+    {
+      "frame": "[A second distinct issue-side claim; never N/A, never 'No clear bias detected']",
+      "reframe": "[A second direct counterclaim]"
+    },
     ...
   ]
 }
@@ -168,7 +194,8 @@ Step 3:
     "biases": [...],
     "bias_claim_quote": [...],
     "justify_bias_claim": [...],
-    "counterpoints": [...]
+    "counterpoints": [...],
+    "perspectives": [{"frame": "...", "reframe": "..."}]
 
 Step 4:
   After **carefully considering and integrating** recommendations, produce a final updated JSON in this format:
@@ -236,7 +263,10 @@ export function generateFrameReframePrompt(articleText: string): string {
 
   return [
     'You are generating a balanced analysis with two opposing columns: Frame and Reframe.',
-    'Use terse, debate-style claims for each perspective.',
+    'Use terse, standalone, affirmative debate-style claims for each perspective.',
+    'Produce 2-4 frame/reframe pairs even when the article is straight reporting and no explicit bias is detectable.',
+    'If bias is sparse, use commonly held public disagreements around the issue: political divides, stakeholder tradeoffs, rights/safety tensions, cost/risk disputes, or accountability arguments.',
+    'Never return N/A or "No clear bias detected" as a frame or reframe.',
     'Return JSON only in the format described below.',
     format,
     '--- ARTICLE START ---',

--- a/packages/ai-engine/src/schema.ts
+++ b/packages/ai-engine/src/schema.ts
@@ -1,5 +1,11 @@
 import { z } from 'zod';
 
+const AnalysisPerspectiveSchema = z.object({
+  id: z.string().min(1).optional(),
+  frame: z.string().min(1),
+  reframe: z.string().min(1),
+});
+
 export const AnalysisProviderSchema = z.object({
   provider_id: z.string().min(1),
   model_id: z.string().min(1),
@@ -14,19 +20,41 @@ export const AnalysisResultSchema = z.object({
   counterpoints: z.array(z.string()),
   sentimentScore: z.number().min(-1).max(1).optional(),
   confidence: z.number().optional(),
-  perspectives: z.array(
-    z.object({
-      id: z.string().min(1).optional(),
-      frame: z.string().min(1),
-      reframe: z.string().min(1),
-    }),
-  ).optional(),
+  perspectives: z.array(AnalysisPerspectiveSchema).optional(),
   provider_id: z.string().min(1).optional(),
   model_id: z.string().min(1).optional(),
   provider: AnalysisProviderSchema.optional(),
 });
 
+export function isPlaceholderPerspectiveText(value: string): boolean {
+  const normalized = value.trim().toLowerCase().replace(/\s+/g, ' ').replace(/[.!]+$/g, '');
+  return normalized === 'n/a'
+    || normalized === 'na'
+    || normalized === 'n.a'
+    || normalized === 'not applicable'
+    || normalized === 'no clear bias detected';
+}
+
+const GeneratedPerspectiveTextSchema = z
+  .string()
+  .refine((value) => value.trim().length > 0, {
+    message: 'Generated perspective text must be non-empty after trimming',
+  })
+  .refine((value) => !isPlaceholderPerspectiveText(value), {
+    message: 'Generated perspective text cannot be a placeholder',
+  });
+
+const GeneratedAnalysisPerspectiveSchema = AnalysisPerspectiveSchema.extend({
+  frame: GeneratedPerspectiveTextSchema,
+  reframe: GeneratedPerspectiveTextSchema,
+});
+
+export const GeneratedAnalysisResultSchema = AnalysisResultSchema.extend({
+  perspectives: z.array(GeneratedAnalysisPerspectiveSchema).min(1),
+});
+
 export type AnalysisResult = z.infer<typeof AnalysisResultSchema>;
+export type GeneratedAnalysisResult = z.infer<typeof GeneratedAnalysisResultSchema>;
 
 export enum AnalysisParseError {
   NO_JSON_OBJECT_FOUND = 'NO_JSON_OBJECT_FOUND',
@@ -34,7 +62,10 @@ export enum AnalysisParseError {
   SCHEMA_VALIDATION_ERROR = 'SCHEMA_VALIDATION_ERROR',
 }
 
-export function parseAnalysisResponse(raw: string): AnalysisResult {
+function parseAnalysisResponseWithSchema<T>(
+  raw: string,
+  schema: z.ZodType<T>,
+): T {
   const jsonMatch = raw.match(/\{[\s\S]*\}/);
   if (!jsonMatch) {
     throw new Error(AnalysisParseError.NO_JSON_OBJECT_FOUND);
@@ -43,11 +74,19 @@ export function parseAnalysisResponse(raw: string): AnalysisResult {
   try {
     const parsed = JSON.parse(jsonMatch[0]);
     const payload = parsed.final_refined || parsed;
-    return AnalysisResultSchema.parse(payload);
+    return schema.parse(payload);
   } catch (err) {
     if (err instanceof z.ZodError) {
       throw new Error(AnalysisParseError.SCHEMA_VALIDATION_ERROR);
     }
     throw new Error(AnalysisParseError.JSON_PARSE_ERROR);
   }
+}
+
+export function parseAnalysisResponse(raw: string): AnalysisResult {
+  return parseAnalysisResponseWithSchema(raw, AnalysisResultSchema);
+}
+
+export function parseGeneratedAnalysisResponse(raw: string): GeneratedAnalysisResult {
+  return parseAnalysisResponseWithSchema(raw, GeneratedAnalysisResultSchema);
 }

--- a/services/news-aggregator/src/analysisRelay.test.ts
+++ b/services/news-aggregator/src/analysisRelay.test.ts
@@ -33,6 +33,7 @@ const VALID_ANALYSIS = {
   justify_bias_claim: ['justification'],
   biases: ['bias'],
   counterpoints: ['counterpoint'],
+  perspectives: [{ frame: 'Public safety requires faster action.', reframe: 'Civil liberties require stricter limits.' }],
 };
 
 function restoreEnv(name: 'OPENAI_API_KEY' | 'ANALYSIS_RELAY_MODEL' | 'VITE_ANALYSIS_MODEL', value?: string) {
@@ -315,10 +316,13 @@ describe('handleAnalyze', () => {
     await handleAnalyze(req as any, res as any);
 
     expect(res.statusCode).toBe(502);
-    expect(res.payload).toEqual({ error: 'No JSON found in OpenAI response' });
+    expect(res.payload).toEqual({
+      error: 'Analysis output failed strict generated schema validation',
+      detail: 'NO_JSON_OBJECT_FOUND',
+    });
   });
 
-  it('returns 500 when schema validation fails', async () => {
+  it('returns 502 when strict generated schema validation fails', async () => {
     process.env.OPENAI_API_KEY = 'test-key';
 
     vi.stubGlobal(
@@ -344,9 +348,86 @@ describe('handleAnalyze', () => {
 
     await handleAnalyze(req as any, res as any);
 
-    expect(res.statusCode).toBe(500);
+    expect(res.statusCode).toBe(502);
     expect(res.payload).toMatchObject({
-      error: expect.stringContaining('Required'),
+      error: 'Analysis output failed strict generated schema validation',
+      detail: 'SCHEMA_VALIDATION_ERROR',
+    });
+  });
+
+  it('rejects generated analysis that omits frame/reframe perspectives', async () => {
+    process.env.OPENAI_API_KEY = 'test-key';
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            choices: [
+              {
+                message: {
+                  content: JSON.stringify({
+                    final_refined: {
+                      ...VALID_ANALYSIS,
+                      perspectives: undefined,
+                    },
+                  }),
+                },
+              },
+            ],
+          }),
+      }),
+    );
+
+    const req = makeRequest({ articleText: 'hello world' });
+    const res = makeResponse();
+
+    await handleAnalyze(req as any, res as any);
+
+    expect(res.statusCode).toBe(502);
+    expect(res.payload).toMatchObject({
+      error: 'Analysis output failed strict generated schema validation',
+      detail: 'SCHEMA_VALIDATION_ERROR',
+    });
+  });
+
+  it('rejects generated analysis with placeholder frame/reframe rows', async () => {
+    process.env.OPENAI_API_KEY = 'test-key';
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            choices: [
+              {
+                message: {
+                  content: JSON.stringify({
+                    final_refined: {
+                      ...VALID_ANALYSIS,
+                      perspectives: [{ frame: 'No clear bias detected', reframe: 'N/A' }],
+                    },
+                  }),
+                },
+              },
+            ],
+          }),
+      }),
+    );
+
+    const req = makeRequest({ articleText: 'hello world' });
+    const res = makeResponse();
+
+    await handleAnalyze(req as any, res as any);
+
+    expect(res.statusCode).toBe(502);
+    expect(res.payload).toMatchObject({
+      error: 'Analysis output failed strict generated schema validation',
+      detail: 'SCHEMA_VALIDATION_ERROR',
     });
   });
 

--- a/services/news-aggregator/src/analysisRelay.ts
+++ b/services/news-aggregator/src/analysisRelay.ts
@@ -1,5 +1,5 @@
 import type { Request, Response } from 'express';
-import { AnalysisResultSchema } from '@vh/ai-engine';
+import { parseGeneratedAnalysisResponse, type GeneratedAnalysisResult } from '@vh/ai-engine';
 import { GOALS_AND_GUIDELINES, PRIMARY_OUTPUT_FORMAT_REQ } from '@vh/ai-engine';
 
 export const MAX_TOKENS = 3000;
@@ -43,7 +43,7 @@ export interface AnalyzeRequest {
 }
 
 export interface AnalyzeResponse {
-  analysis: ReturnType<typeof AnalysisResultSchema.parse>;
+  analysis: GeneratedAnalysisResult;
   provenance: {
     provider_id: string;
     model: string;
@@ -125,16 +125,16 @@ export async function handleAnalyze(req: Request, res: Response): Promise<void> 
       return;
     }
 
-    // Parse the JSON response
-    const jsonMatch = content.match(/\{[\s\S]*\}/);
-    if (!jsonMatch) {
-      res.status(502).json({ error: 'No JSON found in OpenAI response' });
+    let analysis: GeneratedAnalysisResult;
+    try {
+      analysis = parseGeneratedAnalysisResponse(content);
+    } catch (error) {
+      res.status(502).json({
+        error: 'Analysis output failed strict generated schema validation',
+        detail: error instanceof Error ? error.message : 'Unknown parse failure',
+      });
       return;
     }
-
-    const parsed = JSON.parse(jsonMatch[0]);
-    const payload = parsed.final_refined || parsed;
-    const analysis = AnalysisResultSchema.parse(payload);
 
     const result: AnalyzeResponse = {
       analysis: { ...analysis, provider_id: 'openai', model_id: usedModel },

--- a/services/news-aggregator/src/prompts.test.ts
+++ b/services/news-aggregator/src/prompts.test.ts
@@ -49,6 +49,10 @@ describe('generateArticleAnalysisPrompt', () => {
     expect(prompt).toContain('--- ARTICLE START ---');
     expect(prompt).toContain('Body text here.');
     expect(prompt).toContain('--- ARTICLE END ---');
+    expect(prompt).toContain('strict debate-claim styling');
+    expect(prompt).toContain('Never leave perspectives empty');
+    expect(prompt).toContain('common to the issue');
+    expect(prompt).toContain('Never return "N/A" or "No clear bias detected" as a frame or reframe');
   });
 });
 
@@ -89,6 +93,12 @@ describe('parseArticleAnalysisResponse', () => {
       PromptParseError,
     );
   });
+
+  it('throws PromptParseError when article perspectives are empty', () => {
+    expect(() => parseArticleAnalysisResponse(JSON.stringify({ ...valid, perspectives: [] }), meta)).toThrow(
+      PromptParseError,
+    );
+  });
 });
 
 describe('generateBundleSynthesisPrompt', () => {
@@ -109,6 +119,7 @@ describe('generateBundleSynthesisPrompt', () => {
       articleAnalyses: [{ publisher: 'Publisher A', title: 'Title A', analysis: analysis() }],
     });
     expect(prompt).toContain('single-source-only');
+    expect(prompt).toContain('still generate issue-side frame/reframe rows');
     expect(prompt).toContain('Publisher A');
   });
 
@@ -125,6 +136,9 @@ describe('generateBundleSynthesisPrompt', () => {
     expect(prompt).toContain('Publisher A');
     expect(prompt).toContain('Publisher B');
     expect(prompt).toContain('Eligible sources: 2');
+    expect(prompt).toContain('Frame/reframe rules:');
+    expect(prompt).toContain('never return an empty table');
+    expect(prompt).toContain('If explicit source disagreement is sparse');
   });
 });
 
@@ -179,5 +193,14 @@ describe('parseBundleSynthesisResponse', () => {
 
   it('throws PromptParseError for non-object synthesis payload', () => {
     expect(() => parseBundleSynthesisResponse(JSON.stringify('bad payload'), 2)).toThrow(PromptParseError);
+  });
+
+  it('throws PromptParseError for empty frame/reframe table when sources are eligible', () => {
+    expect(() => parseBundleSynthesisResponse(JSON.stringify({
+      summary: 'combined summary',
+      frame_reframe_table: [],
+      warnings: [],
+      synthesis_ready: true,
+    }), 2)).toThrow(PromptParseError);
   });
 });

--- a/services/news-aggregator/src/prompts.ts
+++ b/services/news-aggregator/src/prompts.ts
@@ -55,14 +55,14 @@ const articlePayloadSchema = z
     biases: z.array(z.string()),
     counterpoints: z.array(z.string()),
     confidence: z.number().min(0).max(1),
-    perspectives: z.array(perspectiveSchema),
+    perspectives: z.array(perspectiveSchema).min(1),
   })
   .strict();
 
 const bundlePayloadSchema = z
   .object({
     summary: z.string(),
-    frame_reframe_table: z.array(perspectiveSchema),
+    frame_reframe_table: z.array(perspectiveSchema).min(1),
     warnings: z.array(z.string()).optional(),
     synthesis_ready: z.boolean().optional(),
     synthesis_unavailable_reason: z.string().optional(),
@@ -108,7 +108,11 @@ export function generateArticleAnalysisPrompt(
     'Instructions:',
     '- Summarize core claims neutrally.',
     '- Identify biases with direct supporting quotes.',
-    '- Provide counterpoints and at least one frame/reframe perspective pair.',
+    '- Bias rows must use strict debate-claim styling: each bias is an affirmative claim stated as if an advocate for the article slant were making it; each counterpoint is a direct affirmative counterclaim.',
+    '- If no clear article-level bias can be extracted, use one bias row of "No clear bias detected" with counterpoint "N/A"; do not use that fallback in perspectives.',
+    '- Provide 2-4 frame/reframe perspective pairs. Never leave perspectives empty.',
+    '- Frames are issue-side claims, not publication summaries: public/political/stakeholder sides, legal or institutional tensions, cost/risk disputes, rights/safety debates, or accountability arguments common to the issue.',
+    '- Each frame and reframe must be a standalone, affirmative, terse debate claim. Never return "N/A" or "No clear bias detected" as a frame or reframe.',
     '',
     '--- ARTICLE START ---',
     articleText,
@@ -164,13 +168,15 @@ export function generateBundleSynthesisPrompt(input: BundleSynthesisInput): stri
         `- title: ${entry.title}`,
         `- summary: ${entry.analysis.summary}`,
         `- biases: ${JSON.stringify(entry.analysis.biases)}`,
+        `- counterpoints: ${JSON.stringify(entry.analysis.counterpoints)}`,
+        `- perspectives: ${JSON.stringify(entry.analysis.perspectives)}`,
       ].join('\n');
     })
     .join('\n\n');
 
   const modeInstruction =
     count === 1
-      ? "Only one source is available. Include warning 'single-source-only'."
+      ? "Only one source is available. Include warning 'single-source-only', but still generate issue-side frame/reframe rows."
       : 'Cross-synthesize agreements, conflicts, and frame/reframe differences across sources.';
 
   return [
@@ -182,6 +188,7 @@ export function generateBundleSynthesisPrompt(input: BundleSynthesisInput): stri
     '',
     sourceList,
     '',
+    'Frame/reframe rules: return at least 2 rows when possible; never return an empty table for eligible sources. If explicit source disagreement is sparse, infer common public/political/stakeholder disagreements around the issue. Use standalone affirmative debate claims, not labels, questions, publication summaries, "N/A", or "No clear bias detected".',
     'Output schema: {"summary":"string","frame_reframe_table":[{"frame":"string","reframe":"string"}],"warnings":["string"],"synthesis_ready":true}',
   ].join('\n');
 }


### PR DESCRIPTION
## Summary
- harden article and bundle analysis prompts so eligible analyses produce non-empty frame/reframe perspectives
- keep strict debate-style claim/counterclaim requirements and add fallback guidance for straight-reporting articles with sparse explicit bias
- map explicit analysis perspectives into feed frame rows before legacy bias fallback rows
- document the non-empty frame/reframe contract in foundational/spec docs

## Validation
- pnpm exec vitest run packages/ai-engine/src/prompts.test.ts packages/ai-engine/src/bundlePrompts.test.ts services/news-aggregator/src/prompts.test.ts apps/web-pwa/src/components/feed/newsCardAnalysis.test.ts --config vitest.config.ts
- pnpm --filter @vh/news-aggregator test
- pnpm --filter @vh/ai-engine typecheck
- pnpm --filter @vh/web-pwa typecheck
- pnpm --filter @vh/news-aggregator typecheck
- pnpm docs:check
- pnpm exec vitest run apps/web-pwa/src/server/analysisRelay.test.ts apps/web-pwa/src/server/analysisRelay.budgetAndErrors.test.ts --config vitest.config.ts
- git diff --check
- node tools/scripts/check-diff-coverage.mjs