### PR TITLE
Publish bundle synthesis for story detail

### DIFF
--- a/apps/web-pwa/src/components/feed/NewsCard.sharedTopicIsolation.test.tsx
+++ b/apps/web-pwa/src/components/feed/NewsCard.sharedTopicIsolation.test.tsx
@@ -126,7 +126,7 @@ describe('NewsCard shared-topic isolation', () => {
     resetExpandedCardStore();
   });
 
-  it('expands only the clicked card and runs one analysis when topic_id is shared', async () => {
+  it('expands only the clicked card and does not run card-open analysis when topic_id is shared', async () => {
     const firstItem = makeNewsItem({
       story_id: 'story-one',
       title: 'Story One',
@@ -175,25 +175,18 @@ describe('NewsCard shared-topic isolation', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Story One' }));
 
     await waitFor(() => {
-      expect(mockSynthesizeStoryFromAnalysisPipeline).toHaveBeenCalledTimes(1);
       expect(screen.getAllByText('Synthesis Lens')).toHaveLength(1);
     });
 
-    expect(mockSynthesizeStoryFromAnalysisPipeline).toHaveBeenCalledWith(
-      expect.objectContaining({ story_id: 'story-one' }),
-    );
+    expect(mockSynthesizeStoryFromAnalysisPipeline).not.toHaveBeenCalled();
 
     fireEvent.click(screen.getByRole('button', { name: 'Story Two' }));
 
     await waitFor(() => {
-      expect(mockSynthesizeStoryFromAnalysisPipeline).toHaveBeenCalledTimes(2);
       expect(screen.getAllByText('Synthesis Lens')).toHaveLength(1);
     });
 
-    expect(mockSynthesizeStoryFromAnalysisPipeline).toHaveBeenNthCalledWith(
-      2,
-      expect.objectContaining({ story_id: 'story-two' }),
-    );
+    expect(mockSynthesizeStoryFromAnalysisPipeline).not.toHaveBeenCalled();
 
     expect(
       screen.queryByText('Daily analysis limit reached. Try again tomorrow.'),

--- a/apps/web-pwa/src/components/feed/NewsCard.test.tsx
+++ b/apps/web-pwa/src/components/feed/NewsCard.test.tsx
@@ -332,7 +332,7 @@ describe('NewsCard', () => {
     expect(mockSynthesizeStoryFromAnalysisPipeline).not.toHaveBeenCalled();
     expect(screen.queryByTestId('analysis-status-message')).not.toBeInTheDocument();
   });
-  it('feature flag on prefers canonical V2 synthesis over card analysis when both exist', async () => {
+  it('renders accepted canonical V2 synthesis without invoking card-open analysis', async () => {
     vi.stubEnv('VITE_VH_ANALYSIS_PIPELINE', 'true');
     useNewsStore.getState().setStories([makeStoryBundle()]);
     useSynthesisStore
@@ -354,7 +354,7 @@ describe('NewsCard', () => {
     expect(screen.getByText('Public investment is overdue')).toBeInTheDocument();
     fireEvent.click(screen.getByTestId('news-card-back-button-news-1'));
     expect(screen.getByTestId('news-card-headline-news-1')).toBeInTheDocument();
-    expect(mockSynthesizeStoryFromAnalysisPipeline).toHaveBeenCalledTimes(1);
+    expect(mockSynthesizeStoryFromAnalysisPipeline).not.toHaveBeenCalled();
   });
 
   it('renders a hero image on the card and moves additional source images into the expanded summary', async () => {
@@ -481,7 +481,7 @@ describe('NewsCard', () => {
       'Difficult Extractor: Transit debate follow-up',
     );
   });
-  it('uses provider_id provenance when model metadata is unavailable', async () => {
+  it('omits provisional analysis provenance when accepted synthesis is present', async () => {
     vi.stubEnv('VITE_VH_ANALYSIS_PIPELINE', 'true');
     mockSynthesizeStoryFromAnalysisPipeline.mockResolvedValueOnce({
       summary: 'Provider fallback summary.',
@@ -509,47 +509,28 @@ describe('NewsCard', () => {
       'Council approved a phased transit expansion plan.',
     );
     expect(screen.queryByTestId('news-card-analysis-provider-news-1')).not.toBeInTheDocument();
+    expect(mockSynthesizeStoryFromAnalysisPipeline).not.toHaveBeenCalled();
   });
-  it('omits provenance when analysis metadata is missing', async () => {
+  it('renders feed summary and pending synthesis state when no accepted synthesis exists', async () => {
     vi.stubEnv('VITE_VH_ANALYSIS_PIPELINE', 'true');
-    mockSynthesizeStoryFromAnalysisPipeline.mockResolvedValueOnce({
-      summary: 'Summary without provenance metadata.',
-      frames: [],
-      analyses: [
-        {
-          source_id: 'src-1',
-          publisher: 'Local Paper',
-          url: 'https://example.com/news-1',
-          summary: 'No provider metadata attached.',
-          biases: [],
-          counterpoints: [],
-          biasClaimQuotes: [],
-          justifyBiasClaims: [],
-        },
-      ],
-      relatedLinks: [],
-    });
     useNewsStore.getState().setStories([makeStoryBundle()]);
     render(<NewsCard item={makeNewsItem()} />);
     fireEvent.click(screen.getByTestId('news-card-headline-news-1'));
-    expect(await screen.findByText('Summary without provenance metadata.')).toBeInTheDocument();
+    expect(await screen.findByTestId('news-card-summary-news-1')).toHaveTextContent(
+      'Transit vote split council members along budget priorities.',
+    );
+    expect(screen.getByTestId('news-card-summary-basis-news-1')).toHaveTextContent(
+      'Feed summary hint; synthesis pending',
+    );
+    expect(screen.getByTestId('news-card-synthesis-unavailable-news-1')).toHaveTextContent(
+      'Publish-time synthesis has not been published for this story yet.',
+    );
+    expect(screen.getByTestId('bias-table-empty')).toHaveTextContent('No bias analysis available yet');
     expect(screen.queryByTestId('news-card-analysis-provider-news-1')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('analysis-status-message')).not.toBeInTheDocument();
+    expect(mockSynthesizeStoryFromAnalysisPipeline).not.toHaveBeenCalled();
   });
-  it('omits provenance when analyses list is empty', async () => {
-    vi.stubEnv('VITE_VH_ANALYSIS_PIPELINE', 'true');
-    mockSynthesizeStoryFromAnalysisPipeline.mockResolvedValueOnce({
-      summary: 'Summary with no per-source analyses.',
-      frames: [],
-      analyses: [],
-      relatedLinks: [],
-    });
-    useNewsStore.getState().setStories([makeStoryBundle()]);
-    render(<NewsCard item={makeNewsItem()} />);
-    fireEvent.click(screen.getByTestId('news-card-headline-news-1'));
-    expect(await screen.findByText('Summary with no per-source analyses.')).toBeInTheDocument();
-    expect(screen.queryByTestId('news-card-analysis-provider-news-1')).not.toBeInTheDocument();
-  });
-  it('feature flag on shows staged loading state while analysis is pending', async () => {
+  it('does not show card-analysis loading state while waiting for publish-time synthesis', async () => {
     vi.stubEnv('VITE_VH_ANALYSIS_PIPELINE', 'true');
     mockSynthesizeStoryFromAnalysisPipeline.mockReturnValue(
       new Promise(() => {
@@ -562,11 +543,10 @@ describe('NewsCard', () => {
     expect(
       await screen.findByTestId('news-card-summary-news-1'),
     ).toHaveTextContent('Transit vote split council members along budget priorities.');
-    expect(
-      await screen.findByText('Extracting article text…'),
-    ).toBeInTheDocument();
+    expect(screen.queryByText('Extracting article text…')).not.toBeInTheDocument();
+    expect(mockSynthesizeStoryFromAnalysisPipeline).not.toHaveBeenCalled();
   });
-  it('feature flag on shows error state with retry action', async () => {
+  it('does not expose card-analysis retry state on runtime analysis failures', async () => {
     vi.stubEnv('VITE_VH_ANALYSIS_PIPELINE', 'true');
     mockSynthesizeStoryFromAnalysisPipeline.mockRejectedValueOnce(
       new Error('analysis unavailable'),
@@ -577,21 +557,9 @@ describe('NewsCard', () => {
     expect(
       await screen.findByTestId('news-card-summary-news-1'),
     ).toHaveTextContent('Transit vote split council members along budget priorities.');
-    expect(await screen.findByText('analysis unavailable')).toBeInTheDocument();
-    expect(screen.getByTestId('analysis-retry-button')).toBeInTheDocument();
-  });
-  it('shows removal indicator on analysis error alongside retry action', async () => {
-    vi.stubEnv('VITE_VH_ANALYSIS_PIPELINE', 'true');
-    mockSynthesizeStoryFromAnalysisPipeline.mockRejectedValueOnce(
-      new Error('extraction failed'),
-    );
-    useNewsStore.getState().setStories([makeStoryBundle()]);
-    render(<NewsCard item={makeNewsItem()} />);
-    fireEvent.click(screen.getByTestId('news-card-headline-news-1'));
-    expect(await screen.findByText('extraction failed')).toBeInTheDocument();
-    expect(screen.getByTestId('news-card-analysis-error-news-1')).toBeInTheDocument();
-    expect(screen.getByTestId('removal-indicator')).toBeInTheDocument();
-    expect(screen.getByTestId('analysis-retry-button')).toBeInTheDocument();
+    expect(screen.queryByText('analysis unavailable')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('analysis-retry-button')).not.toBeInTheDocument();
+    expect(mockSynthesizeStoryFromAnalysisPipeline).not.toHaveBeenCalled();
   });
   it('renders BiasTable for analyzed stories', async () => {
     vi.stubEnv('VITE_VH_ANALYSIS_PIPELINE', 'true');
@@ -634,14 +602,15 @@ describe('NewsCard', () => {
     expect((await screen.findAllByRole('button', { name: /Agree with /i })).length).toBeGreaterThanOrEqual(2);
     expect((await screen.findAllByRole('button', { name: /Disagree with /i })).length).toBeGreaterThanOrEqual(2);
   });
-  it('renders voting controls with analysis fallback when synthesis context is missing', async () => {
+  it('does not render stance voting controls when synthesis context is missing', async () => {
     vi.stubEnv('VITE_VH_ANALYSIS_PIPELINE', 'true');
     useNewsStore.getState().setStories([makeStoryBundle()]);
-    // intentionally omit setTopicSynthesis; this mirrors analysis-only live mode
+    // intentionally omit setTopicSynthesis; story detail no longer uses analysis-only live mode
     render(<NewsCard item={makeNewsItem()} />);
     fireEvent.click(screen.getByTestId('news-card-headline-news-1'));
-    expect(await screen.findByTestId('bias-table')).toBeInTheDocument();
-    expect((await screen.findAllByRole('button', { name: /Agree with /i })).length).toBeGreaterThanOrEqual(1);
-    expect((await screen.findAllByRole('button', { name: /Disagree with /i })).length).toBeGreaterThanOrEqual(1);
+    expect(await screen.findByTestId('bias-table-empty')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Agree with /i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Disagree with /i })).not.toBeInTheDocument();
+    expect(mockSynthesizeStoryFromAnalysisPipeline).not.toHaveBeenCalled();
   });
 });

--- a/apps/web-pwa/src/components/feed/NewsCard.test.tsx
+++ b/apps/web-pwa/src/components/feed/NewsCard.test.tsx
@@ -346,6 +346,16 @@ describe('NewsCard', () => {
     expect(screen.getByTestId('news-card-summary-basis-news-1')).toHaveTextContent(
       'Topic synthesis v2',
     );
+    expect(screen.getByTestId('news-card-synthesis-provenance-news-1')).toHaveTextContent(
+      'Generated 2023-11-14T22:13:20.000Z · epoch 2',
+    );
+    expect(screen.getByTestId('news-card-synthesis-provenance-news-1')).toHaveTextContent(
+      'Synthesis syn-1 · candidates 3',
+    );
+    expect(screen.getByTestId('news-card-synthesis-provenance-news-1')).toHaveTextContent(
+      'Providers remote-analysis x3',
+    );
+    expect(screen.queryByTestId('news-card-synthesis-warnings-news-1')).not.toBeInTheDocument();
     expect(screen.queryByText('Pipeline synthesis summary from analyzed sources.')).not.toBeInTheDocument();
     expect(screen.queryByTestId('news-card-analysis-provider-news-1')).not.toBeInTheDocument();
     expect(
@@ -354,6 +364,19 @@ describe('NewsCard', () => {
     expect(screen.getByText('Public investment is overdue')).toBeInTheDocument();
     fireEvent.click(screen.getByTestId('news-card-back-button-news-1'));
     expect(screen.getByTestId('news-card-headline-news-1')).toBeInTheDocument();
+    expect(mockSynthesizeStoryFromAnalysisPipeline).not.toHaveBeenCalled();
+  });
+  it('renders accepted synthesis warnings as provenance callouts', async () => {
+    vi.stubEnv('VITE_VH_ANALYSIS_PIPELINE', 'true');
+    useNewsStore.getState().setStories([makeStoryBundle()]);
+    useSynthesisStore
+      .getState()
+      .setTopicSynthesis('news-1', makeSynthesis({ warnings: ['related_links_excluded_from_analysis'] }));
+    render(<NewsCard item={makeNewsItem()} />);
+    fireEvent.click(screen.getByTestId('news-card-headline-news-1'));
+    expect(await screen.findByTestId('news-card-synthesis-warnings-news-1')).toHaveTextContent(
+      'related_links_excluded_from_analysis',
+    );
     expect(mockSynthesizeStoryFromAnalysisPipeline).not.toHaveBeenCalled();
   });
 

--- a/apps/web-pwa/src/components/feed/NewsCard.tsx
+++ b/apps/web-pwa/src/components/feed/NewsCard.tsx
@@ -105,6 +105,16 @@ export const NewsCard: React.FC<NewsCardProps> = ({ item }) => {
   const storyId = normalizeStoryId(item.story_id) ?? story?.story_id ?? null;
   const synthesisId = synthesis?.synthesis_id ?? null;
   const synthesisEpoch = synthesis?.epoch;
+  const synthesisProvenance = synthesis
+    ? {
+        generatedAt: formatIsoTimestamp(synthesis.created_at),
+        synthesisId: synthesis.synthesis_id,
+        epoch: synthesis.epoch,
+        candidateIds: synthesis.provenance.candidate_ids,
+        providerMix: synthesis.provenance.provider_mix,
+        warnings: synthesis.warnings,
+      }
+    : null;
   const synthesisSummary = synthesis?.facts_summary?.trim() ?? '';
   const hasSynthesisSummary = synthesisSummary.length > 0;
   const rawSummary =
@@ -270,6 +280,7 @@ export const NewsCard: React.FC<NewsCardProps> = ({ item }) => {
               analysis={null}
               analysisId={null}
               synthesisId={synthesisId}
+              synthesisProvenance={synthesisProvenance}
               epoch={synthesisEpoch}
               sourceViewer={singletonVideoSource}
               discussionThread={discussionThread}

--- a/apps/web-pwa/src/components/feed/NewsCard.tsx
+++ b/apps/web-pwa/src/components/feed/NewsCard.tsx
@@ -1,11 +1,10 @@
-import React, { useCallback, useEffect, useMemo, useRef } from 'react';
+import React, { useCallback, useEffect, useMemo } from 'react';
 import { useStore } from 'zustand';
-import type { FeedItem, StoryBundle, StorylineGroup } from '@vh/data-model';
+import type { FeedItem, StorylineGroup } from '@vh/data-model';
 import { useNewsStore } from '../../store/news';
 import { useSynthesisStore } from '../../store/synthesis';
 import { useForumStore } from '../../store/hermesForum';
 import { useViewTracking } from '../../hooks/useViewTracking';
-import { useAnalysis } from './useAnalysis';
 import { NewsCardBack } from './NewsCardBack';
 import { sanitizePublicationNeutralSummary } from './newsCardAnalysis';
 import { useExpandedCardStore } from './expandedCardStore';
@@ -18,7 +17,6 @@ import {
   mergeRelatedLinks,
   normalizeStorylineHeadline,
   previewText,
-  resolveAnalysisProviderModel,
   resolveDisplaySources,
   resolveSingletonVideoSource,
   resolveStoryBundle,
@@ -91,99 +89,50 @@ export const NewsCard: React.FC<NewsCardProps> = ({ item }) => {
     [forumThreads, item, story],
   );
   const primaryStorySource = useMemo(() => getPrimaryStorySource(story), [story]);
-  const analysisStoryRef = useRef<StoryBundle | null>(story);
-  const analysisPipelineEnabled = import.meta.env.VITE_VH_ANALYSIS_PIPELINE === 'true';
-  const analysisStory = useMemo(
-    () => (isExpanded ? analysisStoryRef.current ?? story : story),
-    [isExpanded, story],
-  );
   const singletonVideoSource = useMemo(
-    () => resolveSingletonVideoSource(analysisStory),
-    [analysisStory],
+    () => resolveSingletonVideoSource(story),
+    [story],
   );
   const displaySources = useMemo(
     () => resolveDisplaySources(story),
     [story],
   );
-  const {
-    analysis,
-    status: analysisStatus,
-    error: analysisError,
-    retry: retryAnalysis,
-  } = useAnalysis(analysisStory, isExpanded && singletonVideoSource === null);
   const synthesis = synthesisTopicState?.synthesis ?? null;
   const synthesisLoading = synthesisTopicState?.loading ?? false;
   const synthesisError = synthesisTopicState?.error ?? null;
   const latestActivity = formatIsoTimestamp(item.latest_activity_at);
   const createdAt = formatIsoTimestamp(item.created_at);
   const storyId = normalizeStoryId(item.story_id) ?? story?.story_id ?? null;
-  const computedAnalysisId = analysisStory
-    ? `${analysisStory.story_id}:${analysisStory.provenance_hash}`
-    : null;
   const synthesisId = synthesis?.synthesis_id ?? null;
   const synthesisEpoch = synthesis?.epoch;
-  const analysisFeedbackStatus =
-    analysisPipelineEnabled &&
-    (analysisStatus === 'loading' ||
-      analysisStatus === 'timeout' ||
-      analysisStatus === 'error' ||
-      analysisStatus === 'budget_exceeded')
-      ? analysisStatus
-      : null;
   const synthesisSummary = synthesis?.facts_summary?.trim() ?? '';
-  const analysisSummary =
-    analysisPipelineEnabled && analysisStatus === 'success'
-      ? analysis?.summary?.trim() ?? ''
-      : '';
   const hasSynthesisSummary = synthesisSummary.length > 0;
-  const hasAnalysisSummary = analysisSummary.length > 0;
   const rawSummary =
     synthesisSummary ||
-    analysisSummary ||
     story?.summary_hint?.trim() ||
-    'Summary pending synthesis.';
+    'Analysis pending publish-time synthesis.';
   const summary = sanitizePublicationNeutralSummary(
     rawSummary,
     (story?.sources ?? []).flatMap((source) => [source.source_id, source.publisher]),
   );
   const synthesisFrameRows = synthesis?.frames ?? [];
-  const analysisFrameRows =
-    analysisPipelineEnabled && analysisStatus === 'success' && analysis
-      ? analysis.frames
-      : [];
-  const useAnalysisFrames = synthesisFrameRows.length === 0 && analysisFrameRows.length > 0;
-  const frameRows = synthesisFrameRows.length > 0 ? synthesisFrameRows : analysisFrameRows;
-  const frameAnalysis = useAnalysisFrames ? analysis : null;
-  const analysisNeedsRegeneration =
-    analysisPipelineEnabled
-    && analysisStatus === 'success'
-    && !!analysis
-    && synthesisFrameRows.length === 0
-    && analysisFrameRows.length === 0;
-  const analyzedSourceCount = analysis?.analyses.length ?? 0;
-  const expectedSourceCount = displaySources.length || story?.sources.length || 0;
+  const frameRows = synthesisFrameRows;
   const summaryBasisLabel = hasSynthesisSummary
     ? 'Topic synthesis v2'
-    : hasAnalysisSummary
-      ? analyzedSourceCount > 0 && expectedSourceCount > analyzedSourceCount
-        ? `Provisional card analysis (${analyzedSourceCount}/${expectedSourceCount} sources)`
-        : 'Provisional card analysis'
-      : undefined;
+    : synthesisLoading
+      ? 'Publish-time synthesis loading'
+      : story?.summary_hint?.trim()
+        ? 'Feed summary hint; synthesis pending'
+        : 'Publish-time synthesis pending';
   const frameBasisLabel = synthesisFrameRows.length > 0
     ? 'Topic synthesis frames'
-    : useAnalysisFrames
-      ? `${analyzedSourceCount} ${analyzedSourceCount === 1 ? 'source' : 'sources'} analyzed`
-      : undefined;
-  const analysisProvider =
-    analysisPipelineEnabled &&
-    analysisStatus === 'success' &&
-    (useAnalysisFrames || (!hasSynthesisSummary && hasAnalysisSummary))
-      ? resolveAnalysisProviderModel(analysis)
-      : null;
+    : undefined;
+  const synthesisUnavailable = !synthesisLoading && !synthesis && !synthesisError;
   const relatedLinks = useMemo(
-    () => mergeRelatedLinks(story, analysis),
-    [story, analysis],
+    () => mergeRelatedLinks(story, null),
+    [story],
   );
+  const retryAnalysis = useCallback(() => undefined, []);
   const { heroImage, galleryImages } = useMemo(
     () => resolveStoryMedia(story),
     [story],
@@ -199,24 +148,10 @@ export const NewsCard: React.FC<NewsCardProps> = ({ item }) => {
   useViewTracking(item.topic_id, isExpanded);
 
   const openDetail = useCallback(() => {
-    if (story) {
-      analysisStoryRef.current = story;
-    }
     expandCard(cardInstanceKey);
     startSynthesisHydration(item.topic_id);
     void refreshSynthesisTopic(item.topic_id);
-  }, [cardInstanceKey, expandCard, item.topic_id, refreshSynthesisTopic, startSynthesisHydration, story]);
-
-  useEffect(() => {
-    if (isExpanded) {
-      if (!analysisStoryRef.current && story) {
-        analysisStoryRef.current = story;
-      }
-      return;
-    }
-
-    analysisStoryRef.current = story;
-  }, [isExpanded, story]);
+  }, [cardInstanceKey, expandCard, item.topic_id, refreshSynthesisTopic, startSynthesisHydration]);
 
   useEffect(() => {
     if (!isExpanded) return;
@@ -319,20 +254,21 @@ export const NewsCard: React.FC<NewsCardProps> = ({ item }) => {
               summaryBasisLabel={summaryBasisLabel}
               frameRows={frameRows}
               frameBasisLabel={frameBasisLabel}
-              analysisProvider={analysisProvider}
+              analysisProvider={null}
               galleryImages={galleryImages}
               relatedCoverage={hasStorylineCoverage ? storyline?.related_coverage ?? [] : []}
               relatedLinks={relatedLinks}
               storylineHeadline={storylineHeadline}
               storylineStoryCount={storylineStoryCount}
-              analysisFeedbackStatus={analysisFeedbackStatus}
-              analysisError={analysisError}
+              analysisFeedbackStatus={null}
+              analysisError={null}
               retryAnalysis={retryAnalysis}
-              analysisNeedsRegeneration={analysisNeedsRegeneration}
+              analysisNeedsRegeneration={false}
               synthesisLoading={synthesisLoading}
               synthesisError={synthesisError}
-              analysis={frameAnalysis}
-              analysisId={computedAnalysisId}
+              synthesisUnavailable={synthesisUnavailable}
+              analysis={null}
+              analysisId={null}
               synthesisId={synthesisId}
               epoch={synthesisEpoch}
               sourceViewer={singletonVideoSource}

--- a/apps/web-pwa/src/components/feed/NewsCardBack.tsx
+++ b/apps/web-pwa/src/components/feed/NewsCardBack.tsx
@@ -15,6 +15,18 @@ export interface NewsCardMediaAsset {
   readonly imageUrl: string;
 }
 
+export interface NewsCardSynthesisProvenance {
+  readonly generatedAt: string;
+  readonly synthesisId: string;
+  readonly epoch: number;
+  readonly candidateIds: ReadonlyArray<string>;
+  readonly providerMix: ReadonlyArray<{
+    readonly provider_id: string;
+    readonly count: number;
+  }>;
+  readonly warnings: ReadonlyArray<string>;
+}
+
 export interface NewsCardBackProps {
   readonly headline: string;
   readonly topicId: string;
@@ -53,6 +65,7 @@ export interface NewsCardBackProps {
   readonly analysis: NewsCardAnalysisSynthesis | null;
   readonly analysisId?: string | null;
   readonly synthesisId?: string | null;
+  readonly synthesisProvenance?: NewsCardSynthesisProvenance | null;
   readonly epoch?: number;
   readonly sourceViewer?: {
     readonly publisher: string;
@@ -98,6 +111,7 @@ export const NewsCardBack: React.FC<NewsCardBackProps> = ({
   analysis,
   analysisId,
   synthesisId,
+  synthesisProvenance = null,
   epoch,
   sourceViewer,
   discussionThread,
@@ -143,6 +157,35 @@ export const NewsCardBack: React.FC<NewsCardBackProps> = ({
             >
               {summaryBasisLabel}
             </p>
+          )}
+          {synthesisProvenance && (
+            <div
+              className="space-y-1 rounded-lg border border-slate-200/80 bg-white/75 px-3 py-2 text-[11px] leading-5 text-slate-500 dark:border-slate-800 dark:bg-slate-950/50 dark:text-slate-300"
+              data-testid={`news-card-synthesis-provenance-${topicId}`}
+            >
+              <p>
+                Generated {synthesisProvenance.generatedAt} · epoch {synthesisProvenance.epoch}
+              </p>
+              <p className="break-all">
+                Synthesis {synthesisProvenance.synthesisId} · candidates {synthesisProvenance.candidateIds.length}
+              </p>
+              <p>
+                Providers{' '}
+                {synthesisProvenance.providerMix
+                  .map((provider) => `${provider.provider_id} x${provider.count}`)
+                  .join(', ')}
+              </p>
+            </div>
+          )}
+          {synthesisProvenance && synthesisProvenance.warnings.length > 0 && (
+            <div
+              className="space-y-1 rounded-lg border border-amber-200/80 bg-amber-50/80 px-3 py-2 text-xs text-amber-800 dark:border-amber-900/70 dark:bg-amber-950/30 dark:text-amber-100"
+              data-testid={`news-card-synthesis-warnings-${topicId}`}
+            >
+              {synthesisProvenance.warnings.map((warning) => (
+                <p key={warning}>{warning}</p>
+              ))}
+            </div>
           )}
           <p className="text-sm leading-7 text-slate-700 dark:text-slate-200" data-testid={`news-card-summary-${topicId}`}>
             {summary}

--- a/apps/web-pwa/src/components/feed/NewsCardBack.tsx
+++ b/apps/web-pwa/src/components/feed/NewsCardBack.tsx
@@ -49,6 +49,7 @@ export interface NewsCardBackProps {
   readonly analysisNeedsRegeneration?: boolean;
   readonly synthesisLoading: boolean;
   readonly synthesisError: string | null;
+  readonly synthesisUnavailable?: boolean;
   readonly analysis: NewsCardAnalysisSynthesis | null;
   readonly analysisId?: string | null;
   readonly synthesisId?: string | null;
@@ -93,6 +94,7 @@ export const NewsCardBack: React.FC<NewsCardBackProps> = ({
   analysisNeedsRegeneration = false,
   synthesisLoading,
   synthesisError,
+  synthesisUnavailable = false,
   analysis,
   analysisId,
   synthesisId,
@@ -121,7 +123,6 @@ export const NewsCardBack: React.FC<NewsCardBackProps> = ({
           Collapse
         </button>
       </header>
-
       {sourceViewer && (
         <SourceViewerFrame
           topicId={topicId}
@@ -130,7 +131,6 @@ export const NewsCardBack: React.FC<NewsCardBackProps> = ({
           url={sourceViewer.url}
         />
       )}
-
       <div className="grid gap-4 lg:grid-cols-[minmax(0,1.45fr)_minmax(17rem,0.95fr)]">
         <section className="space-y-3 rounded-[1.5rem] border border-slate-200/90 bg-slate-50/80 p-4 shadow-sm shadow-slate-900/5 dark:border-slate-800 dark:bg-slate-900/80">
           <h4 className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
@@ -185,7 +185,6 @@ export const NewsCardBack: React.FC<NewsCardBackProps> = ({
               </div>
             </div>
           )}
-
           {analysisFeedbackStatus && (
             <AnalysisLoadingState
               status={analysisFeedbackStatus}
@@ -193,7 +192,6 @@ export const NewsCardBack: React.FC<NewsCardBackProps> = ({
               onRetry={retryAnalysis}
             />
           )}
-
           {!analysisFeedbackStatus && (
             <>
               {analysisProvider && (
@@ -207,7 +205,6 @@ export const NewsCardBack: React.FC<NewsCardBackProps> = ({
             </>
           )}
         </section>
-
         <div className="space-y-4">
           {relatedCoverage.length > 0 && (
             <section
@@ -245,7 +242,6 @@ export const NewsCardBack: React.FC<NewsCardBackProps> = ({
               </ul>
             </section>
           )}
-
           {relatedLinks.length > 0 && (
             <section
               className="space-y-2 rounded-[1.5rem] border border-amber-200/90 bg-amber-50/80 p-4 shadow-sm shadow-amber-900/5 dark:border-amber-900/60 dark:bg-amber-950/30"
@@ -276,18 +272,15 @@ export const NewsCardBack: React.FC<NewsCardBackProps> = ({
           )}
         </div>
       </div>
-
       <section className="space-y-3 rounded-[1.5rem] border border-slate-200/90 bg-white/82 p-4 shadow-sm shadow-slate-900/5 dark:border-slate-800 dark:bg-slate-950/80">
         <h4 className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
           Frame / Reframe
         </h4>
-
         {analysisFeedbackStatus === 'error' && (
           <div className="mt-2" data-testid={`news-card-analysis-error-${topicId}`}>
             <RemovalIndicator reason="extraction-failed-permanently" />
           </div>
         )}
-
         {synthesisLoading && (
           <p
             className="mt-2 text-xs text-slate-500"
@@ -296,7 +289,6 @@ export const NewsCardBack: React.FC<NewsCardBackProps> = ({
             Loading synthesis…
           </p>
         )}
-
         {synthesisError && !synthesisLoading && !analysis && (
           <p
             className="mt-2 text-xs text-amber-700"
@@ -305,7 +297,14 @@ export const NewsCardBack: React.FC<NewsCardBackProps> = ({
             Synthesis unavailable.
           </p>
         )}
-
+        {synthesisUnavailable && !analysis && (
+          <p
+            className="mt-2 text-xs text-amber-700"
+            data-testid={`news-card-synthesis-unavailable-${topicId}`}
+          >
+            Publish-time synthesis has not been published for this story yet.
+          </p>
+        )}
         {analysisNeedsRegeneration && !synthesisLoading && (
           <p
             className="mt-2 text-xs text-amber-700"
@@ -314,7 +313,6 @@ export const NewsCardBack: React.FC<NewsCardBackProps> = ({
             Analysis needs regeneration to produce frame/reframe rows.
           </p>
         )}
-
         <div className="mt-2">
           <BiasTable
             analyses={analysis?.analyses ?? []}
@@ -326,11 +324,10 @@ export const NewsCardBack: React.FC<NewsCardBackProps> = ({
             analysisId={analysisId ?? undefined}
             synthesisId={synthesisId ?? undefined}
             epoch={epoch}
-            votingEnabled
+            votingEnabled={Boolean(synthesisId && epoch !== undefined && frameRows.length > 0)}
           />
         </div>
       </section>
-
       <FeedDiscussionSection
         sectionId={`news-card-${topicId}`}
         thread={discussionThread}
@@ -341,5 +338,4 @@ export const NewsCardBack: React.FC<NewsCardBackProps> = ({
     </div>
   );
 };
-
 export default NewsCardBack;

--- a/packages/ai-engine/src/bundlePrompts.test.ts
+++ b/packages/ai-engine/src/bundlePrompts.test.ts
@@ -240,6 +240,18 @@ describe('bundlePrompts', () => {
       expect(prompt).not.toContain('https://example.com/broken');
       expect(prompt).toContain('Verification confidence: 72%');
     });
+
+    it('falls back to all bundle sources when primary sources are absent', () => {
+      const bundleWithoutPrimarySources = {
+        ...bundle,
+        primary_sources: undefined,
+        related_links: undefined,
+      };
+      const prompt = buildBundlePromptFromStoryBundle(bundleWithoutPrimarySources);
+      expect(prompt).toContain('BBC News');
+      expect(prompt).toContain('Broken Publisher');
+      expect(prompt).toContain('covered by 2 sources');
+    });
   });
 
   describe('parseGeneratedBundleSynthesis', () => {
@@ -296,6 +308,9 @@ describe('bundlePrompts', () => {
       );
       expect(() => parseGeneratedBundleSynthesis('{bad json')).toThrow(
         BundleSynthesisParseError.NO_JSON_OBJECT_FOUND,
+      );
+      expect(() => parseGeneratedBundleSynthesis('{bad json}')).toThrow(
+        BundleSynthesisParseError.JSON_PARSE_ERROR,
       );
     });
   });

--- a/packages/ai-engine/src/bundlePrompts.test.ts
+++ b/packages/ai-engine/src/bundlePrompts.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import {
   buildBundlePrompt,
+  buildBundlePromptFromStoryBundle,
+  BundleSynthesisParseError,
   generateBundleSynthesisPrompt,
+  parseGeneratedBundleSynthesis,
   type BundleSynthesisResult,
 } from './bundlePrompts';
-import type { StoryBundleInputCandidate } from './newsTypes';
+import type { StoryBundle, StoryBundleInputCandidate } from './newsTypes';
 
 describe('bundlePrompts', () => {
   const sampleBundle = {
@@ -169,6 +172,131 @@ describe('bundlePrompts', () => {
     it('handles missing verification confidence', () => {
       const prompt = buildBundlePrompt(candidate);
       expect(prompt).toContain('Verification confidence: not available');
+    });
+  });
+
+  describe('buildBundlePromptFromStoryBundle', () => {
+    const bundle: StoryBundle = {
+      schemaVersion: 'story-bundle-v0',
+      story_id: 'story-abc',
+      topic_id: 'topic-markets',
+      headline: 'Markets rally after policy announcement',
+      summary_hint: 'A policy announcement triggered market rallies worldwide.',
+      cluster_window_start: 1700000000000,
+      cluster_window_end: 1700000001000,
+      sources: [
+        {
+          source_id: 'usable-1',
+          publisher: 'BBC News',
+          title: 'Markets up on policy shift',
+          url: 'https://example.com/bbc',
+          url_hash: 'hash-1',
+          published_at: 1700000000000,
+        },
+        {
+          source_id: 'link-only-1',
+          publisher: 'Broken Publisher',
+          title: 'Related but unreadable',
+          url: 'https://example.com/broken',
+          url_hash: 'hash-2',
+          published_at: 1700000000001,
+        },
+      ],
+      primary_sources: [
+        {
+          source_id: 'usable-1',
+          publisher: 'BBC News',
+          title: 'Markets up on policy shift',
+          url: 'https://example.com/bbc',
+          url_hash: 'hash-1',
+          published_at: 1700000000000,
+        },
+      ],
+      related_links: [
+        {
+          source_id: 'link-only-1',
+          publisher: 'Broken Publisher',
+          title: 'Related but unreadable',
+          url: 'https://example.com/broken',
+          url_hash: 'hash-2',
+          published_at: 1700000000001,
+        },
+      ],
+      cluster_features: {
+        entity_keys: ['markets'],
+        time_bucket: '2026-04-20T12',
+        semantic_signature: 'abc123',
+        confidence_score: 0.72,
+      },
+      provenance_hash: 'provhash',
+      created_at: 1700000002000,
+    };
+
+    it('uses only primary analysis-eligible sources when present', () => {
+      const prompt = buildBundlePromptFromStoryBundle(bundle);
+      expect(prompt).toContain('BBC News');
+      expect(prompt).toContain('https://example.com/bbc');
+      expect(prompt).not.toContain('Broken Publisher');
+      expect(prompt).not.toContain('https://example.com/broken');
+      expect(prompt).toContain('Verification confidence: 72%');
+    });
+  });
+
+  describe('parseGeneratedBundleSynthesis', () => {
+    it('parses strict generated bundle output', () => {
+      const parsed = parseGeneratedBundleSynthesis(JSON.stringify({
+        summary: 'Markets rallied after a major policy announcement. Sources agree the move affected investor expectations.',
+        frames: [
+          {
+            frame: 'The policy will boost economic growth.',
+            reframe: 'Short-term gains may mask structural risks.',
+          },
+        ],
+        source_count: 3,
+        source_publishers: ['Fox News', 'The Guardian', 'BBC News'],
+        verification_confidence: 0.85,
+      }));
+
+      expect(parsed.source_count).toBe(3);
+      expect(parsed.frames[0]?.frame).toContain('boost economic growth');
+    });
+
+    it('accepts final_refined wrapper responses', () => {
+      const parsed = parseGeneratedBundleSynthesis(JSON.stringify({
+        final_refined: {
+          summary: 'Markets rallied after a policy announcement.',
+          frames: [
+            {
+              frame: 'The policy supports near-term growth.',
+              reframe: 'The benefits may not survive implementation risks.',
+            },
+          ],
+          source_count: 2,
+          source_publishers: ['A', 'B'],
+          verification_confidence: 0.7,
+        },
+      }));
+
+      expect(parsed.source_publishers).toEqual(['A', 'B']);
+    });
+
+    it('rejects placeholder frame text', () => {
+      expect(() => parseGeneratedBundleSynthesis(JSON.stringify({
+        summary: 'Summary.',
+        frames: [{ frame: 'No clear bias detected.', reframe: 'Counterpoint.' }],
+        source_count: 1,
+        source_publishers: ['A'],
+        verification_confidence: 0.5,
+      }))).toThrow(BundleSynthesisParseError.SCHEMA_VALIDATION_ERROR);
+    });
+
+    it('reports missing and malformed JSON separately', () => {
+      expect(() => parseGeneratedBundleSynthesis('plain text')).toThrow(
+        BundleSynthesisParseError.NO_JSON_OBJECT_FOUND,
+      );
+      expect(() => parseGeneratedBundleSynthesis('{bad json')).toThrow(
+        BundleSynthesisParseError.NO_JSON_OBJECT_FOUND,
+      );
     });
   });
 

--- a/packages/ai-engine/src/bundlePrompts.ts
+++ b/packages/ai-engine/src/bundlePrompts.ts
@@ -6,7 +6,9 @@
  */
 
 import { GOALS_AND_GUIDELINES } from './prompts';
-import type { StoryBundleInputCandidate } from './newsTypes';
+import { isPlaceholderPerspectiveText } from './schema';
+import type { StoryBundle, StoryBundleInputCandidate } from './newsTypes';
+import { z } from 'zod';
 
 /**
  * Deterministic output shape for UI consumption.
@@ -23,6 +25,59 @@ export interface BundleSynthesisResult {
   source_publishers: string[];
   /** Verification confidence from the bundle verification record. */
   verification_confidence: number;
+}
+
+const GeneratedBundleFrameSchema = z
+  .object({
+    frame: z.string().trim().min(1),
+    reframe: z.string().trim().min(1),
+  })
+  .strict()
+  .refine((row) => !isPlaceholderPerspectiveText(row.frame), {
+    message: 'Bundle synthesis frame cannot be a placeholder',
+    path: ['frame'],
+  })
+  .refine((row) => !isPlaceholderPerspectiveText(row.reframe), {
+    message: 'Bundle synthesis reframe cannot be a placeholder',
+    path: ['reframe'],
+  });
+
+export const GeneratedBundleSynthesisResultSchema = z
+  .object({
+    summary: z.string().trim().min(1),
+    frames: z.array(GeneratedBundleFrameSchema).min(1).max(4),
+    source_count: z.number().int().positive(),
+    source_publishers: z.array(z.string().trim().min(1)).min(1),
+    verification_confidence: z.number().min(0).max(1),
+  })
+  .strict();
+
+export type GeneratedBundleSynthesisResult = z.infer<
+  typeof GeneratedBundleSynthesisResultSchema
+>;
+
+export enum BundleSynthesisParseError {
+  NO_JSON_OBJECT_FOUND = 'NO_JSON_OBJECT_FOUND',
+  JSON_PARSE_ERROR = 'JSON_PARSE_ERROR',
+  SCHEMA_VALIDATION_ERROR = 'SCHEMA_VALIDATION_ERROR',
+}
+
+export function parseGeneratedBundleSynthesis(raw: string): GeneratedBundleSynthesisResult {
+  const jsonMatch = raw.match(/\{[\s\S]*\}/);
+  if (!jsonMatch) {
+    throw new Error(BundleSynthesisParseError.NO_JSON_OBJECT_FOUND);
+  }
+
+  try {
+    const parsed = JSON.parse(jsonMatch[0]) as unknown;
+    const payload = (parsed as { final_refined?: unknown }).final_refined ?? parsed;
+    return GeneratedBundleSynthesisResultSchema.parse(payload);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      throw new Error(BundleSynthesisParseError.SCHEMA_VALIDATION_ERROR);
+    }
+    throw new Error(BundleSynthesisParseError.JSON_PARSE_ERROR);
+  }
 }
 
 const BUNDLE_SYNTHESIS_OUTPUT_FORMAT = `
@@ -113,5 +168,28 @@ export function buildBundlePrompt(
       url: s.url,
     })),
     verification_confidence: verificationConfidence,
+  });
+}
+
+export function buildBundlePromptFromStoryBundle(
+  bundle: Pick<
+    StoryBundle,
+    | 'headline'
+    | 'summary_hint'
+    | 'sources'
+    | 'primary_sources'
+    | 'cluster_features'
+  >,
+): string {
+  const analysisSources = bundle.primary_sources ?? bundle.sources;
+  return generateBundleSynthesisPrompt({
+    headline: bundle.headline,
+    summary_hint: bundle.summary_hint,
+    sources: analysisSources.map((source) => ({
+      publisher: source.publisher,
+      title: source.title,
+      url: source.url,
+    })),
+    verification_confidence: bundle.cluster_features.confidence_score,
   });
 }

--- a/packages/gun-client/src/index.ts
+++ b/packages/gun-client/src/index.ts
@@ -191,6 +191,7 @@ export * from './directoryAdapters';
 export * from './docsAdapters';
 export * from './docsKeyManagement';
 export * from './synthesisAdapters';
+export * from './safeLatestSynthesisAdapters';
 export * from './newsAdapters';
 export * from './storylineAdapters';
 export * from './analysisAdapters';

--- a/packages/gun-client/src/safeLatestSynthesisAdapters.ts
+++ b/packages/gun-client/src/safeLatestSynthesisAdapters.ts
@@ -1,0 +1,49 @@
+import { TopicSynthesisV2Schema, type TopicSynthesisV2 } from '@vh/data-model';
+import type { VennClient } from './types';
+import {
+  hasForbiddenSynthesisPayloadFields,
+  readTopicLatestSynthesis,
+  writeTopicLatestSynthesis,
+} from './synthesisAdapters';
+
+export interface SafeLatestSynthesisWriteOptions {
+  canOverwriteExisting?: (existing: TopicSynthesisV2, next: TopicSynthesisV2) => boolean;
+}
+
+export type SafeLatestSynthesisWriteResult =
+  | { status: 'written'; synthesis: TopicSynthesisV2; previous: TopicSynthesisV2 | null }
+  | {
+      status: 'skipped';
+      reason: 'newer_epoch' | 'higher_quorum' | 'ownership_guard';
+      synthesis: TopicSynthesisV2;
+      previous: TopicSynthesisV2;
+    };
+
+export async function writeTopicLatestSynthesisIfNotDowngrade(
+  client: VennClient,
+  synthesis: unknown,
+  options: SafeLatestSynthesisWriteOptions = {},
+): Promise<SafeLatestSynthesisWriteResult> {
+  if (hasForbiddenSynthesisPayloadFields(synthesis)) {
+    throw new Error('Synthesis payload contains forbidden identity/token fields');
+  }
+  const sanitized = TopicSynthesisV2Schema.parse(synthesis);
+  const existing = await readTopicLatestSynthesis(client, sanitized.topic_id);
+
+  if (existing) {
+    if (existing.epoch > sanitized.epoch) {
+      return { status: 'skipped', reason: 'newer_epoch', synthesis: sanitized, previous: existing };
+    }
+
+    if (existing.epoch === sanitized.epoch && existing.quorum.received > sanitized.quorum.received) {
+      return { status: 'skipped', reason: 'higher_quorum', synthesis: sanitized, previous: existing };
+    }
+
+    if (options.canOverwriteExisting && !options.canOverwriteExisting(existing, sanitized)) {
+      return { status: 'skipped', reason: 'ownership_guard', synthesis: sanitized, previous: existing };
+    }
+  }
+
+  await writeTopicLatestSynthesis(client, sanitized);
+  return { status: 'written', synthesis: sanitized, previous: existing };
+}

--- a/packages/gun-client/src/synthesisAdapters.test.ts
+++ b/packages/gun-client/src/synthesisAdapters.test.ts
@@ -409,6 +409,17 @@ describe('synthesisAdapters', () => {
     expect(mesh.writes).toEqual([{ path: 'topics/topic-1/latest', value: next }]);
   });
 
+  it('blocks forbidden identity/token fields before safe latest synthesis writes', async () => {
+    const mesh = createFakeMesh();
+    const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+    const client = createClient(mesh, guard);
+
+    await expect(
+      writeTopicLatestSynthesisIfNotDowngrade(client, { ...SYNTHESIS, bearer_token: 'secret' })
+    ).rejects.toThrow('forbidden identity/token fields');
+    expect(mesh.writes).toHaveLength(0);
+  });
+
   it('writeTopicSynthesis writes epoch and latest paths', async () => {
     const mesh = createFakeMesh();
     const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;

--- a/packages/gun-client/src/synthesisAdapters.test.ts
+++ b/packages/gun-client/src/synthesisAdapters.test.ts
@@ -20,6 +20,7 @@ import {
   writeTopicLatestSynthesis,
   writeTopicSynthesis
 } from './synthesisAdapters';
+import { writeTopicLatestSynthesisIfNotDowngrade } from './safeLatestSynthesisAdapters';
 
 interface FakeMesh {
   root: any;
@@ -333,6 +334,79 @@ describe('synthesisAdapters', () => {
 
     mesh.setRead('topics/topic-1/latest', undefined);
     await expect(readTopicLatestSynthesis(client, 'topic-1')).resolves.toBeNull();
+  });
+
+  it('safely writes latest synthesis without downgrading newer or stronger latest state', async () => {
+    const mesh = createFakeMesh();
+    const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+    const client = createClient(mesh, guard);
+
+    mesh.setRead('topics/topic-1/latest', {
+      ...SYNTHESIS,
+      synthesis_id: 'synth-3',
+      epoch: 3
+    });
+
+    await expect(writeTopicLatestSynthesisIfNotDowngrade(client, SYNTHESIS)).resolves.toMatchObject({
+      status: 'skipped',
+      reason: 'newer_epoch'
+    });
+    expect(mesh.writes).toHaveLength(0);
+
+    mesh.setRead('topics/topic-1/latest', {
+      ...SYNTHESIS,
+      synthesis_id: 'synth-2-stronger',
+      quorum: { ...SYNTHESIS.quorum, received: 5 }
+    });
+
+    await expect(
+      writeTopicLatestSynthesisIfNotDowngrade(client, {
+        ...SYNTHESIS,
+        synthesis_id: 'synth-2-weaker',
+        quorum: { ...SYNTHESIS.quorum, received: 2 }
+      })
+    ).resolves.toMatchObject({
+      status: 'skipped',
+      reason: 'higher_quorum'
+    });
+    expect(mesh.writes).toHaveLength(0);
+  });
+
+  it('honors latest synthesis ownership guards before overwriting existing latest', async () => {
+    const mesh = createFakeMesh();
+    const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+    const client = createClient(mesh, guard);
+    mesh.setRead('topics/topic-1/latest', SYNTHESIS);
+
+    const next = {
+      ...SYNTHESIS,
+      synthesis_id: 'news-bundle:story-1:abc123',
+      quorum: { ...SYNTHESIS.quorum, received: 3 }
+    };
+
+    await expect(
+      writeTopicLatestSynthesisIfNotDowngrade(client, next, {
+        canOverwriteExisting: (existing) => existing.synthesis_id.startsWith('news-bundle:')
+      })
+    ).resolves.toMatchObject({
+      status: 'skipped',
+      reason: 'ownership_guard'
+    });
+    expect(mesh.writes).toHaveLength(0);
+
+    mesh.setRead('topics/topic-1/latest', {
+      ...SYNTHESIS,
+      synthesis_id: 'news-bundle:story-1:old'
+    });
+
+    await expect(
+      writeTopicLatestSynthesisIfNotDowngrade(client, next, {
+        canOverwriteExisting: (existing) => existing.synthesis_id.startsWith('news-bundle:')
+      })
+    ).resolves.toMatchObject({
+      status: 'written'
+    });
+    expect(mesh.writes).toEqual([{ path: 'topics/topic-1/latest', value: next }]);
   });
 
   it('writeTopicSynthesis writes epoch and latest paths', async () => {

--- a/services/news-aggregator/src/bundleSynthesisDaemonConfig.test.ts
+++ b/services/news-aggregator/src/bundleSynthesisDaemonConfig.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { VennClient } from '@vh/gun-client';
+import {
+  createBundleSynthesisEnrichmentFromEnv,
+  isTruthyFlag,
+} from './bundleSynthesisDaemonConfig';
+
+describe('bundleSynthesisDaemonConfig', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('parses truthy feature flags conservatively', () => {
+    expect(isTruthyFlag(undefined)).toBe(false);
+    expect(isTruthyFlag('false')).toBe(false);
+    expect(isTruthyFlag('0')).toBe(false);
+    expect(isTruthyFlag('true')).toBe(true);
+    expect(isTruthyFlag('yes')).toBe(true);
+  });
+
+  it('does not create enrichment when bundle synthesis is disabled', () => {
+    expect(createBundleSynthesisEnrichmentFromEnv({} as VennClient)).toEqual({});
+  });
+
+  it('wires bundle synthesis worker and bounded queue options when enabled', () => {
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    vi.stubEnv('VH_BUNDLE_SYNTHESIS_ENABLED', 'true');
+    vi.stubEnv('VH_BUNDLE_SYNTHESIS_QUEUE_DEPTH', '7');
+
+    const enrichment = createBundleSynthesisEnrichmentFromEnv({} as VennClient, logger);
+
+    expect(typeof enrichment.enrichmentWorker).toBe('function');
+    expect(enrichment.enrichmentQueueOptions?.maxDepth).toBe(7);
+
+    enrichment.enrichmentQueueOptions?.onDrop?.(
+      {
+        story_id: 'story-1',
+        provider: { provider_id: 'remote-analysis', model_id: 'gpt-4o-mini', kind: 'remote' },
+        request: { prompt: 'Prompt', model: 'gpt-4o-mini', max_tokens: 1200, temperature: 0.2 },
+        work_items: [],
+      },
+      { reason: 'queue_full', maxDepth: 7 },
+    );
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      '[vh:bundle-synthesis] queue full; candidate dropped',
+      { story_id: 'story-1', max_depth: 7 },
+    );
+  });
+});

--- a/services/news-aggregator/src/bundleSynthesisDaemonConfig.ts
+++ b/services/news-aggregator/src/bundleSynthesisDaemonConfig.ts
@@ -1,0 +1,68 @@
+import type { VennClient } from '@vh/gun-client';
+import {
+  parsePositiveInt,
+  readEnvVar,
+  type AsyncEnrichmentQueueOptions,
+  type EnrichmentWorker,
+  type LoggerLike,
+} from './daemonUtils';
+import {
+  DEFAULT_BUNDLE_SYNTHESIS_MAX_TOKENS,
+  DEFAULT_BUNDLE_SYNTHESIS_PIPELINE_VERSION,
+  DEFAULT_BUNDLE_SYNTHESIS_RATE_PER_MIN,
+  DEFAULT_BUNDLE_SYNTHESIS_TIMEOUT_MS,
+  getBundleSynthesisModel,
+} from './bundleSynthesisRelay';
+import { createBundleSynthesisWorker } from './bundleSynthesisWorker';
+
+export interface BundleSynthesisDaemonEnrichment {
+  enrichmentWorker?: EnrichmentWorker;
+  enrichmentQueueOptions?: AsyncEnrichmentQueueOptions;
+}
+
+export function isTruthyFlag(value: string | undefined): boolean {
+  if (!value) {
+    return false;
+  }
+  const normalized = value.trim().toLowerCase();
+  return normalized.length > 0 && !['0', 'false', 'off', 'no'].includes(normalized);
+}
+
+export function createBundleSynthesisEnrichmentFromEnv(
+  client: VennClient,
+  logger: LoggerLike = console,
+): BundleSynthesisDaemonEnrichment {
+  const enabled = isTruthyFlag(readEnvVar('VH_BUNDLE_SYNTHESIS_ENABLED'));
+  if (!enabled) {
+    return {};
+  }
+
+  const queueDepth = parsePositiveInt(readEnvVar('VH_BUNDLE_SYNTHESIS_QUEUE_DEPTH'), 32);
+  const worker = createBundleSynthesisWorker({
+    client,
+    model: readEnvVar('VH_BUNDLE_SYNTHESIS_MODEL') ?? getBundleSynthesisModel(),
+    maxTokens: parsePositiveInt(readEnvVar('VH_BUNDLE_SYNTHESIS_MAX_TOKENS'), DEFAULT_BUNDLE_SYNTHESIS_MAX_TOKENS),
+    timeoutMs: parsePositiveInt(readEnvVar('VH_BUNDLE_SYNTHESIS_TIMEOUT_MS'), DEFAULT_BUNDLE_SYNTHESIS_TIMEOUT_MS),
+    ratePerMinute: parsePositiveInt(
+      readEnvVar('VH_BUNDLE_SYNTHESIS_RATE_PER_MIN'),
+      DEFAULT_BUNDLE_SYNTHESIS_RATE_PER_MIN,
+    ),
+    pipelineVersion: readEnvVar('VH_BUNDLE_SYNTHESIS_PIPELINE_VERSION') ?? DEFAULT_BUNDLE_SYNTHESIS_PIPELINE_VERSION,
+    logger,
+  });
+
+  return {
+    enrichmentWorker: async (candidate) => {
+      await worker(candidate);
+    },
+    enrichmentQueueOptions: {
+      maxDepth: queueDepth,
+      onDrop(candidate) {
+        logger.warn('[vh:bundle-synthesis] queue full; candidate dropped', {
+          story_id: candidate.story_id,
+          max_depth: queueDepth,
+        });
+      },
+    },
+  };
+}

--- a/services/news-aggregator/src/bundleSynthesisRelay.ts
+++ b/services/news-aggregator/src/bundleSynthesisRelay.ts
@@ -1,0 +1,115 @@
+import { resolveTokenParam } from './analysisRelay';
+
+export const DEFAULT_BUNDLE_SYNTHESIS_MODEL = 'gpt-4o-mini';
+export const DEFAULT_BUNDLE_SYNTHESIS_MAX_TOKENS = 1200;
+export const DEFAULT_BUNDLE_SYNTHESIS_TIMEOUT_MS = 20_000;
+export const DEFAULT_BUNDLE_SYNTHESIS_RATE_PER_MIN = 20;
+export const DEFAULT_BUNDLE_SYNTHESIS_PIPELINE_VERSION = 'news-bundle-v1';
+
+const RATE_WINDOW_MS = 60_000;
+let requestTimestamps: number[] = [];
+
+export interface BundleSynthesisRelayRequest {
+  prompt: string;
+  model?: string;
+  maxTokens?: number;
+  timeoutMs?: number;
+  ratePerMinute?: number;
+  apiKey?: string;
+  fetchFn?: typeof fetch;
+  now?: () => number;
+}
+
+export interface BundleSynthesisRelayResponse {
+  content: string;
+  model: string;
+}
+
+export function getBundleSynthesisModel(): string {
+  return process.env.VH_BUNDLE_SYNTHESIS_MODEL || DEFAULT_BUNDLE_SYNTHESIS_MODEL;
+}
+
+function assertBundleRateLimit(ratePerMinute: number, nowMs: number): void {
+  const normalizedRate = Math.max(1, Math.floor(ratePerMinute));
+  requestTimestamps = requestTimestamps.filter((timestamp) => nowMs - timestamp < RATE_WINDOW_MS);
+  if (requestTimestamps.length >= normalizedRate) {
+    throw new Error(`Bundle synthesis rate limit exceeded (${normalizedRate}/min)`);
+  }
+  requestTimestamps.push(nowMs);
+}
+
+export function resetBundleSynthesisRelayState(): void {
+  requestTimestamps = [];
+}
+
+export async function postBundleSynthesisCompletion(
+  request: BundleSynthesisRelayRequest,
+): Promise<BundleSynthesisRelayResponse> {
+  const apiKey = request.apiKey ?? process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    throw new Error('Bundle synthesis service not configured (missing OPENAI_API_KEY)');
+  }
+
+  const prompt = request.prompt.trim();
+  if (!prompt) {
+    throw new Error('Bundle synthesis prompt is required');
+  }
+
+  const model = request.model?.trim() || getBundleSynthesisModel();
+  const maxTokens = Math.max(1, Math.floor(request.maxTokens ?? DEFAULT_BUNDLE_SYNTHESIS_MAX_TOKENS));
+  const timeoutMs = Math.max(1, Math.floor(request.timeoutMs ?? DEFAULT_BUNDLE_SYNTHESIS_TIMEOUT_MS));
+  const ratePerMinute = Math.max(1, Math.floor(request.ratePerMinute ?? DEFAULT_BUNDLE_SYNTHESIS_RATE_PER_MIN));
+  const now = request.now ?? Date.now;
+  assertBundleRateLimit(ratePerMinute, now());
+
+  const fetchFn = request.fetchFn ?? fetch;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  const tokenParam = resolveTokenParam(model);
+
+  try {
+    const response = await fetchFn('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model,
+        messages: [
+          {
+            role: 'system',
+            content: 'You synthesize verified news story bundles. Return only strict JSON.',
+          },
+          { role: 'user', content: prompt },
+        ],
+        [tokenParam]: maxTokens,
+        temperature: 0.2,
+        response_format: { type: 'json_object' },
+      }),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      const detail = await response.text().catch(() => 'unknown');
+      throw new Error(`OpenAI bundle synthesis error: HTTP ${response.status}: ${detail.slice(0, 500)}`);
+    }
+
+    const body = (await response.json()) as {
+      choices?: Array<{ message?: { content?: unknown } }>;
+    };
+    const content = body.choices?.[0]?.message?.content;
+    if (typeof content !== 'string' || !content.trim()) {
+      throw new Error('OpenAI bundle synthesis response did not include content');
+    }
+
+    return { content, model };
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw new Error(`Bundle synthesis timed out after ${timeoutMs}ms`);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/services/news-aggregator/src/bundleSynthesisWorker.test.ts
+++ b/services/news-aggregator/src/bundleSynthesisWorker.test.ts
@@ -191,6 +191,48 @@ describe('bundleSynthesisWorker', () => {
     expect(relay).not.toHaveBeenCalled();
   });
 
+  it('scopes idempotency to the configured model', async () => {
+    const candidateIds: string[] = [];
+    const existingCandidate = {
+      candidate_id: 'news-bundle:existing',
+      topic_id: 'topic-1',
+      epoch: 0,
+      critique_notes: [],
+      facts_summary: 'Existing summary',
+      frames: [],
+      warnings: [],
+      divergence_hints: [],
+      provider: { provider_id: 'openai', model_id: 'gpt-4o-mini', kind: 'remote' },
+      created_at: 1700000003000,
+    } satisfies CandidateSynthesis;
+    const readCandidate = vi.fn(
+      async (_client: VennClient, _topicId: string, _epoch: number, candidateId: string) => {
+        candidateIds.push(candidateId);
+        return existingCandidate;
+      },
+    );
+
+    await createBundleSynthesisWorker({
+      client: {} as VennClient,
+      model: 'gpt-4o-mini',
+      readBundle: async () => BUNDLE,
+      readCandidate,
+      relay: vi.fn(),
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    })(CANDIDATE);
+    await createBundleSynthesisWorker({
+      client: {} as VennClient,
+      model: 'gpt-5.2-mini',
+      readBundle: async () => BUNDLE,
+      readCandidate,
+      relay: vi.fn(),
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    })(CANDIDATE);
+
+    expect(candidateIds).toHaveLength(2);
+    expect(candidateIds[0]).not.toBe(candidateIds[1]);
+  });
+
   it('rejects generated output that widens analysis source count', async () => {
     const worker = createBundleSynthesisWorker({
       client: {} as VennClient,

--- a/services/news-aggregator/src/bundleSynthesisWorker.test.ts
+++ b/services/news-aggregator/src/bundleSynthesisWorker.test.ts
@@ -160,15 +160,16 @@ describe('bundleSynthesisWorker', () => {
     expect(writeLatest).toHaveBeenCalledTimes(1);
   });
 
-  it('skips duplicate candidates before spending a model call', async () => {
+  it('recovers synthesis writes from duplicate candidates before spending a model call', async () => {
     const relay = vi.fn();
+    const writtenSyntheses: TopicSynthesisV2[] = [];
     const existingCandidate = {
       candidate_id: 'news-bundle:existing',
       topic_id: 'topic-1',
       epoch: 0,
       critique_notes: [],
       facts_summary: 'Existing summary',
-      frames: [],
+      frames: [{ frame: 'Existing frame', reframe: 'Existing reframe' }],
       warnings: [],
       divergence_hints: [],
       provider: { provider_id: 'openai', model_id: 'gpt-4o-mini', kind: 'remote' },
@@ -179,16 +180,26 @@ describe('bundleSynthesisWorker', () => {
       client: {} as VennClient,
       readBundle: async () => BUNDLE,
       readCandidate: vi.fn(async () => existingCandidate),
+      writeSynthesis: vi.fn(async (_client, synthesis) => {
+        writtenSyntheses.push(synthesis);
+        return synthesis;
+      }),
+      writeLatest: vi.fn(async (_client, synthesis) => ({ status: 'written' as const, synthesis, previous: null })),
       relay,
       logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
     });
 
-    await expect(worker(CANDIDATE)).resolves.toEqual({
-      status: 'skipped',
+    await expect(worker(CANDIDATE)).resolves.toMatchObject({
+      status: 'written',
       storyId: 'story-1',
-      reason: 'duplicate_candidate',
+      latestStatus: 'written',
     });
     expect(relay).not.toHaveBeenCalled();
+    expect(writtenSyntheses).toHaveLength(1);
+    expect(writtenSyntheses[0]).toMatchObject({
+      facts_summary: 'Existing summary',
+      provenance: { candidate_ids: [expect.stringMatching(/^news-bundle:/)] },
+    });
   });
 
   it('scopes idempotency to the configured model', async () => {
@@ -217,6 +228,8 @@ describe('bundleSynthesisWorker', () => {
       model: 'gpt-4o-mini',
       readBundle: async () => BUNDLE,
       readCandidate,
+      writeSynthesis: vi.fn(async (_client, synthesis) => synthesis),
+      writeLatest: vi.fn(async (_client, synthesis) => ({ status: 'written' as const, synthesis, previous: null })),
       relay: vi.fn(),
       logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
     })(CANDIDATE);
@@ -225,6 +238,8 @@ describe('bundleSynthesisWorker', () => {
       model: 'gpt-5.2-mini',
       readBundle: async () => BUNDLE,
       readCandidate,
+      writeSynthesis: vi.fn(async (_client, synthesis) => synthesis),
+      writeLatest: vi.fn(async (_client, synthesis) => ({ status: 'written' as const, synthesis, previous: null })),
       relay: vi.fn(),
       logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
     })(CANDIDATE);

--- a/services/news-aggregator/src/bundleSynthesisWorker.test.ts
+++ b/services/news-aggregator/src/bundleSynthesisWorker.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { NewsRuntimeSynthesisCandidate } from '@vh/ai-engine';
+import type { CandidateSynthesis, StoryBundle, TopicSynthesisV2 } from '@vh/data-model';
+import type { VennClient } from '@vh/gun-client';
+import { createBundleSynthesisWorker } from './bundleSynthesisWorker';
+
+const BUNDLE: StoryBundle = {
+  schemaVersion: 'story-bundle-v0',
+  story_id: 'story-1',
+  topic_id: 'topic-1',
+  headline: 'City council approves housing plan',
+  summary_hint: 'City officials approved a housing plan after public debate.',
+  cluster_window_start: 1700000000000,
+  cluster_window_end: 1700000001000,
+  sources: [
+    {
+      source_id: 'source-analysis',
+      publisher: 'Local Daily',
+      url: 'https://example.com/local',
+      url_hash: 'hash-local',
+      published_at: 1700000000000,
+      title: 'Council approves housing plan',
+    },
+    {
+      source_id: 'source-related',
+      publisher: 'Link Only',
+      url: 'https://example.com/link-only',
+      url_hash: 'hash-link',
+      published_at: 1700000000001,
+      title: 'Related but unreadable story',
+    },
+  ],
+  primary_sources: [
+    {
+      source_id: 'source-analysis',
+      publisher: 'Local Daily',
+      url: 'https://example.com/local',
+      url_hash: 'hash-local',
+      published_at: 1700000000000,
+      title: 'Council approves housing plan',
+    },
+  ],
+  related_links: [
+    {
+      source_id: 'source-related',
+      publisher: 'Link Only',
+      url: 'https://example.com/link-only',
+      url_hash: 'hash-link',
+      published_at: 1700000000001,
+      title: 'Related but unreadable story',
+    },
+  ],
+  cluster_features: {
+    entity_keys: ['housing'],
+    time_bucket: '2026-04-20T12',
+    semantic_signature: 'sig-1',
+    confidence_score: 0.8,
+  },
+  provenance_hash: 'prov-1',
+  created_at: 1700000002000,
+};
+
+const CANDIDATE: NewsRuntimeSynthesisCandidate = {
+  story_id: 'story-1',
+  provider: {
+    provider_id: 'remote-analysis',
+    model_id: 'gpt-4o-mini',
+    kind: 'remote',
+  },
+  request: {
+    prompt: 'Prompt',
+    model: 'gpt-4o-mini',
+    max_tokens: 1200,
+    temperature: 0.2,
+  },
+  work_items: [
+    {
+      story_id: 'story-1',
+      topic_id: 'topic-1',
+      work_type: 'full-analysis',
+      summary_hint: 'Summary',
+      requested_at: 1700000000000,
+    },
+  ],
+};
+
+describe('bundleSynthesisWorker', () => {
+  it('writes publish-time candidate, epoch synthesis, and guarded latest from accepted StoryBundle', async () => {
+    const writtenCandidates: CandidateSynthesis[] = [];
+    const writtenSyntheses: TopicSynthesisV2[] = [];
+    const relay = vi.fn(async () => ({
+      model: 'gpt-4o-mini',
+      content: JSON.stringify({
+        summary: 'Council members approved a housing plan after public debate.',
+        frames: [
+          {
+            frame: 'The plan will expand needed housing supply.',
+            reframe: 'The plan may strain existing neighborhood infrastructure.',
+          },
+        ],
+        source_count: 1,
+        source_publishers: ['Local Daily'],
+        verification_confidence: 0.8,
+      }),
+    }));
+    const writeLatest = vi.fn(async (_client, synthesis: TopicSynthesisV2, options) => {
+      expect(options?.canOverwriteExisting?.({ ...synthesis, synthesis_id: 'manual-synth' }, synthesis)).toBe(false);
+      expect(options?.canOverwriteExisting?.({ ...synthesis, synthesis_id: 'news-bundle:old' }, synthesis)).toBe(true);
+      return { status: 'written' as const, synthesis, previous: null };
+    });
+
+    const worker = createBundleSynthesisWorker({
+      client: {} as VennClient,
+      now: () => 1700000003000,
+      readBundle: async () => BUNDLE,
+      readCandidate: vi.fn(async () => null),
+      writeCandidate: vi.fn(async (_client, candidate) => {
+        writtenCandidates.push(candidate);
+        return candidate;
+      }),
+      writeSynthesis: vi.fn(async (_client, synthesis) => {
+        writtenSyntheses.push(synthesis);
+        return synthesis;
+      }),
+      writeLatest,
+      relay,
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    });
+
+    await expect(worker(CANDIDATE)).resolves.toMatchObject({
+      status: 'written',
+      latestStatus: 'written',
+    });
+
+    expect(relay).toHaveBeenCalledTimes(1);
+    const relayPrompt = relay.mock.calls[0]?.[0].prompt;
+    expect(relayPrompt).toContain('Local Daily');
+    expect(relayPrompt).not.toContain('Link Only');
+
+    expect(writtenCandidates).toHaveLength(1);
+    expect(writtenCandidates[0]).toMatchObject({
+      topic_id: 'topic-1',
+      epoch: 0,
+      facts_summary: 'Council members approved a housing plan after public debate.',
+      warnings: ['single_source_story_bundle', 'related_links_excluded_from_analysis'],
+    });
+    expect(writtenCandidates[0]?.candidate_id).toMatch(/^news-bundle:/);
+
+    expect(writtenSyntheses).toHaveLength(1);
+    expect(writtenSyntheses[0]).toMatchObject({
+      schemaVersion: 'topic-synthesis-v2',
+      topic_id: 'topic-1',
+      epoch: 0,
+      inputs: { story_bundle_ids: ['story-1'] },
+      quorum: { required: 1, received: 1 },
+      provenance: { provider_mix: [{ provider_id: 'openai', count: 1 }] },
+    });
+    expect(writtenSyntheses[0]?.frames[0]?.frame_point_id).toMatch(/^synth-point:/);
+    expect(writtenSyntheses[0]?.synthesis_id).toMatch(/^news-bundle:story-1:/);
+    expect(writeLatest).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips duplicate candidates before spending a model call', async () => {
+    const relay = vi.fn();
+    const existingCandidate = {
+      candidate_id: 'news-bundle:existing',
+      topic_id: 'topic-1',
+      epoch: 0,
+      critique_notes: [],
+      facts_summary: 'Existing summary',
+      frames: [],
+      warnings: [],
+      divergence_hints: [],
+      provider: { provider_id: 'openai', model_id: 'gpt-4o-mini', kind: 'remote' },
+      created_at: 1700000003000,
+    } satisfies CandidateSynthesis;
+
+    const worker = createBundleSynthesisWorker({
+      client: {} as VennClient,
+      readBundle: async () => BUNDLE,
+      readCandidate: vi.fn(async () => existingCandidate),
+      relay,
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    });
+
+    await expect(worker(CANDIDATE)).resolves.toEqual({
+      status: 'skipped',
+      storyId: 'story-1',
+      reason: 'duplicate_candidate',
+    });
+    expect(relay).not.toHaveBeenCalled();
+  });
+
+  it('rejects generated output that widens analysis source count', async () => {
+    const worker = createBundleSynthesisWorker({
+      client: {} as VennClient,
+      readBundle: async () => BUNDLE,
+      readCandidate: vi.fn(async () => null),
+      relay: vi.fn(async () => ({
+        model: 'gpt-4o-mini',
+        content: JSON.stringify({
+          summary: 'Summary.',
+          frames: [{ frame: 'One side supports the plan.', reframe: 'Another side questions the plan.' }],
+          source_count: 2,
+          source_publishers: ['Local Daily', 'Link Only'],
+          verification_confidence: 0.8,
+        }),
+      })),
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    });
+
+    await expect(worker(CANDIDATE)).resolves.toEqual({
+      status: 'rejected',
+      storyId: 'story-1',
+      reason: 'source_count_mismatch',
+    });
+  });
+});

--- a/services/news-aggregator/src/bundleSynthesisWorker.ts
+++ b/services/news-aggregator/src/bundleSynthesisWorker.ts
@@ -69,9 +69,10 @@ function resolveAnalysisSources(bundle: StoryBundle): StoryBundle['sources'] {
   return bundle.primary_sources ?? bundle.sources;
 }
 
-function buildBundleFingerprint(bundle: StoryBundle, pipelineVersion: string): string {
+function buildBundleFingerprint(bundle: StoryBundle, pipelineVersion: string, model: string): string {
   return digest({
     pipelineVersion,
+    model_id: model,
     story_id: bundle.story_id,
     topic_id: bundle.topic_id,
     provenance_hash: bundle.provenance_hash,
@@ -180,7 +181,7 @@ export function createBundleSynthesisWorker(
       return { status: 'skipped', storyId, reason: 'no_analysis_sources' };
     }
 
-    const fingerprint = buildBundleFingerprint(bundle, pipelineVersion);
+    const fingerprint = buildBundleFingerprint(bundle, pipelineVersion, model);
     const candidateId = `news-bundle:${fingerprint.slice(0, 32)}`;
     const synthesisId = `news-bundle:${normalizeIdToken(bundle.story_id)}:${fingerprint.slice(0, 16)}`;
     const existingCandidate = await readCandidate(config.client, bundle.topic_id, BUNDLE_SYNTHESIS_EPOCH, candidateId);

--- a/services/news-aggregator/src/bundleSynthesisWorker.ts
+++ b/services/news-aggregator/src/bundleSynthesisWorker.ts
@@ -31,7 +31,7 @@ const LATEST_OWNER_PREFIX = 'news-bundle:';
 
 export type BundleSynthesisWorkerResult =
   | { status: 'written'; storyId: string; synthesisId: string; latestStatus: 'written' | 'skipped' }
-  | { status: 'skipped'; storyId: string; reason: 'story_missing' | 'duplicate_candidate' | 'no_analysis_sources' }
+  | { status: 'skipped'; storyId: string; reason: 'story_missing' | 'no_analysis_sources' }
   | { status: 'rejected'; storyId: string; reason: 'relay_failed' | 'parse_failed' | 'source_count_mismatch' };
 
 export interface BundleSynthesisWorkerConfig {
@@ -150,6 +150,35 @@ function buildTopicSynthesisPayload(input: {
   };
 }
 
+async function writeAcceptedSynthesis(input: {
+  config: BundleSynthesisWorkerConfig;
+  bundle: StoryBundle;
+  candidateId: string;
+  synthesisId: string;
+  summary: string;
+  frames: CandidateSynthesis['frames'];
+  warnings: string[];
+  createdAt: number;
+  writeSynthesis: (client: VennClient, synthesis: TopicSynthesisV2) => Promise<TopicSynthesisV2>;
+  writeLatest: typeof writeTopicLatestSynthesisIfNotDowngrade;
+}): Promise<{ latestStatus: 'written' | 'skipped' }> {
+  const synthesisPayload = buildTopicSynthesisPayload({
+    synthesisId: input.synthesisId,
+    candidateId: input.candidateId,
+    bundle: input.bundle,
+    summary: input.summary,
+    frames: input.frames,
+    warnings: input.warnings,
+    now: input.createdAt,
+  });
+
+  await input.writeSynthesis(input.config.client, synthesisPayload);
+  const latestResult = await input.writeLatest(input.config.client, synthesisPayload, {
+    canOverwriteExisting: (existing) => existing.synthesis_id.startsWith(LATEST_OWNER_PREFIX),
+  });
+  return { latestStatus: latestResult.status };
+}
+
 export function createBundleSynthesisWorker(
   config: BundleSynthesisWorkerConfig,
 ): (candidate: NewsRuntimeSynthesisCandidate) => Promise<BundleSynthesisWorkerResult> {
@@ -186,11 +215,25 @@ export function createBundleSynthesisWorker(
     const synthesisId = `news-bundle:${normalizeIdToken(bundle.story_id)}:${fingerprint.slice(0, 16)}`;
     const existingCandidate = await readCandidate(config.client, bundle.topic_id, BUNDLE_SYNTHESIS_EPOCH, candidateId);
     if (existingCandidate) {
-      logger.info('[vh:bundle-synthesis] duplicate candidate; skipped model call', {
+      const { latestStatus } = await writeAcceptedSynthesis({
+        config,
+        bundle,
+        candidateId,
+        synthesisId,
+        summary: existingCandidate.facts_summary,
+        frames: existingCandidate.frames,
+        warnings: existingCandidate.warnings,
+        createdAt: existingCandidate.created_at,
+        writeSynthesis,
+        writeLatest,
+      });
+      logger.info('[vh:bundle-synthesis] duplicate candidate recovered synthesis; skipped model call', {
         story_id: storyId,
         candidate_id: candidateId,
+        synthesis_id: synthesisId,
+        latest_status: latestStatus,
       });
-      return { status: 'skipped', storyId, reason: 'duplicate_candidate' };
+      return { status: 'written', storyId, synthesisId, latestStatus };
     }
 
     let response: BundleSynthesisRelayResponse;
@@ -242,20 +285,18 @@ export function createBundleSynthesisWorker(
       model: response.model,
       now: createdAt,
     });
-    const synthesisPayload = buildTopicSynthesisPayload({
+    await writeCandidate(config.client, candidatePayload);
+    const { latestStatus } = await writeAcceptedSynthesis({
+      config,
+      bundle,
       synthesisId,
       candidateId,
-      bundle,
       summary: parsed.summary,
       frames,
       warnings,
-      now: createdAt,
-    });
-
-    await writeCandidate(config.client, candidatePayload);
-    await writeSynthesis(config.client, synthesisPayload);
-    const latestResult = await writeLatest(config.client, synthesisPayload, {
-      canOverwriteExisting: (existing) => existing.synthesis_id.startsWith(LATEST_OWNER_PREFIX),
+      createdAt,
+      writeSynthesis,
+      writeLatest,
     });
 
     logger.info('[vh:bundle-synthesis] synthesis written', {
@@ -263,14 +304,14 @@ export function createBundleSynthesisWorker(
       topic_id: bundle.topic_id,
       candidate_id: candidateId,
       synthesis_id: synthesisId,
-      latest_status: latestResult.status,
+      latest_status: latestStatus,
     });
 
     return {
       status: 'written',
       storyId,
       synthesisId,
-      latestStatus: latestResult.status,
+      latestStatus,
     };
   };
 }

--- a/services/news-aggregator/src/bundleSynthesisWorker.ts
+++ b/services/news-aggregator/src/bundleSynthesisWorker.ts
@@ -1,0 +1,275 @@
+import { createHash } from 'node:crypto';
+import {
+  attachPersistedFramePointIds,
+  buildBundlePromptFromStoryBundle,
+  parseGeneratedBundleSynthesis,
+  type NewsRuntimeSynthesisCandidate,
+} from '@vh/ai-engine';
+import type { CandidateSynthesis, StoryBundle, TopicSynthesisV2 } from '@vh/data-model';
+import {
+  readStoryBundle,
+  readTopicEpochCandidate,
+  writeTopicEpochCandidate,
+  writeTopicEpochSynthesis,
+  writeTopicLatestSynthesisIfNotDowngrade,
+  type VennClient,
+} from '@vh/gun-client';
+import type { LoggerLike } from './daemonUtils';
+import {
+  DEFAULT_BUNDLE_SYNTHESIS_MAX_TOKENS,
+  DEFAULT_BUNDLE_SYNTHESIS_MODEL,
+  DEFAULT_BUNDLE_SYNTHESIS_PIPELINE_VERSION,
+  DEFAULT_BUNDLE_SYNTHESIS_RATE_PER_MIN,
+  DEFAULT_BUNDLE_SYNTHESIS_TIMEOUT_MS,
+  postBundleSynthesisCompletion,
+  type BundleSynthesisRelayResponse,
+} from './bundleSynthesisRelay';
+
+const BUNDLE_SYNTHESIS_EPOCH = 0;
+const PROVIDER_ID = 'openai';
+const LATEST_OWNER_PREFIX = 'news-bundle:';
+
+export type BundleSynthesisWorkerResult =
+  | { status: 'written'; storyId: string; synthesisId: string; latestStatus: 'written' | 'skipped' }
+  | { status: 'skipped'; storyId: string; reason: 'story_missing' | 'duplicate_candidate' | 'no_analysis_sources' }
+  | { status: 'rejected'; storyId: string; reason: 'relay_failed' | 'parse_failed' | 'source_count_mismatch' };
+
+export interface BundleSynthesisWorkerConfig {
+  client: VennClient;
+  logger?: LoggerLike;
+  now?: () => number;
+  model?: string;
+  maxTokens?: number;
+  timeoutMs?: number;
+  ratePerMinute?: number;
+  pipelineVersion?: string;
+  relay?: (request: {
+    prompt: string;
+    model: string;
+    maxTokens: number;
+    timeoutMs: number;
+    ratePerMinute: number;
+  }) => Promise<BundleSynthesisRelayResponse>;
+  readBundle?: (client: VennClient, storyId: string) => Promise<StoryBundle | null>;
+  readCandidate?: typeof readTopicEpochCandidate;
+  writeCandidate?: (client: VennClient, candidate: CandidateSynthesis) => Promise<CandidateSynthesis>;
+  writeSynthesis?: (client: VennClient, synthesis: TopicSynthesisV2) => Promise<TopicSynthesisV2>;
+  writeLatest?: typeof writeTopicLatestSynthesisIfNotDowngrade;
+}
+
+function digest(value: unknown): string {
+  return createHash('sha256').update(JSON.stringify(value)).digest('hex');
+}
+
+function normalizeIdToken(value: string): string {
+  return value.trim().replace(/[^a-zA-Z0-9._:-]+/g, '_') || 'story';
+}
+
+function resolveAnalysisSources(bundle: StoryBundle): StoryBundle['sources'] {
+  return bundle.primary_sources ?? bundle.sources;
+}
+
+function buildBundleFingerprint(bundle: StoryBundle, pipelineVersion: string): string {
+  return digest({
+    pipelineVersion,
+    story_id: bundle.story_id,
+    topic_id: bundle.topic_id,
+    provenance_hash: bundle.provenance_hash,
+    source_hashes: resolveAnalysisSources(bundle).map((source) => ({
+      source_id: source.source_id,
+      url_hash: source.url_hash,
+    })),
+  });
+}
+
+function buildCandidatePayload(input: {
+  candidateId: string;
+  bundle: StoryBundle;
+  summary: string;
+  frames: CandidateSynthesis['frames'];
+  warnings: string[];
+  model: string;
+  now: number;
+}): CandidateSynthesis {
+  return {
+    candidate_id: input.candidateId,
+    topic_id: input.bundle.topic_id,
+    epoch: BUNDLE_SYNTHESIS_EPOCH,
+    critique_notes: ['publish-time story bundle synthesis'],
+    facts_summary: input.summary,
+    frames: input.frames,
+    warnings: input.warnings,
+    divergence_hints: [],
+    provider: {
+      provider_id: PROVIDER_ID,
+      model_id: input.model,
+      kind: 'remote',
+    },
+    created_at: input.now,
+  };
+}
+
+function buildTopicSynthesisPayload(input: {
+  synthesisId: string;
+  candidateId: string;
+  bundle: StoryBundle;
+  summary: string;
+  frames: CandidateSynthesis['frames'];
+  warnings: string[];
+  now: number;
+}): TopicSynthesisV2 {
+  return {
+    schemaVersion: 'topic-synthesis-v2',
+    topic_id: input.bundle.topic_id,
+    epoch: BUNDLE_SYNTHESIS_EPOCH,
+    synthesis_id: input.synthesisId,
+    inputs: {
+      story_bundle_ids: [input.bundle.story_id],
+    },
+    quorum: {
+      required: 1,
+      received: 1,
+      reached_at: input.now,
+      timed_out: false,
+      selection_rule: 'deterministic',
+    },
+    facts_summary: input.summary,
+    frames: attachPersistedFramePointIds(input.synthesisId, input.frames),
+    warnings: input.warnings,
+    divergence_metrics: {
+      disagreement_score: input.frames.length > 0 ? 0.5 : 0,
+      source_dispersion: resolveAnalysisSources(input.bundle).length > 1 ? 1 : 0,
+      candidate_count: 1,
+    },
+    provenance: {
+      candidate_ids: [input.candidateId],
+      provider_mix: [{ provider_id: PROVIDER_ID, count: 1 }],
+    },
+    created_at: input.now,
+  };
+}
+
+export function createBundleSynthesisWorker(
+  config: BundleSynthesisWorkerConfig,
+): (candidate: NewsRuntimeSynthesisCandidate) => Promise<BundleSynthesisWorkerResult> {
+  const logger = config.logger ?? console;
+  const now = config.now ?? Date.now;
+  const model = config.model?.trim() || DEFAULT_BUNDLE_SYNTHESIS_MODEL;
+  const maxTokens = Math.max(1, Math.floor(config.maxTokens ?? DEFAULT_BUNDLE_SYNTHESIS_MAX_TOKENS));
+  const timeoutMs = Math.max(1, Math.floor(config.timeoutMs ?? DEFAULT_BUNDLE_SYNTHESIS_TIMEOUT_MS));
+  const ratePerMinute = Math.max(1, Math.floor(config.ratePerMinute ?? DEFAULT_BUNDLE_SYNTHESIS_RATE_PER_MIN));
+  const pipelineVersion = config.pipelineVersion?.trim() || DEFAULT_BUNDLE_SYNTHESIS_PIPELINE_VERSION;
+  const relay = config.relay ?? postBundleSynthesisCompletion;
+  const readBundle = config.readBundle ?? readStoryBundle;
+  const readCandidate = config.readCandidate ?? readTopicEpochCandidate;
+  const writeCandidate = config.writeCandidate ?? writeTopicEpochCandidate;
+  const writeSynthesis = config.writeSynthesis ?? writeTopicEpochSynthesis;
+  const writeLatest = config.writeLatest ?? writeTopicLatestSynthesisIfNotDowngrade;
+
+  return async (candidate) => {
+    const storyId = candidate.story_id;
+    const bundle = await readBundle(config.client, storyId);
+    if (!bundle) {
+      logger.warn('[vh:bundle-synthesis] story bundle missing; skipped', { story_id: storyId });
+      return { status: 'skipped', storyId, reason: 'story_missing' };
+    }
+
+    const analysisSources = resolveAnalysisSources(bundle);
+    if (analysisSources.length === 0) {
+      logger.warn('[vh:bundle-synthesis] no analysis-eligible sources; skipped', { story_id: storyId });
+      return { status: 'skipped', storyId, reason: 'no_analysis_sources' };
+    }
+
+    const fingerprint = buildBundleFingerprint(bundle, pipelineVersion);
+    const candidateId = `news-bundle:${fingerprint.slice(0, 32)}`;
+    const synthesisId = `news-bundle:${normalizeIdToken(bundle.story_id)}:${fingerprint.slice(0, 16)}`;
+    const existingCandidate = await readCandidate(config.client, bundle.topic_id, BUNDLE_SYNTHESIS_EPOCH, candidateId);
+    if (existingCandidate) {
+      logger.info('[vh:bundle-synthesis] duplicate candidate; skipped model call', {
+        story_id: storyId,
+        candidate_id: candidateId,
+      });
+      return { status: 'skipped', storyId, reason: 'duplicate_candidate' };
+    }
+
+    let response: BundleSynthesisRelayResponse;
+    try {
+      response = await relay({
+        prompt: buildBundlePromptFromStoryBundle(bundle),
+        model,
+        maxTokens,
+        timeoutMs,
+        ratePerMinute,
+      });
+    } catch (error) {
+      logger.warn('[vh:bundle-synthesis] relay failed', { story_id: storyId, error });
+      return { status: 'rejected', storyId, reason: 'relay_failed' };
+    }
+
+    let parsed: ReturnType<typeof parseGeneratedBundleSynthesis>;
+    try {
+      parsed = parseGeneratedBundleSynthesis(response.content);
+    } catch (error) {
+      logger.warn('[vh:bundle-synthesis] generated output rejected', { story_id: storyId, error });
+      return { status: 'rejected', storyId, reason: 'parse_failed' };
+    }
+
+    if (parsed.source_count !== analysisSources.length) {
+      logger.warn('[vh:bundle-synthesis] generated output source count mismatch', {
+        story_id: storyId,
+        expected_source_count: analysisSources.length,
+        generated_source_count: parsed.source_count,
+      });
+      return { status: 'rejected', storyId, reason: 'source_count_mismatch' };
+    }
+
+    const warnings = [
+      ...(analysisSources.length === 1 ? ['single_source_story_bundle'] : []),
+      ...((bundle.related_links?.length ?? 0) > 0 ? ['related_links_excluded_from_analysis'] : []),
+    ];
+    const createdAt = now();
+    const frames = parsed.frames.map((frame) => ({
+      frame: frame.frame,
+      reframe: frame.reframe,
+    }));
+    const candidatePayload = buildCandidatePayload({
+      candidateId,
+      bundle,
+      summary: parsed.summary,
+      frames,
+      warnings,
+      model: response.model,
+      now: createdAt,
+    });
+    const synthesisPayload = buildTopicSynthesisPayload({
+      synthesisId,
+      candidateId,
+      bundle,
+      summary: parsed.summary,
+      frames,
+      warnings,
+      now: createdAt,
+    });
+
+    await writeCandidate(config.client, candidatePayload);
+    await writeSynthesis(config.client, synthesisPayload);
+    const latestResult = await writeLatest(config.client, synthesisPayload, {
+      canOverwriteExisting: (existing) => existing.synthesis_id.startsWith(LATEST_OWNER_PREFIX),
+    });
+
+    logger.info('[vh:bundle-synthesis] synthesis written', {
+      story_id: storyId,
+      topic_id: bundle.topic_id,
+      candidate_id: candidateId,
+      synthesis_id: synthesisId,
+      latest_status: latestResult.status,
+    });
+
+    return {
+      status: 'written',
+      storyId,
+      synthesisId,
+      latestStatus: latestResult.status,
+    };
+  };
+}

--- a/services/news-aggregator/src/daemon.ts
+++ b/services/news-aggregator/src/daemon.ts
@@ -1,4 +1,3 @@
-import { pathToFileURL } from 'node:url';
 import {
   startNewsRuntime,
   type FeedSource,
@@ -31,11 +30,17 @@ import {
   readEnvVar,
   resolveLeaseHolderId,
   verifyStoryClusterHealth,
+  type AsyncEnrichmentQueueOptions,
   type EnrichmentWorker,
   type LoggerLike,
 } from './daemonUtils';
 import { createLeaseGuard } from './leaseGuard';
 import { createDaemonFeedClusterCaptureRecorder } from './clusterCapturePersistence';
+import {
+  createBundleSynthesisEnrichmentFromEnv,
+  isTruthyFlag,
+} from './bundleSynthesisDaemonConfig';
+import { isDirectExecution, runFromCli } from './daemonCli';
 type RuntimeStarter = (config: NewsRuntimeConfig) => NewsRuntimeHandle;
 type RuntimeOrchestratorOptions = NonNullable<NewsRuntimeConfig['orchestratorOptions']> & {
   remoteClusterMaxItemsPerRequest?: number;
@@ -54,6 +59,7 @@ export interface NewsAggregatorDaemonConfig {
   writeBundle?: (client: VennClient, bundle: unknown) => Promise<unknown>;
   removeBundle?: (client: VennClient, storyId: string) => Promise<unknown>;
   enrichmentWorker?: EnrichmentWorker;
+  enrichmentQueueOptions?: AsyncEnrichmentQueueOptions;
   runtimeOrchestratorOptions?: NewsRuntimeConfig['orchestratorOptions'];
   now?: () => number;
   random?: () => number;
@@ -84,7 +90,11 @@ export function createNewsAggregatorDaemon(config: NewsAggregatorDaemonConfig): 
   const leaseRenewIntervalMs = Math.max(5_000, Math.floor(leaseTtlMs / 2));
   const leaseVerificationWindowMs = Math.max(500, Math.min(5_000, Math.floor(leaseTtlMs / 6)));
   const holderId = resolveLeaseHolderId(config.leaseHolderId);
-  const queue = createAsyncEnrichmentQueue(config.enrichmentWorker ?? (() => undefined), logger);
+  const queue = createAsyncEnrichmentQueue(
+    config.enrichmentWorker ?? (() => undefined),
+    logger,
+    config.enrichmentQueueOptions,
+  );
   const clusterCaptureRecorder = createDaemonFeedClusterCaptureRecorder(
     readEnvVar('VH_DAEMON_FEED_RUN_ID'),
   );
@@ -285,6 +295,7 @@ export async function startNewsAggregatorDaemonFromEnv(): Promise<NewsAggregator
     peers: gunPeers.length > 0 ? gunPeers : undefined,
     requireSession: false,
   });
+  const bundleSynthesisEnrichment = createBundleSynthesisEnrichmentFromEnv(client, console);
   const daemon = createNewsAggregatorDaemon({
     client,
     feedSources,
@@ -292,6 +303,7 @@ export async function startNewsAggregatorDaemonFromEnv(): Promise<NewsAggregator
     pollIntervalMs,
     leaseTtlMs,
     leaseHolderId: readEnvVar('VH_NEWS_DAEMON_HOLDER_ID'),
+    ...bundleSynthesisEnrichment,
     runtimeOrchestratorOptions: {
       productionMode: true,
       allowHeuristicFallback: false,
@@ -312,41 +324,9 @@ export async function startNewsAggregatorDaemonFromEnv(): Promise<NewsAggregator
   };
 }
 
-function isDirectExecution(metaUrl: string): boolean {
-  const argvPath = process.argv[1];
-  if (!argvPath) {
-    return false;
-  }
-  try {
-    return pathToFileURL(argvPath).href === metaUrl;
-  } catch {
-    return false;
-  }
-}
-type ProcessLifecycle = Pick<typeof process, 'once' | 'exit'>;
-type CliLogger = Pick<Console, 'info' | 'error'>;
-
-async function runFromCli(
-  startFromEnv: () => Promise<NewsAggregatorDaemonProcessHandle> = startNewsAggregatorDaemonFromEnv,
-  lifecycle: ProcessLifecycle = process,
-  logger: CliLogger = console,
-): Promise<void> {
-  const processHandle = await startFromEnv();
-  const shutdown = async (signal: string): Promise<void> => {
-    logger.info(`[vh:news-daemon] received ${signal}; shutting down`);
-    await processHandle.stop();
-  };
-  for (const signal of ['SIGINT', 'SIGTERM'] as const) {
-    lifecycle.once(signal, () => {
-      void shutdown(signal).finally(() => {
-        lifecycle.exit(0);
-      });
-    });
-  }
-}
 /* c8 ignore start */
 if (isDirectExecution(import.meta.url)) {
-  void runFromCli().catch((error) => {
+  void runFromCli(startNewsAggregatorDaemonFromEnv).catch((error) => {
     console.error('[vh:news-daemon] failed to start', error);
     process.exit(1);
   });
@@ -363,4 +343,5 @@ export const __internal = {
   runFromCli,
   startNewsAggregatorDaemonFromEnv,
   verifyStoryClusterHealth,
+  isTruthyFlag,
 };

--- a/services/news-aggregator/src/daemonCli.ts
+++ b/services/news-aggregator/src/daemonCli.ts
@@ -1,0 +1,36 @@
+import { pathToFileURL } from 'node:url';
+import type { NewsAggregatorDaemonProcessHandle } from './daemon';
+
+export type ProcessLifecycle = Pick<typeof process, 'once' | 'exit'>;
+export type CliLogger = Pick<Console, 'info' | 'error'>;
+
+export function isDirectExecution(metaUrl: string): boolean {
+  const argvPath = process.argv[1];
+  if (!argvPath) {
+    return false;
+  }
+  try {
+    return pathToFileURL(argvPath).href === metaUrl;
+  } catch {
+    return false;
+  }
+}
+
+export async function runFromCli(
+  startFromEnv: () => Promise<NewsAggregatorDaemonProcessHandle>,
+  lifecycle: ProcessLifecycle = process,
+  logger: CliLogger = console,
+): Promise<void> {
+  const processHandle = await startFromEnv();
+  const shutdown = async (signal: string): Promise<void> => {
+    logger.info(`[vh:news-daemon] received ${signal}; shutting down`);
+    await processHandle.stop();
+  };
+  for (const signal of ['SIGINT', 'SIGTERM'] as const) {
+    lifecycle.once(signal, () => {
+      void shutdown(signal).finally(() => {
+        lifecycle.exit(0);
+      });
+    });
+  }
+}

--- a/services/news-aggregator/src/daemonCli.ts
+++ b/services/news-aggregator/src/daemonCli.ts
@@ -1,8 +1,10 @@
 import { pathToFileURL } from 'node:url';
-import type { NewsAggregatorDaemonProcessHandle } from './daemon';
 
 export type ProcessLifecycle = Pick<typeof process, 'once' | 'exit'>;
 export type CliLogger = Pick<Console, 'info' | 'error'>;
+export interface CliDaemonProcessHandle {
+  stop(): Promise<void>;
+}
 
 export function isDirectExecution(metaUrl: string): boolean {
   const argvPath = process.argv[1];
@@ -17,7 +19,7 @@ export function isDirectExecution(metaUrl: string): boolean {
 }
 
 export async function runFromCli(
-  startFromEnv: () => Promise<NewsAggregatorDaemonProcessHandle>,
+  startFromEnv: () => Promise<CliDaemonProcessHandle>,
   lifecycle: ProcessLifecycle = process,
   logger: CliLogger = console,
 ): Promise<void> {

--- a/services/news-aggregator/src/daemonUtils.test.ts
+++ b/services/news-aggregator/src/daemonUtils.test.ts
@@ -110,6 +110,36 @@ describe('daemonUtils', () => {
     expect(worker).not.toHaveBeenCalled();
   });
 
+  it('drops enrichment candidates when bounded queue is full', async () => {
+    const worker = vi.fn(async () => undefined);
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    const onDrop = vi.fn();
+
+    const queue = createAsyncEnrichmentQueue(worker, logger, {
+      maxDepth: 2,
+      onDrop,
+    });
+
+    queue.enqueue({ ...CANDIDATE, story_id: 'story-1' });
+    queue.enqueue({ ...CANDIDATE, story_id: 'story-2' });
+    queue.enqueue({ ...CANDIDATE, story_id: 'story-3' });
+
+    expect(onDrop).toHaveBeenCalledWith(
+      expect.objectContaining({ story_id: 'story-3' }),
+      { reason: 'queue_full', maxDepth: 2 },
+    );
+    expect(logger.warn).toHaveBeenCalledWith(
+      '[vh:news-daemon] enrichment queue full; dropped candidate',
+      { story_id: 'story-3', max_depth: 2 },
+    );
+
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    expect(worker).toHaveBeenCalledTimes(2);
+    expect(queue.size()).toBe(0);
+  });
+
   it('derives StoryCluster health URLs across pathname shapes', () => {
     expect(deriveStoryClusterHealthUrl('https://storycluster.example.com')).toBe(
       'https://storycluster.example.com/health',

--- a/services/news-aggregator/src/daemonUtils.ts
+++ b/services/news-aggregator/src/daemonUtils.ts
@@ -3,11 +3,17 @@ import {
   FeedSourceSchema,
   TopicMappingSchema,
   type FeedSource,
-  type NewsRuntimeSynthesisCandidate,
   type TopicMapping,
 } from '@vh/ai-engine';
 import type { NewsIngestionLease } from '@vh/gun-client';
 import { resolveStarterFeedSources, type ResolvedStarterFeedSources } from './sourceRegistry';
+export {
+  createAsyncEnrichmentQueue,
+  type AsyncEnrichmentQueue,
+  type AsyncEnrichmentQueueOptions,
+  type EnrichmentWorker,
+  type LoggerLike,
+} from './enrichmentQueue';
 
 export const DEFAULT_TOPIC_MAPPING: TopicMapping = {
   defaultTopicId: 'topic-news',
@@ -17,79 +23,12 @@ export const DEFAULT_TOPIC_MAPPING: TopicMapping = {
 export const DEFAULT_LEASE_TTL_MS = 2 * 60 * 1000;
 export const DEFAULT_STORYCLUSTER_REMOTE_TIMEOUT_MS = 90_000;
 
-export type LoggerLike = Pick<Console, 'info' | 'warn' | 'error'>;
-
 export interface StoryClusterRemoteConfig {
   endpointUrl: string;
   healthUrl: string;
   timeoutMs: number;
   maxItemsPerRequest?: number;
   headers: Record<string, string>;
-}
-export type EnrichmentWorker = (candidate: NewsRuntimeSynthesisCandidate) => Promise<void> | void;
-
-export interface AsyncEnrichmentQueue {
-  enqueue(candidate: NewsRuntimeSynthesisCandidate): void;
-  size(): number;
-  stop(): void;
-}
-export function createAsyncEnrichmentQueue(worker: EnrichmentWorker, logger: LoggerLike): AsyncEnrichmentQueue {
-  const pending: NewsRuntimeSynthesisCandidate[] = [];
-  let draining = false;
-  let stopped = false;
-  let drainScheduled = false;
-
-  const drain = async (): Promise<void> => {
-    if (draining || stopped) {
-      return;
-    }
-
-    draining = true;
-    try {
-      while (!stopped && pending.length > 0) {
-        const next = pending.shift();
-        if (!next) {
-          continue;
-        }
-
-        try {
-          await worker(next);
-        } catch (error) {
-          logger.warn('[vh:news-daemon] enrichment worker failed', error);
-        }
-      }
-    } finally {
-      draining = false;
-    }
-  };
-
-  return {
-    enqueue(candidate: NewsRuntimeSynthesisCandidate) {
-      if (stopped) {
-        return;
-      }
-
-      pending.push(candidate);
-      if (drainScheduled || draining) {
-        return;
-      }
-
-      drainScheduled = true;
-      queueMicrotask(() => {
-        drainScheduled = false;
-        void drain();
-      });
-    },
-
-    size() {
-      return pending.length;
-    },
-
-    stop() {
-      stopped = true;
-      pending.length = 0;
-    },
-  };
 }
 
 export function readEnvVar(name: string): string | undefined {

--- a/services/news-aggregator/src/enrichmentQueue.ts
+++ b/services/news-aggregator/src/enrichmentQueue.ts
@@ -1,0 +1,94 @@
+import type { NewsRuntimeSynthesisCandidate } from '@vh/ai-engine';
+
+export type LoggerLike = Pick<Console, 'info' | 'warn' | 'error'>;
+export type EnrichmentWorker = (candidate: NewsRuntimeSynthesisCandidate) => Promise<void> | void;
+
+export interface AsyncEnrichmentQueueOptions {
+  maxDepth?: number;
+  onDrop?: (
+    candidate: NewsRuntimeSynthesisCandidate,
+    detail: { reason: 'queue_full'; maxDepth: number },
+  ) => void;
+}
+
+export interface AsyncEnrichmentQueue {
+  enqueue(candidate: NewsRuntimeSynthesisCandidate): void;
+  size(): number;
+  stop(): void;
+}
+
+export function createAsyncEnrichmentQueue(
+  worker: EnrichmentWorker,
+  logger: LoggerLike,
+  options: AsyncEnrichmentQueueOptions = {},
+): AsyncEnrichmentQueue {
+  const pending: NewsRuntimeSynthesisCandidate[] = [];
+  const maxDepth =
+    typeof options.maxDepth === 'number' && Number.isFinite(options.maxDepth) && options.maxDepth > 0
+      ? Math.floor(options.maxDepth)
+      : undefined;
+  let draining = false;
+  let stopped = false;
+  let drainScheduled = false;
+
+  const drain = async (): Promise<void> => {
+    if (draining || stopped) {
+      return;
+    }
+
+    draining = true;
+    try {
+      while (!stopped && pending.length > 0) {
+        const next = pending.shift();
+        if (!next) {
+          continue;
+        }
+
+        try {
+          await worker(next);
+        } catch (error) {
+          logger.warn('[vh:news-daemon] enrichment worker failed', error);
+        }
+      }
+    } finally {
+      draining = false;
+    }
+  };
+
+  return {
+    enqueue(candidate: NewsRuntimeSynthesisCandidate) {
+      if (stopped) {
+        return;
+      }
+
+      if (maxDepth !== undefined && pending.length >= maxDepth) {
+        options.onDrop?.(candidate, { reason: 'queue_full', maxDepth });
+        logger.warn('[vh:news-daemon] enrichment queue full; dropped candidate', {
+          story_id: candidate.story_id,
+          max_depth: maxDepth,
+        });
+        return;
+      }
+
+      pending.push(candidate);
+      if (drainScheduled || draining) {
+        return;
+      }
+
+      drainScheduled = true;
+      queueMicrotask(() => {
+        drainScheduled = false;
+        void drain();
+      });
+    },
+
+    size() {
+      return pending.length;
+    },
+
+    stop() {
+      stopped = true;
+      pending.length = 0;
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- adds publish-time bundle synthesis worker for accepted StoryBundle inputs, using primary/analysis-eligible sources only
- adds guarded latest TopicSynthesisV2 writes so bundle synthesis cannot overwrite newer, stronger, or non-news-bundle-owned latest records
- wires daemon env config, bounded enrichment queue, and OpenAI relay defaults for bundle synthesis
- changes NewsCard detail rendering to hydrate accepted TopicSynthesisV2 only; card-open runtime analysis is no longer invoked

## Verification
- pnpm --filter @vh/news-aggregator typecheck
- pnpm --filter @vh/news-aggregator exec vitest run src/bundleSynthesisDaemonConfig.test.ts --config ./vitest.config.ts --reporter=verbose
- pnpm --filter @vh/news-aggregator exec vitest run src/bundleSynthesisWorker.test.ts src/daemonUtils.test.ts src/daemon.coverage.test.ts --config ./vitest.config.ts --reporter=verbose
- pnpm --filter @vh/news-aggregator exec vitest run src/daemon.test.ts src/daemon.production.test.ts src/daemon.coverage.test.ts --config ./vitest.config.ts --reporter=verbose
- pnpm --filter @vh/gun-client typecheck
- pnpm --filter @vh/gun-client exec vitest run src/synthesisAdapters.test.ts --reporter=verbose
- pnpm --filter @vh/web-pwa typecheck
- pnpm exec vitest run apps/web-pwa/src/components/feed/NewsCard.test.tsx apps/web-pwa/src/components/feed/NewsCard.sharedTopicIsolation.test.tsx apps/web-pwa/src/components/feed/NewsCard.expandedFocus.test.tsx apps/web-pwa/src/components/feed/NewsCard.storyline.test.tsx --reporter=verbose
- pnpm exec vitest run packages/ai-engine/src/bundlePrompts.test.ts --reporter=verbose
- pnpm --filter @vh/ai-engine typecheck
- pnpm --filter @vh/web-pwa build
- pnpm --filter @vh/news-aggregator build:source-health-deps
- git diff --check

## Notes
- Local `pnpm lint:loc` is not a reliable signal in this checkout because it scans stale nested `.claude/worktrees` and `.tmp` copies; every touched non-test source file is <= 350 lines.
- `pnpm --filter @vh/web-pwa typecheck:test` still fails on pre-existing unrelated test typing debt outside this slice.
