### PR TITLE
Align MVP roadmap with current main

### DIFF
--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -13,6 +13,9 @@ This document defines compile-time flags used by the web PWA for FPD rollout.
   - **Description:** Enables strict production proof validation policy.
     - `false`: non-production tolerance (still uses attestation-bound deterministic beta-local proof generation)
     - `true`: strict production mode (configured district enforcement + production guard)
+  - **Important:** this flag tightens client-side validation policy; it does
+    not by itself replace the current deterministic proof provider with
+    cryptographic residency proof acquisition.
   - **Production requirement:** `true`
   - **MVP beta note:** A Web PWA beta may run with `false` only if product copy
     explicitly uses beta-local identity/proof language and avoids verified-human,
@@ -50,5 +53,8 @@ This document defines compile-time flags used by the web PWA for FPD rollout.
 1. Production builds must enforce `VITE_CONSTITUENCY_PROOF_REAL=true`.
    Public beta builds that intentionally keep this flag `false` are not
    production-proof builds and must be labeled/copy-reviewed accordingly.
+   A production-proof launch also requires a real cryptographic proof provider;
+   the flag alone is not sufficient evidence of residency proof or Sybil
+   resistance.
 2. E2E-mode (`VITE_E2E_MODE=true`) is test-only and cannot ship.
 3. Any flag change requires a new build artifact because flags are compile-time constants.

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -11,9 +11,12 @@ This document defines compile-time flags used by the web PWA for FPD rollout.
 - **`VITE_CONSTITUENCY_PROOF_REAL`**
   - **Default:** `false`
   - **Description:** Enables strict production proof validation policy.
-    - `false`: non-production tolerance (still uses real attestation-bound proof generation)
+    - `false`: non-production tolerance (still uses attestation-bound deterministic beta-local proof generation)
     - `true`: strict production mode (configured district enforcement + production guard)
   - **Production requirement:** `true`
+  - **MVP beta note:** A Web PWA beta may run with `false` only if product copy
+    explicitly uses beta-local identity/proof language and avoids verified-human,
+    one-human-one-vote, district-proof, and Sybil-resistance claims.
 
 - **`VITE_E2E_MODE`**
   - **Default:** `false`
@@ -45,5 +48,7 @@ This document defines compile-time flags used by the web PWA for FPD rollout.
 ## Deployment guardrails
 
 1. Production builds must enforce `VITE_CONSTITUENCY_PROOF_REAL=true`.
+   Public beta builds that intentionally keep this flag `false` are not
+   production-proof builds and must be labeled/copy-reviewed accordingly.
 2. E2E-mode (`VITE_E2E_MODE=true`) is test-only and cannot ship.
 3. Any flag change requires a new build artifact because flags are compile-time constants.

--- a/docs/plans/PR_B_TOPIC_SYNTHESIS_V2_BUNDLE_SPINE_CONTRACT.md
+++ b/docs/plans/PR_B_TOPIC_SYNTHESIS_V2_BUNDLE_SPINE_CONTRACT.md
@@ -1,11 +1,13 @@
 # PR B TopicSynthesisV2 Bundle Spine Implementation Contract
 
-Status: Queued after PR #523
+Status: Implemented by PR #528; historical contract retained for audit
 Owner: VHC Core Engineering
-Last Updated: 2026-04-17
+Last Updated: 2026-04-21
 
-This plan preserves the implementation contract for the PR B follow-on to PR
-#523. It is a non-authoritative execution artifact. Normative behavior remains
+This plan preserved the implementation contract for the PR B follow-on to PR
+#523. PR #528 merged the bundle synthesis worker and story-detail accepted
+synthesis path into `main`; this file is now a non-authoritative historical
+audit artifact. Normative behavior remains
 owned by `docs/specs/topic-synthesis-v2.md`,
 `docs/specs/spec-news-aggregator-v0.md`,
 `docs/specs/spec-topic-discovery-ranking-v0.md`, and the canonical docs listed
@@ -13,12 +15,36 @@ in `docs/CANON_MAP.md`.
 
 ## Branch Strategy
 
-- PR #523 (`coord/analysis-cache-hygiene`) lands standalone on `main` first.
-- PR B is cut fresh from `main` after PR #523 merges.
-- PR B depends on the PR #523 expansion of `isPlaceholderPerspectiveText` to
+- PR #523 (`coord/analysis-cache-hygiene`) landed standalone on `main` first.
+- PR B was cut fresh from `main` after PR #523 merged.
+- PR B depended on the PR #523 expansion of `isPlaceholderPerspectiveText` to
   include `Frame unavailable`, `Reframe unavailable`, and `Summary unavailable`.
