### PR TITLE
Add accepted synthesis correction gate

### DIFF
--- a/apps/web-pwa/src/components/feed/MvpNewsLoop.release.test.tsx
+++ b/apps/web-pwa/src/components/feed/MvpNewsLoop.release.test.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { FeedItem, StoryBundle, TopicSynthesisV2 } from '@vh/data-model';
+import type { FeedItem, StoryBundle, TopicSynthesisCorrection, TopicSynthesisV2 } from '@vh/data-model';
 import type { HermesComment, HermesThread } from '@vh/types';
 import { DEFAULT_RANKING_CONFIG } from '@vh/data-model';
 import { useNewsStore } from '../../store/news';
@@ -221,6 +221,26 @@ function makeSynthesis(overrides: Partial<TopicSynthesisV2> = {}): TopicSynthesi
   };
 }
 
+function makeCorrection(overrides: Partial<TopicSynthesisCorrection> = {}): TopicSynthesisCorrection {
+  return {
+    schemaVersion: 'topic-synthesis-correction-v1',
+    correction_id: 'correction-mvp-1',
+    topic_id: 'news-1',
+    synthesis_id: 'syn-accepted-mvp',
+    epoch: 2,
+    status: 'suppressed',
+    reason_code: 'inaccurate_summary',
+    reason: 'Operator verified this accepted synthesis should not be shown.',
+    operator_id: 'release-ops',
+    created_at: NOW + 2,
+    audit: {
+      action: 'synthesis_correction',
+      notes: 'MVP release gate correction fixture.',
+    },
+    ...overrides,
+  };
+}
+
 function makeThread(overrides: Partial<HermesThread> = {}): HermesThread {
   return {
     id: 'news-story:story-news-1',
@@ -339,6 +359,26 @@ describe('MVP Web PWA news loop release gates', () => {
     expect(screen.getByTestId('news-card-synthesis-provenance-news-1')).toHaveTextContent('syn-accepted-mvp');
     expect(screen.getByTestId('bias-table')).toHaveTextContent('Public investment is overdue');
     expect(screen.getByTestId('news-card-stance-scope-news-1')).toHaveTextContent('not to the story as a whole');
+    expect(analysisPipelineState.synthesizeStoryFromAnalysisPipeline).not.toHaveBeenCalled();
+  });
+
+  it('mvp gate: synthesis correction hides bad accepted analysis with audit provenance', async () => {
+    const item = seedAcceptedStory();
+    useSynthesisStore.getState().setTopicCorrection(item.topic_id, makeCorrection());
+
+    render(<NewsCard item={item} />);
+
+    fireEvent.click(screen.getByTestId('news-card-headline-news-1'));
+
+    expect(await screen.findByTestId('news-card-detail-news-1')).toBeInTheDocument();
+    expect(screen.getByTestId('news-card-summary-basis-news-1')).toHaveTextContent('Operator correction');
+    expect(screen.getByTestId('news-card-summary-news-1')).toHaveTextContent('suppressed by an operator');
+    expect(screen.getByTestId('news-card-synthesis-correction-news-1')).toHaveTextContent('correction-mvp-1');
+    expect(screen.getByTestId('news-card-synthesis-correction-news-1')).toHaveTextContent('release-ops');
+    expect(screen.getByTestId('news-card-synthesis-correction-state-news-1')).toHaveTextContent('not shown');
+    expect(screen.queryByTestId('news-card-synthesis-provenance-news-1')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('bias-table')).not.toBeInTheDocument();
+    expect(screen.queryByText('Public investment is overdue')).not.toBeInTheDocument();
     expect(analysisPipelineState.synthesizeStoryFromAnalysisPipeline).not.toHaveBeenCalled();
   });
 

--- a/apps/web-pwa/src/components/feed/NewsCard.test.tsx
+++ b/apps/web-pwa/src/components/feed/NewsCard.test.tsx
@@ -2,7 +2,7 @@
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { FeedItem, StoryBundle, TopicSynthesisV2 } from '@vh/data-model';
+import type { FeedItem, StoryBundle, TopicSynthesisCorrection, TopicSynthesisV2 } from '@vh/data-model';
 import type { HermesThread } from '@vh/types';
 import { useNewsStore } from '../../store/news';
 import { useSynthesisStore } from '../../store/synthesis';
@@ -122,6 +122,26 @@ function makeSynthesis(overrides: Partial<TopicSynthesisV2> = {}): TopicSynthesi
       provider_mix: [{ provider_id: 'remote-analysis', count: 3 }],
     },
     created_at: NOW,
+    ...overrides,
+  };
+}
+
+function makeCorrection(overrides: Partial<TopicSynthesisCorrection> = {}): TopicSynthesisCorrection {
+  return {
+    schemaVersion: 'topic-synthesis-correction-v1',
+    correction_id: 'correction-1',
+    topic_id: 'news-1',
+    synthesis_id: 'syn-1',
+    epoch: 2,
+    status: 'suppressed',
+    reason_code: 'inaccurate_summary',
+    reason: 'Operator verified the accepted synthesis should not be displayed.',
+    operator_id: 'ops-user-1',
+    created_at: NOW + 1,
+    audit: {
+      action: 'synthesis_correction',
+      notes: 'component test fixture',
+    },
     ...overrides,
   };
 }
@@ -366,6 +386,63 @@ describe('NewsCard', () => {
     expect(screen.getByTestId('news-card-headline-news-1')).toBeInTheDocument();
     expect(mockSynthesizeStoryFromAnalysisPipeline).not.toHaveBeenCalled();
   });
