### PR TITLE
Wire bundle synthesis daemon spine

### DIFF
--- a/docs/plans/PR_B_TOPIC_SYNTHESIS_V2_BUNDLE_SPINE_CONTRACT.md
+++ b/docs/plans/PR_B_TOPIC_SYNTHESIS_V2_BUNDLE_SPINE_CONTRACT.md
@@ -236,7 +236,7 @@ export interface BundleSynthesisWorkerDeps {
   writeTopicEpochCandidate: typeof writeTopicEpochCandidate;
   writeTopicEpochSynthesis: typeof writeTopicEpochSynthesis;
   writeTopicLatestSynthesisIfNotDowngrade: typeof writeTopicLatestSynthesisIfNotDowngrade;
-  relay: (prompt: string) => Promise<string>;
+  relay: (prompt: string, context?: { storyId: string; topicId: string }) => Promise<string>;
   modelId: string;
   now: () => number;
   logger: LoggerLike;
@@ -271,7 +271,7 @@ Required worker flow:
    `provenance_hash`, and `model_id`.
 6. Check idempotency with `readTopicEpochCandidate(client, topicId, 0, candidateId)`.
 7. Build the prompt from the re-read bundle via `buildBundlePromptFromStoryBundle`.
-8. Call relay inside worker-local `try/catch`; map AbortError or timeout-like
+8. Call relay with `{ storyId, topicId }` inside worker-local `try/catch`; map AbortError or timeout-like
    failures to `relay_timeout`, and other failures to `relay_failed`.
 9. Parse with `parseGeneratedBundleSynthesis`.
 10. If parsed `source_count` differs from the bundle-derived source count,
@@ -337,7 +337,8 @@ Create a sibling module to `analysisRelay.ts`:
 - Honor `VH_BUNDLE_SYNTHESIS_TIMEOUT_MS` with `AbortController`.
 - Use a per-story rate limiter, default `20/min`.
 - Export `postBundleSynthesisCompletion(prompt, opts)` returning raw completion
-  text.
+  text. Production worker wiring must pass `rateLimitKey` derived from
+  `context.storyId` so the limiter is story-scoped.
 - Throw `AbortError` on timeout.
 - Throw an `Error` containing HTTP status detail for non-2xx upstream responses.
 
@@ -517,4 +518,3 @@ Dashboard signals for canary:
 9. Summary, frame, and reframe strings are trimmed before storage.
 10. Relay timeouts and upstream failures surface as bundle-synth telemetry.
 11. Model source-count mismatch blocks all writes.
-

--- a/packages/ai-engine/src/bundlePrompts.test.ts
+++ b/packages/ai-engine/src/bundlePrompts.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import {
+  BundleSynthesisParseError,
   buildBundlePrompt,
+  buildBundlePromptFromStoryBundle,
   generateBundleSynthesisPrompt,
+  parseGeneratedBundleSynthesis,
   type BundleSynthesisResult,
 } from './bundlePrompts';
-import type { StoryBundleInputCandidate } from './newsTypes';
+import type { StoryBundle, StoryBundleInputCandidate } from './newsTypes';
 
 describe('bundlePrompts', () => {
   const sampleBundle = {
@@ -169,6 +172,207 @@ describe('bundlePrompts', () => {
     it('handles missing verification confidence', () => {
       const prompt = buildBundlePrompt(candidate);
       expect(prompt).toContain('Verification confidence: not available');
+    });
+  });
+
+  describe('buildBundlePromptFromStoryBundle', () => {
+    const storyBundle: StoryBundle = {
+      schemaVersion: 'story-bundle-v0',
+      story_id: 'story-1',
+      topic_id: 'topic-markets',
+      headline: 'Markets rally after policy announcement',
+      summary_hint: 'A policy announcement triggered market rallies worldwide.',
+      cluster_window_start: 1700000000000,
+      cluster_window_end: 1700003600000,
+      sources: [
+        {
+          source_id: 'fox-latest',
+          publisher: 'Fox News',
+          title: 'Markets surge on policy news',
+          url: 'https://example.com/fox',
+          url_hash: 'hash-1',
+          published_at: 1700000001000,
+        },
+        {
+          source_id: 'bbc-general',
+          publisher: 'BBC News',
+          title: 'Global markets up on policy shift',
+          url: 'https://example.com/bbc',
+          url_hash: 'hash-2',
+          published_at: 1700000002000,
+        },
+      ],
+      cluster_features: {
+        entity_keys: ['markets', 'policy'],
+        time_bucket: '2026-04-17T21',
+        semantic_signature: 'sig-markets',
+        confidence_score: 0.82,
+      },
+      provenance_hash: 'prov-1',
+      created_at: 1700000003000,
+    };
+
+    it('preserves source titles and uses bundle confidence by default', () => {
+      const prompt = buildBundlePromptFromStoryBundle(storyBundle);
+
+      expect(prompt).toContain('Markets surge on policy news');
+      expect(prompt).toContain('Global markets up on policy shift');
+      expect(prompt).toContain('Summary hint (from feed):');
+      expect(prompt).toContain('Verification confidence: 82%');
+    });
+
+    it('uses primary_sources when present', () => {
+      const prompt = buildBundlePromptFromStoryBundle({
+        ...storyBundle,
+        primary_sources: [storyBundle.sources[1]!],
+      });
+
+      expect(prompt).toContain('Global markets up on policy shift');
+      expect(prompt).not.toContain('Markets surge on policy news');
+    });
+
+    it('omits hint and confidence when neither is available', () => {
+      const prompt = buildBundlePromptFromStoryBundle({
+        ...storyBundle,
+        summary_hint: undefined,
+        cluster_features: {
+          ...storyBundle.cluster_features,
+          confidence_score: undefined,
+        },
+      });
+
+      expect(prompt).not.toContain('Summary hint (from feed):');
+      expect(prompt).toContain('Verification confidence: not available');
+    });
+
+    it('lets explicit verification confidence override bundle confidence', () => {
+      const prompt = buildBundlePromptFromStoryBundle(storyBundle, {
+        verificationConfidence: 0.91,
+      });
+
+      expect(prompt).toContain('Verification confidence: 91%');
+    });
+  });
+
+  describe('parseGeneratedBundleSynthesis', () => {
+    const validPayload = {
+      summary: 'Markets rallied after a major policy announcement.',
+      frames: [
+        {
+          frame: 'The policy will boost economic growth.',
+          reframe: 'Short-term gains may mask structural issues.',
+        },
+        {
+          frame: 'Officials should move quickly to preserve momentum.',
+          reframe: 'Officials should slow down until safeguards are clear.',
+        },
+      ],
+      source_count: 3,
+      source_publishers: ['Fox News', 'The Guardian', 'BBC News'],
+      verification_confidence: 0.85,
+    };
+
+    it('parses valid JSON and trims persisted text fields', () => {
+      const result = parseGeneratedBundleSynthesis(
+        JSON.stringify({
+          ...validPayload,
+          summary: `  ${validPayload.summary}  `,
+          frames: [
+            {
+              frame: `  ${validPayload.frames[0]!.frame}  `,
+              reframe: validPayload.frames[0]!.reframe,
+            },
+            {
+              frame: validPayload.frames[1]!.frame,
+              reframe: `  ${validPayload.frames[1]!.reframe}  `,
+            },
+          ],
+          source_publishers: ['  Fox News  ', 'The Guardian', 'BBC News'],
+        }),
+      );
+
+      expect(result.summary).toBe(validPayload.summary);
+      expect(result.frames[0]!.frame).toBe(validPayload.frames[0]!.frame);
+      expect(result.frames[1]!.reframe).toBe(validPayload.frames[1]!.reframe);
+      expect(result.source_publishers[0]).toBe('Fox News');
+    });
+
+    it('unwraps final_refined payloads', () => {
+      expect(
+        parseGeneratedBundleSynthesis(JSON.stringify({ final_refined: validPayload })),
+      ).toEqual(validPayload);
+    });
+
+    it('handles fenced JSON and leading prose', () => {
+      expect(parseGeneratedBundleSynthesis(`\`\`\`json\n${JSON.stringify(validPayload)}\n\`\`\``)).toEqual(
+        validPayload,
+      );
+      expect(parseGeneratedBundleSynthesis(`Here it is:\n${JSON.stringify(validPayload)}`)).toEqual(
+        validPayload,
+      );
+    });
+
+    it('rejects blank, too few, too many, placeholder, and invalid-shape payloads', () => {
+      expect(() =>
+        parseGeneratedBundleSynthesis(JSON.stringify({ ...validPayload, summary: '   ' })),
+      ).toThrow(BundleSynthesisParseError.SCHEMA_VALIDATION_ERROR);
+
+      expect(() =>
+        parseGeneratedBundleSynthesis(JSON.stringify({ ...validPayload, frames: [validPayload.frames[0]] })),
+      ).toThrow(BundleSynthesisParseError.SCHEMA_VALIDATION_ERROR);
+
+      expect(() =>
+        parseGeneratedBundleSynthesis(
+          JSON.stringify({
+            ...validPayload,
+            frames: [
+              ...validPayload.frames,
+              { frame: 'Frame three is valid.', reframe: 'Reframe three is valid.' },
+              { frame: 'Frame four is valid.', reframe: 'Reframe four is valid.' },
+              { frame: 'Frame five is invalid.', reframe: 'Reframe five is invalid.' },
+            ],
+          }),
+        ),
+      ).toThrow(BundleSynthesisParseError.SCHEMA_VALIDATION_ERROR);
+
+      for (const placeholder of ['N/A', 'No clear bias detected', 'Frame unavailable.']) {
+        expect(() =>
+          parseGeneratedBundleSynthesis(
+            JSON.stringify({
+              ...validPayload,
+              frames: [
+                { frame: placeholder, reframe: validPayload.frames[0]!.reframe },
+                validPayload.frames[1],
+              ],
+            }),
+          ),
+        ).toThrow(BundleSynthesisParseError.SCHEMA_VALIDATION_ERROR);
+      }
+
+      expect(() =>
+        parseGeneratedBundleSynthesis(
+          JSON.stringify({
+            ...validPayload,
+            frames: [
+              validPayload.frames[0],
+              { frame: validPayload.frames[1]!.frame, reframe: '  N/A  ' },
+            ],
+          }),
+        ),
+      ).toThrow(BundleSynthesisParseError.SCHEMA_VALIDATION_ERROR);
+
+      expect(() =>
+        parseGeneratedBundleSynthesis(JSON.stringify({ ...validPayload, source_count: -1 })),
+      ).toThrow(BundleSynthesisParseError.SCHEMA_VALIDATION_ERROR);
+    });
+
+    it('classifies no-json and malformed-json failures', () => {
+      expect(() => parseGeneratedBundleSynthesis('no json here')).toThrow(
+        BundleSynthesisParseError.NO_JSON_OBJECT_FOUND,
+      );
+      expect(() => parseGeneratedBundleSynthesis('{ "summary": }')).toThrow(
+        BundleSynthesisParseError.JSON_PARSE_ERROR,
+      );
     });
   });
 

--- a/packages/ai-engine/src/bundlePrompts.ts
+++ b/packages/ai-engine/src/bundlePrompts.ts
@@ -5,8 +5,10 @@
  * Kept separate from prompts.ts to respect the 350 LOC cap.
  */
 
+import { z } from 'zod';
 import { GOALS_AND_GUIDELINES } from './prompts';
-import type { StoryBundleInputCandidate } from './newsTypes';
+import { isPlaceholderPerspectiveText } from './schema';
+import type { StoryBundle, StoryBundleInputCandidate } from './newsTypes';
 
 /**
  * Deterministic output shape for UI consumption.
@@ -114,4 +116,79 @@ export function buildBundlePrompt(
     })),
     verification_confidence: verificationConfidence,
   });
+}
+
+export function buildBundlePromptFromStoryBundle(
+  bundle: StoryBundle,
+  opts?: { verificationConfidence?: number },
+): string {
+  const sources = bundle.primary_sources ?? bundle.sources;
+  const verificationConfidence =
+    opts?.verificationConfidence ?? bundle.cluster_features.confidence_score;
+
+  return generateBundleSynthesisPrompt({
+    headline: bundle.headline,
+    sources: sources.map((source) => ({
+      publisher: source.publisher,
+      title: source.title,
+      url: source.url,
+    })),
+    summary_hint: bundle.summary_hint,
+    verification_confidence: verificationConfidence,
+  });
+}
+
+const TrimmedNonEmptyString = z
+  .string()
+  .transform((value) => value.trim())
+  .refine((value) => value.length > 0, 'must be non-empty after trimming');
+
+const BundlePerspectiveTextSchema = TrimmedNonEmptyString.refine(
+  (value) => !isPlaceholderPerspectiveText(value),
+  'must not be a placeholder',
+);
+
+const BundleFrameSchema = z
+  .object({
+    frame: BundlePerspectiveTextSchema,
+    reframe: BundlePerspectiveTextSchema,
+  })
+  .strict();
+
+export const GeneratedBundleSynthesisResultSchema = z
+  .object({
+    summary: TrimmedNonEmptyString,
+    frames: z.array(BundleFrameSchema).min(2).max(4),
+    source_count: z.number().int().positive(),
+    source_publishers: z.array(TrimmedNonEmptyString).min(1),
+    verification_confidence: z.number().min(0).max(1),
+  })
+  .strict();
+
+export type GeneratedBundleSynthesisResult = z.infer<
+  typeof GeneratedBundleSynthesisResultSchema
+>;
+
+export enum BundleSynthesisParseError {
+  NO_JSON_OBJECT_FOUND = 'NO_JSON_OBJECT_FOUND',
+  JSON_PARSE_ERROR = 'JSON_PARSE_ERROR',
+  SCHEMA_VALIDATION_ERROR = 'SCHEMA_VALIDATION_ERROR',
+}
+
+export function parseGeneratedBundleSynthesis(raw: string): GeneratedBundleSynthesisResult {
+  const jsonMatch = raw.match(/\{[\s\S]*\}/);
+  if (!jsonMatch) {
+    throw new Error(BundleSynthesisParseError.NO_JSON_OBJECT_FOUND);
+  }
+
+  try {
+    const parsed = JSON.parse(jsonMatch[0]);
+    const payload = parsed.final_refined || parsed;
+    return GeneratedBundleSynthesisResultSchema.parse(payload);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      throw new Error(BundleSynthesisParseError.SCHEMA_VALIDATION_ERROR);
+    }
+    throw new Error(BundleSynthesisParseError.JSON_PARSE_ERROR);
+  }
 }

--- a/packages/gun-client/src/synthesisAdapters.test.ts
+++ b/packages/gun-client/src/synthesisAdapters.test.ts
@@ -17,6 +17,7 @@ import {
   writeTopicDigest,
   writeTopicEpochCandidate,
   writeTopicEpochSynthesis,
+  writeTopicLatestSynthesisIfNotDowngrade,
   writeTopicLatestSynthesis,
   writeTopicSynthesis
 } from './synthesisAdapters';
@@ -331,6 +332,96 @@ describe('synthesisAdapters', () => {
     await expect(readTopicLatestSynthesis(client, 'topic-1')).resolves.toBeNull();
   });
 
+  it('writeTopicLatestSynthesisIfNotDowngrade writes when latest is empty', async () => {
+    const mesh = createFakeMesh();
+    const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+    const client = createClient(mesh, guard);
+    const ownershipGuard = vi.fn(() => false);
+
+    await expect(
+      writeTopicLatestSynthesisIfNotDowngrade(client, SYNTHESIS, { ownershipGuard }),
+    ).resolves.toEqual({ written: true });
+
+    expect(ownershipGuard).not.toHaveBeenCalled();
+    expect(mesh.writes).toEqual([{ path: 'topics/topic-1/latest', value: SYNTHESIS }]);
+  });
+
+  it('writeTopicLatestSynthesisIfNotDowngrade writes when existing epoch is lower', async () => {
+    const mesh = createFakeMesh();
+    mesh.setRead('topics/topic-1/latest', { ...SYNTHESIS, epoch: 1 });
+    const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+    const client = createClient(mesh, guard);
+
+    await expect(writeTopicLatestSynthesisIfNotDowngrade(client, SYNTHESIS)).resolves.toEqual({
+      written: true,
+    });
+
+    expect(mesh.writes).toEqual([{ path: 'topics/topic-1/latest', value: SYNTHESIS }]);
+  });
+
+  it('writeTopicLatestSynthesisIfNotDowngrade skips higher existing epoch', async () => {
+    const mesh = createFakeMesh();
+    mesh.setRead('topics/topic-1/latest', { ...SYNTHESIS, epoch: 3 });
+    const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+    const client = createClient(mesh, guard);
+
+    await expect(writeTopicLatestSynthesisIfNotDowngrade(client, SYNTHESIS)).resolves.toEqual({
+      written: false,
+      reason: 'downgrade_existing_epoch',
+    });
+
+    expect(mesh.writes).toEqual([]);
+  });
+
+  it('writeTopicLatestSynthesisIfNotDowngrade skips higher same-epoch quorum', async () => {
+    const mesh = createFakeMesh();
+    mesh.setRead('topics/topic-1/latest', {
+      ...SYNTHESIS,
+      quorum: { ...SYNTHESIS.quorum, received: SYNTHESIS.quorum.received + 1 },
+    });
+    const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+    const client = createClient(mesh, guard);
+
+    await expect(writeTopicLatestSynthesisIfNotDowngrade(client, SYNTHESIS)).resolves.toEqual({
+      written: false,
+      reason: 'downgrade_existing_quorum',
+    });
+
+    expect(mesh.writes).toEqual([]);
+  });
+
+  it('writeTopicLatestSynthesisIfNotDowngrade refreshes equal epoch and quorum', async () => {
+    const mesh = createFakeMesh();
+    mesh.setRead('topics/topic-1/latest', { ...SYNTHESIS });
+    const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+    const client = createClient(mesh, guard);
+
+    await expect(writeTopicLatestSynthesisIfNotDowngrade(client, SYNTHESIS)).resolves.toEqual({
+      written: true,
+    });
+
+    expect(mesh.writes).toEqual([{ path: 'topics/topic-1/latest', value: SYNTHESIS }]);
+  });
+
+  it('writeTopicLatestSynthesisIfNotDowngrade honors ownership guard after downgrade checks', async () => {
+    const mesh = createFakeMesh();
+    const existing = { ...SYNTHESIS, synthesis_id: 'forum:epoch-zero' };
+    mesh.setRead('topics/topic-1/latest', existing);
+    const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+    const client = createClient(mesh, guard);
+    const ownershipGuard = vi.fn(() => false);
+
+    await expect(
+      writeTopicLatestSynthesisIfNotDowngrade(client, SYNTHESIS, { ownershipGuard }),
+    ).resolves.toEqual({
+      written: false,
+      reason: 'ownership_guard_rejected',
+    });
+
+    expect(ownershipGuard).toHaveBeenCalledWith(existing);
+    expect(mesh.writes).toEqual([]);
+  });
+
   it('writeTopicSynthesis writes epoch and latest paths', async () => {
     const mesh = createFakeMesh();
     const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
@@ -450,5 +541,9 @@ describe('synthesisAdapters', () => {
     await expect(writeTopicLatestSynthesis(client, { ...SYNTHESIS, refresh_token: 'forbidden' })).rejects.toThrow(
       'forbidden identity/token fields'
     );
+
+    await expect(
+      writeTopicLatestSynthesisIfNotDowngrade(client, { ...SYNTHESIS, identity_id: 'forbidden' }),
+    ).rejects.toThrow('forbidden identity/token fields');
   });
 });

--- a/packages/gun-client/src/synthesisAdapters.ts
+++ b/packages/gun-client/src/synthesisAdapters.ts
@@ -323,6 +323,42 @@ export async function writeTopicLatestSynthesis(client: VennClient, synthesis: u
   return sanitized;
 }
 
+export interface SafeLatestWriteOptions {
+  ownershipGuard?: (existing: TopicSynthesisV2) => boolean;
+}
+
+export type SafeLatestWriteResult =
+  | { written: true }
+  | {
+      written: false;
+      reason: 'downgrade_existing_epoch' | 'downgrade_existing_quorum' | 'ownership_guard_rejected';
+    };
+
+export async function writeTopicLatestSynthesisIfNotDowngrade(
+  client: VennClient,
+  synthesis: unknown,
+  opts: SafeLatestWriteOptions = {},
+): Promise<SafeLatestWriteResult> {
+  assertNoForbiddenSynthesisFields(synthesis);
+  const sanitized = TopicSynthesisV2Schema.parse(synthesis);
+  const existing = await readTopicLatestSynthesis(client, sanitized.topic_id);
+
+  if (existing) {
+    if (existing.epoch > sanitized.epoch) {
+      return { written: false, reason: 'downgrade_existing_epoch' };
+    }
+    if (existing.epoch === sanitized.epoch && existing.quorum.received > sanitized.quorum.received) {
+      return { written: false, reason: 'downgrade_existing_quorum' };
+    }
+    if (opts.ownershipGuard && !opts.ownershipGuard(existing)) {
+      return { written: false, reason: 'ownership_guard_rejected' };
+    }
+  }
+
+  await putWithAck(getTopicLatestSynthesisChain(client, normalizeTopicId(sanitized.topic_id)), sanitized);
+  return { written: true };
+}
+
 export async function writeTopicSynthesis(client: VennClient, synthesis: unknown): Promise<TopicSynthesisV2> {
   const sanitized = await writeTopicEpochSynthesis(client, synthesis);
   await writeTopicLatestSynthesis(client, sanitized);

--- a/services/news-aggregator/src/bundleSynthesisRelay.test.ts
+++ b/services/news-aggregator/src/bundleSynthesisRelay.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  DEFAULT_BUNDLE_SYNTHESIS_MAX_TOKENS,
+  BUNDLE_SYNTHESIS_RATE_WINDOW_MS,
+  buildBundleOpenAIChatRequest,
+  checkBundleSynthesisRateLimit,
+  getBundleSynthesisModel,
+  postBundleSynthesisCompletion,
+  resetBundleSynthesisRateLimits,
+} from './bundleSynthesisRelay';
+
+const ORIGINAL_OPENAI_KEY = process.env.OPENAI_API_KEY;
+const ORIGINAL_MODEL = process.env.VH_BUNDLE_SYNTHESIS_MODEL;
+
+beforeEach(() => {
+  resetBundleSynthesisRateLimits();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  delete process.env.OPENAI_API_KEY;
+  delete process.env.VH_BUNDLE_SYNTHESIS_MODEL;
+});
+
+afterEach(() => {
+  if (ORIGINAL_OPENAI_KEY === undefined) {
+    delete process.env.OPENAI_API_KEY;
+  } else {
+    process.env.OPENAI_API_KEY = ORIGINAL_OPENAI_KEY;
+  }
+  if (ORIGINAL_MODEL === undefined) {
+    delete process.env.VH_BUNDLE_SYNTHESIS_MODEL;
+  } else {
+    process.env.VH_BUNDLE_SYNTHESIS_MODEL = ORIGINAL_MODEL;
+  }
+  vi.unstubAllGlobals();
+});
+
+describe('bundleSynthesisRelay', () => {
+  it('builds OpenAI chat requests with model/token env defaults', () => {
+    process.env.VH_BUNDLE_SYNTHESIS_MODEL = 'gpt-5.2';
+
+    const request = buildBundleOpenAIChatRequest('prompt text');
+
+    expect(getBundleSynthesisModel()).toBe('gpt-5.2');
+    expect(request.model).toBe('gpt-5.2');
+    expect(request).toMatchObject({
+      max_completion_tokens: DEFAULT_BUNDLE_SYNTHESIS_MAX_TOKENS,
+      response_format: { type: 'json_object' },
+    });
+    expect(request.messages[1]).toEqual({ role: 'user', content: 'prompt text' });
+  });
+
+  it('rate-limits by key and resets after the window', () => {
+    const nowSpy = vi.spyOn(Date, 'now');
+    nowSpy.mockReturnValue(10_000);
+
+    expect(checkBundleSynthesisRateLimit('story-1', 1)).toBe(true);
+    expect(checkBundleSynthesisRateLimit('story-1', 1)).toBe(false);
+    expect(checkBundleSynthesisRateLimit('story-2', 1)).toBe(true);
+
+    nowSpy.mockReturnValue(10_000 + BUNDLE_SYNTHESIS_RATE_WINDOW_MS + 1);
+    expect(checkBundleSynthesisRateLimit('story-1', 1)).toBe(true);
+  });
+
+  it('posts bundle synthesis completions and returns raw model text', async () => {
+    process.env.OPENAI_API_KEY = 'test-key';
+    const fetchFn = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          choices: [{ message: { content: '{"summary":"ok"}' } }],
+        }),
+        { status: 200 },
+      ),
+    );
+
+    await expect(
+      postBundleSynthesisCompletion('prompt text', {
+        model: 'gpt-4o-mini',
+        maxTokens: 42,
+        timeoutMs: 1000,
+        rateLimitKey: 'story-1',
+        fetchFn,
+      }),
+    ).resolves.toBe('{"summary":"ok"}');
+
+    expect(fetchFn).toHaveBeenCalledWith(
+      'https://api.openai.com/v1/chat/completions',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({ Authorization: 'Bearer test-key' }),
+      }),
+    );
+  });
+
+  it('throws on missing key, rate limit, upstream errors, and missing content', async () => {
+    await expect(postBundleSynthesisCompletion('prompt')).rejects.toThrow('missing OPENAI_API_KEY');
+
+    process.env.OPENAI_API_KEY = 'test-key';
+    const okFetch = vi.fn(async () => new Response(JSON.stringify({ choices: [] }), { status: 200 }));
+
+    await expect(
+      postBundleSynthesisCompletion('prompt', {
+        rateLimitKey: 'story-limited',
+        rateLimitPerMinute: 1,
+        fetchFn: okFetch,
+      }),
+    ).rejects.toThrow('No content in OpenAI response');
+    await expect(
+      postBundleSynthesisCompletion('prompt', {
+        rateLimitKey: 'story-limited',
+        rateLimitPerMinute: 1,
+        fetchFn: okFetch,
+      }),
+    ).rejects.toThrow('rate limit exceeded');
+
+    await expect(
+      postBundleSynthesisCompletion('prompt', {
+        rateLimitKey: 'story-http',
+        fetchFn: vi.fn(async () => new Response('bad', { status: 502 })),
+      }),
+    ).rejects.toThrow('OpenAI API error: 502');
+  });
+});

--- a/services/news-aggregator/src/bundleSynthesisRelay.ts
+++ b/services/news-aggregator/src/bundleSynthesisRelay.ts
@@ -1,0 +1,135 @@
+import { resolveTokenParam } from './analysisRelay';
+
+export const DEFAULT_BUNDLE_SYNTHESIS_MODEL = 'gpt-4o-mini';
+export const DEFAULT_BUNDLE_SYNTHESIS_MAX_TOKENS = 1_200;
+export const DEFAULT_BUNDLE_SYNTHESIS_TIMEOUT_MS = 20_000;
+export const DEFAULT_BUNDLE_SYNTHESIS_RATE_PER_MIN = 20;
+export const BUNDLE_SYNTHESIS_RATE_WINDOW_MS = 60_000;
+
+export interface BundleSynthesisCompletionOptions {
+  model?: string;
+  maxTokens?: number;
+  timeoutMs?: number;
+  rateLimitKey?: string;
+  rateLimitPerMinute?: number;
+  fetchFn?: typeof fetch;
+}
+
+const rateLimits = new Map<string, { count: number; resetAt: number }>();
+
+function parsePositiveInt(value: string | undefined, fallback: number): number {
+  const parsed = Number.parseInt(value ?? '', 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+export function getBundleSynthesisModel(): string {
+  return process.env.VH_BUNDLE_SYNTHESIS_MODEL || DEFAULT_BUNDLE_SYNTHESIS_MODEL;
+}
+
+export function getBundleSynthesisMaxTokens(): number {
+  return parsePositiveInt(
+    process.env.VH_BUNDLE_SYNTHESIS_MAX_TOKENS,
+    DEFAULT_BUNDLE_SYNTHESIS_MAX_TOKENS,
+  );
+}
+
+export function getBundleSynthesisTimeoutMs(): number {
+  return parsePositiveInt(
+    process.env.VH_BUNDLE_SYNTHESIS_TIMEOUT_MS,
+    DEFAULT_BUNDLE_SYNTHESIS_TIMEOUT_MS,
+  );
+}
+
+export function getBundleSynthesisRatePerMinute(): number {
+  return parsePositiveInt(
+    process.env.VH_BUNDLE_SYNTHESIS_RATE_PER_MIN,
+    DEFAULT_BUNDLE_SYNTHESIS_RATE_PER_MIN,
+  );
+}
+
+export function checkBundleSynthesisRateLimit(
+  key: string,
+  limit = getBundleSynthesisRatePerMinute(),
+): boolean {
+  const now = Date.now();
+  const entry = rateLimits.get(key);
+  if (!entry || now > entry.resetAt) {
+    rateLimits.set(key, { count: 1, resetAt: now + BUNDLE_SYNTHESIS_RATE_WINDOW_MS });
+    return true;
+  }
+  if (entry.count >= limit) {
+    return false;
+  }
+  entry.count += 1;
+  return true;
+}
+
+export function resetBundleSynthesisRateLimits(): void {
+  rateLimits.clear();
+}
+
+export function buildBundleOpenAIChatRequest(prompt: string, model?: string, maxTokens?: number) {
+  const usedModel = model || getBundleSynthesisModel();
+  const tokenParam = resolveTokenParam(usedModel);
+  return {
+    model: usedModel,
+    messages: [
+      {
+        role: 'system' as const,
+        content: 'You are a cross-source news synthesis engine. Return strict JSON only.',
+      },
+      { role: 'user' as const, content: prompt },
+    ],
+    [tokenParam]: maxTokens ?? getBundleSynthesisMaxTokens(),
+    temperature: 0.3,
+    response_format: { type: 'json_object' as const },
+  };
+}
+
+export async function postBundleSynthesisCompletion(
+  prompt: string,
+  options: BundleSynthesisCompletionOptions = {},
+): Promise<string> {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    throw new Error('Bundle synthesis service not configured (missing OPENAI_API_KEY)');
+  }
+
+  const rateLimitKey = options.rateLimitKey ?? 'bundle-synthesis:global';
+  if (!checkBundleSynthesisRateLimit(rateLimitKey, options.rateLimitPerMinute)) {
+    throw new Error(`Bundle synthesis rate limit exceeded for ${rateLimitKey}`);
+  }
+
+  const timeoutMs = options.timeoutMs ?? getBundleSynthesisTimeoutMs();
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  const fetchFn = options.fetchFn ?? fetch;
+
+  try {
+    const response = await fetchFn('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify(
+        buildBundleOpenAIChatRequest(prompt, options.model, options.maxTokens),
+      ),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      const detail = await response.text().catch(() => 'unknown');
+      throw new Error(`OpenAI API error: ${response.status} ${detail}`);
+    }
+
+    const body = (await response.json()) as any;
+    const content = body?.choices?.[0]?.message?.content;
+    if (typeof content !== 'string' || content.trim().length === 0) {
+      throw new Error('No content in OpenAI response');
+    }
+    return content;
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/services/news-aggregator/src/bundleSynthesisWorker.test.ts
+++ b/services/news-aggregator/src/bundleSynthesisWorker.test.ts
@@ -1,0 +1,381 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { CandidateSynthesis, TopicSynthesisV2 } from '@vh/data-model';
+import type { NewsRuntimeSynthesisCandidate, StoryBundle } from '@vh/ai-engine';
+import { createBundleSynthesisWorker } from './bundleSynthesisWorker';
+import type { BundleSynthesisWorkerDeps } from './bundleSynthesisWorker';
+
+const writeTopicSynthesisMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@vh/gun-client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@vh/gun-client')>();
+  return {
+    ...actual,
+    writeTopicSynthesis: writeTopicSynthesisMock,
+  };
+});
+
+const NOW = 1_700_000_000_000;
+
+function makeCandidate(overrides: Partial<NewsRuntimeSynthesisCandidate> = {}): NewsRuntimeSynthesisCandidate {
+  return {
+    story_id: 'story-1',
+    provider: {
+      provider_id: 'remote-analysis',
+      model_id: 'gpt-4o-mini',
+      kind: 'remote',
+    },
+    request: {
+      prompt: 'headline',
+      model: 'gpt-4o-mini',
+      max_tokens: 1200,
+      temperature: 0.3,
+    },
+    work_items: [
+      {
+        story_id: 'story-1',
+        topic_id: 'wrong-topic',
+        work_type: 'full-analysis',
+        summary_hint: 'headline',
+        requested_at: NOW,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function makeBundle(overrides: Partial<StoryBundle> = {}): StoryBundle {
+  return {
+    schemaVersion: 'story-bundle-v0',
+    story_id: 'story-1',
+    topic_id: 'topic-from-bundle',
+    headline: 'Markets rally after policy announcement',
+    summary_hint: 'Markets rallied after a policy announcement.',
+    cluster_window_start: NOW - 3_600_000,
+    cluster_window_end: NOW,
+    sources: [
+      {
+        source_id: 'fox-latest',
+        publisher: 'Fox News',
+        title: 'Markets surge on policy news',
+        url: 'https://example.com/fox',
+        url_hash: 'hash-1',
+        published_at: NOW - 2_000,
+      },
+      {
+        source_id: 'bbc-general',
+        publisher: 'BBC News',
+        title: 'Global markets up on policy shift',
+        url: 'https://example.com/bbc',
+        url_hash: 'hash-2',
+        published_at: NOW - 1_000,
+      },
+      {
+        source_id: 'guardian-us',
+        publisher: 'The Guardian',
+        title: 'Policy drives market gains',
+        url: 'https://example.com/guardian',
+        url_hash: 'hash-3',
+        published_at: NOW,
+      },
+    ],
+    cluster_features: {
+      entity_keys: ['markets', 'policy'],
+      time_bucket: '2026-04-17T21',
+      semantic_signature: 'sig-markets',
+      confidence_score: 0.82,
+    },
+    provenance_hash: 'prov-a',
+    created_at: NOW,
+    ...overrides,
+  };
+}
+
+function validRaw(overrides: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    summary: 'Markets rallied after a policy announcement.',
+    frames: [
+      {
+        frame: 'The policy will boost economic growth.',
+        reframe: 'Short-term gains may mask structural risks.',
+      },
+      {
+        frame: 'Officials should move quickly to preserve momentum.',
+        reframe: 'Officials should slow down until safeguards are clear.',
+      },
+    ],
+    source_count: 3,
+    source_publishers: ['Ghost Publisher'],
+    verification_confidence: 0.82,
+    ...overrides,
+  });
+}
+
+function makeDeps(overrides: Partial<BundleSynthesisWorkerDeps> = {}) {
+  const logger = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+  const deps: BundleSynthesisWorkerDeps = {
+    client: { id: 'client' } as any,
+    readStoryBundle: vi.fn().mockResolvedValue(makeBundle()) as any,
+    readTopicEpochCandidate: vi.fn().mockResolvedValue(null) as any,
+    writeTopicEpochCandidate: vi.fn(async (_client, candidate) => candidate as CandidateSynthesis) as any,
+    writeTopicEpochSynthesis: vi.fn(async (_client, synthesis) => synthesis as TopicSynthesisV2) as any,
+    writeTopicLatestSynthesisIfNotDowngrade: vi.fn(async () => ({ written: true as const })) as any,
+    relay: vi.fn().mockResolvedValue(validRaw()),
+    modelId: 'gpt-4o-mini',
+    now: vi.fn(() => NOW),
+    logger,
+    ...overrides,
+  };
+  return { deps, logger };
+}
+
+describe('bundle synthesis worker', () => {
+  afterEach(() => {
+    expect(writeTopicSynthesisMock).not.toHaveBeenCalled();
+    writeTopicSynthesisMock.mockClear();
+  });
+
+  it('writes candidate, epoch synthesis, and latest on the happy path', async () => {
+    const { deps, logger } = makeDeps();
+
+    await createBundleSynthesisWorker(deps)(makeCandidate());
+
+    expect(deps.readStoryBundle).toHaveBeenCalledWith(deps.client, 'story-1');
+    expect(deps.writeTopicEpochCandidate).toHaveBeenCalledTimes(1);
+    expect(deps.writeTopicEpochSynthesis).toHaveBeenCalledTimes(1);
+    expect(deps.writeTopicLatestSynthesisIfNotDowngrade).toHaveBeenCalledTimes(1);
+
+    const candidatePayload = vi.mocked(deps.writeTopicEpochCandidate).mock.calls[0]![1] as CandidateSynthesis;
+    const synthesisPayload = vi.mocked(deps.writeTopicEpochSynthesis).mock.calls[0]![1] as TopicSynthesisV2;
+
+    expect(candidatePayload.topic_id).toBe('topic-from-bundle');
+    expect(candidatePayload.candidate_id).toMatch(/^news-bundle:[a-f0-9]{64}$/);
+    expect(synthesisPayload.topic_id).toBe('topic-from-bundle');
+    expect(synthesisPayload.epoch).toBe(0);
+    expect(synthesisPayload.synthesis_id).toBe('news-bundle:story-1:prov-a');
+    expect(synthesisPayload.quorum).toMatchObject({ required: 1, received: 1 });
+    expect(logger.info).toHaveBeenCalledWith(
+      '[vh:bundle-synth] done',
+      expect.objectContaining({
+        story_id: 'story-1',
+        topic_id: 'topic-from-bundle',
+        publishers: ['BBC News', 'Fox News', 'The Guardian'],
+        latest_written: true,
+      }),
+    );
+  });
+
+  it('skips missing bundles without relay or writes', async () => {
+    const { deps, logger } = makeDeps({
+      readStoryBundle: vi.fn().mockResolvedValue(null) as any,
+    });
+
+    await createBundleSynthesisWorker(deps)(makeCandidate());
+
+    expect(deps.relay).not.toHaveBeenCalled();
+    expect(deps.writeTopicEpochCandidate).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      '[vh:bundle-synth] bundle_missing',
+      expect.objectContaining({ story_id: 'story-1' }),
+    );
+  });
+
+  it('uses bundle topic id and ignores candidate work item topic id', async () => {
+    const { deps } = makeDeps({
+      readStoryBundle: vi.fn().mockResolvedValue(makeBundle({ topic_id: 'correct-topic' })) as any,
+    });
+
+    await createBundleSynthesisWorker(deps)(makeCandidate());
+
+    const candidatePayload = vi.mocked(deps.writeTopicEpochCandidate).mock.calls[0]![1] as CandidateSynthesis;
+    const synthesisPayload = vi.mocked(deps.writeTopicEpochSynthesis).mock.calls[0]![1] as TopicSynthesisV2;
+    expect(candidatePayload.topic_id).toBe('correct-topic');
+    expect(synthesisPayload.topic_id).toBe('correct-topic');
+  });
+
+  it('derives provenance-sensitive candidate ids and idempotently skips existing candidates', async () => {
+    const { deps } = makeDeps();
+    const worker = createBundleSynthesisWorker(deps);
+
+    await worker(makeCandidate());
+    const first = vi.mocked(deps.writeTopicEpochCandidate).mock.calls[0]![1] as CandidateSynthesis;
+
+    vi.mocked(deps.readStoryBundle).mockResolvedValueOnce(makeBundle({ provenance_hash: 'prov-b' }) as any);
+    await worker(makeCandidate());
+    const second = vi.mocked(deps.writeTopicEpochCandidate).mock.calls[1]![1] as CandidateSynthesis;
+
+    expect(second.candidate_id).not.toBe(first.candidate_id);
+
+    const { deps: skipDeps, logger } = makeDeps({
+      readTopicEpochCandidate: vi.fn().mockResolvedValue(first) as any,
+    });
+    await createBundleSynthesisWorker(skipDeps)(makeCandidate());
+
+    expect(skipDeps.relay).not.toHaveBeenCalled();
+    expect(skipDeps.writeTopicEpochCandidate).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledWith(
+      '[vh:bundle-synth] idempotent_skip',
+      expect.objectContaining({ candidate_id: first.candidate_id }),
+    );
+  });
+
+  it('rejects source-count mismatches and keeps bundle publishers as telemetry truth', async () => {
+    const { deps, logger } = makeDeps({
+      relay: vi.fn().mockResolvedValue(validRaw({ source_count: 1 })),
+    });
+
+    await createBundleSynthesisWorker(deps)(makeCandidate());
+
+    expect(deps.writeTopicEpochCandidate).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      '[vh:bundle-synth] source_count_mismatch',
+      expect.objectContaining({ parsed_source_count: 1, actual_source_count: 3 }),
+    );
+
+    const { deps: okDeps, logger: okLogger } = makeDeps({
+      relay: vi.fn().mockResolvedValue(
+        validRaw({ source_count: 3, source_publishers: ['Fake1', 'Fake2', 'Fake3'] }),
+      ),
+    });
+    await createBundleSynthesisWorker(okDeps)(makeCandidate());
+
+    expect(okLogger.info).toHaveBeenCalledWith(
+      '[vh:bundle-synth] done',
+      expect.objectContaining({
+        publishers: ['BBC News', 'Fox News', 'The Guardian'],
+      }),
+    );
+  });
+
+  it('adds single-source warnings from bundle reality', async () => {
+    const bundle = makeBundle({ sources: [makeBundle().sources[0]!] });
+    const { deps } = makeDeps({
+      readStoryBundle: vi.fn().mockResolvedValue(bundle) as any,
+      relay: vi.fn().mockResolvedValue(validRaw({ source_count: 1 })),
+    });
+
+    await createBundleSynthesisWorker(deps)(makeCandidate());
+
+    const candidatePayload = vi.mocked(deps.writeTopicEpochCandidate).mock.calls[0]![1] as CandidateSynthesis;
+    const synthesisPayload = vi.mocked(deps.writeTopicEpochSynthesis).mock.calls[0]![1] as TopicSynthesisV2;
+    expect(candidatePayload.warnings).toEqual(['single-source-only']);
+    expect(synthesisPayload.warnings).toEqual(['single-source-only']);
+  });
+
+  it('contains relay failures locally and emits typed telemetry', async () => {
+    const abortError = new Error('operation aborted by timeout');
+    abortError.name = 'AbortError';
+    const { deps, logger } = makeDeps({
+      relay: vi.fn().mockRejectedValue(abortError),
+    });
+
+    await createBundleSynthesisWorker(deps)(makeCandidate());
+
+    expect(deps.writeTopicEpochCandidate).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      '[vh:bundle-synth] relay_timeout',
+      expect.objectContaining({ error_message: 'operation aborted by timeout' }),
+    );
+
+    const { deps: failedDeps, logger: failedLogger } = makeDeps({
+      relay: vi.fn().mockRejectedValue('HTTP 500: server error'),
+    });
+    await createBundleSynthesisWorker(failedDeps)(makeCandidate());
+
+    expect(failedDeps.writeTopicEpochCandidate).not.toHaveBeenCalled();
+    expect(failedLogger.warn).toHaveBeenCalledWith(
+      '[vh:bundle-synth] relay_failed',
+      expect.objectContaining({ error_message: 'HTTP 500: server error' }),
+    );
+  });
+
+  it('rejects parse failures without writing and accepts final_refined payloads', async () => {
+    const { deps, logger } = makeDeps({
+      relay: vi.fn().mockResolvedValue('not json at all'),
+    });
+
+    await createBundleSynthesisWorker(deps)(makeCandidate());
+
+    expect(deps.writeTopicEpochCandidate).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      '[vh:bundle-synth] parse_failed',
+      expect.objectContaining({ parse_error_code: 'NO_JSON_OBJECT_FOUND' }),
+    );
+
+    const { deps: placeholderDeps } = makeDeps({
+      relay: vi.fn().mockResolvedValue(
+        validRaw({
+          frames: [
+            { frame: 'N/A', reframe: 'N/A' },
+            { frame: 'No clear bias detected', reframe: 'Frame unavailable.' },
+          ],
+        }),
+      ),
+    });
+    await createBundleSynthesisWorker(placeholderDeps)(makeCandidate());
+    expect(placeholderDeps.writeTopicEpochCandidate).not.toHaveBeenCalled();
+
+    const { deps: wrappedDeps } = makeDeps({
+      relay: vi.fn().mockResolvedValue(JSON.stringify({ final_refined: JSON.parse(validRaw()) })),
+    });
+    await createBundleSynthesisWorker(wrappedDeps)(makeCandidate());
+    expect(wrappedDeps.writeTopicEpochCandidate).toHaveBeenCalledTimes(1);
+  });
+
+  it('threads latest-write skip reasons while still writing epoch synthesis', async () => {
+    for (const reason of [
+      'downgrade_existing_epoch',
+      'downgrade_existing_quorum',
+      'ownership_guard_rejected',
+    ] as const) {
+      const { deps, logger } = makeDeps({
+        writeTopicLatestSynthesisIfNotDowngrade: vi.fn(async () => ({
+          written: false as const,
+          reason,
+        })) as any,
+      });
+
+      await createBundleSynthesisWorker(deps)(makeCandidate());
+
+      expect(deps.writeTopicEpochSynthesis).toHaveBeenCalledTimes(1);
+      expect(logger.info).toHaveBeenCalledWith(
+        '[vh:bundle-synth] latest_skipped',
+        expect.objectContaining({ reason }),
+      );
+    }
+  });
+
+  it('trims parsed model strings before writing', async () => {
+    const { deps } = makeDeps({
+      relay: vi.fn().mockResolvedValue(
+        validRaw({
+          summary: '  Trimmed summary.  ',
+          frames: [
+            {
+              frame: '  Trimmed frame.  ',
+              reframe: '  Trimmed reframe.  ',
+            },
+            {
+              frame: 'Second frame.',
+              reframe: 'Second reframe.',
+            },
+          ],
+        }),
+      ),
+    });
+
+    await createBundleSynthesisWorker(deps)(makeCandidate());
+
+    const candidatePayload = vi.mocked(deps.writeTopicEpochCandidate).mock.calls[0]![1] as CandidateSynthesis;
+    const synthesisPayload = vi.mocked(deps.writeTopicEpochSynthesis).mock.calls[0]![1] as TopicSynthesisV2;
+    expect(candidatePayload.facts_summary).toBe('Trimmed summary.');
+    expect(candidatePayload.frames[0]).toEqual({
+      frame: 'Trimmed frame.',
+      reframe: 'Trimmed reframe.',
+    });
+    expect(synthesisPayload.facts_summary).toBe('Trimmed summary.');
+  });
+});

--- a/services/news-aggregator/src/bundleSynthesisWorker.ts
+++ b/services/news-aggregator/src/bundleSynthesisWorker.ts
@@ -1,0 +1,303 @@
+import { createHash } from 'node:crypto';
+import {
+  readStoryBundle,
+  readTopicEpochCandidate,
+  writeTopicEpochCandidate,
+  writeTopicEpochSynthesis,
+  writeTopicLatestSynthesisIfNotDowngrade,
+  type SafeLatestWriteResult,
+  type VennClient,
+} from '@vh/gun-client';
+import {
+  buildBundlePromptFromStoryBundle,
+  parseGeneratedBundleSynthesis,
+  type GeneratedBundleSynthesisResult,
+  type NewsRuntimeSynthesisCandidate,
+  type StoryBundle,
+} from '@vh/ai-engine';
+import type { CandidateSynthesis, TopicSynthesisV2 } from '@vh/data-model';
+import type { EnrichmentWorker, LoggerLike } from './daemonUtils';
+
+const DEFAULT_PIPELINE_VERSION = 'news-bundle-v1';
+const SYNTHESIS_ID_PREFIX = 'news-bundle:';
+
+export interface BundleSynthesisWorkerDeps {
+  client: VennClient;
+  readStoryBundle: typeof readStoryBundle;
+  readTopicEpochCandidate: typeof readTopicEpochCandidate;
+  writeTopicEpochCandidate: typeof writeTopicEpochCandidate;
+  writeTopicEpochSynthesis: typeof writeTopicEpochSynthesis;
+  writeTopicLatestSynthesisIfNotDowngrade: typeof writeTopicLatestSynthesisIfNotDowngrade;
+  relay: (prompt: string, context?: { storyId: string; topicId: string }) => Promise<string>;
+  modelId: string;
+  now: () => number;
+  logger: LoggerLike;
+  pipelineVersion?: string;
+}
+
+function sha256Hex(input: string): string {
+  return createHash('sha256').update(input).digest('hex');
+}
+
+function deriveCandidateId(
+  storyId: string,
+  provenanceHash: string,
+  modelId: string,
+  pipelineVersion = DEFAULT_PIPELINE_VERSION,
+): string {
+  const input = `${pipelineVersion}|${storyId}|${provenanceHash}|${modelId}`;
+  return `${SYNTHESIS_ID_PREFIX}${sha256Hex(input)}`;
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && (error.name === 'AbortError' || /abort|timeout/i.test(error.message));
+}
+
+function sortedPublishers(bundle: StoryBundle): string[] {
+  const sources = bundle.primary_sources ?? bundle.sources;
+  return Array.from(new Set(sources.map((source) => source.publisher))).sort();
+}
+
+function toCandidatePayload(input: {
+  candidateId: string;
+  topicId: string;
+  parsed: GeneratedBundleSynthesisResult;
+  modelId: string;
+  warnings: string[];
+  now: number;
+}): CandidateSynthesis {
+  return {
+    candidate_id: input.candidateId,
+    topic_id: input.topicId,
+    epoch: 0,
+    critique_notes: [],
+    facts_summary: input.parsed.summary,
+    frames: input.parsed.frames,
+    warnings: input.warnings,
+    divergence_hints: [],
+    provider: {
+      provider_id: 'openai',
+      model_id: input.modelId,
+      kind: 'remote',
+    },
+    created_at: input.now,
+  };
+}
+
+function toSynthesisPayload(input: {
+  storyId: string;
+  topicId: string;
+  provenanceHash: string;
+  candidateId: string;
+  parsed: GeneratedBundleSynthesisResult;
+  warnings: string[];
+  now: number;
+}): TopicSynthesisV2 {
+  return {
+    schemaVersion: 'topic-synthesis-v2',
+    topic_id: input.topicId,
+    epoch: 0,
+    synthesis_id: `${SYNTHESIS_ID_PREFIX}${input.storyId}:${input.provenanceHash.slice(0, 16)}`,
+    inputs: { story_bundle_ids: [input.storyId] },
+    quorum: {
+      required: 1,
+      received: 1,
+      reached_at: input.now,
+      timed_out: false,
+      selection_rule: 'deterministic',
+    },
+    facts_summary: input.parsed.summary,
+    frames: input.parsed.frames,
+    warnings: input.warnings,
+    divergence_metrics: {
+      disagreement_score: 0,
+      source_dispersion: 0,
+      candidate_count: 1,
+    },
+    provenance: {
+      candidate_ids: [input.candidateId],
+      provider_mix: [{ provider_id: 'openai', count: 1 }],
+    },
+    created_at: input.now,
+  };
+}
+
+export function createBundleSynthesisWorker(deps: BundleSynthesisWorkerDeps): EnrichmentWorker {
+  const pipelineVersion = deps.pipelineVersion ?? DEFAULT_PIPELINE_VERSION;
+
+  return async (candidate: NewsRuntimeSynthesisCandidate) => {
+    const storyId = candidate.story_id;
+    const startedAt = deps.now();
+
+    const bundle = await deps.readStoryBundle(deps.client, storyId);
+    if (!bundle) {
+      deps.logger.warn('[vh:bundle-synth] bundle_missing', {
+        story_id: storyId,
+        pipeline_version: pipelineVersion,
+        model_id: deps.modelId,
+      });
+      return;
+    }
+
+    const topicId = bundle.topic_id;
+    const provenanceHash = bundle.provenance_hash;
+    const bundleSources = bundle.primary_sources ?? bundle.sources;
+    const actualSourceCount = bundleSources.length;
+    const actualPublishers = sortedPublishers(bundle as StoryBundle);
+    const candidateId = deriveCandidateId(storyId, provenanceHash, deps.modelId, pipelineVersion);
+
+    deps.logger.info('[vh:bundle-synth] start', {
+      story_id: storyId,
+      topic_id: topicId,
+      provenance_hash: provenanceHash,
+      candidate_id: candidateId,
+      pipeline_version: pipelineVersion,
+      model_id: deps.modelId,
+    });
+
+    const existingCandidate = await deps.readTopicEpochCandidate(deps.client, topicId, 0, candidateId);
+    if (existingCandidate) {
+      deps.logger.info('[vh:bundle-synth] idempotent_skip', {
+        story_id: storyId,
+        topic_id: topicId,
+        candidate_id: candidateId,
+        pipeline_version: pipelineVersion,
+        model_id: deps.modelId,
+      });
+      return;
+    }
+
+    const prompt = buildBundlePromptFromStoryBundle(bundle as StoryBundle);
+    let raw: string;
+    try {
+      raw = await deps.relay(prompt, { storyId, topicId });
+    } catch (error) {
+      const event = isAbortError(error) ? 'relay_timeout' : 'relay_failed';
+      deps.logger.warn(`[vh:bundle-synth] ${event}`, {
+        story_id: storyId,
+        topic_id: topicId,
+        model_id: deps.modelId,
+        pipeline_version: pipelineVersion,
+        error_message: error instanceof Error ? error.message : String(error),
+        latency_ms: Math.max(0, deps.now() - startedAt),
+      });
+      return;
+    }
+
+    let parsed: GeneratedBundleSynthesisResult;
+    try {
+      parsed = parseGeneratedBundleSynthesis(raw);
+    } catch (error) {
+      deps.logger.warn('[vh:bundle-synth] parse_failed', {
+        story_id: storyId,
+        topic_id: topicId,
+        model_id: deps.modelId,
+        pipeline_version: pipelineVersion,
+        parse_error_code: error instanceof Error ? error.message : 'unknown',
+      });
+      return;
+    }
+
+    if (parsed.source_count !== actualSourceCount) {
+      deps.logger.warn('[vh:bundle-synth] source_count_mismatch', {
+        story_id: storyId,
+        topic_id: topicId,
+        model_id: deps.modelId,
+        pipeline_version: pipelineVersion,
+        parsed_source_count: parsed.source_count,
+        actual_source_count: actualSourceCount,
+      });
+      return;
+    }
+
+    const now = deps.now();
+    const warnings = actualSourceCount === 1 ? ['single-source-only'] : [];
+    const candidatePayload = toCandidatePayload({
+      candidateId,
+      topicId,
+      parsed,
+      modelId: deps.modelId,
+      warnings,
+      now,
+    });
+
+    await deps.writeTopicEpochCandidate(deps.client, candidatePayload);
+    deps.logger.info('[vh:bundle-synth] candidate_written', {
+      story_id: storyId,
+      candidate_id: candidateId,
+      epoch: 0,
+      quorum_received: 1,
+      pipeline_version: pipelineVersion,
+      model_id: deps.modelId,
+    });
+
+    const synthesisPayload = toSynthesisPayload({
+      storyId,
+      topicId,
+      provenanceHash,
+      candidateId,
+      parsed,
+      warnings,
+      now,
+    });
+
+    await deps.writeTopicEpochSynthesis(deps.client, synthesisPayload);
+    deps.logger.info('[vh:bundle-synth] epoch_synthesis_written', {
+      story_id: storyId,
+      topic_id: topicId,
+      synthesis_id: synthesisPayload.synthesis_id,
+      epoch: 0,
+      pipeline_version: pipelineVersion,
+      model_id: deps.modelId,
+    });
+
+    const latestResult: SafeLatestWriteResult = await deps.writeTopicLatestSynthesisIfNotDowngrade(
+      deps.client,
+      synthesisPayload,
+      {
+        ownershipGuard: (existing) => existing.synthesis_id.startsWith(SYNTHESIS_ID_PREFIX),
+      },
+    );
+
+    if (latestResult.written) {
+      deps.logger.info('[vh:bundle-synth] latest_written', {
+        story_id: storyId,
+        topic_id: topicId,
+        synthesis_id: synthesisPayload.synthesis_id,
+        pipeline_version: pipelineVersion,
+        model_id: deps.modelId,
+      });
+    } else {
+      deps.logger.info('[vh:bundle-synth] latest_skipped', {
+        story_id: storyId,
+        topic_id: topicId,
+        reason: latestResult.reason,
+        pipeline_version: pipelineVersion,
+        model_id: deps.modelId,
+      });
+    }
+
+    deps.logger.info('[vh:bundle-synth] done', {
+      story_id: storyId,
+      topic_id: topicId,
+      candidate_id: candidateId,
+      synthesis_id: synthesisPayload.synthesis_id,
+      actual_source_count: actualSourceCount,
+      publishers: actualPublishers,
+      latest_written: latestResult.written,
+      latest_skip_reason: latestResult.written ? undefined : latestResult.reason,
+      latency_ms: Math.max(0, deps.now() - startedAt),
+      pipeline_version: pipelineVersion,
+      model_id: deps.modelId,
+    });
+  };
+}
+
+export const bundleSynthesisWorkerInternal = {
+  DEFAULT_PIPELINE_VERSION,
+  SYNTHESIS_ID_PREFIX,
+  deriveCandidateId,
+  isAbortError,
+  toCandidatePayload,
+  toSynthesisPayload,
+};

--- a/services/news-aggregator/src/daemon.env.test.ts
+++ b/services/news-aggregator/src/daemon.env.test.ts
@@ -48,6 +48,7 @@ async function loadSubject(options: {
   const readNewsIngestionLease = vi.fn().mockResolvedValue(null);
   const writeNewsIngestionLease = vi.fn().mockResolvedValue(makeLease());
   const verifyStoryClusterHealth = vi.fn().mockResolvedValue(undefined);
+  const createBundleSynthesisWorker = vi.fn(() => vi.fn());
 
   vi.doMock('@vh/ai-engine', async () => {
     const actual = await vi.importActual<typeof import('@vh/ai-engine')>('@vh/ai-engine');
@@ -97,11 +98,23 @@ async function loadSubject(options: {
     };
   });
 
+  vi.doMock('./bundleSynthesisWorker', () => ({
+    createBundleSynthesisWorker,
+  }));
+
+  vi.doMock('./bundleSynthesisRelay', () => ({
+    getBundleSynthesisMaxTokens: vi.fn(() => 1200),
+    getBundleSynthesisModel: vi.fn(() => 'gpt-4o-mini'),
+    getBundleSynthesisTimeoutMs: vi.fn(() => 20_000),
+    postBundleSynthesisCompletion: vi.fn(),
+  }));
+
   const subject = await import('./daemon');
   return {
     subject,
     startNewsRuntime,
     createNodeMeshClient,
+    createBundleSynthesisWorker,
     verifyStoryClusterHealth,
     runtimeHandle,
   };
@@ -110,6 +123,7 @@ async function loadSubject(options: {
 describe('startNewsAggregatorDaemonFromEnv', () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllEnvs();
   });
 
   it('starts with explicit peers and primary lease ttl env', async () => {
@@ -196,5 +210,53 @@ describe('startNewsAggregatorDaemonFromEnv', () => {
     );
 
     await processHandle.stop();
+  });
+
+  it('wires bundle synthesis worker only when enabled and keyed', async () => {
+    vi.stubEnv('OPENAI_API_KEY', 'test-key');
+    const {
+      subject,
+      createBundleSynthesisWorker,
+    } = await loadSubject({
+      env: {
+        VITE_NEWS_FEED_SOURCES: '[]',
+        VITE_NEWS_TOPIC_MAPPING: '{}',
+        VH_BUNDLE_SYNTHESIS_ENABLED: 'true',
+        VH_BUNDLE_SYNTHESIS_QUEUE_DEPTH: '32',
+      },
+      gunPeers: [],
+      pollIntervalMs: undefined,
+      leaseTtlMs: 60_000,
+    });
+
+    const processHandle = await subject.startNewsAggregatorDaemonFromEnv();
+
+    expect(createBundleSynthesisWorker).toHaveBeenCalledWith(
+      expect.objectContaining({
+        modelId: 'gpt-4o-mini',
+        pipelineVersion: 'news-bundle-v1',
+      }),
+    );
+
+    await processHandle.stop();
+  });
+
+  it('fails startup when bundle synthesis is enabled without an OpenAI key', async () => {
+    vi.stubEnv('OPENAI_API_KEY', '');
+    const { subject, createBundleSynthesisWorker } = await loadSubject({
+      env: {
+        VITE_NEWS_FEED_SOURCES: '[]',
+        VITE_NEWS_TOPIC_MAPPING: '{}',
+        VH_BUNDLE_SYNTHESIS_ENABLED: 'true',
+      },
+      gunPeers: [],
+      pollIntervalMs: undefined,
+      leaseTtlMs: 60_000,
+    });
+
+    await expect(subject.startNewsAggregatorDaemonFromEnv()).rejects.toThrow(
+      'OPENAI_API_KEY is required',
+    );
+    expect(createBundleSynthesisWorker).not.toHaveBeenCalled();
   });
 });

--- a/services/news-aggregator/src/daemon.test.ts
+++ b/services/news-aggregator/src/daemon.test.ts
@@ -96,6 +96,12 @@ describe('news aggregator daemon', () => {
   });
 
   it('parses feed + topic env config with safe fallbacks', () => {
+    expect(__internal.isEnvTruthy('true')).toBe(true);
+    expect(__internal.isEnvTruthy('1')).toBe(true);
+    expect(__internal.isEnvTruthy('yes')).toBe(true);
+    expect(__internal.isEnvTruthy('on')).toBe(true);
+    expect(__internal.isEnvTruthy('false')).toBe(false);
+
     expect(__internal.parseFeedSources(undefined).length).toBeGreaterThan(0);
     expect(__internal.parseFeedSources('not-json').length).toBeGreaterThan(0);
 
@@ -340,6 +346,64 @@ describe('news aggregator daemon', () => {
     expect(enrichmentWorker).toHaveBeenCalledTimes(1);
     expect(daemon.enrichmentQueueDepth()).toBe(0);
 
+    resolveEnrichment?.();
+    await Promise.resolve();
+
+    await daemon.stop();
+  });
+
+  it('applies enrichment queue maxDepth and logs dropped candidates', async () => {
+    const logger = makeLogger();
+    const runtimeHandle = makeRuntimeHandle();
+    const timers = makeTimerControls();
+
+    let resolveEnrichment: (() => void) | null = null;
+    const enrichmentWorker = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveEnrichment = resolve;
+        }),
+    );
+
+    const heldLease = makeLease();
+    const startRuntime = vi.fn(() => runtimeHandle);
+    const readLease = vi.fn().mockResolvedValueOnce(null).mockResolvedValueOnce(heldLease);
+    const writeLease = vi.fn(async () => heldLease);
+
+    const daemon = createNewsAggregatorDaemon({
+      client: { id: 'client-queue-depth' } as VennClient,
+      feedSources: [...FEED_SOURCES],
+      topicMapping: { ...TOPIC_MAPPING },
+      startRuntime,
+      readLease,
+      writeLease,
+      enrichmentWorker,
+      enrichmentQueueMaxDepth: 1,
+      logger,
+      setIntervalFn: timers.setIntervalFn,
+      clearIntervalFn: timers.clearIntervalFn,
+      leaseHolderId: 'vh-news-daemon:test',
+    });
+
+    await daemon.start();
+
+    const runtimeConfig = startRuntime.mock.calls[0]?.[0] as NewsRuntimeConfig;
+    runtimeConfig.onSynthesisCandidate?.({ ...CANDIDATE, story_id: 'story-1' });
+    runtimeConfig.onSynthesisCandidate?.({ ...CANDIDATE, story_id: 'story-2' });
+
+    expect(daemon.enrichmentQueueDepth()).toBe(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      '[vh:bundle-synth] queue_full',
+      expect.objectContaining({
+        story_id: 'story-2',
+        queue_depth: 1,
+        max_depth: 1,
+        reason: 'queue_full',
+      }),
+    );
+
+    await Promise.resolve();
+    expect(enrichmentWorker).toHaveBeenCalledTimes(1);
     resolveEnrichment?.();
     await Promise.resolve();
 

--- a/services/news-aggregator/src/daemon.ts
+++ b/services/news-aggregator/src/daemon.ts
@@ -9,11 +9,16 @@ import {
 import {
   createNodeMeshClient,
   readNewsIngestionLease,
+  readStoryBundle,
+  readTopicEpochCandidate,
   removeNewsBundle,
   removeNewsStoryline,
   writeNewsIngestionLease,
   writeNewsStoryline,
   writeStoryBundle,
+  writeTopicEpochCandidate,
+  writeTopicEpochSynthesis,
+  writeTopicLatestSynthesisIfNotDowngrade,
   type NewsIngestionLease,
   type VennClient,
 } from '@vh/gun-client';
@@ -36,6 +41,13 @@ import {
 } from './daemonUtils';
 import { createLeaseGuard } from './leaseGuard';
 import { createDaemonFeedClusterCaptureRecorder } from './clusterCapturePersistence';
+import { createBundleSynthesisWorker } from './bundleSynthesisWorker';
+import {
+  getBundleSynthesisMaxTokens,
+  getBundleSynthesisModel,
+  getBundleSynthesisTimeoutMs,
+  postBundleSynthesisCompletion,
+} from './bundleSynthesisRelay';
 type RuntimeStarter = (config: NewsRuntimeConfig) => NewsRuntimeHandle;
 type RuntimeOrchestratorOptions = NonNullable<NewsRuntimeConfig['orchestratorOptions']> & {
   remoteClusterMaxItemsPerRequest?: number;
@@ -54,6 +66,7 @@ export interface NewsAggregatorDaemonConfig {
   writeBundle?: (client: VennClient, bundle: unknown) => Promise<unknown>;
   removeBundle?: (client: VennClient, storyId: string) => Promise<unknown>;
   enrichmentWorker?: EnrichmentWorker;
+  enrichmentQueueMaxDepth?: number;
   runtimeOrchestratorOptions?: NewsRuntimeConfig['orchestratorOptions'];
   now?: () => number;
   random?: () => number;
@@ -84,7 +97,17 @@ export function createNewsAggregatorDaemon(config: NewsAggregatorDaemonConfig): 
   const leaseRenewIntervalMs = Math.max(5_000, Math.floor(leaseTtlMs / 2));
   const leaseVerificationWindowMs = Math.max(500, Math.min(5_000, Math.floor(leaseTtlMs / 6)));
   const holderId = resolveLeaseHolderId(config.leaseHolderId);
-  const queue = createAsyncEnrichmentQueue(config.enrichmentWorker ?? (() => undefined), logger);
+  const queue = createAsyncEnrichmentQueue(config.enrichmentWorker ?? (() => undefined), logger, {
+    maxDepth: config.enrichmentQueueMaxDepth,
+    onDrop(candidate, reason, queueDepth) {
+      logger.warn('[vh:bundle-synth] queue_full', {
+        story_id: candidate.story_id,
+        queue_depth: queueDepth,
+        max_depth: config.enrichmentQueueMaxDepth,
+        reason,
+      });
+    },
+  });
   const clusterCaptureRecorder = createDaemonFeedClusterCaptureRecorder(
     readEnvVar('VH_DAEMON_FEED_RUN_ID'),
   );
@@ -285,6 +308,38 @@ export async function startNewsAggregatorDaemonFromEnv(): Promise<NewsAggregator
     peers: gunPeers.length > 0 ? gunPeers : undefined,
     requireSession: false,
   });
+  const bundleSynthesisEnabled = isEnvTruthy(readEnvVar('VH_BUNDLE_SYNTHESIS_ENABLED'));
+  if (bundleSynthesisEnabled && !process.env.OPENAI_API_KEY?.trim()) {
+    throw new Error('OPENAI_API_KEY is required when VH_BUNDLE_SYNTHESIS_ENABLED=true');
+  }
+
+  const bundleSynthesisModel = getBundleSynthesisModel();
+  const bundleSynthesisTimeoutMs = getBundleSynthesisTimeoutMs();
+  const bundleSynthesisMaxTokens = getBundleSynthesisMaxTokens();
+  const bundleSynthesisQueueDepth = parseOptionalPositiveInt(
+    readEnvVar('VH_BUNDLE_SYNTHESIS_QUEUE_DEPTH'),
+  ) ?? 32;
+  const enrichmentWorker = bundleSynthesisEnabled
+    ? createBundleSynthesisWorker({
+        client,
+        readStoryBundle,
+        readTopicEpochCandidate,
+        writeTopicEpochCandidate,
+        writeTopicEpochSynthesis,
+        writeTopicLatestSynthesisIfNotDowngrade,
+        relay: (prompt, context) =>
+          postBundleSynthesisCompletion(prompt, {
+            model: bundleSynthesisModel,
+            timeoutMs: bundleSynthesisTimeoutMs,
+            maxTokens: bundleSynthesisMaxTokens,
+            rateLimitKey: context ? `bundle-synthesis:${context.storyId}` : 'bundle-synthesis:unknown',
+          }),
+        modelId: bundleSynthesisModel,
+        now: Date.now,
+        logger: console,
+        pipelineVersion: readEnvVar('VH_BUNDLE_SYNTHESIS_PIPELINE_VERSION') ?? 'news-bundle-v1',
+      })
+    : undefined;
   const daemon = createNewsAggregatorDaemon({
     client,
     feedSources,
@@ -292,6 +347,8 @@ export async function startNewsAggregatorDaemonFromEnv(): Promise<NewsAggregator
     pollIntervalMs,
     leaseTtlMs,
     leaseHolderId: readEnvVar('VH_NEWS_DAEMON_HOLDER_ID'),
+    enrichmentWorker,
+    enrichmentQueueMaxDepth: bundleSynthesisEnabled ? bundleSynthesisQueueDepth : undefined,
     runtimeOrchestratorOptions: {
       productionMode: true,
       allowHeuristicFallback: false,
@@ -310,6 +367,11 @@ export async function startNewsAggregatorDaemonFromEnv(): Promise<NewsAggregator
       await client.shutdown();
     },
   };
+}
+
+function isEnvTruthy(value: string | undefined): boolean {
+  const normalized = value?.trim().toLowerCase();
+  return normalized === 'true' || normalized === '1' || normalized === 'yes' || normalized === 'on';
 }
 
 function isDirectExecution(metaUrl: string): boolean {
@@ -354,6 +416,7 @@ if (isDirectExecution(import.meta.url)) {
 /* c8 ignore stop */
 export const __internal = {
   buildLeasePayload,
+  isEnvTruthy,
   isDirectExecution,
   parseFeedSources,
   parseGunPeers,

--- a/services/news-aggregator/src/daemonUtils.test.ts
+++ b/services/news-aggregator/src/daemonUtils.test.ts
@@ -110,6 +110,37 @@ describe('daemonUtils', () => {
     expect(worker).not.toHaveBeenCalled();
   });
 
+  it('drops candidates above maxDepth and preserves unbounded default behavior', async () => {
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    const worker = vi.fn(async () => undefined);
+    const onDrop = vi.fn();
+    const bounded = createAsyncEnrichmentQueue(worker, logger, {
+      maxDepth: 2,
+      onDrop,
+    });
+
+    bounded.enqueue({ ...CANDIDATE, story_id: 'story-1' });
+    bounded.enqueue({ ...CANDIDATE, story_id: 'story-2' });
+    bounded.enqueue({ ...CANDIDATE, story_id: 'story-3' });
+
+    expect(bounded.size()).toBe(2);
+    expect(onDrop).toHaveBeenCalledWith(
+      expect.objectContaining({ story_id: 'story-3' }),
+      'queue_full',
+      2,
+    );
+
+    const unbounded = createAsyncEnrichmentQueue(worker, logger);
+    unbounded.enqueue({ ...CANDIDATE, story_id: 'story-a' });
+    unbounded.enqueue({ ...CANDIDATE, story_id: 'story-b' });
+    unbounded.enqueue({ ...CANDIDATE, story_id: 'story-c' });
+
+    expect(unbounded.size()).toBe(3);
+
+    bounded.stop();
+    unbounded.stop();
+  });
+
   it('derives StoryCluster health URLs across pathname shapes', () => {
     expect(deriveStoryClusterHealthUrl('https://storycluster.example.com')).toBe(
       'https://storycluster.example.com/health',

--- a/services/news-aggregator/src/daemonUtils.ts
+++ b/services/news-aggregator/src/daemonUtils.ts
@@ -33,7 +33,19 @@ export interface AsyncEnrichmentQueue {
   size(): number;
   stop(): void;
 }
-export function createAsyncEnrichmentQueue(worker: EnrichmentWorker, logger: LoggerLike): AsyncEnrichmentQueue {
+export interface AsyncEnrichmentQueueOptions {
+  maxDepth?: number;
+  onDrop?: (
+    candidate: NewsRuntimeSynthesisCandidate,
+    reason: 'queue_full',
+    queueDepth: number,
+  ) => void;
+}
+export function createAsyncEnrichmentQueue(
+  worker: EnrichmentWorker,
+  logger: LoggerLike,
+  options: AsyncEnrichmentQueueOptions = {},
+): AsyncEnrichmentQueue {
   const pending: NewsRuntimeSynthesisCandidate[] = [];
   let draining = false;
   let stopped = false;
@@ -66,6 +78,11 @@ export function createAsyncEnrichmentQueue(worker: EnrichmentWorker, logger: Log
   return {
     enqueue(candidate: NewsRuntimeSynthesisCandidate) {
       if (stopped) {
+        return;
+      }
+
+      if (options.maxDepth !== undefined && pending.length >= options.maxDepth) {
+        options.onDrop?.(candidate, 'queue_full', pending.length);
         return;
       }
 

--- a/services/news-aggregator/src/index.ts
+++ b/services/news-aggregator/src/index.ts
@@ -69,6 +69,29 @@ export {
 export type { AnalyzeRequest, AnalyzeResponse } from './analysisRelay';
 
 export {
+  BUNDLE_SYNTHESIS_RATE_WINDOW_MS,
+  DEFAULT_BUNDLE_SYNTHESIS_MAX_TOKENS,
+  DEFAULT_BUNDLE_SYNTHESIS_MODEL,
+  DEFAULT_BUNDLE_SYNTHESIS_RATE_PER_MIN,
+  DEFAULT_BUNDLE_SYNTHESIS_TIMEOUT_MS,
+  buildBundleOpenAIChatRequest,
+  checkBundleSynthesisRateLimit,
+  getBundleSynthesisMaxTokens,
+  getBundleSynthesisModel,
+  getBundleSynthesisRatePerMinute,
+  getBundleSynthesisTimeoutMs,
+  postBundleSynthesisCompletion,
+  resetBundleSynthesisRateLimits,
+} from './bundleSynthesisRelay';
+export type { BundleSynthesisCompletionOptions } from './bundleSynthesisRelay';
+
+export {
+  bundleSynthesisWorkerInternal,
+  createBundleSynthesisWorker,
+} from './bundleSynthesisWorker';
+export type { BundleSynthesisWorkerDeps } from './bundleSynthesisWorker';
+
+export {
   ArticleTextService,
   ArticleTextServiceError,
   FETCH_TIMEOUT_MS,

--- a/services/news-aggregator/src/prompts.ts
+++ b/services/news-aggregator/src/prompts.ts
@@ -147,7 +147,7 @@ export function parseArticleAnalysisResponse(
   };
 }
 
-/** Generate multi-source synthesis prompt from N per-article analyses. */
+/** @deprecated Use @vh/ai-engine bundlePrompts. */
 export function generateBundleSynthesisPrompt(input: BundleSynthesisInput): string {
   const count = input.articleAnalyses.length;
 
@@ -193,7 +193,7 @@ export function generateBundleSynthesisPrompt(input: BundleSynthesisInput): stri
   ].join('\n');
 }
 
-/** Parse raw LLM response into BundleSynthesisResult. */
+/** @deprecated Use @vh/ai-engine bundlePrompts. */
 export function parseBundleSynthesisResponse(raw: string, sourceCount: number): BundleSynthesisResult {
   if (sourceCount === 0) {
     return {


### PR DESCRIPTION
## Summary

Implements PR B: the TopicSynthesisV2 bundle-synthesis spine and daemon worker, exactly against the preserved implementation contract in `docs/plans/PR_B_TOPIC_SYNTHESIS_V2_BUNDLE_SPINE_CONTRACT.md`.

Key changes:
- Adds strict `@vh/ai-engine` bundle synthesis parsing with trimmed output, `final_refined` unwrap support, source-count gating, and placeholder frame/reframe rejection.
- Adds `buildBundlePromptFromStoryBundle` so daemon prompts preserve source titles and default verification confidence from the bundle's cluster confidence.
- Adds `writeTopicLatestSynthesisIfNotDowngrade` in `@vh/gun-client` so daemon bundle synthesis cannot downgrade higher-epoch or higher-quorum forum synthesis.
- Adds a feature-flagged news-aggregator bundle synthesis worker and relay path wired through the existing enrichment queue.
- Adds queue max-depth protection and structured `[vh:bundle-synth]` telemetry.
- Deprecates the service-local bundle prompt helpers in favor of `@vh/ai-engine/bundlePrompts`.

## Why

The feed needs a real through-line from daily article automation through bundling into public feed synthesis. This PR gives clustered/singleton news bundles a daemon-side synthesis path that writes `TopicSynthesisV2` for NewsCard consumption while preserving forum synthesis precedence.

## Safety

- Worker treats `NewsRuntimeSynthesisCandidate` as a trigger only; it re-reads `StoryBundle` by `story_id` before prompt generation.
- Idempotency key is provenance-sensitive: `news-bundle-v1|story_id|provenance_hash|model_id`.
- Bundle synthesis writes at `epoch: 0`, `quorum.received: 1`.
- `/latest` updates are guarded by epoch, quorum, and `news-bundle:` ownership prefix.
- Worker never imports or calls `writeTopicSynthesis`; the test suite mocks and asserts that invariant.
- Relay, parse, source-count mismatch, missing bundle, and idempotency failures return cleanly without writes.

## Validation

- `pnpm exec vitest run packages/ai-engine/src/bundlePrompts.test.ts --config vitest.config.ts`
- `pnpm --filter @vh/gun-client test -- synthesisAdapters`
- `pnpm --filter @vh/news-aggregator test -- bundleSynthesisWorker bundleSynthesisRelay daemon daemonUtils`
- `pnpm --filter @vh/news-aggregator test`
- `pnpm --filter @vh/news-aggregator typecheck`
- `pnpm -r typecheck`
- `pnpm docs:check`
- `git diff --check`
- `pnpm -r build`

Notes: local Node is `v23.10.0`, so pnpm/Hardhat emit the existing engine warning (`>=20 <23`), but typecheck, tests, docs, diff check, and repo build passed.