-- Expected conflict surface is near zero: PR B adds bundle-synthesis spine code
-  and does not touch the PR #523 feed-analysis hygiene files.
+- The PR B work landed as PR #528, adding bundle-synthesis spine code and story
+  detail rendering from accepted `TopicSynthesisV2`.
+
+## Landed In PR #528
+
+- `services/news-aggregator/src/bundleSynthesisWorker.ts`
+- `services/news-aggregator/src/bundleSynthesisRelay.ts`
+- `services/news-aggregator/src/bundleSynthesisDaemonConfig.ts`
+- `services/news-aggregator/src/enrichmentQueue.ts`
+- `packages/ai-engine/src/bundlePrompts.ts`
+- `packages/gun-client/src/safeLatestSynthesisAdapters.ts`
+- story-detail rendering updates in `apps/web-pwa/src/components/feed/NewsCard.tsx`
+  and `apps/web-pwa/src/components/feed/NewsCardBack.tsx`
+
+Known follow-ons after PR #528:
+
+- ledger-driven `primary_sources` / `related_links` enrichment in the generic
+  bundle publication path;
+- correction/admin controls for suppressing or regenerating bad accepted
+  synthesis artifacts;
+- deterministic release smoke coverage for accepted synthesis availability in
+  launch snapshots.
+
+The remaining sections intentionally preserve the original imperative contract
+language for auditability. Do not read those sections as current "not built yet"
+backlog unless they are also listed as follow-ons above.
 
 ## Short Recommendation
 
@@ -517,4 +543,3 @@ Dashboard signals for canary:
 9. Summary, frame, and reframe strings are trimmed before storage.
 10. Relay timeouts and upstream failures surface as bundle-synth telemetry.
 11. Model source-count mismatch blocks all writes.
-

