### PR TITLE
Harden article text retry and rejection artifacts

### DIFF
--- a/services/news-aggregator/src/__tests__/articleTextService.test.ts
+++ b/services/news-aggregator/src/__tests__/articleTextService.test.ts
@@ -198,6 +198,41 @@ describe('ArticleTextService', () => {
     });
   });
 
+  it('retries live extraction instead of returning cached retryable failures', async () => {
+    const cache = new ArticleTextCache();
+    const url = 'https://allowed.com/transient';
+
+    cache.rememberFailure({
+      url,
+      urlHash: urlHash(url),
+      code: 'fetch-failed',
+      message: 'temporary network failure',
+      statusCode: 502,
+      retryable: true,
+      failedAt: 1,
+    });
+
+    const fetchFn = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(makeHtml(makeWords(220), 'Recovered'), { status: 200 }),
+    );
+    const primaryExtractor = vi.fn().mockResolvedValue({
+      title: 'Recovered',
+      text: makeWords(220),
+    });
+    const service = new ArticleTextService({
+      allowlist: new Set(['allowed.com']),
+      cache,
+      fetchFn,
+      primaryExtractor,
+    });
+
+    const result = await service.extract(url);
+
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(result.title).toBe('Recovered');
+    expect(result.cacheHit).toBe('none');
+  });
+
   it('retries retryable fetch failures, then succeeds and records lifecycle metadata', async () => {
     const fetchFn = vi
       .fn<typeof fetch>()

--- a/services/news-aggregator/src/articleTextService.ts
+++ b/services/news-aggregator/src/articleTextService.ts
@@ -220,7 +220,7 @@ export class ArticleTextService {
       return { ...directHit.entry.value, cacheHit: 'urlHash', attempts: 0 } satisfies ArticleTextResult;
     }
 
-    if (directHit?.entry.kind === 'failure') {
+    if (directHit?.entry.kind === 'failure' && !directHit.entry.value.retryable) {
       const failure = directHit.entry.value;
       throw new ArticleTextServiceError(failure.code, failure.message, failure.statusCode, failure.retryable);
     }

--- a/services/news-aggregator/src/bundleSynthesisEvalArtifact.ts
+++ b/services/news-aggregator/src/bundleSynthesisEvalArtifact.ts
@@ -61,6 +61,9 @@ function rejectedBundleStage(input: {
   rejectionReason: string;
   bundleResponse?: BundleSynthesisRelayResponse;
 }): AnalysisEvalValidatorEvent['stage'] {
+  if (input.rejectionReason === 'source_text_unavailable') {
+    return 'source_extraction';
+  }
   if (input.rejectionReason === 'source_count_mismatch') {
     return 'bundle_synthesis_source_count';
   }

--- a/services/news-aggregator/src/bundleSynthesisWorker.test.ts
+++ b/services/news-aggregator/src/bundleSynthesisWorker.test.ts
@@ -457,6 +457,58 @@ describe('bundleSynthesisWorker', () => {
     ]);
   });
 
+  it('persists rejected eval artifacts when no source text is readable', async () => {
+    const artifacts: AnalysisEvalArtifact[] = [];
+    const articleTextService = {
+      extract: vi.fn(async () => {
+        throw new Error('fetch failed');
+      }),
+    };
+    const relay = vi.fn();
+
+    const worker = createBundleSynthesisWorker({
+      client: {} as VennClient,
+      now: () => 1700000003000,
+      readBundle: async () => BUNDLE,
+      readCandidate: vi.fn(async () => null),
+      articleTextService,
+      relay,
+      analysisEvalArtifactWriter: {
+        write: vi.fn(async (artifact) => {
+          artifacts.push(artifact);
+        }),
+      },
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    });
+
+    await expect(worker(CANDIDATE)).resolves.toEqual({
+      status: 'rejected',
+      storyId: 'story-1',
+      reason: 'source_text_unavailable',
+    });
+
+    expect(relay).not.toHaveBeenCalled();
+    expect(artifacts).toHaveLength(1);
+    expect(artifacts[0]).toMatchObject({
+      lifecycle_status: 'rejected',
+      rejection_reason: 'source_text_unavailable',
+      story: {
+        story_id: 'story-1',
+        analysis_source_ids: ['source-analysis'],
+        readable_source_ids: [],
+        analyzed_source_ids: [],
+      },
+      source_articles: [],
+      warnings: ['source_text_unavailable:source-analysis'],
+    });
+    expect(artifacts[0]?.validator_failures).toContainEqual(
+      expect.objectContaining({
+        stage: 'source_extraction',
+        code: 'source_text_unavailable',
+      }),
+    );
+  });
+
   it('rejects generated output that widens analysis source count', async () => {
     const artifacts: AnalysisEvalArtifact[] = [];
     const worker = createBundleSynthesisWorker({

--- a/services/news-aggregator/src/bundleSynthesisWorker.ts
+++ b/services/news-aggregator/src/bundleSynthesisWorker.ts
@@ -114,6 +114,16 @@ export function createBundleSynthesisWorker(
       return { status: 'skipped', storyId, reason: 'no_analysis_sources' };
     }
 
+    const request = {
+      provider_id: PROVIDER_ID,
+      model,
+      max_tokens: maxTokens,
+      timeout_ms: timeoutMs,
+      rate_per_minute: ratePerMinute,
+      temperature,
+      pipeline_version: pipelineVersion,
+    };
+
     const extracted = await extractReadableBundleSources({
       storyId,
       sources: analysisSources,
@@ -122,6 +132,28 @@ export function createBundleSynthesisWorker(
     });
     if (extracted.readableSources.length === 0) {
       logger.warn('[vh:bundle-synthesis] no readable analysis sources; rejected', { story_id: storyId });
+      await persistRejectedBundleSynthesisEvalArtifact({
+        context: {
+          writer: analysisEvalArtifactWriter,
+          logger,
+          bundle,
+          analysisSources,
+          readableSources: [],
+          extractionWarnings: extracted.warnings,
+          articleAnalysis: {
+            analyzedSources: [],
+            failedSources: [],
+            warnings: [],
+          },
+          request,
+          candidateId: `news-bundle:unreadable:${normalizeIdToken(bundle.story_id)}:${bundle.provenance_hash.slice(0, 12)}`,
+          synthesisId: `news-bundle:${normalizeIdToken(bundle.story_id)}:unreadable-${bundle.provenance_hash.slice(0, 12)}`,
+        },
+        capturedAt: now(),
+        rejectionReason: 'source_text_unavailable',
+        warnings: dedupeWarnings(extracted.warnings),
+        error: new Error('No readable article text was available for the analysis sources.'),
+      });
       return { status: 'rejected', storyId, reason: 'source_text_unavailable' };
     }
 
@@ -181,15 +213,7 @@ export function createBundleSynthesisWorker(
       readableSources: extracted.readableSources,
       extractionWarnings: extracted.warnings,
       articleAnalysis,
-      request: {
-        provider_id: PROVIDER_ID,
-        model,
-        max_tokens: maxTokens,
-        timeout_ms: timeoutMs,
-        rate_per_minute: ratePerMinute,
-        temperature,
-        pipeline_version: pipelineVersion,
-      },
+      request,
       candidateId,
       synthesisId,
     };


### PR DESCRIPTION
## Summary
- do not serve cached retryable article-text failures; retry live extraction so transient source fetch failures do not strand visible stories in synthesis-pending state
- persist rejected analysis/eval artifacts when a story has no readable full-text source, including a source-extraction validator failure
- add regression coverage for retryable failure cache behavior and no-readable-source artifact persistence

## Why
The restarted public stack on merged `main` produced a healthy feed and accepted artifacts, but one visible AP singleton stayed on feed-summary-only because article text extraction had cached a retryable transient fetch failure. The worker also logged `source_text_unavailable` without writing an eval artifact, leaving a gap in the collection policy we just made real.

## Verification
- `pnpm --filter @vh/news-aggregator test -- src/__tests__/articleTextService.test.ts`
- `pnpm --filter @vh/news-aggregator test -- bundleSynthesisWorker.test.ts`
- `pnpm --filter @vh/news-aggregator typecheck`
- `pnpm --filter @vh/news-aggregator test`
- `git diff --check`