### PR TITLE
Implement feed detail stance UI

### DIFF
--- a/apps/web-pwa/src/components/feed/BiasTable.test.tsx
+++ b/apps/web-pwa/src/components/feed/BiasTable.test.tsx
@@ -243,6 +243,58 @@ describe('BiasTable', () => {
     expect(screen.queryByTestId(`cell-vote-${synthesisPointIds.frame0}`)).not.toBeInTheDocument();
   });
 
+  it('accepted synthesis mode uses persisted point IDs as display and canonical IDs', async () => {
+    const legacyPointIds = await deriveExpectedPointIds();
+    render(
+      <BiasTable
+        analyses={[makeAnalysis()]}
+        frames={[
+          {
+            frame_point_id: 'persisted-frame-0',
+            frame: FRAMES[0]!.frame,
+            reframe_point_id: 'persisted-reframe-0',
+            reframe: FRAMES[0]!.reframe,
+          },
+        ]}
+        topicId={TOPIC_ID}
+        analysisId={ANALYSIS_ID}
+        synthesisId={SYNTHESIS_ID}
+        epoch={EPOCH}
+        votingEnabled
+        votingPointIdMode="accepted-synthesis"
+      />,
+    );
+
+    expect(await screen.findByTestId('cell-vote-persisted-frame-0')).toHaveAttribute(
+      'data-canonical-point-id',
+      'persisted-frame-0',
+    );
+    expect(screen.getByTestId('cell-vote-persisted-reframe-0')).toHaveAttribute(
+      'data-canonical-point-id',
+      'persisted-reframe-0',
+    );
+    expect(screen.queryByTestId(`cell-vote-${legacyPointIds.frame0}`)).not.toBeInTheDocument();
+  });
+
+  it('accepted synthesis mode does not render stance controls for rows missing persisted point IDs', async () => {
+    const legacyPointIds = await deriveExpectedPointIds();
+    const { container } = render(
+      <BiasTable
+        analyses={[makeAnalysis()]}
+        frames={FRAMES}
+        topicId={TOPIC_ID}
+        analysisId={ANALYSIS_ID}
+        synthesisId={SYNTHESIS_ID}
+        epoch={EPOCH}
+        votingEnabled
+        votingPointIdMode="accepted-synthesis"
+      />,
+    );
+
+    expect(container.querySelector('[data-testid^="cell-vote-"]')).not.toBeInTheDocument();
+    expect(screen.queryByTestId(`cell-vote-${legacyPointIds.frame0}`)).not.toBeInTheDocument();
+  });
+
   it('derives canonical vote ids from the explicit synthesis context when it exists', async () => {
     const legacyPointIds = await deriveExpectedPointIds();
     const stableSynthesisPointIds = await deriveExpectedSynthesisPointIds(SYNTHESIS_ID);

--- a/apps/web-pwa/src/components/feed/BiasTable.tsx
+++ b/apps/web-pwa/src/components/feed/BiasTable.tsx
@@ -21,6 +21,7 @@ export interface BiasTableProps {
   readonly synthesisId?: string;
   readonly epoch?: number;
   readonly votingEnabled?: boolean;
+  readonly votingPointIdMode?: 'legacy-compatible' | 'accepted-synthesis';
 }
 
 function biasTableDiagnosticsEnabled(): boolean {
@@ -63,6 +64,7 @@ interface ExpandableRowProps {
   readonly synthesisFramePointId?: string;
   readonly synthesisReframePointId?: string;
   readonly votingEnabled?: boolean;
+  readonly votingPointIdMode?: 'legacy-compatible' | 'accepted-synthesis';
 }
 
 function ExpandableRow({
@@ -79,6 +81,7 @@ function ExpandableRow({
   synthesisFramePointId,
   synthesisReframePointId,
   votingEnabled,
+  votingPointIdMode = 'legacy-compatible',
 }: ExpandableRowProps): React.ReactElement {
   const [expanded, setExpanded] = useState(false);
   const toggle = useCallback(() => setExpanded((v) => !v), []);
@@ -88,8 +91,14 @@ function ExpandableRow({
     (analysis?.justifyBiasClaims?.length ?? 0) > 0;
 
   const showVoting = !!(votingEnabled && topicId && synthesisId && epoch !== undefined);
-  const voteFramePointId = framePointId ?? synthesisFramePointId;
-  const voteReframePointId = reframePointId ?? synthesisReframePointId;
+  const voteFramePointId = votingPointIdMode === 'accepted-synthesis'
+    ? synthesisFramePointId
+    : framePointId ?? synthesisFramePointId;
+  const voteReframePointId = votingPointIdMode === 'accepted-synthesis'
+    ? synthesisReframePointId
+    : reframePointId ?? synthesisReframePointId;
+  const frameSynthesisPointId = synthesisFramePointId ?? voteFramePointId;
+  const reframeSynthesisPointId = synthesisReframePointId ?? voteReframePointId;
 
   return (
     <>
@@ -105,10 +114,11 @@ function ExpandableRow({
             <CellVoteControls
               topicId={topicId!}
               pointId={voteFramePointId}
-              synthesisPointId={synthesisFramePointId}
+              synthesisPointId={frameSynthesisPointId}
               synthesisId={synthesisId!}
               epoch={epoch!}
               analysisId={analysisId}
+              pointLabel={frame}
             />
           )}
         </td>
@@ -118,10 +128,11 @@ function ExpandableRow({
             <CellVoteControls
               topicId={topicId!}
               pointId={voteReframePointId}
-              synthesisPointId={synthesisReframePointId}
+              synthesisPointId={reframeSynthesisPointId}
               synthesisId={synthesisId!}
               epoch={epoch!}
               analysisId={analysisId}
+              pointLabel={reframe}
             />
           )}
         </td>
@@ -192,6 +203,7 @@ export const BiasTable: React.FC<BiasTableProps> = ({
   synthesisId,
   epoch,
   votingEnabled = false,
+  votingPointIdMode = 'legacy-compatible',
 }) => {
   const hasExplicitSynthesisContext = synthesisId !== undefined && epoch !== undefined;
   const stableVotingContextId = hasExplicitSynthesisContext
@@ -213,6 +225,9 @@ export const BiasTable: React.FC<BiasTableProps> = ({
     synthesisId: hasVotingContext ? effectiveSynthesisId : undefined,
     epoch: hasVotingContext ? effectiveEpoch : undefined,
     votingEnabled: hasVotingContext,
+    synthesisPointIdMode: votingPointIdMode === 'accepted-synthesis'
+      ? 'persisted-only'
+      : 'persisted-or-derived',
   });
 
   useEffect(() => {
@@ -241,6 +256,7 @@ export const BiasTable: React.FC<BiasTableProps> = ({
       legacy_point_mappings: Object.keys(legacyPointIds).length,
       synthesis_point_mappings: Object.keys(synthesisPointIds).length,
       point_mappings_ready: Object.keys(synthesisPointIds).length === expectedPointMappings,
+      point_id_mode: votingPointIdMode,
       voting_context_ready: hasVotingContext,
     };
 
@@ -263,6 +279,7 @@ export const BiasTable: React.FC<BiasTableProps> = ({
     synthesisPointIds,
     topicId,
     votingEnabled,
+    votingPointIdMode,
   ]);
 
   const rowAnalysisMap = buildRowAnalysisMap(frames, analyses);
@@ -328,6 +345,7 @@ export const BiasTable: React.FC<BiasTableProps> = ({
                   synthesisFramePointId={synthesisPointIds[pointMapKey(index, 'frame')]}
                   synthesisReframePointId={synthesisPointIds[pointMapKey(index, 'reframe')]}
                   votingEnabled={hasVotingContext}
+                  votingPointIdMode={votingPointIdMode}
                 />
               ))
             ) : (

--- a/apps/web-pwa/src/components/feed/CellVoteControls.tsx
+++ b/apps/web-pwa/src/components/feed/CellVoteControls.tsx
@@ -12,6 +12,7 @@ export interface CellVoteControlsProps {
   readonly epoch: number;
   readonly analysisId?: string;
   readonly disabled?: boolean;
+  readonly pointLabel?: string;
 }
 
 function biasTableDiagnosticsEnabled(): boolean {
@@ -31,6 +32,7 @@ export const CellVoteControls: React.FC<CellVoteControlsProps> = ({
   epoch,
   analysisId,
   disabled = false,
+  pointLabel,
 }) => {
   type AggregateSnapshot = {
     readonly contextKey: string;
@@ -115,6 +117,7 @@ export const CellVoteControls: React.FC<CellVoteControlsProps> = ({
   }
 
   const hasIdPartition = !!(legacyPointId && legacyPointId !== canonicalPointId);
+  const accessibleTarget = pointLabel?.trim() || pointId;
 
   useEffect(() => {
     const payload = {
@@ -218,7 +221,7 @@ export const CellVoteControls: React.FC<CellVoteControlsProps> = ({
               ? 'bg-green-200 text-green-800'
               : 'bg-slate-100 text-slate-600 hover:bg-green-50'
           }`}
-          aria-label={`Agree with ${pointId}`}
+          aria-label={`Agree with ${accessibleTarget}`}
           aria-pressed={currentVote === 1}
           disabled={disabled}
           onClick={() => handleVote(1)}
@@ -236,7 +239,7 @@ export const CellVoteControls: React.FC<CellVoteControlsProps> = ({
               ? 'bg-red-200 text-red-800'
               : 'bg-slate-100 text-slate-600 hover:bg-red-50'
           }`}
-          aria-label={`Disagree with ${pointId}`}
+          aria-label={`Disagree with ${accessibleTarget}`}
           aria-pressed={currentVote === -1}
           disabled={disabled}
           onClick={() => handleVote(-1)}

--- a/apps/web-pwa/src/components/feed/NewsCard.test.tsx
+++ b/apps/web-pwa/src/components/feed/NewsCard.test.tsx
@@ -614,16 +614,38 @@ describe('NewsCard', () => {
       'Synthesis unavailable.',
     );
   });
-  it('threads analysisId from story through to BiasTable voting controls', async () => {
+  it('renders story-detail stance controls from accepted synthesis point IDs', async () => {
     vi.stubEnv('VITE_VH_ANALYSIS_PIPELINE', 'true');
     useNewsStore.getState().setStories([makeStoryBundle()]);
     useSynthesisStore.getState().setTopicSynthesis('news-1', makeSynthesis());
+    const setAgreementSpy = vi.spyOn(useSentimentState.getState(), 'setAgreement');
     render(<NewsCard item={makeNewsItem()} />);
     fireEvent.click(screen.getByTestId('news-card-headline-news-1'));
     expect(await screen.findByTestId('bias-table')).toBeInTheDocument();
-    // Voting controls appear because topic + synthesis context are threaded
-    expect((await screen.findAllByRole('button', { name: /Agree with /i })).length).toBeGreaterThanOrEqual(2);
-    expect((await screen.findAllByRole('button', { name: /Disagree with /i })).length).toBeGreaterThanOrEqual(2);
+    expect(screen.getByTestId('news-card-stance-scope-news-1')).toHaveTextContent(
+      'Stance controls apply to individual frame and reframe items about this story, not to the story as a whole.',
+    );
+
+    const agreeFrame = await screen.findByTestId('cell-vote-agree-syn-1:0:frame');
+    const disagreeReframe = await screen.findByTestId('cell-vote-disagree-syn-1:0:reframe');
+    expect(agreeFrame).toHaveAccessibleName('Agree with Public investment is overdue');
+    expect(agreeFrame).toHaveAttribute('data-display-point-id', 'syn-1:0:frame');
+    expect(agreeFrame).toHaveAttribute('data-canonical-point-id', 'syn-1:0:frame');
+    expect(disagreeReframe).toHaveAccessibleName('Disagree with Budget risk should slow rollout');
+    expect(disagreeReframe).toHaveAttribute('data-display-point-id', 'syn-1:0:reframe');
+    expect(disagreeReframe).toHaveAttribute('data-canonical-point-id', 'syn-1:0:reframe');
+
+    fireEvent.click(agreeFrame);
+    expect(setAgreementSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        topicId: 'news-1',
+        pointId: 'syn-1:0:frame',
+        synthesisPointId: 'syn-1:0:frame',
+        synthesisId: 'syn-1',
+        epoch: 2,
+        desired: 1,
+      }),
+    );
   });
   it('does not render stance voting controls when synthesis context is missing', async () => {
     vi.stubEnv('VITE_VH_ANALYSIS_PIPELINE', 'true');

--- a/apps/web-pwa/src/components/feed/NewsCardBack.storyline.test.tsx
+++ b/apps/web-pwa/src/components/feed/NewsCardBack.storyline.test.tsx
@@ -91,4 +91,21 @@ describe('NewsCardBack storyline presentation', () => {
       'Analysis needs regeneration to produce frame/reframe rows.',
     );
   });
+
+  it('does not present stance controls for frame rows without persisted point IDs', () => {
+    renderBack({
+      frameRows: [
+        {
+          frame: 'A funding frame',
+          reframe: 'A budget-risk reframe',
+        },
+      ],
+      synthesisId: 'synthesis-1',
+      epoch: 1,
+    });
+
+    expect(screen.queryByTestId('news-card-stance-scope-news-1')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Agree with/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Disagree with/i })).not.toBeInTheDocument();
+  });
 });

--- a/apps/web-pwa/src/components/feed/NewsCardBack.tsx
+++ b/apps/web-pwa/src/components/feed/NewsCardBack.tsx
@@ -319,6 +319,14 @@ export const NewsCardBack: React.FC<NewsCardBackProps> = ({
         <h4 className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
           Frame / Reframe
         </h4>
+        {frameRows.length > 0 && synthesisId && epoch !== undefined && (
+          <p
+            className="text-xs leading-5 text-slate-500 dark:text-slate-400"
+            data-testid={`news-card-stance-scope-${topicId}`}
+          >
+            Stance controls apply to individual frame and reframe items about this story, not to the story as a whole.
+          </p>
+        )}
         {analysisFeedbackStatus === 'error' && (
           <div className="mt-2" data-testid={`news-card-analysis-error-${topicId}`}>
             <RemovalIndicator reason="extraction-failed-permanently" />
@@ -368,6 +376,7 @@ export const NewsCardBack: React.FC<NewsCardBackProps> = ({
             synthesisId={synthesisId ?? undefined}
             epoch={epoch}
             votingEnabled={Boolean(synthesisId && epoch !== undefined && frameRows.length > 0)}
+            votingPointIdMode="accepted-synthesis"
           />
         </div>
       </section>

--- a/apps/web-pwa/src/components/feed/NewsCardBack.tsx
+++ b/apps/web-pwa/src/components/feed/NewsCardBack.tsx
@@ -119,6 +119,10 @@ export const NewsCardBack: React.FC<NewsCardBackProps> = ({
   createThread = null,
   onCollapse,
 }) => {
+  const hasAcceptedStanceTargets = frameRows.some(
+    (row) => Boolean(row.frame_point_id?.trim() || row.reframe_point_id?.trim()),
+  );
+
   return (
     <div data-testid={`news-card-back-${topicId}`} className="space-y-5">
       <header className="flex flex-wrap items-start justify-between gap-4 rounded-[1.75rem] border border-slate-200/90 bg-slate-50/85 p-4 shadow-sm shadow-slate-900/5 dark:border-slate-800 dark:bg-slate-900/80">
@@ -319,7 +323,7 @@ export const NewsCardBack: React.FC<NewsCardBackProps> = ({
         <h4 className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
           Frame / Reframe
         </h4>
-        {frameRows.length > 0 && synthesisId && epoch !== undefined && (
+        {hasAcceptedStanceTargets && synthesisId && epoch !== undefined && (
           <p
             className="text-xs leading-5 text-slate-500 dark:text-slate-400"
             data-testid={`news-card-stance-scope-${topicId}`}
@@ -375,7 +379,7 @@ export const NewsCardBack: React.FC<NewsCardBackProps> = ({
             analysisId={analysisId ?? undefined}
             synthesisId={synthesisId ?? undefined}
             epoch={epoch}
-            votingEnabled={Boolean(synthesisId && epoch !== undefined && frameRows.length > 0)}
+            votingEnabled={Boolean(synthesisId && epoch !== undefined && hasAcceptedStanceTargets)}
             votingPointIdMode="accepted-synthesis"
           />
         </div>

--- a/apps/web-pwa/src/components/feed/useBiasPointIds.test.tsx
+++ b/apps/web-pwa/src/components/feed/useBiasPointIds.test.tsx
@@ -7,7 +7,7 @@ import { useBiasPointIds } from './useBiasPointIds';
 const deriveAnalysisKeyMock = vi.hoisted(() => vi.fn());
 const derivePointIdMock = vi.hoisted(() => vi.fn());
 const deriveSynthesisPointIdMock = vi.hoisted(() => vi.fn());
-const getDevModelOverrideMock = vi.hoisted(() => vi.fn(() => null));
+const getDevModelOverrideMock = vi.hoisted(() => vi.fn<() => string | null>(() => null));
 
 vi.mock('@vh/data-model', () => ({
   deriveAnalysisKey: (...args: unknown[]) => deriveAnalysisKeyMock(...args),
@@ -32,6 +32,7 @@ function HookHarness(props: {
   synthesisId?: string;
   epoch?: number;
   votingEnabled?: boolean;
+  synthesisPointIdMode?: 'persisted-or-derived' | 'persisted-only';
 }) {
   const pointIds = useBiasPointIds(props);
   return <pre data-testid="point-ids">{JSON.stringify(pointIds)}</pre>;
@@ -102,6 +103,32 @@ describe('useBiasPointIds', () => {
     await waitFor(() => {
       expect(screen.getByTestId('point-ids')).toHaveTextContent('"legacyPointIds":{"frame:0":"legacy:frame:Frame A","reframe:0":"legacy:reframe:Reframe A"}');
       expect(screen.getByTestId('point-ids')).toHaveTextContent('"synthesisPointIds":{"frame:0":"persisted-frame-point","reframe:0":"persisted-reframe-point"}');
+    });
+
+    expect(deriveSynthesisPointIdMock).not.toHaveBeenCalled();
+  });
+
+  it('persisted-only synthesis mode never derives text-based canonical point IDs', async () => {
+    render(
+      <HookHarness
+        frames={[
+          {
+            frame_point_id: 'persisted-frame-point',
+            frame: 'Frame A',
+            reframe: 'Reframe A',
+          },
+        ]}
+        topicId="topic-1"
+        synthesisId="synth-1"
+        epoch={2}
+        votingEnabled
+        synthesisPointIdMode="persisted-only"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('point-ids')).toHaveTextContent('"legacyPointIds":{}');
+      expect(screen.getByTestId('point-ids')).toHaveTextContent('"synthesisPointIds":{"frame:0":"persisted-frame-point"}');
     });
 
     expect(deriveSynthesisPointIdMock).not.toHaveBeenCalled();

--- a/apps/web-pwa/src/components/feed/useBiasPointIds.ts
+++ b/apps/web-pwa/src/components/feed/useBiasPointIds.ts
@@ -41,6 +41,7 @@ interface UseBiasPointIdsParams {
   readonly synthesisId?: string;
   readonly epoch?: number;
   readonly votingEnabled?: boolean;
+  readonly synthesisPointIdMode?: 'persisted-or-derived' | 'persisted-only';
 }
 
 export interface UseBiasPointIdsResult {
@@ -55,6 +56,7 @@ export function useBiasPointIds({
   synthesisId,
   epoch,
   votingEnabled,
+  synthesisPointIdMode = 'persisted-or-derived',
 }: UseBiasPointIdsParams): UseBiasPointIdsResult {
   const [modelScopeKey, setModelScopeKey] = useState(getModelScopeKey);
   const [legacyPointIds, setLegacyPointIds] = useState<Record<string, string>>({});
@@ -136,29 +138,35 @@ export function useBiasPointIds({
           const nextSynthesisPointIds: Record<string, string> = {};
           for (let rowIndex = 0; rowIndex < frames.length; rowIndex += 1) {
             const row = frames[rowIndex]!;
-            const [framePointId, reframePointId] = await Promise.all([
-              row.frame_point_id
-                ? Promise.resolve(row.frame_point_id)
-                : deriveSynthesisPointId({
+            const framePointId = row.frame_point_id
+              ? row.frame_point_id
+              : synthesisPointIdMode === 'persisted-only'
+                ? null
+                : await deriveSynthesisPointId({
                     topic_id: topicId!,
                     synthesis_id: synthesisId!,
                     epoch: epoch!,
                     column: 'frame',
                     text: row.frame,
-                  }),
-              row.reframe_point_id
-                ? Promise.resolve(row.reframe_point_id)
-                : deriveSynthesisPointId({
+                  });
+            const reframePointId = row.reframe_point_id
+              ? row.reframe_point_id
+              : synthesisPointIdMode === 'persisted-only'
+                ? null
+                : await deriveSynthesisPointId({
                     topic_id: topicId!,
                     synthesis_id: synthesisId!,
                     epoch: epoch!,
                     column: 'reframe',
                     text: row.reframe,
-                  }),
-            ]);
+                  });
 
-            nextSynthesisPointIds[pointMapKey(rowIndex, 'frame')] = framePointId;
-            nextSynthesisPointIds[pointMapKey(rowIndex, 'reframe')] = reframePointId;
+            if (framePointId) {
+              nextSynthesisPointIds[pointMapKey(rowIndex, 'frame')] = framePointId;
+            }
+            if (reframePointId) {
+              nextSynthesisPointIds[pointMapKey(rowIndex, 'reframe')] = reframePointId;
+            }
           }
 
           return nextSynthesisPointIds;
@@ -194,6 +202,7 @@ export function useBiasPointIds({
     modelScopeKey,
     shouldDeriveLegacyIds,
     shouldDeriveSynthesisIds,
+    synthesisPointIdMode,
     synthesisId,
     topicId,
   ]);

--- a/docs/specs/spec-civic-sentiment.md
+++ b/docs/specs/spec-civic-sentiment.md
@@ -52,6 +52,7 @@ Rules:
 2. `agreement = 0` is neutral and non-counting in point aggregates.
 3. Familiars cannot add separate sentiment identities.
 4. Event-level signals are sensitive and must remain local/encrypted.
+5. New feed/story-detail stance writes must use persisted `frame_point_id` or `reframe_point_id` values from the accepted `TopicSynthesisV2`; text-derived point ids are compatibility aliases, not the canonical write path for accepted synthesis.
 
 ## 3. Aggregate contract (public)
 

--- a/docs/specs/spec-topic-discovery-ranking-v0.md
+++ b/docs/specs/spec-topic-discovery-ranking-v0.md
@@ -205,6 +205,8 @@ Required card affordances:
 - engagement counts
 - forum comments below frame/reframe content
 
+Stance controls on `NEWS_STORY` detail are enabled only for accepted synthesis frame/reframe cells that carry persisted `frame_point_id` / `reframe_point_id` values. Missing point ids must produce a non-votable cell rather than deriving a canonical write id from mutable display text.
+
 News-created forum threads must link with `sourceSynthesisId` + `sourceEpoch` when available and preserve the feed `topic_id` as the thread `topicId`. Legacy `sourceAnalysisId` is read-only compatibility.
 
 Continuous stream behavior:


### PR DESCRIPTION
## Summary

- harden `NewsCardBack` so story-detail stance voting uses an explicit accepted-synthesis mode
- require persisted `frame_point_id` / `reframe_point_id` for accepted story-detail stance controls instead of deriving canonical write ids from mutable text
- pass human-readable frame/reframe labels into vote button accessible names while keeping canonical point ids in data attributes
- document the accepted-synthesis stance rule in the civic sentiment and topic discovery specs

## Validation

- `pnpm exec vitest run apps/web-pwa/src/components/feed/NewsCard.test.tsx apps/web-pwa/src/components/feed/BiasTable.test.tsx apps/web-pwa/src/components/feed/CellVoteControls.test.tsx apps/web-pwa/src/components/feed/useBiasPointIds.test.tsx --reporter=verbose`
- `pnpm --filter @vh/web-pwa typecheck`
- `pnpm deps:check`
- `git diff --check`
- `node tools/scripts/check-diff-coverage.mjs`
- `pnpm --filter @vh/web-pwa build`

## Notes

`pnpm --filter @vh/web-pwa typecheck:test` still exits 2 from existing unrelated test typing debt across the web test suite. I reran it and confirmed the touched feed files are not present in the reported errors.
