### PR TITLE
Align docs after report intake admin merge

### DIFF
--- a/docs/plans/VENN_NEWS_MVP_ROADMAP_2026-04-20.md
+++ b/docs/plans/VENN_NEWS_MVP_ROADMAP_2026-04-20.md
@@ -2,7 +2,7 @@
 
 > Status: Draft v4 docs-aligned implementation tracker
 > Date: 2026-04-20
-> Last alignment audit: 2026-04-25 after PR #542 merged into `main` at `fd7ed17e`
+> Last alignment audit: 2026-04-26 after PR #543 merged into `main` at `5ea6558c`
 > Target: Four-week Web PWA MVP launch path after remaining Week 0 decisions and launch blockers are resolved
 > Scope: News feed, story analysis, frame/reframe stance, threaded discussion, and durable aggregate civic metadata
 
@@ -384,7 +384,7 @@ Week 0 should be executed as a short PR stack, not as an open-ended planning loo
 
 Recommended sequencing:
 
-- PR #527, PR #528, PR #530, PR #531, PR #532, PR #533, PR #535, PR #536, PR #537, PR #538, PR #539, and PR #542 are now in `main`; feed/detail stance/thread work can base on stable point ids, accepted publish-time synthesis, honest beta-local proof semantics, active personalization ranking, deterministic story discussion threads, release-gate evidence, accepted synthesis correction, story-thread comment hide/restore moderation, and curated fallback launch content.
+- PR #527, PR #528, PR #530, PR #531, PR #532, PR #533, PR #535, PR #536, PR #537, PR #538, PR #539, PR #542, and PR #543 are now in `main`; feed/detail stance/thread work can base on stable point ids, accepted publish-time synthesis, honest beta-local proof semantics, active personalization ranking, deterministic story discussion threads, release-gate evidence, accepted synthesis correction, story-thread comment hide/restore moderation, curated fallback launch content, and minimum report-to-action admin workflow.
 - Compliance, broader admin workflow UX, trust-gated operator roles, and ops/cost visibility are now the highest-value Week 0 blockers. The core feed/detail/stance/thread product loop, minimum correction/moderation remediation paths, report intake/admin action path, and curated fallback launch content have implementation and deterministic release-gate coverage.
 - Week 1 starts only after every row in the go/no-go table has a `go` decision or an explicit accepted no-go consequence.
 

--- a/docs/specs/spec-data-topology-privacy-v0.md
+++ b/docs/specs/spec-data-topology-privacy-v0.md
@@ -2,11 +2,11 @@
 
 > Status: Normative Spec
 > Owner: VHC Spec Owners
-> Last Reviewed: 2026-03-03
+> Last Reviewed: 2026-04-26
 > Depends On: docs/foundational/System_Architecture.md, docs/CANON_MAP.md
 
 
-Version: 0.2
+Version: 0.3
 Status: Canonical (V2-first)
 
 Defines data placement, mesh path conventions, and privacy constraints for Season 0.
@@ -18,7 +18,9 @@ Defines data placement, mesh path conventions, and privacy constraints for Seaso
 | StoryBundle | local cache/index | `vh/news/stories/<storyId>` | optional | optional hash anchor | optional blob | Public |
 | TopicDigest | local cache/index | `vh/topics/<topicId>/digests/<digestId>` | optional | - | - | Public-derived |
 | TopicSynthesisV2 | local cache/index | `vh/topics/<topicId>/epochs/<epoch>/synthesis` | - | optional hash anchor | - | Public |
+| TopicSynthesisCorrection | local cache/index | `vh/topics/<topicId>/synthesis_corrections/*` | - | optional hash anchor | - | Public audit |
 | Topic latest pointer | local cache/index | `vh/topics/<topicId>/latest` | - | - | - | Public |
