### PR TITLE
Reject stale placeholder analysis frames

### DIFF
--- a/apps/web-pwa/src/components/feed/newsCardAnalysis.test.ts
+++ b/apps/web-pwa/src/components/feed/newsCardAnalysis.test.ts
@@ -103,6 +103,12 @@ describe('newsCardAnalysis', () => {
             summary: 'Publisher One says rollout should move fast. More context.',
             biases: ['Urgency justifies immediate funding.'],
             counterpoints: ['Fiscal safeguards should gate spending.'],
+            perspectives: [
+              {
+                frame: 'Urgency justifies immediate funding.',
+                reframe: 'Fiscal safeguards should gate spending.',
+              },
+            ],
           }),
         };
       }
@@ -113,6 +119,12 @@ describe('newsCardAnalysis', () => {
             summary: 'Publisher Two focuses on budget risk.',
             biases: ['Costs are spiraling beyond control.'],
             counterpoints: ['Phasing can cap exposure while expanding service.'],
+            perspectives: [
+              {
+                frame: 'Costs are spiraling beyond control.',
+                reframe: 'Phasing can cap exposure while expanding service.',
+              },
+            ],
           }),
         };
       }
@@ -122,6 +134,12 @@ describe('newsCardAnalysis', () => {
           summary: 'Publisher Three emphasizes implementation details.',
           biases: ['Operational complexity will stall delivery.'],
           counterpoints: ['Existing transit authority can absorb phased changes.'],
+          perspectives: [
+            {
+              frame: 'Operational complexity will stall delivery.',
+              reframe: 'Existing transit authority can absorb phased changes.',
+            },
+          ],
         }),
       };
     };