+
+  it('renders suppressed synthesis as corrected and hides stale summary, provenance, and frame rows', async () => {
+    useNewsStore.getState().setStories([makeStoryBundle()]);
+    useSynthesisStore.getState().setTopicSynthesis('news-1', makeSynthesis());
+    useSynthesisStore.getState().setTopicCorrection('news-1', makeCorrection());
+
+    render(<NewsCard item={makeNewsItem()} />);
+    fireEvent.click(screen.getByTestId('news-card-headline-news-1'));
+
+    expect(await screen.findByTestId('news-card-summary-basis-news-1')).toHaveTextContent('Operator correction');
+    expect(screen.getByTestId('news-card-summary-news-1')).toHaveTextContent('suppressed by an operator');
+    expect(screen.getByTestId('news-card-synthesis-correction-news-1')).toHaveTextContent('correction-1');
+    expect(screen.getByTestId('news-card-synthesis-correction-news-1')).toHaveTextContent('ops-user-1');
+    expect(screen.getByTestId('news-card-synthesis-correction-state-news-1')).toHaveTextContent('not shown');
+    expect(screen.queryByTestId('news-card-synthesis-provenance-news-1')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('bias-table')).not.toBeInTheDocument();
+    expect(screen.queryByText('Council approved a phased transit expansion plan.')).not.toBeInTheDocument();
+    expect(screen.queryByText('Public investment is overdue')).not.toBeInTheDocument();
+  });
+
+  it('renders operator unavailable state without treating stale accepted synthesis as valid', async () => {
+    useNewsStore.getState().setStories([makeStoryBundle()]);
+    useSynthesisStore.getState().setTopicSynthesis('news-1', makeSynthesis());
+    useSynthesisStore.getState().setTopicCorrection(
+      'news-1',
+      makeCorrection({
+        status: 'unavailable',
+        reason_code: 'operator_override',
+        reason: 'Operator pulled the artifact pending regeneration.',
+      }),
+    );
+
+    render(<NewsCard item={makeNewsItem()} />);
+    fireEvent.click(screen.getByTestId('news-card-headline-news-1'));
+
+    expect(await screen.findByTestId('news-card-summary-news-1')).toHaveTextContent('marked unavailable by an operator');
+    expect(screen.getByTestId('news-card-synthesis-correction-state-news-1')).toHaveTextContent(
+      'marked unavailable by an operator',
+    );
+    expect(screen.queryByTestId('bias-table')).not.toBeInTheDocument();
+  });
+
+  it('ignores stale corrections when a newer accepted synthesis is current', async () => {
+    useNewsStore.getState().setStories([makeStoryBundle()]);
+    useSynthesisStore.getState().setTopicSynthesis('news-1', makeSynthesis({ synthesis_id: 'syn-2', epoch: 3 }));
+    useSynthesisStore.getState().setTopicCorrection('news-1', makeCorrection());
+
+    render(<NewsCard item={makeNewsItem()} />);
+    fireEvent.click(screen.getByTestId('news-card-headline-news-1'));
+
+    expect(await screen.findByTestId('news-card-summary-news-1')).toHaveTextContent(
+      'Council approved a phased transit expansion plan.',
+    );
+    expect(screen.queryByTestId('news-card-synthesis-correction-news-1')).not.toBeInTheDocument();
+    expect(screen.getByTestId('bias-table')).toHaveTextContent('Public investment is overdue');
+  });
+
   it('renders accepted synthesis warnings as provenance callouts', async () => {
     vi.stubEnv('VITE_VH_ANALYSIS_PIPELINE', 'true');
     useNewsStore.getState().setStories([makeStoryBundle()]);

--- a/apps/web-pwa/src/components/feed/NewsCard.tsx
+++ b/apps/web-pwa/src/components/feed/NewsCard.tsx
@@ -106,36 +106,53 @@ export const NewsCard: React.FC<NewsCardProps> = ({ item }) => {
     [story],
   );
   const synthesis = synthesisTopicState?.synthesis ?? null;
+  const synthesisCorrection = synthesisTopicState?.correction ?? null;
   const synthesisLoading = synthesisTopicState?.loading ?? false;
   const synthesisError = synthesisTopicState?.error ?? null;
+  const correctionBlocksSynthesis = Boolean(
+    synthesisCorrection
+      && (!synthesis
+        || (
+          synthesisCorrection.synthesis_id === synthesis.synthesis_id
+          && synthesisCorrection.epoch === synthesis.epoch
+          && synthesisCorrection.topic_id === synthesis.topic_id
+        ))
+  );
+  const effectiveSynthesis = correctionBlocksSynthesis ? null : synthesis;
   const latestActivity = formatIsoTimestamp(item.latest_activity_at);
   const createdAt = formatIsoTimestamp(item.created_at);
   const storyId = normalizeStoryId(item.story_id) ?? story?.story_id ?? null;
-  const synthesisId = synthesis?.synthesis_id ?? null;
-  const synthesisEpoch = synthesis?.epoch;
-  const synthesisProvenance = synthesis
+  const synthesisId = effectiveSynthesis?.synthesis_id ?? null;
+  const synthesisEpoch = effectiveSynthesis?.epoch;
+  const synthesisProvenance = effectiveSynthesis
     ? {
-        generatedAt: formatIsoTimestamp(synthesis.created_at),
-        synthesisId: synthesis.synthesis_id,
-        epoch: synthesis.epoch,
-        candidateIds: synthesis.provenance.candidate_ids,
-        providerMix: synthesis.provenance.provider_mix,
-        warnings: synthesis.warnings,
+        generatedAt: formatIsoTimestamp(effectiveSynthesis.created_at),
+        synthesisId: effectiveSynthesis.synthesis_id,
+        epoch: effectiveSynthesis.epoch,
+        candidateIds: effectiveSynthesis.provenance.candidate_ids,
+        providerMix: effectiveSynthesis.provenance.provider_mix,
+        warnings: effectiveSynthesis.warnings,
       }
     : null;
-  const synthesisSummary = synthesis?.facts_summary?.trim() ?? '';
+  const synthesisSummary = effectiveSynthesis?.facts_summary?.trim() ?? '';
   const hasSynthesisSummary = synthesisSummary.length > 0;
   const rawSummary =
-    synthesisSummary ||
-    story?.summary_hint?.trim() ||
-    'Analysis pending publish-time synthesis.';
+    correctionBlocksSynthesis
+      ? synthesisCorrection?.status === 'suppressed'
+        ? 'Accepted synthesis was suppressed by an operator.'
+        : 'Accepted synthesis was marked unavailable by an operator.'
+      : synthesisSummary ||
+        story?.summary_hint?.trim() ||
+        'Analysis pending publish-time synthesis.';
   const summary = sanitizePublicationNeutralSummary(
     rawSummary,
     (story?.sources ?? []).flatMap((source) => [source.source_id, source.publisher]),
   );
-  const synthesisFrameRows = synthesis?.frames ?? [];
+  const synthesisFrameRows = effectiveSynthesis?.frames ?? [];
   const frameRows = synthesisFrameRows;
-  const summaryBasisLabel = hasSynthesisSummary
+  const summaryBasisLabel = correctionBlocksSynthesis
+    ? 'Operator correction'
+    : hasSynthesisSummary
     ? 'Topic synthesis v2'
     : synthesisLoading
       ? 'Publish-time synthesis loading'
@@ -145,7 +162,7 @@ export const NewsCard: React.FC<NewsCardProps> = ({ item }) => {
   const frameBasisLabel = synthesisFrameRows.length > 0
     ? 'Topic synthesis frames'
     : undefined;
-  const synthesisUnavailable = !synthesisLoading && !synthesis && !synthesisError;
+  const synthesisUnavailable = !synthesisLoading && !effectiveSynthesis && !synthesisError && !correctionBlocksSynthesis;
   const relatedLinks = useMemo(
     () => mergeRelatedLinks(story, null),
     [story],
@@ -285,6 +302,7 @@ export const NewsCard: React.FC<NewsCardProps> = ({ item }) => {
               synthesisLoading={synthesisLoading}
               synthesisError={synthesisError}
               synthesisUnavailable={synthesisUnavailable}
+              synthesisCorrection={correctionBlocksSynthesis ? synthesisCorrection : null}
               analysis={null}
               analysisId={null}
               synthesisId={synthesisId}

--- a/apps/web-pwa/src/components/feed/NewsCardBack.tsx
+++ b/apps/web-pwa/src/components/feed/NewsCardBack.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import type { TopicSynthesisCorrection } from '@vh/data-model';
 import type { HermesThread } from '@vh/types';
 import type { NewsCardAnalysisSynthesis } from './newsCardAnalysis';
 import { AnalysisLoadingState } from './AnalysisLoadingState';
@@ -62,6 +63,7 @@ export interface NewsCardBackProps {
   readonly synthesisLoading: boolean;
   readonly synthesisError: string | null;
   readonly synthesisUnavailable?: boolean;
+  readonly synthesisCorrection?: TopicSynthesisCorrection | null;
   readonly analysis: NewsCardAnalysisSynthesis | null;
   readonly analysisId?: string | null;
   readonly synthesisId?: string | null;
@@ -109,6 +111,7 @@ export const NewsCardBack: React.FC<NewsCardBackProps> = ({
   synthesisLoading,
   synthesisError,
   synthesisUnavailable = false,
+  synthesisCorrection = null,
   analysis,
   analysisId,
   synthesisId,
@@ -123,6 +126,11 @@ export const NewsCardBack: React.FC<NewsCardBackProps> = ({
   const hasAcceptedStanceTargets = frameRows.some(
     (row) => Boolean(row.frame_point_id?.trim() || row.reframe_point_id?.trim()),
   );
+  const correctionBlocksSynthesis = Boolean(synthesisCorrection);
+  const correctionTimestamp = synthesisCorrection ? new Date(synthesisCorrection.created_at).toISOString() : null;
+  const correctionStateLabel = synthesisCorrection?.status === 'suppressed'
+    ? 'Accepted synthesis suppressed'
+    : 'Accepted synthesis unavailable';
 
   return (
     <div data-testid={`news-card-back-${topicId}`} className="space-y-5">
@@ -190,6 +198,22 @@ export const NewsCardBack: React.FC<NewsCardBackProps> = ({
               {synthesisProvenance.warnings.map((warning) => (
                 <p key={warning}>{warning}</p>
               ))}
+            </div>
+          )}
+          {synthesisCorrection && (
+            <div
+              className="space-y-1 rounded-lg border border-rose-200/80 bg-rose-50/80 px-3 py-2 text-xs leading-5 text-rose-800 dark:border-rose-900/70 dark:bg-rose-950/30 dark:text-rose-100"
+              data-testid={`news-card-synthesis-correction-${topicId}`}
+            >
+              <p className="font-semibold">{correctionStateLabel}</p>
+              <p>
+                Reason {synthesisCorrection.reason_code}
+                {synthesisCorrection.reason ? `: ${synthesisCorrection.reason}` : ''}
+              </p>
+              <p>
+                Operator {synthesisCorrection.operator_id} · {correctionTimestamp}
+              </p>
+              <p className="break-all">Correction {synthesisCorrection.correction_id}</p>
             </div>
           )}
           <p className="text-sm leading-7 text-slate-700 dark:text-slate-200" data-testid={`news-card-summary-${topicId}`}>
@@ -324,7 +348,7 @@ export const NewsCardBack: React.FC<NewsCardBackProps> = ({
         <h4 className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
           Frame / Reframe
         </h4>
-        {hasAcceptedStanceTargets && synthesisId && epoch !== undefined && (
+        {hasAcceptedStanceTargets && synthesisId && epoch !== undefined && !correctionBlocksSynthesis && (
           <p
             className="text-xs leading-5 text-slate-500 dark:text-slate-400"
             data-testid={`news-card-stance-scope-${topicId}`}
@@ -353,7 +377,7 @@ export const NewsCardBack: React.FC<NewsCardBackProps> = ({
             Synthesis unavailable.
           </p>
         )}
-        {synthesisUnavailable && !analysis && (
+        {synthesisUnavailable && !analysis && !correctionBlocksSynthesis && (
           <p
             className="mt-2 text-xs text-amber-700"
             data-testid={`news-card-synthesis-unavailable-${topicId}`}
@@ -361,7 +385,17 @@ export const NewsCardBack: React.FC<NewsCardBackProps> = ({
             Publish-time synthesis has not been published for this story yet.
           </p>
         )}
-        {analysisNeedsRegeneration && !synthesisLoading && (
+        {synthesisCorrection && (
+          <p
+            className="mt-2 text-xs text-rose-700 dark:text-rose-100"
+            data-testid={`news-card-synthesis-correction-state-${topicId}`}
+          >
+            {synthesisCorrection.status === 'suppressed'
+              ? 'Accepted synthesis was suppressed by an operator and is not shown.'
+              : 'Accepted synthesis was marked unavailable by an operator and is not shown.'}
+          </p>
+        )}
+        {analysisNeedsRegeneration && !synthesisLoading && !correctionBlocksSynthesis && (
           <p
             className="mt-2 text-xs text-amber-700"
             data-testid={`news-card-analysis-regeneration-${topicId}`}
@@ -369,21 +403,23 @@ export const NewsCardBack: React.FC<NewsCardBackProps> = ({
             Analysis needs regeneration to produce frame/reframe rows.
           </p>
         )}
-        <div className="mt-2">
-          <BiasTable
-            analyses={analysis?.analyses ?? []}
-            frames={frameRows}
-            providerLabel={analysisProvider ?? undefined}
-            basisLabel={frameBasisLabel}
-            loading={synthesisLoading && frameRows.length === 0}
-            topicId={topicId}
-            analysisId={analysisId ?? undefined}
-            synthesisId={synthesisId ?? undefined}
-            epoch={epoch}
-            votingEnabled={Boolean(synthesisId && epoch !== undefined && hasAcceptedStanceTargets)}
-            votingPointIdMode="accepted-synthesis"
-          />
-        </div>
+        {!correctionBlocksSynthesis && (
+          <div className="mt-2">
+            <BiasTable
+              analyses={analysis?.analyses ?? []}
+              frames={frameRows}
+              providerLabel={analysisProvider ?? undefined}
+              basisLabel={frameBasisLabel}
+              loading={synthesisLoading && frameRows.length === 0}
+              topicId={topicId}
+              analysisId={analysisId ?? undefined}
+              synthesisId={synthesisId ?? undefined}
+              epoch={epoch}
+              votingEnabled={Boolean(synthesisId && epoch !== undefined && hasAcceptedStanceTargets)}
+              votingPointIdMode="accepted-synthesis"
+            />
+          </div>
+        )}
       </section>
       <FeedDiscussionSection
         sectionId={`news-card-${topicId}`}

--- a/apps/web-pwa/src/components/feed/TopicCard.test.tsx
+++ b/apps/web-pwa/src/components/feed/TopicCard.test.tsx
@@ -87,6 +87,8 @@ function makeSynthesisResult(overrides: Partial<UseSynthesisResult> = {}): UseSy
     topicId: 'topic-42',
     epoch: null,
     synthesis: null,
+    correction: null,
+    effectiveStatus: 'synthesis_unavailable',
     hydrated: false,
     loading: false,
     error: null,

--- a/apps/web-pwa/src/hooks/useSynthesis.ts
+++ b/apps/web-pwa/src/hooks/useSynthesis.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect } from 'react';
 import { useStore } from 'zustand';
-import type { TopicSynthesisV2 } from '@vh/data-model';
+import type { TopicSynthesisCorrection, TopicSynthesisV2 } from '@vh/data-model';
 import { useSynthesisStore, type SynthesisState, type SynthesisTopicState } from '../store/synthesis';
 
 export interface UseSynthesisResult {
@@ -15,6 +15,12 @@ export interface UseSynthesisResult {
 
   /** Latest synthesis payload for the topic. */
   readonly synthesis: TopicSynthesisV2 | null;
+
+  /** Latest operator correction for the accepted synthesis artifact. */
+  readonly correction: TopicSynthesisCorrection | null;
+
+  /** Effective detail status after applying correction state. */
+  readonly effectiveStatus: SynthesisTopicState['effectiveStatus'];
 
   /** Whether live hydration has been attached for the topic. */
   readonly hydrated: boolean;
@@ -33,6 +39,8 @@ const EMPTY_TOPIC_STATE: SynthesisTopicState = {
   topicId: '',
   epoch: null,
   synthesis: null,
+  correction: null,
+  effectiveStatus: 'synthesis_unavailable',
   hydrated: false,
   loading: false,
   error: null
@@ -73,6 +81,8 @@ export function useSynthesis(topicId?: string | null): UseSynthesisResult {
     topicId: normalizedTopicId || null,
     epoch: topicState.epoch,
     synthesis: topicState.synthesis,
+    correction: topicState.correction,
+    effectiveStatus: topicState.effectiveStatus,
     hydrated: topicState.hydrated,
     loading: topicState.loading,
     error: topicState.error,

--- a/apps/web-pwa/src/store/synthesis/hydration.test.ts
+++ b/apps/web-pwa/src/store/synthesis/hydration.test.ts
@@ -1,14 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { TopicSynthesisV2 } from '@vh/data-model';
+import type { TopicSynthesisCorrection, TopicSynthesisV2 } from '@vh/data-model';
 import type { SynthesisState } from './types';
 
 const gunMocks = vi.hoisted(() => ({
   getTopicLatestSynthesisChain: vi.fn(),
+  getTopicLatestSynthesisCorrectionChain: vi.fn(),
   hasForbiddenSynthesisPayloadFields: vi.fn<(payload: unknown) => boolean>()
 }));
 
 vi.mock('@vh/gun-client', () => ({
   getTopicLatestSynthesisChain: gunMocks.getTopicLatestSynthesisChain,
+  getTopicLatestSynthesisCorrectionChain: gunMocks.getTopicLatestSynthesisCorrectionChain,
   hasForbiddenSynthesisPayloadFields: gunMocks.hasForbiddenSynthesisPayloadFields
 }));
 
@@ -58,6 +60,24 @@ function synthesis(overrides: Partial<TopicSynthesisV2> = {}): TopicSynthesisV2 
   };
 }
 
+function correction(overrides: Partial<TopicSynthesisCorrection> = {}): TopicSynthesisCorrection {
+  return {
+    schemaVersion: 'topic-synthesis-correction-v1',
+    correction_id: 'correction-1',
+    topic_id: 'topic-1',
+    synthesis_id: 'synth-3',
+    epoch: 3,
+    status: 'suppressed',
+    reason_code: 'inaccurate_summary',
+    operator_id: 'ops-user-1',
+    created_at: 300,
+    audit: {
+      action: 'synthesis_correction'
+    },
+    ...overrides
+  };
+}
+
 interface SubscribableChain {
   chain: { on: ReturnType<typeof vi.fn> };
   emit: (data: unknown) => void;
@@ -85,6 +105,7 @@ function createStore() {
     topics: {},
     getTopicState: vi.fn(),
     setTopicSynthesis: vi.fn(),
+    setTopicCorrection: vi.fn(),
     setTopicHydrated: vi.fn(),
     setTopicLoading: vi.fn(),
     setTopicError: vi.fn(),
@@ -103,7 +124,9 @@ function createStore() {
 describe('hydrateSynthesisStore', () => {
   beforeEach(() => {
     gunMocks.getTopicLatestSynthesisChain.mockReset();
+    gunMocks.getTopicLatestSynthesisCorrectionChain.mockReset();
     gunMocks.hasForbiddenSynthesisPayloadFields.mockReset();
+    gunMocks.getTopicLatestSynthesisCorrectionChain.mockReturnValue({ on: undefined });
     gunMocks.hasForbiddenSynthesisPayloadFields.mockReturnValue(false);
     vi.resetModules();
   });
@@ -124,6 +147,7 @@ describe('hydrateSynthesisStore', () => {
 
   it('returns false when subscription is unsupported', async () => {
     gunMocks.getTopicLatestSynthesisChain.mockReturnValue({ on: undefined });
+    gunMocks.getTopicLatestSynthesisCorrectionChain.mockReturnValue({ on: undefined });
 
     const { hydrateSynthesisStore } = await import('./hydration');
     const { store } = createStore();
@@ -134,6 +158,7 @@ describe('hydrateSynthesisStore', () => {
   it('attaches once per store/topic pair', async () => {
     const chain = createSubscribableChain();
     gunMocks.getTopicLatestSynthesisChain.mockReturnValue(chain.chain);
+    gunMocks.getTopicLatestSynthesisCorrectionChain.mockReturnValue({ on: undefined });
 
     const { hydrateSynthesisStore } = await import('./hydration');
     const { store } = createStore();
@@ -151,6 +176,7 @@ describe('hydrateSynthesisStore', () => {
     gunMocks.getTopicLatestSynthesisChain
       .mockReturnValueOnce(chainA.chain)
       .mockReturnValueOnce(chainB.chain);
+    gunMocks.getTopicLatestSynthesisCorrectionChain.mockReturnValue({ on: undefined });
 
     const { hydrateSynthesisStore } = await import('./hydration');
     const { store } = createStore();
@@ -165,6 +191,7 @@ describe('hydrateSynthesisStore', () => {
   it('hydrates valid synthesis payloads', async () => {
     const chain = createSubscribableChain();
     gunMocks.getTopicLatestSynthesisChain.mockReturnValue(chain.chain);
+    gunMocks.getTopicLatestSynthesisCorrectionChain.mockReturnValue({ on: undefined });
 
     const { hydrateSynthesisStore } = await import('./hydration');
     const { store, state } = createStore();
@@ -178,9 +205,53 @@ describe('hydrateSynthesisStore', () => {
     expect(state.setTopicError).toHaveBeenCalledWith('topic-1', null);
   });
 
+  it('hydrates valid synthesis correction payloads', async () => {
+    const synthesisChain = { on: undefined };
+    const correctionChain = createSubscribableChain();
+    gunMocks.getTopicLatestSynthesisChain.mockReturnValue(synthesisChain);
+    gunMocks.getTopicLatestSynthesisCorrectionChain.mockReturnValue(correctionChain.chain);
+
+    const { hydrateSynthesisStore } = await import('./hydration');
+    const { store, state } = createStore();
+
+    hydrateSynthesisStore(() => ({}) as never, store, 'topic-1');
+
+    correctionChain.emit({ _: { '#': 'meta' }, ...correction() });
+
+    expect(state.setTopicCorrection).toHaveBeenCalledWith(
+      'topic-1',
+      expect.objectContaining({ correction_id: 'correction-1' })
+    );
+    expect(state.setTopicHydrated).toHaveBeenCalledWith('topic-1', true);
+    expect(state.setTopicError).toHaveBeenCalledWith('topic-1', null);
+  });
+
+  it('ignores forbidden, invalid, and cross-topic correction payloads', async () => {
+    const correctionChain = createSubscribableChain();
+    gunMocks.getTopicLatestSynthesisChain.mockReturnValue({ on: undefined });
+    gunMocks.getTopicLatestSynthesisCorrectionChain.mockReturnValue(correctionChain.chain);
+    gunMocks.hasForbiddenSynthesisPayloadFields.mockImplementation((payload: unknown) => {
+      return typeof payload === 'object' && payload !== null && 'token' in payload;
+    });
+
+    const { hydrateSynthesisStore } = await import('./hydration');
+    const { store, state } = createStore();
+
+    hydrateSynthesisStore(() => ({}) as never, store, 'topic-1');
+
+    correctionChain.emit({ ...correction(), token: 'forbidden' });
+    correctionChain.emit({ invalid: true });
+    correctionChain.emit(correction({ topic_id: 'topic-2' }));
+
+    expect(state.setTopicCorrection).not.toHaveBeenCalled();
+    expect(state.setTopicHydrated).not.toHaveBeenCalled();
+    expect(state.setTopicError).not.toHaveBeenCalled();
+  });
+
   it('ignores invalid and forbidden payloads', async () => {
     const chain = createSubscribableChain();
     gunMocks.getTopicLatestSynthesisChain.mockReturnValue(chain.chain);
+    gunMocks.getTopicLatestSynthesisCorrectionChain.mockReturnValue({ on: undefined });
     gunMocks.hasForbiddenSynthesisPayloadFields.mockImplementation((payload: unknown) => {
       return typeof payload === 'object' && payload !== null && 'token' in payload;
     });
@@ -195,6 +266,7 @@ describe('hydrateSynthesisStore', () => {
     chain.emit({ ...synthesis(), token: 'forbidden' });
 
     expect(state.setTopicSynthesis).not.toHaveBeenCalled();
+    expect(state.setTopicCorrection).not.toHaveBeenCalled();
     expect(state.setTopicHydrated).not.toHaveBeenCalled();
     expect(state.setTopicError).not.toHaveBeenCalled();
   });

--- a/apps/web-pwa/src/store/synthesis/hydration.ts
+++ b/apps/web-pwa/src/store/synthesis/hydration.ts
@@ -1,6 +1,12 @@
-import { TopicSynthesisV2Schema, type TopicSynthesisV2 } from '@vh/data-model';
+import {
+  TopicSynthesisCorrectionSchema,
+  TopicSynthesisV2Schema,
+  type TopicSynthesisCorrection,
+  type TopicSynthesisV2,
+} from '@vh/data-model';
 import {
   getTopicLatestSynthesisChain,
+  getTopicLatestSynthesisCorrectionChain,
   hasForbiddenSynthesisPayloadFields,
   type ChainWithGet,
   type VennClient
@@ -30,6 +36,16 @@ function parseSynthesis(data: unknown): TopicSynthesisV2 | null {
   }
 
   const parsed = TopicSynthesisV2Schema.safeParse(payload);
+  return parsed.success ? parsed.data : null;
+}
+
+function parseCorrection(data: unknown): TopicSynthesisCorrection | null {
+  const payload = stripGunMetadata(data);
+  if (hasForbiddenSynthesisPayloadFields(payload)) {
+    return null;
+  }
+
+  const parsed = TopicSynthesisCorrectionSchema.safeParse(payload);
   return parsed.success ? parsed.data : null;
 }
 
@@ -68,22 +84,38 @@ export function hydrateSynthesisStore(
   }
 
   const latestChain = getTopicLatestSynthesisChain(client, normalizedTopicId);
-  if (!canSubscribe(latestChain)) {
+  const correctionChain = getTopicLatestSynthesisCorrectionChain(client, normalizedTopicId);
+  if (!canSubscribe(latestChain) && !canSubscribe(correctionChain)) {
     return false;
   }
 
   hydratedTopics.add(normalizedTopicId);
 
-  latestChain.on!((data: unknown) => {
-    const synthesis = parseSynthesis(data);
-    if (!synthesis) {
-      return;
-    }
+  if (canSubscribe(latestChain)) {
+    latestChain.on!((data: unknown) => {
+      const synthesis = parseSynthesis(data);
+      if (!synthesis) {
+        return;
+      }
 
-    store.getState().setTopicSynthesis(normalizedTopicId, synthesis);
-    store.getState().setTopicHydrated(normalizedTopicId, true);
-    store.getState().setTopicError(normalizedTopicId, null);
-  });
+      store.getState().setTopicSynthesis(normalizedTopicId, synthesis);
+      store.getState().setTopicHydrated(normalizedTopicId, true);
+      store.getState().setTopicError(normalizedTopicId, null);
+    });
+  }
+
+  if (canSubscribe(correctionChain)) {
+    correctionChain.on!((data: unknown) => {
+      const correction = parseCorrection(data);
+      if (!correction || correction.topic_id !== normalizedTopicId) {
+        return;
+      }
+
+      store.getState().setTopicCorrection(normalizedTopicId, correction);
+      store.getState().setTopicHydrated(normalizedTopicId, true);
+      store.getState().setTopicError(normalizedTopicId, null);
+    });
+  }
 
   return true;
 }

--- a/apps/web-pwa/src/store/synthesis/index.test.ts
+++ b/apps/web-pwa/src/store/synthesis/index.test.ts
@@ -1,9 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { TopicSynthesisV2 } from '@vh/data-model';
+import type { TopicSynthesisCorrection, TopicSynthesisV2 } from '@vh/data-model';
 
 const hydrateSynthesisStoreMock = vi.fn<(...args: unknown[]) => boolean>();
 const hasForbiddenSynthesisPayloadFieldsMock = vi.fn<(payload: unknown) => boolean>();
 const readTopicLatestSynthesisMock = vi.fn<(client: unknown, topicId: string) => Promise<TopicSynthesisV2 | null>>();
+const readTopicLatestSynthesisCorrectionMock = vi.fn<
+  (client: unknown, topicId: string) => Promise<TopicSynthesisCorrection | null>
+>();
 
 vi.mock('./hydration', () => ({
   hydrateSynthesisStore: hydrateSynthesisStoreMock
@@ -11,6 +14,7 @@ vi.mock('./hydration', () => ({
 
 vi.mock('@vh/gun-client', () => ({
   hasForbiddenSynthesisPayloadFields: hasForbiddenSynthesisPayloadFieldsMock,
+  readTopicLatestSynthesisCorrection: readTopicLatestSynthesisCorrectionMock,
   readTopicLatestSynthesis: readTopicLatestSynthesisMock
 }));
 
@@ -61,15 +65,37 @@ function synthesis(overrides: Partial<TopicSynthesisV2> = {}): TopicSynthesisV2 
   };
 }
 
+function correction(overrides: Partial<TopicSynthesisCorrection> = {}): TopicSynthesisCorrection {
+  return {
+    schemaVersion: 'topic-synthesis-correction-v1',
+    correction_id: 'correction-1',
+    topic_id: 'topic-1',
+    synthesis_id: 'synth-1',
+    epoch: 1,
+    status: 'suppressed',
+    reason_code: 'inaccurate_summary',
+    reason: 'Summary overstates the source material.',
+    operator_id: 'ops-user-1',
+    created_at: 300,
+    audit: {
+      action: 'synthesis_correction',
+      notes: 'fixture correction',
+    },
+    ...overrides
+  };
+}
+
 describe('synthesis store', () => {
   beforeEach(() => {
     hydrateSynthesisStoreMock.mockReset();
     hasForbiddenSynthesisPayloadFieldsMock.mockReset();
     readTopicLatestSynthesisMock.mockReset();
+    readTopicLatestSynthesisCorrectionMock.mockReset();
 
     hydrateSynthesisStoreMock.mockReturnValue(false);
     hasForbiddenSynthesisPayloadFieldsMock.mockReturnValue(false);
     readTopicLatestSynthesisMock.mockResolvedValue(null);
+    readTopicLatestSynthesisCorrectionMock.mockResolvedValue(null);
 
     vi.resetModules();
   });
@@ -90,6 +116,8 @@ describe('synthesis store', () => {
       topicId: 'topic-1',
       epoch: null,
       synthesis: null,
+      correction: null,
+      effectiveStatus: 'synthesis_unavailable',
       hydrated: false,
       loading: false,
       error: null
@@ -99,6 +127,8 @@ describe('synthesis store', () => {
       topicId: '',
       epoch: null,
       synthesis: null,
+      correction: null,
+      effectiveStatus: 'synthesis_unavailable',
       hydrated: false,
       loading: false,
       error: null
@@ -115,12 +145,75 @@ describe('synthesis store', () => {
     const first = store.getState().getTopicState('topic-1');
     expect(first.epoch).toBe(1);
     expect(first.synthesis?.synthesis_id).toBe('synth-1');
+    expect(first.effectiveStatus).toBe('accepted_available');
     expect(first.error).toBeNull();
 
     store.getState().setTopicSynthesis('topic-1', null);
     const cleared = store.getState().getTopicState('topic-1');
     expect(cleared.epoch).toBeNull();
     expect(cleared.synthesis).toBeNull();
+    expect(cleared.effectiveStatus).toBe('synthesis_unavailable');
+  });
+
+  it('setTopicCorrection validates payloads and suppresses matching accepted synthesis', async () => {
+    const { createSynthesisStore } = await import('./index');
+    const store = createSynthesisStore({ enabled: true, resolveClient: () => null });
+
+    store.getState().setTopicSynthesis('topic-1', synthesis());
+    store.getState().setTopicCorrection('topic-1', correction());
+
+    const suppressed = store.getState().getTopicState('topic-1');
+    expect(suppressed.correction?.correction_id).toBe('correction-1');
+    expect(suppressed.effectiveStatus).toBe('synthesis_suppressed');
+
+    store.getState().setTopicSynthesis('topic-1', synthesis({ synthesis_id: 'synth-2', epoch: 2 }));
+    expect(store.getState().getTopicState('topic-1').effectiveStatus).toBe('accepted_available');
+
+    store.getState().setTopicCorrection('topic-1', null);
+    expect(store.getState().getTopicState('topic-1').correction).toBeNull();
+  });
+
+  it('setTopicCorrection can mark a topic unavailable before latest synthesis is hydrated', async () => {
+    const { createSynthesisStore } = await import('./index');
+    const store = createSynthesisStore({ enabled: true, resolveClient: () => null });
+
+    store.getState().setTopicCorrection('topic-1', correction({ status: 'unavailable' }));
+
+    const topic = store.getState().getTopicState('topic-1');
+    expect(topic.synthesis).toBeNull();
+    expect(topic.correction?.status).toBe('unavailable');
+    expect(topic.effectiveStatus).toBe('synthesis_unavailable');
+  });
+
+  it('setTopicCorrection clears correction state and restores accepted synthesis availability', async () => {
+    const { createSynthesisStore } = await import('./index');
+    const store = createSynthesisStore({ enabled: true, resolveClient: () => null });
+
+    store.getState().setTopicSynthesis('topic-1', synthesis());
+    store.getState().setTopicCorrection('topic-1', correction());
+    expect(store.getState().getTopicState('topic-1').effectiveStatus).toBe('synthesis_suppressed');
+
+    store.getState().setTopicCorrection('topic-1', null);
+
+    const topic = store.getState().getTopicState('topic-1');
+    expect(topic.correction).toBeNull();
+    expect(topic.effectiveStatus).toBe('accepted_available');
+  });
+
+  it('setTopicCorrection ignores invalid, forbidden, and cross-topic correction payloads', async () => {
+    hasForbiddenSynthesisPayloadFieldsMock.mockImplementation((payload: unknown) => {
+      return typeof payload === 'object' && payload !== null && 'token' in payload;
+    });
+
+    const { createSynthesisStore } = await import('./index');
+    const store = createSynthesisStore({ enabled: true, resolveClient: () => null });
+
+    store.getState().setTopicCorrection('topic-1', { ...correction(), token: 'bad' } as TopicSynthesisCorrection);
+    store.getState().setTopicCorrection('topic-1', { invalid: true } as unknown as TopicSynthesisCorrection);
+    store.getState().setTopicCorrection('topic-1', correction({ topic_id: 'topic-2' }));
+    store.getState().setTopicCorrection('   ', correction());
+
+    expect(store.getState().topics).toEqual({});
   });
 
   it('setTopicSynthesis ignores forbidden/invalid payloads and invalid topic ids', async () => {
@@ -154,6 +247,8 @@ describe('synthesis store', () => {
         topicId: 'topic-1',
         epoch: null,
         synthesis: null,
+        correction: null,
+        effectiveStatus: 'synthesis_unavailable',
         hydrated: true,
         loading: true,
         error: 'oops'
@@ -192,6 +287,7 @@ describe('synthesis store', () => {
     await enabled.getState().refreshTopic('   ');
 
     expect(readTopicLatestSynthesisMock).not.toHaveBeenCalled();
+    expect(readTopicLatestSynthesisCorrectionMock).not.toHaveBeenCalled();
   });
 
   it('refreshTopic clears loading when no client is available', async () => {
@@ -203,6 +299,7 @@ describe('synthesis store', () => {
     expect(store.getState().getTopicState('topic-1').loading).toBe(false);
     expect(store.getState().getTopicState('topic-1').error).toBeNull();
     expect(readTopicLatestSynthesisMock).not.toHaveBeenCalled();
+    expect(readTopicLatestSynthesisCorrectionMock).not.toHaveBeenCalled();
   });
 
   it('refreshTopic hydrates + loads latest synthesis', async () => {
@@ -220,6 +317,7 @@ describe('synthesis store', () => {
 
     expect(hydrateSynthesisStoreMock).toHaveBeenCalled();
     expect(readTopicLatestSynthesisMock).toHaveBeenCalledWith(client, 'topic-x');
+    expect(readTopicLatestSynthesisCorrectionMock).toHaveBeenCalledWith(client, 'topic-x');
 
     const state = store.getState().getTopicState('topic-x');
     expect(state.hydrated).toBe(true);
@@ -227,6 +325,21 @@ describe('synthesis store', () => {
     expect(state.error).toBeNull();
     expect(state.epoch).toBe(8);
     expect(state.synthesis?.synthesis_id).toBe('synth-8');
+    expect(state.effectiveStatus).toBe('accepted_available');
+  });
+
+  it('refreshTopic hydrates correction state and exposes effective unavailable/suppressed state', async () => {
+    readTopicLatestSynthesisMock.mockResolvedValue(synthesis());
+    readTopicLatestSynthesisCorrectionMock.mockResolvedValue(correction({ status: 'unavailable' }));
+
+    const { createSynthesisStore } = await import('./index');
+    const store = createSynthesisStore({ enabled: true, resolveClient: () => ({}) as never });
+
+    await store.getState().refreshTopic('topic-1');
+
+    const topic = store.getState().getTopicState('topic-1');
+    expect(topic.correction?.status).toBe('unavailable');
+    expect(topic.effectiveStatus).toBe('synthesis_unavailable');
   });
 
   it('refreshTopic handles null latest (no synthesis available)', async () => {
@@ -240,6 +353,7 @@ describe('synthesis store', () => {
     const topic = store.getState().getTopicState('topic-1');
     expect(topic.synthesis).toBeNull();
     expect(topic.epoch).toBeNull();
+    expect(topic.effectiveStatus).toBe('synthesis_unavailable');
     expect(topic.loading).toBe(false);
     expect(topic.error).toBeNull();
   });

--- a/apps/web-pwa/src/store/synthesis/index.ts
+++ b/apps/web-pwa/src/store/synthesis/index.ts
@@ -1,7 +1,13 @@
 import { create, type StoreApi } from 'zustand';
-import { TopicSynthesisV2Schema, type TopicSynthesisV2 } from '@vh/data-model';
+import {
+  TopicSynthesisCorrectionSchema,
+  TopicSynthesisV2Schema,
+  type TopicSynthesisCorrection,
+  type TopicSynthesisV2,
+} from '@vh/data-model';
 import {
   hasForbiddenSynthesisPayloadFields,
+  readTopicLatestSynthesisCorrection,
   readTopicLatestSynthesis,
   type VennClient
 } from '@vh/gun-client';
@@ -18,6 +24,7 @@ type InternalDeps = SynthesisDeps & {
     topicId: string
   ) => boolean;
   readLatest: (client: VennClient, topicId: string) => Promise<TopicSynthesisV2 | null>;
+  readLatestCorrection: (client: VennClient, topicId: string) => Promise<TopicSynthesisCorrection | null>;
 };
 
 const INITIAL_STATE: Pick<SynthesisState, 'topics'> = {
@@ -29,6 +36,8 @@ function createEmptyTopicState(topicId: string): SynthesisTopicState {
     topicId,
     epoch: null,
     synthesis: null,
+    correction: null,
+    effectiveStatus: 'synthesis_unavailable',
     hydrated: false,
     loading: false,
     error: null
@@ -49,6 +58,37 @@ function parseSynthesis(value: unknown): TopicSynthesisV2 | null {
   return parsed.success ? parsed.data : null;
 }
 
+function parseCorrection(value: unknown): TopicSynthesisCorrection | null {
+  if (hasForbiddenSynthesisPayloadFields(value)) {
+    return null;
+  }
+
+  const parsed = TopicSynthesisCorrectionSchema.safeParse(value);
+  return parsed.success ? parsed.data : null;
+}
+
+function correctionApplies(
+  synthesis: TopicSynthesisV2 | null,
+  correction: TopicSynthesisCorrection
+): boolean {
+  if (!synthesis) {
+    return true;
+  }
+  return correction.topic_id === synthesis.topic_id
+    && correction.synthesis_id === synthesis.synthesis_id
+    && correction.epoch === synthesis.epoch;
+}
+
+function resolveEffectiveStatus(
+  synthesis: TopicSynthesisV2 | null,
+  correction: TopicSynthesisCorrection | null
+): SynthesisTopicState['effectiveStatus'] {
+  if (correction && correctionApplies(synthesis, correction)) {
+    return correction.status === 'suppressed' ? 'synthesis_suppressed' : 'synthesis_unavailable';
+  }
+  return synthesis ? 'accepted_available' : 'synthesis_unavailable';
+}
+
 function upsertTopicState(
   topics: Readonly<Record<string, SynthesisTopicState>>,
   topicId: string,
@@ -67,7 +107,8 @@ export function createSynthesisStore(overrides?: Partial<InternalDeps>): StoreAp
     resolveClient: resolveClientFromAppStore,
     enabled: true,
     hydrateTopic: hydrateSynthesisStore,
-    readLatest: readTopicLatestSynthesis
+    readLatest: readTopicLatestSynthesis,
+    readLatestCorrection: readTopicLatestSynthesisCorrection
   };
 
   const deps: InternalDeps = {
@@ -105,6 +146,28 @@ export function createSynthesisStore(overrides?: Partial<InternalDeps>): StoreAp
           ...current,
           synthesis: validated,
           epoch: validated?.epoch ?? null,
+          effectiveStatus: resolveEffectiveStatus(validated, current.correction),
+          error: null
+        }))
+      }));
+    },
+
+    setTopicCorrection(topicId: string, correction: TopicSynthesisCorrection | null) {
+      const normalizedTopicId = normalizeTopicId(topicId);
+      if (!normalizedTopicId) {
+        return;
+      }
+
+      const validated = correction === null ? null : parseCorrection(correction);
+      if (correction !== null && (!validated || validated.topic_id !== normalizedTopicId)) {
+        return;
+      }
+
+      set((state) => ({
+        topics: upsertTopicState(state.topics, normalizedTopicId, (current) => ({
+          ...current,
+          correction: validated,
+          effectiveStatus: resolveEffectiveStatus(current.synthesis, validated),
           error: null
         }))
       }));
@@ -170,14 +233,23 @@ export function createSynthesisStore(overrides?: Partial<InternalDeps>): StoreAp
       get().setTopicError(normalizedTopicId, null);
 
       try {
-        const latest = await deps.readLatest(client, normalizedTopicId);
+        const [latest, latestCorrection] = await Promise.all([
+          deps.readLatest(client, normalizedTopicId),
+          deps.readLatestCorrection(client, normalizedTopicId)
+        ]);
         const validatedLatest = latest === null ? null : parseSynthesis(latest);
+        const validatedCorrection = latestCorrection === null ? null : parseCorrection(latestCorrection);
 
         set((state) => ({
           topics: upsertTopicState(state.topics, normalizedTopicId, (current) => ({
             ...current,
             synthesis: validatedLatest,
             epoch: validatedLatest?.epoch ?? null,
+            correction: validatedCorrection?.topic_id === normalizedTopicId ? validatedCorrection : null,
+            effectiveStatus: resolveEffectiveStatus(
+              validatedLatest,
+              validatedCorrection?.topic_id === normalizedTopicId ? validatedCorrection : null
+            ),
             loading: false,
             error: null
           }))
@@ -223,7 +295,8 @@ export function createMockSynthesisStore(seedSynthesis: TopicSynthesisV2[] = [])
     resolveClient: () => null,
     enabled: true,
     hydrateTopic: () => false,
-    readLatest: async () => null
+    readLatest: async () => null,
+    readLatestCorrection: async () => null
   });
 
   for (const synthesis of seedSynthesis) {

--- a/apps/web-pwa/src/store/synthesis/types.ts
+++ b/apps/web-pwa/src/store/synthesis/types.ts
@@ -1,4 +1,9 @@
-import type { TopicSynthesisV2 } from '@vh/data-model';
+import type { TopicSynthesisCorrection, TopicSynthesisV2 } from '@vh/data-model';
+
+export type SynthesisEffectiveStatus =
+  | 'accepted_available'
+  | 'synthesis_unavailable'
+  | 'synthesis_suppressed';
 
 export interface SynthesisTopicState {
   /** Topic identifier scoped to this entry. */
@@ -9,6 +14,12 @@ export interface SynthesisTopicState {
 
   /** Latest synthesis payload for the topic. */
   readonly synthesis: TopicSynthesisV2 | null;
+
+  /** Latest operator correction that applies to an accepted synthesis artifact. */
+  readonly correction: TopicSynthesisCorrection | null;
+
+  /** Effective story-detail state after applying correction records. */
+  readonly effectiveStatus: SynthesisEffectiveStatus;
 
   /** Whether live hydration has been attached for this topic. */
   readonly hydrated: boolean;
@@ -29,6 +40,7 @@ export interface SynthesisState {
 
   getTopicState(topicId: string): SynthesisTopicState;
   setTopicSynthesis(topicId: string, synthesis: TopicSynthesisV2 | null): void;
+  setTopicCorrection(topicId: string, correction: TopicSynthesisCorrection | null): void;
   setTopicHydrated(topicId: string, hydrated: boolean): void;
   setTopicLoading(topicId: string, loading: boolean): void;
   setTopicError(topicId: string, error: string | null): void;

--- a/docs/plans/VENN_NEWS_MVP_ROADMAP_2026-04-20.md
+++ b/docs/plans/VENN_NEWS_MVP_ROADMAP_2026-04-20.md
@@ -403,7 +403,7 @@ Recommended sequencing:
 | Release gates | Go for the core Web PWA news loop. | `pnpm check:mvp-release-gates` passes and writes `.tmp/mvp-release-gates/latest/mvp-release-gates-report.json`. | Do not claim release-readiness from source health or story correctness alone; the MVP gate report is the required loop evidence. |
 | Compliance | No-go for public beta. | Privacy, terms, UGC/moderation, support, data deletion, telemetry consent, and content/copyright minimums have accepted drafts. | No public beta or App Store/TestFlight submission. Internal-only testing can continue. |
 | Launch content fallback | No-go. | A curated validated snapshot exists with enough stories to exercise singleton, bundle, preferences, frames, stance, related links, and threads. | Live ingestion instability can block demos and QA; do not depend on the live feed as the only launch data path. |
-| Correction/admin path | No-go. | Operators can suppress bad analysis, mark analysis unavailable, hide abusive thread content, and preserve an audit trail. | Public launch is unsafe; a single bad summary or abusive thread has no controlled remediation path. |
+| Correction/admin path | Partial; accepted synthesis correction path implemented in `coord/synthesis-correction-path`. | Operators can suppress or mark an accepted `TopicSynthesisV2` unavailable with typed audit metadata; story detail hides stale summary/frame rows and `pnpm check:mvp-release-gates` includes a deterministic `synthesis_correction` smoke. Abusive thread moderation remains open. | Public launch still needs thread moderation and compliance artifacts; do not claim this row fully green until abusive thread content can be hidden with an audit trail. |
 | Ops/cost visibility | Partial. | Model ids, model invocation counts, source health artifacts, release report path, and bad-analysis reports are visible. | Remote-model spend and product failures remain opaque; do not scale beyond a small internal beta. |
 
 ### W0.1 Persisted point ids
@@ -656,6 +656,7 @@ Acceptance checks:
 | Source health | `pnpm check:news-sources:health` exists | Required from a reliable runner. |
 | Feed smoke | `pnpm check:mvp-release-gates` includes `feed_render` | Fixture-backed Web PWA smoke proves feed render plus preference ranking/filtering. |
 | Story-detail smoke | `pnpm check:mvp-release-gates` includes `story_detail` | Fixture-backed smoke opens headline detail from accepted `TopicSynthesisV2`. |
+| Synthesis correction smoke | `pnpm check:mvp-release-gates` includes `synthesis_correction` | Fixture-backed smoke proves a corrected accepted synthesis does not render stale summary/frame rows and exposes audit provenance. |
 | Point-stance persistence/convergence smoke | `pnpm check:mvp-release-gates` includes `point_stance` | Story detail smoke writes/restores final stance against accepted synthesis point ids. |
 | Thread persistence smoke | `pnpm check:mvp-release-gates` includes `story_thread` | Deterministic `news-story:*` thread id, reply persistence, and reload attachment are covered. |
 | iOS build | Missing because no iOS shell | Only required if Week 0 chooses iOS. |
@@ -669,8 +670,11 @@ The MVP's value rests on accurate summaries and frame/reframe items. The release
 
 - users can report inaccurate analysis;
 - operators can suppress or regenerate a bad analysis artifact;
-- story detail can show corrected/updated provenance;
+- accepted `TopicSynthesisV2` artifacts now have a typed correction record for `suppressed` or `unavailable` state, with operator id, reason code, timestamp, and audit metadata;
+- story detail hides corrected accepted synthesis summaries/frame rows and shows the correction provenance instead;
 - launch copy does not imply editorial omniscience.
+
+Still required: report intake/regeneration workflow polish and audited abusive-thread moderation.
 
 ### Cost and model budget
 

--- a/packages/data-model/package.json
+++ b/packages/data-model/package.json
@@ -4,11 +4,11 @@
   "private": true,
   "type": "module",
   "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "types": "src/index.ts",
   "exports": {
     ".": {
-      "import": "./dist/index.js",
-      "types": "./src/index.ts"
+      "types": "./src/index.ts",
+      "import": "./dist/index.js"
     }
   },
   "scripts": {

--- a/packages/data-model/src/schemas/hermes/synthesis.test.ts
+++ b/packages/data-model/src/schemas/hermes/synthesis.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import {
   CandidateSynthesisSchema,
+  TopicDigestInputSchema,
+  TopicSynthesisCorrectionSchema,
   TopicSynthesisV2Schema,
   StoryBundleInputSchema,
-  TopicDigestInputSchema,
   TopicSeedInputSchema,
   ResynthesisThresholdsSchema,
   SynthesisDefaultsSchema,
@@ -463,6 +464,69 @@ describe('TopicSynthesisV2Schema', () => {
 
     const withOauthToken = { ...validSynthesis, oauth_token: 'tok' };
     expect(TopicSynthesisV2Schema.safeParse(withOauthToken).success).toBe(false);
+  });
+});
+
+// ── TopicSynthesisCorrectionSchema ─────────────────────────────────
+
+describe('TopicSynthesisCorrectionSchema', () => {
+  const validCorrection = {
+    schemaVersion: 'topic-synthesis-correction-v1' as const,
+    correction_id: 'correction-1',
+    topic_id: 'topic-1',
+    synthesis_id: 'synth-1',
+    epoch: 2,
+    status: 'suppressed' as const,
+    reason_code: 'inaccurate_summary' as const,
+    reason: 'Operator verified the summary overstated the vote outcome.',
+    operator_id: 'ops-user-1',
+    created_at: 1700000000000,
+    audit: {
+      action: 'synthesis_correction' as const,
+      notes: 'Suppressed before public beta handoff.',
+    },
+  };
+
+  it('accepts valid correction records with audit metadata', () => {
+    const parsed = TopicSynthesisCorrectionSchema.safeParse(validCorrection);
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.audit.action).toBe('synthesis_correction');
+      expect(parsed.data.operator_id).toBe('ops-user-1');
+    }
+  });
+
+  it('accepts unavailable correction records and supersession audit links', () => {
+    expect(
+      TopicSynthesisCorrectionSchema.safeParse({
+        ...validCorrection,
+        status: 'unavailable',
+        reason_code: 'operator_override',
+        audit: {
+          action: 'synthesis_correction',
+          supersedes_correction_id: 'correction-0',
+        },
+      }).success,
+    ).toBe(true);
+  });
+
+  it('rejects malformed correction payloads', () => {
+    expect(TopicSynthesisCorrectionSchema.safeParse({ ...validCorrection, correction_id: '   ' }).success).toBe(false);
+    expect(TopicSynthesisCorrectionSchema.safeParse({ ...validCorrection, synthesis_id: '' }).success).toBe(false);
+    expect(TopicSynthesisCorrectionSchema.safeParse({ ...validCorrection, epoch: -1 }).success).toBe(false);
+    expect(TopicSynthesisCorrectionSchema.safeParse({ ...validCorrection, status: 'hidden' }).success).toBe(false);
+    expect(TopicSynthesisCorrectionSchema.safeParse({ ...validCorrection, reason_code: 'misc' }).success).toBe(false);
+    expect(TopicSynthesisCorrectionSchema.safeParse({ ...validCorrection, operator_id: '' }).success).toBe(false);
+    expect(TopicSynthesisCorrectionSchema.safeParse({ ...validCorrection, audit: { action: 'other' } }).success).toBe(false);
+  });
+
+  it('is strict so correction records cannot smuggle unrelated fields', () => {
+    expect(
+      TopicSynthesisCorrectionSchema.safeParse({
+        ...validCorrection,
+        wallet: '0x123',
+      }).success,
+    ).toBe(false);
   });
 });
 

--- a/packages/data-model/src/schemas/hermes/synthesis.ts
+++ b/packages/data-model/src/schemas/hermes/synthesis.ts
@@ -5,6 +5,13 @@ import { z } from 'zod';
 const TopicId = z.string().min(1);
 const PointId = z.string().trim().min(1);
 const PositiveTimestamp = z.number().int().nonnegative();
+const CorrectionReasonCode = z.enum([
+  'inaccurate_summary',
+  'bad_frame',
+  'source_attribution_error',
+  'policy_violation',
+  'operator_override',
+]);
 
 const FrameSchema = z.object({
   frame_point_id: PointId.optional(),
@@ -127,6 +134,30 @@ export const TopicSynthesisV2Schema = z
   })
   .strict();
 
+// ── Accepted synthesis correction state ────────────────────────────
+
+export const TopicSynthesisCorrectionSchema = z
+  .object({
+    schemaVersion: z.literal('topic-synthesis-correction-v1'),
+    correction_id: z.string().trim().min(1),
+    topic_id: TopicId,
+    synthesis_id: z.string().trim().min(1),
+    epoch: z.number().int().nonnegative(),
+    status: z.enum(['suppressed', 'unavailable']),
+    reason_code: CorrectionReasonCode,
+    reason: z.string().trim().min(1).optional(),
+    operator_id: z.string().trim().min(1),
+    created_at: PositiveTimestamp,
+    audit: z
+      .object({
+        action: z.literal('synthesis_correction'),
+        supersedes_correction_id: z.string().trim().min(1).optional(),
+        notes: z.string().trim().min(1).optional(),
+      })
+      .strict(),
+  })
+  .strict();
+
 // ── Re-synthesis trigger thresholds (spec §5.4) ───────────────────
 
 export const ResynthesisThresholdsSchema = z.object({
@@ -152,6 +183,7 @@ export type TopicSeedInput = z.infer<typeof TopicSeedInputSchema>;
 export type CandidateSynthesis = z.infer<typeof CandidateSynthesisSchema>;
 export type SynthesisFrame = z.infer<typeof SynthesisFrameSchema>;
 export type TopicSynthesisV2 = z.infer<typeof TopicSynthesisV2Schema>;
+export type TopicSynthesisCorrection = z.infer<typeof TopicSynthesisCorrectionSchema>;
 export type ResynthesisThresholds = z.infer<typeof ResynthesisThresholdsSchema>;
 export type SynthesisDefaults = z.infer<typeof SynthesisDefaultsSchema>;
 

--- a/packages/e2e/src/mvp-release-gates.mjs
+++ b/packages/e2e/src/mvp-release-gates.mjs
@@ -47,6 +47,20 @@ const GATES = [
     artifactRefs: ['apps/web-pwa/src/components/feed/MvpNewsLoop.release.test.tsx'],
   },
   {
+    id: 'synthesis_correction',
+    label: 'Operator correction hides bad accepted synthesis with audit provenance',
+    command: [
+      'pnpm',
+      ['exec', 'vitest', 'run', 'apps/web-pwa/src/components/feed/MvpNewsLoop.release.test.tsx', '-t', 'mvp gate: synthesis correction'],
+    ],
+    artifactRefs: [
+      'apps/web-pwa/src/components/feed/MvpNewsLoop.release.test.tsx',
+      'apps/web-pwa/src/store/synthesis/index.ts',
+      'packages/data-model/src/schemas/hermes/synthesis.ts',
+      'packages/gun-client/src/synthesisAdapters.ts',
+    ],
+  },
+  {
     id: 'point_stance',
     label: 'Frame/reframe point stance persists and restores',
     command: [

--- a/packages/gun-client/package.json
+++ b/packages/gun-client/package.json
@@ -4,11 +4,11 @@
   "private": true,
   "type": "module",
   "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "types": "src/index.ts",
   "exports": {
     ".": {
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./src/index.ts",
+      "import": "./dist/index.js"
     }
   },
   "scripts": {

--- a/packages/gun-client/src/synthesisAdapters.test.ts
+++ b/packages/gun-client/src/synthesisAdapters.test.ts
@@ -1,22 +1,27 @@
 import { describe, expect, it, vi } from 'vitest';
-import type { CandidateSynthesis, StoryBundle, TopicDigest, TopicSynthesisV2 } from '@vh/data-model';
+import type { CandidateSynthesis, StoryBundle, TopicDigest, TopicSynthesisCorrection, TopicSynthesisV2 } from '@vh/data-model';
 import type { TopologyGuard } from './topology';
 import type { VennClient } from './types';
 import { HydrationBarrier } from './sync/barrier';
 import {
   getTopicEpochCandidateChain,
   getTopicEpochCandidatesChain,
+  getTopicLatestSynthesisCorrectionChain,
+  getTopicSynthesisCorrectionChain,
   hasForbiddenSynthesisPayloadFields,
   readStoryBundle,
   readTopicDigest,
   readTopicEpochCandidate,
   readTopicEpochCandidates,
   readTopicEpochSynthesis,
+  readTopicLatestSynthesisCorrection,
   readTopicLatestSynthesis,
+  readTopicSynthesisCorrection,
   writeStoryBundle,
   writeTopicDigest,
   writeTopicEpochCandidate,
   writeTopicEpochSynthesis,
+  writeTopicSynthesisCorrection,
   writeTopicLatestSynthesis,
   writeTopicSynthesis
 } from './synthesisAdapters';
@@ -149,6 +154,23 @@ const SYNTHESIS: TopicSynthesisV2 = {
   created_at: 1700000002000
 };
 
+const CORRECTION: TopicSynthesisCorrection = {
+  schemaVersion: 'topic-synthesis-correction-v1',
+  correction_id: 'correction-1',
+  topic_id: 'topic-1',
+  synthesis_id: 'synth-2',
+  epoch: 2,
+  status: 'suppressed',
+  reason_code: 'inaccurate_summary',
+  reason: 'Summary overstates what the source material supports.',
+  operator_id: 'ops-user-1',
+  created_at: 1700000003000,
+  audit: {
+    action: 'synthesis_correction',
+    notes: 'Suppressed from release gate fixture.',
+  },
+};
+
 const DIGEST: TopicDigest = {
   digest_id: 'digest-1',
   topic_id: 'topic-1',
@@ -209,6 +231,24 @@ describe('synthesisAdapters', () => {
     await chain.put(CANDIDATE);
 
     expect(guard.validateWrite).toHaveBeenCalledWith('vh/topics/topic-1/epochs/2/candidates/candidate-1/', CANDIDATE);
+  });
+
+  it('builds synthesis correction chains and guards writes', async () => {
+    const mesh = createFakeMesh();
+    const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+    const client = createClient(mesh, guard);
+
+    await getTopicSynthesisCorrectionChain(client, 'topic-1', 'correction-1').put(CORRECTION);
+    await getTopicLatestSynthesisCorrectionChain(client, 'topic-1').put(CORRECTION);
+
+    expect(guard.validateWrite).toHaveBeenCalledWith(
+      'vh/topics/topic-1/synthesis_corrections/correction-1/',
+      CORRECTION
+    );
+    expect(guard.validateWrite).toHaveBeenCalledWith(
+      'vh/topics/topic-1/synthesis_corrections/latest/',
+      CORRECTION
+    );
   });
 
   it('detects forbidden synthesis payload fields recursively', () => {
@@ -334,6 +374,57 @@ describe('synthesisAdapters', () => {
 
     mesh.setRead('topics/topic-1/latest', undefined);
     await expect(readTopicLatestSynthesis(client, 'topic-1')).resolves.toBeNull();
+  });
+
+  it('writes and reads synthesis correction payloads with audit metadata', async () => {
+    const mesh = createFakeMesh();
+    mesh.setRead('topics/topic-1/synthesis_corrections/correction-1', {
+      _: { '#': 'meta' },
+      ...CORRECTION
+    });
+    mesh.setRead('topics/topic-1/synthesis_corrections/latest', {
+      _: { '#': 'meta' },
+      ...CORRECTION
+    });
+
+    const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+    const client = createClient(mesh, guard);
+
+    const written = await writeTopicSynthesisCorrection(client, CORRECTION);
+    expect(written).toEqual(CORRECTION);
+    expect(mesh.writes).toEqual([
+      { path: 'topics/topic-1/synthesis_corrections/correction-1', value: CORRECTION },
+      { path: 'topics/topic-1/synthesis_corrections/latest', value: CORRECTION }
+    ]);
+
+    await expect(readTopicSynthesisCorrection(client, 'topic-1', 'correction-1')).resolves.toEqual(CORRECTION);
+    await expect(readTopicLatestSynthesisCorrection(client, 'topic-1')).resolves.toEqual(CORRECTION);
+
+    mesh.setRead('topics/topic-1/synthesis_corrections/correction-1', undefined);
+    await expect(readTopicSynthesisCorrection(client, 'topic-1', 'correction-1')).resolves.toBeNull();
+
+    mesh.setRead('topics/topic-1/synthesis_corrections/latest', undefined);
+    await expect(readTopicLatestSynthesisCorrection(client, 'topic-1')).resolves.toBeNull();
+
+    mesh.setRead('topics/topic-1/synthesis_corrections/latest', { invalid: true });
+    await expect(readTopicLatestSynthesisCorrection(client, 'topic-1')).resolves.toBeNull();
+
+    mesh.setRead('topics/topic-1/synthesis_corrections/latest', { ...CORRECTION, token: 'bad' });
+    await expect(readTopicLatestSynthesisCorrection(client, 'topic-1')).resolves.toBeNull();
+  });
+
+  it('rejects malformed correction writes and surfaces correction ack errors', async () => {
+    const mesh = createFakeMesh();
+    const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+    const client = createClient(mesh, guard);
+
+    await expect(writeTopicSynthesisCorrection(client, { ...CORRECTION, status: 'hidden' })).rejects.toThrow();
+    await expect(writeTopicSynthesisCorrection(client, { ...CORRECTION, oauth_token: 'secret' })).rejects.toThrow(
+      'forbidden identity/token fields'
+    );
+
+    mesh.setPutError('topics/topic-1/synthesis_corrections/correction-1', 'correction write failed');
+    await expect(writeTopicSynthesisCorrection(client, CORRECTION)).rejects.toThrow('correction write failed');
   });
 
   it('safely writes latest synthesis without downgrading newer or stronger latest state', async () => {
@@ -539,5 +630,6 @@ describe('synthesisAdapters', () => {
     await expect(writeTopicLatestSynthesis(client, { ...SYNTHESIS, refresh_token: 'forbidden' })).rejects.toThrow(
       'forbidden identity/token fields'
     );
+    await expect(readTopicSynthesisCorrection(client, 'topic-1', '   ')).rejects.toThrow('correctionId is required');
   });
 });

--- a/packages/gun-client/src/synthesisAdapters.ts
+++ b/packages/gun-client/src/synthesisAdapters.ts
@@ -1,9 +1,11 @@
 import {
   CandidateSynthesisSchema,
   TopicDigestInputSchema,
+  TopicSynthesisCorrectionSchema,
   TopicSynthesisV2Schema,
   type CandidateSynthesis,
   type TopicDigest,
+  type TopicSynthesisCorrection,
   type TopicSynthesisV2
 } from '@vh/data-model';
 import { createGuardedChain, type ChainAck, type ChainWithGet } from './chain';
@@ -40,6 +42,14 @@ function topicEpochSynthesisPath(topicId: string, epoch: string): string {
 
 function topicLatestPath(topicId: string): string {
   return `vh/topics/${topicId}/latest/`;
+}
+
+function topicSynthesisCorrectionPath(topicId: string, correctionId: string): string {
+  return `vh/topics/${topicId}/synthesis_corrections/${correctionId}/`;
+}
+
+function topicLatestSynthesisCorrectionPath(topicId: string): string {
+  return `vh/topics/${topicId}/synthesis_corrections/latest/`;
 }
 
 function topicDigestPath(topicId: string, digestId: string): string {
@@ -152,6 +162,15 @@ function parseSynthesis(data: unknown): TopicSynthesisV2 | null {
   return parsed.success ? parsed.data : null;
 }
 
+function parseSynthesisCorrection(data: unknown): TopicSynthesisCorrection | null {
+  const payload = stripGunMetadata(data);
+  if (hasForbiddenSynthesisPayloadFields(payload)) {
+    return null;
+  }
+  const parsed = TopicSynthesisCorrectionSchema.safeParse(payload);
+  return parsed.success ? parsed.data : null;
+}
+
 function parseDigest(data: unknown): TopicDigest | null {
   const payload = stripGunMetadata(data);
   if (hasForbiddenSynthesisPayloadFields(payload)) {
@@ -238,6 +257,36 @@ export function getTopicLatestSynthesisChain(client: VennClient, topicId: string
   return createGuardedChain(chain, client.hydrationBarrier, client.topologyGuard, topicLatestPath(topicId));
 }
 
+export function getTopicSynthesisCorrectionChain(
+  client: VennClient,
+  topicId: string,
+  correctionId: string
+): ChainWithGet<TopicSynthesisCorrection> {
+  const chain = client.mesh
+    .get('topics')
+    .get(topicId)
+    .get('synthesis_corrections')
+    .get(correctionId) as unknown as ChainWithGet<TopicSynthesisCorrection>;
+  return createGuardedChain(
+    chain,
+    client.hydrationBarrier,
+    client.topologyGuard,
+    topicSynthesisCorrectionPath(topicId, correctionId)
+  );
+}
+
+export function getTopicLatestSynthesisCorrectionChain(
+  client: VennClient,
+  topicId: string
+): ChainWithGet<TopicSynthesisCorrection> {
+  const chain = client.mesh
+    .get('topics')
+    .get(topicId)
+    .get('synthesis_corrections')
+    .get('latest') as unknown as ChainWithGet<TopicSynthesisCorrection>;
+  return createGuardedChain(chain, client.hydrationBarrier, client.topologyGuard, topicLatestSynthesisCorrectionPath(topicId));
+}
+
 export function getTopicDigestChain(client: VennClient, topicId: string, digestId: string): ChainWithGet<TopicDigest> {
   const chain = client.mesh.get('topics').get(topicId).get('digests').get(digestId) as unknown as ChainWithGet<TopicDigest>;
   return createGuardedChain(chain, client.hydrationBarrier, client.topologyGuard, topicDigestPath(topicId, digestId));
@@ -320,6 +369,48 @@ export async function writeTopicLatestSynthesis(client: VennClient, synthesis: u
   assertNoForbiddenSynthesisFields(synthesis);
   const sanitized = TopicSynthesisV2Schema.parse(synthesis);
   await putWithAck(getTopicLatestSynthesisChain(client, normalizeTopicId(sanitized.topic_id)), sanitized);
+  return sanitized;
+}
+
+export async function readTopicSynthesisCorrection(
+  client: VennClient,
+  topicId: string,
+  correctionId: string
+): Promise<TopicSynthesisCorrection | null> {
+  const raw = await readOnce(
+    getTopicSynthesisCorrectionChain(
+      client,
+      normalizeTopicId(topicId),
+      normalizeId(correctionId, 'correctionId')
+    )
+  );
+  if (raw === null) {
+    return null;
+  }
+  return parseSynthesisCorrection(raw);
+}
+
+export async function readTopicLatestSynthesisCorrection(
+  client: VennClient,
+  topicId: string
+): Promise<TopicSynthesisCorrection | null> {
+  const raw = await readOnce(getTopicLatestSynthesisCorrectionChain(client, normalizeTopicId(topicId)));
+  if (raw === null) {
+    return null;
+  }
+  return parseSynthesisCorrection(raw);
+}
+
+export async function writeTopicSynthesisCorrection(
+  client: VennClient,
+  correction: unknown
+): Promise<TopicSynthesisCorrection> {
+  assertNoForbiddenSynthesisFields(correction);
+  const sanitized = TopicSynthesisCorrectionSchema.parse(correction);
+  const topicId = normalizeTopicId(sanitized.topic_id);
+  const correctionId = normalizeId(sanitized.correction_id, 'correctionId');
+  await putWithAck(getTopicSynthesisCorrectionChain(client, topicId, correctionId), sanitized);
+  await putWithAck(getTopicLatestSynthesisCorrectionChain(client, topicId), sanitized);
   return sanitized;
 }
 

--- a/packages/gun-client/src/topology.test.ts
+++ b/packages/gun-client/src/topology.test.ts
@@ -99,6 +99,20 @@ describe('TopologyGuard', () => {
       })
     ).not.toThrow();
     expect(() =>
+      guard.validateWrite('vh/topics/topic-1/synthesis_corrections/latest', {
+        schemaVersion: 'topic-synthesis-correction-v1',
+        correction_id: 'correction-1',
+        topic_id: 'topic-1',
+        synthesis_id: 'synth-1',
+        epoch: 2,
+        status: 'suppressed',
+        reason_code: 'inaccurate_summary',
+        operator_id: 'ops-user-1',
+        created_at: 1700000000000,
+        audit: { action: 'synthesis_correction' },
+      })
+    ).not.toThrow();
+    expect(() =>
       guard.validateWrite('vh/aggregates/topics/topic-1/engagement/actors/actor-1', {
         schema_version: 'topic-engagement-actor-v1',
         topic_id: 'topic-1',

--- a/packages/gun-client/src/topology.ts
+++ b/packages/gun-client/src/topology.ts
@@ -36,6 +36,7 @@ const DEFAULT_RULES: TopologyRule[] = [
   { pathPrefix: 'vh/topics/*/epochs/*/candidates/*', classification: 'public' },
   { pathPrefix: 'vh/topics/*/epochs/*/synthesis', classification: 'public' },
   { pathPrefix: 'vh/topics/*/latest', classification: 'public' },
+  { pathPrefix: 'vh/topics/*/synthesis_corrections/*', classification: 'public' },
   { pathPrefix: 'vh/topics/*/digests/*', classification: 'public' },
   { pathPrefix: 'vh/topics/*/articles/*', classification: 'public' },
   { pathPrefix: 'vh/discovery/items/*', classification: 'public' },

--- a/tools/scripts/check-diff-coverage.mjs
+++ b/tools/scripts/check-diff-coverage.mjs
@@ -64,6 +64,7 @@ const COVERAGE_EXCLUDES = [
   /^apps\/web-pwa\/src\/store\/index\.ts$/,
   /^apps\/web-pwa\/src\/store\/news\/types\.ts$/,
   /^apps\/web-pwa\/src\/store\/discovery\/types\.ts$/,
+  /^apps\/web-pwa\/src\/store\/synthesis\/types\.ts$/,
   /^apps\/web-pwa\/src\/hooks\/(useIdentity|useRegion|useFeedStore|useSentimentState)\.ts$/,
   /^apps\/web-pwa\/src\/utils\/markdown\.ts$/,
   /^packages\/e2e\//,


### PR DESCRIPTION
## Summary
- Add a strict `TopicSynthesisCorrection` schema for accepted synthesis artifacts with suppress/unavailable state, reason code, operator id, timestamp, and audit metadata.
- Add Gun correction read/write helpers under `vh/topics/*/synthesis_corrections/*`, with latest and appendable correction records.
- Hydrate correction state in the Web PWA synthesis store and make `NewsCard`/`NewsCardBack` hide stale accepted summary/frame rows when a matching correction blocks the artifact.
- Extend `pnpm check:mvp-release-gates` with a deterministic `synthesis_correction` smoke and update the roadmap to mark accepted synthesis correction implemented while leaving abusive thread moderation/compliance open.

## Validation
- `pnpm exec vitest run packages/data-model/src/schemas/hermes/synthesis.test.ts --reporter=verbose`
- `pnpm exec vitest run packages/gun-client/src/synthesisAdapters.test.ts packages/gun-client/src/topology.test.ts --reporter=verbose`
- `pnpm exec vitest run apps/web-pwa/src/store/synthesis/index.test.ts apps/web-pwa/src/store/synthesis/hydration.test.ts --reporter=verbose`
- `pnpm exec vitest run apps/web-pwa/src/components/feed/NewsCard.test.tsx apps/web-pwa/src/components/feed/MvpNewsLoop.release.test.tsx --reporter=verbose`
- `pnpm exec vitest run apps/web-pwa/src/hooks/useSynthesis.test.ts apps/web-pwa/src/components/feed/TopicCard.test.tsx --reporter=verbose`
- `pnpm --filter @vh/web-pwa typecheck`
- `pnpm --filter @vh/gun-client typecheck`
- `pnpm --filter @vh/data-model typecheck`
- `pnpm --filter @vh/e2e typecheck`
- `pnpm check:mvp-release-gates`
- `pnpm lint`
- `pnpm deps:check`
- `pnpm --filter @vh/e2e exec vitest run src/mvp-release-gates.vitest.mjs --reporter=verbose`
- `git diff --check`
- `node tools/scripts/check-diff-coverage.mjs`

Latest MVP report: `.tmp/mvp-release-gates/latest/mvp-release-gates-report.json`, overall `pass`, branch `coord/synthesis-correction-path`, commit `5b987eb8b3d88b4a9f81356458e54500477a21f9`.