+| HermesNewsReport | local cache/operator queue | `vh/news/reports/*` and `vh/news/reports/index/status/*` | - | - | - | Public workflow/audit |
 | SentimentSignal event | local state | forbidden | `~<devicePub>/outbox/sentiment/<eventId>` | - | - | Sensitive |
 | AggregateSentiment (legacy summary) | local cache | compatibility-only; canonical public point aggregates use `PointAggregateSnapshotV1` below | - | optional aggregate anchor | - | Public |
 | TopicEngagementAggregateV1 | local cache | `vh/aggregates/topics/<topicId>/engagement/summary` | - | optional aggregate anchor | - | Public |
@@ -32,20 +34,25 @@ Defines data placement, mesh path conventions, and privacy constraints for Seaso
 | PointAggregateSnapshotV1 | local cache | `vh/aggregates/topics/<topicId>/syntheses/<synthesisId>/epochs/<epoch>/points/<pointId>` | - | optional hash anchor | - | Public |
 | VoteIntentRecord | local durable queue | forbidden | optional encrypted backup | - | - | Sensitive |
 | VoteAdmissionReceipt | local state | forbidden | - | - | - | Internal |
+| Hermes forum thread/comment/moderation | local cache/index | `vh/forum/*` including `comment_moderations/*` | - | optional hash anchor for public audit | - | Public/Public audit |
 
 ## 2. Canonical path conventions (V2)
 
 Allowed public V2 namespaces:
 
 - `vh/news/stories/*`
+- `vh/news/reports/*`
+- `vh/news/reports/index/status/*`
 - `vh/topics/*/digests/*`
 - `vh/topics/*/epochs/*`
 - `vh/topics/*/articles/*`
+- `vh/topics/*/synthesis_corrections/*`
 - `vh/aggregates/topics/*`
 - `vh/aggregates/topics/*/engagement/summary` (topic Eye/Lightbulb aggregate)
 - `vh/aggregates/topics/*/engagement/actors/*` (Season 0 migration input; topic-scoped actor id only, no proof/nullifier payload)
 - `vh/discovery/*`
 - `vh/civic/reps/*`
+- `vh/forum/*`
 - `vh/aggregates/topics/*/syntheses/*/epochs/*/points/*` (PointAggregateSnapshotV1 delivery)
 
 Disallowed in public namespaces:
@@ -56,6 +63,13 @@ Disallowed in public namespaces:
 - raw constituency proofs
 - per-user sentiment events
 - local receipt payloads containing personal contact details
+
+News report and moderation paths are public audit/workflow surfaces. They MUST
+NOT include private contact information, raw identity artifacts, private proof
+material, provider secrets, or personal support correspondence. `reporter_id`
+and `operator_id` are public pseudonymous identifiers; product copy must not
+present these records as a complete compliance, appeal, or case-management
+system.
 
 ## 3. Sensitive data rules
 

--- a/docs/specs/spec-hermes-forum-v0.md
+++ b/docs/specs/spec-hermes-forum-v0.md
@@ -2,11 +2,11 @@
 
 > Status: Normative Spec
 > Owner: VHC Spec Owners
-> Last Reviewed: 2026-04-25
+> Last Reviewed: 2026-04-26
 > Depends On: docs/foundational/System_Architecture.md, docs/CANON_MAP.md
 
 
-Version: 0.8
+Version: 0.9
 Status: Canonical for Season 0 (V2-first alignment)
 Context: Public topic discourse, reply/article publishing, and elevation entrypoint.
 
@@ -159,6 +159,7 @@ interface CommentModeration {
   audit: {
     action: 'comment_moderation';
     supersedes_moderation_id?: string;
+    source_report_id?: string;
     notes?: string;
   };
 }
@@ -179,8 +180,102 @@ Read/write requirements:
 - preserve audit metadata;
 - never render a hidden comment's original markdown, reply composer, or vote
   controls in story detail;
