### PR TITLE
Harden synthesis payload topic validation

### DIFF
--- a/apps/web-pwa/src/store/synthesis/index.test.ts
+++ b/apps/web-pwa/src/store/synthesis/index.test.ts
@@ -226,6 +226,7 @@ describe('synthesis store', () => {
 
     store.getState().setTopicSynthesis('topic-1', { ...synthesis(), token: 'bad' } as TopicSynthesisV2);
     store.getState().setTopicSynthesis('topic-1', { invalid: true } as unknown as TopicSynthesisV2);
+    store.getState().setTopicSynthesis('topic-1', synthesis({ topic_id: 'topic-2' }));
     store.getState().setTopicSynthesis('   ', synthesis());
 
     expect(store.getState().topics).toEqual({});
@@ -369,6 +370,22 @@ describe('synthesis store', () => {
     const topic = store.getState().getTopicState('topic-1');
     expect(topic.synthesis).toBeNull();
     expect(topic.epoch).toBeNull();
+  });
+
+  it('refreshTopic drops cross-topic latest synthesis payloads', async () => {
+    readTopicLatestSynthesisMock.mockResolvedValue(synthesis({ topic_id: 'topic-2' }));
+    readTopicLatestSynthesisCorrectionMock.mockResolvedValue(correction());
+
+    const { createSynthesisStore } = await import('./index');
+    const store = createSynthesisStore({ enabled: true, resolveClient: () => ({}) as never });
+
+    await store.getState().refreshTopic('topic-1');
+
+    const topic = store.getState().getTopicState('topic-1');
+    expect(topic.synthesis).toBeNull();
+    expect(topic.epoch).toBeNull();
+    expect(topic.correction?.correction_id).toBe('correction-1');
+    expect(topic.effectiveStatus).toBe('synthesis_suppressed');
   });
 
   it('refreshTopic captures thrown errors', async () => {

--- a/apps/web-pwa/src/store/synthesis/index.ts
+++ b/apps/web-pwa/src/store/synthesis/index.ts
@@ -137,7 +137,7 @@ export function createSynthesisStore(overrides?: Partial<InternalDeps>): StoreAp
       }
 
       const validated = synthesis === null ? null : parseSynthesis(synthesis);
-      if (synthesis !== null && !validated) {
+      if (synthesis !== null && (!validated || validated.topic_id !== normalizedTopicId)) {
         return;
       }
 
@@ -239,17 +239,16 @@ export function createSynthesisStore(overrides?: Partial<InternalDeps>): StoreAp
         ]);
         const validatedLatest = latest === null ? null : parseSynthesis(latest);
         const validatedCorrection = latestCorrection === null ? null : parseCorrection(latestCorrection);
+        const topicLatest = validatedLatest?.topic_id === normalizedTopicId ? validatedLatest : null;
+        const topicCorrection = validatedCorrection?.topic_id === normalizedTopicId ? validatedCorrection : null;
 
         set((state) => ({
           topics: upsertTopicState(state.topics, normalizedTopicId, (current) => ({
             ...current,
-            synthesis: validatedLatest,
-            epoch: validatedLatest?.epoch ?? null,
-            correction: validatedCorrection?.topic_id === normalizedTopicId ? validatedCorrection : null,
-            effectiveStatus: resolveEffectiveStatus(
-              validatedLatest,
-              validatedCorrection?.topic_id === normalizedTopicId ? validatedCorrection : null
-            ),
+            synthesis: topicLatest,
+            epoch: topicLatest?.epoch ?? null,
+            correction: topicCorrection,
+            effectiveStatus: resolveEffectiveStatus(topicLatest, topicCorrection),
             loading: false,
             error: null
           }))

--- a/packages/gun-client/src/synthesisAdapters.test.ts
+++ b/packages/gun-client/src/synthesisAdapters.test.ts
@@ -346,6 +346,12 @@ describe('synthesisAdapters', () => {
 
     await expect(readTopicEpochSynthesis(client, 'topic-1', 2)).resolves.toEqual(SYNTHESIS);
 
+    mesh.setRead('topics/topic-1/epochs/2/synthesis', { ...SYNTHESIS, topic_id: 'topic-2' });
+    await expect(readTopicEpochSynthesis(client, 'topic-1', 2)).resolves.toBeNull();
+
+    mesh.setRead('topics/topic-1/epochs/2/synthesis', { ...SYNTHESIS, epoch: 3 });
+    await expect(readTopicEpochSynthesis(client, 'topic-1', 2)).resolves.toBeNull();
+
     mesh.setRead('topics/topic-1/epochs/2/synthesis', undefined);
     await expect(readTopicEpochSynthesis(client, 'topic-1', 2)).resolves.toBeNull();
 
@@ -371,6 +377,9 @@ describe('synthesisAdapters', () => {
     expect(mesh.writes[0]).toEqual({ path: 'topics/topic-1/latest', value: SYNTHESIS });
 
     await expect(readTopicLatestSynthesis(client, 'topic-1')).resolves.toEqual(SYNTHESIS);
+
+    mesh.setRead('topics/topic-1/latest', { ...SYNTHESIS, topic_id: 'topic-2' });
+    await expect(readTopicLatestSynthesis(client, 'topic-1')).resolves.toBeNull();
 
     mesh.setRead('topics/topic-1/latest', undefined);
     await expect(readTopicLatestSynthesis(client, 'topic-1')).resolves.toBeNull();
@@ -399,6 +408,18 @@ describe('synthesisAdapters', () => {
 
     await expect(readTopicSynthesisCorrection(client, 'topic-1', 'correction-1')).resolves.toEqual(CORRECTION);
     await expect(readTopicLatestSynthesisCorrection(client, 'topic-1')).resolves.toEqual(CORRECTION);
+
+    mesh.setRead('topics/topic-1/synthesis_corrections/correction-1', { ...CORRECTION, topic_id: 'topic-2' });
+    await expect(readTopicSynthesisCorrection(client, 'topic-1', 'correction-1')).resolves.toBeNull();
+
+    mesh.setRead('topics/topic-1/synthesis_corrections/correction-1', {
+      ...CORRECTION,
+      correction_id: 'correction-2'
+    });
+    await expect(readTopicSynthesisCorrection(client, 'topic-1', 'correction-1')).resolves.toBeNull();
+
+    mesh.setRead('topics/topic-1/synthesis_corrections/latest', { ...CORRECTION, topic_id: 'topic-2' });
+    await expect(readTopicLatestSynthesisCorrection(client, 'topic-1')).resolves.toBeNull();
 
     mesh.setRead('topics/topic-1/synthesis_corrections/correction-1', undefined);
     await expect(readTopicSynthesisCorrection(client, 'topic-1', 'correction-1')).resolves.toBeNull();

--- a/packages/gun-client/src/synthesisAdapters.ts
+++ b/packages/gun-client/src/synthesisAdapters.ts
@@ -340,11 +340,14 @@ export async function writeTopicEpochCandidate(client: VennClient, candidate: un
 }
 
 export async function readTopicEpochSynthesis(client: VennClient, topicId: string, epoch: number): Promise<TopicSynthesisV2 | null> {
-  const raw = await readOnce(getTopicEpochSynthesisChain(client, normalizeTopicId(topicId), normalizeEpoch(epoch)));
+  const normalizedTopicId = normalizeTopicId(topicId);
+  const normalizedEpoch = normalizeEpoch(epoch);
+  const raw = await readOnce(getTopicEpochSynthesisChain(client, normalizedTopicId, normalizedEpoch));
   if (raw === null) {
     return null;
   }
-  return parseSynthesis(raw);
+  const parsed = parseSynthesis(raw);
+  return parsed?.topic_id === normalizedTopicId && String(parsed.epoch) === normalizedEpoch ? parsed : null;
 }
 
 export async function writeTopicEpochSynthesis(client: VennClient, synthesis: unknown): Promise<TopicSynthesisV2> {
@@ -358,11 +361,13 @@ export async function writeTopicEpochSynthesis(client: VennClient, synthesis: un
 }
 
 export async function readTopicLatestSynthesis(client: VennClient, topicId: string): Promise<TopicSynthesisV2 | null> {
-  const raw = await readOnce(getTopicLatestSynthesisChain(client, normalizeTopicId(topicId)));
+  const normalizedTopicId = normalizeTopicId(topicId);
+  const raw = await readOnce(getTopicLatestSynthesisChain(client, normalizedTopicId));
   if (raw === null) {
     return null;
   }
-  return parseSynthesis(raw);
+  const parsed = parseSynthesis(raw);
+  return parsed?.topic_id === normalizedTopicId ? parsed : null;
 }
 
 export async function writeTopicLatestSynthesis(client: VennClient, synthesis: unknown): Promise<TopicSynthesisV2> {
@@ -377,28 +382,33 @@ export async function readTopicSynthesisCorrection(
   topicId: string,
   correctionId: string
 ): Promise<TopicSynthesisCorrection | null> {
+  const normalizedTopicId = normalizeTopicId(topicId);
+  const normalizedCorrectionId = normalizeId(correctionId, 'correctionId');
   const raw = await readOnce(
     getTopicSynthesisCorrectionChain(
       client,
-      normalizeTopicId(topicId),
-      normalizeId(correctionId, 'correctionId')
+      normalizedTopicId,
+      normalizedCorrectionId
     )
   );
   if (raw === null) {
     return null;
   }
-  return parseSynthesisCorrection(raw);
+  const parsed = parseSynthesisCorrection(raw);
+  return parsed?.topic_id === normalizedTopicId && parsed.correction_id === normalizedCorrectionId ? parsed : null;
 }
 
 export async function readTopicLatestSynthesisCorrection(
   client: VennClient,
   topicId: string
 ): Promise<TopicSynthesisCorrection | null> {
-  const raw = await readOnce(getTopicLatestSynthesisCorrectionChain(client, normalizeTopicId(topicId)));
+  const normalizedTopicId = normalizeTopicId(topicId);
+  const raw = await readOnce(getTopicLatestSynthesisCorrectionChain(client, normalizedTopicId));
   if (raw === null) {
     return null;
   }
-  return parseSynthesisCorrection(raw);
+  const parsed = parseSynthesisCorrection(raw);
+  return parsed?.topic_id === normalizedTopicId ? parsed : null;
 }
 
 export async function writeTopicSynthesisCorrection(


### PR DESCRIPTION
## Summary
- reject accepted synthesis payloads when the payload topic or epoch does not match the Gun path being read
- reject synthesis correction payloads when the payload topic or correction id does not match the correction path being read
- make the web synthesis store ignore cross-topic synthesis payloads before they can affect effective story-detail state

## Verification
- pnpm --filter @vh/gun-client exec vitest run src/synthesisAdapters.test.ts --reporter=verbose
- pnpm exec vitest run apps/web-pwa/src/store/synthesis/index.test.ts --reporter=verbose
- pnpm --filter @vh/gun-client typecheck
- pnpm --filter @vh/web-pwa typecheck
- git diff --check
- node tools/scripts/check-diff-coverage.mjs
- pnpm deps:check
- pnpm check:mvp-release-gates
- pnpm lint

## Review note
This is a follow-up hardening from the review of merged PR #537. The merged correction path is structurally sound; this closes a public-data integrity edge where a schema-valid payload stored under the wrong topic path could otherwise hydrate into the requested topic.