@@ -168,15 +186,15 @@ describe('newsCardAnalysis', () => {
 
     expect(result.frames).toEqual([
       {
-        frame: 'Publisher One: Urgency justifies immediate funding.',
+        frame: 'Urgency justifies immediate funding.',
         reframe: 'Fiscal safeguards should gate spending.',
       },
       {
-        frame: 'Publisher Two: Costs are spiraling beyond control.',
+        frame: 'Costs are spiraling beyond control.',
         reframe: 'Phasing can cap exposure while expanding service.',
       },
       {
-        frame: 'Publisher Three: Operational complexity will stall delivery.',
+        frame: 'Operational complexity will stall delivery.',
         reframe: 'Existing transit authority can absorb phased changes.',
       },
     ]);
@@ -417,7 +435,7 @@ describe('newsCardAnalysis', () => {
     expect(rows[0]!.frame).not.toContain('No clear bias detected');
   });
 
-  it('falls back to legacy bias rows when explicit perspectives are unavailable', () => {
+  it('does not fall back to publication-prefixed bias rows when perspectives are missing', () => {
     const rows = newsCardAnalysisInternal.toFrameRows([
       {
         source_id: 'source-1',
@@ -431,12 +449,7 @@ describe('newsCardAnalysis', () => {
       },
     ]);
 
-    expect(rows).toEqual([
-      {
-        frame: 'Publisher One: Urgency justifies immediate action.',
-        reframe: 'Verification should precede irreversible action.',
-      },
-    ]);
+    expect(rows).toEqual([]);
   });
 
   it('does not render legacy placeholder bias rows as frame/reframe UI', () => {
@@ -464,6 +477,32 @@ describe('newsCardAnalysis', () => {
     ]);
 
     expect(rows).toEqual([]);
+  });
+
+  it('filters individual placeholder perspectives from real rows', () => {
+    const rows = newsCardAnalysisInternal.toFrameRows([
+      {
+        source_id: 'source-1',
+        publisher: 'Publisher One',
+        url: 'https://example.com/1',
+        summary: 'Summary.',
+        biases: [],
+        counterpoints: [],
+        biasClaimQuotes: [],
+        justifyBiasClaims: [],
+        perspectives: [
+          { frame: 'N/A', reframe: 'N/A' },
+          { frame: 'Real frame', reframe: 'Real reframe' },
+        ],
+      },
+    ]);
+
+    expect(rows).toEqual([
+      {
+        frame: 'Real frame',
+        reframe: 'Real reframe',
+      },
+    ]);
   });
 
   it('toSourceAnalysis maps bias_claim_quote and justify_bias_claim', () => {

--- a/apps/web-pwa/src/components/feed/newsCardAnalysis.ts
+++ b/apps/web-pwa/src/components/feed/newsCardAnalysis.ts
@@ -347,21 +347,7 @@ function toFrameRows(
 ): ReadonlyArray<{ frame: string; reframe: string }> {
   const rows: Array<{ frame: string; reframe: string }> = [];
   for (const sa of analyses) {
-    const perspectiveRows = normalizePerspectiveRows(sa.perspectives);
-    if (perspectiveRows.length > 0) {
-      rows.push(...perspectiveRows);
-      continue;
-    }
-
-    const count = Math.max(sa.biases.length, sa.counterpoints.length);
-    for (let i = 0; i < count; i++) {
-      const bias = sa.biases[i]?.trim() || 'No clear bias detected';
-      const cp = sa.counterpoints[i]?.trim() || 'N/A';
-      if (isPlaceholderPerspectiveText(bias) || isPlaceholderPerspectiveText(cp)) {
-        continue;
-      }
-      rows.push({ frame: `${sa.publisher}: ${bias}`, reframe: cp });
-    }
+    rows.push(...normalizePerspectiveRows(sa.perspectives));
   }
   return rows.slice(0, MAX_FRAME_ROWS);
 }

--- a/apps/web-pwa/src/components/feed/useAnalysisMesh.test.ts
+++ b/apps/web-pwa/src/components/feed/useAnalysisMesh.test.ts
@@ -178,7 +178,12 @@ describe('useAnalysisMesh', () => {
       pipeline_version: 'news-card-analysis-v1',
       model_scope: 'model:default',
       summary: 'cbs-politics: Emergency talks began. guardian-us: Mediators convened.',
-      frames: [],
+      frames: [
+        {
+          frame: 'Accountability requires rapid public disclosure.',
+          reframe: 'Negotiation integrity requires limited disclosure.',
+        },
+      ],
       analyses: [
         {
           source_id: 'cbs-politics',
@@ -208,6 +213,39 @@ describe('useAnalysisMesh', () => {
     await expect(readMeshAnalysis(story, 'model:default')).resolves.toMatchObject({
       summary: 'Emergency talks began. Mediators convened.',
     });
+  });
+
+  it('treats direct-hit artifacts with only placeholder frames as cache misses', async () => {
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+    const story = makeStoryBundle();
+
+    mockReadAnalysis.mockResolvedValueOnce({
+      schemaVersion: 'story-analysis-v1',
+      story_id: story.story_id,
+      topic_id: story.topic_id,
+      provenance_hash: story.provenance_hash,
+      analysisKey: 'derived-key',
+      pipeline_version: 'news-card-analysis-v1',
+      model_scope: 'model:default',
+      summary: 'Stale placeholder summary',
+      frames: [{ frame: 'N/A', reframe: 'No clear bias detected' }],
+      analyses: [],
+      provider: { provider_id: 'p', model: 'm' },
+      created_at: '2026-02-18T22:00:00.000Z',
+      bundle_identity: analysisMeshInternal.buildAnalysisBundleIdentity(story),
+    } as any);
+
+    await expect(readMeshAnalysis(story, 'model:default')).resolves.toBeNull();
+
+    expect(mockReadLatestAnalysis).not.toHaveBeenCalled();
+    expect(infoSpy).toHaveBeenCalledWith(
+      '[vh:analysis:mesh]',
+      expect.objectContaining({
+        story_id: story.story_id,
+        read_path: 'stale-placeholder-rejected',
+        source: 'derived-key',
+      }),
+    );
   });
 
   it('falls back to latest pointer when derived-key read misses', async () => {
@@ -377,6 +415,38 @@ describe('useAnalysisMesh', () => {
     );
   }, 20_000);
 
+  it('treats latest-pointer artifacts with only placeholder frames as cache misses', async () => {
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+    const story = makeStoryBundle();
+
+    mockReadAnalysis.mockResolvedValueOnce(null);
+    mockReadLatestAnalysis.mockResolvedValueOnce({
+      schemaVersion: 'story-analysis-v1',
+      story_id: story.story_id,
+      topic_id: story.topic_id,
+      provenance_hash: story.provenance_hash,
+      analysisKey: 'latest-placeholder',
+      pipeline_version: 'news-card-analysis-v1',
+      model_scope: 'model:default',
+      summary: 'Stale placeholder latest summary',
+      frames: [{ frame: '  ', reframe: 'n/a' }],
+      analyses: [],
+      provider: { provider_id: 'p', model: 'm' },
+      created_at: '2026-02-18T22:00:00.000Z',
+    } as any);
+
+    await expect(readMeshAnalysis(story, 'model:default')).resolves.toBeNull();
+
+    expect(infoSpy).toHaveBeenCalledWith(
+      '[vh:analysis:mesh]',
+      expect.objectContaining({
+        story_id: story.story_id,
+        read_path: 'stale-placeholder-rejected',
+        source: 'latest-pointer',
+      }),
+    );
+  });
+
   it('returns null on mesh read errors', async () => {
     const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
@@ -465,7 +535,7 @@ describe('useAnalysisMesh', () => {
     warnSpy.mockRestore();
   });
 
-  it('normalizes sparse synthesis fields while building artifacts', async () => {
+  it('throws when all synthesis frames are placeholders while building artifacts', async () => {
     const story = makeStoryBundle();
     const synthesis = makeSynthesis({
       summary: '   ',
@@ -486,27 +556,33 @@ describe('useAnalysisMesh', () => {
       ],
     });
 
-    const artifact = await analysisMeshInternal.toArtifact(story, synthesis, 'model:default');
+    await expect(
+      analysisMeshInternal.toArtifact(story, synthesis, 'model:default'),
+    ).rejects.toThrow(/empty_frames/);
+  });
 
-    expect(artifact.summary).toBe('Summary unavailable.');
-    expect(artifact.frames).toEqual([
-      { frame: 'Frame unavailable.', reframe: 'Reframe unavailable.' },
-    ]);
-    expect(artifact.analyses[0]).toMatchObject({
-      source_id: story.story_id,
-      publisher: 'Unknown publisher',
-      url: 'https://example.invalid/analysis',
-      summary: 'Summary unavailable.',
-      biases: [],
-      counterpoints: [],
-      biasClaimQuotes: [],
-      justifyBiasClaims: [],
-    });
-    expect(artifact.provider).toEqual({
-      provider_id: 'unknown-provider',
-      model: 'unknown-model',
-      timestamp: artifact.provider.timestamp,
-    });
+  it('skips mesh writes when synthesis frames are all placeholders', async () => {
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+    const story = makeStoryBundle();
+
+    await writeMeshAnalysis(
+      story,
+      makeSynthesis({
+        frames: [{ frame: 'N/A', reframe: 'Frame unavailable.' }],
+      }),
+      'model:default',
+    );
+
+    expect(mockWriteAnalysis).not.toHaveBeenCalled();
+    expect(infoSpy).toHaveBeenCalledWith(
+      '[vh:analysis:mesh-write]',
+      expect.objectContaining({
+        source: 'news-card',
+        event: 'mesh_write_skipped',
+        story_id: story.story_id,
+        reason: 'empty_frames',
+      }),
+    );
   });
 
   it('derives distinct analysis keys when model scope changes', async () => {

--- a/apps/web-pwa/src/components/feed/useAnalysisMesh.ts
+++ b/apps/web-pwa/src/components/feed/useAnalysisMesh.ts
@@ -5,6 +5,7 @@ import {
   type StoryBundle,
 } from '@vh/data-model';
 import { readAnalysis, readLatestAnalysis, writeAnalysis } from '@vh/gun-client';
+import { isPlaceholderPerspectiveText } from '../../../../../packages/ai-engine/src/schema';
 import { resolveClientFromAppStore } from '../../store/clientResolver';
 import { logAnalysisMeshWrite } from '../../utils/analysisTelemetry';
 import {
@@ -83,6 +84,13 @@ const ANALYSIS_PENDING_OWNER =
     ? crypto.randomUUID()
     : `pending-${Math.random().toString(16).slice(2)}`;
 
+class MeshArtifactInvalidError extends Error {
+  constructor(public readonly reason: 'empty_frames') {
+    super(`mesh artifact invalid: ${reason}`);
+    this.name = 'MeshArtifactInvalidError';
+  }
+}
+
 function isCrossModelReuseEnabled(): boolean {
   const viteValue = (import.meta as any).env?.VITE_VH_ANALYSIS_CROSS_MODEL_REUSE;
   const processValue =
@@ -131,6 +139,24 @@ const MESH_DEBUG_ENABLED = isMeshDebugEnabled();
 function ensureNonEmpty(value: string | undefined | null, fallback: string): string {
   const normalized = value?.trim();
   return normalized && normalized.length > 0 ? normalized : fallback;
+}
+
+function filterValidFrameRows(
+  rows: ReadonlyArray<{ frame: string; reframe: string }>,
+): Array<{ frame: string; reframe: string }> {
+  const valid: Array<{ frame: string; reframe: string }> = [];
+  for (const row of rows) {
+    const frame = row.frame?.trim() ?? '';
+    const reframe = row.reframe?.trim() ?? '';
+    if (!frame || !reframe) {
+      continue;
+    }
+    if (isPlaceholderPerspectiveText(frame) || isPlaceholderPerspectiveText(reframe)) {
+      continue;
+    }
+    valid.push({ frame, reframe });
+  }
+  return valid;
 }
 
 function buildAnalysisBundleIdentity(story: StoryBundle): StoryAnalysisBundleIdentity {
@@ -269,10 +295,7 @@ function toSynthesis(artifact: StoryAnalysisArtifact): NewsCardAnalysisSynthesis
       artifact.summary,
       artifact.analyses.flatMap((entry) => [entry.source_id, entry.publisher]),
     ),
-    frames: artifact.frames.map((row) => ({
-      frame: row.frame,
-      reframe: row.reframe,
-    })),
+    frames: filterValidFrameRows(artifact.frames),
     analyses: artifact.analyses.map((entry) => ({
       source_id: entry.source_id,
       publisher: entry.publisher,
@@ -310,6 +333,10 @@ async function toArtifact(
   const firstProvider = synthesis.analyses.find(
     (analysis) => analysis.provider_id?.trim() || analysis.model_id?.trim(),
   );
+  const validFrames = filterValidFrameRows(synthesis.frames);
+  if (validFrames.length === 0) {
+    throw new MeshArtifactInvalidError('empty_frames');
+  }
 
   return {
     schemaVersion: 'story-analysis-v1',
@@ -320,10 +347,7 @@ async function toArtifact(
     pipeline_version: ANALYSIS_PIPELINE_VERSION,
     model_scope: modelScopeKey,
     summary: ensureNonEmpty(synthesis.summary, 'Summary unavailable.'),
-    frames: synthesis.frames.map((row) => ({
-      frame: ensureNonEmpty(row.frame, 'Frame unavailable.'),
-      reframe: ensureNonEmpty(row.reframe, 'Reframe unavailable.'),
-    })),
+    frames: validFrames,
     analyses: synthesis.analyses.map((entry) => ({
       source_id: ensureNonEmpty(entry.source_id, story.story_id),
       publisher: ensureNonEmpty(entry.publisher, 'Unknown publisher'),
@@ -371,10 +395,19 @@ export async function readMeshAnalysis(
   }
 
   const startedAt = Date.now();
-  const emitTelemetry = (readPath: 'derived-key' | 'derived-key-invalid' | 'latest-pointer' | 'miss') => {
+  const emitTelemetry = (
+    readPath:
+      | 'derived-key'
+      | 'derived-key-invalid'
+      | 'latest-pointer'
+      | 'stale-placeholder-rejected'
+      | 'miss',
+    source?: 'derived-key' | 'latest-pointer',
+  ) => {
     console.info('[vh:analysis:mesh]', {
       story_id: story.story_id,
       read_path: readPath,
+      ...(source ? { source } : {}),
       latency_ms: Date.now() - startedAt,
     });
   };
@@ -453,8 +486,20 @@ export async function readMeshAnalysis(
           provenance_hash: directArtifact.provenance_hash,
           model_scope: directArtifact.model_scope,
         });
+        const synthesis = toSynthesis(directArtifact);
+        if (synthesis.frames.length === 0) {
+          logMeshDebug('read-derived-key-placeholder-rejected', {
+            story_id: story.story_id,
+            attempt,
+            analysis_key: directArtifact.analysisKey,
+            provenance_hash: directArtifact.provenance_hash,
+            model_scope: directArtifact.model_scope,
+          });
+          emitTelemetry('stale-placeholder-rejected', 'derived-key');
+          return null;
+        }
         emitTelemetry('derived-key');
-        return toSynthesis(directArtifact);
+        return synthesis;
       }
 
       logMeshDebug('read-derived-key-miss', {
@@ -527,8 +572,20 @@ export async function readMeshAnalysis(
             model_scope: latestArtifact.model_scope,
             provenance_mode: 'exact',
           });
+          const synthesis = toSynthesis(latestArtifact);
+          if (synthesis.frames.length === 0) {
+            logMeshDebug('read-latest-pointer-placeholder-rejected', {
+              story_id: story.story_id,
+              attempt,
+              analysis_key: latestArtifact.analysisKey,
+              provenance_hash: latestArtifact.provenance_hash,
+              model_scope: latestArtifact.model_scope,
+            });
+            emitTelemetry('stale-placeholder-rejected', 'latest-pointer');
+            return null;
+          }
           emitTelemetry('latest-pointer');
-          return toSynthesis(latestArtifact);
+          return synthesis;
         }
       }
 
@@ -608,6 +665,23 @@ export async function writeMeshAnalysis(
       latency_ms: Math.max(0, Date.now() - startedAt),
     });
   } catch (error) {
+    if (error instanceof MeshArtifactInvalidError) {
+      logMeshDebug('write-skipped', {
+        story_id: story.story_id,
+        reason: error.reason,
+        latency_ms: Math.max(0, Date.now() - startedAt),
+      });
+
+      logAnalysisMeshWrite({
+        source: 'news-card',
+        event: 'mesh_write_skipped',
+        story_id: story.story_id,
+        reason: error.reason,
+        latency_ms: Math.max(0, Date.now() - startedAt),
+      });
+      return;
+    }
+
     logMeshDebug('write-failed', {
       story_id: story.story_id,
       analysis_key: debugArtifact?.analysisKey,
@@ -776,6 +850,7 @@ export async function clearPendingMeshAnalysis(
 export const analysisMeshInternal = {
   buildAnalysisBundleIdentity,
   clearPendingMeshAnalysis,
+  filterValidFrameRows,
   readPendingMeshAnalysis,
   toArtifact,
   toSynthesis,

--- a/docs/plans/PR_B_TOPIC_SYNTHESIS_V2_BUNDLE_SPINE_CONTRACT.md
+++ b/docs/plans/PR_B_TOPIC_SYNTHESIS_V2_BUNDLE_SPINE_CONTRACT.md
@@ -1,0 +1,520 @@
+# PR B TopicSynthesisV2 Bundle Spine Implementation Contract
+
+Status: Queued after PR #523
+Owner: VHC Core Engineering
+Last Updated: 2026-04-17
+
+This plan preserves the implementation contract for the PR B follow-on to PR
+#523. It is a non-authoritative execution artifact. Normative behavior remains
+owned by `docs/specs/topic-synthesis-v2.md`,
+`docs/specs/spec-news-aggregator-v0.md`,
+`docs/specs/spec-topic-discovery-ranking-v0.md`, and the canonical docs listed
+in `docs/CANON_MAP.md`.
+
+## Branch Strategy
+
+- PR #523 (`coord/analysis-cache-hygiene`) lands standalone on `main` first.
+- PR B is cut fresh from `main` after PR #523 merges.
+- PR B depends on the PR #523 expansion of `isPlaceholderPerspectiveText` to
+  include `Frame unavailable`, `Reframe unavailable`, and `Summary unavailable`.
+- Expected conflict surface is near zero: PR B adds bundle-synthesis spine code
+  and does not touch the PR #523 feed-analysis hygiene files.
+
+## Short Recommendation
+
+Build the daemon worker as a thin consumer of the existing
+`onSynthesisCandidate` hook in `packages/ai-engine/src/newsRuntime.ts`,
+treating the candidate as a trigger signal only. Inside the worker,
+`readStoryBundle(client, story_id)` is the sole authoritative input.
+
+Canonical prompt and strict parser logic live in
+`packages/ai-engine/src/bundlePrompts.ts`. The parser mirrors
+`parseGeneratedAnalysisResponse`, including `parsed.final_refined || parsed`,
+and trims all persisted text before schema validation. The worker derives
+`source_count` and publishers from the re-read `StoryBundle`, cross-checks the
+model's `source_count` as a quality gate, and never calls
+`writeTopicSynthesis`.
+
+The worker writes via:
+
+1. `writeTopicEpochCandidate`
+2. `writeTopicEpochSynthesis`
+3. `writeTopicLatestSynthesisIfNotDowngrade`
+
+News-bundle synthesis is always written at `epoch: 0` with
+`quorum: { required: 1, received: 1 }`. The `/latest` write uses an
+`ownershipGuard` requiring the existing `/latest.synthesis_id` to start with
+`news-bundle:` before allowing equal-epoch equal-quorum refresh. Forum synthesis
+at a higher epoch, or with a higher same-epoch quorum, wins naturally.
+
+Relay calls are contained inside worker-local `try/catch` blocks so timeouts
+and upstream failures emit `[vh:bundle-synth] relay_timeout` or
+`[vh:bundle-synth] relay_failed`, never only the generic daemon enrichment error.
+
+## Architecture Decisions
+
+| Decision | Value |
+|---|---|
+| Prompt and parser location | `packages/ai-engine/src/bundlePrompts.ts` |
+| Daemon hook | Existing `onSynthesisCandidate` in `services/news-aggregator/src/daemon.ts` |
+| Freshness anchor | `readStoryBundle(client, candidate.story_id)` |
+| Idempotency key | `sha256("news-bundle-v1|" + story_id + "|" + provenance_hash + "|" + model_id)` |
+| Epoch | `0`; news-bundle synthesis never advances epoch |
+| `/latest` write | `writeTopicLatestSynthesisIfNotDowngrade` with `ownershipGuard` |
+| Queue | Existing `createAsyncEnrichmentQueue`, extended with `maxDepth` |
+| Concurrency | Single-worker, queue-serialized daemon pattern |
+| Feature flag | `VH_BUNDLE_SYNTHESIS_ENABLED`, server-only |
+| Metadata-only input | Headline, publisher, title, URL, optional `summary_hint`; no article full text |
+
+## File-By-File Contract
+
+### `packages/ai-engine/src/bundlePrompts.ts`
+
+Extend the existing prompt-only module. Add imports:
+
+```ts
+import { z } from 'zod';
+import { isPlaceholderPerspectiveText } from './schema';
+import type { StoryBundle } from './newsTypes';
+```
+
+Add a trim-first strict generated-output schema:
+
+```ts
+const TrimmedNonEmptyString = z
+  .string()
+  .transform((value) => value.trim())
+  .refine((value) => value.length > 0, 'must be non-empty after trimming');
+
+const BundlePerspectiveTextSchema = TrimmedNonEmptyString.refine(
+  (value) => !isPlaceholderPerspectiveText(value),
+  'must not be a placeholder',
+);
+
+const BundleFrameSchema = z
+  .object({
+    frame: BundlePerspectiveTextSchema,
+    reframe: BundlePerspectiveTextSchema,
+  })
+  .strict();
+
+export const GeneratedBundleSynthesisResultSchema = z
+  .object({
+    summary: TrimmedNonEmptyString,
+    frames: z.array(BundleFrameSchema).min(2).max(4),
+    source_count: z.number().int().positive(),
+    source_publishers: z.array(TrimmedNonEmptyString).min(1),
+    verification_confidence: z.number().min(0).max(1),
+  })
+  .strict();
+
+export type GeneratedBundleSynthesisResult = z.infer<
+  typeof GeneratedBundleSynthesisResultSchema
+>;
+```
+
+Add parser behavior matching the existing generated-analysis parser:
+
+```ts
+export enum BundleSynthesisParseError {
+  NO_JSON_OBJECT_FOUND = 'NO_JSON_OBJECT_FOUND',
+  JSON_PARSE_ERROR = 'JSON_PARSE_ERROR',
+  SCHEMA_VALIDATION_ERROR = 'SCHEMA_VALIDATION_ERROR',
+}
+
+export function parseGeneratedBundleSynthesis(raw: string): GeneratedBundleSynthesisResult {
+  const jsonMatch = raw.match(/\{[\s\S]*\}/);
+  if (!jsonMatch) {
+    throw new Error(BundleSynthesisParseError.NO_JSON_OBJECT_FOUND);
+  }
+
+  try {
+    const parsed = JSON.parse(jsonMatch[0]);
+    const payload = parsed.final_refined || parsed;
+    return GeneratedBundleSynthesisResultSchema.parse(payload);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      throw new Error(BundleSynthesisParseError.SCHEMA_VALIDATION_ERROR);
+    }
+    throw new Error(BundleSynthesisParseError.JSON_PARSE_ERROR);
+  }
+}
+```
+
+Add `buildBundlePromptFromStoryBundle(bundle, opts)` so source titles are
+preserved:
+
+```ts
+export function buildBundlePromptFromStoryBundle(
+  bundle: StoryBundle,
+  opts?: { verificationConfidence?: number },
+): string {
+  const sources = bundle.primary_sources ?? bundle.sources;
+  const verificationConfidence =
+    opts?.verificationConfidence ?? bundle.cluster_features.confidence_score;
+
+  return generateBundleSynthesisPrompt({
+    headline: bundle.headline,
+    sources: sources.map((source) => ({
+      publisher: source.publisher,
+      title: source.title,
+      url: source.url,
+    })),
+    summary_hint: bundle.summary_hint,
+    verification_confidence: verificationConfidence,
+  });
+}
+```
+
+`buildBundlePrompt(StoryBundleInputCandidate)` stays unchanged.
+
+### `packages/gun-client/src/synthesisAdapters.ts`
+
+Add a non-downgrading latest writer after `writeTopicLatestSynthesis`:
+
+```ts
+export interface SafeLatestWriteOptions {
+  ownershipGuard?: (existing: TopicSynthesisV2) => boolean;
+}
+
+export type SafeLatestWriteResult =
+  | { written: true }
+  | {
+      written: false;
+      reason:
+        | 'downgrade_existing_epoch'
+        | 'downgrade_existing_quorum'
+        | 'ownership_guard_rejected';
+    };
+
+export async function writeTopicLatestSynthesisIfNotDowngrade(
+  client: VennClient,
+  synthesis: unknown,
+  opts: SafeLatestWriteOptions = {},
+): Promise<SafeLatestWriteResult> {
+  assertNoForbiddenSynthesisFields(synthesis);
+  const sanitized = TopicSynthesisV2Schema.parse(synthesis);
+  const existing = await readTopicLatestSynthesis(client, sanitized.topic_id);
+
+  if (existing) {
+    if (existing.epoch > sanitized.epoch) {
+      return { written: false, reason: 'downgrade_existing_epoch' };
+    }
+    if (
+      existing.epoch === sanitized.epoch &&
+      existing.quorum.received > sanitized.quorum.received
+    ) {
+      return { written: false, reason: 'downgrade_existing_quorum' };
+    }
+    if (opts.ownershipGuard && !opts.ownershipGuard(existing)) {
+      return { written: false, reason: 'ownership_guard_rejected' };
+    }
+  }
+
+  await putWithAck(
+    getTopicLatestSynthesisChain(client, normalizeTopicId(sanitized.topic_id)),
+    sanitized,
+  );
+  return { written: true };
+}
+```
+
+`writeTopicSynthesis` remains unchanged for current forum bridge compatibility.
+PR B worker code must not import or call it.
+
+### `services/news-aggregator/src/bundleSynthesisWorker.ts`
+
+Create a new worker module. It must not import `writeTopicSynthesis`.
+
+Required injected dependencies:
+
+```ts
+export interface BundleSynthesisWorkerDeps {
+  client: VennClient;
+  readStoryBundle: typeof readStoryBundle;
+  readTopicEpochCandidate: typeof readTopicEpochCandidate;
+  writeTopicEpochCandidate: typeof writeTopicEpochCandidate;
+  writeTopicEpochSynthesis: typeof writeTopicEpochSynthesis;
+  writeTopicLatestSynthesisIfNotDowngrade: typeof writeTopicLatestSynthesisIfNotDowngrade;
+  relay: (prompt: string) => Promise<string>;
+  modelId: string;
+  now: () => number;
+  logger: LoggerLike;
+}
+```
+
+Required constants and candidate id:
+
+```ts
+const PIPELINE_VERSION = 'news-bundle-v1';
+const SYNTHESIS_ID_PREFIX = 'news-bundle:';
+
+async function deriveCandidateId(
+  storyId: string,
+  provenanceHash: string,
+  modelId: string,
+): Promise<string> {
+  const input = `${PIPELINE_VERSION}|${storyId}|${provenanceHash}|${modelId}`;
+  const digest = await sha256Hex(input);
+  return `${SYNTHESIS_ID_PREFIX}${digest}`;
+}
+```
+
+Required worker flow:
+
+1. Read `StoryBundle` fresh by `candidate.story_id`.
+2. Return with `bundle_missing` telemetry if absent.
+3. Use `bundle.topic_id`, never `candidate.work_items[0].topic_id`, for writes.
+4. Use `bundle.primary_sources ?? bundle.sources` for actual source count and
+   publisher telemetry.
+5. Derive `candidate_id` from `pipeline_version`, `story_id`,
+   `provenance_hash`, and `model_id`.
+6. Check idempotency with `readTopicEpochCandidate(client, topicId, 0, candidateId)`.
+7. Build the prompt from the re-read bundle via `buildBundlePromptFromStoryBundle`.
+8. Call relay inside worker-local `try/catch`; map AbortError or timeout-like
+   failures to `relay_timeout`, and other failures to `relay_failed`.
+9. Parse with `parseGeneratedBundleSynthesis`.
+10. If parsed `source_count` differs from the bundle-derived source count,
+    emit `source_count_mismatch` and return without writes.
+11. Write `CandidateSynthesis` at epoch `0`.
+12. Write `TopicSynthesisV2` at epoch `0`.
+13. Conditionally write `/latest` through `writeTopicLatestSynthesisIfNotDowngrade`
+    using an ownership guard:
+
+```ts
+{
+  ownershipGuard: (existing) =>
+    existing.synthesis_id.startsWith(SYNTHESIS_ID_PREFIX),
+}
+```
+
+The persisted `CandidateSynthesis` must use:
+
+- `candidate_id`: derived id
+- `topic_id`: re-read `bundle.topic_id`
+- `epoch`: `0`
+- `facts_summary`: trimmed parsed summary
+- `frames`: trimmed parsed frames
+- `warnings`: `['single-source-only']` only when actual bundle source count is `1`
+- `provider`: `{ provider_id: 'openai', model_id, kind: 'remote' }`
+- `created_at`: `now()`
+
+The persisted `TopicSynthesisV2` must use:
+
+- `schemaVersion`: `topic-synthesis-v2`
+- `topic_id`: re-read `bundle.topic_id`
+- `epoch`: `0`
+- `synthesis_id`: `news-bundle:${storyId}:${provenanceHash.slice(0, 16)}`
+- `inputs`: `{ story_bundle_ids: [storyId] }`
+- `quorum`: `{ required: 1, received: 1, reached_at: now, timed_out: false, selection_rule: 'deterministic' }`
+- `facts_summary`: trimmed parsed summary
+- `frames`: trimmed parsed frames
+- `warnings`: same as candidate
+- `divergence_metrics`: `{ disagreement_score: 0, source_dispersion: 0, candidate_count: 1 }`
+- `provenance`: candidate id and OpenAI provider mix
+- `created_at`: `now()`
+
+### `services/news-aggregator/src/daemonUtils.ts`
+
+Extend `createAsyncEnrichmentQueue` with optional `maxDepth` and `onDrop`:
+
+- Default remains unbounded to preserve existing behavior.
+- When `pending.length >= maxDepth`, do not enqueue the candidate.
+- Emit/drop reason: `queue_full`.
+
+### `services/news-aggregator/src/daemon.ts`
+
+Parse `VH_BUNDLE_SYNTHESIS_*` vars in `startNewsAggregatorDaemonFromEnv`.
+When `VH_BUNDLE_SYNTHESIS_ENABLED` is truthy, construct the bundle synthesis
+worker and pass it to `createNewsAggregatorDaemon` through the existing
+`enrichmentWorker` seam.
+
+### `services/news-aggregator/src/bundleSynthesisRelay.ts`
+
+Create a sibling module to `analysisRelay.ts`:
+
+- Use the same token-parameter and OpenAI chat-completions request pattern.
+- Honor `VH_BUNDLE_SYNTHESIS_TIMEOUT_MS` with `AbortController`.
+- Use a per-story rate limiter, default `20/min`.
+- Export `postBundleSynthesisCompletion(prompt, opts)` returning raw completion
+  text.
+- Throw `AbortError` on timeout.
+- Throw an `Error` containing HTTP status detail for non-2xx upstream responses.
+
+### `services/news-aggregator/src/prompts.ts`
+
+Add deprecation JSDoc to service-local bundle prompt/parser exports:
+
+```ts
+/** @deprecated Use @vh/ai-engine bundlePrompts. */
+```
+
+Do not delete them in PR B.
+
+## Not Changed In PR B
+
+- `apps/web-pwa/src/store/synthesis/pipelineBridge.ts` still uses
+  `writeTopicSynthesis`; migrate it in a later PR after daemon canary.
+- `packages/data-model/src/schemas/hermes/synthesis.ts` remains unchanged.
+- Forum quorum logic remains unchanged.
+
+## Required Tests
+
+### `packages/ai-engine/src/bundlePrompts.test.ts`
+
+- Valid JSON parses and returns trimmed fields.
+- `final_refined` wrapper parses identically to bare payload.
+- Leading/trailing whitespace in summary, frames, reframes, and publishers is
+  trimmed.
+- Blank-after-trim summary is rejected with `SCHEMA_VALIDATION_ERROR`.
+- `frames.length < 2` is rejected.
+- `frames.length > 4` is rejected.
+- Placeholder frames are rejected: `N/A`, `No clear bias detected`,
+  `Frame unavailable`.
+- Placeholder reframes with surrounding whitespace are rejected.
+- Fenced JSON parses through the greedy JSON-object extraction.
+- Leading prose before JSON parses.
+- No JSON object throws `NO_JSON_OBJECT_FOUND`.
+- Malformed JSON throws `JSON_PARSE_ERROR`.
+- `buildBundlePromptFromStoryBundle` preserves source titles literally.
+- `buildBundlePromptFromStoryBundle` uses `primary_sources` when present, else
+  `sources`.
+- Summary hint is included when set and omitted when undefined.
+- Cluster `confidence_score` renders as verification confidence when no
+  explicit option is passed.
+- Explicit verification confidence overrides cluster confidence.
+
+### `services/news-aggregator/src/bundleSynthesisWorker.test.ts`
+
+- Happy path writes candidate, epoch synthesis, and `/latest` on an empty topic.
+- Written `topic_id` comes from the re-read bundle, not candidate work items.
+- Candidate id changes when `provenance_hash` changes and is stable otherwise.
+- Source-count mismatch logs `source_count_mismatch` and writes nothing.
+- Parsed `source_publishers` are not treated as ground truth in telemetry.
+- Single-source warning is derived from bundle source count.
+- AbortError relay failure logs `relay_timeout`, writes nothing, and returns.
+- Non-timeout relay failure logs `relay_failed`, writes nothing, and returns.
+- Non-Error relay rejection is logged as `relay_failed`.
+- Parser failures write nothing and log `parse_failed`.
+- `final_refined` relay payload writes successfully.
+- Missing bundle logs `bundle_missing`; no relay call; no writes.
+- Existing candidate id logs `idempotent_skip`; no relay call; no writes.
+- Higher existing epoch protects `/latest`.
+- Strictly higher same-epoch quorum protects `/latest`.
+- Equal epoch/equal quorum with `news-bundle:` prefix refreshes `/latest`.
+- Non-`news-bundle:` epoch-0 latest is protected by `ownership_guard_rejected`.
+- Empty latest writes.
+- Test suite mocks `writeTopicSynthesis` and asserts it is never called.
+- Whitespace in relay summary/frame/reframe is trimmed before write adapters see
+  payloads.
+
+### `packages/gun-client/src/synthesisAdapters.test.ts`
+
+- Safe latest writer writes when `/latest` is empty.
+- Writes when existing epoch is strictly lower.
+- Skips with `downgrade_existing_epoch` when existing epoch is strictly higher.
+- Skips with `downgrade_existing_quorum` when epochs are equal and existing
+  quorum is strictly higher.
+- Writes when epochs and quorums are equal.
+- Calls `ownershipGuard` only when an existing latest exists.
+- Returning `false` from `ownershipGuard` yields `ownership_guard_rejected`.
+- Existing privacy guard still rejects identity/token fields.
+
+### `services/news-aggregator/src/daemon.test.ts`
+
+- Bundle worker is wired only when `VH_BUNDLE_SYNTHESIS_ENABLED` is truthy.
+- Disabled mode preserves the no-op enrichment worker behavior.
+- Existing lease/leadership tests remain green.
+
+### `services/news-aggregator/src/daemonUtils.test.ts`
+
+- `maxDepth` drops the next candidate and emits `queue_full`.
+- Unset `maxDepth` preserves current unbounded behavior.
+
+## Validation Commands
+
+Run from repo root after implementation:
+
+```bash
+pnpm --filter @vh/ai-engine test -- bundlePrompts
+pnpm --filter @vh/gun-client test -- synthesisAdapters
+pnpm --filter @vh/news-aggregator test -- bundleSynthesisWorker
+pnpm --filter @vh/news-aggregator test -- daemon
+pnpm --filter @vh/news-aggregator test -- daemonUtils
+pnpm -r typecheck
+pnpm -r build
+pnpm docs:check
+git diff --check
+```
+
+Manual canary:
+
+1. Set `VH_BUNDLE_SYNTHESIS_ENABLED=true`,
+   `VH_BUNDLE_SYNTHESIS_MODEL=gpt-4o-mini`, and `OPENAI_API_KEY`.
+2. Point the daemon at a staging Gun peer.
+3. Wait for one daemon tick.
+4. Confirm `[vh:bundle-synth] done` with `latest_written: true` for new topics.
+5. Confirm protected topics report `latest_written: false` with a skip reason.
+6. Read `/latest` through `readTopicLatestSynthesis` and assert:
+   - `frames.length >= 2`
+   - no empty or placeholder frame/reframe text
+   - no leading or trailing whitespace
+   - `facts_summary` is trimmed
+
+## Env Flags
+
+| Var | Default | Purpose |
+|---|---|---|
+| `VH_BUNDLE_SYNTHESIS_ENABLED` | `false` | Master switch |
+| `VH_BUNDLE_SYNTHESIS_MODEL` | `gpt-4o-mini` | OpenAI model |
+| `VH_BUNDLE_SYNTHESIS_TIMEOUT_MS` | `20000` | Per-job relay timeout |
+| `VH_BUNDLE_SYNTHESIS_MAX_TOKENS` | `1200` | Completion budget |
+| `VH_BUNDLE_SYNTHESIS_QUEUE_DEPTH` | `32` | Queue max depth |
+| `VH_BUNDLE_SYNTHESIS_RATE_PER_MIN` | `20` | Story-id-scoped rate limit |
+| `OPENAI_API_KEY` | required when enabled | Shared OpenAI key |
+| `VH_BUNDLE_SYNTHESIS_PIPELINE_VERSION` | `news-bundle-v1` | Candidate-id cache scope |
+
+All variables are server-side only and must not be exposed as `VITE_*`.
+
+## Telemetry
+
+Emit structured JSON under `[vh:bundle-synth]`. Shared fields should include
+`daemon_holder_id`, `pipeline_version`, and `model_id` when available.
+
+| Event | Level | Key fields |
+|---|---|---|
+| `bundle_synth.start` | info | `story_id`, `topic_id`, `provenance_hash`, `candidate_id` |
+| `bundle_synth.bundle_missing` | warn | `story_id` |
+| `bundle_synth.idempotent_skip` | info | `story_id`, `topic_id`, `candidate_id` |
+| `bundle_synth.relay_timeout` | warn | `story_id`, `topic_id`, `model_id`, `error_message`, `latency_ms` |
+| `bundle_synth.relay_failed` | warn | `story_id`, `topic_id`, `model_id`, `error_message`, `latency_ms` |
+| `bundle_synth.parse_failed` | warn | `story_id`, `topic_id`, `parse_error_code` |
+| `bundle_synth.source_count_mismatch` | warn | `story_id`, `topic_id`, `parsed_source_count`, `actual_source_count` |
+| `bundle_synth.candidate_written` | info | `story_id`, `candidate_id`, `epoch`, `quorum_received` |
+| `bundle_synth.epoch_synthesis_written` | info | `story_id`, `topic_id`, `synthesis_id`, `epoch` |
+| `bundle_synth.latest_written` | info | `story_id`, `topic_id`, `synthesis_id` |
+| `bundle_synth.latest_skipped` | info | `story_id`, `topic_id`, `reason`, `existing_quorum_received`, `existing_epoch`, `existing_synthesis_id_prefix` |
+| `bundle_synth.queue_full` | warn | `story_id`, `queue_depth`, `max_depth` |
+| `bundle_synth.done` | info | `story_id`, `topic_id`, `candidate_id`, `synthesis_id`, `actual_source_count`, `publishers`, `latest_written`, `latest_skip_reason`, `latency_ms` |
+
+Dashboard signals for canary:
+
+- Ratio of `latest_written=true` to `bundle_synth.start`.
+- Per-hour `parse_failed` and `source_count_mismatch`.
+- p95 `latency_ms`.
+- `ownership_guard_rejected` count.
+
+## Acceptance Criteria
+
+1. Freshness is anchored on `readStoryBundle(story_id)`.
+2. Runtime candidate is used only as a trigger.
+3. Source titles are preserved into the prompt.
+4. Idempotency is provenance-sensitive through `candidate_id`.
+5. Written `topic_id` always matches the re-read bundle.
+6. `/latest` cannot be downgraded by daemon bundle synthesis.
+7. Non-`news-bundle:` epoch-0 latest records are protected.
+8. Daemon worker never imports or calls `writeTopicSynthesis`.
+9. Summary, frame, and reframe strings are trimmed before storage.
+10. Relay timeouts and upstream failures surface as bundle-synth telemetry.
+11. Model source-count mismatch blocks all writes.
+

--- a/packages/ai-engine/src/__tests__/schema.test.ts
+++ b/packages/ai-engine/src/__tests__/schema.test.ts
@@ -3,6 +3,7 @@ import {
   AnalysisParseError,
   GeneratedAnalysisResultSchema,
   AnalysisResultSchema,
+  isPlaceholderPerspectiveText,
   parseAnalysisResponse,
   parseGeneratedAnalysisResponse,
 } from '../schema';
@@ -103,6 +104,12 @@ describe('AnalysisResultSchema', () => {
     expect(() => parseGeneratedAnalysisResponse(JSON.stringify(placeholderPayload))).toThrow(
       AnalysisParseError.SCHEMA_VALIDATION_ERROR,
     );
+  });
+
+  it('recognizes legacy unavailable sentinels as placeholder perspective text', () => {
+    expect(isPlaceholderPerspectiveText('Frame unavailable.')).toBe(true);
+    expect(isPlaceholderPerspectiveText('Reframe unavailable.')).toBe(true);
+    expect(isPlaceholderPerspectiveText('Summary unavailable.')).toBe(true);
   });
 
   it('throws parse errors for invalid payloads', () => {

--- a/packages/ai-engine/src/schema.ts
+++ b/packages/ai-engine/src/schema.ts
@@ -32,7 +32,10 @@ export function isPlaceholderPerspectiveText(value: string): boolean {
     || normalized === 'na'
     || normalized === 'n.a'
     || normalized === 'not applicable'
-    || normalized === 'no clear bias detected';
+    || normalized === 'no clear bias detected'
+    || normalized === 'frame unavailable'
+    || normalized === 'reframe unavailable'
+    || normalized === 'summary unavailable';
 }
 
 const GeneratedPerspectiveTextSchema = z


### PR DESCRIPTION
## Summary
- reject cached mesh analysis artifacts whose frame/reframe rows are empty or placeholder-only
- stop writing placeholder frame sentinels back into the mesh
- remove publisher-prefixed legacy bias fallback rows from frame/reframe UI
- extend the shared placeholder classifier to catch legacy unavailable sentinels
- preserve the PR B TopicSynthesisV2 bundle-synthesis spine implementation contract in docs/plans/PR_B_TOPIC_SYNTHESIS_V2_BUNDLE_SPINE_CONTRACT.md

## Validation
- pnpm --filter @vh/web-pwa typecheck
- pnpm exec vitest run packages/ai-engine/src/__tests__/schema.test.ts apps/web-pwa/src/components/feed/newsCardAnalysis.test.ts apps/web-pwa/src/components/feed/useAnalysisMesh.test.ts --config vitest.config.ts
- pnpm exec vitest run apps/web-pwa/src --config vitest.config.ts
- pnpm --filter @vh/web-pwa build
- pnpm docs:check
- git diff --check

Post-doc update validation:
- pnpm docs:check
- git diff --check

Note: the package-level `pnpm --filter @vh/ai-engine test` command exits cleanly but does not run a dedicated package script in this repo; the targeted schema Vitest file is included above.