-- do not claim report intake, user blocking, or a full admin queue exists from
-  this minimum hide/restore path alone.
+- when the action originates from the news report queue, preserve
+  `audit.source_report_id`;
+- do not claim user blocking, trust-gated operator roles, notification
+  workflow, or a full trust-and-safety console exists from this minimum
+  hide/restore path alone.
+
+### 2.3.3 News report intake and operator action records
+
+Accepted synthesis artifacts and story-thread comments can be reported into a
+minimum audited operator queue. Reports are workflow/audit records; submitting a
+report does not by itself suppress synthesis or hide comment content.
+
+```ts
+type NewsReportReasonCode =
+  | 'inaccurate_summary'
+  | 'bad_frame'
+  | 'source_attribution_error'
+  | 'policy_violation'
+  | 'abusive_content'
+  | 'spam'
+  | 'other';
+
+type NewsReportStatus = 'pending' | 'reviewed' | 'actioned';
+
+type NewsReportResolution =
+  | 'dismissed'
+  | 'synthesis_suppressed'
+  | 'synthesis_unavailable'
+  | 'comment_hidden'
+  | 'comment_restored';
+
+type NewsReportTarget =
+  | {
+      type: 'synthesis';
+      topic_id: string;
+      synthesis_id: string;
+      epoch: number;
+      story_id?: string;
+    }
+  | {
+      type: 'story_thread_comment';
+      thread_id: string;
+      comment_id: string;
+      story_id?: string;
+      topic_id?: string;
+    };
+
+interface NewsReport {
+  schemaVersion: 'hermes-news-report-v1';
+  report_id: string;
+  target: NewsReportTarget;
+  reason_code: NewsReportReasonCode;
+  reason?: string;
+  reporter_id: string;
+  reporter_handle?: string;
+  created_at: number;
+  status: NewsReportStatus;
+  audit: {
+    action: 'news_report';
+    operator_id?: string;
+    reviewed_at?: number;
+    resolution?: NewsReportResolution;
+    correction_id?: string;
+    moderation_id?: string;
+    notes?: string;
+  };
+}
+```
+
+Storage paths:
+
+- Report record path: `vh/news/reports/<report_id>/`
+- Status queue/index path:
+  `vh/news/reports/index/status/<status>/<report_id>/`
+
+Read/write requirements:
+
+- validate records with `HermesNewsReportSchema`;
+- reject report records whose embedded `report_id` does not match the path
+  being read;
+- validate status queue pointers and filter stale queue entries by the actual
+  report status;
+- `pending` reports must not contain operator review metadata;
+- `reviewed` reports are dismissals only;
+- `actioned` reports must link to a remediation artifact through
+  `correction_id` or `moderation_id` as appropriate;
+- synthesis actions write existing `topic-synthesis-correction-v1` records
+  with `audit.source_report_id`;
+- comment actions write existing `hermes-comment-moderation-v1` records with
+  `audit.source_report_id`;
+- `/admin/reports` is a minimal internal operator queue for refresh, dismiss,
+  suppress/unavailable synthesis, and hide/restore comment actions.
+
+Out of scope for the current implementation: public policy text, user block UX,
+trust-gated operator-role enforcement, notifications/escalation, and a broader
+case-management console.
 
 ### 2.4 Post type contract (reply vs article)
 
@@ -542,6 +637,7 @@ Storage and sync:
 
 - [x] Gun adapters for threads/comments/indexes
 - [x] Gun adapters for audited comment hide/restore moderation
+- [x] Gun adapters for typed news report intake and status queue indexes
 - [ ] Gun adapters for standalone post publication path
 - [x] Hydration with required-field checks and Zod validation
 - [x] Deduplication TTL map
@@ -560,7 +656,8 @@ UX:
 - [x] Story-detail reply list/composer renders below accepted synthesis frame/reframe table
 - [x] Thread create/comment load/comment post failures surface as recoverable UI states
 - [x] Audited hide/restore moderation state hides story-reply content with provenance