--- a/docs/plans/VENN_NEWS_MVP_ROADMAP_2026-04-20.md
+++ b/docs/plans/VENN_NEWS_MVP_ROADMAP_2026-04-20.md
@@ -311,7 +311,12 @@ type RelatedLink = {
 };
 ```
 
-The split exists in schema/service work but must be plumbed through bundle publication, feed store hydration, and `NewsCardBack` rendering with the discriminator preserved.
+The split exists in schema/service work, feed hydration, and `NewsCardBack`
+rendering. PR #528 preserves the analysis boundary for bundle synthesis by using
+`primary_sources` when present and excluding `related_links` from prompt input.
+The remaining source-split implementation gap is ledger-driven enrichment in
+the generic bundle publication path, so bundled stories reliably publish
+`primary_sources` and `related_links` with the discriminator preserved.
 
 ### Point stance intent
 

--- a/docs/plans/VENN_NEWS_MVP_ROADMAP_2026-04-20.md
+++ b/docs/plans/VENN_NEWS_MVP_ROADMAP_2026-04-20.md
@@ -2,8 +2,8 @@
 
 > Status: Draft v3 docs-aligned implementation tracker
 > Date: 2026-04-20
-> Last alignment audit: 2026-04-20 on `coord/point-id-contract` after PR #527 verification
-> Target: Four-week Web PWA MVP launch path after remaining Week 0 blockers are resolved
+> Last alignment audit: 2026-04-21 on `main` at `92186d6c` after PR #527 and PR #528 merged
+> Target: Four-week Web PWA MVP launch path after remaining Week 0 decisions and launch blockers are resolved
 > Scope: News feed, story analysis, frame/reframe stance, threaded discussion, and durable aggregate civic metadata
 
 ## Executive decision
@@ -30,14 +30,14 @@ This roadmap is grounded in the current codebase state rather than the desired a
 | Area | Current state | Roadmap consequence |
 | --- | --- | --- |
 | App shell | `/apps/` contains `web-pwa` only. No Capacitor, Expo, React Native, Xcode project, or iOS shell is present. | Web PWA is the selected four-week MVP target. TestFlight/App Store is a parallel follow-on, not a launch blocker. |
-| Frame point identity | PR #527 / `coord/point-id-contract` requires accepted `TopicSynthesisV2.frames[]` to carry `frame_point_id` and `reframe_point_id`; candidate frames may supply optional ids; the pipeline fills missing ids; web readers prefer persisted ids with legacy text-derived alias fallback. | W0.1 is implemented in PR #527 and must be in the implementation base before feed/detail stance UI work begins. Semantic id mapping across future regenerated syntheses remains a promotion-time responsibility. |
-| Sentiment key | Active sentiment docs, schemas, readers, writers, and aggregate paths now use `(topic_id, synthesis_id, epoch, point_id)`. Only archival sprint history still references older keys. | W0.2 is implemented in PR #527; new stance work should use the four-tuple only. |
+| Frame point identity | PR #527 is merged into `main`. Accepted `TopicSynthesisV2.frames[]` carry `frame_point_id` and `reframe_point_id`; candidate frames may supply optional ids; the pipeline fills missing ids; web readers prefer persisted ids with legacy text-derived alias fallback. | W0.1 is complete for the MVP base. Semantic id mapping across future regenerated syntheses remains a promotion-time responsibility. |
+| Sentiment key | PR #527 is merged into `main`. Active sentiment docs, schemas, readers, writers, and aggregate paths now use `(topic_id, synthesis_id, epoch, point_id)`. Only archival sprint history still references older keys. | W0.2 is complete for the MVP base; new stance work should use the four-tuple only. |
 | Topic preferences | Preference state exists in the discovery store, but ranking/filter composition does not consume it. | Preference tuning is net-new ranking work, not polish. |
 | Story-level engagement summary | `PointAggregateSnapshotV1` and `TopicEngagementAggregateV1` exist. A materialized `StoryEngagementSummary` rollup does not. | Story aggregate metadata is net-new compute/read model work; do not show story-level sentiment beyond per-point aggregates until this lands. |
-| Source split / related links | `StoryBundle.related_links`, item eligibility policy/ledger, and UI related-link rendering exist. Publish-time enrichment from the ledger and discriminator-preserving hydration are incomplete. | Related links may display below evidence, but only `analysis_eligible` sources may feed summaries/frame tables. W0.4 must carry the split through publication. |
-| Bundle synthesis worker | Bundle synthesis is specified in the PR B contract and prompt/helper work exists, but the news-aggregator worker is not landed. | Publish-time accepted synthesis, model/provenance metadata, and source split enrichment are the next hard dependency. |
-| Click-time analysis | `NewsCard` hydrates stored `TopicSynthesisV2` on expansion, but with `VITE_VH_ANALYSIS_PIPELINE=true` it can still call `useAnalysis(...)` and render provisional card analysis as a fallback. | W0.4 must remove hidden blocking card-open analysis as the normal path: accepted synthesis first; explicit pending/unavailable state on miss. |
-| Constituency proof | Stance paths currently rely on mocked/permissive constituency proof plumbing. | MVP can ship with beta-local identity semantics only if the product copy is honest; verified-human claims are out of scope until real proof is active. |
+| Source split / related links | `StoryBundle.related_links`, item eligibility policy/ledger, and UI related-link rendering exist. PR #528 ensures bundle synthesis excludes `related_links` when present and uses `primary_sources` as the analysis source set. The generic cluster publication path still does not derive `primary_sources` / `related_links` from the item-eligibility ledger by default. | Related links may display below evidence, but only analysis-eligible sources may feed summaries/frame tables. Ledger-driven source-split enrichment remains a follow-on. |
+| Bundle synthesis worker | PR #528 is merged into `main`. The news-aggregator now has `bundleSynthesisWorker`, `bundleSynthesisRelay`, queue wiring, guarded latest writes, model-sensitive idempotency, and story-detail UI provenance. | W0.4 is complete for publish-time accepted synthesis. Story detail can render accepted stored synthesis or explicit pending/unavailable state without hidden card-open analysis. |
+| Click-time analysis | `NewsCard` now hydrates stored `TopicSynthesisV2` on expansion and no longer calls `useAnalysis(...)` as the normal detail path. The legacy `useAnalysis` hook remains for non-card/runtime analysis paths and tests. | The headline-click contract is accepted synthesis first. Missing synthesis is surfaced as loading/pending/unavailable instead of silently generating card-open analysis. |
+| Constituency proof | Runtime proof acquisition derives an attestation-bound deterministic proof from the identity nullifier and configured district; mock proofs are rejected by voting paths. This is still not cryptographic residency proof or production Sybil resistance. | `identity-honesty-scope` remains the next Week 0 decision: MVP copy must say beta-local identity/proof semantics unless real cryptographic proof is explicitly pulled into scope. |
 | Release gates | Core repo gates exist. MVP feed/detail/stance/thread smokes and compliance checklist scripts do not. | Week 3 must build the release evidence harness; it cannot simply "run the gates." |
 
 ## Non-negotiable product contract
@@ -127,7 +127,7 @@ MVP implication:
 
 - no generic story like/dislike button as the primary sentiment mechanic;
 - no public per-user/nullifier stance payloads;
-- no claim that public beta stance equals verified one-human-one-vote while constituency proofs remain mocked;
+- no claim that public beta stance equals verified one-human-one-vote while proof semantics remain beta-local and non-cryptographic;
 - local/beta identity can enforce "one local final stance" but not full Sybil resistance.
 
 ### Source and analysis semantics
@@ -365,32 +365,32 @@ Week 0 should be executed as a short PR stack, not as an open-ended planning loo
 
 | Order | PR slice | Current status | Scope | Required output |
 | --- | --- | --- | --- | --- |
-| 1 | `point-id-contract` | Implemented in PR #527; dependent branches must base on it. | Persist stable `frame_point_id` and `reframe_point_id` on accepted `TopicSynthesisV2.frames[]`; keep text-derived ids as compatibility aliases. | Schema/tests/generator/readers agree on persisted point ids; alias behavior is documented. |
-| 2 | `sentiment-four-tuple-spec` | Paired into PR #527; dependent branches must base on it. | Patch sentiment docs/tests around `(topic_id, synthesis_id, epoch, point_id)`. | No active spec text describes final stance as keyed only by `(topic_id, epoch, point_id)`. |
+| 1 | `point-id-contract` | Complete; merged in PR #527. | Persist stable `frame_point_id` and `reframe_point_id` on accepted `TopicSynthesisV2.frames[]`; keep text-derived ids as compatibility aliases. | Schema/tests/generator/readers agree on persisted point ids; alias behavior is documented. |
+| 2 | `sentiment-four-tuple-spec` | Complete; merged in PR #527. | Patch sentiment docs/tests around `(topic_id, synthesis_id, epoch, point_id)`. | No active spec text describes final stance as keyed only by `(topic_id, epoch, point_id)`. |
 | 3 | `launch-surface-decision` | Resolved: Web PWA. | Remove native iOS/TestFlight from the four-week critical path. | Web PWA is recorded as the MVP launch target; native packaging is a parallel follow-on. |
-| 4 | `bundle-synthesis-dependency` | Next slice. | Resolve PR B / bundle synthesis dependency for accepted publish-time synthesis and source split enrichment. | Story detail can render accepted stored synthesis or an explicit pending/unavailable state without a hidden card-open analysis pass. |
-| 5 | `identity-honesty-scope` | Open. | Decide beta-local identity vs real constituency proof for MVP copy and stance guarantees. | Product copy, release notes, and stance path claims match the actual proof layer. |
+| 4 | `bundle-synthesis-dependency` | Complete; merged in PR #528. | Resolve PR B / bundle synthesis dependency for accepted publish-time synthesis and source split handling. | Story detail renders accepted stored synthesis or explicit pending/unavailable state without a hidden card-open analysis pass. |
+| 5 | `identity-honesty-scope` | Open; next right slice. | Decide beta-local identity vs real constituency proof for MVP copy and stance guarantees. | Product copy, release notes, and stance path claims match the actual proof layer. |
 | 6 | `mvp-release-gates` | Open. | Add or name deterministic feed/detail/stance/thread release gates. | Missing smoke/check scripts have owners, fixtures, pass/fail semantics, and report locations. |
 | 7 | `compliance-public-beta-minimums` | Open. | Privacy, terms, UGC/moderation, support, data deletion, telemetry consent, and content/copyright boundaries. | Public launch cannot proceed unless each compliance artifact has an owner and minimum accepted draft. |
 | 8 | `launch-ops-and-correction-path` | Open. | Curated fallback snapshot, bad-analysis suppression/regeneration, report queue, model/cost telemetry, and release artifact visibility. | Operators have minimum levers for stale feed data, bad summaries, abusive threads, and runaway model usage. |
 
 Recommended sequencing:
 
-- PR #527 should land before any feed/detail stance UI branch.
-- PR 4 is the next critical-path product slice because headline detail needs accepted publish-time synthesis.
-- PRs 5 through 8 can run in parallel once PR 4 is underway, but they should not block the bundle synthesis path.
+- PR #527 and PR #528 are now in `main`; feed/detail stance work can base on stable point ids and accepted publish-time synthesis.
+- PR 5 is now the next critical-path decision because stance UX depends on honest identity/proof claims.
+- PRs 6 through 8 can run in parallel once PR 5 is underway, but they should not block the feed-personalization and stance-detail implementation slices.
 - Week 1 starts only after every row in the go/no-go table has a `go` decision or an explicit accepted no-go consequence.
 
 ### Week 0 go/no-go table
 
 | Blocker | Current decision | Go condition | No-go consequence |
 | --- | --- | --- | --- |
-| Persisted frame/reframe point ids | Go when PR #527 is in the implementation base. | Accepted synthesis frames carry stable `frame_point_id` and `reframe_point_id`; legacy text-hash ids are compatibility only. | Do not start point-stance implementation. Building on text-hash ids knowingly ships vote orphaning on frame edits. |
-| Sentiment key | Go when PR #527 is in the implementation base. | Docs, schemas, readers, writers, and tests agree on `(topic_id, synthesis_id, epoch, point_id)`. | Do not split stance work across contributors; conflicting three-tuple/four-tuple implementations will corrupt compatibility assumptions. |
+| Persisted frame/reframe point ids | Go; PR #527 is merged into `main`. | Accepted synthesis frames carry stable `frame_point_id` and `reframe_point_id`; legacy text-hash ids are compatibility only. | Do not regress to text-hash ids. Building on text-hash ids knowingly ships vote orphaning on frame edits. |
+| Sentiment key | Go; PR #527 is merged into `main`. | Docs, schemas, readers, writers, and tests agree on `(topic_id, synthesis_id, epoch, point_id)`. | Do not split stance work across contributors; conflicting three-tuple/four-tuple implementations will corrupt compatibility assumptions. |
 | Launch surface | Go: Web PWA. | Web PWA remains the launch target; native shell work is outside the four-week critical path. | If native packaging becomes required again, restart scope and schedule around a real iOS build gate. |
-| Bundle synthesis path | No-go; next slice. | Accepted publish-time synthesis, source split, model id, generated time, warnings, and provenance are available to story detail, or pending/unavailable fallback is explicitly designed. | Story detail must not claim complete Venn analysis. It may ship with explicit pending/unavailable states, or Week 1 detail work waits. |
+| Bundle synthesis path | Go; PR #528 is merged into `main`. | Accepted publish-time synthesis, model id, generated time, warnings, and provenance are available to story detail; missing synthesis has explicit loading/pending/unavailable states. | Do not reintroduce hidden card-open analysis as the normal path. |
 | Topic preferences | No-go. | Ranking/filter semantics are defined and have at least one deterministic test proving preferences change feed output. | Do not market the feed as tunable. Keep preference UI hidden or label it as inactive. |
-| Identity/proof | Open. | Real constituency proof is active, or beta-local identity constraints and copy are approved. | No verified-human, one-human-one-vote, district-proof, or Sybil-resistant claims in product copy. |
+| Identity/proof | Open; next right slice. | Real cryptographic constituency proof is active, or beta-local identity constraints and copy are approved. | No verified-human, one-human-one-vote, district-proof, or Sybil-resistant claims in product copy. |
 | Story engagement rollup | No-go for visible story aggregate sentiment. | `StoryEngagementSummary` is either implemented as a derived read model or explicitly deferred from visible UI. | Do not show story-level aggregate sentiment beyond existing per-point aggregate data. |
 | Release gates | No-go. | Feed, story-detail, point-stance, and story-thread smokes have scripts or named owners/fixtures with pass/fail semantics. | No launch-readiness claim. The MVP can continue feature work, but cannot enter release freeze. |
 | Compliance | No-go for public beta. | Privacy, terms, UGC/moderation, support, data deletion, telemetry consent, and content/copyright minimums have accepted drafts. | No public beta or App Store/TestFlight submission. Internal-only testing can continue. |
@@ -402,7 +402,7 @@ Recommended sequencing:
 
 Decision: make persisted frame/reframe point ids the canonical path.
 
-Status: implemented in PR #527; dependent branches must base on it.
+Status: implemented in PR #527 and merged into `main`.
 
 Implemented:
 
@@ -426,7 +426,7 @@ Exit criteria:
 
 Decision: the canonical key is `(topic_id, synthesis_id, epoch, point_id)`.
 
-Status: implemented in PR #527; dependent branches must base on it.
+Status: implemented in PR #527 and merged into `main`.
 
 Implemented:
 
@@ -460,16 +460,26 @@ Exit criteria:
 
 Decision: launch detail should use accepted publish-time synthesis.
 
-Required:
+Status: implemented in PR #528 and merged into `main`.
 
-- merge or replace PR B / bundle synthesis worker;
-- ensure bundle publication carries accepted synthesis, source split, model id, generated time, warnings, and provenance;
-- define fallback when accepted synthesis is absent;
-- stop treating card-open runtime analysis as the normal detail path.
+Implemented:
+
+- news-aggregator bundle synthesis worker and relay;
+- model-sensitive idempotency and duplicate-candidate recovery;
+- guarded latest synthesis writes;
+- publish-time synthesis provenance surfaced in story detail;
+- explicit loading, pending, and unavailable states when accepted synthesis is absent;
+- card detail no longer treats runtime `useAnalysis(...)` as the normal path.
+
+Remaining follow-on:
+
+- ledger-driven `primary_sources` / `related_links` enrichment in the generic bundle publication path;
+- correction/admin controls for suppressing or regenerating bad accepted synthesis artifacts;
+- deterministic release smoke that proves current feed snapshots contain accepted synthesis coverage.
 
 Exit criteria:
 
-- headline click can render from stored bundle/detail data without an invisible blocking analysis pass.
+- headline click renders from stored bundle/detail data without an invisible blocking analysis pass.
 
 ### W0.5 Identity honesty
 
@@ -477,7 +487,7 @@ Decision: MVP ships with beta-local identity unless real constituency proof is p
 
 Required:
 
-- product copy must avoid verified-human or one-human-one-vote claims if proof remains mocked;
+- product copy must avoid verified-human or one-human-one-vote claims if proof remains beta-local and non-cryptographic;
 - stance path must still enforce local final stance and budgets;
 - release notes must distinguish beta-local identity from future LUMA proof.
 
@@ -758,6 +768,7 @@ The plan is ready to build when reviewers agree on:
 
 - Web PWA launch surface remains accepted;
 - PR #527 is in the implementation base for persisted point ids and the four-tuple sentiment contract;
+- PR #528 is in the implementation base for accepted publish-time bundle synthesis;
 - story-level sentiment as aggregate metadata only;
 - analyzed-source versus related-link evidence boundaries;
 - accepted publish-time synthesis as the headline-click data contract;

--- a/docs/specs/spec-identity-trust-constituency.md
+++ b/docs/specs/spec-identity-trust-constituency.md
@@ -80,7 +80,12 @@ attestation_input (VIO liveness / dev stub)
 
 ### 2.1.2 Session Expiry and Refresh
 
-**Current state (Season 0 transitional):** Sessions have no TTL - once created, they persist in local storage indefinitely until the user clears app data or re-attests. `useIdentity` has no expiry check.
+**Current state (Season 0 transitional):** Session lifecycle fields and helpers
+exist (`createdAt`, `expiresAt`, `DEFAULT_SESSION_TTL_MS`, near-expiry checks).
+`useIdentity` migrates legacy sessions and enforces expiry only when
+`VITE_SESSION_LIFECYCLE_ENABLED=true`. With the flag disabled, new and migrated
+sessions use `expiresAt = 0` and remain non-expiring until the user clears app
+data, revokes identity, or re-attests.
 
 **Target state (Season 0 v0.2):**
 - Sessions SHOULD carry an `expiresAt` timestamp (recommended: 7 days from creation for Silver assurance).
@@ -103,7 +108,9 @@ interface SessionResponse {
 
 ### 2.1.3 Session Revocation
 
-**Current state:** Session revocation is not implemented. There is no mechanism to invalidate a session.
+**Current state:** Local session revocation is implemented. `useIdentity.revokeSession()`
+clears identity state, published identity, sentiment signal state, and the local
+identity vault. Remote lost-device revocation remains deferred.
 
 **Target contract:**
 - A user MAY revoke their own session via an explicit "Sign Out" / "Clear Identity" action.
@@ -117,7 +124,9 @@ interface SessionResponse {
 
 ### 2.1.4 Timeout Semantics
 
-**Current state:** `useIdentity` has no TTL or timeout. Sessions are checked only at creation time.
+**Current state:** `useIdentity.checkSessionExpiry()` checks expiry at action
+boundaries when `VITE_SESSION_LIFECYCLE_ENABLED=true`; E2E and lifecycle-disabled
+profiles treat sessions as valid for transitional compatibility.
 
 **Target contract:**
 - Each trust-gated action SHOULD re-validate `expiresAt` before proceeding.
@@ -144,7 +153,7 @@ The following mock behaviors exist in the codebase and are documented here as **
 |------|-----------|-----------|--------|
 | E2E (`VITE_E2E_MODE=true`) | `1.0` | `mock-nullifier-<random>` | `useIdentity.ts:93` |
 | Dev fallback (attestation timeout) | `0.95` | real derivation | `useIdentity.ts:106` |
-| Stub constituency proof | N/A | `mock-nullifier` | `constituencyProof.ts:17` |
+| Stub constituency proof | N/A | `mock-nullifier` | `constituencyProof.ts:17`; test/dev helper only, voting paths reject mock proofs |
 
 **Invariants for mock sessions:**
 - Mock sessions MUST pass all trust gates (they use scores ≥ 0.95).
@@ -182,7 +191,11 @@ The following mock behaviors exist in the codebase and are documented here as **
 
 ### 4.1 Constituency Proof Interface (Canonical)
 
-The `ConstituencyProof` interface is the canonical shape for all constituency verification across the system. Current implementation in `getMockConstituencyProof()` (`apps/web-pwa/src/store/bridge/constituencyProof.ts`) returns this shape.
+The `ConstituencyProof` interface is the canonical shape for all constituency
+verification across the system. The active runtime proof acquisition path uses
+`getRealConstituencyProof()` (`apps/web-pwa/src/store/bridge/realConstituencyProof.ts`)
+through `useRegion()`. `getMockConstituencyProof()` remains a test/dev shape
+helper only and must not be the basis for production-like voting paths.
 
 ```ts
 interface ConstituencyProof {
@@ -219,12 +232,18 @@ interface ProofVerificationResult {
 
 ### 4.3 Proof Acquisition: Current Season 0 Runtime State
 
-**Season 0 reality (runtime):** Constituency proof acquisition uses an attestation-bound deterministic provider (`getRealConstituencyProof`) built from session nullifier + configured district.
+**Season 0 reality (runtime):** Constituency proof acquisition uses an
+attestation-bound deterministic provider (`getRealConstituencyProof`) built
+from session nullifier + configured district.
 
 Current runtime behavior:
 - `useRegion()` derives proof from identity session nullifier and configured district hash.
 - `useConstituencyProof()` hard-rejects mock proofs (`mock-*`) on voting paths.
 - Freshness remains non-cryptographic in Season 0 (non-empty root check).
+- This is beta-local proof semantics, not production Sybil resistance or
+  cryptographic residency proof. Product copy must not claim verified-human,
+  one-human-one-vote, district-proof, or Sybil-resistant guarantees until the
+  cryptographic acquisition and verification steps below are active.
 
 Transitional/test helpers:
 - `getMockConstituencyProof()` remains for tests/dev scaffolding only.
@@ -332,10 +351,11 @@ interface OnBehalfOfAssertion {
 
 | Component | Path | Status | Notes |
 |-----------|------|--------|-------|
-| `useIdentity` hook | `apps/web-pwa/src/hooks/useIdentity.ts` | Season 0 transitional | Session creation, trust check at 0.5, dev fallback at 0.95. No TTL/expiry yet. |
+| `useIdentity` hook | `apps/web-pwa/src/hooks/useIdentity.ts` | Season 0 transitional | Session creation, trust check at 0.5, dev fallback at 0.95, flag-gated lifecycle expiry, and local revocation. |
 | `useIdentity` tests | `apps/web-pwa/src/hooks/useIdentity.test.ts` | Season 0 transitional | Covers mock session paths. |
 | `TrustGate` component | `apps/web-pwa/src/components/hermes/forum/TrustGate.tsx` | Spec-aligned | Threshold-gated UI wrapper; checks `trustScore < 0.5`. |
-| `getMockConstituencyProof()` | `apps/web-pwa/src/store/bridge/constituencyProof.ts` | Season 0 transitional (STUB) | Returns mock proof shape. Will be replaced by real acquisition in Phase 4–5. |
+| `getRealConstituencyProof()` | `apps/web-pwa/src/store/bridge/realConstituencyProof.ts` | Season 0 beta-local | Deterministic proof shape derived from nullifier + configured district; not cryptographic residency proof. |
+| `getMockConstituencyProof()` | `apps/web-pwa/src/store/bridge/constituencyProof.ts` | Test/dev helper | Returns mock proof shape; voting paths reject mock proof values. |
 | `useGovernance` hook | `apps/web-pwa/src/hooks/useGovernance.ts` | Spec-aligned | `normalizeTrustScore()`, `MIN_TRUST_TO_VOTE = 0.7`. |
 | `ActionComposer` | `apps/web-pwa/src/components/bridge/ActionComposer.tsx` | Spec-aligned | Draft gate at 0.5, send gate at 0.7 (per CAK §7.1). |
 | `RepresentativeSelector` | `apps/web-pwa/src/components/bridge/RepresentativeSelector.tsx` | Spec-aligned | View gate at 0.5 with constituency proof requirement. |
@@ -358,7 +378,7 @@ This section explicitly defines the boundary between what Season 0 implements an
 | Off-chain session model | `SessionResponse` with `trustScore`, `nullifier`, `scaledTrustScore` | Phase 1 |
 | Trust-gated surfaces | All UI/action boundaries enforce `TRUST_THRESHOLDS` (§2) | Phase 1 |
 | Constituency proof interface | `ConstituencyProof { district_hash, nullifier, merkle_root }` shape is stable | Phase 1 |
-| Stub proof acquisition | `getMockConstituencyProof()` — satisfies interface, not cryptographically valid | Phase 1 (stub) |
+| Beta-local proof acquisition | `getRealConstituencyProof()` derives deterministic proof shape from nullifier + configured district; not cryptographic residency proof | Phase 1 beta-local |
 | On-chain scaled attestation | Attestor bridge writes `scaledTrustScore` and `bytes32Nullifier` to UBE/QF/Faucet | Phase 1 |
 | Daily participation budgets | Per-nullifier action caps (posts, comments, votes, analyses, shares, moderation, civic_actions) | Phase 1 |
 | Familiar delegation | Scoped, expiring, revocable grants; trust + budget inheritance; Tier 3 human approval | Phase 1 |
@@ -387,10 +407,10 @@ This section explicitly defines the boundary between what Season 0 implements an
 
 These items work in Season 0 but are explicitly marked as transitional and MUST be addressed before Season 1:
 
-1. **Hardcoded magic numbers:** Trust thresholds (0.5, 0.7) are inline across 10+ files. Target: single `TRUST_THRESHOLDS` constant (see §2 consolidation target).
-2. **No session expiry:** `useIdentity` has no TTL. Target: `expiresAt` field + lazy expiry check (see §2.1.2).
-3. **No session revocation UI:** No "Sign Out" or "Clear Identity" flow. Target: explicit revocation path (see §2.1.3).
-4. **Mock constituency proofs:** `getMockConstituencyProof()` is a stub. Target: real acquisition flow (see §4.4).
+1. **Threshold consolidation still incomplete on older surfaces:** Shared trust constants exist, but some older docs/surfaces still reference raw `0.5` and `0.7` boundaries. Target: active code paths should import canonical constants where practical.
+2. **Session expiry is flag-gated:** lifecycle fields and lazy expiry checks exist, but lifecycle enforcement depends on `VITE_SESSION_LIFECYCLE_ENABLED=true`; lifecycle-disabled sessions remain transitional non-expiring sessions.
+3. **No session revocation UI:** `useIdentity.revokeSession()` exists, but a user-facing "Sign Out" or "Clear Identity" flow still needs product wiring.
+4. **Beta-local constituency proof:** voting paths reject mock proof values and use deterministic proof derivation, but cryptographic residency proof acquisition is still deferred (see §4.4).
 5. **Device-bound nullifier:** Nullifier is per-device, not per-human. Target: multi-device linking with higher assurance (see §5).
 6. **Dev fallback trust score:** `0.95` fallback on attestation timeout is convenient but masks real verifier issues. Target: remove or gate behind explicit dev flag.
 

--- a/docs/specs/spec-topic-discovery-ranking-v0.md
+++ b/docs/specs/spec-topic-discovery-ranking-v0.md
@@ -141,7 +141,21 @@ hotness =
 All coefficients and decay parameters must be config-driven and versioned.
 Top-window diversification parameters and future personalization weights are also config-driven; consumers must not hard-code storyline caps, entity-overlap penalties, or category preference defaults in card components.
 
-Season 0 personalization scaffold:
+Season 0 active implementation:
+
+The active `FeedPersonalizationConfig` schema currently persists only
+`preferredCategories`. The discovery store carries this value through state,
+but `composeFeed(...)` and feed pagination do not yet consume it, so the feed
+must not be marketed as tunable until the ranking slice lands with deterministic
+tests proving changed ordering or filtering.
+
+```ts
+interface FeedPersonalizationConfig {
+  preferredCategories: string[];
+}
+```
+
+Target personalization scaffold:
 
 ```ts
 interface FeedPersonalizationConfig {


### PR DESCRIPTION
## Summary
- mark PR #527/#528 dependencies as merged and update the MVP roadmap go/no-go table
- convert the PR B bundle synthesis contract into a historical audit artifact with explicit post-#528 follow-ons
- align identity/proof and personalization docs with the current runtime state

## Verification
- git diff --check
- pnpm deps:check
- pnpm --filter @vh/web-pwa typecheck
- pnpm --filter @vh/news-aggregator typecheck

## Next slice verified
- identity-honesty-scope remains the next right slice before stance/detail polish, because runtime proof is beta-local/deterministic while some UI copy still says verified proof.
