### PR TITLE
Align docs with MVP moderation closeout

### DIFF
--- a/docs/plans/VENN_NEWS_MVP_ROADMAP_2026-04-20.md
+++ b/docs/plans/VENN_NEWS_MVP_ROADMAP_2026-04-20.md
@@ -2,7 +2,7 @@
 
 > Status: Draft v4 docs-aligned implementation tracker
 > Date: 2026-04-20
-> Last alignment audit: 2026-04-24 on `main` at `7e3c818e` after PR #533 merged
+> Last alignment audit: 2026-04-25 on `main` at `ee77ec15` after PR #539 merged
 > Target: Four-week Web PWA MVP launch path after remaining Week 0 decisions and launch blockers are resolved
 > Scope: News feed, story analysis, frame/reframe stance, threaded discussion, and durable aggregate civic metadata
 
@@ -208,7 +208,7 @@ Required:
 - users can reply to the story thread (implemented in story detail in PR #533);
 - replies persist across reload (covered by forum storage paths and component/store tests; still needs a release smoke);
 - thread count and latest activity can appear on feed cards;
-- basic safety affordances exist: report, hide, block, and moderation queue/path (still open).
+- basic safety affordances exist: audited hide/restore moderation exists for story-thread comments; report intake, user block UX, and a broader moderation queue/admin workflow remain open.
 
 The forum system should be reused. The MVP should not create a second comment model.
 
@@ -377,14 +377,14 @@ Week 0 should be executed as a short PR stack, not as an open-ended planning loo
 | 3 | `launch-surface-decision` | Resolved: Web PWA. | Remove native iOS/TestFlight from the four-week critical path. | Web PWA is recorded as the MVP launch target; native packaging is a parallel follow-on. |
 | 4 | `bundle-synthesis-dependency` | Complete; merged in PR #528. | Resolve PR B / bundle synthesis dependency for accepted publish-time synthesis and source split handling. | Story detail renders accepted stored synthesis or explicit pending/unavailable state without a hidden card-open analysis pass. |
 | 5 | `identity-honesty-scope` | Complete; merged in PR #530. Web PWA beta uses beta-local proof assurance; real constituency proof remains deferred. | Decide beta-local identity vs real constituency proof for MVP copy and stance guarantees. | Product copy, release notes, and stance path claims match the actual proof layer. |
-| 6 | `mvp-release-gates` | Complete; `pnpm check:mvp-release-gates`. | Deterministic feed/detail/stance/thread release gates are named and report-backed. | `.tmp/mvp-release-gates/latest/mvp-release-gates-report.json` records command, artifact refs, timestamps, and pass/fail/setup-scarcity semantics for source health, story correctness, feed render, story detail, point stance, and story thread gates. |
+| 6 | `mvp-release-gates` | Complete; merged in PR #535 and hardened in PR #536. | Deterministic feed/detail/stance/thread/correction/moderation release gates are named and report-backed. | `.tmp/mvp-release-gates/latest/mvp-release-gates-report.json` records command, artifact refs, timestamps, and pass/fail/setup-scarcity semantics for source health, story correctness, feed render, story detail, synthesis correction, point stance, story thread, and story-thread moderation gates. |
 | 7 | `compliance-public-beta-minimums` | Open. | Privacy, terms, UGC/moderation, support, data deletion, telemetry consent, and content/copyright boundaries. | Public launch cannot proceed unless each compliance artifact has an owner and minimum accepted draft. |
-| 8 | `launch-ops-and-correction-path` | Open. | Curated fallback snapshot, bad-analysis suppression/regeneration, report queue, model/cost telemetry, and release artifact visibility. | Operators have minimum levers for stale feed data, bad summaries, abusive threads, and runaway model usage. |
+| 8 | `launch-ops-and-correction-path` | Partial; accepted synthesis correction merged in PR #537 and hardened in PR #538; story-thread comment hide/restore moderation merged in PR #539. | Curated fallback snapshot, report queue, model/cost telemetry, and release artifact visibility remain open; bad accepted synthesis and abusive story-thread comments now have minimum audited remediation paths. | Operators have typed audit records for suppressing/unavailable accepted synthesis artifacts and hiding/restoring story-thread comments. Remaining launch-ops work must cover stale feed fallback content, report intake, broader admin workflow UX, and runaway model visibility. |
 
 Recommended sequencing:
 
-- PR #527, PR #528, PR #530, PR #531, PR #532, and PR #533 are now in `main`; feed/detail stance/thread work can base on stable point ids, accepted publish-time synthesis, honest beta-local proof semantics, active personalization ranking, and deterministic story discussion threads.
-- PRs 6 through 8 are now the highest-value Week 0 blockers because the core feed/detail/stance/thread product loop has implementation coverage but not launch-grade evidence, compliance, or operator correction controls.
+- PR #527, PR #528, PR #530, PR #531, PR #532, PR #533, PR #535, PR #536, PR #537, PR #538, and PR #539 are now in `main`; feed/detail stance/thread work can base on stable point ids, accepted publish-time synthesis, honest beta-local proof semantics, active personalization ranking, deterministic story discussion threads, release-gate evidence, accepted synthesis correction, and story-thread comment hide/restore moderation.
+- Compliance, launch-content fallback, report intake, broader admin workflow UX, and ops/cost visibility are now the highest-value Week 0 blockers. The core feed/detail/stance/thread product loop and minimum correction/moderation remediation paths have implementation and deterministic release-gate coverage.
 - Week 1 starts only after every row in the go/no-go table has a `go` decision or an explicit accepted no-go consequence.
 
 ### Week 0 go/no-go table
@@ -659,6 +659,7 @@ Acceptance checks:
 | Synthesis correction smoke | `pnpm check:mvp-release-gates` includes `synthesis_correction` | Fixture-backed smoke proves a corrected accepted synthesis does not render stale summary/frame rows and exposes audit provenance. |
 | Point-stance persistence/convergence smoke | `pnpm check:mvp-release-gates` includes `point_stance` | Story detail smoke writes/restores final stance against accepted synthesis point ids. |
 | Thread persistence smoke | `pnpm check:mvp-release-gates` includes `story_thread` | Deterministic `news-story:*` thread id, reply persistence, and reload attachment are covered. |
+| Story-thread moderation smoke | `pnpm check:mvp-release-gates` includes `story_thread_moderation` | Fixture-backed smoke proves audited hide/restore moderation hides abusive reply content while preserving the deterministic story thread. |
 | iOS build | Missing because no iOS shell | Only required if Week 0 chooses iOS. |
 | Privacy/UGC/deletion checklist | Missing | Add Week 3B; public launch blocker. |
 
@@ -790,6 +791,9 @@ The plan is ready to build when reviewers agree on:
 - PR #531 is in the implementation base for feed personalization ranking;
 - PR #532 is in the implementation base for accepted-synthesis stance UI;
 - PR #533 is in the implementation base for deterministic story-thread detail integration;
+- PR #535 and PR #536 are in the implementation base for deterministic MVP release-gate evidence;
+- PR #537 and PR #538 are in the implementation base for accepted synthesis correction;
+- PR #539 is in the implementation base for audited story-thread comment hide/restore moderation;
 - story-level sentiment as aggregate metadata only;
 - analyzed-source versus related-link evidence boundaries;
 - accepted publish-time synthesis as the headline-click data contract;

--- a/docs/specs/spec-hermes-forum-v0.md
+++ b/docs/specs/spec-hermes-forum-v0.md
@@ -2,11 +2,11 @@
 
 > Status: Normative Spec
 > Owner: VHC Spec Owners
-> Last Reviewed: 2026-04-16
+> Last Reviewed: 2026-04-25
 > Depends On: docs/foundational/System_Architecture.md, docs/CANON_MAP.md
 
 
-Version: 0.7
+Version: 0.8
 Status: Canonical for Season 0 (V2-first alignment)
 Context: Public topic discourse, reply/article publishing, and elevation entrypoint.
 
@@ -28,7 +28,7 @@ This spec restores implementation-level details from Sprint 3/3.5 while aligning
 ```ts
 interface Thread {
   id: string;
-  schemaVersion: 'hermes-thread-v1';
+  schemaVersion: 'hermes-thread-v0';
   title: string; // <= 200
   content: string; // markdown, <= 10_000
   author: string; // principal nullifier
@@ -101,7 +101,7 @@ interface Comment {
   timestamp: number;
 
   // stance model (Sprint 3.5+)
-  stance: 'concur' | 'counter';
+  stance: 'concur' | 'counter' | 'discuss';
 
   // legacy, read-only
   type?: 'reply' | 'counterpoint';
@@ -126,6 +126,8 @@ Write path requirements:
 - Always write `schemaVersion: 'hermes-comment-v1'`
 - Always write `stance`
 - Never write `type` for new comments
+- New comments may use `concur`, `counter`, or `discuss`; legacy `type`
+  migration maps only `reply` -> `concur` and `counterpoint` -> `counter`.
 
 Zod contract pattern:
 
@@ -135,6 +137,50 @@ export const HermesCommentSchema = z.union([
   HermesCommentSchemaV1, // read/write
 ]);
 ```
+
+### 2.3.2 Comment moderation schema
+
+Story-thread comment moderation is an appendable audited record plus a
+latest-by-comment pointer. It does not delete the original comment payload.
+Readers apply the latest record for a comment; `hidden` records hide content and
+reply/vote controls, while `restored` records render the comment normally.
+
+```ts
+interface CommentModeration {
+  schemaVersion: 'hermes-comment-moderation-v1';
+  moderation_id: string;
+  thread_id: string;
+  comment_id: string;
+  status: 'hidden' | 'restored';
+  reason_code: string;
+  reason?: string;
+  operator_id: string;
+  created_at: number;
+  audit: {
+    action: 'comment_moderation';
+    supersedes_moderation_id?: string;
+    notes?: string;
+  };
+}
+```
+
+Storage paths:
+
+- Append/audit path:
+  `vh/forum/threads/<thread_id>/comment_moderations/<moderation_id>/`
+- Latest effective state path:
+  `vh/forum/threads/<thread_id>/comment_moderations/latest/<comment_id>/`
+
+Read/write requirements:
+
+- validate the record with `HermesCommentModerationSchema`;
+- reject records whose embedded `thread_id`, `comment_id`, or `moderation_id`
+  does not match the path being read;
+- preserve audit metadata;
+- never render a hidden comment's original markdown, reply composer, or vote
+  controls in story detail;
+- do not claim report intake, user blocking, or a full admin queue exists from
+  this minimum hide/restore path alone.
 
 ### 2.4 Post type contract (reply vs article)
 
@@ -495,6 +541,7 @@ Core:
 Storage and sync:
 
 - [x] Gun adapters for threads/comments/indexes
+- [x] Gun adapters for audited comment hide/restore moderation
 - [ ] Gun adapters for standalone post publication path
 - [x] Hydration with required-field checks and Zod validation
 - [x] Deduplication TTL map
@@ -512,7 +559,8 @@ UX:
 - [x] Reply 240-char hard cap
 - [x] Story-detail reply list/composer renders below accepted synthesis frame/reframe table
 - [x] Thread create/comment load/comment post failures surface as recoverable UI states
-- [ ] Report/hide/block/moderation queue affordances for story replies
+- [x] Audited hide/restore moderation state hides story-reply content with provenance
+- [ ] Report intake, user block UX, and broader moderation queue/admin affordances for story replies
 - [ ] Convert-to-article CTA + docs handoff
 - [ ] Article publish back into topic/forum surface
 
@@ -528,3 +576,4 @@ UX:
 8. V2 linkage by `{topicId, synthesisId, epoch}`.
 9. Privacy invariant checks (no secrets in public forum paths).
 10. Feed-shell regression: forum cards remain discoverable through the `Topics` filter without requiring a primary HERMES tab in the public app chrome.
+11. Comment moderation schema rejects malformed/path-mismatched payloads, preserves audit metadata, and hides moderated story-reply content without changing deterministic `news-story:*` thread identity.

--- a/docs/specs/spec-identity-trust-constituency.md
+++ b/docs/specs/spec-identity-trust-constituency.md
@@ -52,7 +52,7 @@ References:
   | Dashboard tier display | ≥ 0.5 / ≥ 0.7 | ≥ 5000 / ≥ 7000 | Visual tier indicator | `dashboardContent.tsx:183,178` |
   | QF / governance votes | ≥ 0.7 | ≥ 7000 | High-impact civic action | `useGovernance.ts:30` (`MIN_TRUST_TO_VOTE`) |
   | CAK send/finalize + receipt | ≥ 0.7 | ≥ 7000 | Outbound civic forwarding | `ActionComposer.tsx:73` (per CAK §7.1) |
-  | Future moderation actions | ≥ 0.7 | ≥ 7000 | Placeholder - not yet implemented | - |
+  | Moderation/admin actions | ≥ 0.7 | ≥ 7000 | High-impact remediation path; story-thread hide/restore records exist, operator UI/trust gate still TBD | `HermesCommentModerationSchema`, `forumAdapters.ts` |
   | Future high-privilege | 0.7-0.8 | 7000-8000 | Reserved range for Season 1+ | - |
 
   **Consolidation target (impl guidance, not spec-normative):** Extract a single `TRUST_THRESHOLDS` constant (e.g., in `packages/types/src/identity.ts` or a shared constants module) and replace all inline magic numbers. This is an implementation task, not a spec requirement - but implementations SHOULD converge on one import.


### PR DESCRIPTION
## Summary
- refresh the Venn News MVP roadmap alignment marker and Week 0 sequencing through PR #539
- update release-gate and correction/admin rows to include `synthesis_correction` and `story_thread_moderation`
- add the implemented `hermes-comment-moderation-v1` contract and storage paths to the HERMES forum spec
- correct active forum spec drift for `hermes-thread-v0` and the implemented `discuss` comment stance
- update identity trust threshold docs so moderation/admin actions are no longer described as wholly unimplemented

## Verification
- `pnpm docs:check`
- `git diff --check`
