### PR TITLE
Add report intake admin action workflow

### DIFF
--- a/apps/web-pwa/src/components/admin/NewsReportAdminQueue.test.tsx
+++ b/apps/web-pwa/src/components/admin/NewsReportAdminQueue.test.tsx
@@ -1,0 +1,146 @@
+/* @vitest-environment jsdom */
+import React from 'react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { HermesNewsReport } from '@vh/data-model';
+import { NewsReportAdminQueue } from './NewsReportAdminQueue';
+import { useNewsReportStore, type NewsReportOperatorAction } from '../../store/newsReports';
+
+const SYNTHESIS_REPORT: HermesNewsReport = {
+  schemaVersion: 'hermes-news-report-v1',
+  report_id: 'report-synthesis-1',
+  target: {
+    type: 'synthesis',
+    topic_id: 'topic-1',
+    synthesis_id: 'synthesis-1',
+    epoch: 2,
+    story_id: 'story-1',
+  },
+  reason_code: 'inaccurate_summary',
+  reason: 'Wrong source attribution.',
+  reporter_id: 'reporter-1',
+  created_at: 100,
+  status: 'pending',
+  audit: { action: 'news_report' },
+};
+
+const COMMENT_REPORT: HermesNewsReport = {
+  schemaVersion: 'hermes-news-report-v1',
+  report_id: 'report-comment-1',
+  target: {
+    type: 'story_thread_comment',
+    thread_id: 'news-story:story-1',
+    comment_id: 'comment-1',
+  },
+  reason_code: 'abusive_content',
+  reporter_id: 'reporter-2',
+  created_at: 101,
+  status: 'pending',
+  audit: { action: 'news_report' },
+};
+
+const originalState = useNewsReportStore.getState();
+
+describe('NewsReportAdminQueue', () => {
+  beforeEach(() => {
+    const reports = new Map<string, HermesNewsReport>([
+      [SYNTHESIS_REPORT.report_id, SYNTHESIS_REPORT],
+      [COMMENT_REPORT.report_id, COMMENT_REPORT],
+    ]);
+    const applyOperatorAction = vi.fn(
+      async (reportId: string, action: NewsReportOperatorAction, operatorId = 'operator-local') => {
+        const current = useNewsReportStore.getState().reports.get(reportId);
+        if (!current) throw new Error('Report not found');
+        const updated: HermesNewsReport = {
+          ...current,
+          status: action === 'dismiss' ? 'reviewed' : 'actioned',
+          audit: {
+            action: 'news_report',
+            operator_id: operatorId,
+            reviewed_at: 200,
+            resolution:
+              action === 'dismiss'
+                ? 'dismissed'
+                : action === 'suppress_synthesis'
+                  ? 'synthesis_suppressed'
+                  : action === 'mark_synthesis_unavailable'
+                    ? 'synthesis_unavailable'
+                    : action === 'hide_comment'
+                      ? 'comment_hidden'
+                      : 'comment_restored',
+          },
+        };
+        useNewsReportStore.setState((state) => {
+          const next = new Map(state.reports);
+          next.set(reportId, updated);
+          return { ...state, reports: next };
+        });
+        return updated;
+      },
+    );
+
+    useNewsReportStore.setState({
+      ...originalState,
+      reports,
+      loading: false,
+      error: null,
+      refreshQueue: vi.fn(async () => Array.from(reports.values())),
+      applyOperatorAction,
+    }, true);
+  });
+
+  afterEach(() => {
+    cleanup();
+    useNewsReportStore.setState(originalState, true);
+  });
+
+  it('mvp gate: report intake admin action queue routes reports to audited remediation', async () => {
+    render(<NewsReportAdminQueue />);
+
+    expect(screen.getByTestId('news-report-row-report-synthesis-1')).toHaveTextContent('Wrong source attribution.');
+    expect(screen.getByTestId('news-report-row-report-comment-1')).toHaveTextContent('abusive_content');
+
+    fireEvent.change(screen.getByTestId('news-report-operator-id'), { target: { value: 'ops-1' } });
+    fireEvent.click(screen.getByTestId('news-report-suppress-report-synthesis-1'));
+
+    await waitFor(() =>
+      expect(useNewsReportStore.getState().applyOperatorAction).toHaveBeenCalledWith(
+        'report-synthesis-1',
+        'suppress_synthesis',
+        'ops-1',
+      ),
+    );
+    await waitFor(() => expect(screen.queryByTestId('news-report-row-report-synthesis-1')).not.toBeInTheDocument());
+    expect(useNewsReportStore.getState().reports.get('report-synthesis-1')?.audit).toMatchObject({
+      action: 'news_report',
+      operator_id: 'ops-1',
+      reviewed_at: 200,
+      resolution: 'synthesis_suppressed',
+    });
+
+    fireEvent.click(screen.getByTestId('news-report-hide-report-comment-1'));
+    await waitFor(() =>
+      expect(useNewsReportStore.getState().applyOperatorAction).toHaveBeenCalledWith(
+        'report-comment-1',
+        'hide_comment',
+        'ops-1',
+      ),
+    );
+    expect(useNewsReportStore.getState().reports.get('report-comment-1')?.audit.resolution).toBe('comment_hidden');
+  });
+
+  it('dismisses pending reports without applying a remediation action', async () => {
+    render(<NewsReportAdminQueue />);
+    fireEvent.click(screen.getByTestId('news-report-dismiss-report-comment-1'));
+
+    await waitFor(() =>
+      expect(useNewsReportStore.getState().applyOperatorAction).toHaveBeenCalledWith(
+        'report-comment-1',
+        'dismiss',
+        'operator-local',
+      ),
+    );
+    expect(useNewsReportStore.getState().reports.get('report-comment-1')?.audit.resolution).toBe('dismissed');
+  });
+});