-- [ ] Report intake, user block UX, and broader moderation queue/admin affordances for story replies
+- [x] Minimum report intake and `/admin/reports` operator action queue for accepted synthesis and story replies
+- [ ] User block UX, trust-gated operator roles, notifications/escalation, and broader moderation queue/admin affordances
 - [ ] Convert-to-article CTA + docs handoff
 - [ ] Article publish back into topic/forum surface
 
@@ -577,3 +674,4 @@ UX:
 9. Privacy invariant checks (no secrets in public forum paths).
 10. Feed-shell regression: forum cards remain discoverable through the `Topics` filter without requiring a primary HERMES tab in the public app chrome.
 11. Comment moderation schema rejects malformed/path-mismatched payloads, preserves audit metadata, and hides moderated story-reply content without changing deterministic `news-story:*` thread identity.
+12. News report schema and Gun adapters reject malformed/path-mismatched payloads, preserve operator audit metadata, and route pending reports to audited synthesis correction or comment moderation actions.

--- a/docs/specs/spec-identity-trust-constituency.md
+++ b/docs/specs/spec-identity-trust-constituency.md
@@ -2,11 +2,11 @@
 
 > Status: Normative Spec (Canonical)
 > Owner: VHC Spec Owners
-> Last Reviewed: 2026-03-03
+> Last Reviewed: 2026-04-26
 > Depends On: docs/foundational/System_Architecture.md, docs/foundational/LUMA_BriefWhitePaper.md
 
 
-Version: 0.2
+Version: 0.3
 Status: Canonical for Season 0 (Sprints 2-5)
 
 This spec is the single contract for identity, trustScore, and constituency across LUMA (identity), GWC (economics/governance), and VENN (civic signals). All client, mesh, and chain components must conform to these types and invariants.
@@ -52,7 +52,7 @@ References:
   | Dashboard tier display | ≥ 0.5 / ≥ 0.7 | ≥ 5000 / ≥ 7000 | Visual tier indicator | `dashboardContent.tsx:183,178` |
   | QF / governance votes | ≥ 0.7 | ≥ 7000 | High-impact civic action | `useGovernance.ts:30` (`MIN_TRUST_TO_VOTE`) |
   | CAK send/finalize + receipt | ≥ 0.7 | ≥ 7000 | Outbound civic forwarding | `ActionComposer.tsx:73` (per CAK §7.1) |
-  | Moderation/admin actions | ≥ 0.7 | ≥ 7000 | High-impact remediation path; story-thread hide/restore records exist, operator UI/trust gate still TBD | `HermesCommentModerationSchema`, `forumAdapters.ts` |
+  | Moderation/admin actions | ≥ 0.7 | ≥ 7000 | High-impact remediation path; minimum `/admin/reports` operator UI and audited report-to-action records exist, trust-gated operator roles still TBD | `HermesNewsReportSchema`, `NewsReportAdminQueue.tsx`, `newsReportAdapters.ts` |
   | Future high-privilege | 0.7-0.8 | 7000-8000 | Reserved range for Season 1+ | - |
 
   **Consolidation target (impl guidance, not spec-normative):** Extract a single `TRUST_THRESHOLDS` constant (e.g., in `packages/types/src/identity.ts` or a shared constants module) and replace all inline magic numbers. This is an implementation task, not a spec requirement - but implementations SHOULD converge on one import.


### PR DESCRIPTION
## Summary
- update the forum spec with the current `hermes-news-report-v1` report contract, `/admin/reports` operator queue, and `source_report_id` audit provenance
- update topology/privacy docs for report, correction, forum, and comment-moderation public workflow/audit paths
- update identity trust thresholds and roadmap alignment markers after PR #543 landed on `main`

## Verification
- `pnpm docs:check`
- `git diff --check`
- `pnpm lint`

## Notes
- This is a docs-only alignment audit. It keeps compliance artifacts, trust-gated operator roles, notifications/escalation, and broader admin workflow UX marked as remaining work.
