### PR TITLE
Implement story detail thread integration

### DIFF
--- a/apps/web-pwa/src/components/feed/FeedDiscussionSection.test.tsx
+++ b/apps/web-pwa/src/components/feed/FeedDiscussionSection.test.tsx
@@ -1,0 +1,199 @@
+/* @vitest-environment jsdom */
+
+import React from 'react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { HermesComment, HermesThread } from '@vh/types';
+import { FeedDiscussionSection } from './FeedDiscussionSection';
+
+const forumState = vi.hoisted(() => ({
+  comments: new Map<string, HermesComment[]>(),
+  loadComments: vi.fn(),
+  createThread: vi.fn(),
+  createComment: vi.fn(),
+}));
+
+vi.mock('../../store/hermesForum', () => ({
+  useForumStore: (selector?: (state: typeof forumState) => unknown) =>
+    selector ? selector(forumState) : forumState,
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children, params, ...props }: React.PropsWithChildren<{ params: { threadId: string } }>) => (
+    <a href={`/hermes/${params.threadId}`} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock('../hermes/CommentStream', () => ({
+  CommentStream: ({ threadId, comments }: { threadId: string; comments: HermesComment[] }) => (
+    <div data-testid={`comment-stream-${threadId}`}>
+      {comments.map((comment) => (
+        <p key={comment.id}>{comment.content}</p>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock('../hermes/forum/TrustGate', () => ({
+  TrustGate: ({ children }: React.PropsWithChildren) => <>{children}</>,
+}));
+
+vi.mock('../hermes/forum/SlideToPost', () => ({
+  SlideToPost: ({ onChange, disabled }: { onChange: (value: number) => void; disabled?: boolean }) => (
+    <button type="button" data-testid="slide-to-post-mock" disabled={disabled} onClick={() => onChange(10)}>
+      Slide
+    </button>
+  ),
+}));
+
+function makeThread(overrides: Partial<HermesThread> = {}): HermesThread {
+  return {
+    id: 'thread-1',
+    schemaVersion: 'hermes-thread-v0',
+    title: 'Transit discussion',
+    content: 'Discuss the transit story.',
+    author: 'author-1',
+    timestamp: 1_700_000_000_000,
+    tags: ['news'],
+    upvotes: 0,
+    downvotes: 0,
+    score: 0,
+    topicId: 'news-1',
+    isHeadline: true,
+    ...overrides,
+  };
+}
+
+function makeComment(overrides: Partial<HermesComment> = {}): HermesComment {
+  return {
+    id: 'comment-1',
+    schemaVersion: 'hermes-comment-v1',
+    threadId: 'thread-1',
+    parentId: null,
+    content: 'First comment',
+    author: 'commenter-1',
+    timestamp: 1_700_000_000_100,
+    stance: 'discuss',
+    upvotes: 0,
+    downvotes: 0,
+    type: 'reply',
+    ...overrides,
+  };
+}
+
+describe('FeedDiscussionSection', () => {
+  beforeEach(() => {
+    forumState.comments = new Map();
+    forumState.loadComments.mockReset();
+    forumState.createThread.mockReset();
+    forumState.createComment.mockReset();
+    forumState.loadComments.mockResolvedValue([]);
+    forumState.createThread.mockResolvedValue(makeThread());
+    forumState.createComment.mockResolvedValue(makeComment());
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('loads existing story-thread comments and switches from fallback count to loaded count', async () => {
+    const thread = makeThread();
+    forumState.comments.set(thread.id, [
+      makeComment({ id: 'comment-1', content: 'First loaded comment' }),
+      makeComment({ id: 'comment-2', content: 'Second loaded comment' }),
+    ]);
+
+    render(
+      <FeedDiscussionSection
+        sectionId="news-card-news-1"
+        thread={thread}
+        fallbackCommentCount={5}
+      />,
+    );
+
+    expect(screen.getByTestId('news-card-news-1-discussion-count')).toHaveTextContent('2 comments');
+    expect(await screen.findByTestId('comment-stream-thread-1')).toHaveTextContent('First loaded comment');
+    expect(forumState.loadComments).toHaveBeenCalledWith('thread-1');
+    await waitFor(() => {
+      expect(screen.getByTestId('news-card-news-1-discussion-count')).toHaveTextContent('2 comments');
+    });
+  });
+
+  it('surfaces comment-load failures and retries the same story thread', async () => {
+    const thread = makeThread();
+    forumState.loadComments
+      .mockRejectedValueOnce(new Error('relay unavailable'))
+      .mockResolvedValueOnce([]);
+
+    render(<FeedDiscussionSection sectionId="news-card-news-1" thread={thread} />);
+
+    expect(await screen.findByTestId('news-card-news-1-discussion-load-error')).toHaveTextContent(
+      'relay unavailable',
+    );
+
+    fireEvent.click(screen.getByTestId('news-card-news-1-discussion-retry-load'));
+
+    await waitFor(() => expect(forumState.loadComments).toHaveBeenCalledTimes(2));
+    expect(await screen.findByTestId('news-card-news-1-discussion-empty')).toHaveTextContent(
+      'No comments yet. Start the discussion.',
+    );
+  });
+
+  it('starts a story discussion and immediately renders the created headline thread', async () => {
+    const created = makeThread({
+      id: 'news-story:story-news-1',
+      title: 'City council votes on transit plan',
+      sourceSynthesisId: 'syn-1',
+      sourceEpoch: 2,
+      sourceUrl: 'https://example.com/news-1',
+      topicId: 'news-1',
+    });
+    forumState.createThread.mockResolvedValueOnce(created);
+
+    render(
+      <FeedDiscussionSection
+        sectionId="news-card-news-1"
+        thread={null}
+        createThread={{
+          defaultTitle: 'City council votes on transit plan',
+          sourceSynthesisId: 'syn-1',
+          sourceEpoch: 2,
+          sourceUrl: 'https://example.com/news-1',
+          topicId: 'news-1',
+          threadId: 'news-story:story-news-1',
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('news-card-news-1-discussion-new-thread-toggle'));
+    fireEvent.change(screen.getByTestId('thread-content'), {
+      target: { value: 'Opening the story thread.' },
+    });
+    fireEvent.click(screen.getByTestId('submit-thread-btn'));
+
+    await waitFor(() => expect(forumState.createThread).toHaveBeenCalledTimes(1));
+    expect(forumState.createThread).toHaveBeenCalledWith(
+      'City council votes on transit plan',
+      'Opening the story thread.',
+      [],
+      { sourceSynthesisId: 'syn-1', sourceEpoch: 2 },
+      {
+        sourceUrl: 'https://example.com/news-1',
+        topicId: 'news-1',
+        threadId: 'news-story:story-news-1',
+        isHeadline: true,
+      },
+    );
+    expect(await screen.findByTestId('news-card-news-1-thread-head')).toHaveTextContent(
+      'City council votes on transit plan',
+    );
+    expect(screen.getByTestId('news-card-news-1-open-thread')).toHaveAttribute(
+      'href',
+      '/hermes/news-story:story-news-1',
+    );
+    expect(screen.queryByTestId('news-card-news-1-discussion-new-thread-toggle')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web-pwa/src/components/feed/FeedDiscussionSection.tsx
+++ b/apps/web-pwa/src/components/feed/FeedDiscussionSection.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Link } from '@tanstack/react-router';
 import type { HermesComment, HermesThread } from '@vh/types';
 import { useForumStore } from '../../store/hermesForum';
@@ -21,6 +21,7 @@ export interface FeedDiscussionSectionProps {
     readonly sourceEpoch?: number;
     readonly sourceUrl?: string;
     readonly topicId?: string;
+    readonly threadId?: string;
   } | null;
 }
 
@@ -32,14 +33,46 @@ export const FeedDiscussionSection: React.FC<FeedDiscussionSectionProps> = ({
   fallbackCommentCount = 0,
   createThread = null,
 }) => {
-  const threadId = thread?.id ?? null;
+  const [createdThread, setCreatedThread] = useState<HermesThread | null>(null);
+  const effectiveThread = thread ?? createdThread;
+  const threadId = effectiveThread?.id ?? null;
   const loadComments = useForumStore((state) => state.loadComments);
   const comments = useForumStore((state) =>
     threadId ? state.comments.get(threadId) ?? EMPTY_COMMENTS : EMPTY_COMMENTS,
   );
   const [loaded, setLoaded] = useState(false);
+  const [loadAttempt, setLoadAttempt] = useState(0);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [showComposer, setShowComposer] = useState(false);
   const [showNewThreadForm, setShowNewThreadForm] = useState(false);
+  const createThreadKey = useMemo(
+    () =>
+      createThread
+        ? [
+            createThread.defaultTitle,
+            createThread.sourceSynthesisId ?? '',
+            createThread.sourceEpoch ?? '',
+            createThread.sourceUrl ?? '',
+            createThread.topicId ?? '',
+            createThread.threadId ?? '',
+          ].join('|')
+        : 'none',
+    [createThread],
+  );
+
+  useEffect(() => {
+    if (thread) {
+      setCreatedThread(null);
+    }
+  }, [thread]);
+
+  useEffect(() => {
+    if (thread) {
+      return;
+    }
+    setCreatedThread(null);
+    setShowNewThreadForm(false);
+  }, [createThreadKey, sectionId, thread]);
 
   useEffect(() => {
     setShowComposer(false);
@@ -48,23 +81,33 @@ export const FeedDiscussionSection: React.FC<FeedDiscussionSectionProps> = ({
   useEffect(() => {
     if (!threadId) {
       setLoaded(false);
+      setLoadError(null);
       return;
     }
 
     let active = true;
     setLoaded(false);
-    void loadComments(threadId).then(() => {
-      if (active) {
-        setLoaded(true);
-      }
-    });
+    setLoadError(null);
+    void loadComments(threadId)
+      .then(() => {
+        if (active) {
+          setLoaded(true);
+        }
+      })
+      .catch((err) => {
+        if (active) {
+          setLoadError(err instanceof Error ? err.message : 'Unable to load comments');
+        }
+      });
 
     return () => {
       active = false;
     };
-  }, [loadComments, threadId]);
+  }, [loadAttempt, loadComments, threadId]);
 
-  const commentCount = Math.max(fallbackCommentCount, comments.length);
+  const commentCount = loaded || comments.length > 0
+    ? comments.length
+    : Math.max(fallbackCommentCount, comments.length);
 
   return (
     <section
@@ -83,14 +126,14 @@ export const FeedDiscussionSection: React.FC<FeedDiscussionSectionProps> = ({
             </span>
           </div>
           <p className="text-sm text-slate-500 dark:text-slate-400">
-            {thread ? 'Threaded replies stay attached to this topic.' : emptyMessage}
+            {effectiveThread ? 'Threaded replies stay attached to this story.' : emptyMessage}
           </p>
         </div>
 
-        {thread && (
+        {effectiveThread && (
           <Link
             to="/hermes/$threadId"
-            params={{ threadId: thread.id }}
+            params={{ threadId: effectiveThread.id }}
             className="rounded-full border border-slate-200/80 bg-white/90 px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.16em] text-slate-600 transition hover:border-slate-300 hover:bg-slate-50 hover:text-slate-900 dark:border-slate-700 dark:bg-slate-900/80 dark:text-slate-200 dark:hover:bg-slate-800"
             data-testid={`${sectionId}-open-thread`}
           >
@@ -99,7 +142,7 @@ export const FeedDiscussionSection: React.FC<FeedDiscussionSectionProps> = ({
         )}
       </header>
 
-      {thread ? (
+      {effectiveThread ? (
         <>
           <div
             className="rounded-[1.5rem] border border-slate-200/80 bg-slate-50/80 p-4 dark:border-slate-800 dark:bg-slate-900/80"
@@ -107,17 +150,35 @@ export const FeedDiscussionSection: React.FC<FeedDiscussionSectionProps> = ({
           >
             <div className="flex flex-wrap items-center gap-2">
               <span className="rounded-full bg-slate-900 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-white dark:bg-white dark:text-slate-900">
-                {thread.isHeadline ? 'Headline thread' : 'Forum thread'}
+                {effectiveThread.isHeadline ? 'Headline thread' : 'Forum thread'}
               </span>
             </div>
-            <p className="mt-3 text-lg text-slate-900 dark:text-white">{thread.title}</p>
+            <p className="mt-3 text-lg text-slate-900 dark:text-white">{effectiveThread.title}</p>
             <div className="mt-2 flex flex-wrap items-center gap-2 text-[11px] text-slate-500 dark:text-slate-400">
-              <span>By {thread.author.slice(0, 10)}…</span>
-              <span>{new Date(thread.timestamp).toLocaleString()}</span>
+              <span>By {effectiveThread.author.slice(0, 10)}…</span>
+              <span>{new Date(effectiveThread.timestamp).toLocaleString()}</span>
             </div>
           </div>
 
-          {!loaded && (
+          {loadError && (
+            <div
+              className="space-y-2 rounded-[1.25rem] border border-amber-200 bg-amber-50/80 px-4 py-3 text-sm text-amber-800 dark:border-amber-900/60 dark:bg-amber-950/30 dark:text-amber-100"
+              role="alert"
+              data-testid={`${sectionId}-discussion-load-error`}
+            >
+              <p>Could not load comments: {loadError}</p>
+              <button
+                type="button"
+                className="rounded-full border border-amber-300 bg-white/80 px-3 py-1 text-xs font-semibold uppercase tracking-[0.14em] text-amber-800 transition hover:bg-amber-100 dark:border-amber-800 dark:bg-amber-950/50 dark:text-amber-100"
+                onClick={() => setLoadAttempt((value) => value + 1)}
+                data-testid={`${sectionId}-discussion-retry-load`}
+              >
+                Retry
+              </button>
+            </div>
+          )}
+
+          {!loaded && !loadError && (
             <p className="text-sm text-slate-500 dark:text-slate-400" data-testid={`${sectionId}-discussion-loading`}>
               Loading comments…
             </p>
@@ -134,7 +195,7 @@ export const FeedDiscussionSection: React.FC<FeedDiscussionSectionProps> = ({
 
           {comments.length > 0 && (
             <div className="rounded-[1.5rem] border border-slate-200/80 bg-slate-50/55 p-2 dark:border-slate-800 dark:bg-slate-900/70">
-              <CommentStream threadId={thread.id} comments={comments} />
+              <CommentStream threadId={effectiveThread.id} comments={comments} />
             </div>
           )}
 
@@ -165,7 +226,7 @@ export const FeedDiscussionSection: React.FC<FeedDiscussionSectionProps> = ({
             {showComposer && (
               <TrustGate>
                 <CommentComposer
-                  threadId={thread.id}
+                  threadId={effectiveThread.id}
                   onSubmit={async () => setShowComposer(false)}
                 />
               </TrustGate>
@@ -200,7 +261,11 @@ export const FeedDiscussionSection: React.FC<FeedDiscussionSectionProps> = ({
                 sourceEpoch={createThread.sourceEpoch}
                 sourceUrl={createThread.sourceUrl}
                 topicId={createThread.topicId}
-                onSuccess={() => setShowNewThreadForm(false)}
+                threadId={createThread.threadId}
+                onSuccess={(nextThread) => {
+                  setCreatedThread(nextThread);
+                  setShowNewThreadForm(false);
+                }}
               />
             </TrustGate>
           )}

--- a/apps/web-pwa/src/components/feed/NewsCard.tsx
+++ b/apps/web-pwa/src/components/feed/NewsCard.tsx
@@ -9,7 +9,11 @@ import { NewsCardBack } from './NewsCardBack';
 import { sanitizePublicationNeutralSummary } from './newsCardAnalysis';
 import { useExpandedCardStore } from './expandedCardStore';
 import { useDiscoveryStore } from '../../store/discovery';
-import { getPrimaryStorySource, resolveStoryDiscussionThread } from '../../utils/feedDiscussionThreads';
+import {
+  getPrimaryStorySource,
+  getStoryDiscussionThreadId,
+  resolveStoryDiscussionThread,
+} from '../../utils/feedDiscussionThreads';
 import { getFeedItemDetailId, normalizeStoryId } from '../../utils/feedItemIdentity';
 import { NewsCardFront } from './NewsCardFront';
 import {
@@ -87,6 +91,10 @@ export const NewsCard: React.FC<NewsCardProps> = ({ item }) => {
   const discussionThread = useMemo(
     () => resolveStoryDiscussionThread(forumThreads.values(), item, story),
     [forumThreads, item, story],
+  );
+  const storyDiscussionThreadId = useMemo(
+    () => getStoryDiscussionThreadId(item, story),
+    [item, story],
   );
   const primaryStorySource = useMemo(() => getPrimaryStorySource(story), [story]);
   const singletonVideoSource = useMemo(
@@ -293,6 +301,7 @@ export const NewsCard: React.FC<NewsCardProps> = ({ item }) => {
                       sourceEpoch: synthesisEpoch,
                       sourceUrl: primaryStorySource.url,
                       topicId: item.topic_id,
+                      threadId: storyDiscussionThreadId,
                     }
                   : null
               }

--- a/apps/web-pwa/src/components/feed/NewsCardBack.tsx
+++ b/apps/web-pwa/src/components/feed/NewsCardBack.tsx
@@ -80,6 +80,7 @@ export interface NewsCardBackProps {
     readonly sourceEpoch?: number;
     readonly sourceUrl?: string;
     readonly topicId?: string;
+    readonly threadId?: string;
   } | null;
   readonly onCollapse: () => void;
 }

--- a/apps/web-pwa/src/components/hermes/forum/CommentComposer.test.tsx
+++ b/apps/web-pwa/src/components/hermes/forum/CommentComposer.test.tsx
@@ -67,6 +67,19 @@ describe('CommentComposer', () => {
     expect(onSubmit).toHaveBeenCalled();
   });
 
+  it('surfaces post failures without clearing the reply draft', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    createCommentMock.mockRejectedValueOnce(new Error('Gun client not ready'));
+    render(<CommentComposer threadId="thread-1" parentId="parent-1" />);
+
+    typeIntoComposer('A reply that should remain editable');
+    fireEvent.click(screen.getByTestId('submit-comment-btn'));
+
+    expect(await screen.findByTestId('comment-composer-error')).toHaveTextContent('Gun client not ready');
+    expect(screen.getByTestId('comment-composer')).toHaveValue('A reply that should remain editable');
+    warnSpy.mockRestore();
+  });
+
   // ── Counter display at various lengths ──
 
   describe('character counter', () => {

--- a/apps/web-pwa/src/components/hermes/forum/CommentComposer.tsx
+++ b/apps/web-pwa/src/components/hermes/forum/CommentComposer.tsx
@@ -33,6 +33,7 @@ export const CommentComposer: React.FC<Props> = ({
   const [busy, setBusy] = useState(false);
   const [sliderValue, setSliderValue] = useState(50);
   const [overflowAttempted, setOverflowAttempted] = useState(false);
+  const [postError, setPostError] = useState<string | null>(null);
 
   const enforceLimit = !isThreadCreation;
   const charCount = content.length;
@@ -48,9 +49,11 @@ export const CommentComposer: React.FC<Props> = ({
       if (enforceLimit && raw.length > REPLY_CHAR_LIMIT) {
         setContent(raw.slice(0, REPLY_CHAR_LIMIT));
         setOverflowAttempted(true);
+        setPostError(null);
         return;
       }
       setContent(raw);
+      setPostError(null);
     },
     [enforceLimit],
   );
@@ -71,6 +74,7 @@ export const CommentComposer: React.FC<Props> = ({
         const truncated = before + paste.slice(0, Math.max(0, allowed)) + after;
         setContent(truncated.slice(0, REPLY_CHAR_LIMIT));
         setOverflowAttempted(true);
+        setPostError(null);
       }
     },
     [enforceLimit, content],
@@ -99,6 +103,7 @@ export const CommentComposer: React.FC<Props> = ({
     if (!content.trim() || busy || submitBlocked) return;
 
     setBusy(true);
+    setPostError(null);
     try {
       const stance = sliderToStance(sliderValue);
       await createComment(threadId, content.trim(), stance, parentId);
@@ -108,7 +113,9 @@ export const CommentComposer: React.FC<Props> = ({
       incrementCommentPostCount();
       await onSubmit?.();
     } catch (err) {
+      const message = err instanceof Error ? err.message : 'Comment post failed';
       console.warn('[vh:forum] Comment post failed:', err);
+      setPostError(message);
     } finally {
       setBusy(false);
     }
@@ -195,6 +202,7 @@ export const CommentComposer: React.FC<Props> = ({
         )}
         <div className="flex justify-end">
           <button
+            type="button"
             className="rounded-lg px-6 py-2 text-sm font-semibold text-white shadow-sm transition-all hover:shadow-md hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed"
             style={{ backgroundColor: getButtonColor(sliderValue) }}
             onClick={() => void handlePost()}
@@ -204,6 +212,15 @@ export const CommentComposer: React.FC<Props> = ({
             {busy ? 'Posting…' : 'Post Comment'}
           </button>
         </div>
+        {postError && (
+          <p
+            className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700 dark:border-red-900/60 dark:bg-red-950/30 dark:text-red-200"
+            role="alert"
+            data-testid="comment-composer-error"
+          >
+            {postError}
+          </p>
+        )}
       </div>
     </div>
   );

--- a/apps/web-pwa/src/components/hermes/forum/NewThreadForm.test.tsx
+++ b/apps/web-pwa/src/components/hermes/forum/NewThreadForm.test.tsx
@@ -6,7 +6,19 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import '@testing-library/jest-dom/vitest';
 import { NewThreadForm } from './NewThreadForm';
 
-const createThreadMock = vi.fn(async () => ({ id: 'thread-1' }));
+const createdThread = {
+  id: 'thread-1',
+  schemaVersion: 'hermes-thread-v0',
+  title: 'Thread title',
+  content: 'Thread content',
+  author: 'author-1',
+  timestamp: 1,
+  tags: [],
+  upvotes: 0,
+  downvotes: 0,
+  score: 0,
+};
+const createThreadMock = vi.fn(async () => createdThread);
 
 vi.mock('../../../store/hermesForum', () => ({
   useForumStore: () => ({ createThread: createThreadMock })
@@ -50,6 +62,39 @@ describe('NewThreadForm', () => {
     );
   });
 
+  it('passes story topic and deterministic thread id through headline thread opts', async () => {
+    const onSuccess = vi.fn();
+    render(
+      <NewThreadForm
+        sourceSynthesisId="synth-1"
+        sourceEpoch={4}
+        defaultTitle="Default"
+        sourceUrl="https://example.com/article"
+        topicId="news-1"
+        threadId="news-story:story-1"
+        onSuccess={onSuccess}
+      />,
+    );
+
+    fireEvent.change(screen.getByTestId('thread-content'), { target: { value: 'Thread content' } });
+    fireEvent.click(screen.getByTestId('submit-thread-btn'));
+
+    await waitFor(() => expect(createThreadMock).toHaveBeenCalledTimes(1));
+    expect(createThreadMock).toHaveBeenCalledWith(
+      'Default',
+      'Thread content',
+      [],
+      { sourceSynthesisId: 'synth-1', sourceEpoch: 4 },
+      {
+        sourceUrl: 'https://example.com/article',
+        topicId: 'news-1',
+        threadId: 'news-story:story-1',
+        isHeadline: true,
+      },
+    );
+    expect(onSuccess).toHaveBeenCalledWith(createdThread);
+  });
+
   it('calls createThread with opts undefined when sourceUrl is absent', async () => {
     render(<NewThreadForm sourceSynthesisId="synth-2" />);
 
@@ -84,5 +129,19 @@ describe('NewThreadForm', () => {
       { sourceSynthesisId: 'synth-3', sourceEpoch: undefined },
       undefined,
     );
+  });
+
+  it('surfaces createThread failures without clearing the draft', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    createThreadMock.mockRejectedValueOnce(new Error('Gun client not ready'));
+    render(<NewThreadForm sourceSynthesisId="synth-4" defaultTitle="Draft title" />);
+
+    fireEvent.change(screen.getByTestId('thread-content'), { target: { value: 'Draft content' } });
+    fireEvent.click(screen.getByTestId('submit-thread-btn'));
+
+    expect(await screen.findByTestId('thread-form-error')).toHaveTextContent('Gun client not ready');
+    expect(screen.getByTestId('thread-title')).toHaveValue('Draft title');
+    expect(screen.getByTestId('thread-content')).toHaveValue('Draft content');
+    warnSpy.mockRestore();
   });
 });

--- a/apps/web-pwa/src/components/hermes/forum/NewThreadForm.tsx
+++ b/apps/web-pwa/src/components/hermes/forum/NewThreadForm.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import type { HermesThread } from '@vh/types';
 import { useForumStore } from '../../../store/hermesForum';
 
 interface Props {
@@ -7,7 +8,8 @@ interface Props {
   defaultTitle?: string;
   sourceUrl?: string;
   topicId?: string;
-  onSuccess?: () => void;
+  threadId?: string;
+  onSuccess?: (thread: HermesThread) => void;
 }
 
 export const NewThreadForm: React.FC<Props> = ({
@@ -16,6 +18,7 @@ export const NewThreadForm: React.FC<Props> = ({
   defaultTitle,
   sourceUrl,
   topicId,
+  threadId,
   onSuccess,
 }) => {
   const { createThread } = useForumStore();
@@ -23,16 +26,23 @@ export const NewThreadForm: React.FC<Props> = ({
   const [content, setContent] = useState('');
   const [tags, setTags] = useState('');
   const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const handleSubmit = async () => {
     if (!title.trim() || !content.trim() || busy) return;
     setBusy(true);
+    setError(null);
     try {
       const parsedTags = tags.split(',').map((t) => t.trim()).filter(Boolean);
-      const opts = sourceUrl || topicId
-        ? { ...(sourceUrl ? { sourceUrl } : {}), ...(topicId ? { topicId } : {}), isHeadline: true as const }
+      const opts = sourceUrl || topicId || threadId
+        ? {
+            ...(sourceUrl ? { sourceUrl } : {}),
+            ...(topicId ? { topicId } : {}),
+            ...(threadId ? { threadId } : {}),
+            isHeadline: true as const,
+          }
         : undefined;
-      await createThread(
+      const thread = await createThread(
         title.trim(),
         content.trim(),
         parsedTags,
@@ -42,7 +52,11 @@ export const NewThreadForm: React.FC<Props> = ({
       setTitle('');
       setContent('');
       setTags('');
-      onSuccess?.();
+      onSuccess?.(thread);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Thread creation failed';
+      console.warn('[vh:forum] Thread creation failed:', err);
+      setError(message);
     } finally {
       setBusy(false);
     }
@@ -79,6 +93,7 @@ export const NewThreadForm: React.FC<Props> = ({
           onChange={(e) => setTags(e.target.value)}
         />
         <button
+          type="button"
           className="rounded-lg px-4 py-2 text-sm font-medium shadow-sm transition hover:shadow-md disabled:opacity-50"
           style={{ backgroundColor: 'var(--btn-primary-bg)', color: 'var(--btn-primary-text)' }}
           onClick={() => void handleSubmit()}
@@ -87,6 +102,15 @@ export const NewThreadForm: React.FC<Props> = ({
         >
           {busy ? 'Posting…' : 'Post thread'}
         </button>
+        {error && (
+          <p
+            className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700 dark:border-red-900/60 dark:bg-red-950/30 dark:text-red-200"
+            role="alert"
+            data-testid="thread-form-error"
+          >
+            {error}
+          </p>
+        )}
       </div>
     </div>
   );

--- a/apps/web-pwa/src/store/forum/index.ts
+++ b/apps/web-pwa/src/store/forum/index.ts
@@ -55,7 +55,7 @@ export function createForumStore(overrides?: Partial<ForumDeps>) {
         throw new Error(`Budget denied: ${budgetCheck.reason}`);
       }
       const client = ensureClient(deps.resolveClient);
-      const threadId = deps.randomId();
+      const threadId = opts?.threadId?.trim() || deps.randomId();
       const threadData: Record<string, unknown> = {
         id: threadId,
         schemaVersion: 'hermes-thread-v0',

--- a/apps/web-pwa/src/store/forum/types.ts
+++ b/apps/web-pwa/src/store/forum/types.ts
@@ -26,7 +26,7 @@ export interface ForumState {
     content: string,
     tags: string[],
     sourceContext?: ThreadSourceContextInput,
-    opts?: { sourceUrl?: string; isHeadline?: boolean; topicId?: string }
+    opts?: { sourceUrl?: string; isHeadline?: boolean; topicId?: string; threadId?: string }
   ): Promise<HermesThread>;
   createComment(
     threadId: string,

--- a/apps/web-pwa/src/store/hermesForum.test.ts
+++ b/apps/web-pwa/src/store/hermesForum.test.ts
@@ -189,6 +189,28 @@ describe('hermesForum store', () => {
     expect(thread.topicId).toBe('story-topic-1');
   });
 
+  it('createThread uses an explicit threadId for deterministic story discussion threads', async () => {
+    setIdentity('story-thread-id');
+    const store = createForumStore({ resolveClient: () => ({} as any), randomId: () => 'random-thread', now: () => 1 });
+
+    const thread = await store
+      .getState()
+      .createThread('title', 'content', ['news'], undefined, {
+        threadId: 'news-story:story-1',
+        topicId: 'story-topic-1',
+        isHeadline: true,
+      });
+
+    expect(thread.id).toBe('news-story:story-1');
+    expect(thread.topicId).toBe('story-topic-1');
+    expect(thread.isHeadline).toBe(true);
+    expect(threadWrites[0]).toMatchObject({
+      id: 'news-story:story-1',
+      topicId: 'story-topic-1',
+      isHeadline: true,
+    });
+  });
+
   it('createThread writes synthesis source context and not legacy analysis context', async () => {
     setIdentity('synthesis-thread');
     const store = createForumStore({ resolveClient: () => ({} as any), randomId: () => 'thread-synth', now: () => 1 });

--- a/apps/web-pwa/src/utils/feedDiscussionThreads.test.ts
+++ b/apps/web-pwa/src/utils/feedDiscussionThreads.test.ts
@@ -3,6 +3,7 @@ import type { FeedItem, StoryBundle } from '@vh/data-model';
 import type { HermesThread } from '@vh/types';
 import {
   getPrimaryStorySource,
+  getStoryDiscussionThreadId,
   resolveStoryDiscussionThread,
   resolveTopicThread,
 } from './feedDiscussionThreads';
@@ -96,6 +97,9 @@ describe('feed discussion thread resolution', () => {
     const item = makeFeedItem();
     const story = makeStory();
 
+    expect(resolveStoryDiscussionThread([
+      makeThread({ id: 'news-story:story-1', topicId: 'renamed-topic' }),
+    ], item, story)?.id).toBe('news-story:story-1');
     expect(resolveStoryDiscussionThread([makeThread({ id: 'by-topic', topicId: 'topic-1' })], item, story)?.id)
       .toBe('by-topic');
     expect(resolveStoryDiscussionThread([makeThread({ id: 'by-synthesis', sourceSynthesisId: 'story-1' })], item, story)?.id)
@@ -136,6 +140,16 @@ describe('feed discussion thread resolution', () => {
     expect(resolveStoryDiscussionThread([
       makeThread({ id: 'feed-story', sourceAnalysisId: 'fallback-story' }),
     ], item, null)?.id).toBe('feed-story');
+  });
+
+  it('derives a deterministic story discussion thread id from story identity', () => {
+    expect(getStoryDiscussionThreadId(makeFeedItem(), makeStory())).toBe('news-story:story-1');
+    expect(getStoryDiscussionThreadId(makeFeedItem({ story_id: 'feed story/id' }), null)).toBe(
+      'news-story:feed%20story%2Fid',
+    );
+    expect(getStoryDiscussionThreadId(makeFeedItem({ story_id: undefined, topic_id: 'topic/fallback' }), null)).toBe(
+      'news-story:topic%2Ffallback',
+    );
   });
 
   it('returns the primary source projection when story provenance exists', () => {

--- a/apps/web-pwa/src/utils/feedDiscussionThreads.test.ts
+++ b/apps/web-pwa/src/utils/feedDiscussionThreads.test.ts
@@ -150,6 +150,16 @@ describe('feed discussion thread resolution', () => {
     expect(getStoryDiscussionThreadId(makeFeedItem({ story_id: undefined, topic_id: 'topic/fallback' }), null)).toBe(
       'news-story:topic%2Ffallback',
     );
+    expect(getStoryDiscussionThreadId(makeFeedItem({
+      story_id: undefined,
+      topic_id: '   ',
+      title: 'Title fallback',
+    }), null)).toBe('news-story:Title%20fallback');
+    expect(getStoryDiscussionThreadId(makeFeedItem({
+      story_id: undefined,
+      topic_id: '   ',
+      title: '   ',
+    }), null)).toBe('news-story:unknown');
   });
 
   it('returns the primary source projection when story provenance exists', () => {

--- a/apps/web-pwa/src/utils/feedDiscussionThreads.test.ts
+++ b/apps/web-pwa/src/utils/feedDiscussionThreads.test.ts
@@ -116,6 +116,28 @@ describe('feed discussion thread resolution', () => {
       .toBe('by-url');
   });
 
+  it('prefers the deterministic story thread over legacy story and topic matches', () => {
+    const item = makeFeedItem();
+    const story = makeStory();
+    const exact = makeThread({ id: 'news-story:story-1', timestamp: 1 });
+    const newerTopicMatch = makeThread({
+      id: 'newer-topic-match',
+      topicId: 'topic-1',
+      isHeadline: true,
+      timestamp: 10_000,
+    });
+    const newerSourceMatch = makeThread({
+      id: 'newer-source-match',
+      sourceSynthesisId: 'story-1',
+      isHeadline: true,
+      timestamp: 20_000,
+    });
+
+    expect(resolveStoryDiscussionThread([newerTopicMatch, newerSourceMatch, exact], item, story)?.id).toBe(
+      'news-story:story-1',
+    );
+  });
+
   it('falls back to feed story id and ignores invalid source urls that do not match', () => {
     const item = makeFeedItem({ topic_id: 'other-topic', story_id: 'fallback-story' });
     const story = makeStory({

--- a/apps/web-pwa/src/utils/feedDiscussionThreads.ts
+++ b/apps/web-pwa/src/utils/feedDiscussionThreads.ts
@@ -62,6 +62,7 @@ export function resolveStoryDiscussionThread(
 ): HermesThread | null {
   const topicId = normalizeToken(item.topic_id);
   const storyId = normalizeToken(story?.story_id) ?? normalizeStoryId(item.story_id);
+  const expectedThreadId = getStoryDiscussionThreadId(item, story);
   const sourceUrlSet = new Set(
     (story?.sources ?? [])
       .map((source) => normalizeUrl(source.url))
@@ -75,6 +76,7 @@ export function resolveStoryDiscussionThread(
 
   return pickThread(
     Array.from(threads).filter((thread) => {
+      const threadId = normalizeToken(thread.id);
       const threadTopicId = normalizeToken(thread.topicId);
       const threadSourceSynthesisId = normalizeToken(thread.sourceSynthesisId);
       const threadSourceAnalysisId = normalizeToken(thread.sourceAnalysisId);
@@ -82,6 +84,7 @@ export function resolveStoryDiscussionThread(
       const threadSourceUrl = normalizeUrl(thread.sourceUrl);
 
       return (
+        (threadId !== null && threadId === expectedThreadId) ||
         (topicId !== null && threadTopicId === topicId) ||
         (storyId !== null && threadSourceSynthesisId === storyId) ||
         (storyId !== null && threadSourceAnalysisId === storyId) ||
@@ -92,6 +95,15 @@ export function resolveStoryDiscussionThread(
       );
     }),
   );
+}
+
+export function getStoryDiscussionThreadId(
+  item: FeedItem,
+  story: StoryBundle | null,
+): string {
+  const storyId = normalizeToken(story?.story_id) ?? normalizeStoryId(item.story_id);
+  const stableToken = storyId ?? normalizeToken(item.topic_id) ?? normalizeToken(item.title) ?? 'unknown';
+  return `news-story:${encodeURIComponent(stableToken)}`;
 }
 
 export function getPrimaryStorySource(story: StoryBundle | null): {

--- a/apps/web-pwa/src/utils/feedDiscussionThreads.ts
+++ b/apps/web-pwa/src/utils/feedDiscussionThreads.ts
@@ -74,9 +74,16 @@ export function resolveStoryDiscussionThread(
       .filter((hash): hash is string => hash !== null),
   );
 
+  const candidateThreads = Array.from(threads);
+  const exactThreadMatches = candidateThreads.filter(
+    (thread) => normalizeToken(thread.id) === expectedThreadId,
+  );
+  if (exactThreadMatches.length > 0) {
+    return pickThread(exactThreadMatches);
+  }
+
   return pickThread(
-    Array.from(threads).filter((thread) => {
-      const threadId = normalizeToken(thread.id);
+    candidateThreads.filter((thread) => {
       const threadTopicId = normalizeToken(thread.topicId);
       const threadSourceSynthesisId = normalizeToken(thread.sourceSynthesisId);
       const threadSourceAnalysisId = normalizeToken(thread.sourceAnalysisId);
@@ -84,7 +91,6 @@ export function resolveStoryDiscussionThread(
       const threadSourceUrl = normalizeUrl(thread.sourceUrl);
 
       return (
-        (threadId !== null && threadId === expectedThreadId) ||
         (topicId !== null && threadTopicId === topicId) ||
         (storyId !== null && threadSourceSynthesisId === storyId) ||
         (storyId !== null && threadSourceAnalysisId === storyId) ||

--- a/docs/specs/spec-hermes-forum-v0.md
+++ b/docs/specs/spec-hermes-forum-v0.md
@@ -70,11 +70,13 @@ Back-compat notes:
 - Threads without proposal remain valid.
 - Read path accepts `sourceAnalysisId`; write path emits `sourceSynthesisId`.
 - Missing `sourceEpoch` is valid for legacy records.
+- News story detail may pass an explicit deterministic `threadId` when creating a headline thread. This is limited to story-linked forum threads and does not change native forum thread id generation.
 
 ### 2.2 Topic linkage rules
 
 - One topic can have many threads; each thread has exactly one `topicId`.
 - For externally sourced stories, `topicId` may be derived from clustered story identity.
+- Story-linked headline threads keep `topicId` on the feed topic, link back to accepted synthesis with `sourceSynthesisId` + `sourceEpoch` when available, and may use a deterministic `news-story:<encoded story-or-topic token>` id so detail cards and `/hermes/$threadId` open the same conversation.
 - For native user threads, derive deterministic topic IDs using a prefix + thread ID.
 
 ```ts

--- a/docs/specs/spec-topic-discovery-ranking-v0.md
+++ b/docs/specs/spec-topic-discovery-ranking-v0.md
@@ -207,7 +207,9 @@ Required card affordances:
 
 Stance controls on `NEWS_STORY` detail are enabled only for accepted synthesis frame/reframe cells that carry persisted `frame_point_id` / `reframe_point_id` values. Missing point ids must produce a non-votable cell rather than deriving a canonical write id from mutable display text.
 
-News-created forum threads must link with `sourceSynthesisId` + `sourceEpoch` when available and preserve the feed `topic_id` as the thread `topicId`. Legacy `sourceAnalysisId` is read-only compatibility.
+News-created forum threads must link with `sourceSynthesisId` + `sourceEpoch` when available and preserve the feed `topic_id` as the thread `topicId`. Story detail must create deterministic headline-thread ids from accepted story/feed identity (`news-story:<encoded story-or-topic token>`) so the same story reopens the same conversation. Legacy `sourceAnalysisId` is read-only compatibility.
+
+The forum block below the frame/reframe table is the canonical story conversation surface for the MVP. It must render from the linked Hermes thread, expose comment-load and post-write failures as recoverable UI states, and must not trigger or reinterpret synthesis, summary, or stance semantics.
 
 Continuous stream behavior:
 


### PR DESCRIPTION
## Summary
- add deterministic story-linked headline thread ids for news story detail discussions
- render newly-created story threads immediately and expose recoverable comment-load/thread-create/comment-post failures
- document the story-detail forum contract without changing accepted synthesis or stance semantics

## Verification
- pnpm exec vitest run apps/web-pwa/src/components/feed/FeedDiscussionSection.test.tsx apps/web-pwa/src/components/feed/NewsCard.test.tsx apps/web-pwa/src/components/feed/NewsCard.storyline.test.tsx apps/web-pwa/src/utils/feedDiscussionThreads.test.ts apps/web-pwa/src/components/hermes/forum/NewThreadForm.test.tsx apps/web-pwa/src/components/hermes/forum/CommentComposer.test.tsx apps/web-pwa/src/store/hermesForum.test.ts apps/web-pwa/src/store/hermesForum.commentsAndHydration.test.ts --reporter=verbose
- pnpm --filter @vh/web-pwa typecheck
- pnpm deps:check
- pnpm --filter @vh/web-pwa build
- node tools/scripts/check-diff-coverage.mjs
- git diff --check
- pnpm lint