--- a/apps/web-pwa/src/components/admin/NewsReportAdminQueue.tsx
+++ b/apps/web-pwa/src/components/admin/NewsReportAdminQueue.tsx
@@ -1,0 +1,193 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import type { HermesNewsReport } from '@vh/data-model';
+import { useNewsReportStore, type NewsReportOperatorAction } from '../../store/newsReports';
+
+function targetLabel(report: HermesNewsReport): string {
+  if (report.target.type === 'synthesis') {
+    return `Synthesis ${report.target.synthesis_id} · topic ${report.target.topic_id} · epoch ${report.target.epoch}`;
+  }
+  return `Comment ${report.target.comment_id} · thread ${report.target.thread_id}`;
+}
+
+function targetKind(report: HermesNewsReport): string {
+  return report.target.type === 'synthesis' ? 'Accepted synthesis' : 'Story-thread comment';
+}
+
+export const NewsReportAdminQueue: React.FC = () => {
+  const reportMap = useNewsReportStore((state) => state.reports);
+  const loading = useNewsReportStore((state) => state.loading);
+  const error = useNewsReportStore((state) => state.error);
+  const refreshQueue = useNewsReportStore((state) => state.refreshQueue);
+  const applyOperatorAction = useNewsReportStore((state) => state.applyOperatorAction);
+  const reports = useMemo(
+    () =>
+      Array.from(reportMap.values())
+        .filter((report) => report.status === 'pending')
+        .sort((a, b) => a.created_at - b.created_at || a.report_id.localeCompare(b.report_id)),
+    [reportMap],
+  );
+  const [operatorId, setOperatorId] = useState('operator-local');
+  const [busyReportId, setBusyReportId] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  useEffect(() => {
+    void refreshQueue().catch(() => undefined);
+  }, [refreshQueue]);
+
+  const runAction = async (reportId: string, action: NewsReportOperatorAction) => {
+    setBusyReportId(reportId);
+    setActionError(null);
+    try {
+      await applyOperatorAction(reportId, action, operatorId);
+    } catch (err: unknown) {
+      setActionError(err instanceof Error ? err.message : 'Unable to apply report action');
+    } finally {
+      setBusyReportId(null);
+    }
+  };
+
+  return (
+    <section
+      className="space-y-4 rounded-[1.5rem] border border-slate-200/90 bg-white/84 p-5 shadow-sm shadow-slate-900/5 dark:border-slate-800 dark:bg-slate-950/80"
+      data-testid="news-report-admin-queue"
+    >
+      <header className="flex flex-wrap items-start justify-between gap-3">
+        <div className="space-y-1">
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
+            Operator Queue
+          </p>
+          <h2 className="text-xl font-semibold text-slate-950 dark:text-white">News Reports</h2>
+        </div>
+        <div className="flex flex-wrap items-center gap-2 text-xs">
+          <label className="font-semibold uppercase tracking-[0.14em] text-slate-500" htmlFor="news-report-operator-id">
+            Operator
+          </label>
+          <input
+            id="news-report-operator-id"
+            value={operatorId}
+            onChange={(event) => setOperatorId(event.currentTarget.value)}
+            className="rounded-md border border-slate-200 bg-white px-2 py-1 text-sm text-slate-700 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100"
+            data-testid="news-report-operator-id"
+          />
+          <button
+            type="button"
+            className="rounded-full border border-slate-300 bg-white px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.14em] text-slate-700 transition hover:border-slate-400 hover:bg-slate-50 disabled:opacity-60 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:hover:bg-slate-800"
+            onClick={() => void refreshQueue()}
+            disabled={loading}
+            data-testid="news-report-refresh"
+          >
+            {loading ? 'Refreshing' : 'Refresh'}
+          </button>
+        </div>
+      </header>
+
+      {error && (
+        <p className="rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800" role="alert">
+          {error}
+        </p>
+      )}
+      {actionError && (
+        <p className="rounded-lg border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-800" role="alert">
+          {actionError}
+        </p>
+      )}
+
+      {reports.length === 0 ? (
+        <p className="rounded-[1.25rem] border border-dashed border-slate-200 bg-slate-50/70 px-4 py-5 text-sm text-slate-500 dark:border-slate-700 dark:bg-slate-900/70 dark:text-slate-400">
+          No pending reports.
+        </p>
+      ) : (
+        <ul className="space-y-3">
+          {reports.map((report) => {
+            const busy = busyReportId === report.report_id;
+            return (
+              <li
+                key={report.report_id}
+                className="space-y-3 rounded-[1.25rem] border border-slate-200/90 bg-slate-50/80 p-4 dark:border-slate-800 dark:bg-slate-900/80"
+                data-testid={`news-report-row-${report.report_id}`}
+              >
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div className="space-y-1">
+                    <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
+                      {targetKind(report)}
+                    </p>
+                    <p className="break-all text-sm font-medium text-slate-900 dark:text-white">
+                      {targetLabel(report)}
+                    </p>
+                    <p className="text-sm text-slate-600 dark:text-slate-300">
+                      {report.reason_code}
+                      {report.reason ? `: ${report.reason}` : ''}
+                    </p>
+                    <p className="text-xs text-slate-500 dark:text-slate-400">
+                      Report {report.report_id} · by {report.reporter_id} · {new Date(report.created_at).toISOString()}
+                    </p>
+                  </div>
+                  <span className="rounded-full bg-slate-200 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.14em] text-slate-600 dark:bg-slate-800 dark:text-slate-300">
+                    {report.status}
+                  </span>
+                </div>
+
+                <div className="flex flex-wrap gap-2">
+                  {report.target.type === 'synthesis' ? (
+                    <>
+                      <button
+                        type="button"
+                        className="rounded-full bg-rose-700 px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.14em] text-white transition hover:bg-rose-800 disabled:opacity-60"
+                        disabled={busy}
+                        onClick={() => void runAction(report.report_id, 'suppress_synthesis')}
+                        data-testid={`news-report-suppress-${report.report_id}`}
+                      >
+                        Suppress synthesis
+                      </button>
+                      <button
+                        type="button"
+                        className="rounded-full border border-amber-300 bg-amber-50 px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.14em] text-amber-800 transition hover:bg-amber-100 disabled:opacity-60"
+                        disabled={busy}
+                        onClick={() => void runAction(report.report_id, 'mark_synthesis_unavailable')}
+                        data-testid={`news-report-unavailable-${report.report_id}`}
+                      >
+                        Mark unavailable
+                      </button>
+                    </>
+                  ) : (
+                    <>
+                      <button
+                        type="button"
+                        className="rounded-full bg-rose-700 px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.14em] text-white transition hover:bg-rose-800 disabled:opacity-60"
+                        disabled={busy}
+                        onClick={() => void runAction(report.report_id, 'hide_comment')}
+                        data-testid={`news-report-hide-${report.report_id}`}
+                      >
+                        Hide comment
+                      </button>
+                      <button
+                        type="button"
+                        className="rounded-full border border-emerald-300 bg-emerald-50 px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.14em] text-emerald-800 transition hover:bg-emerald-100 disabled:opacity-60"
+                        disabled={busy}
+                        onClick={() => void runAction(report.report_id, 'restore_comment')}
+                        data-testid={`news-report-restore-${report.report_id}`}
+                      >
+                        Restore comment
+                      </button>
+                    </>
+                  )}
+                  <button
+                    type="button"
+                    className="rounded-full border border-slate-300 bg-white px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.14em] text-slate-700 transition hover:border-slate-400 hover:bg-slate-50 disabled:opacity-60 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:hover:bg-slate-800"
+                    disabled={busy}
+                    onClick={() => void runAction(report.report_id, 'dismiss')}
+                    data-testid={`news-report-dismiss-${report.report_id}`}
+                  >
+                    Dismiss
+                  </button>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+};
+
+export default NewsReportAdminQueue;

--- a/apps/web-pwa/src/components/feed/NewsCard.tsx
+++ b/apps/web-pwa/src/components/feed/NewsCard.tsx
@@ -285,6 +285,7 @@ export const NewsCard: React.FC<NewsCardProps> = ({ item }) => {
             <NewsCardBack
               headline={item.title}
               topicId={item.topic_id}
+              storyId={storyId}
               summary={summary}
               summaryBasisLabel={summaryBasisLabel}
               frameRows={frameRows}

--- a/apps/web-pwa/src/components/feed/NewsCardBack.report.test.tsx
+++ b/apps/web-pwa/src/components/feed/NewsCardBack.report.test.tsx
@@ -1,0 +1,92 @@
+/* @vitest-environment jsdom */
+import React from 'react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NewsCardBack } from './NewsCardBack';
+
+const submitSynthesisReportMock = vi.fn(async () => undefined);
+
+vi.mock('../../store/newsReports', () => ({
+  useNewsReportStore: (selector?: (state: { submitSynthesisReport: typeof submitSynthesisReportMock }) => unknown) => {
+    const state = { submitSynthesisReport: submitSynthesisReportMock };
+    return selector ? selector(state) : state;
+  },
+}));
+
+vi.mock('../../store/hermesForum', () => ({
+  useForumStore: (selector?: (state: { loadComments: () => Promise<unknown[]>; comments: Map<string, unknown[]> }) => unknown) => {
+    const state = { loadComments: vi.fn(async () => []), comments: new Map() };
+    return selector ? selector(state) : state;
+  },
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children }: { children: React.ReactNode }) => <a href="/hermes/mock">{children}</a>,
+}));
+
+describe('NewsCardBack report intake', () => {
+  beforeEach(() => {
+    submitSynthesisReportMock.mockReset();
+  });
+
+  afterEach(() => cleanup());
+
+  it('submits accepted synthesis reports without mutating correction state', async () => {
+    render(
+      <NewsCardBack
+        headline="Launch housing bundle"
+        topicId="topic-1"
+        storyId="story-1"
+        summary="Accepted synthesis summary."
+        summaryBasisLabel="Topic synthesis v2"
+        frameRows={[{
+          frame_point_id: 'frame-1',
+          frame: 'Housing supply is constrained.',
+          reframe_point_id: 'reframe-1',
+          reframe: 'Tenant protections must come first.',
+        }]}
+        frameBasisLabel="Topic synthesis frames"
+        analysisProvider={null}
+        galleryImages={[]}
+        relatedCoverage={[]}
+        relatedLinks={[]}
+        storylineHeadline={null}
+        storylineStoryCount={0}
+        analysisFeedbackStatus={null}
+        analysisError={null}
+        retryAnalysis={() => undefined}
+        synthesisLoading={false}
+        synthesisError={null}
+        synthesisUnavailable={false}
+        analysis={null}
+        analysisId={null}
+        synthesisId="synthesis-1"
+        synthesisProvenance={null}
+        epoch={3}
+        sourceViewer={null}
+        discussionThread={null}
+        fallbackCommentCount={0}
+        createThread={null}
+        onCollapse={() => undefined}
+      />,
+    );
+
+    fireEvent.change(screen.getByTestId('news-card-synthesis-report-reason-topic-1'), {
+      target: { value: 'bad_frame' },
+    });
+    fireEvent.click(screen.getByTestId('news-card-synthesis-report-submit-topic-1'));
+
+    await waitFor(() =>
+      expect(submitSynthesisReportMock).toHaveBeenCalledWith({
+        topicId: 'topic-1',
+        synthesisId: 'synthesis-1',
+        epoch: 3,
+        storyId: 'story-1',
+        reasonCode: 'bad_frame',
+      }),
+    );
+    expect(screen.getByTestId('news-card-summary-topic-1')).toHaveTextContent('Accepted synthesis summary.');
+    expect(screen.queryByTestId('news-card-synthesis-correction-topic-1')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web-pwa/src/components/feed/NewsCardBack.tsx
+++ b/apps/web-pwa/src/components/feed/NewsCardBack.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
-import type { TopicSynthesisCorrection } from '@vh/data-model';
+import React, { useState } from 'react';
+import type { HermesNewsReportReasonCode, TopicSynthesisCorrection } from '@vh/data-model';
 import type { HermesThread } from '@vh/types';
+import { useNewsReportStore } from '../../store/newsReports';
 import type { NewsCardAnalysisSynthesis } from './newsCardAnalysis';
 import { AnalysisLoadingState } from './AnalysisLoadingState';
 import { BiasTable, type BiasTableFrameRow } from './BiasTable';
@@ -31,6 +32,7 @@ export interface NewsCardSynthesisProvenance {
 export interface NewsCardBackProps {
   readonly headline: string;
   readonly topicId: string;
+  readonly storyId?: string | null;
   readonly summary: string;
   readonly summaryBasisLabel?: string;
   readonly frameRows: ReadonlyArray<BiasTableFrameRow>;
@@ -94,6 +96,7 @@ export interface NewsCardBackProps {
 export const NewsCardBack: React.FC<NewsCardBackProps> = ({
   headline,
   topicId,
+  storyId,
   summary,
   summaryBasisLabel,
   frameRows,
@@ -123,6 +126,7 @@ export const NewsCardBack: React.FC<NewsCardBackProps> = ({
   createThread = null,
   onCollapse,
 }) => {
+  const submitSynthesisReport = useNewsReportStore((state) => state.submitSynthesisReport);
   const hasAcceptedStanceTargets = frameRows.some(
     (row) => Boolean(row.frame_point_id?.trim() || row.reframe_point_id?.trim()),
   );
@@ -131,6 +135,30 @@ export const NewsCardBack: React.FC<NewsCardBackProps> = ({
   const correctionStateLabel = synthesisCorrection?.status === 'suppressed'
     ? 'Accepted synthesis suppressed'
     : 'Accepted synthesis unavailable';
+  const [reportReason, setReportReason] = useState<HermesNewsReportReasonCode>('inaccurate_summary');
+  const [reportStatus, setReportStatus] = useState<'idle' | 'submitting' | 'submitted' | 'error'>('idle');
+  const [reportError, setReportError] = useState<string | null>(null);
+  const canReportSynthesis = Boolean(synthesisId && epoch !== undefined && !correctionBlocksSynthesis);
+  const handleReportSynthesis = async () => {
+    if (!synthesisId || epoch === undefined) {
+      return;
+    }
+    setReportStatus('submitting');
+    setReportError(null);
+    try {
+      await submitSynthesisReport({
+        topicId,
+        synthesisId,
+        epoch,
+        storyId,
+        reasonCode: reportReason,
+      });
+      setReportStatus('submitted');
+    } catch (error: unknown) {
+      setReportStatus('error');
+      setReportError(error instanceof Error ? error.message : 'Unable to submit report');
+    }
+  };
 
   return (
     <div data-testid={`news-card-back-${topicId}`} className="space-y-5">
@@ -219,6 +247,42 @@ export const NewsCardBack: React.FC<NewsCardBackProps> = ({
           <p className="text-sm leading-7 text-slate-700 dark:text-slate-200" data-testid={`news-card-summary-${topicId}`}>
             {summary}
           </p>
+          {canReportSynthesis && (
+            <div
+              className="flex flex-wrap items-center gap-2 rounded-lg border border-slate-200/80 bg-white/75 px-3 py-2 text-xs text-slate-600 dark:border-slate-800 dark:bg-slate-950/50 dark:text-slate-300"
+              data-testid={`news-card-synthesis-report-${topicId}`}
+            >
+              <label className="sr-only" htmlFor={`news-card-synthesis-report-reason-${topicId}`}>
+                Report reason
+              </label>
+              <select
+                id={`news-card-synthesis-report-reason-${topicId}`}
+                value={reportReason}
+                onChange={(event) => setReportReason(event.currentTarget.value as HermesNewsReportReasonCode)}
+                className="rounded-md border border-slate-200 bg-white px-2 py-1 text-xs text-slate-700 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100"
+                data-testid={`news-card-synthesis-report-reason-${topicId}`}
+              >
+                <option value="inaccurate_summary">Inaccurate summary</option>
+                <option value="bad_frame">Bad frame</option>
+                <option value="source_attribution_error">Source attribution</option>
+                <option value="policy_violation">Policy issue</option>
+              </select>
+              <button
+                type="button"
+                className="rounded-full border border-slate-300 bg-white px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.14em] text-slate-700 transition hover:border-slate-400 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:hover:bg-slate-800"
+                onClick={handleReportSynthesis}
+                disabled={reportStatus === 'submitting' || reportStatus === 'submitted'}
+                data-testid={`news-card-synthesis-report-submit-${topicId}`}
+              >
+                {reportStatus === 'submitted' ? 'Reported' : reportStatus === 'submitting' ? 'Reporting' : 'Report synthesis'}
+              </button>
+              {reportStatus === 'error' && reportError && (
+                <span className="text-rose-700 dark:text-rose-200" role="alert">
+                  {reportError}
+                </span>
+              )}
+            </div>
+          )}
 
           {galleryImages.length > 0 && (
             <div

--- a/apps/web-pwa/src/components/hermes/CommentStream.test.tsx
+++ b/apps/web-pwa/src/components/hermes/CommentStream.test.tsx
@@ -8,6 +8,7 @@ import { CommentStream } from './CommentStream';
 
 const voteMock = vi.fn();
 const createCommentMock = vi.fn(async () => undefined);
+const submitCommentReportMock = vi.fn(async () => undefined);
 let trustScore = 1;
 
 const c = (overrides: any) => ({
@@ -35,6 +36,13 @@ vi.mock('../../store/hermesForum', () => ({
   useForumStore: (selector?: (s: typeof mockStore) => any) => (selector ? selector(mockStore) : mockStore)
 }));
 
+vi.mock('../../store/newsReports', () => ({
+  useNewsReportStore: (selector?: (s: { submitCommentReport: typeof submitCommentReportMock }) => any) => {
+    const state = { submitCommentReport: submitCommentReportMock };
+    return selector ? selector(state) : state;
+  }
+}));
+
 vi.mock('../../hooks/useIdentity', () => ({
   useIdentity: () => ({ identity: { session: { trustScore } } })
 }));
@@ -47,6 +55,7 @@ describe('CommentStream', () => {
     mockStore.userVotes = new Map();
     voteMock.mockReset();
     createCommentMock.mockReset();
+    submitCommentReportMock.mockReset();
     trustScore = 1;
   });
 
@@ -118,6 +127,23 @@ describe('CommentStream', () => {
 
     expect(screen.getByText('restored content')).toBeInTheDocument();
     expect(screen.queryByTestId('comment-hidden-restored-comment')).not.toBeInTheDocument();
+  });
+
+  it('submits a story-thread comment report without hiding the comment directly', async () => {
+    const comments: any[] = [
+      c({ id: 'reported-comment', content: 'visible reported content', author: 'alice', timestamp: 1, stance: 'concur' })
+    ];
+
+    render(<CommentStream threadId="news-story:story-1" comments={comments as any} />);
+    fireEvent.click(screen.getByTestId('comment-report-submit-reported-comment'));
+
+    await waitFor(() => expect(submitCommentReportMock).toHaveBeenCalledWith({
+      threadId: 'news-story:story-1',
+      commentId: 'reported-comment',
+      reasonCode: 'abusive_content'
+    }));
+    expect(screen.getByText('visible reported content')).toBeInTheDocument();
+    expect(screen.queryByTestId('comment-hidden-reported-comment')).not.toBeInTheDocument();
   });
 
   it('renders root comments in chronological order', () => {

--- a/apps/web-pwa/src/components/hermes/CommentStream.tsx
+++ b/apps/web-pwa/src/components/hermes/CommentStream.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useMemo, useState } from 'react';
+import type { HermesNewsReportReasonCode } from '@vh/data-model';
 import type { HermesComment, HermesCommentModeration } from '@vh/types';
 import { useForumStore } from '../../store/hermesForum';
+import { useNewsReportStore } from '../../store/newsReports';
 import { renderMarkdown } from '../../utils/markdown';
 import { cardMaxWidth, ChildrenContainer, stanceMeta } from './commentStreamLayout';
 import { CommentComposer } from './forum/CommentComposer';
@@ -49,11 +51,15 @@ const CommentItem: React.FC<CommentItemProps> = ({
   );
 
   const meta = stanceMeta(comment.stance);
+  const submitCommentReport = useNewsReportStore((state) => state.submitCommentReport);
   const score = comment.upvotes - comment.downvotes;
   const maxW = cardMaxWidth(depth);
   const isHidden = moderation?.status === 'hidden';
 
   const [showReply, setShowReply] = useState(false);
+  const [reportReason, setReportReason] = useState<HermesNewsReportReasonCode>('abusive_content');
+  const [reportStatus, setReportStatus] = useState<'idle' | 'submitting' | 'submitted' | 'error'>('idle');
+  const [reportError, setReportError] = useState<string | null>(null);
   const [childrenCollapsed, setChildrenCollapsed] = useState(() => depth >= 3 && children.length > 0);
   const [userToggled, setUserToggled] = useState(false);
 
@@ -66,6 +72,22 @@ const CommentItem: React.FC<CommentItemProps> = ({
   const handleToggle = () => {
     setUserToggled(true);
     setChildrenCollapsed((v) => !v);
+  };
+
+  const handleReportComment = async () => {
+    setReportStatus('submitting');
+    setReportError(null);
+    try {
+      await submitCommentReport({
+        threadId,
+        commentId: comment.id,
+        reasonCode: reportReason,
+      });
+      setReportStatus('submitted');
+    } catch (error: unknown) {
+      setReportStatus('error');
+      setReportError(error instanceof Error ? error.message : 'Unable to submit report');
+    }
   };
 
   const isDiscuss = comment.stance === 'discuss';
@@ -192,6 +214,42 @@ const CommentItem: React.FC<CommentItemProps> = ({
                         ↩ Reply
                       </button>
                     </TrustGate>
+                  )}
+
+                  {!isHidden && (
+                    <div className="flex flex-wrap items-center gap-2" data-testid={`comment-report-${comment.id}`}>
+                      <label className="sr-only" htmlFor={`comment-report-reason-${comment.id}`}>
+                        Report reason
+                      </label>
+                      <select
+                        id={`comment-report-reason-${comment.id}`}
+                        value={reportReason}
+                        onChange={(event) => setReportReason(event.currentTarget.value as HermesNewsReportReasonCode)}
+                        className="rounded border border-slate-200 bg-white px-2 py-1 text-xs text-slate-600 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200"
+                        data-testid={`comment-report-reason-${comment.id}`}
+                      >
+                        <option value="abusive_content">Abusive content</option>
+                        <option value="spam">Spam</option>
+                        <option value="policy_violation">Policy issue</option>
+                        <option value="other">Other</option>
+                      </select>
+                      <button
+                        className="font-medium text-slate-500 hover:text-slate-800 disabled:cursor-not-allowed disabled:opacity-60 dark:hover:text-slate-200"
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          void handleReportComment();
+                        }}
+                        disabled={reportStatus === 'submitting' || reportStatus === 'submitted'}
+                        data-testid={`comment-report-submit-${comment.id}`}
+                      >
+                        {reportStatus === 'submitted' ? 'Reported' : reportStatus === 'submitting' ? 'Reporting' : 'Report'}
+                      </button>
+                      {reportStatus === 'error' && reportError && (
+                        <span className="text-rose-700 dark:text-rose-200" role="alert">
+                          {reportError}
+                        </span>
+                      )}
+                    </div>
                   )}
 
                   {children.length > 0 && (

--- a/apps/web-pwa/src/routes/index.tsx
+++ b/apps/web-pwa/src/routes/index.tsx
@@ -13,6 +13,7 @@ import { IDChip } from '../components/hermes/IDChip';
 import { ScanContact } from '../components/hermes/ScanContact';
 import { DashboardPage } from './dashboardContent';
 import { DevColorPanel } from '../components/DevColorPanel';
+import { NewsReportAdminQueue } from '../components/admin/NewsReportAdminQueue';
 
 const RootComponent = () => (
   <RootShell>
@@ -92,6 +93,8 @@ const RootShell = ({ children }: { children: React.ReactNode }) => {
 const HomeComponent = () => <FeedList />;
 
 const DashboardComponent = DashboardPage;
+
+const AdminReportsComponent = () => <NewsReportAdminQueue />;
 
 const GovernanceComponent = () => (
   <section className="space-y-4">
@@ -219,10 +222,16 @@ const dashboardRoute = createRoute({
   path: '/dashboard',
   component: DashboardComponent
 });
+const adminReportsRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/admin/reports',
+  component: AdminReportsComponent
+});
 
 export const routeTree = rootRoute.addChildren([
   indexRoute,
   hermesRoute.addChildren([hermesIndexRoute, hermesMessagesRoute, hermesMessagesChannelRoute, hermesThreadRoute]),
   governanceRoute,
-  dashboardRoute
+  dashboardRoute,
+  adminReportsRoute
 ]);

--- a/apps/web-pwa/src/store/newsReports.defaults.test.ts
+++ b/apps/web-pwa/src/store/newsReports.defaults.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { HermesNewsReport } from '@vh/data-model';
+import type { VennClient } from '@vh/gun-client';
+
+const client = {} as VennClient;
+const loadIdentityMock = vi.hoisted(() => vi.fn());
+const writeNewsReportMock = vi.hoisted(() => vi.fn(async (_client: VennClient, report: HermesNewsReport) => report));
+
+vi.mock('./clientResolver', () => ({
+  resolveClientFromAppStore: () => client,
+}));
+
+vi.mock('./forum/persistence', () => ({
+  loadIdentity: loadIdentityMock,
+}));
+
+vi.mock('@vh/gun-client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@vh/gun-client')>();
+  return {
+    ...actual,
+    writeNewsReport: writeNewsReportMock,
+  };
+});
+
+describe('news report store default dependencies', () => {
+  beforeEach(() => {
+    loadIdentityMock.mockReset();
+    writeNewsReportMock.mockClear();
+    vi.stubGlobal('crypto', {
+      randomUUID: () => 'uuid-1',
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('uses the published identity and crypto UUID default submit path', async () => {
+    const { createNewsReportsStore } = await import('./newsReports');
+    loadIdentityMock.mockReturnValue({ session: { nullifier: 'reporter-default' } });
+    const store = createNewsReportsStore();
+
+    const report = await store.getState().submitSynthesisReport({
+      topicId: 'topic-1',
+      synthesisId: 'synthesis-1',
+      epoch: 1,
+      reasonCode: 'inaccurate_summary',
+    });
+
+    expect(report).toMatchObject({
+      report_id: 'report-uuid-1',
+      reporter_id: 'reporter-default',
+    });
+    expect(writeNewsReportMock).toHaveBeenCalledWith(client, report);
+  });
+
+  it('falls back to a timestamp random id and rejects missing default identity', async () => {
+    const { createNewsReportsStore } = await import('./newsReports');
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(500);
+    const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.5);
+    vi.stubGlobal('crypto', {});
+    loadIdentityMock.mockReturnValue({ session: { nullifier: 'reporter-default' } });
+    const store = createNewsReportsStore();
+
+    const report = await store.getState().submitCommentReport({
+      threadId: 'news-story:story-1',
+      commentId: 'comment-1',
+      reasonCode: 'abusive_content',
+    });
+
+    expect(report.report_id).toBe('report-500-8');
+
+    loadIdentityMock.mockReturnValue(null);
+    await expect(
+      store.getState().submitCommentReport({
+        threadId: 'news-story:story-1',
+        commentId: 'comment-2',
+        reasonCode: 'spam',
+      }),
+    ).rejects.toThrow('Identity is required');
+    randomSpy.mockRestore();
+    nowSpy.mockRestore();
+  });
+});

--- a/apps/web-pwa/src/store/newsReports.test.ts
+++ b/apps/web-pwa/src/store/newsReports.test.ts
@@ -1,0 +1,419 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  HermesCommentModeration,
+  HermesNewsReport,
+  TopicSynthesisCorrection,
+} from '@vh/data-model';
+import type { VennClient } from '@vh/gun-client';
+import { createNewsReportsStore } from './newsReports';
+import { useForumStore } from './hermesForum';
+import { useSynthesisStore } from './synthesis';
+
+const CLIENT = {} as VennClient;
+
+const SYNTHESIS_REPORT: HermesNewsReport = {
+  schemaVersion: 'hermes-news-report-v1',
+  report_id: 'report-synthesis-1',
+  target: {
+    type: 'synthesis',
+    topic_id: 'topic-1',
+    synthesis_id: 'synthesis-1',
+    epoch: 2,
+    story_id: 'story-1',
+  },
+  reason_code: 'inaccurate_summary',
+  reason: 'Wrong source attribution.',
+  reporter_id: 'reporter-1',
+  created_at: 100,
+  status: 'pending',
+  audit: {
+    action: 'news_report',
+  },
+};
+
+const COMMENT_REPORT: HermesNewsReport = {
+  schemaVersion: 'hermes-news-report-v1',
+  report_id: 'report-comment-1',
+  target: {
+    type: 'story_thread_comment',
+    thread_id: 'news-story:story-1',
+    comment_id: 'comment-1',
+    topic_id: 'topic-1',
+    story_id: 'story-1',
+  },
+  reason_code: 'abusive_content',
+  reporter_id: 'reporter-2',
+  created_at: 101,
+  status: 'pending',
+  audit: {
+    action: 'news_report',
+  },
+};
+
+describe('news report store', () => {
+  beforeEach(() => {
+    useSynthesisStore.getState().reset();
+    useForumStore.setState((state) => ({
+      ...state,
+      commentModeration: new Map(),
+    }));
+  });
+
+  it('submits synthesis reports with target, reporter, reason, and audit metadata', async () => {
+    const writeReport = vi.fn(async (_client: VennClient, report: HermesNewsReport) => report);
+    const store = createNewsReportsStore({
+      resolveClient: () => CLIENT,
+      getReporterId: () => 'reporter-1',
+      now: () => 123,
+      randomId: () => 'synthesis-1',
+      writeReport,
+    });
+
+    const report = await store.getState().submitSynthesisReport({
+      topicId: 'topic-1',
+      synthesisId: 'synthesis-1',
+      epoch: 2,
+      storyId: 'story-1',
+      reasonCode: 'inaccurate_summary',
+      reason: 'Wrong source attribution.',
+      reporterHandle: 'Lou',
+    });
+
+    expect(report).toMatchObject({
+      report_id: 'report-synthesis-1',
+      reporter_id: 'reporter-1',
+      reporter_handle: 'Lou',
+      status: 'pending',
+      audit: { action: 'news_report' },
+      target: {
+        type: 'synthesis',
+        topic_id: 'topic-1',
+        synthesis_id: 'synthesis-1',
+        epoch: 2,
+        story_id: 'story-1',
+      },
+    });
+    expect(writeReport).toHaveBeenCalledWith(CLIENT, report);
+    expect(store.getState().getPendingReports()).toEqual([report]);
+  });
+
+  it('submits story-thread comment reports without mutating moderation state', async () => {
+    const writeReport = vi.fn(async (_client: VennClient, report: HermesNewsReport) => report);
+    const store = createNewsReportsStore({
+      resolveClient: () => CLIENT,
+      getReporterId: () => 'reporter-2',
+      now: () => 124,
+      randomId: () => 'comment-1',
+      writeReport,
+    });
+
+    const report = await store.getState().submitCommentReport({
+      threadId: 'news-story:story-1',
+      commentId: 'comment-1',
+      topicId: 'topic-1',
+      storyId: 'story-1',
+      reasonCode: 'abusive_content',
+    });
+
+    expect(report).toMatchObject({
+      report_id: 'report-comment-1',
+      reporter_id: 'reporter-2',
+      status: 'pending',
+      target: {
+        type: 'story_thread_comment',
+        thread_id: 'news-story:story-1',
+        comment_id: 'comment-1',
+      },
+    });
+    expect(useForumStore.getState().getCommentModeration('news-story:story-1', 'comment-1')).toBeNull();
+  });
+
+  it('hydrates pending reports in deterministic queue order', async () => {
+    const newest = { ...COMMENT_REPORT, report_id: 'report-newest', created_at: 300 };
+    const oldest = { ...SYNTHESIS_REPORT, report_id: 'report-oldest', created_at: 10 };
+    const sameTimestamp = { ...SYNTHESIS_REPORT, report_id: 'report-a', created_at: 300 };
+    const store = createNewsReportsStore({
+      resolveClient: () => CLIENT,
+      readQueue: vi.fn(async () => [newest, oldest, sameTimestamp]),
+    });
+
+    await expect(store.getState().refreshQueue()).resolves.toEqual([newest, oldest, sameTimestamp]);
+    expect(store.getState().getPendingReports().map((report) => report.report_id)).toEqual([
+      'report-oldest',
+      'report-a',
+      'report-newest',
+    ]);
+  });
+
+  it('ignores malformed reports and surfaces queue refresh failures', async () => {
+    const readQueue = vi.fn(async () => {
+      throw 'queue unavailable';
+    });
+    const store = createNewsReportsStore({
+      resolveClient: () => CLIENT,
+      readQueue,
+    });
+
+    store.getState().setReport({ ...SYNTHESIS_REPORT, report_id: ' ' } as HermesNewsReport);
+    expect(store.getState().getReport(' ')).toBeNull();
+    expect(store.getState().getReport('missing')).toBeNull();
+    expect(store.getState().getPendingReports()).toEqual([]);
+
+    await expect(store.getState().refreshQueue()).rejects.toBe('queue unavailable');
+    expect(store.getState().loading).toBe(false);
+    expect(store.getState().error).toBe('Failed to refresh reports');
+  });
+
+  it('applies synthesis suppression actions and links correction audit back to the report', async () => {
+    let writtenCorrection: TopicSynthesisCorrection | null = null;
+    const writeCorrection = vi.fn(async (_client: VennClient, correction: TopicSynthesisCorrection) => {
+      writtenCorrection = correction;
+      return correction;
+    });
+    const writeReport = vi.fn(async (_client: VennClient, report: HermesNewsReport) => report);
+    const store = createNewsReportsStore({
+      resolveClient: () => CLIENT,
+      now: () => 200,
+      readReport: vi.fn(async () => SYNTHESIS_REPORT),
+      writeCorrection,
+      writeReport,
+    });
+    store.getState().setReport(SYNTHESIS_REPORT);
+
+    const updated = await store.getState().applyOperatorAction(
+      'report-synthesis-1',
+      'suppress_synthesis',
+      'ops-1',
+      'Confirmed bad attribution.',
+    );
+
+    expect(writtenCorrection).toMatchObject({
+      correction_id: 'correction-report-synthesis-1-suppress',
+      topic_id: 'topic-1',
+      synthesis_id: 'synthesis-1',
+      epoch: 2,
+      status: 'suppressed',
+      reason_code: 'inaccurate_summary',
+      operator_id: 'ops-1',
+      audit: {
+        action: 'synthesis_correction',
+        source_report_id: 'report-synthesis-1',
+      },
+    });
+    expect(useSynthesisStore.getState().topics['topic-1'].correction?.correction_id).toBe(
+      'correction-report-synthesis-1-suppress',
+    );
+    expect(updated).toMatchObject({
+      status: 'actioned',
+      audit: {
+        action: 'news_report',
+        operator_id: 'ops-1',
+        reviewed_at: 200,
+        resolution: 'synthesis_suppressed',
+        correction_id: 'correction-report-synthesis-1-suppress',
+      },
+    });
+    expect(writeReport).toHaveBeenLastCalledWith(CLIENT, updated);
+  });
+
+  it('maps non-synthesis report reasons when applying synthesis correction actions', async () => {
+    const writeCorrection = vi.fn(async (_client: VennClient, correction: TopicSynthesisCorrection) => correction);
+    const store = createNewsReportsStore({
+      resolveClient: () => CLIENT,
+      now: () => 203,
+      writeCorrection,
+      writeReport: vi.fn(async (_client, report) => report),
+    });
+    store.getState().setReport({ ...SYNTHESIS_REPORT, report_id: 'report-spam', reason_code: 'spam' });
+    store.getState().setReport({ ...SYNTHESIS_REPORT, report_id: 'report-abusive', reason_code: 'abusive_content' });
+    store.getState().setReport({ ...SYNTHESIS_REPORT, report_id: 'report-other', reason_code: 'other' });
+
+    await store.getState().applyOperatorAction('report-spam', 'mark_synthesis_unavailable', 'ops-1');
+    await store.getState().applyOperatorAction('report-abusive', 'mark_synthesis_unavailable', 'ops-1');
+    await store.getState().applyOperatorAction('report-other', 'suppress_synthesis', 'ops-1');
+
+    expect(writeCorrection).toHaveBeenNthCalledWith(
+      1,
+      CLIENT,
+      expect.objectContaining({ reason_code: 'policy_violation' }),
+    );
+    expect(writeCorrection).toHaveBeenNthCalledWith(
+      2,
+      CLIENT,
+      expect.objectContaining({ reason_code: 'policy_violation' }),
+    );
+    expect(writeCorrection).toHaveBeenNthCalledWith(
+      3,
+      CLIENT,
+      expect.objectContaining({ reason_code: 'operator_override' }),
+    );
+  });
+
+  it('applies comment hide actions and links moderation audit back to the report', async () => {
+    let writtenModeration: HermesCommentModeration | null = null;
+    const writeModeration = vi.fn(async (_client: VennClient, moderation: HermesCommentModeration) => {
+      writtenModeration = moderation;
+      return moderation;
+    });
+    const store = createNewsReportsStore({
+      resolveClient: () => CLIENT,
+      now: () => 201,
+      readReport: vi.fn(async () => COMMENT_REPORT),
+      writeModeration,
+      writeReport: vi.fn(async (_client, report) => report),
+    });
+    store.getState().setReport(COMMENT_REPORT);
+
+    const updated = await store.getState().applyOperatorAction('report-comment-1', 'hide_comment', 'ops-2');
+
+    expect(writtenModeration).toMatchObject({
+      moderation_id: 'moderation-report-comment-1-hide',
+      thread_id: 'news-story:story-1',
+      comment_id: 'comment-1',
+      status: 'hidden',
+      reason_code: 'abusive_content',
+      operator_id: 'ops-2',
+      audit: {
+        action: 'comment_moderation',
+        source_report_id: 'report-comment-1',
+      },
+    });
+    expect(useForumStore.getState().getCommentModeration('news-story:story-1', 'comment-1')?.moderation_id).toBe(
+      'moderation-report-comment-1-hide',
+    );
+    expect(updated.audit.resolution).toBe('comment_hidden');
+  });
+
+  it('applies comment restore actions and rejects synthesis actions on comment reports', async () => {
+    const writeModeration = vi.fn(async (_client: VennClient, moderation: HermesCommentModeration) => moderation);
+    const store = createNewsReportsStore({
+      resolveClient: () => CLIENT,
+      now: () => 204,
+      writeModeration,
+      writeReport: vi.fn(async (_client, report) => report),
+    });
+    store.getState().setReport(COMMENT_REPORT);
+
+    await expect(store.getState().applyOperatorAction('report-comment-1', 'suppress_synthesis', 'ops-2')).rejects.toThrow(
+      'Operator action does not match report target',
+    );
+
+    const restored = await store.getState().applyOperatorAction('report-comment-1', 'restore_comment', 'ops-2');
+    expect(writeModeration).toHaveBeenCalledWith(
+      CLIENT,
+      expect.objectContaining({
+        moderation_id: 'moderation-report-comment-1-restore',
+        status: 'restored',
+      }),
+    );
+    expect(restored.audit.resolution).toBe('comment_restored');
+  });
+
+  it('dismisses reports and rejects mismatched operator actions', async () => {
+    const store = createNewsReportsStore({
+      resolveClient: () => CLIENT,
+      now: () => 202,
+      writeReport: vi.fn(async (_client, report) => report),
+    });
+    store.getState().setReport(SYNTHESIS_REPORT);
+
+    await expect(store.getState().applyOperatorAction('report-synthesis-1', 'hide_comment', 'ops-1')).rejects.toThrow(
+      'Operator action does not match report target',
+    );
+
+    const dismissed = await store.getState().applyOperatorAction('report-synthesis-1', 'dismiss', 'ops-1');
+    expect(dismissed).toMatchObject({
+      status: 'reviewed',
+      audit: {
+        action: 'news_report',
+        operator_id: 'ops-1',
+        reviewed_at: 202,
+        resolution: 'dismissed',
+      },
+    });
+  });
+
+  it('rejects missing, already-reviewed, and blank operator action inputs', async () => {
+    const store = createNewsReportsStore({
+      resolveClient: () => CLIENT,
+      now: () => 205,
+      readReport: vi.fn(async () => null),
+      writeReport: vi.fn(async (_client, report) => report),
+    });
+
+    await expect(store.getState().applyOperatorAction(' ', 'dismiss', 'ops-1')).rejects.toThrow('reportId is required');
+    await expect(store.getState().applyOperatorAction('missing', 'dismiss', 'ops-1')).rejects.toThrow('Report not found');
+
+    store.getState().setReport({ ...SYNTHESIS_REPORT, status: 'reviewed', audit: {
+      action: 'news_report',
+      operator_id: 'ops-1',
+      reviewed_at: 1,
+      resolution: 'dismissed',
+    } });
+    await expect(store.getState().applyOperatorAction('report-synthesis-1', 'dismiss', 'ops-1')).rejects.toThrow(
+      'Report has already been reviewed',
+    );
+
+    store.getState().setReport(SYNTHESIS_REPORT);
+    await expect(store.getState().applyOperatorAction('report-synthesis-1', 'dismiss', ' ')).rejects.toThrow(
+      'operatorId is required',
+    );
+  });
+
+  it('rejects submissions without mesh client or identity', async () => {
+    const noClientStore = createNewsReportsStore({
+      resolveClient: () => null,
+      getReporterId: () => 'reporter-1',
+    });
+    await expect(
+      noClientStore.getState().submitSynthesisReport({
+        topicId: 'topic-1',
+        synthesisId: 'synthesis-1',
+        epoch: 1,
+        reasonCode: 'bad_frame',
+      }),
+    ).rejects.toThrow('mesh client is ready');
+
+    const noIdentityStore = createNewsReportsStore({
+      resolveClient: () => CLIENT,
+      getReporterId: () => null,
+    });
+    await expect(
+      noIdentityStore.getState().submitCommentReport({
+        threadId: 'thread-1',
+        commentId: 'comment-1',
+        reasonCode: 'abusive_content',
+      }),
+    ).rejects.toThrow('Identity is required');
+  });
+
+  it('rejects blank submission identifiers and resets local state', async () => {
+    const store = createNewsReportsStore({
+      resolveClient: () => CLIENT,
+      getReporterId: () => 'reporter-1',
+      writeReport: vi.fn(async (_client, report) => report),
+    });
+
+    await expect(
+      store.getState().submitSynthesisReport({
+        topicId: ' ',
+        synthesisId: 'synthesis-1',
+        epoch: 1,
+        reasonCode: 'bad_frame',
+      }),
+    ).rejects.toThrow('topicId is required');
+    await expect(
+      store.getState().submitCommentReport({
+        threadId: 'thread-1',
+        commentId: ' ',
+        reasonCode: 'abusive_content',
+      }),
+    ).rejects.toThrow('commentId is required');
+
+    store.getState().setReport(SYNTHESIS_REPORT);
+    expect(store.getState().getPendingReports()).toHaveLength(1);
+    store.getState().reset();
+    expect(store.getState().getPendingReports()).toEqual([]);
+    expect(store.getState().error).toBeNull();
+  });
+});

--- a/apps/web-pwa/src/store/newsReports.ts
+++ b/apps/web-pwa/src/store/newsReports.ts
@@ -1,0 +1,389 @@
+import { create } from 'zustand';
+import {
+  HermesNewsReportSchema,
+  type HermesCommentModeration,
+  type HermesNewsReport,
+  type HermesNewsReportReasonCode,
+  type HermesNewsReportStatus,
+  type TopicSynthesisCorrection,
+} from '@vh/data-model';
+import {
+  readNewsReport,
+  readNewsReportsByStatus,
+  writeForumCommentModeration,
+  writeNewsReport,
+  writeTopicSynthesisCorrection,
+  type VennClient,
+} from '@vh/gun-client';
+import { resolveClientFromAppStore } from './clientResolver';
+import { loadIdentity } from './forum/persistence';
+import { useForumStore } from './hermesForum';
+import { useSynthesisStore } from './synthesis';
+
+export type NewsReportOperatorAction =
+  | 'dismiss'
+  | 'suppress_synthesis'
+  | 'mark_synthesis_unavailable'
+  | 'hide_comment'
+  | 'restore_comment';
+
+export interface SubmitSynthesisReportInput {
+  readonly topicId: string;
+  readonly synthesisId: string;
+  readonly epoch: number;
+  readonly storyId?: string | null;
+  readonly reasonCode: HermesNewsReportReasonCode;
+  readonly reason?: string;
+  readonly reporterHandle?: string;
+}
+
+export interface SubmitCommentReportInput {
+  readonly threadId: string;
+  readonly commentId: string;
+  readonly storyId?: string | null;
+  readonly topicId?: string | null;
+  readonly reasonCode: HermesNewsReportReasonCode;
+  readonly reason?: string;
+  readonly reporterHandle?: string;
+}
+
+export interface NewsReportsState {
+  readonly reports: Map<string, HermesNewsReport>;
+  readonly loading: boolean;
+  readonly error: string | null;
+  setReport(report: HermesNewsReport): void;
+  getReport(reportId: string): HermesNewsReport | null;
+  getPendingReports(): HermesNewsReport[];
+  refreshQueue(status?: HermesNewsReportStatus): Promise<HermesNewsReport[]>;
+  submitSynthesisReport(input: SubmitSynthesisReportInput): Promise<HermesNewsReport>;
+  submitCommentReport(input: SubmitCommentReportInput): Promise<HermesNewsReport>;
+  applyOperatorAction(
+    reportId: string,
+    action: NewsReportOperatorAction,
+    operatorId?: string,
+    notes?: string
+  ): Promise<HermesNewsReport>;
+  reset(): void;
+}
+
+interface NewsReportsDeps {
+  resolveClient: () => VennClient | null;
+  now: () => number;
+  randomId: () => string;
+  getReporterId: () => string | null;
+  readReport: (client: VennClient, reportId: string) => Promise<HermesNewsReport | null>;
+  readQueue: (client: VennClient, status: HermesNewsReportStatus) => Promise<HermesNewsReport[]>;
+  writeReport: (client: VennClient, report: HermesNewsReport) => Promise<HermesNewsReport>;
+  writeCorrection: (client: VennClient, correction: TopicSynthesisCorrection) => Promise<TopicSynthesisCorrection>;
+  writeModeration: (client: VennClient, moderation: HermesCommentModeration) => Promise<HermesCommentModeration>;
+}
+
+function normalizeOptional(value: string | null | undefined): string | undefined {
+  const normalized = value?.trim();
+  return normalized ? normalized : undefined;
+}
+
+function normalizeRequired(value: string, name: string): string {
+  const normalized = value.trim();
+  if (!normalized) {
+    throw new Error(`${name} is required`);
+  }
+  return normalized;
+}
+
+function resolveDefaultReporterId(): string | null {
+  return loadIdentity()?.session.nullifier ?? null;
+}
+
+function defaultRandomId(): string {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return crypto.randomUUID();
+  }
+  return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+function makeArtifactId(prefix: string, reportId: string, action: string): string {
+  return `${prefix}-${reportId}-${action}`.replace(/[^A-Za-z0-9:_-]+/g, '-');
+}
+
+function mapCorrectionReasonCode(reasonCode: HermesNewsReportReasonCode): TopicSynthesisCorrection['reason_code'] {
+  switch (reasonCode) {
+    case 'inaccurate_summary':
+    case 'bad_frame':
+    case 'source_attribution_error':
+    case 'policy_violation':
+      return reasonCode;
+    case 'abusive_content':
+    case 'spam':
+      return 'policy_violation';
+    case 'other':
+      return 'operator_override';
+  }
+}
+
+function upsertReport(reports: Map<string, HermesNewsReport>, report: HermesNewsReport): Map<string, HermesNewsReport> {
+  const next = new Map(reports);
+  next.set(report.report_id, report);
+  return next;
+}
+
+function sortReports(reports: Iterable<HermesNewsReport>): HermesNewsReport[] {
+  return Array.from(reports).sort((a, b) => a.created_at - b.created_at || a.report_id.localeCompare(b.report_id));
+}
+
+function ensureClient(client: VennClient | null): VennClient {
+  if (!client) {
+    throw new Error('Report intake is unavailable until the mesh client is ready');
+  }
+  return client;
+}
+
+function ensureReporter(reporterId: string | null): string {
+  if (!reporterId) {
+    throw new Error('Identity is required to submit a report');
+  }
+  return reporterId;
+}
+
+export function createNewsReportsStore(overrides?: Partial<NewsReportsDeps>) {
+  const defaults: NewsReportsDeps = {
+    resolveClient: resolveClientFromAppStore,
+    now: () => Date.now(),
+    randomId: defaultRandomId,
+    getReporterId: resolveDefaultReporterId,
+    readReport: readNewsReport,
+    readQueue: readNewsReportsByStatus,
+    writeReport: writeNewsReport,
+    writeCorrection: writeTopicSynthesisCorrection,
+    writeModeration: writeForumCommentModeration,
+  };
+  const deps = { ...defaults, ...overrides };
+
+  return create<NewsReportsState>((set, get) => ({
+    reports: new Map(),
+    loading: false,
+    error: null,
+
+    setReport(report) {
+      const parsed = HermesNewsReportSchema.safeParse(report);
+      if (!parsed.success) {
+        return;
+      }
+      set((state) => ({
+        reports: upsertReport(state.reports, parsed.data),
+        error: null,
+      }));
+    },
+
+    getReport(reportId) {
+      const normalizedReportId = normalizeOptional(reportId);
+      return normalizedReportId ? get().reports.get(normalizedReportId) ?? null : null;
+    },
+
+    getPendingReports() {
+      return sortReports(Array.from(get().reports.values()).filter((report) => report.status === 'pending'));
+    },
+
+    async refreshQueue(status = 'pending') {
+      const client = ensureClient(deps.resolveClient());
+      set({ loading: true, error: null });
+      try {
+        const reports = await deps.readQueue(client, status);
+        set((state) => {
+          const next = new Map(state.reports);
+          for (const report of reports) {
+            next.set(report.report_id, report);
+          }
+          return { reports: next, loading: false, error: null };
+        });
+        return reports;
+      } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : 'Failed to refresh reports';
+        set({ loading: false, error: message });
+        throw error;
+      }
+    },
+
+    async submitSynthesisReport(input) {
+      const client = ensureClient(deps.resolveClient());
+      const reporterId = ensureReporter(deps.getReporterId());
+      const report: HermesNewsReport = HermesNewsReportSchema.parse({
+        schemaVersion: 'hermes-news-report-v1',
+        report_id: `report-${deps.randomId()}`,
+        target: {
+          type: 'synthesis',
+          topic_id: normalizeRequired(input.topicId, 'topicId'),
+          synthesis_id: normalizeRequired(input.synthesisId, 'synthesisId'),
+          epoch: input.epoch,
+          story_id: normalizeOptional(input.storyId),
+        },
+        reason_code: input.reasonCode,
+        reason: normalizeOptional(input.reason),
+        reporter_id: reporterId,
+        reporter_handle: normalizeOptional(input.reporterHandle),
+        created_at: deps.now(),
+        status: 'pending',
+        audit: {
+          action: 'news_report',
+        },
+      });
+      const written = await deps.writeReport(client, report);
+      get().setReport(written);
+      return written;
+    },
+
+    async submitCommentReport(input) {
+      const client = ensureClient(deps.resolveClient());
+      const reporterId = ensureReporter(deps.getReporterId());
+      const report: HermesNewsReport = HermesNewsReportSchema.parse({
+        schemaVersion: 'hermes-news-report-v1',
+        report_id: `report-${deps.randomId()}`,
+        target: {
+          type: 'story_thread_comment',
+          thread_id: normalizeRequired(input.threadId, 'threadId'),
+          comment_id: normalizeRequired(input.commentId, 'commentId'),
+          story_id: normalizeOptional(input.storyId),
+          topic_id: normalizeOptional(input.topicId),
+        },
+        reason_code: input.reasonCode,
+        reason: normalizeOptional(input.reason),
+        reporter_id: reporterId,
+        reporter_handle: normalizeOptional(input.reporterHandle),
+        created_at: deps.now(),
+        status: 'pending',
+        audit: {
+          action: 'news_report',
+        },
+      });
+      const written = await deps.writeReport(client, report);
+      get().setReport(written);
+      return written;
+    },
+
+    async applyOperatorAction(reportId, action, operatorId = 'operator-local', notes) {
+      const normalizedReportId = normalizeRequired(reportId, 'reportId');
+      const normalizedOperatorId = normalizeRequired(operatorId, 'operatorId');
+      const client = ensureClient(deps.resolveClient());
+      const existingReport = get().reports.get(normalizedReportId) ?? await deps.readReport(client, normalizedReportId);
+      if (!existingReport) {
+        throw new Error('Report not found');
+      }
+      if (existingReport.status !== 'pending') {
+        throw new Error('Report has already been reviewed');
+      }
+
+      const reviewedAt = deps.now();
+      let updated: HermesNewsReport;
+
+      if (action === 'dismiss') {
+        updated = HermesNewsReportSchema.parse({
+          ...existingReport,
+          status: 'reviewed',
+          audit: {
+            action: 'news_report',
+            operator_id: normalizedOperatorId,
+            reviewed_at: reviewedAt,
+            resolution: 'dismissed',
+            notes: normalizeOptional(notes),
+          },
+        });
+        const written = await deps.writeReport(client, updated);
+        get().setReport(written);
+        return written;
+      }
+
+      if (existingReport.target.type === 'synthesis') {
+        if (action !== 'suppress_synthesis' && action !== 'mark_synthesis_unavailable') {
+          throw new Error('Operator action does not match report target');
+        }
+        const correctionId = makeArtifactId(
+          'correction',
+          existingReport.report_id,
+          action === 'suppress_synthesis' ? 'suppress' : 'unavailable',
+        );
+        const correction: TopicSynthesisCorrection = {
+          schemaVersion: 'topic-synthesis-correction-v1',
+          correction_id: correctionId,
+          topic_id: existingReport.target.topic_id,
+          synthesis_id: existingReport.target.synthesis_id,
+          epoch: existingReport.target.epoch,
+          status: action === 'suppress_synthesis' ? 'suppressed' : 'unavailable',
+          reason_code: mapCorrectionReasonCode(existingReport.reason_code),
+          reason: normalizeOptional(existingReport.reason),
+          operator_id: normalizedOperatorId,
+          created_at: reviewedAt,
+          audit: {
+            action: 'synthesis_correction',
+            source_report_id: existingReport.report_id,
+            notes: normalizeOptional(notes),
+          },
+        };
+        const writtenCorrection = await deps.writeCorrection(client, correction);
+        useSynthesisStore.getState().setTopicCorrection(writtenCorrection.topic_id, writtenCorrection);
+        updated = HermesNewsReportSchema.parse({
+          ...existingReport,
+          status: 'actioned',
+          audit: {
+            action: 'news_report',
+            operator_id: normalizedOperatorId,
+            reviewed_at: reviewedAt,
+            resolution: action === 'suppress_synthesis' ? 'synthesis_suppressed' : 'synthesis_unavailable',
+            correction_id: writtenCorrection.correction_id,
+            notes: normalizeOptional(notes),
+          },
+        });
+        const written = await deps.writeReport(client, updated);
+        get().setReport(written);
+        return written;
+      }
+
+      if (action !== 'hide_comment' && action !== 'restore_comment') {
+        throw new Error('Operator action does not match report target');
+      }
+      const moderationId = makeArtifactId(
+        'moderation',
+        existingReport.report_id,
+        action === 'hide_comment' ? 'hide' : 'restore',
+      );
+      const moderation: HermesCommentModeration = {
+        schemaVersion: 'hermes-comment-moderation-v1',
+        moderation_id: moderationId,
+        thread_id: existingReport.target.thread_id,
+        comment_id: existingReport.target.comment_id,
+        status: action === 'hide_comment' ? 'hidden' : 'restored',
+        reason_code: existingReport.reason_code,
+        reason: normalizeOptional(existingReport.reason),
+        operator_id: normalizedOperatorId,
+        created_at: reviewedAt,
+        audit: {
+          action: 'comment_moderation',
+          source_report_id: existingReport.report_id,
+          notes: normalizeOptional(notes),
+        },
+      };
+      const writtenModeration = await deps.writeModeration(client, moderation);
+      useForumStore.getState().setCommentModeration(writtenModeration.thread_id, writtenModeration);
+      updated = HermesNewsReportSchema.parse({
+        ...existingReport,
+        status: 'actioned',
+        audit: {
+          action: 'news_report',
+          operator_id: normalizedOperatorId,
+          reviewed_at: reviewedAt,
+          resolution: action === 'hide_comment' ? 'comment_hidden' : 'comment_restored',
+          moderation_id: writtenModeration.moderation_id,
+          notes: normalizeOptional(notes),
+        },
+      });
+      const written = await deps.writeReport(client, updated);
+      get().setReport(written);
+      return written;
+    },
+
+    reset() {
+      set({ reports: new Map(), loading: false, error: null });
+    },
+  }));
+}
+
+export const useNewsReportStore = createNewsReportsStore();

--- a/docs/plans/VENN_NEWS_MVP_ROADMAP_2026-04-20.md
+++ b/docs/plans/VENN_NEWS_MVP_ROADMAP_2026-04-20.md
@@ -2,7 +2,7 @@
 
 > Status: Draft v4 docs-aligned implementation tracker
 > Date: 2026-04-20
-> Last alignment audit: 2026-04-25 in PR #542, based on `main` at `d9eb8114` after PR #541 merged
+> Last alignment audit: 2026-04-25 after PR #542 merged into `main` at `fd7ed17e`
 > Target: Four-week Web PWA MVP launch path after remaining Week 0 decisions and launch blockers are resolved
 > Scope: News feed, story analysis, frame/reframe stance, threaded discussion, and durable aggregate civic metadata
 
@@ -38,9 +38,9 @@ This roadmap is grounded in the current codebase state rather than the desired a
 | Bundle synthesis worker | PR #528 is merged into `main`. The news-aggregator now has `bundleSynthesisWorker`, `bundleSynthesisRelay`, queue wiring, guarded latest writes, model-sensitive idempotency, and story-detail UI provenance. | W0.4 is complete for publish-time accepted synthesis. Story detail can render accepted stored synthesis or explicit pending/unavailable state without hidden card-open analysis. |
 | Click-time analysis | `NewsCard` now hydrates stored `TopicSynthesisV2` on expansion and no longer calls `useAnalysis(...)` as the normal detail path. The legacy `useAnalysis` hook remains for non-card/runtime analysis paths and tests. | The headline-click contract is accepted synthesis first. Missing synthesis is surfaced as loading/pending/unavailable instead of silently generating card-open analysis. |
 | Story detail stance UI | PR #532 is merged into `main`. `NewsCardBack` renders accepted synthesis frame/reframe rows with persisted `frame_point_id` / `reframe_point_id` stance targets and disables voting when accepted point ids are absent. | W2 point-stance UI is implemented at MVP level. Remaining stance work is release evidence, aggregate freshness policy, and any product polish found in smoke testing. |
-| Story discussion UI | PR #533 is merged into `main`. Story detail uses deterministic `news-story:<encoded story-or-topic token>` headline thread ids, resolves exact deterministic matches before legacy topic/source matches, renders the thread below the frame/reframe table, and exposes recoverable load/create/post errors. Story-thread comment hide/restore moderation now has a typed audit path and deterministic gate coverage. | W2 story-thread rendering, reply composer, and minimum audited hide/restore moderation are implemented at MVP level. Remaining thread work is report intake, user block UX, and compliance/policy artifacts. |
+| Story discussion UI | PR #533 is merged into `main`. Story detail uses deterministic `news-story:<encoded story-or-topic token>` headline thread ids, resolves exact deterministic matches before legacy topic/source matches, renders the thread below the frame/reframe table, and exposes recoverable load/create/post errors. Story-thread comment hide/restore moderation now has a typed audit path and deterministic gate coverage. Story-thread comments can be reported into the operator queue and actioned through the existing audited hide/restore records. | W2 story-thread rendering, reply composer, minimum audited hide/restore moderation, and minimum report-to-action workflow are implemented at MVP level. Remaining thread work is user block UX, compliance/policy artifacts, and richer operator workflow polish. |
 | Constituency proof | Runtime proof acquisition derives an attestation-bound deterministic proof from the identity nullifier and configured district; mock proofs are rejected by voting paths; accepted stance proof is exposed as beta-local assurance. This is still not cryptographic residency proof or production Sybil resistance. | `identity-honesty-scope` resolves the Web PWA beta path: copy must say beta-local identity/proof semantics unless real cryptographic proof is explicitly pulled into scope later. |
-| Release gates | `pnpm check:mvp-release-gates` now composes source health, StoryCluster correctness, deterministic Web PWA feed/detail/stance/thread/moderation smokes, and the curated launch-content snapshot gate. It writes `.tmp/mvp-release-gates/latest/mvp-release-gates-report.json` with per-gate `pass`, `fail`, `setup_scarcity`, or `skipped_not_in_scope` status. Compliance checklist scripts remain separate. | Week 3A release evidence harness is present for the core news loop and curated fallback content; public launch still needs compliance artifacts and broader ops/admin polish. |
+| Release gates | `pnpm check:mvp-release-gates` now composes source health, StoryCluster correctness, deterministic Web PWA feed/detail/stance/thread/moderation smokes, the curated launch-content snapshot gate, and the report-intake/admin-action smoke. It writes `.tmp/mvp-release-gates/latest/mvp-release-gates-report.json` with per-gate `pass`, `fail`, `setup_scarcity`, or `skipped_not_in_scope` status. Compliance checklist scripts remain separate. | Week 3A release evidence harness is present for the core news loop, curated fallback content, and minimum report-to-action workflow; public launch still needs compliance artifacts and broader ops/admin polish. |
 | Launch content fallback | `packages/e2e/fixtures/launch-content/validated-snapshot.json` is the committed curated fallback snapshot. `pnpm check:launch-content-snapshot` validates coverage and writes `.tmp/launch-content-snapshot/latest/launch-content-snapshot-report.json`; validated-snapshot local stack mode falls back to this committed fixture when passing publisher-canary artifacts are absent. | Internal demo/QA can exercise representative singleton, bundled, preference, accepted synthesis, correction, thread, and moderation states without live ingestion. This does not prove live ingestion freshness or source operations. |
 
 ## Non-negotiable product contract
@@ -207,9 +207,9 @@ Required:
 - every news story has a stable thread identity (implemented for story detail in PR #533);
 - thread identity is derived from the story/topic identity, not transient route state (implemented as deterministic `news-story:*` ids in PR #533);
 - users can reply to the story thread (implemented in story detail in PR #533);
-- replies persist across reload (covered by forum storage paths and component/store tests; still needs a release smoke);
+- replies persist across reload (covered by forum storage paths, component/store tests, and the `story_thread` MVP gate);
 - thread count and latest activity can appear on feed cards;
-- basic safety affordances exist: audited hide/restore moderation exists for story-thread comments; report intake, user block UX, and a broader moderation queue/admin workflow remain open.
+- basic safety affordances exist: audited hide/restore moderation exists for story-thread comments, and report intake can route story-thread reports to audited hide/restore actions; user block UX, trust-gated operator roles, and broader moderation workflow polish remain open.
 
 The forum system should be reused. The MVP should not create a second comment model.
 
@@ -378,14 +378,14 @@ Week 0 should be executed as a short PR stack, not as an open-ended planning loo
 | 3 | `launch-surface-decision` | Resolved: Web PWA. | Remove native iOS/TestFlight from the four-week critical path. | Web PWA is recorded as the MVP launch target; native packaging is a parallel follow-on. |
 | 4 | `bundle-synthesis-dependency` | Complete; merged in PR #528. | Resolve PR B / bundle synthesis dependency for accepted publish-time synthesis and source split handling. | Story detail renders accepted stored synthesis or explicit pending/unavailable state without a hidden card-open analysis pass. |
 | 5 | `identity-honesty-scope` | Complete; merged in PR #530. Web PWA beta uses beta-local proof assurance; real constituency proof remains deferred. | Decide beta-local identity vs real constituency proof for MVP copy and stance guarantees. | Product copy, release notes, and stance path claims match the actual proof layer. |
-| 6 | `mvp-release-gates` | Complete; merged in PR #535 and hardened in PR #536; launch-content snapshot gate added as a follow-on closeout slice. | Deterministic feed/detail/stance/thread/correction/moderation and launch-content fallback release gates are named and report-backed. | `.tmp/mvp-release-gates/latest/mvp-release-gates-report.json` records command, artifact refs, timestamps, and pass/fail/setup-scarcity semantics for source health, story correctness, feed render, story detail, synthesis correction, point stance, story thread, story-thread moderation, and `launch_content_snapshot` gates. |
+| 6 | `mvp-release-gates` | Complete; merged in PR #535 and hardened in PR #536; launch-content snapshot and report-intake/admin-action gates added as follow-on closeout slices. | Deterministic feed/detail/stance/thread/correction/moderation, launch-content fallback, and report-to-action release gates are named and report-backed. | `.tmp/mvp-release-gates/latest/mvp-release-gates-report.json` records command, artifact refs, timestamps, and pass/fail/setup-scarcity semantics for source health, story correctness, feed render, story detail, synthesis correction, point stance, story thread, story-thread moderation, `launch_content_snapshot`, and `report_intake_admin_action` gates. |
 | 7 | `compliance-public-beta-minimums` | Open. | Privacy, terms, UGC/moderation, support, data deletion, telemetry consent, and content/copyright boundaries. | Public launch cannot proceed unless each compliance artifact has an owner and minimum accepted draft. |
-| 8 | `launch-ops-and-correction-path` | Partial; accepted synthesis correction merged in PR #537 and hardened in PR #538; story-thread comment hide/restore moderation merged in PR #539; curated validated snapshot fallback is implemented. | Report queue, model/cost telemetry, broader admin UX, and release artifact visibility remain open; bad accepted synthesis, abusive story-thread comments, and stale live-feed/demo scarcity now have minimum audited or deterministic fallback paths. | Operators have typed audit records for suppressing/unavailable accepted synthesis artifacts and hiding/restoring story-thread comments. Internal QA/demo has a committed curated fallback snapshot and `pnpm check:launch-content-snapshot`. Remaining launch-ops work must cover report intake, broader admin workflow UX, compliance artifacts, and runaway model visibility. |
+| 8 | `launch-ops-and-correction-path` | Partial; accepted synthesis correction merged in PR #537 and hardened in PR #538; story-thread comment hide/restore moderation merged in PR #539; curated validated snapshot fallback is implemented; minimum report intake and operator action queue are implemented. | Model/cost telemetry, richer admin UX, and release artifact visibility remain open; bad accepted synthesis, abusive story-thread comments, and stale live-feed/demo scarcity now have minimum audited or deterministic fallback paths. | Operators have typed audit records for suppressing/unavailable accepted synthesis artifacts and hiding/restoring story-thread comments, plus a typed report queue that routes user reports to those existing actions or dismissal. Internal QA/demo has a committed curated fallback snapshot and `pnpm check:launch-content-snapshot`. Remaining launch-ops work must cover broader admin workflow UX, compliance artifacts, trust-gated operator roles, escalation policy, and runaway model visibility. |
 
 Recommended sequencing:
 
-- PR #527, PR #528, PR #530, PR #531, PR #532, PR #533, PR #535, PR #536, PR #537, PR #538, and PR #539 are now in `main`; feed/detail stance/thread work can base on stable point ids, accepted publish-time synthesis, honest beta-local proof semantics, active personalization ranking, deterministic story discussion threads, release-gate evidence, accepted synthesis correction, and story-thread comment hide/restore moderation.
-- Compliance, report intake, broader admin workflow UX, and ops/cost visibility are now the highest-value Week 0 blockers. The core feed/detail/stance/thread product loop, minimum correction/moderation remediation paths, and curated fallback launch content have implementation and deterministic release-gate coverage.
+- PR #527, PR #528, PR #530, PR #531, PR #532, PR #533, PR #535, PR #536, PR #537, PR #538, PR #539, and PR #542 are now in `main`; feed/detail stance/thread work can base on stable point ids, accepted publish-time synthesis, honest beta-local proof semantics, active personalization ranking, deterministic story discussion threads, release-gate evidence, accepted synthesis correction, story-thread comment hide/restore moderation, and curated fallback launch content.
+- Compliance, broader admin workflow UX, trust-gated operator roles, and ops/cost visibility are now the highest-value Week 0 blockers. The core feed/detail/stance/thread product loop, minimum correction/moderation remediation paths, report intake/admin action path, and curated fallback launch content have implementation and deterministic release-gate coverage.
 - Week 1 starts only after every row in the go/no-go table has a `go` decision or an explicit accepted no-go consequence.
 
 ### Week 0 go/no-go table
@@ -404,7 +404,7 @@ Recommended sequencing:
 | Release gates | Go for the core Web PWA news loop. | `pnpm check:mvp-release-gates` passes and writes `.tmp/mvp-release-gates/latest/mvp-release-gates-report.json`. | Do not claim release-readiness from source health or story correctness alone; the MVP gate report is the required loop evidence. |
 | Compliance | No-go for public beta. | Privacy, terms, UGC/moderation, support, data deletion, telemetry consent, and content/copyright minimums have accepted drafts. | No public beta or App Store/TestFlight submission. Internal-only testing can continue. |
 | Launch content fallback | Go for internal demo/QA fallback. | A curated validated snapshot exists with enough stories to exercise singleton, bundle, preferences, accepted synthesis frames, stance targets, analyzed sources, related links, deterministic story threads, synthesis correction, and comment moderation states. `pnpm check:launch-content-snapshot` passes and `pnpm check:mvp-release-gates` includes `launch_content_snapshot`. | This does not make live ingestion healthy or compliant for public launch. Keep live freshness/source-ops claims separate from curated fallback readiness. |
-| Correction/admin path | Go for minimum MVP remediation controls; accepted synthesis correction and story-thread comment hide/restore moderation are implemented. | Operators can suppress or mark an accepted `TopicSynthesisV2` unavailable with typed audit metadata; story detail hides stale summary/frame rows; operators can hide or restore abusive story-thread comments with typed audit metadata; `pnpm check:mvp-release-gates` includes deterministic `synthesis_correction` and `story_thread_moderation` smokes. | Public launch still needs compliance artifacts, report intake, policy text, and broader admin workflow polish; do not imply a full trust-and-safety operations console exists. |
+| Correction/admin path | Go for minimum MVP remediation controls; accepted synthesis correction, story-thread comment hide/restore moderation, and report intake/admin action queue are implemented. | Users can report accepted synthesis artifacts and story-thread comments; operators can dismiss reports or apply existing suppress/unavailable/hide/restore actions with typed audit metadata and `source_report_id` provenance; story detail hides stale summary/frame rows and moderated comment content; `pnpm check:mvp-release-gates` includes deterministic `synthesis_correction`, `story_thread_moderation`, and `report_intake_admin_action` smokes. | Public launch still needs compliance artifacts, policy text, trust-gated operator roles, notification/escalation workflow, and broader admin UX polish; do not imply a full trust-and-safety operations console exists. |
 | Ops/cost visibility | Partial. | Model ids, model invocation counts, source health artifacts, release report path, and bad-analysis reports are visible. | Remote-model spend and product failures remain opaque; do not scale beyond a small internal beta. |
 
 ### W0.1 Persisted point ids
@@ -662,6 +662,7 @@ Acceptance checks:
 | Thread persistence smoke | `pnpm check:mvp-release-gates` includes `story_thread` | Deterministic `news-story:*` thread id, reply persistence, and reload attachment are covered. |
 | Story-thread moderation smoke | `pnpm check:mvp-release-gates` includes `story_thread_moderation` | Fixture-backed smoke proves audited hide/restore moderation hides abusive reply content while preserving the deterministic story thread. |
 | Launch-content fallback snapshot | `pnpm check:mvp-release-gates` includes `launch_content_snapshot`; separate command is `pnpm check:launch-content-snapshot` | Curated snapshot validates singleton stories, bundles, preference ranking/filtering, accepted synthesis point ids, analyzed-source versus related-link boundaries, deterministic story threads, persisted replies, synthesis correction, and hidden/restored comment moderation states. |
+| Report intake/admin action smoke | `pnpm check:mvp-release-gates` includes `report_intake_admin_action` | Deterministic Web PWA smoke proves pending synthesis and story-thread reports appear in the operator queue and route to audited remediation/dismissal actions. |
 | iOS build | Missing because no iOS shell | Only required if Week 0 chooses iOS. |
 | Privacy/UGC/deletion checklist | Missing | Add Week 3B; public launch blocker. |
 
@@ -672,14 +673,17 @@ Acceptance checks:
 The MVP's value rests on accurate summaries and frame/reframe items. The release plan needs a correction path:
 
 - users can report inaccurate analysis;
-- operators can suppress or regenerate a bad analysis artifact;
+- users can report abusive story-thread comments;
+- operators can dismiss reports or route them to existing remediation records;
+- operators can suppress or mark unavailable a bad analysis artifact;
+- report audit metadata links operator remediation artifacts back through `source_report_id`;
 - accepted `TopicSynthesisV2` artifacts now have a typed correction record for `suppressed` or `unavailable` state, with operator id, reason code, timestamp, and audit metadata;
 - story detail hides corrected accepted synthesis summaries/frame rows and shows the correction provenance instead;
 - story-thread comments now have a typed hide/restore moderation record with operator id, reason code, timestamp, and audit metadata;
 - story detail hides moderated abusive reply content and shows a moderation placeholder instead;
 - launch copy does not imply editorial omniscience.
 
-Still required: report intake/regeneration workflow polish, compliance policy artifacts, and broader admin workflow UX.
+Still required: regeneration workflow polish, compliance policy artifacts, trust-gated operator roles, notifications/escalation policy, and broader admin workflow UX.
 
 ### Cost and model budget
 
@@ -725,7 +729,7 @@ The stance path must be budgeted:
 - bounded write attempts;
 - local cooldown against rapid toggling;
 - aggregate projection must not count raw clicks;
-- moderation/reporting budgets for thread abuse.
+- moderation/reporting budgets for thread abuse beyond the minimum report queue.
 
 ### Data retention and deletion
 

--- a/packages/data-model/src/index.ts
+++ b/packages/data-model/src/index.ts
@@ -14,6 +14,7 @@ export * from './schemas/hermes/directory';
 export * from './schemas/hermes/storyBundle';
 export * from './schemas/hermes/storylineGroup';
 export * from './schemas/hermes/synthesis';
+export * from './schemas/hermes/newsReport';
 export * from './schemas/hermes/sentiment';
 export * from './schemas/hermes/notification';
 export * from './schemas/hermes/elevation';

--- a/packages/data-model/src/schemas/hermes/forum.test.ts
+++ b/packages/data-model/src/schemas/hermes/forum.test.ts
@@ -397,11 +397,13 @@ describe('HermesCommentModerationSchema', () => {
       status: 'restored',
       audit: {
         action: 'comment_moderation',
-        supersedes_moderation_id: 'mod-1'
+        supersedes_moderation_id: 'mod-1',
+        source_report_id: 'report-1'
       }
     });
     expect(restored.status).toBe('restored');
     expect(restored.audit.supersedes_moderation_id).toBe('mod-1');
+    expect(restored.audit.source_report_id).toBe('report-1');
   });
 
   it('rejects malformed moderation payloads', () => {

--- a/packages/data-model/src/schemas/hermes/forum.ts
+++ b/packages/data-model/src/schemas/hermes/forum.ts
@@ -140,6 +140,7 @@ export const HermesCommentModerationSchema = z.object({
   audit: z.object({
     action: z.literal('comment_moderation'),
     supersedes_moderation_id: z.string().min(1).optional(),
+    source_report_id: z.string().min(1).optional(),
     notes: z.string().min(1).optional()
   }).strict()
 }).strict();

--- a/packages/data-model/src/schemas/hermes/newsReport.test.ts
+++ b/packages/data-model/src/schemas/hermes/newsReport.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from 'vitest';
+import {
+  HermesNewsReportSchema,
+  type HermesNewsReport,
+} from './newsReport';
+
+const PENDING_SYNTHESIS_REPORT: HermesNewsReport = {
+  schemaVersion: 'hermes-news-report-v1',
+  report_id: 'report-synthesis-1',
+  target: {
+    type: 'synthesis',
+    topic_id: 'topic-1',
+    synthesis_id: 'synthesis-1',
+    epoch: 4,
+    story_id: 'story-1',
+  },
+  reason_code: 'inaccurate_summary',
+  reason: 'The summary attributes the quote to the wrong source.',
+  reporter_id: 'reporter-1',
+  reporter_handle: 'Lou',
+  created_at: 123,
+  status: 'pending',
+  audit: {
+    action: 'news_report',
+  },
+};
+
+const PENDING_COMMENT_REPORT: HermesNewsReport = {
+  schemaVersion: 'hermes-news-report-v1',
+  report_id: 'report-comment-1',
+  target: {
+    type: 'story_thread_comment',
+    thread_id: 'news-story:story-1',
+    comment_id: 'comment-1',
+    story_id: 'story-1',
+    topic_id: 'topic-1',
+  },
+  reason_code: 'abusive_content',
+  reporter_id: 'reporter-2',
+  created_at: 124,
+  status: 'pending',
+  audit: {
+    action: 'news_report',
+  },
+};
+
+describe('HermesNewsReportSchema', () => {
+  it('accepts pending synthesis and story-thread comment reports', () => {
+    expect(HermesNewsReportSchema.safeParse(PENDING_SYNTHESIS_REPORT).success).toBe(true);
+    expect(HermesNewsReportSchema.safeParse(PENDING_COMMENT_REPORT).success).toBe(true);
+  });
+
+  it('accepts dismissed reviewed reports with operator audit metadata', () => {
+    const parsed = HermesNewsReportSchema.parse({
+      ...PENDING_SYNTHESIS_REPORT,
+      status: 'reviewed',
+      audit: {
+        action: 'news_report',
+        operator_id: 'ops-1',
+        reviewed_at: 200,
+        resolution: 'dismissed',
+        notes: 'The accepted synthesis matched source material.',
+      },
+    });
+
+    expect(parsed.audit.operator_id).toBe('ops-1');
+    expect(parsed.audit.resolution).toBe('dismissed');
+  });
+
+  it('accepts actioned reports linked to correction or moderation artifacts', () => {
+    expect(
+      HermesNewsReportSchema.safeParse({
+        ...PENDING_SYNTHESIS_REPORT,
+        status: 'actioned',
+        audit: {
+          action: 'news_report',
+          operator_id: 'ops-1',
+          reviewed_at: 200,
+          resolution: 'synthesis_suppressed',
+          correction_id: 'correction-1',
+        },
+      }).success,
+    ).toBe(true);
+
+    expect(
+      HermesNewsReportSchema.safeParse({
+        ...PENDING_COMMENT_REPORT,
+        status: 'actioned',
+        audit: {
+          action: 'news_report',
+          operator_id: 'ops-1',
+          reviewed_at: 201,
+          resolution: 'comment_hidden',
+          moderation_id: 'moderation-1',
+        },
+      }).success,
+    ).toBe(true);
+  });
+
+  it('rejects malformed or inconsistent report payloads', () => {
+    const invalidPayloads = [
+      { ...PENDING_SYNTHESIS_REPORT, report_id: ' ' },
+      { ...PENDING_SYNTHESIS_REPORT, reporter_id: '' },
+      { ...PENDING_SYNTHESIS_REPORT, reason: ' ' },
+      { ...PENDING_SYNTHESIS_REPORT, reason_code: 'misc' },
+      { ...PENDING_SYNTHESIS_REPORT, target: { ...PENDING_SYNTHESIS_REPORT.target, topic_id: '' } },
+      { ...PENDING_SYNTHESIS_REPORT, audit: { action: 'wrong' } },
+      { ...PENDING_SYNTHESIS_REPORT, audit: { action: 'news_report', operator_id: 'ops-1' } },
+      {
+        ...PENDING_SYNTHESIS_REPORT,
+        status: 'reviewed',
+        audit: { action: 'news_report', reviewed_at: 200, resolution: 'dismissed' },
+      },
+      {
+        ...PENDING_SYNTHESIS_REPORT,
+        status: 'reviewed',
+        audit: { action: 'news_report', operator_id: 'ops-1', reviewed_at: 200, resolution: 'synthesis_suppressed' },
+      },
+      {
+        ...PENDING_SYNTHESIS_REPORT,
+        status: 'actioned',
+        audit: { action: 'news_report', operator_id: 'ops-1', reviewed_at: 200, resolution: 'dismissed' },
+      },
+      {
+        ...PENDING_COMMENT_REPORT,
+        status: 'actioned',
+        audit: { action: 'news_report', operator_id: 'ops-1', reviewed_at: 200, resolution: 'synthesis_suppressed' },
+      },
+      {
+        ...PENDING_SYNTHESIS_REPORT,
+        status: 'actioned',
+        audit: { action: 'news_report', operator_id: 'ops-1', reviewed_at: 200, resolution: 'synthesis_suppressed' },
+      },
+      {
+        ...PENDING_SYNTHESIS_REPORT,
+        status: 'actioned',
+        audit: { action: 'news_report', operator_id: 'ops-1', reviewed_at: 200, resolution: 'comment_hidden' },
+      },
+      {
+        ...PENDING_COMMENT_REPORT,
+        status: 'actioned',
+        audit: { action: 'news_report', operator_id: 'ops-1', reviewed_at: 200, resolution: 'comment_hidden' },
+      },
+      {
+        ...PENDING_SYNTHESIS_REPORT,
+        status: 'actioned',
+        audit: {
+          action: 'news_report',
+          operator_id: 'ops-1',
+          reviewed_at: 200,
+          resolution: 'synthesis_suppressed',
+          moderation_id: 'moderation-1',
+        },
+      },
+      {
+        ...PENDING_COMMENT_REPORT,
+        status: 'actioned',
+        audit: {
+          action: 'news_report',
+          operator_id: 'ops-1',
+          reviewed_at: 200,
+          resolution: 'comment_hidden',
+          correction_id: 'correction-1',
+          moderation_id: 'moderation-1',
+        },
+      },
+      { ...PENDING_SYNTHESIS_REPORT, token: 'secret' },
+    ];
+
+    for (const payload of invalidPayloads) {
+      expect(HermesNewsReportSchema.safeParse(payload).success).toBe(false);
+    }
+  });
+});

--- a/packages/data-model/src/schemas/hermes/newsReport.ts
+++ b/packages/data-model/src/schemas/hermes/newsReport.ts
@@ -1,0 +1,183 @@
+import { z } from 'zod';
+
+const NonEmptyString = z.string().trim().min(1);
+const PositiveTimestamp = z.number().int().nonnegative();
+
+export const HermesNewsReportReasonCodeSchema = z.enum([
+  'inaccurate_summary',
+  'bad_frame',
+  'source_attribution_error',
+  'policy_violation',
+  'abusive_content',
+  'spam',
+  'other',
+]);
+
+export const HermesNewsReportStatusSchema = z.enum(['pending', 'reviewed', 'actioned']);
+
+export const HermesNewsReportResolutionSchema = z.enum([
+  'dismissed',
+  'synthesis_suppressed',
+  'synthesis_unavailable',
+  'comment_hidden',
+  'comment_restored',
+]);
+
+export const HermesNewsReportTargetSchema = z.discriminatedUnion('type', [
+  z
+    .object({
+      type: z.literal('synthesis'),
+      topic_id: NonEmptyString,
+      synthesis_id: NonEmptyString,
+      epoch: PositiveTimestamp,
+      story_id: NonEmptyString.optional(),
+    })
+    .strict(),
+  z
+    .object({
+      type: z.literal('story_thread_comment'),
+      thread_id: NonEmptyString,
+      comment_id: NonEmptyString,
+      story_id: NonEmptyString.optional(),
+      topic_id: NonEmptyString.optional(),
+    })
+    .strict(),
+]);
+
+export const HermesNewsReportAuditSchema = z
+  .object({
+    action: z.literal('news_report'),
+    operator_id: NonEmptyString.optional(),
+    reviewed_at: PositiveTimestamp.optional(),
+    resolution: HermesNewsReportResolutionSchema.optional(),
+    correction_id: NonEmptyString.optional(),
+    moderation_id: NonEmptyString.optional(),
+    notes: NonEmptyString.optional(),
+  })
+  .strict();
+
+export const HermesNewsReportSchema = z
+  .object({
+    schemaVersion: z.literal('hermes-news-report-v1'),
+    report_id: NonEmptyString,
+    target: HermesNewsReportTargetSchema,
+    reason_code: HermesNewsReportReasonCodeSchema,
+    reason: NonEmptyString.optional(),
+    reporter_id: NonEmptyString,
+    reporter_handle: NonEmptyString.optional(),
+    created_at: PositiveTimestamp,
+    status: HermesNewsReportStatusSchema,
+    audit: HermesNewsReportAuditSchema,
+  })
+  .strict()
+  .superRefine((value, ctx) => {
+    const hasReviewMetadata = Boolean(
+      value.audit.operator_id ||
+        value.audit.reviewed_at !== undefined ||
+        value.audit.resolution ||
+        value.audit.correction_id ||
+        value.audit.moderation_id
+    );
+
+    if (value.status === 'pending' && hasReviewMetadata) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['audit'],
+        message: 'pending reports must not include operator review metadata',
+      });
+    }
+
+    if (value.status !== 'pending') {
+      if (!value.audit.operator_id) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['audit', 'operator_id'],
+          message: 'operator_id is required after review',
+        });
+      }
+      if (value.audit.reviewed_at === undefined) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['audit', 'reviewed_at'],
+          message: 'reviewed_at is required after review',
+        });
+      }
+      if (!value.audit.resolution) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['audit', 'resolution'],
+          message: 'resolution is required after review',
+        });
+      }
+    }
+
+    if (value.status === 'reviewed' && value.audit.resolution && value.audit.resolution !== 'dismissed') {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['audit', 'resolution'],
+        message: 'reviewed reports can only use dismissed resolution',
+      });
+    }
+
+    if (value.status === 'actioned' && value.audit.resolution === 'dismissed') {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['audit', 'resolution'],
+        message: 'actioned reports require a remediation resolution',
+      });
+    }
+
+    if (value.audit.correction_id && value.target.type !== 'synthesis') {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['audit', 'correction_id'],
+        message: 'correction_id is only valid for synthesis reports',
+      });
+    }
+
+    if (value.audit.moderation_id && value.target.type !== 'story_thread_comment') {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['audit', 'moderation_id'],
+        message: 'moderation_id is only valid for story-thread comment reports',
+      });
+    }
+
+    if (value.audit.resolution?.startsWith('synthesis_') && value.target.type !== 'synthesis') {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['audit', 'resolution'],
+        message: 'synthesis resolutions require a synthesis target',
+      });
+    }
+
+    if (value.audit.resolution?.startsWith('synthesis_') && !value.audit.correction_id) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['audit', 'correction_id'],
+        message: 'synthesis resolutions require correction_id',
+      });
+    }
+
+    if (value.audit.resolution?.startsWith('comment_') && value.target.type !== 'story_thread_comment') {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['audit', 'resolution'],
+        message: 'comment resolutions require a story-thread comment target',
+      });
+    }
+
+    if (value.audit.resolution?.startsWith('comment_') && !value.audit.moderation_id) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['audit', 'moderation_id'],
+        message: 'comment resolutions require moderation_id',
+      });
+    }
+  });
+
+export type HermesNewsReportReasonCode = z.infer<typeof HermesNewsReportReasonCodeSchema>;
+export type HermesNewsReportStatus = z.infer<typeof HermesNewsReportStatusSchema>;
+export type HermesNewsReportResolution = z.infer<typeof HermesNewsReportResolutionSchema>;
+export type HermesNewsReportTarget = z.infer<typeof HermesNewsReportTargetSchema>;
+export type HermesNewsReport = z.infer<typeof HermesNewsReportSchema>;

--- a/packages/data-model/src/schemas/hermes/synthesis.test.ts
+++ b/packages/data-model/src/schemas/hermes/synthesis.test.ts
@@ -505,6 +505,7 @@ describe('TopicSynthesisCorrectionSchema', () => {
         audit: {
           action: 'synthesis_correction',
           supersedes_correction_id: 'correction-0',
+          source_report_id: 'report-1',
         },
       }).success,
     ).toBe(true);
@@ -518,6 +519,7 @@ describe('TopicSynthesisCorrectionSchema', () => {
     expect(TopicSynthesisCorrectionSchema.safeParse({ ...validCorrection, reason_code: 'misc' }).success).toBe(false);
     expect(TopicSynthesisCorrectionSchema.safeParse({ ...validCorrection, operator_id: '' }).success).toBe(false);
     expect(TopicSynthesisCorrectionSchema.safeParse({ ...validCorrection, audit: { action: 'other' } }).success).toBe(false);
+    expect(TopicSynthesisCorrectionSchema.safeParse({ ...validCorrection, audit: { action: 'synthesis_correction', source_report_id: ' ' } }).success).toBe(false);
   });
 
   it('is strict so correction records cannot smuggle unrelated fields', () => {

--- a/packages/data-model/src/schemas/hermes/synthesis.ts
+++ b/packages/data-model/src/schemas/hermes/synthesis.ts
@@ -152,6 +152,7 @@ export const TopicSynthesisCorrectionSchema = z
       .object({
         action: z.literal('synthesis_correction'),
         supersedes_correction_id: z.string().trim().min(1).optional(),
+        source_report_id: z.string().trim().min(1).optional(),
         notes: z.string().trim().min(1).optional(),
       })
       .strict(),

--- a/packages/e2e/src/mvp-release-gates.mjs
+++ b/packages/e2e/src/mvp-release-gates.mjs
@@ -106,6 +106,27 @@ const GATES = [
       'apps/web-pwa/src/store/newsSnapshotBootstrap.launchContent.test.tsx',
     ],
   },
+  {
+    id: 'report_intake_admin_action',
+    label: 'Report intake queue routes bad synthesis and thread reports to audited operator actions',
+    command: [
+      'pnpm',
+      [
+        'exec',
+        'vitest',
+        'run',
+        'apps/web-pwa/src/components/admin/NewsReportAdminQueue.test.tsx',
+        '-t',
+        'mvp gate: report intake admin action',
+      ],
+    ],
+    artifactRefs: [
+      'apps/web-pwa/src/components/admin/NewsReportAdminQueue.test.tsx',
+      'apps/web-pwa/src/store/newsReports.ts',
+      'packages/data-model/src/schemas/hermes/newsReport.ts',
+      'packages/gun-client/src/newsReportAdapters.ts',
+    ],
+  },
 ];
 
 function nowIso() {

--- a/packages/gun-client/src/forumAdapters.test.ts
+++ b/packages/gun-client/src/forumAdapters.test.ts
@@ -160,6 +160,8 @@ describe('forumAdapters', () => {
       { ...MODERATION, reason: 42 },
       { ...MODERATION, audit: { action: 'comment_moderation', supersedes_moderation_id: '' } },
       { ...MODERATION, audit: { action: 'comment_moderation', supersedes_moderation_id: 42 } },
+      { ...MODERATION, audit: { action: 'comment_moderation', source_report_id: '' } },
+      { ...MODERATION, audit: { action: 'comment_moderation', source_report_id: 42 } },
       { ...MODERATION, audit: { action: 'comment_moderation', notes: '' } },
       { ...MODERATION, audit: { action: 'comment_moderation', notes: 42 } },
       { ...MODERATION, moderation_id: ' ' },
@@ -190,6 +192,7 @@ describe('forumAdapters', () => {
       status: 'restored' as const,
       audit: {
         action: 'comment_moderation' as const,
+        source_report_id: 'report-1',
         supersedes_moderation_id: 'mod-1'
       }
     };

--- a/packages/gun-client/src/forumAdapters.ts
+++ b/packages/gun-client/src/forumAdapters.ts
@@ -137,6 +137,9 @@ function hasBlankModerationFields(moderation: HermesCommentModeration): boolean 
   return (
     moderation.audit.supersedes_moderation_id !== undefined &&
     moderation.audit.supersedes_moderation_id.trim() === ''
+  ) || (
+    moderation.audit.source_report_id !== undefined &&
+    moderation.audit.source_report_id.trim() === ''
   ) || (moderation.audit.notes !== undefined && moderation.audit.notes.trim() === '');
 }
 

--- a/packages/gun-client/src/index.ts
+++ b/packages/gun-client/src/index.ts
@@ -191,6 +191,7 @@ export * from './directoryAdapters';
 export * from './docsAdapters';
 export * from './docsKeyManagement';
 export * from './synthesisAdapters';
+export * from './newsReportAdapters';
 export * from './safeLatestSynthesisAdapters';
 export * from './newsAdapters';
 export * from './storylineAdapters';

--- a/packages/gun-client/src/newsReportAdapters.test.ts
+++ b/packages/gun-client/src/newsReportAdapters.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { HermesNewsReport } from '@vh/data-model';
+import { HydrationBarrier } from './sync/barrier';
+import type { TopologyGuard } from './topology';
+import type { VennClient } from './index';
+import {
+  getNewsReportChain,
+  getNewsReportStatusIndexChain,
+  getNewsReportStatusIndexEntryChain,
+  readNewsReport,
+  readNewsReportsByStatus,
+  writeNewsReport,
+} from './newsReportAdapters';
+
+const REPORT: HermesNewsReport = {
+  schemaVersion: 'hermes-news-report-v1',
+  report_id: 'report-1',
+  target: {
+    type: 'synthesis',
+    topic_id: 'topic-1',
+    synthesis_id: 'synthesis-1',
+    epoch: 2,
+    story_id: 'story-1',
+  },
+  reason_code: 'inaccurate_summary',
+  reason: 'Wrong source attribution.',
+  reporter_id: 'reporter-1',
+  created_at: 123,
+  status: 'pending',
+  audit: {
+    action: 'news_report',
+  },
+};
+
+function createMockChain() {
+  const chain: any = {};
+  chain.once = vi.fn((cb?: (data: unknown) => void) => cb?.({}));
+  chain.put = vi.fn((_value: unknown, cb?: (ack?: { err?: string }) => void) => cb?.({}));
+  chain.get = vi.fn(() => chain);
+  return chain;
+}
+
+function createClient(chain: any, guard: TopologyGuard): VennClient {
+  const barrier = new HydrationBarrier();
+  barrier.markReady();
+  return {
+    gun: { get: vi.fn(() => chain) } as any,
+    mesh: chain,
+    hydrationBarrier: barrier,
+    topologyGuard: guard,
+    config: { peers: [] },
+    storage: {} as any,
+    user: {} as any,
+    chat: {} as any,
+    outbox: {} as any,
+    sessionReady: true,
+    markSessionReady: vi.fn(),
+    linkDevice: vi.fn(),
+    shutdown: vi.fn(),
+  };
+}
+
+describe('newsReportAdapters', () => {
+  it('guards report and queue index writes', async () => {
+    const chain = createMockChain();
+    const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+    const client = createClient(chain, guard);
+
+    await getNewsReportChain(client, 'report-1').put(REPORT);
+    await getNewsReportStatusIndexChain(client, 'pending').put({});
+    await getNewsReportStatusIndexEntryChain(client, 'pending', 'report-1').put({ report_id: 'report-1' });
+
+    expect(guard.validateWrite).toHaveBeenCalledWith('vh/news/reports/report-1/', REPORT);
+    expect(guard.validateWrite).toHaveBeenCalledWith('vh/news/reports/index/status/pending/', {});
+    expect(guard.validateWrite).toHaveBeenCalledWith(
+      'vh/news/reports/index/status/pending/report-1/',
+      { report_id: 'report-1' },
+    );
+  });
+
+  it('writes report records and status queue pointers', async () => {
+    const chain = createMockChain();
+    const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+    const client = createClient(chain, guard);
+
+    await expect(writeNewsReport(client, REPORT)).resolves.toEqual(REPORT);
+
+    expect(guard.validateWrite).toHaveBeenCalledWith('vh/news/reports/report-1/', REPORT);
+    expect(guard.validateWrite).toHaveBeenCalledWith(
+      'vh/news/reports/index/status/pending/report-1/',
+      { report_id: 'report-1', created_at: 123, target_type: 'synthesis' },
+    );
+  });
+
+  it('reads path-bound report records and rejects mismatched ids', async () => {
+    const chain = createMockChain();
+    const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+    const client = createClient(chain, guard);
+
+    chain.once.mockImplementationOnce((cb?: (data: unknown) => void) => cb?.(REPORT));
+    await expect(readNewsReport(client, 'report-1')).resolves.toEqual(REPORT);
+
+    chain.once.mockImplementationOnce((cb?: (data: unknown) => void) => cb?.({ ...REPORT, report_id: 'other' }));
+    await expect(readNewsReport(client, 'report-1')).resolves.toBeNull();
+
+    chain.once.mockImplementationOnce((cb?: (data: unknown) => void) => cb?.({ ...REPORT, token: 'secret' }));
+    await expect(readNewsReport(client, 'report-1')).resolves.toBeNull();
+
+    chain.once.mockImplementationOnce((cb?: (data: unknown) => void) => cb?.(null));
+    await expect(readNewsReport(client, 'report-1')).resolves.toBeNull();
+
+    chain.once.mockImplementationOnce((cb?: (data: unknown) => void) => cb?.('not-a-report'));
+    await expect(readNewsReport(client, 'report-1')).resolves.toBeNull();
+  });
+
+  it('hydrates deterministic pending queues and filters stale or mismatched entries', async () => {
+    const actionedReport: HermesNewsReport = {
+      ...REPORT,
+      report_id: 'report-actioned',
+      status: 'actioned',
+      audit: {
+        action: 'news_report',
+        operator_id: 'ops-1',
+        reviewed_at: 200,
+        resolution: 'synthesis_suppressed',
+        correction_id: 'correction-1',
+      },
+    };
+    const olderReport: HermesNewsReport = {
+      ...REPORT,
+      report_id: 'report-older',
+      created_at: 10,
+    };
+    const tiedReport: HermesNewsReport = {
+      ...REPORT,
+      report_id: 'report-a',
+      created_at: REPORT.created_at,
+    };
+
+    const chain = createMockChain();
+    const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+    const client = createClient(chain, guard);
+
+    chain.once
+      .mockImplementationOnce((cb?: (data: unknown) => void) =>
+        cb?.({
+          'report-1': { report_id: 'report-1', created_at: 123 },
+          'report-actioned': { report_id: 'report-actioned', created_at: 124 },
+          'report-bad-pointer': { report_id: 'other' },
+          'report-number-pointer': { report_id: 1 },
+          'report-primitive-pointer': 'bad',
+          ' ': true,
+          'report-null': true,
+          'report-a': true,
+          'report-older': true,
+        }),
+      )
+      .mockImplementationOnce((cb?: (data: unknown) => void) => cb?.(REPORT))
+      .mockImplementationOnce((cb?: (data: unknown) => void) => cb?.(tiedReport))
+      .mockImplementationOnce((cb?: (data: unknown) => void) => cb?.(actionedReport))
+      .mockImplementationOnce((cb?: (data: unknown) => void) => cb?.(null))
+      .mockImplementationOnce((cb?: (data: unknown) => void) => cb?.(olderReport));
+
+    await expect(readNewsReportsByStatus(client, 'pending')).resolves.toEqual([olderReport, REPORT, tiedReport]);
+  });
+
+  it('returns an empty queue for non-object status indexes', async () => {
+    const chain = createMockChain();
+    const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+    const client = createClient(chain, guard);
+
+    chain.once.mockImplementationOnce((cb?: (data: unknown) => void) => cb?.(null));
+    await expect(readNewsReportsByStatus(client, 'pending')).resolves.toEqual([]);
+
+    chain.once.mockImplementationOnce((cb?: (data: unknown) => void) => cb?.('not-an-index'));
+    await expect(readNewsReportsByStatus(client, 'pending')).resolves.toEqual([]);
+  });
+
+  it('rejects malformed writes and invalid read arguments', async () => {
+    const chain = createMockChain();
+    const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+    const client = createClient(chain, guard);
+
+    await expect(writeNewsReport(client, { ...REPORT, report_id: ' ' })).rejects.toThrow();
+    await expect(writeNewsReport(client, { ...REPORT, status: 'reviewed' })).rejects.toThrow();
+    await expect(readNewsReport(client, ' ')).rejects.toThrow('reportId is required');
+    await expect(readNewsReportsByStatus(client, 'closed' as never)).rejects.toThrow('status is invalid');
+  });
+
+  it('surfaces report write ack failures', async () => {
+    const chain = createMockChain();
+    chain.put.mockImplementationOnce((_value: unknown, cb?: (ack?: { err?: string }) => void) => cb?.({ err: 'boom' }));
+    const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+    const client = createClient(chain, guard);
+
+    await expect(writeNewsReport(client, REPORT)).rejects.toThrow('boom');
+  });
+
+  it('surfaces status index write ack failures', async () => {
+    const chain = createMockChain();
+    chain.put
+      .mockImplementationOnce((_value: unknown, cb?: (ack?: { err?: string }) => void) => cb?.({}))
+      .mockImplementationOnce((_value: unknown, cb?: (ack?: { err?: string }) => void) => cb?.({ err: 'index boom' }));
+    const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+    const client = createClient(chain, guard);
+
+    await expect(writeNewsReport(client, REPORT)).rejects.toThrow('index boom');
+  });
+});

--- a/packages/gun-client/src/newsReportAdapters.ts
+++ b/packages/gun-client/src/newsReportAdapters.ts
@@ -1,0 +1,177 @@
+import {
+  HermesNewsReportSchema,
+  HermesNewsReportStatusSchema,
+  type HermesNewsReport,
+  type HermesNewsReportStatus,
+} from '@vh/data-model';
+import { createGuardedChain, type ChainAck, type ChainWithGet } from './chain';
+import type { VennClient } from './types';
+
+function newsReportPath(reportId: string): string {
+  return `vh/news/reports/${reportId}/`;
+}
+
+function newsReportStatusIndexPath(status: string): string {
+  return `vh/news/reports/index/status/${status}/`;
+}
+
+function newsReportStatusIndexEntryPath(status: string, reportId: string): string {
+  return `vh/news/reports/index/status/${status}/${reportId}/`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object';
+}
+
+function stripGunMetadata(data: unknown): unknown {
+  if (!isRecord(data)) {
+    return data;
+  }
+  const { _, ...rest } = data as Record<string, unknown> & { _?: unknown };
+  return rest;
+}
+
+function normalizeId(value: string, name: string): string {
+  const normalized = value.trim();
+  if (!normalized) {
+    throw new Error(`${name} is required`);
+  }
+  return normalized;
+}
+
+function parseReport(data: unknown): HermesNewsReport | null {
+  const payload = stripGunMetadata(data);
+  const parsed = HermesNewsReportSchema.safeParse(payload);
+  return parsed.success ? parsed.data : null;
+}
+
+function parseStatus(value: string): HermesNewsReportStatus {
+  const parsed = HermesNewsReportStatusSchema.safeParse(value);
+  if (!parsed.success) {
+    throw new Error('status is invalid');
+  }
+  return parsed.data;
+}
+
+function parseQueuePointer(value: unknown, key: string): string | null {
+  if (value === true) {
+    return key;
+  }
+  const payload = stripGunMetadata(value);
+  if (!isRecord(payload)) {
+    return null;
+  }
+  const reportId = typeof payload.report_id === 'string' ? payload.report_id.trim() : '';
+  return reportId && reportId === key ? reportId : null;
+}
+
+function readOnce<T>(chain: ChainWithGet<T>): Promise<T | null> {
+  return new Promise<T | null>((resolve) => {
+    chain.once((data) => {
+      resolve((data ?? null) as T | null);
+    });
+  });
+}
+
+async function putWithAck<T>(chain: ChainWithGet<T>, value: T): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    chain.put(value, (ack?: ChainAck) => {
+      if (ack?.err) {
+        reject(new Error(ack.err));
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+export function getNewsReportChain(client: VennClient, reportId: string): ChainWithGet<HermesNewsReport> {
+  const chain = client.mesh
+    .get('news')
+    .get('reports')
+    .get(reportId) as unknown as ChainWithGet<HermesNewsReport>;
+  return createGuardedChain(chain, client.hydrationBarrier, client.topologyGuard, newsReportPath(reportId));
+}
+
+export function getNewsReportStatusIndexChain(
+  client: VennClient,
+  status: HermesNewsReportStatus
+): ChainWithGet<Record<string, unknown>> {
+  const chain = client.mesh
+    .get('news')
+    .get('reports')
+    .get('index')
+    .get('status')
+    .get(status) as unknown as ChainWithGet<Record<string, unknown>>;
+  return createGuardedChain(chain, client.hydrationBarrier, client.topologyGuard, newsReportStatusIndexPath(status));
+}
+
+export function getNewsReportStatusIndexEntryChain(
+  client: VennClient,
+  status: HermesNewsReportStatus,
+  reportId: string
+): ChainWithGet<Record<string, unknown>> {
+  const chain = client.mesh
+    .get('news')
+    .get('reports')
+    .get('index')
+    .get('status')
+    .get(status)
+    .get(reportId) as unknown as ChainWithGet<Record<string, unknown>>;
+  return createGuardedChain(
+    chain,
+    client.hydrationBarrier,
+    client.topologyGuard,
+    newsReportStatusIndexEntryPath(status, reportId)
+  );
+}
+
+export async function readNewsReport(client: VennClient, reportId: string): Promise<HermesNewsReport | null> {
+  const normalizedReportId = normalizeId(reportId, 'reportId');
+  const raw = await readOnce(getNewsReportChain(client, normalizedReportId));
+  if (raw === null) {
+    return null;
+  }
+  const parsed = parseReport(raw);
+  return parsed?.report_id === normalizedReportId ? parsed : null;
+}
+
+export async function readNewsReportsByStatus(
+  client: VennClient,
+  status: HermesNewsReportStatus
+): Promise<HermesNewsReport[]> {
+  const normalizedStatus = parseStatus(status);
+  const rawIndex = await readOnce(getNewsReportStatusIndexChain(client, normalizedStatus));
+  if (!isRecord(rawIndex)) {
+    return [];
+  }
+
+  const reportIds = Object.entries(rawIndex)
+    .filter(([key]) => key !== '_')
+    .flatMap(([key, value]) => {
+      const normalizedKey = key.trim();
+      if (!normalizedKey) {
+        return [];
+      }
+      const reportId = parseQueuePointer(value, normalizedKey);
+      return reportId ? [reportId] : [];
+    })
+    .sort((a, b) => a.localeCompare(b));
+
+  const reports = await Promise.all(reportIds.map((reportId) => readNewsReport(client, reportId)));
+  return reports
+    .filter((report): report is HermesNewsReport => Boolean(report && report.status === normalizedStatus))
+    .sort((a, b) => a.created_at - b.created_at || a.report_id.localeCompare(b.report_id));
+}
+
+export async function writeNewsReport(client: VennClient, report: unknown): Promise<HermesNewsReport> {
+  const sanitized = HermesNewsReportSchema.parse(report);
+  const reportId = normalizeId(sanitized.report_id, 'reportId');
+  await putWithAck(getNewsReportChain(client, reportId), sanitized);
+  await putWithAck(getNewsReportStatusIndexEntryChain(client, sanitized.status, reportId), {
+    report_id: reportId,
+    created_at: sanitized.created_at,
+    target_type: sanitized.target.type,
+  });
+  return sanitized;
+}

--- a/packages/gun-client/src/topology.test.ts
+++ b/packages/gun-client/src/topology.test.ts
@@ -126,6 +126,23 @@ describe('TopologyGuard', () => {
       })
     ).not.toThrow();
     expect(() =>
+      guard.validateWrite('vh/news/reports/report-1', {
+        schemaVersion: 'hermes-news-report-v1',
+        report_id: 'report-1',
+        target: {
+          type: 'synthesis',
+          topic_id: 'topic-1',
+          synthesis_id: 'synthesis-1',
+          epoch: 1,
+        },
+        reason_code: 'inaccurate_summary',
+        reporter_id: 'reporter-1',
+        created_at: 123,
+        status: 'pending',
+        audit: { action: 'news_report' },
+      })
+    ).not.toThrow();
+    expect(() =>
       guard.validateWrite('vh/aggregates/topics/topic-1/engagement/actors/actor-1', {
         schema_version: 'topic-engagement-actor-v1',
         topic_id: 'topic-1',

--- a/packages/gun-client/src/topology.ts
+++ b/packages/gun-client/src/topology.ts
@@ -33,6 +33,8 @@ const DEFAULT_RULES: TopologyRule[] = [
   { pathPrefix: 'vh/news/index/hot/*', classification: 'public' },
   { pathPrefix: 'vh/news/runtime/lease/*', classification: 'public' },
   { pathPrefix: 'vh/news/removed/*', classification: 'public' },
+  { pathPrefix: 'vh/news/reports/*', classification: 'public' },
+  { pathPrefix: 'vh/news/reports/index/status/*', classification: 'public' },
   { pathPrefix: 'vh/topics/*/epochs/*/candidates/*', classification: 'public' },
   { pathPrefix: 'vh/topics/*/epochs/*/synthesis', classification: 'public' },
   { pathPrefix: 'vh/topics/*/latest', classification: 'public' },

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -252,6 +252,7 @@ export interface HermesCommentModeration {
   audit: {
     action: 'comment_moderation';
     supersedes_moderation_id?: string;
+    source_report_id?: string;
     notes?: string;
   };
 }


### PR DESCRIPTION
## Summary
- add typed `hermes-news-report-v1` report intake records with Gun read/write queue helpers and path validation
- add Web PWA report submission store, synthesis/comment report affordances, and a minimal `/admin/reports` operator queue
- route operator actions to existing synthesis correction and comment moderation primitives with `source_report_id` audit provenance
- extend `pnpm check:mvp-release-gates` with `report_intake_admin_action` and update the roadmap state

## Verification
- `pnpm exec vitest run apps/web-pwa/src/store/newsReports.test.ts apps/web-pwa/src/store/newsReports.defaults.test.ts packages/data-model/src/schemas/hermes/newsReport.test.ts packages/gun-client/src/newsReportAdapters.test.ts --reporter=verbose`
- `pnpm exec vitest run packages/data-model/src/schemas/hermes/newsReport.test.ts packages/gun-client/src/newsReportAdapters.test.ts apps/web-pwa/src/store/newsReports.test.ts apps/web-pwa/src/components/admin/NewsReportAdminQueue.test.tsx apps/web-pwa/src/components/feed/NewsCardBack.report.test.tsx apps/web-pwa/src/components/hermes/CommentStream.test.tsx --reporter=verbose`
- `pnpm --filter @vh/e2e exec vitest run src/mvp-release-gates.vitest.mjs --reporter=verbose`
- `pnpm check:launch-content-snapshot`
- `pnpm check:mvp-release-gates`
- `node tools/scripts/check-diff-coverage.mjs`
- `pnpm --filter @vh/data-model typecheck`
- `pnpm --filter @vh/gun-client typecheck`
- `pnpm --filter @vh/web-pwa typecheck`
- `pnpm --filter @vh/types typecheck`
- `pnpm --filter @vh/e2e typecheck`
- `pnpm docs:check`
- `pnpm lint`
- `pnpm deps:check`
- `git diff --check main...HEAD`

Latest local reports record branch `coord/report-intake-admin-actions`, commit `c1389a0b7b254cd20ea30596584d542e6cca8edd`, and `overallStatus: pass`.