### PR TITLE
Harden forum moderation adapter schema validation

### DIFF
--- a/packages/gun-client/src/forumAdapters.test.ts
+++ b/packages/gun-client/src/forumAdapters.test.ts
@@ -156,6 +156,7 @@ describe('forumAdapters', () => {
       { ...MODERATION, audit: null },
       { ...MODERATION, audit: { action: 'wrong' } },
       { ...MODERATION, reason: '' },
+      { ...MODERATION, reason: ' ' },
       { ...MODERATION, reason: 42 },
       { ...MODERATION, audit: { action: 'comment_moderation', supersedes_moderation_id: '' } },
       { ...MODERATION, audit: { action: 'comment_moderation', supersedes_moderation_id: 42 } },
@@ -167,7 +168,9 @@ describe('forumAdapters', () => {
       { ...MODERATION, reason_code: ' ' },
       { ...MODERATION, operator_id: ' ' },
       { ...MODERATION, created_at: -1 },
-      { ...MODERATION, created_at: 1.5 }
+      { ...MODERATION, created_at: 1.5 },
+      { ...MODERATION, token: 'secret' },
+      { ...MODERATION, audit: { action: 'comment_moderation', notes: 'fixture', token: 'secret' } }
     ];
 
     for (const payload of invalidPayloads) {
@@ -213,6 +216,9 @@ describe('forumAdapters', () => {
 
     chain.once.mockImplementationOnce((cb?: (data: unknown) => void) => cb?.({ ...MODERATION, audit: { action: 'wrong' } }));
     await expect(readForumLatestCommentModeration(client, 'news-story:story-1', 'comment-1')).resolves.toBeNull();
+
+    chain.once.mockImplementationOnce((cb?: (data: unknown) => void) => cb?.({ ...MODERATION, token: 'secret' }));
+    await expect(readForumCommentModeration(client, 'news-story:story-1', 'mod-1')).resolves.toBeNull();
   });
 
   it('surfaces moderation write ack failures', async () => {

--- a/packages/gun-client/src/forumAdapters.ts
+++ b/packages/gun-client/src/forumAdapters.ts
@@ -1,4 +1,5 @@
 import type { HermesComment, HermesCommentModeration, HermesThread } from '@vh/types';
+import { HermesCommentModerationSchema } from '@vh/data-model';
 import { createGuardedChain, type ChainAck, type ChainWithGet } from './chain';
 import type { VennClient } from './types';
 
@@ -120,40 +121,32 @@ function normalizeId(value: string, name: string): string {
   return normalized;
 }
 
+function hasBlankModerationFields(moderation: HermesCommentModeration): boolean {
+  if (
+    moderation.moderation_id.trim() === '' ||
+    moderation.thread_id.trim() === '' ||
+    moderation.comment_id.trim() === '' ||
+    moderation.reason_code.trim() === '' ||
+    moderation.operator_id.trim() === ''
+  ) {
+    return true;
+  }
+  if (moderation.reason !== undefined && moderation.reason.trim() === '') {
+    return true;
+  }
+  return (
+    moderation.audit.supersedes_moderation_id !== undefined &&
+    moderation.audit.supersedes_moderation_id.trim() === ''
+  ) || (moderation.audit.notes !== undefined && moderation.audit.notes.trim() === '');
+}
+
 function parseCommentModeration(data: unknown): HermesCommentModeration | null {
   const payload = stripGunMetadata(data);
-  if (!isRecord(payload)) {
+  const parsed = HermesCommentModerationSchema.safeParse(payload);
+  if (!parsed.success || hasBlankModerationFields(parsed.data)) {
     return null;
   }
-  const audit = payload.audit;
-  if (!isRecord(audit) || audit.action !== 'comment_moderation') {
-    return null;
-  }
-  if (
-    payload.schemaVersion !== 'hermes-comment-moderation-v1' ||
-    typeof payload.moderation_id !== 'string' || payload.moderation_id.trim() === '' ||
-    typeof payload.thread_id !== 'string' || payload.thread_id.trim() === '' ||
-    typeof payload.comment_id !== 'string' || payload.comment_id.trim() === '' ||
-    (payload.status !== 'hidden' && payload.status !== 'restored') ||
-    typeof payload.reason_code !== 'string' || payload.reason_code.trim() === '' ||
-    typeof payload.operator_id !== 'string' || payload.operator_id.trim() === '' ||
-    typeof payload.created_at !== 'number' || !Number.isInteger(payload.created_at) || payload.created_at < 0
-  ) {
-    return null;
-  }
-  if ('reason' in payload && (typeof payload.reason !== 'string' || payload.reason.trim() === '')) {
-    return null;
-  }
-  if (
-    'supersedes_moderation_id' in audit &&
-    (typeof audit.supersedes_moderation_id !== 'string' || audit.supersedes_moderation_id.trim() === '')
-  ) {
-    return null;
-  }
-  if ('notes' in audit && (typeof audit.notes !== 'string' || audit.notes.trim() === '')) {
-    return null;
-  }
-  return payload as unknown as HermesCommentModeration;
+  return parsed.data;
 }
 
 function readOnce<T>(chain: ChainWithGet<T>): Promise<T | null> {


### PR DESCRIPTION
## Summary
- switch forum moderation adapter parsing to the strict `HermesCommentModerationSchema`
- retain nonblank trim validation for public moderation identifiers and audit strings
- add adapter coverage for top-level and nested extra-field rejection before read/write

## Review context
This is a follow-up from reviewing merged PR #539/#540. The audited moderation path is implemented, documented, and release-gated; this closes a schema drift gap where the adapter could accept extra fields even though the data-model contract is strict.

## Verification
- pnpm --filter @vh/gun-client exec vitest run src/forumAdapters.test.ts --reporter=verbose
- pnpm --filter @vh/gun-client typecheck
- git diff --check
- pnpm exec vitest run apps/web-pwa/src/components/hermes/CommentStream.test.tsx apps/web-pwa/src/store/hermesForum.commentsAndHydration.test.ts apps/web-pwa/src/components/feed/MvpNewsLoop.release.test.tsx --reporter=verbose
- pnpm exec vitest run packages/data-model/src/schemas/hermes/forum.test.ts --reporter=verbose
- pnpm --filter @vh/web-pwa typecheck
- node tools/scripts/check-diff-coverage.mjs
- pnpm deps:check
- pnpm docs:check
- pnpm check:mvp-release-gates
- pnpm lint