### PR TITLE
Align stance proof claims with beta-local identity

### DIFF
--- a/apps/web-pwa/src/components/AnalysisView.test.tsx
+++ b/apps/web-pwa/src/components/AnalysisView.test.tsx
@@ -88,6 +88,10 @@ function seedDefaults(): void {
       merkle_root: 'root-1',
     },
     error: null,
+    assurance: 'beta_local',
+    canClaimVerifiedHuman: false,
+    canClaimDistrictProof: false,
+    canClaimSybilResistance: false,
   });
 
   useSynthesisPointIdsMock.mockReturnValue({
@@ -140,7 +144,7 @@ describe('AnalysisView', () => {
     cleanup();
   });
 
-  it('submits votes with validated constituency proof from useConstituencyProof', () => {
+  it('submits votes with beta-local proof from useConstituencyProof', () => {
     const setAgreementSpy = vi.spyOn(useSentimentState.getState(), 'setAgreement');
 
     render(<AnalysisView item={sample} />);
@@ -163,7 +167,7 @@ describe('AnalysisView', () => {
       }),
     );
 
-    expect(screen.queryByText('Create an account to cast votes')).not.toBeInTheDocument();
+    expect(screen.queryByText('Create or sign in to save stance')).not.toBeInTheDocument();
   });
 
   it('submits reframe votes using synthesis reframe point IDs', () => {
@@ -288,7 +292,11 @@ describe('AnalysisView', () => {
     useIdentityMock.mockReturnValue({ identity: null, status: 'ready' });
     useConstituencyProofMock.mockReturnValue({
       proof: null,
-      error: 'Identity nullifier unavailable; create/sign in before voting',
+      error: 'Identity unavailable; create or sign in to save your stance',
+      assurance: 'none',
+      canClaimVerifiedHuman: false,
+      canClaimDistrictProof: false,
+      canClaimSybilResistance: false,
     });
 
     render(<AnalysisView item={sample} />);
@@ -297,7 +305,7 @@ describe('AnalysisView', () => {
     fireEvent.click(screen.getByLabelText('Disagree reframe'));
 
     expect(setAgreementSpy).not.toHaveBeenCalled();
-    expect(screen.getByText('Create an account to cast votes')).toBeInTheDocument();
+    expect(screen.getByText('Create or sign in to save stance')).toBeInTheDocument();
   });
 
   it('clears prior warning timer on repeated blocked vote attempts', () => {
@@ -305,7 +313,11 @@ describe('AnalysisView', () => {
     useIdentityMock.mockReturnValue({ identity: null, status: 'ready' });
     useConstituencyProofMock.mockReturnValue({
       proof: null,
-      error: 'Identity nullifier unavailable; create/sign in before voting',
+      error: 'Identity unavailable; create or sign in to save your stance',
+      assurance: 'none',
+      canClaimVerifiedHuman: false,
+      canClaimDistrictProof: false,
+      canClaimSybilResistance: false,
     });
 
     try {
@@ -314,7 +326,7 @@ describe('AnalysisView', () => {
       fireEvent.click(screen.getByLabelText('Agree reframe'));
       fireEvent.click(screen.getByLabelText('Agree reframe'));
 
-      expect(screen.getByText('Create an account to cast votes')).toBeInTheDocument();
+      expect(screen.getByText('Create or sign in to save stance')).toBeInTheDocument();
       expect(clearTimeoutSpy).toHaveBeenCalled();
     } finally {
       clearTimeoutSpy.mockRestore();
@@ -325,43 +337,54 @@ describe('AnalysisView', () => {
     useIdentityMock.mockReturnValue({ identity: null, status: 'ready' });
     useConstituencyProofMock.mockReturnValue({
       proof: null,
-      error: 'Identity nullifier unavailable; create/sign in before voting',
+      error: 'Identity unavailable; create or sign in to save your stance',
+      assurance: 'none',
+      canClaimVerifiedHuman: false,
+      canClaimDistrictProof: false,
+      canClaimSybilResistance: false,
     });
 
     render(<AnalysisView item={sample} />);
 
     fireEvent.click(screen.getByLabelText('Agree frame'));
 
-    expect(screen.getByText('Create an account to cast votes')).toBeInTheDocument();
+    expect(screen.getByText('Create or sign in to save stance')).toBeInTheDocument();
   });
 
   it('shows proof-specific vote block message when proof validation fails', () => {
     useConstituencyProofMock.mockReturnValue({
       proof: null,
-      error: 'Mock constituency proof detected; voting requires a verified proof source',
+      error: 'Mock proof detected; beta-local identity required to save stance',
+      assurance: 'none',
+      canClaimVerifiedHuman: false,
+      canClaimDistrictProof: false,
+      canClaimSybilResistance: false,
     });
 
     render(<AnalysisView item={sample} />);
 
     fireEvent.click(screen.getByLabelText('Agree frame'));
 
-    expect(screen.getByText('Proof verification required to cast votes')).toBeInTheDocument();
+    expect(screen.getByText('Beta-local identity proof required to save stance')).toBeInTheDocument();
   });
 
-  it('forwards undefined proof payload when hook returns undefined proof', () => {
+  it('blocks stance writes when the proof payload is undefined', () => {
     const setAgreementSpy = vi.spyOn(useSentimentState.getState(), 'setAgreement');
-    useConstituencyProofMock.mockReturnValue({ proof: undefined, error: null });
+    useConstituencyProofMock.mockReturnValue({
+      proof: undefined,
+      error: null,
+      assurance: 'none',
+      canClaimVerifiedHuman: false,
+      canClaimDistrictProof: false,
+      canClaimSybilResistance: false,
+    });
 
     render(<AnalysisView item={sample} />);
 
     fireEvent.click(screen.getByLabelText('Agree frame'));
 
-    expect(setAgreementSpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        pointId: 'pa:frame',
-        constituency_proof: undefined,
-      }),
-    );
+    expect(setAgreementSpy).not.toHaveBeenCalled();
+    expect(screen.getByText('Beta-local identity proof required to save stance')).toBeInTheDocument();
   });
 
   it('renders zero aggregate fallback when mesh aggregates are unavailable', () => {

--- a/apps/web-pwa/src/components/AnalysisView.tsx
+++ b/apps/web-pwa/src/components/AnalysisView.tsx
@@ -86,7 +86,7 @@ function PerspectiveRow({
       epoch: 0,
       analysisId: itemId,
       desired,
-      constituency_proof: proof ?? undefined,
+      constituency_proof: proof!,
     });
   };
 

--- a/apps/web-pwa/src/components/AnalysisView.tsx
+++ b/apps/web-pwa/src/components/AnalysisView.tsx
@@ -55,9 +55,9 @@ function PerspectiveRow({
   const setAgreement = useSentimentState((s) => s.setAgreement);
   const { proof, error: proofError } = useConstituencyProof();
   const { identity } = useIdentity();
-  const canVote = Boolean(identity) && proof !== null;
+  const canVote = Boolean(identity) && proof != null;
   const blockedReason: 'identity' | 'proof' =
-    !identity || proofError?.includes('Identity nullifier unavailable')
+    !identity || proofError?.includes('Identity unavailable')
       ? 'identity'
       : 'proof';
   const { aggregate: frameAggregate } = usePointAggregate({
@@ -263,8 +263,8 @@ export const AnalysisView: React.FC<AnalysisViewProps> = ({ item }) => {
           {warn && (
             <span className="inline-flex items-center rounded-full bg-amber-100 px-3 py-1 text-[11px] font-semibold text-amber-800 shadow-sm animate-pulse">
               {warnReason === 'proof'
-                ? 'Proof verification required to cast votes'
-                : 'Create an account to cast votes'}
+                ? 'Beta-local identity proof required to save stance'
+                : 'Create or sign in to save stance'}
             </span>
           )}
         </div>

--- a/apps/web-pwa/src/components/feed/CellVoteControls.test.tsx
+++ b/apps/web-pwa/src/components/feed/CellVoteControls.test.tsx
@@ -2,6 +2,7 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { VoteAdmissionReceipt } from '@vh/data-model';
 import { CellVoteControls } from './CellVoteControls';
 import { useSentimentState } from '../../hooks/useSentimentState';
 
@@ -24,6 +25,19 @@ const BASE_PROPS = {
   analysisId: 'story-1:prov-1',
 };
 
+function deniedReceipt(reason?: string): VoteAdmissionReceipt {
+  const receipt: VoteAdmissionReceipt = {
+    receipt_id: 'test-denial',
+    accepted: false,
+    topic_id: BASE_PROPS.topicId,
+    synthesis_id: BASE_PROPS.synthesisId,
+    epoch: BASE_PROPS.epoch,
+    point_id: BASE_PROPS.pointId,
+    admitted_at: 0,
+  };
+  return reason ? { ...receipt, reason } : receipt;
+}
+
 function seedValidProof(): void {
   useConstituencyProofMock.mockReturnValue({
     proof: {
@@ -32,6 +46,10 @@ function seedValidProof(): void {
       merkle_root: 'root-1',
     },
     error: null,
+    assurance: 'beta_local',
+    canClaimVerifiedHuman: false,
+    canClaimDistrictProof: false,
+    canClaimSybilResistance: false,
   });
 }
 
@@ -41,7 +59,7 @@ function invokeReactClick(element: HTMLElement): void {
     throw new Error('React props key not found on rendered button');
   }
   const reactProps = (element as unknown as Record<string, { onClick?: () => void }>)[reactPropsKey];
-  reactProps.onClick?.();
+  reactProps?.onClick?.();
 }
 
 describe('CellVoteControls', () => {
@@ -75,6 +93,15 @@ describe('CellVoteControls', () => {
     render(<CellVoteControls {...BASE_PROPS} />);
     expect(screen.getByTestId('cell-vote-agree-point-abc')).toBeInTheDocument();
     expect(screen.getByTestId('cell-vote-disagree-point-abc')).toBeInTheDocument();
+  });
+
+  it('labels accepted deterministic proof as beta-local stance assurance', () => {
+    render(<CellVoteControls {...BASE_PROPS} />);
+
+    expect(screen.getByTestId('cell-vote-assurance-point-abc')).toHaveTextContent(
+      'Beta-local stance',
+    );
+    expect(screen.queryByText(/verified proof/i)).not.toBeInTheDocument();
   });
 
   it('click agree calls setAgreement with synthesis_id + epoch context', () => {
@@ -126,10 +153,9 @@ describe('CellVoteControls', () => {
   });
 
   it('budget exceeded shows "Daily vote limit reached"', () => {
-    vi.spyOn(useSentimentState.getState(), 'setAgreement').mockReturnValue({
-      denied: true,
-      reason: 'Daily limit reached for sentiment_votes/day',
-    });
+    vi.spyOn(useSentimentState.getState(), 'setAgreement').mockReturnValue(
+      deniedReceipt('Daily limit reached for sentiment_votes/day'),
+    );
 
     render(<CellVoteControls {...BASE_PROPS} />);
     fireEvent.click(screen.getByTestId('cell-vote-agree-point-abc'));
@@ -142,22 +168,25 @@ describe('CellVoteControls', () => {
   it('missing proof shows proof warning and sign-in denial text on vote', () => {
     useConstituencyProofMock.mockReturnValue({
       proof: null,
-      error: 'Mock constituency proof detected; voting requires a verified proof source',
+      error: 'Mock proof detected; beta-local identity required to save stance',
+      assurance: 'none',
+      canClaimVerifiedHuman: false,
+      canClaimDistrictProof: false,
+      canClaimSybilResistance: false,
     });
-    vi.spyOn(useSentimentState.getState(), 'setAgreement').mockReturnValue({
-      denied: true,
-      reason: 'Missing constituency proof',
-    });
+    vi.spyOn(useSentimentState.getState(), 'setAgreement').mockReturnValue(
+      deniedReceipt('Missing constituency proof'),
+    );
 
     render(<CellVoteControls {...BASE_PROPS} />);
 
     expect(screen.getByTestId('cell-vote-unweighted-point-abc')).toHaveTextContent(
-      'Mock constituency proof detected; voting requires a verified proof source',
+      'Mock proof detected; beta-local identity required to save stance',
     );
 
     fireEvent.click(screen.getByTestId('cell-vote-agree-point-abc'));
     expect(screen.getByTestId('cell-vote-denial-point-abc')).toHaveTextContent(
-      'Sign in to make your vote count',
+      'Create or sign in to save your stance',
     );
   });
 
@@ -165,24 +194,41 @@ describe('CellVoteControls', () => {
     useConstituencyProofMock.mockReturnValue({
       proof: null,
       error: null,
+      assurance: 'none',
+      canClaimVerifiedHuman: false,
+      canClaimDistrictProof: false,
+      canClaimSybilResistance: false,
     });
 
     render(<CellVoteControls {...BASE_PROPS} />);
 
     expect(screen.getByTestId('cell-vote-unweighted-point-abc')).toHaveTextContent(
-      'Voting requires verified proof',
+      'Create or sign in to save your stance',
+    );
+  });
+
+  it('treats undefined proof as unavailable proof for display safety', () => {
+    useConstituencyProofMock.mockReturnValue({
+      proof: undefined,
+      error: null,
+      assurance: 'none',
+      canClaimVerifiedHuman: false,
+      canClaimDistrictProof: false,
+      canClaimSybilResistance: false,
+    });
+
+    render(<CellVoteControls {...BASE_PROPS} />);
+
+    expect(screen.queryByTestId('cell-vote-assurance-point-abc')).not.toBeInTheDocument();
+    expect(screen.getByTestId('cell-vote-unweighted-point-abc')).toHaveTextContent(
+      'Create or sign in to save your stance',
     );
   });
 
   it('denial with no reason clears visible denial message', () => {
     vi.spyOn(useSentimentState.getState(), 'setAgreement')
-      .mockReturnValueOnce({
-        denied: true,
-        reason: 'Daily limit reached for sentiment_votes/day',
-      })
-      .mockReturnValueOnce({
-        denied: true,
-      } as never);
+      .mockReturnValueOnce(deniedReceipt('Daily limit reached for sentiment_votes/day'))
+      .mockReturnValueOnce(deniedReceipt());
 
     render(<CellVoteControls {...BASE_PROPS} />);
 
@@ -194,10 +240,9 @@ describe('CellVoteControls', () => {
   });
 
   it('synthesis-context denial shows waiting message', () => {
-    vi.spyOn(useSentimentState.getState(), 'setAgreement').mockReturnValue({
-      denied: true,
-      reason: 'Missing synthesis context',
-    });
+    vi.spyOn(useSentimentState.getState(), 'setAgreement').mockReturnValue(
+      deniedReceipt('Missing synthesis context'),
+    );
 
     render(<CellVoteControls {...BASE_PROPS} />);
     fireEvent.click(screen.getByTestId('cell-vote-agree-point-abc'));
@@ -326,6 +371,7 @@ describe('CellVoteControls', () => {
           synthesis_id: 'synth-1',
           display_point_id: 'point-abc',
           canonical_point_id: 'synth-point-xyz',
+          proof_assurance: 'beta_local',
           id_partition: true,
         }),
       );

--- a/apps/web-pwa/src/components/feed/CellVoteControls.tsx
+++ b/apps/web-pwa/src/components/feed/CellVoteControls.tsx
@@ -47,9 +47,10 @@ export const CellVoteControls: React.FC<CellVoteControlsProps> = ({
   );
   const setAgreement = useSentimentState((s) => s.setAgreement);
   const [denial, setDenial] = useState<string | null>(null);
-  const { proof, error: proofError } = useConstituencyProof();
+  const { proof, error: proofError, assurance } = useConstituencyProof();
 
-  const hasProof = proof !== null;
+  const hasProof = proof != null;
+  const isBetaLocalProof = hasProof && assurance === 'beta_local';
   const optimisticAgrees = currentVote === 1 ? 1 : 0;
   const optimisticDisagrees = currentVote === -1 ? 1 : 0;
   const { aggregate, status: aggregateStatus } = usePointAggregate({
@@ -125,6 +126,7 @@ export const CellVoteControls: React.FC<CellVoteControlsProps> = ({
       canonical_point_id: canonicalPointId,
       synthesis_point_id: synthesisPointId ?? null,
       has_proof: hasProof,
+      proof_assurance: assurance,
       aggregate_status: aggregateStatus,
       id_partition: hasIdPartition,
     };
@@ -135,6 +137,7 @@ export const CellVoteControls: React.FC<CellVoteControlsProps> = ({
   }, [
     aggregate,
     aggregateStatus,
+    assurance,
     canonicalPointId,
     epoch,
     hasIdPartition,
@@ -195,7 +198,7 @@ export const CellVoteControls: React.FC<CellVoteControlsProps> = ({
     ? denial.includes('synthesis context')
       ? 'Waiting for synthesis context'
       : denial.includes('constituency') || denial.includes('proof')
-        ? 'Sign in to make your vote count'
+        ? 'Create or sign in to save your stance'
         : 'Daily vote limit reached'
     : null;
 
@@ -245,12 +248,20 @@ export const CellVoteControls: React.FC<CellVoteControlsProps> = ({
           - {displayDisagrees}
         </button>
       </div>
+      {isBetaLocalProof && (
+        <span
+          className="text-[10px] text-slate-500"
+          data-testid={`cell-vote-assurance-${pointId}`}
+        >
+          Beta-local stance
+        </span>
+      )}
       {!hasProof && (
         <span
           className="text-[10px] text-amber-600"
           data-testid={`cell-vote-unweighted-${pointId}`}
         >
-          {proofError ?? 'Voting requires verified proof'}
+          {proofError ?? 'Create or sign in to save your stance'}
         </span>
       )}
       {denialText && (

--- a/apps/web-pwa/src/hooks/useConstituencyProof.test.ts
+++ b/apps/web-pwa/src/hooks/useConstituencyProof.test.ts
@@ -45,7 +45,11 @@ describe('useConstituencyProof', () => {
     const { result } = renderHook(() => useConstituencyProof());
 
     expect(result.current.proof).toBeNull();
-    expect(result.current.error).toMatch(/nullifier unavailable/i);
+    expect(result.current.error).toMatch(/create or sign in to save your stance/i);
+    expect(result.current.assurance).toBe('none');
+    expect(result.current.canClaimVerifiedHuman).toBe(false);
+    expect(result.current.canClaimDistrictProof).toBe(false);
+    expect(result.current.canClaimSybilResistance).toBe(false);
   });
 
   it('returns explicit error when region proof is missing', () => {
@@ -57,7 +61,8 @@ describe('useConstituencyProof', () => {
     const { result } = renderHook(() => useConstituencyProof());
 
     expect(result.current.proof).toBeNull();
-    expect(result.current.error).toMatch(/proof unavailable/i);
+    expect(result.current.error).toMatch(/beta-local identity proof unavailable/i);
+    expect(result.current.assurance).toBe('none');
   });
 
   it('returns explicit error when proof nullifier mismatches identity', () => {
@@ -75,7 +80,8 @@ describe('useConstituencyProof', () => {
     const { result } = renderHook(() => useConstituencyProof());
 
     expect(result.current.proof).toBeNull();
-    expect(result.current.error).toMatch(/nullifier_mismatch/i);
+    expect(result.current.error).toMatch(/invalid beta-local proof: nullifier_mismatch/i);
+    expect(result.current.assurance).toBe('none');
   });
 
   it('returns explicit error when proof is stale', () => {
@@ -93,7 +99,8 @@ describe('useConstituencyProof', () => {
     const { result } = renderHook(() => useConstituencyProof());
 
     expect(result.current.proof).toBeNull();
-    expect(result.current.error).toMatch(/stale_proof/i);
+    expect(result.current.error).toMatch(/invalid beta-local proof: stale_proof/i);
+    expect(result.current.assurance).toBe('none');
   });
 
   it('hard-stops when proof source is mock-backed', () => {
@@ -111,7 +118,8 @@ describe('useConstituencyProof', () => {
     const { result } = renderHook(() => useConstituencyProof());
 
     expect(result.current.proof).toBeNull();
-    expect(result.current.error).toMatch(/mock constituency proof/i);
+    expect(result.current.error).toMatch(/mock proof detected/i);
+    expect(result.current.assurance).toBe('none');
   });
 
   it('rejects transitional proof when real mode is enabled', () => {
@@ -131,6 +139,7 @@ describe('useConstituencyProof', () => {
 
     expect(result.current.proof).toBeNull();
     expect(result.current.error).toMatch(/transitional proof rejected/i);
+    expect(result.current.assurance).toBe('none');
   });
 
   it('validates real mode against configured district (not proof district self-reference)', () => {
@@ -150,10 +159,11 @@ describe('useConstituencyProof', () => {
     const { result } = renderHook(() => useConstituencyProof());
 
     expect(result.current.proof).toBeNull();
-    expect(result.current.error).toMatch(/district_mismatch/i);
+    expect(result.current.error).toMatch(/invalid beta-local proof: district_mismatch/i);
+    expect(result.current.assurance).toBe('none');
   });
 
-  it('accepts real proof when real mode is enabled and configured district matches', () => {
+  it('accepts strict-mode proof as beta-local when configured district matches', () => {
     const proof: ConstituencyProof = {
       district_hash: 'district-expected',
       nullifier: 'null-1',
@@ -171,9 +181,13 @@ describe('useConstituencyProof', () => {
 
     expect(result.current.error).toBeNull();
     expect(result.current.proof).toEqual(proof);
+    expect(result.current.assurance).toBe('beta_local');
+    expect(result.current.canClaimVerifiedHuman).toBe(false);
+    expect(result.current.canClaimDistrictProof).toBe(false);
+    expect(result.current.canClaimSybilResistance).toBe(false);
   });
 
-  it('accepts transitional proof when real mode is disabled', () => {
+  it('accepts transitional proof as beta-local when strict mode is disabled', () => {
     const proof: ConstituencyProof = {
       district_hash: 't9n-district-1',
       nullifier: 'null-1',
@@ -190,9 +204,11 @@ describe('useConstituencyProof', () => {
 
     expect(result.current.error).toBeNull();
     expect(result.current.proof).toEqual(proof);
+    expect(result.current.assurance).toBe('beta_local');
+    expect(result.current.canClaimVerifiedHuman).toBe(false);
   });
 
-  it('returns verified proof when identity and region proof align', () => {
+  it('returns beta-local proof when identity and region proof align', () => {
     const proof: ConstituencyProof = {
       district_hash: 'district-1',
       nullifier: 'null-1',
@@ -208,5 +224,7 @@ describe('useConstituencyProof', () => {
 
     expect(result.current.error).toBeNull();
     expect(result.current.proof).toEqual(proof);
+    expect(result.current.assurance).toBe('beta_local');
+    expect(result.current.canClaimVerifiedHuman).toBe(false);
   });
 });

--- a/apps/web-pwa/src/hooks/useConstituencyProof.ts
+++ b/apps/web-pwa/src/hooks/useConstituencyProof.ts
@@ -6,9 +6,39 @@ import { useRegion } from './useRegion';
 import { isProofVerificationEnabled } from '../store/bridge/constituencyProof';
 import { getConfiguredDistrict } from '../store/bridge/districtConfig';
 
+export type ConstituencyProofAssurance = 'none' | 'beta_local';
+
 export interface ConstituencyProofState {
   readonly proof: ConstituencyProof | null;
   readonly error: string | null;
+  readonly assurance: ConstituencyProofAssurance;
+  readonly canClaimVerifiedHuman: false;
+  readonly canClaimDistrictProof: false;
+  readonly canClaimSybilResistance: false;
+}
+
+const NO_PRODUCTION_PROOF_CLAIMS = {
+  canClaimVerifiedHuman: false,
+  canClaimDistrictProof: false,
+  canClaimSybilResistance: false,
+} as const;
+
+function blockedProof(error: string): ConstituencyProofState {
+  return {
+    proof: null,
+    error,
+    assurance: 'none',
+    ...NO_PRODUCTION_PROOF_CLAIMS,
+  };
+}
+
+function acceptedBetaLocalProof(proof: ConstituencyProof): ConstituencyProofState {
+  return {
+    proof,
+    error: null,
+    assurance: 'beta_local',
+    ...NO_PRODUCTION_PROOF_CLAIMS,
+  };
 }
 
 function isMockProof(proof: ConstituencyProof): boolean {
@@ -20,8 +50,12 @@ function isTransitionalProof(proof: ConstituencyProof): boolean {
 }
 
 /**
- * L1 guardrail: ensure feed voting has a valid constituency proof derived from identity.
+ * L1 guardrail: ensure feed voting has a valid beta-local proof derived from identity.
  * If identity/proof is missing or malformed, callers get a clear error and can hard-stop writes.
+ *
+ * Current Season 0 runtime intentionally does not expose production proof claims:
+ * the deterministic `s0-root-*` provider can support MVP stance persistence, but
+ * not verified-human, district-proof, or Sybil-resistant product language.
  */
 export function useConstituencyProof(): ConstituencyProofState {
   const { identity } = useIdentity();
@@ -31,42 +65,29 @@ export function useConstituencyProof(): ConstituencyProofState {
   return useMemo(() => {
     const nullifier = identity?.session?.nullifier;
     if (!nullifier) {
-      return {
-        proof: null,
-        error: 'Identity nullifier unavailable; create/sign in before voting',
-      };
+      return blockedProof('Identity unavailable; create or sign in to save your stance');
     }
 
     if (!proof) {
-      return {
-        proof: null,
-        error: 'Constituency proof unavailable for current identity',
-      };
+      return blockedProof('Beta-local identity proof unavailable for current identity');
     }
 
     if (isMockProof(proof)) {
-      return {
-        proof: null,
-        error: 'Mock constituency proof detected; voting requires a verified proof source',
-      };
+      return blockedProof('Mock proof detected; beta-local identity required to save stance');
     }
 
     if (realMode && isTransitionalProof(proof)) {
-      return {
-        proof: null,
-        error: 'Transitional proof rejected in production mode; real proof provider required',
-      };
+      return blockedProof('Transitional proof rejected in strict mode; production proof provider required');
     }
 
     const expectedDistrict = realMode ? getConfiguredDistrict() : proof.district_hash;
     const verification = verifyConstituencyProof(proof, nullifier, expectedDistrict);
     if (!verification.valid) {
-      return {
-        proof: null,
-        error: `Invalid constituency proof: ${verification.error}`,
-      };
+      return blockedProof(`Invalid beta-local proof: ${verification.error}`);
     }
 
-    return { proof, error: null };
+    // Today every accepted runtime proof is beta-local. Do not infer stronger
+    // assurance from the canonical shape until a cryptographic provider lands.
+    return acceptedBetaLocalProof(proof);
   }, [identity?.session?.nullifier, proof, realMode]);
 }

--- a/apps/web-pwa/src/store/bridge/__tests__/realConstituencyProof.test.ts
+++ b/apps/web-pwa/src/store/bridge/__tests__/realConstituencyProof.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import { verifyConstituencyProof } from '@vh/types';
 import { ConstituencyProofSchema } from '@vh/data-model';
-import { getRealConstituencyProof } from '../realConstituencyProof';
+import {
+  BETA_LOCAL_MERKLE_ROOT_PREFIX,
+  getRealConstituencyProof,
+  isBetaLocalConstituencyProof,
+} from '../realConstituencyProof';
 
 function isMockProof(proof: { district_hash: string; merkle_root: string }): boolean {
   return proof.district_hash === 'mock-district-hash' || proof.merkle_root === 'mock-root';
@@ -22,6 +26,15 @@ describe('getRealConstituencyProof', () => {
     expect(proof.district_hash).toBe(district);
     expect(proof.nullifier).toBe(nullifier);
     expect(proof.merkle_root).toBeTruthy();
+    expect(proof.merkle_root).toMatch(
+      new RegExp(`^${BETA_LOCAL_MERKLE_ROOT_PREFIX}`),
+    );
+  });
+
+  it('labels generated proof material as beta-local, not cryptographic residency proof', () => {
+    const proof = getRealConstituencyProof(nullifier, district);
+
+    expect(isBetaLocalConstituencyProof(proof)).toBe(true);
   });
 
   it('is not mock', () => {

--- a/apps/web-pwa/src/store/bridge/realConstituencyProof.ts
+++ b/apps/web-pwa/src/store/bridge/realConstituencyProof.ts
@@ -1,10 +1,15 @@
 /**
  * Season 0 attestation-bound constituency proof provider.
  * Non-mock, non-transitional. District from external config, root session-bound.
+ *
+ * This is beta-local proof material. It preserves the canonical proof shape for
+ * the MVP stance path, but it is not cryptographic residency proof.
  * Spec: spec-identity-trust-constituency.md v0.2 §4.1, §4.3
  */
 
 import type { ConstituencyProof } from '@vh/types';
+
+export const BETA_LOCAL_MERKLE_ROOT_PREFIX = 's0-root-';
 
 function hashFragment(input: string): string {
   let hash = 0x811c9dc5;
@@ -19,7 +24,14 @@ function deriveRoot(nullifier: string, districtHash: string): string {
   const basis = `s0:${nullifier}:${districtHash}`;
   const first = hashFragment(basis);
   const second = hashFragment(`${basis}:${first}`);
-  return `s0-root-${first}${second}`;
+  return `${BETA_LOCAL_MERKLE_ROOT_PREFIX}${first}${second}`;
+}
+
+export function isBetaLocalConstituencyProof(
+  proof: Pick<ConstituencyProof, 'merkle_root'> | null | undefined,
+): boolean {
+  return typeof proof?.merkle_root === 'string'
+    && proof.merkle_root.startsWith(BETA_LOCAL_MERKLE_ROOT_PREFIX);
 }
 
 export function getRealConstituencyProof(

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -20,6 +20,9 @@ This document defines compile-time flags used by the web PWA for FPD rollout.
   - **MVP beta note:** A Web PWA beta may run with `false` only if product copy
     explicitly uses beta-local identity/proof language and avoids verified-human,
     one-human-one-vote, district-proof, and Sybil-resistance claims.
+  - **Runtime copy contract:** stance UI must follow `useConstituencyProof()`
+    assurance metadata. Current accepted proofs are `beta_local`; this supports
+    point-level stance persistence but not production proof claims.
 
 - **`VITE_E2E_MODE`**
   - **Default:** `false`

--- a/docs/plans/VENN_NEWS_MVP_ROADMAP_2026-04-20.md
+++ b/docs/plans/VENN_NEWS_MVP_ROADMAP_2026-04-20.md
@@ -37,7 +37,7 @@ This roadmap is grounded in the current codebase state rather than the desired a
 | Source split / related links | `StoryBundle.related_links`, item eligibility policy/ledger, and UI related-link rendering exist. PR #528 ensures bundle synthesis excludes `related_links` when present and uses `primary_sources` as the analysis source set. The generic cluster publication path still does not derive `primary_sources` / `related_links` from the item-eligibility ledger by default. | Related links may display below evidence, but only analysis-eligible sources may feed summaries/frame tables. Ledger-driven source-split enrichment remains a follow-on. |
 | Bundle synthesis worker | PR #528 is merged into `main`. The news-aggregator now has `bundleSynthesisWorker`, `bundleSynthesisRelay`, queue wiring, guarded latest writes, model-sensitive idempotency, and story-detail UI provenance. | W0.4 is complete for publish-time accepted synthesis. Story detail can render accepted stored synthesis or explicit pending/unavailable state without hidden card-open analysis. |
 | Click-time analysis | `NewsCard` now hydrates stored `TopicSynthesisV2` on expansion and no longer calls `useAnalysis(...)` as the normal detail path. The legacy `useAnalysis` hook remains for non-card/runtime analysis paths and tests. | The headline-click contract is accepted synthesis first. Missing synthesis is surfaced as loading/pending/unavailable instead of silently generating card-open analysis. |
-| Constituency proof | Runtime proof acquisition derives an attestation-bound deterministic proof from the identity nullifier and configured district; mock proofs are rejected by voting paths. This is still not cryptographic residency proof or production Sybil resistance. | `identity-honesty-scope` remains the next Week 0 decision: MVP copy must say beta-local identity/proof semantics unless real cryptographic proof is explicitly pulled into scope. |
+| Constituency proof | Runtime proof acquisition derives an attestation-bound deterministic proof from the identity nullifier and configured district; mock proofs are rejected by voting paths; accepted stance proof is exposed as beta-local assurance. This is still not cryptographic residency proof or production Sybil resistance. | `identity-honesty-scope` resolves the Web PWA beta path: copy must say beta-local identity/proof semantics unless real cryptographic proof is explicitly pulled into scope later. |
 | Release gates | Core repo gates exist. MVP feed/detail/stance/thread smokes and compliance checklist scripts do not. | Week 3 must build the release evidence harness; it cannot simply "run the gates." |
 
 ## Non-negotiable product contract
@@ -374,7 +374,7 @@ Week 0 should be executed as a short PR stack, not as an open-ended planning loo
 | 2 | `sentiment-four-tuple-spec` | Complete; merged in PR #527. | Patch sentiment docs/tests around `(topic_id, synthesis_id, epoch, point_id)`. | No active spec text describes final stance as keyed only by `(topic_id, epoch, point_id)`. |
 | 3 | `launch-surface-decision` | Resolved: Web PWA. | Remove native iOS/TestFlight from the four-week critical path. | Web PWA is recorded as the MVP launch target; native packaging is a parallel follow-on. |
 | 4 | `bundle-synthesis-dependency` | Complete; merged in PR #528. | Resolve PR B / bundle synthesis dependency for accepted publish-time synthesis and source split handling. | Story detail renders accepted stored synthesis or explicit pending/unavailable state without a hidden card-open analysis pass. |
-| 5 | `identity-honesty-scope` | Open; next right slice. | Decide beta-local identity vs real constituency proof for MVP copy and stance guarantees. | Product copy, release notes, and stance path claims match the actual proof layer. |
+| 5 | `identity-honesty-scope` | Complete in this slice: Web PWA beta uses beta-local proof assurance; real constituency proof remains deferred. | Decide beta-local identity vs real constituency proof for MVP copy and stance guarantees. | Product copy, release notes, and stance path claims match the actual proof layer. |
 | 6 | `mvp-release-gates` | Open. | Add or name deterministic feed/detail/stance/thread release gates. | Missing smoke/check scripts have owners, fixtures, pass/fail semantics, and report locations. |
 | 7 | `compliance-public-beta-minimums` | Open. | Privacy, terms, UGC/moderation, support, data deletion, telemetry consent, and content/copyright boundaries. | Public launch cannot proceed unless each compliance artifact has an owner and minimum accepted draft. |
 | 8 | `launch-ops-and-correction-path` | Open. | Curated fallback snapshot, bad-analysis suppression/regeneration, report queue, model/cost telemetry, and release artifact visibility. | Operators have minimum levers for stale feed data, bad summaries, abusive threads, and runaway model usage. |
@@ -382,7 +382,7 @@ Week 0 should be executed as a short PR stack, not as an open-ended planning loo
 Recommended sequencing:
 
 - PR #527 and PR #528 are now in `main`; feed/detail stance work can base on stable point ids and accepted publish-time synthesis.
-- PR 5 is now the next critical-path decision because stance UX depends on honest identity/proof claims.
+- PR 5 resolves the stance UX identity/proof claim boundary for Web PWA beta. The next product implementation slice should be feed-personalization ranking because `preferredCategories` exists but ranking does not yet consume it.
 - PRs 6 through 8 can run in parallel once PR 5 is underway, but they should not block the feed-personalization and stance-detail implementation slices.
 - Week 1 starts only after every row in the go/no-go table has a `go` decision or an explicit accepted no-go consequence.
 
@@ -395,7 +395,7 @@ Recommended sequencing:
 | Launch surface | Go: Web PWA. | Web PWA remains the launch target; native shell work is outside the four-week critical path. | If native packaging becomes required again, restart scope and schedule around a real iOS build gate. |
 | Bundle synthesis path | Go; PR #528 is merged into `main`. | Accepted publish-time synthesis, model id, generated time, warnings, and provenance are available to story detail; missing synthesis has explicit loading/pending/unavailable states. | Do not reintroduce hidden card-open analysis as the normal path. |
 | Topic preferences | No-go. | Ranking/filter semantics are defined and have at least one deterministic test proving preferences change feed output. | Do not market the feed as tunable. Keep preference UI hidden or label it as inactive. |
-| Identity/proof | Open; next right slice. | Real cryptographic constituency proof is active, or beta-local identity constraints and copy are approved. | No verified-human, one-human-one-vote, district-proof, or Sybil-resistant claims in product copy. |
+| Identity/proof | Go for Web PWA beta. Current stance path is beta-local and must stay labeled that way. | Real cryptographic constituency proof is active, or beta-local identity constraints and copy are approved. | No verified-human, one-human-one-vote, district-proof, or Sybil-resistant claims in product copy. |
 | Story engagement rollup | No-go for visible story aggregate sentiment. | `StoryEngagementSummary` is either implemented as a derived read model or explicitly deferred from visible UI. | Do not show story-level aggregate sentiment beyond existing per-point aggregate data. |
 | Release gates | No-go. | Feed, story-detail, point-stance, and story-thread smokes have scripts or named owners/fixtures with pass/fail semantics. | No launch-readiness claim. The MVP can continue feature work, but cannot enter release freeze. |
 | Compliance | No-go for public beta. | Privacy, terms, UGC/moderation, support, data deletion, telemetry consent, and content/copyright minimums have accepted drafts. | No public beta or App Store/TestFlight submission. Internal-only testing can continue. |
@@ -495,10 +495,13 @@ Required:
 - product copy must avoid verified-human or one-human-one-vote claims if proof remains beta-local and non-cryptographic;
 - stance path must still enforce local final stance and budgets;
 - release notes must distinguish beta-local identity from future LUMA proof.
+- runtime proof state must expose assurance metadata so UI copy can distinguish beta-local stance persistence from future production proof.
 
 Exit criteria:
 
-- no user-facing claim exceeds the actual proof layer.
+- no user-facing claim exceeds the actual proof layer;
+- accepted deterministic proof is labeled beta-local in the stance UI;
+- missing-proof and blocked-stance copy tells the user to create/sign in or restore beta-local proof without claiming production verification.
 
 ### W0.6 Release evidence backlog
 

--- a/docs/specs/spec-civic-sentiment.md
+++ b/docs/specs/spec-civic-sentiment.md
@@ -151,7 +151,7 @@ District dashboards must remain aggregate-only:
 
 These clarifications are binding for the active production-wiring program.
 
-1. **Unified vote admission policy (required):** Feed and AnalysisView MUST enforce identical admission rules (verified proof, valid synthesis context, budget checks). No bypass write path is allowed.
+1. **Unified vote admission policy (required):** Feed and AnalysisView MUST enforce identical admission rules (valid release-mode proof, valid synthesis context, budget checks). No bypass write path is allowed. Current Web PWA MVP proof semantics are beta-local, so product copy MUST NOT describe admitted stances as verified-human, district-proof, one-human-one-vote, or Sybil-resistant.
 2. **Canonical point identity migration (required):** If point identity root changes, implementations MUST use dual-write + backfill + compatibility-read during migration window.
 3. **Legacy sunset (required):** Compatibility read paths must have explicit sunset criteria (time + release-count) and telemetry to prove safe removal.
 4. **Aggregate visibility (required):** UI sentiment counters MUST read mesh aggregates (with resilience controls), not local-write-only projections.

--- a/docs/specs/spec-identity-trust-constituency.md
+++ b/docs/specs/spec-identity-trust-constituency.md
@@ -239,6 +239,9 @@ from session nullifier + configured district.
 Current runtime behavior:
 - `useRegion()` derives proof from identity session nullifier and configured district hash.
 - `useConstituencyProof()` hard-rejects mock proofs (`mock-*`) on voting paths.
+- `useConstituencyProof()` exposes assurance metadata. Accepted runtime proofs
+  are labeled `assurance: "beta_local"` and `canClaimVerifiedHuman`,
+  `canClaimDistrictProof`, and `canClaimSybilResistance` are all `false`.
 - Freshness remains non-cryptographic in Season 0 (non-empty root check).
 - This is beta-local proof semantics, not production Sybil resistance or
   cryptographic residency proof. Product copy must not claim verified-human,


### PR DESCRIPTION
## Summary

- adds explicit beta-local assurance metadata to `useConstituencyProof()` so stance UI can distinguish MVP persistence from future production proof
- labels deterministic `s0-root-*` proof material as beta-local and documents that it is not cryptographic residency proof
- removes user-facing “verified proof” / “cast votes” stance copy from feed controls and legacy analysis view, replacing it with beta-local/save-stance language
- blocks the legacy AnalysisView path from treating an undefined proof payload as vote-capable
- updates MVP roadmap/spec/feature-flag docs so the Web PWA beta path is clear: beta-local stance persistence is in scope; verified-human, district-proof, one-human-one-vote, and Sybil-resistance claims are not

## Verification

- `pnpm exec vitest run apps/web-pwa/src/hooks/useConstituencyProof.test.ts apps/web-pwa/src/components/feed/CellVoteControls.test.tsx apps/web-pwa/src/components/AnalysisView.test.tsx apps/web-pwa/src/store/bridge/__tests__/realConstituencyProof.test.ts --reporter=verbose`
- `pnpm --filter @vh/web-pwa typecheck`
- `pnpm deps:check`
- `node tools/scripts/check-diff-coverage.mjs`
- `git diff --check`

## Notes

- `pnpm --filter @vh/web-pwa typecheck:test` still fails on pre-existing repo-wide test TS debt in unrelated files. I verified the rerun output no longer includes touched files after cleaning the local `CellVoteControls` test typing issues surfaced by that sweep.
