### PR TITLE
Harden public news live pipeline

### DIFF
--- a/apps/web-pwa/src/components/feed/FeedShell.lazyLoading.test.tsx
+++ b/apps/web-pwa/src/components/feed/FeedShell.lazyLoading.test.tsx
@@ -1,6 +1,6 @@
 /* @vitest-environment jsdom */
 
-import { act, cleanup, render, screen } from '@testing-library/react';
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import React from 'react';
@@ -157,6 +157,33 @@ describe('FeedShell lazy loading', () => {
         } as unknown as IntersectionObserver;
       }),
     );
+  });
+
+  it('hydrates a direct story detail route that is outside the current feed window', async () => {
+    mockSearch = { detail: 'news:story-direct-route' };
+    const originalEnsureStory = useNewsStore.getState().ensureStory;
+    const ensureStory = vi.fn(async (storyId: string) => {
+      useDiscoveryStore.getState().mergeItems([
+        makeFeedItem({
+          topic_id: 'topic-direct-route',
+          story_id: storyId,
+          title: 'Direct route story',
+        }),
+      ]);
+      return true;
+    });
+    useNewsStore.setState({ ensureStory });
+
+    try {
+      render(<LiveFeedHarness />);
+
+      await waitFor(() => {
+        expect(ensureStory).toHaveBeenCalledWith('story-direct-route');
+      });
+      expect(await screen.findByTestId('news-card-detail-topic-direct-route')).toBeInTheDocument();
+    } finally {
+      useNewsStore.setState({ ensureStory: originalEnsureStory });
+    }
   });
 
   afterEach(() => {

--- a/apps/web-pwa/src/components/feed/FeedShell.tsx
+++ b/apps/web-pwa/src/components/feed/FeedShell.tsx
@@ -13,10 +13,27 @@ import { useFeedShellRouteState } from './useFeedShellRouteState';
 
 const TOP_SCROLL_THRESHOLD_PX = 24;
 const PULL_REFRESH_THRESHOLD_PX = 72;
+const DIRECT_STORY_LOAD_RETRY_MS = 1_000;
+const DIRECT_STORY_LOAD_MAX_ATTEMPTS = 12;
 
 export interface FeedShellProps {
   /** Discovery feed hook result (injected for testability). */
   readonly feedResult: UseDiscoveryFeedResult;
+}
+
+function normalizeDirectNewsStoryId(detailId: string | null, storyId: string | null): string | null {
+  const normalizedStoryId = storyId?.trim();
+  if (normalizedStoryId) {
+    return normalizedStoryId;
+  }
+
+  const normalizedDetailId = detailId?.trim();
+  if (!normalizedDetailId?.startsWith('news:')) {
+    return null;
+  }
+
+  const candidate = normalizedDetailId.slice('news:'.length).trim();
+  return candidate && !candidate.includes(':') ? candidate : null;
 }
 
 /**
@@ -51,6 +68,7 @@ export const FeedShell: React.FC<FeedShellProps> = ({ feedResult }) => {
   const setDiscoveryFeed = useStore(useFeedStore, (state) => state.setDiscoveryFeed);
   const discoveryItems = useStore(useDiscoveryStore, (state) => state.items);
   const refreshLatest = useStore(useNewsStore, (state) => state.refreshLatest);
+  const ensureStory = useStore(useNewsStore, (state) => state.ensureStory);
   const storylinesById = useStore(useNewsStore, (state) => state.storylinesById);
   const {
     expandedStoryId,
@@ -80,6 +98,10 @@ export const FeedShell: React.FC<FeedShellProps> = ({ feedResult }) => {
   const [refreshing, setRefreshing] = useState(false);
 
   const focusedStoryline = selectedStorylineId ? storylinesById[selectedStorylineId] ?? null : null;
+  const directRouteStoryId = useMemo(
+    () => normalizeDirectNewsStoryId(searchDetailId, searchStoryId),
+    [searchDetailId, searchStoryId],
+  );
   const totalItems = pagedFeed.length;
   const newsCount = useMemo(
     () => pagedFeed.filter((item) => item.kind === 'NEWS_STORY').length,
@@ -264,6 +286,52 @@ export const FeedShell: React.FC<FeedShellProps> = ({ feedResult }) => {
     setDiscoveryFeed,
     sortMode,
   ]);
+
+  useEffect(() => {
+    if (!directRouteStoryId) {
+      return;
+    }
+
+    const storyAlreadyComposed =
+      feed.some(
+        (item) =>
+          item.kind === 'NEWS_STORY' &&
+          item.story_id?.trim() === directRouteStoryId,
+      ) ||
+      pagedFeed.some(
+        (item) =>
+          item.kind === 'NEWS_STORY' &&
+          item.story_id?.trim() === directRouteStoryId,
+      );
+    if (storyAlreadyComposed) {
+      return;
+    }
+
+    let cancelled = false;
+    let attempts = 0;
+    let retryTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const loadDirectStory = () => {
+      if (cancelled || attempts >= DIRECT_STORY_LOAD_MAX_ATTEMPTS) {
+        return;
+      }
+      attempts += 1;
+      void ensureStory(directRouteStoryId).then((loaded) => {
+        if (cancelled || loaded || attempts >= DIRECT_STORY_LOAD_MAX_ATTEMPTS) {
+          return;
+        }
+        retryTimer = setTimeout(loadDirectStory, DIRECT_STORY_LOAD_RETRY_MS);
+      });
+    };
+
+    loadDirectStory();
+    return () => {
+      cancelled = true;
+      if (retryTimer) {
+        clearTimeout(retryTimer);
+      }
+    };
+  }, [directRouteStoryId, ensureStory, feed, pagedFeed]);
 
   const onTouchStart = useCallback(
     (event: React.TouchEvent<HTMLDivElement>) => {

--- a/apps/web-pwa/src/hooks/voteIntentMaterializer.test.ts
+++ b/apps/web-pwa/src/hooks/voteIntentMaterializer.test.ts
@@ -313,7 +313,29 @@ describe('voteIntentMaterializer', () => {
     expect(meshWriteSpy).toHaveBeenCalledWith(expect.objectContaining({ success: true }));
   });
 
-  it('replayVoteIntentQueue keeps intent pending after timeout recovery until a later acknowledged replay', async () => {
+  it('replayVoteIntentQueue writes the voter node before full aggregate fan-in', async () => {
+    const client = {} as VennClient;
+    vi.spyOn(ClientResolver, 'resolveClientFromAppStore').mockReturnValue(client);
+    vi.spyOn(SentimentTelemetry, 'logMeshWriteResult').mockImplementation(() => {});
+
+    const readRowsSpy = vi.spyOn(GunClient, 'readAggregateVoterRows').mockResolvedValue([]);
+    vi.spyOn(GunClient, 'readPointAggregateSnapshot').mockResolvedValue(null);
+    const writeVoterSpy = vi.spyOn(GunClient, 'writeVoterNode').mockResolvedValue({
+      point_id: 'point-1',
+      agreement: 1,
+      weight: 1,
+      updated_at: new Date(100).toISOString(),
+    });
+    vi.spyOn(GunClient, 'writePointAggregateSnapshot')
+      .mockImplementation(async (_client, snapshot) => PointAggregateSnapshotV1Schema.parse(snapshot));
+
+    enqueueIntent(makeIntent({ intent_id: 'write-before-fanin', seq: 100, emitted_at: 100 }));
+
+    await expect(replayVoteIntentQueue({ limit: 10, now: () => 500 })).resolves.toEqual({ replayed: 1, failed: 0 });
+    expect(writeVoterSpy.mock.invocationCallOrder[0]!).toBeLessThan(readRowsSpy.mock.invocationCallOrder[0]!);
+  });
+
+  it('replayVoteIntentQueue clears readback-confirmed timeout recovery after snapshot projection', async () => {
     const client = {} as VennClient;
     vi.spyOn(ClientResolver, 'resolveClientFromAppStore').mockReturnValue(client);
     const meshWriteSpy = vi.spyOn(SentimentTelemetry, 'logMeshWriteResult').mockImplementation(() => {});
@@ -343,7 +365,7 @@ describe('voteIntentMaterializer', () => {
 
     const result = await replayVoteIntentQueue({ limit: 10, now: () => 500 });
 
-    expect(result).toEqual({ replayed: 0, failed: 1 });
+    expect(result).toEqual({ replayed: 1, failed: 0 });
     expect(writeSnapshotSpy).toHaveBeenCalledWith(
       client,
       expect.objectContaining({
@@ -352,7 +374,7 @@ describe('voteIntentMaterializer', () => {
         participants: 1,
       }),
     );
-    expect(getPendingIntents().map((item) => item.intent_id)).toEqual(['timeout-recovered']);
+    expect(getPendingIntents()).toEqual([]);
     expect(warnSpy).toHaveBeenCalledWith(
       '[vh:vote:intent-replay:timeout-recovered]',
       expect.objectContaining({
@@ -368,12 +390,11 @@ describe('voteIntentMaterializer', () => {
       expect.objectContaining({
         topic_id: 'topic-1',
         point_id: 'point-1',
-        success: false,
+        success: true,
         timed_out: true,
         voter_node_ok: true,
         snapshot_ok: true,
         readback_recovered: true,
-        error: 'aggregate-write-needs-replay',
       }),
     );
   });
@@ -409,7 +430,7 @@ describe('voteIntentMaterializer', () => {
     expect(getPendingIntents().map((item) => item.intent_id)).toEqual(['timeout-stale']);
   });
 
-  it('replayVoteIntentQueue keeps string timeout recoveries pending until a later acknowledged replay', async () => {
+  it('replayVoteIntentQueue clears string timeout recoveries after readback-confirmed snapshot projection', async () => {
     const client = {} as VennClient;
     vi.spyOn(ClientResolver, 'resolveClientFromAppStore').mockReturnValue(client);
 
@@ -437,9 +458,9 @@ describe('voteIntentMaterializer', () => {
 
     const result = await replayVoteIntentQueue({ limit: 10, now: () => 501 });
 
-    expect(result).toEqual({ replayed: 0, failed: 1 });
+    expect(result).toEqual({ replayed: 1, failed: 0 });
     expect(writeSnapshotSpy).toHaveBeenCalledTimes(1);
-    expect(getPendingIntents().map((item) => item.intent_id)).toEqual(['timeout-string-recovered']);
+    expect(getPendingIntents()).toEqual([]);
   });
 
   it('replayVoteIntentQueue keeps intent pending when timeout readback point_id mismatches', async () => {
@@ -646,7 +667,8 @@ describe('voteIntentMaterializer', () => {
     await Promise.resolve();
     expect(replaySpy).toHaveBeenCalledTimes(1);
 
-    resolveReplay?.({ replayed: 0, failed: 0 });
+    const resolve = resolveReplay as ((value: { replayed: number; failed: number }) => void) | null;
+    resolve?.({ replayed: 0, failed: 0 });
     await Promise.resolve();
     await Promise.resolve();
   });
@@ -740,7 +762,7 @@ describe('voteIntentMaterializer', () => {
     expect(getPendingIntents()).toHaveLength(0);
 
     expect(writeVoterSpy).toHaveBeenCalledTimes(1);
-    expect(writeVoterSpy.mock.calls[0][5]).toEqual({
+    expect(writeVoterSpy.mock.calls[0]![5]).toEqual({
       point_id: 'point-1',
       agreement: 1,
       weight: 1,
@@ -748,16 +770,18 @@ describe('voteIntentMaterializer', () => {
     });
 
     expect(writeSnapshotSpy).toHaveBeenCalledTimes(1);
-    const snapshotArg = writeSnapshotSpy.mock.calls[0][1] as Record<string, unknown>;
+    const snapshotArg = writeSnapshotSpy.mock.calls[0]![1] as Record<string, unknown>;
     expect(PointAggregateSnapshotV1Schema.safeParse(snapshotArg).success).toBe(true);
     expect(snapshotArg).not.toHaveProperty('nullifier');
     expect(snapshotArg).not.toHaveProperty('constituency_proof');
     expect(snapshotArg).not.toHaveProperty('proof_ref');
   });
 
-  it('failed projection remains retryable in queue', async () => {
+  it('clears persisted voter-node intents even when snapshot materialization fails', async () => {
     const client = {} as VennClient;
     vi.spyOn(ClientResolver, 'resolveClientFromAppStore').mockReturnValue(client);
+    const meshWriteSpy = vi.spyOn(SentimentTelemetry, 'logMeshWriteResult').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     vi.spyOn(GunClient, 'readAggregateVoterRows').mockResolvedValue([]);
     vi.spyOn(GunClient, 'readPointAggregateSnapshot').mockResolvedValue(null);
     vi.spyOn(GunClient, 'writeVoterNode').mockResolvedValue({
@@ -772,13 +796,19 @@ describe('voteIntentMaterializer', () => {
 
     enqueueIntent(makeIntent({ intent_id: 'retry-1', seq: 100, emitted_at: 100 }));
 
-    const first = await replayVoteIntentQueue({ limit: 10, now: () => 1000 });
-    expect(first).toEqual({ replayed: 0, failed: 1 });
-    expect(getPendingIntents().map((item) => item.intent_id)).toEqual(['retry-1']);
-
-    writeSnapshotSpy.mockImplementation(async (_client, snapshot) => PointAggregateSnapshotV1Schema.parse(snapshot));
-    const second = await replayVoteIntentQueue({ limit: 10, now: () => 1001 });
-    expect(second).toEqual({ replayed: 1, failed: 0 });
+    const result = await replayVoteIntentQueue({ limit: 10, now: () => 1000 });
+    expect(result).toEqual({ replayed: 1, failed: 0 });
     expect(getPendingIntents()).toHaveLength(0);
+    expect(meshWriteSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+        voter_node_ok: true,
+        snapshot_ok: false,
+      }),
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[vh:vote:intent-replay:snapshot-materialization-failed]',
+      expect.objectContaining({ error: 'materialize-fail' }),
+    );
   });
 });

--- a/apps/web-pwa/src/hooks/voteIntentMaterializer.test.ts
+++ b/apps/web-pwa/src/hooks/voteIntentMaterializer.test.ts
@@ -14,6 +14,7 @@ import {
   scheduleVoteIntentReplay,
   voteIntentMaterializerInternal,
 } from './voteIntentMaterializer';
+import { projectIntentRecord } from './voteIntentProjection';
 
 function makeIntent(overrides: Partial<VoteIntentRecord> = {}): VoteIntentRecord {
   return {
@@ -333,6 +334,96 @@ describe('voteIntentMaterializer', () => {
 
     await expect(replayVoteIntentQueue({ limit: 10, now: () => 500 })).resolves.toEqual({ replayed: 1, failed: 0 });
     expect(writeVoterSpy.mock.invocationCallOrder[0]!).toBeLessThan(readRowsSpy.mock.invocationCallOrder[0]!);
+  });
+
+  it('projectIntentRecord defers snapshot materialization when aggregate fan-in hangs', async () => {
+    vi.useFakeTimers();
+    const client = {} as VennClient;
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      vi.spyOn(GunClient, 'writeVoterNode').mockResolvedValue({
+        point_id: 'point-1',
+        agreement: 1,
+        weight: 1,
+        updated_at: new Date(100).toISOString(),
+      });
+      vi.spyOn(GunClient, 'readAggregateVoterRows').mockReturnValue(new Promise(() => {}));
+      const writeSnapshotSpy = vi.spyOn(GunClient, 'writePointAggregateSnapshot');
+
+      const result = projectIntentRecord({
+        client,
+        record: makeIntent({ intent_id: 'snapshot-critical-timeout', seq: 100, emitted_at: 100 }),
+        now: () => 500,
+        materializePointSnapshot,
+      });
+      await vi.advanceTimersByTimeAsync(3_000);
+
+      await expect(result).resolves.toEqual({
+        topic_id: 'topic-1',
+        point_id: 'point-1',
+        voter_node_ok: true,
+        snapshot_ok: false,
+        readback_recovered: false,
+        timed_out: false,
+      });
+      expect(writeSnapshotSpy).not.toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[vh:vote:intent-replay:snapshot-materialization-deferred]',
+        expect.objectContaining({
+          topic_id: 'topic-1',
+          synthesis_id: 'synth-1',
+          epoch: 1,
+          point_id: 'point-1',
+          timeout_ms: 3_000,
+        }),
+      );
+    } finally {
+      warnSpy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
+  it('projectIntentRecord logs string snapshot materialization failures without retrying the voter row', async () => {
+    const client = {} as VennClient;
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      vi.spyOn(GunClient, 'writeVoterNode').mockResolvedValue({
+        point_id: 'point-1',
+        agreement: 1,
+        weight: 1,
+        updated_at: new Date(100).toISOString(),
+      });
+      vi.spyOn(GunClient, 'readAggregateVoterRows').mockRejectedValue('rows-failed-string');
+      const writeSnapshotSpy = vi.spyOn(GunClient, 'writePointAggregateSnapshot');
+
+      await expect(projectIntentRecord({
+        client,
+        record: makeIntent({ intent_id: 'snapshot-string-failure', seq: 100, emitted_at: 100 }),
+        now: () => 500,
+        materializePointSnapshot,
+      })).resolves.toEqual({
+        topic_id: 'topic-1',
+        point_id: 'point-1',
+        voter_node_ok: true,
+        snapshot_ok: false,
+        readback_recovered: false,
+        timed_out: false,
+      });
+
+      expect(writeSnapshotSpy).not.toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[vh:vote:intent-replay:snapshot-materialization-failed]',
+        expect.objectContaining({
+          topic_id: 'topic-1',
+          synthesis_id: 'synth-1',
+          epoch: 1,
+          point_id: 'point-1',
+          error: 'rows-failed-string',
+        }),
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   it('replayVoteIntentQueue clears readback-confirmed timeout recovery after snapshot projection', async () => {

--- a/apps/web-pwa/src/hooks/voteIntentMaterializer.ts
+++ b/apps/web-pwa/src/hooks/voteIntentMaterializer.ts
@@ -158,17 +158,13 @@ export async function replayVoteIntentQueue(options?: {
       });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      const needsReplay = message === 'aggregate-write-needs-replay';
       logMeshWriteResult({
         topic_id: record.topic_id,
         point_id: record.point_id,
         success: false,
         latency_ms: Math.max(0, now() - startedAt),
         error: message,
-        voter_node_ok: needsReplay ? true : undefined,
-        snapshot_ok: needsReplay ? true : undefined,
-        readback_recovered: needsReplay ? true : undefined,
-        timed_out: needsReplay || message.includes('aggregate-put-ack-timeout'),
+        timed_out: message.includes('aggregate-put-ack-timeout'),
       });
       throw error;
     }

--- a/apps/web-pwa/src/hooks/voteIntentProjection.ts
+++ b/apps/web-pwa/src/hooks/voteIntentProjection.ts
@@ -28,6 +28,8 @@ export interface ReplayProjectionResult {
   timed_out: boolean;
 }
 
+const SNAPSHOT_MATERIALIZATION_CRITICAL_TIMEOUT_MS = 3_000;
+
 export function toPointTuple(record: VoteIntentRecord): PointTuple {
   return {
     topic_id: record.topic_id,
@@ -116,6 +118,50 @@ function rowToIntent(row: AggregateVoterPointRow, tuple: PointTuple): VoteIntent
   };
 }
 
+async function awaitSnapshotMaterialization(params: {
+  readonly tuple: PointTuple;
+  readonly run: () => Promise<void>;
+}): Promise<boolean> {
+  let settled = false;
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+  const materialization = params.run()
+    .then(() => {
+      settled = true;
+      if (timeoutId) clearTimeout(timeoutId);
+      return true;
+    })
+    .catch((error) => {
+      settled = true;
+      if (timeoutId) clearTimeout(timeoutId);
+      console.warn('[vh:vote:intent-replay:snapshot-materialization-failed]', {
+        topic_id: params.tuple.topic_id,
+        synthesis_id: params.tuple.synthesis_id,
+        epoch: params.tuple.epoch,
+        point_id: params.tuple.point_id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return false;
+    });
+
+  const deadline = new Promise<boolean>((resolve) => {
+    timeoutId = setTimeout(() => {
+      if (!settled) {
+        console.warn('[vh:vote:intent-replay:snapshot-materialization-deferred]', {
+          topic_id: params.tuple.topic_id,
+          synthesis_id: params.tuple.synthesis_id,
+          epoch: params.tuple.epoch,
+          point_id: params.tuple.point_id,
+          timeout_ms: SNAPSHOT_MATERIALIZATION_CRITICAL_TIMEOUT_MS,
+        });
+        resolve(false);
+      }
+    }, SNAPSHOT_MATERIALIZATION_CRITICAL_TIMEOUT_MS);
+  });
+
+  return Promise.race([materialization, deadline]);
+}
+
 export async function projectIntentRecord(params: {
   client: VennClient;
   record: VoteIntentRecord;
@@ -128,132 +174,126 @@ export async function projectIntentRecord(params: {
   }) => PointAggregateSnapshotV1;
 }): Promise<ReplayProjectionResult> {
   const tuple = toPointTuple(params.record);
-  const currentRows = await readAggregateVoterRows(
-    params.client,
-    tuple.topic_id,
-    tuple.synthesis_id,
-    tuple.epoch,
-    tuple.point_id,
-  );
-
-  const existingRow = currentRows.find((row) => row.voter_id === params.record.voter_id);
-  const existingIntent = existingRow ? rowToIntent(existingRow, tuple) : null;
-  const incomingWins = !existingIntent || compareIntentLww(params.record, existingIntent) >= 0;
-  const nextRows = [...currentRows];
   let voterNodeOk = false;
   let readbackRecovered = false;
   let timedOut = false;
+  let nextRow: AggregateVoterPointRow | null = null;
 
-  if (incomingWins) {
-    const updatedAtIso = new Date(normalizeNonNegativeInt(params.record.emitted_at)).toISOString();
-    let nextRow: AggregateVoterPointRow | null = null;
+  const updatedAtIso = new Date(normalizeNonNegativeInt(params.record.emitted_at)).toISOString();
 
-    try {
-      await writeVoterNode(
+  try {
+    await writeVoterNode(
+      params.client,
+      tuple.topic_id,
+      tuple.synthesis_id,
+      tuple.epoch,
+      params.record.voter_id,
+      {
+        point_id: tuple.point_id,
+        agreement: params.record.agreement,
+        weight: params.record.weight,
+        updated_at: updatedAtIso,
+      },
+    );
+
+    nextRow = {
+      voter_id: params.record.voter_id,
+      node: {
+        point_id: tuple.point_id,
+        agreement: params.record.agreement,
+        weight: params.record.weight,
+        updated_at: updatedAtIso,
+      },
+      updated_at_ms: normalizeNonNegativeInt(params.record.emitted_at),
+    };
+    voterNodeOk = true;
+  } catch (error) {
+    if (!isAckTimeoutError(error)) {
+      throw error;
+    }
+
+    const recovered = await readAggregateVoterNode(
+      params.client,
+      tuple.topic_id,
+      tuple.synthesis_id,
+      tuple.epoch,
+      params.record.voter_id,
+      tuple.point_id,
+    );
+
+    if (!recovered || !matchesRecoveredIntentNode({
+      record: params.record,
+      tuple,
+      recovered,
+    })) {
+      throw error;
+    }
+
+    nextRow = {
+      voter_id: params.record.voter_id,
+      node: recovered,
+      updated_at_ms: normalizeMaybeTimestampMs(recovered.updated_at),
+    };
+    voterNodeOk = true;
+    readbackRecovered = true;
+    timedOut = true;
+    console.warn('[vh:vote:intent-replay:timeout-recovered]', {
+      topic_id: tuple.topic_id,
+      synthesis_id: tuple.synthesis_id,
+      epoch: tuple.epoch,
+      point_id: tuple.point_id,
+      voter_id: params.record.voter_id,
+      intent_id: params.record.intent_id,
+    });
+  }
+
+  /* c8 ignore next 3 */
+  if (!nextRow) {
+    throw new Error('intent-replay-next-row-missing');
+  }
+
+  const snapshotOk = await awaitSnapshotMaterialization({
+    tuple,
+    run: async () => {
+      const currentRows = await readAggregateVoterRows(
         params.client,
         tuple.topic_id,
         tuple.synthesis_id,
         tuple.epoch,
-        params.record.voter_id,
-        {
-          point_id: tuple.point_id,
-          agreement: params.record.agreement,
-          weight: params.record.weight,
-          updated_at: updatedAtIso,
-        },
+        tuple.point_id,
       );
-
-      nextRow = {
-        voter_id: params.record.voter_id,
-        node: {
-          point_id: tuple.point_id,
-          agreement: params.record.agreement,
-          weight: params.record.weight,
-          updated_at: updatedAtIso,
-        },
-        updated_at_ms: normalizeNonNegativeInt(params.record.emitted_at),
-      };
-      voterNodeOk = true;
-    } catch (error) {
-      if (!isAckTimeoutError(error)) {
-        throw error;
+      const nextRows = [...currentRows];
+      const replaceIndex = nextRows.findIndex((row) => row.voter_id === params.record.voter_id);
+      if (replaceIndex >= 0) {
+        nextRows[replaceIndex] = nextRow;
+      } else {
+        nextRows.push(nextRow);
       }
-
-      const recovered = await readAggregateVoterNode(
+      const previousSnapshot = await readPointAggregateSnapshot(
         params.client,
         tuple.topic_id,
         tuple.synthesis_id,
         tuple.epoch,
-        params.record.voter_id,
         tuple.point_id,
       );
 
-      if (!recovered || !matchesRecoveredIntentNode({
-        record: params.record,
+      const intentsForSnapshot = nextRows.map((row) => rowToIntent(row, tuple));
+      const snapshot = params.materializePointSnapshot({
         tuple,
-        recovered,
-      })) {
-        throw error;
-      }
-
-      nextRow = {
-        voter_id: params.record.voter_id,
-        node: recovered,
-        updated_at_ms: normalizeMaybeTimestampMs(recovered.updated_at),
-      };
-      voterNodeOk = true;
-      readbackRecovered = true;
-      timedOut = true;
-      console.warn('[vh:vote:intent-replay:timeout-recovered]', {
-        topic_id: tuple.topic_id,
-        synthesis_id: tuple.synthesis_id,
-        epoch: tuple.epoch,
-        point_id: tuple.point_id,
-        voter_id: params.record.voter_id,
-        intent_id: params.record.intent_id,
+        intents: intentsForSnapshot,
+        previousSnapshot,
+        computedAtMs: params.now(),
       });
-    }
 
-    /* c8 ignore next 3 */
-    if (!nextRow) {
-      throw new Error('intent-replay-next-row-missing');
-    }
-
-    const replaceIndex = nextRows.findIndex((row) => row.voter_id === params.record.voter_id);
-    if (replaceIndex >= 0) {
-      nextRows[replaceIndex] = nextRow;
-    } else {
-      nextRows.push(nextRow);
-    }
-  }
-
-  const previousSnapshot = await readPointAggregateSnapshot(
-    params.client,
-    tuple.topic_id,
-    tuple.synthesis_id,
-    tuple.epoch,
-    tuple.point_id,
-  );
-
-  const intentsForSnapshot = nextRows.map((row) => rowToIntent(row, tuple));
-  const snapshot = params.materializePointSnapshot({
-    tuple,
-    intents: intentsForSnapshot,
-    previousSnapshot,
-    computedAtMs: params.now(),
+      await writePointAggregateSnapshot(params.client, snapshot);
+    },
   });
-
-  await writePointAggregateSnapshot(params.client, snapshot);
-
-  if (readbackRecovered) {
-    throw new Error('aggregate-write-needs-replay');
-  }
 
   return {
     topic_id: tuple.topic_id,
     point_id: tuple.point_id,
     voter_node_ok: voterNodeOk,
-    snapshot_ok: true,
+    snapshot_ok: snapshotOk,
     readback_recovered: readbackRecovered,
     timed_out: timedOut,
   };

--- a/apps/web-pwa/src/store/forum/index.ts
+++ b/apps/web-pwa/src/store/forum/index.ts
@@ -20,7 +20,8 @@ import { loadIdentity, loadVotesFromStorage, persistVotes } from './persistence'
 import {
   ensureIdentity, ensureClient, stripUndefined, serializeThreadForGun, isCommentSeen,
   markCommentSeen, addThread, addComment, adjustVoteCounts, findCommentThread,
-  setCommentModerationState, getCommentModerationState, visibleCommentsForThread, parseThreadFromGun
+  setCommentModerationState, getCommentModerationState, visibleCommentsForThread, parseThreadFromGun,
+  THREAD_JSON_FIELD
 } from './helpers';
 import { hydrateFromGun } from './hydration';
 import { createMockForumStore } from './mockStore';
@@ -43,7 +44,16 @@ const COMMENT_INDEX_ENTRY_SNAPSHOT_DRAIN_MS = 1_000;
 const COMMENT_SNAPSHOT_REPLAY_INTERVAL_MS = 5_000;
 const COMMENT_DURABILITY_READBACK_TIMEOUT_MS = 15_000;
 const COMMENT_DURABILITY_READBACK_POLL_MS = 500;
+const COMMENT_DURABILITY_WRITE_ATTEMPTS = 3;
+const COMMENT_DURABILITY_ATTEMPT_MIN_TIMEOUT_MS = 8_000;
+const COMMENT_DURABILITY_ATTEMPT_TIMEOUT_MS = 25_000;
 const THREAD_PUT_ACK_TIMEOUT_MS = 5_000;
+const THREAD_FIELD_PUT_ACK_TIMEOUT_MS = 750;
+const THREAD_FAST_READ_TIMEOUT_MS = 500;
+const THREAD_FAST_READBACK_TIMEOUT_MS = 1_500;
+const THREAD_WRITE_RETRY_ATTEMPTS = 3;
+const THREAD_DURABILITY_READBACK_TIMEOUT_MS = 15_000;
+const THREAD_DURABILITY_READBACK_POLL_MS = 500;
 const COMMENT_INDEX_SCHEMA_VERSION = 'hermes-comment-index-v1';
 const COMMENT_INDEX_ENTRY_KEY = 'current';
 const COMMENT_INDEX_ENTRIES_KEY = 'entries';
@@ -80,7 +90,8 @@ const THREAD_SCALAR_FIELDS = [
   'sourceAnalysisId',
   'sourceEpoch',
   'sourceUrl',
-  'urlHash'
+  'urlHash',
+  THREAD_JSON_FIELD
 ] as const;
 
 type CommentWriteChain = ReturnType<typeof getForumCommentsChain>;
@@ -143,8 +154,6 @@ function putWithBoundedAck<T>(
       }
     };
 
-    startTimer();
-
     const putResult = chain.put(value as never, (ack?: { err?: string }) => {
       if (settled) {
         return;
@@ -158,15 +167,20 @@ function putWithBoundedAck<T>(
       resolve('ack');
     });
 
-    if (putResult && typeof (putResult as PromiseLike<unknown>).then === 'function') {
-      (putResult as PromiseLike<unknown>).then(undefined, (error: unknown) => {
-        if (settled) {
-          return;
+    if (putResult instanceof Promise) {
+      putResult.then(
+        () => {
+          startTimer();
+        },
+        (error: unknown) => {
+          if (settled) {
+            return;
+          }
+          settled = true;
+          clearTimer();
+          reject(error instanceof Error ? error : new Error(String(error)));
         }
-        settled = true;
-        clearTimer();
-        reject(error instanceof Error ? error : new Error(String(error)));
-      });
+      );
     } else {
       startTimer();
     }
@@ -177,12 +191,54 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => globalThis.setTimeout(resolve, ms));
 }
 
+function withTimeout<T>(
+  work: Promise<T>,
+  timeoutMs: number,
+  message: string
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    let settled = false;
+    const timer = globalThis.setTimeout(() => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      reject(new Error(message));
+    }, timeoutMs);
+    work.then(
+      (value) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        globalThis.clearTimeout(timer);
+        resolve(value);
+      },
+      (error) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        globalThis.clearTimeout(timer);
+        reject(error);
+      }
+    );
+  });
+}
+
 function shouldConfirmCommentDurability(): boolean {
   try {
     return (import.meta as { env?: { MODE?: string } }).env?.MODE !== 'test';
   } catch {
     return true;
   }
+}
+
+function commentDurabilityAttemptTimeoutMs(readbackTimeoutMs: number): number {
+  return Math.min(
+    COMMENT_DURABILITY_ATTEMPT_TIMEOUT_MS,
+    Math.max(COMMENT_DURABILITY_ATTEMPT_MIN_TIMEOUT_MS, readbackTimeoutMs + 5_000)
+  );
 }
 
 function parseCommentEnvelope(value: unknown, threadId: string, commentId?: string): HermesComment | null {
@@ -400,8 +456,12 @@ async function readCommentIndexScalars(indexChain: ReadChain, threadId: string):
   return parseCommentIndex(stripUndefined(Object.fromEntries(entries)), threadId);
 }
 
-async function readThreadSnapshot(threadChain: ReadChain, threadId: string): Promise<HermesThread | null> {
-  const direct = parseThreadSnapshot(await readNodeOnce(threadChain, THREAD_READ_TIMEOUT_MS), threadId);
+async function readThreadSnapshot(
+  threadChain: ReadChain,
+  threadId: string,
+  readTimeoutMs = THREAD_READ_TIMEOUT_MS
+): Promise<HermesThread | null> {
+  const direct = parseThreadSnapshot(await readNodeOnce(threadChain, readTimeoutMs), threadId);
   if (direct) {
     return direct;
   }
@@ -409,13 +469,240 @@ async function readThreadSnapshot(threadChain: ReadChain, threadId: string): Pro
   const entries = await Promise.all(
     THREAD_SCALAR_FIELDS.map(async (field) => [
       field,
-      await readScalar(threadChain, field, THREAD_READ_TIMEOUT_MS)
+      await readScalar(threadChain, field, readTimeoutMs)
     ] as const)
   );
   return parseThreadSnapshot(
     stripUndefined(Object.fromEntries(entries) as Partial<Record<ThreadScalarField, unknown>>),
     threadId
   );
+}
+
+async function waitForThreadReadback(
+  client: ForumClient,
+  threadId: string,
+  timeoutMs = THREAD_DURABILITY_READBACK_TIMEOUT_MS,
+  readTimeoutMs = THREAD_READ_TIMEOUT_MS
+): Promise<boolean> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    const thread = await readThreadSnapshot(
+      getForumThreadChain(client, threadId) as unknown as ReadChain,
+      threadId,
+      readTimeoutMs
+    );
+    if (thread) {
+      return true;
+    }
+    await sleep(THREAD_DURABILITY_READBACK_POLL_MS);
+  }
+  return false;
+}
+
+function resolveRelayForumThreadEndpoint(client: ForumClient): string | null {
+  const peer = client.config?.peers?.[0];
+  if (!peer || typeof fetch !== 'function') {
+    return null;
+  }
+  try {
+    const base = typeof window !== 'undefined' ? window.location.href : 'http://127.0.0.1/';
+    const url = new URL(peer, base);
+    return `${url.origin}/vh/forum/thread`;
+  } catch {
+    return null;
+  }
+}
+
+function resolveRelayForumCommentEndpoint(client: ForumClient): string | null {
+  const peer = client.config?.peers?.[0];
+  if (!peer || typeof fetch !== 'function') {
+    return null;
+  }
+  try {
+    const base = typeof window !== 'undefined' ? window.location.href : 'http://127.0.0.1/';
+    const url = new URL(peer, base);
+    return `${url.origin}/vh/forum/comment`;
+  } catch {
+    return null;
+  }
+}
+
+async function writeThreadViaRelayFallback(
+  client: ForumClient,
+  threadForGun: Record<string, unknown>
+): Promise<boolean> {
+  const endpoint = resolveRelayForumThreadEndpoint(client);
+  if (!endpoint) {
+    return false;
+  }
+  try {
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ thread: threadForGun }),
+    });
+    if (!response.ok) {
+      return false;
+    }
+    const payload = await response.json().catch(() => null) as { ok?: unknown } | null;
+    return payload?.ok === true;
+  } catch (error) {
+    console.warn('[vh:forum] Relay thread write fallback failed:', {
+      thread_id: threadForGun.id,
+      error: error instanceof Error ? error.message : String(error)
+    });
+    return false;
+  }
+}
+
+async function writeCommentViaRelayFallback(
+  client: ForumClient,
+  comment: HermesComment
+): Promise<boolean> {
+  const endpoint = resolveRelayForumCommentEndpoint(client);
+  if (!endpoint) {
+    return false;
+  }
+  try {
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ comment }),
+    });
+    if (!response.ok) {
+      return false;
+    }
+    const payload = await response.json().catch(() => null) as {
+      ok?: unknown;
+      thread_id?: unknown;
+      comment_id?: unknown;
+    } | null;
+    return payload?.ok === true
+      && payload.thread_id === comment.threadId
+      && payload.comment_id === comment.id;
+  } catch (error) {
+    console.warn('[vh:forum] Relay comment write fallback failed:', {
+      thread_id: comment.threadId,
+      comment_id: comment.id,
+      error: error instanceof Error ? error.message : String(error)
+    });
+    return false;
+  }
+}
+
+async function putThreadWithDurability(
+  client: ForumClient,
+  threadForGun: Record<string, unknown>,
+  timeoutMs: number
+): Promise<'ack' | 'readback'> {
+  const threadId = String(threadForGun.id ?? '').trim();
+  if (!threadId) {
+    throw new Error('thread-write-missing-id');
+  }
+  const envelope = threadForGun[THREAD_JSON_FIELD];
+  const envelopeReadback: Promise<CommentPutOutcome | 'readback'> =
+    typeof envelope === 'string' && envelope.trim().length > 0
+      ? (async () => {
+        const threadChain = getForumThreadChain(client, threadId);
+        await putWithBoundedAck(
+          threadChain.get(THREAD_JSON_FIELD) as unknown as PutChain<string>,
+          envelope,
+          THREAD_FIELD_PUT_ACK_TIMEOUT_MS
+        ).catch((error) => {
+          console.warn('[vh:forum] Thread envelope write failed:', {
+            thread_id: threadId,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          return 'timeout' as const;
+        });
+        return (await waitForThreadReadback(
+          client,
+          threadId,
+          THREAD_FAST_READBACK_TIMEOUT_MS,
+          THREAD_FAST_READ_TIMEOUT_MS
+        ))
+          ? 'readback'
+          : 'timeout';
+      })()
+      : Promise.resolve('timeout');
+
+  let relayFallbackAttempted = false;
+  for (let attempt = 1; attempt <= THREAD_WRITE_RETRY_ATTEMPTS; attempt += 1) {
+    const threadChain = getForumThreadChain(client, threadId);
+    const scalarProjection = putRecordScalarFieldsWithBoundedAck(
+      threadChain as unknown as { get(key: string): PutChain<unknown> },
+      threadForGun,
+      THREAD_FIELD_PUT_ACK_TIMEOUT_MS
+    ).catch((error) => {
+      console.warn('[vh:forum] Thread scalar projection failed:', {
+        thread_id: threadId,
+        attempt,
+        error: error instanceof Error ? error.message : String(error)
+      });
+    });
+    const fullPut = putWithBoundedAck(
+      threadChain as unknown as PutChain<Record<string, unknown>>,
+      threadForGun,
+      timeoutMs
+    );
+    const scalarReadback = scalarProjection.then(async () => (
+      await waitForThreadReadback(
+        client,
+        threadId,
+        THREAD_FAST_READBACK_TIMEOUT_MS,
+        THREAD_FAST_READ_TIMEOUT_MS
+      )
+        ? 'readback'
+        : 'timeout'
+    ));
+    const firstOutcome = await Promise.race([fullPut, scalarReadback, envelopeReadback]);
+    if (firstOutcome === 'ack') {
+      return firstOutcome;
+    }
+    if (firstOutcome === 'readback') {
+      void fullPut.catch((error) => {
+        console.warn('[vh:forum] Thread full-node write settled after scalar readback:', {
+          thread_id: threadId,
+          attempt,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
+      return firstOutcome;
+    }
+
+    const outcome = await fullPut;
+    if (outcome === 'ack') {
+      return 'ack';
+    }
+    await scalarProjection;
+    console.warn('[vh:forum] Thread write ack timed out:', {
+      thread_id: threadId,
+      attempt,
+      max_attempts: THREAD_WRITE_RETRY_ATTEMPTS,
+    });
+
+    if (await waitForThreadReadback(
+      client,
+      threadId,
+      THREAD_FAST_READBACK_TIMEOUT_MS,
+      THREAD_FAST_READ_TIMEOUT_MS
+    )) {
+      return 'readback';
+    }
+
+    if (!relayFallbackAttempted) {
+      relayFallbackAttempted = true;
+      if (await writeThreadViaRelayFallback(client, threadForGun)) {
+        return 'readback';
+      }
+    }
+  }
+
+  if (await waitForThreadReadback(client, threadId)) {
+    return 'readback';
+  }
+
+  throw new Error(`thread-write-not-durable:${threadId}`);
 }
 
 function readCommentIndexEntrySnapshot(entriesChain: ReadChain, threadId: string): Promise<string[]> {
@@ -799,6 +1086,55 @@ export function createForumStore(overrides?: Partial<ForumDeps>) {
     );
   };
 
+  const writeCommentWithDurability = async (
+    client: ForumClient,
+    threadId: string,
+    cleanComment: HermesComment
+  ): Promise<void> => {
+    let lastError: unknown = null;
+
+    for (let attempt = 1; attempt <= COMMENT_DURABILITY_WRITE_ATTEMPTS; attempt += 1) {
+      try {
+        await withTimeout(
+          (async () => {
+            await writeCommentToGun(client, threadId, cleanComment);
+            await updateCommentIndex(client, threadId, cleanComment.id);
+            await waitForDurableCommentReadback(client, threadId, cleanComment.id);
+          })(),
+          commentDurabilityAttemptTimeoutMs(deps.commentDurabilityTimeoutMs),
+          `comment-write-attempt-timeout:${threadId}:${cleanComment.id}`
+        );
+        return;
+      } catch (error) {
+        lastError = error;
+        if (await writeCommentViaRelayFallback(client, cleanComment)) {
+          console.warn('[vh:forum] Comment write confirmed by relay fallback:', {
+            thread_id: threadId,
+            comment_id: cleanComment.id,
+            attempt,
+            error: error instanceof Error ? error.message : String(error)
+          });
+          return;
+        }
+        if (attempt >= COMMENT_DURABILITY_WRITE_ATTEMPTS) {
+          break;
+        }
+        console.warn('[vh:forum] Comment durable write failed; retrying:', {
+          thread_id: threadId,
+          comment_id: cleanComment.id,
+          attempt,
+          max_attempts: COMMENT_DURABILITY_WRITE_ATTEMPTS,
+          error: error instanceof Error ? error.message : String(error)
+        });
+      }
+    }
+
+    if (lastError instanceof Error) {
+      throw lastError;
+    }
+    throw new Error(`comment-write-not-durable:${threadId}:${cleanComment.id}`);
+  };
+
   const hydrateCommentIndex = (
     threadId: string,
     commentsChain: CommentWriteChain,
@@ -895,13 +1231,13 @@ export function createForumStore(overrides?: Partial<ForumDeps>) {
       }
       console.info('[vh:forum] Creating thread:', threadForGun.id);
       console.debug('[vh:forum] Thread data for Gun:', JSON.stringify(threadForGun, null, 2));
-      const threadWriteOutcome = await putWithBoundedAck(
-        getForumThreadChain(client, threadForGun.id as string) as unknown as PutChain<Record<string, unknown>>,
+      const threadWriteOutcome = await putThreadWithDurability(
+        client,
         threadForGun,
         deps.threadPutAckTimeoutMs
       );
-      if (threadWriteOutcome === 'timeout') {
-        console.warn('[vh:forum] Thread write ack timed out, continuing after local write:', threadForGun.id);
+      if (threadWriteOutcome === 'readback') {
+        console.warn('[vh:forum] Thread write confirmed by readback after ack timeouts:', threadForGun.id);
       } else {
         console.info('[vh:forum] Thread written successfully to path: vh/forum/threads/' + threadForGun.id);
       }
@@ -955,9 +1291,7 @@ export function createForumStore(overrides?: Partial<ForumDeps>) {
       };
       console.info('[vh:forum] Creating comment:', cleanComment.id, 'for thread:', threadId);
       console.debug('[vh:forum] Comment data:', JSON.stringify(cleanComment, null, 2));
-      await writeCommentToGun(client, threadId, cleanComment);
-      await updateCommentIndex(client, threadId, cleanComment.id);
-      await waitForDurableCommentReadback(client, threadId, cleanComment.id);
+      await writeCommentWithDurability(client, threadId, cleanComment);
       // TOCTOU: consumeAction runs after async Gun write. Concurrent createComment calls
       // at budget limit-1 can both pass canPerformAction, both persist to Gun, then the
       // second consume throws. The orphaned Gun record is a known local-first tradeoff.

--- a/apps/web-pwa/src/store/hermesForum.test.ts
+++ b/apps/web-pwa/src/store/hermesForum.test.ts
@@ -13,8 +13,10 @@ const {
   dateIndexWrites,
   tagIndexWrites,
   threadChain,
+  threadFieldChain,
   commentsChain,
   commentIndexChain,
+  getForumCommentsChainMock,
   getForumCommentIndexChainMock,
   getForumDateIndexChainMock,
   getForumTagIndexChainMock
@@ -24,8 +26,17 @@ const {
   const commentIndexWrites: any[] = [];
   const dateIndexWrites: Array<{ id: string; value: any }> = [];
   const tagIndexWrites: Array<{ tag: string; id: string; value: any }> = [];
+  const threadFieldChain = {
+    get: vi.fn(() => threadFieldChain),
+    once: vi.fn(),
+    put: vi.fn((_value: any, cb?: (ack?: { err?: string }) => void) => {
+      cb?.({});
+    })
+  } as any;
 
   const threadChain = {
+    get: vi.fn(() => threadFieldChain),
+    once: vi.fn(),
     put: vi.fn((value: any, cb?: (ack?: { err?: string }) => void) => {
       threadWrites.push(value);
       cb?.({});
@@ -55,6 +66,7 @@ const {
     })
   } as any;
 
+  const getForumCommentsChainMock = vi.fn(() => commentsChain);
   const getForumCommentIndexChainMock = vi.fn(() => commentIndexChain);
 
   const getForumDateIndexChainMock = vi.fn(() => ({
@@ -80,8 +92,10 @@ const {
     dateIndexWrites,
     tagIndexWrites,
     threadChain,
+    threadFieldChain,
     commentsChain,
     commentIndexChain,
+    getForumCommentsChainMock,
     getForumCommentIndexChainMock,
     getForumDateIndexChainMock,
     getForumTagIndexChainMock
@@ -93,7 +107,7 @@ vi.mock('@vh/gun-client', async (orig) => {
   return {
     ...actual,
     getForumThreadChain: vi.fn(() => threadChain),
-    getForumCommentsChain: vi.fn(() => commentsChain),
+    getForumCommentsChain: getForumCommentsChainMock,
     getForumCommentIndexChain: getForumCommentIndexChainMock,
     getForumDateIndexChain: getForumDateIndexChainMock,
     getForumTagIndexChain: getForumTagIndexChainMock
@@ -136,7 +150,21 @@ beforeEach(() => {
   commentIndexWrites.length = 0;
   dateIndexWrites.length = 0;
   tagIndexWrites.length = 0;
-  threadChain.put.mockClear();
+  threadChain.put.mockReset();
+  threadChain.put.mockImplementation((value: any, cb?: (ack?: { err?: string }) => void) => {
+    threadWrites.push(value);
+    cb?.({});
+  });
+  threadChain.get.mockReset();
+  threadChain.get.mockImplementation(() => threadFieldChain);
+  threadChain.once.mockReset();
+  threadFieldChain.put.mockReset();
+  threadFieldChain.put.mockImplementation((_value: any, cb?: (ack?: { err?: string }) => void) => {
+    cb?.({});
+  });
+  threadFieldChain.get.mockReset();
+  threadFieldChain.get.mockImplementation(() => threadFieldChain);
+  threadFieldChain.once.mockReset();
   commentsChain.put.mockClear();
   commentsChain.get.mockClear();
   commentsChain.map.mockClear();
@@ -144,19 +172,36 @@ beforeEach(() => {
   commentIndexChain.get.mockClear();
   commentIndexChain.once.mockClear();
   commentIndexChain.map.mockClear();
+  getForumCommentsChainMock.mockClear();
+  getForumCommentsChainMock.mockReturnValue(commentsChain);
   getForumCommentIndexChainMock.mockClear();
+  getForumCommentIndexChainMock.mockReturnValue(commentIndexChain);
   getForumDateIndexChainMock.mockClear();
   getForumTagIndexChainMock.mockClear();
 });
 
 describe('hermesForum store', () => {
   const setIdentity = (nullifier: string, trustScore = 1) => {
-    publishIdentity({ session: { nullifier, trustScore, scaledTrustScore: Math.round(trustScore * 10000) } });
+    publishIdentity({
+      session: {
+        nullifier,
+        trustScore,
+        scaledTrustScore: Math.round(trustScore * 10000),
+        expiresAt: Date.now() + 60_000,
+      },
+    });
     useXpLedger.getState().setActiveNullifier(nullifier);
   };
 
   it('rejects thread creation when trustScore is low', async () => {
-    publishIdentity({ session: { nullifier: 'low', trustScore: 0.2, scaledTrustScore: 2000 } });
+    publishIdentity({
+      session: {
+        nullifier: 'low',
+        trustScore: 0.2,
+        scaledTrustScore: 2000,
+        expiresAt: Date.now() + 60_000,
+      },
+    });
     const store = createForumStore({ resolveClient: () => ({} as any), randomId: () => 'thread-1', now: () => 1 });
     await expect(store.getState().createThread('title', 'content', [])).rejects.toThrow(
       'Insufficient trustScore for forum actions'
@@ -239,10 +284,14 @@ describe('hermesForum store', () => {
     });
   });
 
-  it('createThread resolves when the local Gun write does not acknowledge', async () => {
+  it('createThread resolves when an unacknowledged write is readable', async () => {
     setIdentity('unacked-thread-id');
-    threadChain.put.mockImplementationOnce((value: any) => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    threadChain.put.mockImplementation((value: any) => {
       threadWrites.push(value);
+    });
+    threadChain.once.mockImplementation((cb: (value: any) => void) => {
+      cb(threadWrites[0]);
     });
     const store = createForumStore({
       resolveClient: () => ({} as any),
@@ -251,12 +300,201 @@ describe('hermesForum store', () => {
       threadPutAckTimeoutMs: 1,
     });
 
+    try {
+      const thread = await store.getState().createThread('title', 'content', ['news']);
+
+      expect(thread).toMatchObject({ id: 'thread-unacked' });
+      expect(store.getState().threads.get('thread-unacked')).toMatchObject({ id: 'thread-unacked' });
+      expect(threadWrites[0]).toMatchObject({ id: 'thread-unacked' });
+      expect(threadChain.put).toHaveBeenCalledTimes(1);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('createThread projects scalar fields when an unacknowledged write is not directly readable', async () => {
+    setIdentity('unacked-thread-scalar-readback');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const scalarValues = new Map<string, unknown>();
+    threadChain.put.mockImplementation((value: any) => {
+      threadWrites.push(value);
+    });
+    threadChain.once.mockImplementation((cb: (value: any) => void) => {
+      cb(undefined);
+    });
+    threadChain.get.mockImplementation((field: string) => ({
+      put: vi.fn((value: unknown, cb?: (ack?: { err?: string }) => void) => {
+        if (field !== '__thread_json') {
+          scalarValues.set(field, value);
+        }
+        cb?.({});
+      }),
+      once: vi.fn((cb: (value: unknown) => void) => {
+        cb(field === '__thread_json' ? undefined : scalarValues.get(field));
+      })
+    }));
+    const store = createForumStore({
+      resolveClient: () => ({} as any),
+      randomId: () => 'thread-unacked-scalar-readback',
+      now: () => 1,
+      threadPutAckTimeoutMs: 1,
+    });
+
+    try {
+      const thread = await store.getState().createThread('title', 'content', ['news']);
+
+      expect(thread).toMatchObject({ id: 'thread-unacked-scalar-readback' });
+      expect(store.getState().threads.get('thread-unacked-scalar-readback')).toMatchObject({ id: 'thread-unacked-scalar-readback' });
+      expect(scalarValues.get('id')).toBe('thread-unacked-scalar-readback');
+      expect(scalarValues.get('tags')).toBe('[\"news\"]');
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('createThread can confirm scalar projection before the full thread put acknowledges', async () => {
+    setIdentity('thread-scalar-fast-path');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const scalarValues = new Map<string, unknown>();
+    threadChain.put.mockImplementation((value: any) => {
+      threadWrites.push(value);
+    });
+    threadChain.once.mockImplementation((cb: (value: any) => void) => {
+      cb(undefined);
+    });
+    threadChain.get.mockImplementation((field: string) => ({
+      put: vi.fn((value: unknown, cb?: (ack?: { err?: string }) => void) => {
+        if (field !== '__thread_json') {
+          scalarValues.set(field, value);
+        }
+        cb?.({});
+      }),
+      once: vi.fn((cb: (value: unknown) => void) => {
+        cb(field === '__thread_json' ? undefined : scalarValues.get(field));
+      })
+    }));
+    const store = createForumStore({
+      resolveClient: () => ({} as any),
+      randomId: () => 'thread-scalar-fast-path',
+      now: () => 1,
+      threadPutAckTimeoutMs: 60_000,
+    });
+
+    try {
+      const thread = await store.getState().createThread('title', 'content', ['news']);
+
+      expect(thread).toMatchObject({ id: 'thread-scalar-fast-path' });
+      expect(store.getState().threads.get('thread-scalar-fast-path')).toMatchObject({ id: 'thread-scalar-fast-path' });
+      expect(threadWrites[0]).toMatchObject({ id: 'thread-scalar-fast-path' });
+      expect(scalarValues.get('id')).toBe('thread-scalar-fast-path');
+      expect(scalarValues.get('content')).toBe('content');
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('createThread starts ack timeout after guarded put preflight resolves', async () => {
+    setIdentity('thread-guarded-put');
+    threadChain.put.mockImplementation((value: any, cb?: (ack?: { err?: string }) => void) => {
+      threadWrites.push(value);
+      return new Promise<void>((resolve) => {
+        setTimeout(() => {
+          cb?.({});
+          resolve();
+        }, 10);
+      });
+    });
+    threadChain.once.mockImplementation((cb: (value: any) => void) => {
+      cb(undefined);
+    });
+    threadChain.get.mockImplementation(() => ({
+      put: vi.fn((_value: unknown, cb?: (ack?: { err?: string }) => void) => {
+        cb?.({});
+      }),
+      once: vi.fn((cb: (value: unknown) => void) => {
+        cb(undefined);
+      })
+    }));
+    const store = createForumStore({
+      resolveClient: () => ({} as any),
+      randomId: () => 'thread-guarded-put',
+      now: () => 1,
+      threadPutAckTimeoutMs: 1,
+    });
+
     const thread = await store.getState().createThread('title', 'content', ['news']);
 
-    expect(thread).toMatchObject({ id: 'thread-unacked' });
-    expect(store.getState().threads.get('thread-unacked')).toMatchObject({ id: 'thread-unacked' });
-    expect(threadWrites[0]).toMatchObject({ id: 'thread-unacked' });
+    expect(thread).toMatchObject({ id: 'thread-guarded-put' });
+    expect(threadChain.put).toHaveBeenCalledTimes(1);
+    expect(threadWrites[0]).toMatchObject({ id: 'thread-guarded-put' });
   });
+
+  it('createThread does not adopt Gun thenables before starting the ack timeout', async () => {
+    setIdentity('thread-gun-thenable');
+    const gunThenable = { then: vi.fn() };
+    threadChain.put.mockImplementation((value: any) => {
+      threadWrites.push(value);
+      return gunThenable;
+    });
+    threadChain.once.mockImplementation((cb: (value: any) => void) => {
+      cb(threadWrites[0]);
+    });
+    const store = createForumStore({
+      resolveClient: () => ({} as any),
+      randomId: () => 'thread-gun-thenable',
+      now: () => 1,
+      threadPutAckTimeoutMs: 1,
+    });
+
+    const thread = await store.getState().createThread('title', 'content', ['news']);
+
+    expect(thread).toMatchObject({ id: 'thread-gun-thenable' });
+    expect(gunThenable.then).not.toHaveBeenCalled();
+    expect(store.getState().threads.get('thread-gun-thenable')).toMatchObject({ id: 'thread-gun-thenable' });
+  });
+
+  it('createThread can recover through the relay thread fallback when Gun readback fails', async () => {
+    setIdentity('thread-relay-fallback');
+    const originalFetch = globalThis.fetch;
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ ok: true })
+    })) as unknown as typeof fetch;
+    globalThis.fetch = fetchMock;
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    threadChain.put.mockImplementation(() => undefined);
+    threadChain.once.mockImplementation((cb: (value: any) => void) => {
+      cb(undefined);
+    });
+    threadChain.get.mockImplementation(() => ({
+      put: vi.fn(),
+      once: vi.fn((cb: (value: unknown) => void) => cb(undefined))
+    }));
+    const store = createForumStore({
+      resolveClient: () => ({ config: { peers: ['http://127.0.0.1:7777/gun'] } } as any),
+      randomId: () => 'thread-relay-fallback',
+      now: () => 1,
+      threadPutAckTimeoutMs: 1,
+    });
+
+    try {
+      const thread = await store.getState().createThread('title', 'content', ['news']);
+
+      expect(thread).toMatchObject({ id: 'thread-relay-fallback' });
+      expect(fetchMock).toHaveBeenCalledWith(
+        'http://127.0.0.1:7777/vh/forum/thread',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+        })
+      );
+      expect(store.getState().threads.get('thread-relay-fallback')).toMatchObject({ id: 'thread-relay-fallback' });
+      expect(useXpLedger.getState().budget?.usage.find((entry) => entry.actionKey === 'posts/day')?.count).toBe(1);
+    } finally {
+      globalThis.fetch = originalFetch;
+      warnSpy.mockRestore();
+    }
+  }, 8_000);
 
   it('createThread writes synthesis source context and not legacy analysis context', async () => {
     setIdentity('synthesis-thread');
@@ -560,6 +798,157 @@ describe('hermesForum store', () => {
     );
   });
 
+  it('createComment retries when the indexed comment is not durable on first readback', async () => {
+    setIdentity('budget-comment-durable-retry');
+    let storedComment: any;
+    let fullPutAttempts = 0;
+    const fieldValues = new Map<string, unknown>();
+    const fieldNodes = new Map<string, any>();
+    const commentNode = {
+      get: vi.fn((field: string) => {
+        if (!fieldNodes.has(field)) {
+          fieldNodes.set(field, {
+            put: vi.fn((value: unknown, cb?: (ack?: { err?: string }) => void) => {
+              if (fullPutAttempts >= 2) {
+                fieldValues.set(field, value);
+              }
+              cb?.({});
+            }),
+            once: vi.fn((cb: (value: unknown) => void) => cb(fieldValues.get(field)))
+          });
+        }
+        return fieldNodes.get(field);
+      }),
+      put: vi.fn((value: unknown, cb?: (ack?: { err?: string }) => void) => {
+        fullPutAttempts += 1;
+        if (fullPutAttempts >= 2) {
+          storedComment = value;
+        }
+        cb?.({});
+      }),
+      once: vi.fn((cb: (value: unknown) => void) => cb(storedComment))
+    };
+    const commentsRoot = {
+      get: vi.fn(() => commentNode)
+    };
+
+    let currentIndex: any;
+    const entryValues = new Map<string, unknown>();
+    const scalarNode = (field: string) => ({
+      put: vi.fn((value: unknown, cb?: (ack?: { err?: string }) => void) => {
+        if (currentIndex && typeof currentIndex === 'object') {
+          currentIndex = { ...currentIndex, [field]: value };
+        }
+        cb?.({});
+      }),
+      once: vi.fn((cb: (value: unknown) => void) => cb(currentIndex?.[field]))
+    });
+    const indexChain = {
+      get: vi.fn((field: string) => scalarNode(field)),
+      once: vi.fn((cb: (value: unknown) => void) => cb(currentIndex)),
+      put: vi.fn((value: unknown, cb?: (ack?: { err?: string }) => void) => {
+        currentIndex = value;
+        cb?.({});
+      })
+    };
+    const entriesChain = {
+      get: vi.fn((commentId: string) => ({
+        get: vi.fn((field: string) => scalarNode(field)),
+        once: vi.fn((cb: (value: unknown) => void) => cb(entryValues.get(commentId))),
+        put: vi.fn((value: unknown, cb?: (ack?: { err?: string }) => void) => {
+          entryValues.set(commentId, value);
+          cb?.({});
+        })
+      })),
+      map: vi.fn(() => ({
+        once: vi.fn((cb: (value: unknown, key?: string) => void) => {
+          for (const [key, value] of entryValues) {
+            cb(value, key);
+          }
+        })
+      }))
+    };
+    const indexRoot = {
+      get: vi.fn((key: string) => {
+        if (key === 'current') return indexChain;
+        if (key === 'entries') return entriesChain;
+        return indexChain.get(key);
+      })
+    };
+
+    getForumCommentsChainMock.mockReturnValue(commentsRoot as any);
+    getForumCommentIndexChainMock.mockReturnValue(indexRoot as any);
+    const store = createForumStore({
+      resolveClient: () => ({} as any),
+      randomId: () => 'comment-durable-retry',
+      now: () => 5,
+      confirmCommentDurability: true,
+      commentDurabilityTimeoutMs: 1
+    });
+
+    await store.getState().createComment('thread-1', 'hello', 'reply');
+
+    expect(commentNode.put).toHaveBeenCalledTimes(2);
+    expect(store.getState().comments.get('thread-1')?.map((comment) => comment.id)).toEqual(['comment-durable-retry']);
+    expect(useXpLedger.getState().budget?.usage.find((entry) => entry.actionKey === 'comments/day')?.count).toBe(1);
+  }, 10_000);
+
+  it('createComment falls back to the relay comment endpoint when durability does not converge', async () => {
+    vi.useFakeTimers();
+    setIdentity('budget-comment-relay-fallback');
+    const fieldNode = {
+      put: vi.fn(),
+      once: vi.fn((cb: (value: unknown) => void) => cb(undefined))
+    };
+    const commentNode = {
+      get: vi.fn(() => fieldNode),
+      put: vi.fn(),
+      once: vi.fn((cb: (value: unknown) => void) => cb(undefined))
+    };
+    const commentsRoot = {
+      get: vi.fn(() => commentNode)
+    };
+    getForumCommentsChainMock.mockReturnValue(commentsRoot as any);
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        ok: true,
+        thread_id: 'thread-1',
+        comment_id: 'comment-relay-fallback'
+      })
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    try {
+      const store = createForumStore({
+        resolveClient: () => ({ config: { peers: ['http://127.0.0.1:7777/gun'] } } as any),
+        randomId: () => 'comment-relay-fallback',
+        now: () => 5,
+        confirmCommentDurability: true,
+        commentDurabilityTimeoutMs: 1
+      });
+
+      const pending = store.getState().createComment('thread-1', 'hello', 'reply');
+      await vi.advanceTimersByTimeAsync(10_000);
+      await expect(pending).resolves.toMatchObject({ id: 'comment-relay-fallback' });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        'http://127.0.0.1:7777/vh/forum/comment',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: expect.stringContaining('"id":"comment-relay-fallback"')
+        })
+      );
+      expect(store.getState().comments.get('thread-1')?.map((comment) => comment.id)).toEqual([
+        'comment-relay-fallback'
+      ]);
+    } finally {
+      vi.unstubAllGlobals();
+      vi.useRealTimers();
+    }
+  }, 10_000);
+
   it('createComment denied at comments/day limit throws and does not write to Gun', async () => {
     setIdentity('budget-comment-limit');
     for (let i = 0; i < 50; i += 1) {
@@ -641,15 +1030,21 @@ describe('hermesForum store', () => {
     expect(after).toBe(before);
   });
 
-  it('createComment with Gun write failure does not consume budget', async () => {
+  it('createComment with persistent Gun write failure does not consume budget', async () => {
     setIdentity('budget-comment-gun-failure');
     const store = createForumStore({ resolveClient: () => ({} as any), randomId: () => 'comment-budget-gun-failure', now: () => 5 });
     const before = useXpLedger.getState().budget?.usage.find((entry) => entry.actionKey === 'comments/day')?.count ?? 0;
-    commentsChain.put.mockImplementationOnce((_value: any, cb?: (ack?: { err?: string }) => void) => {
+    const defaultCommentPut = commentsChain.put.getMockImplementation();
+    commentsChain.put.mockImplementation((_value: any, cb?: (ack?: { err?: string }) => void) => {
       cb?.({ err: 'fail' });
     });
 
-    await expect(store.getState().createComment('thread-1', 'hello', 'reply')).rejects.toThrow('fail');
+    try {
+      await expect(store.getState().createComment('thread-1', 'hello', 'reply')).rejects.toThrow('fail');
+      expect(commentsChain.put).toHaveBeenCalledTimes(3);
+    } finally {
+      commentsChain.put.mockImplementation(defaultCommentPut);
+    }
 
     const after = useXpLedger.getState().budget?.usage.find((entry) => entry.actionKey === 'comments/day')?.count ?? 0;
     expect(after).toBe(before);

--- a/apps/web-pwa/src/store/news/hydration.identity.test.ts
+++ b/apps/web-pwa/src/store/news/hydration.identity.test.ts
@@ -54,6 +54,7 @@ function createStore() {
     setStorylines: vi.fn(),
     upsertStoryline: vi.fn(),
     removeStoryline: vi.fn(),
+    ensureStory: vi.fn(),
     refreshLatest: vi.fn(),
     startHydration: vi.fn(),
     setLoading: vi.fn(),

--- a/apps/web-pwa/src/store/news/hydration.storylines.test.ts
+++ b/apps/web-pwa/src/store/news/hydration.storylines.test.ts
@@ -114,6 +114,7 @@ function createStore() {
     setStorylines: vi.fn(),
     upsertStoryline: vi.fn(),
     removeStoryline: vi.fn(),
+    ensureStory: vi.fn(),
     refreshLatest: vi.fn(),
     startHydration: vi.fn(),
     setLoading: vi.fn(),

--- a/apps/web-pwa/src/store/news/hydration.test.ts
+++ b/apps/web-pwa/src/store/news/hydration.test.ts
@@ -97,7 +97,7 @@ function createStore(initialLatestIndex: Record<string, number> = {}) {
     setStories: vi.fn(),
     upsertStory: vi.fn(),
     removeStory: vi.fn((storyId: string) => {
-      (state as { stories: StoryBundle[] }).stories = state.stories.filter((story) => story.story_id !== storyId);
+      (state as unknown as { stories: StoryBundle[] }).stories = state.stories.filter((story) => story.story_id !== storyId);
       delete (state.latestIndex as Record<string, number>)[storyId];
       delete (state.hotIndex as Record<string, number>)[storyId];
     }),
@@ -122,6 +122,7 @@ function createStore(initialLatestIndex: Record<string, number> = {}) {
     removeStoryline: vi.fn((storylineId: string) => {
       delete (state.storylinesById as Record<string, unknown>)[storylineId];
     }),
+    ensureStory: vi.fn(),
     refreshLatest: vi.fn(),
     startHydration: vi.fn(),
     setLoading: vi.fn(),
@@ -285,7 +286,7 @@ describe('hydrateNewsStore', () => {
 
     const { hydrateNewsStore } = await import('./hydration');
     const { store, state } = createStore();
-    state.stories = [story({ story_id: 'story-present' })];
+    (state as unknown as { stories: StoryBundle[] }).stories = [story({ story_id: 'story-present' })];
 
     hydrateNewsStore(() => client as never, store);
 

--- a/apps/web-pwa/src/store/news/index.test.ts
+++ b/apps/web-pwa/src/store/news/index.test.ts
@@ -147,7 +147,7 @@ describe('news store', () => {
       const { createNewsStore } = await import('./index');
       const store = createNewsStore({ resolveClient: () => null });
 
-      const baseSource = story().sources[0];
+      const baseSource = story().sources[0]!;
       store.getState().setStories([
         story({
           story_id: 's-one',
@@ -189,7 +189,7 @@ describe('news store', () => {
       const { createNewsStore } = await import('./index');
       const store = createNewsStore({ resolveClient: () => null });
 
-      const baseSource = story().sources[0];
+      const baseSource = story().sources[0]!;
       store.getState().setStories([
         story({
           story_id: 'object-config-1',
@@ -218,7 +218,7 @@ describe('news store', () => {
       const { createNewsStore } = await import('./index');
       const store = createNewsStore({ resolveClient: () => null });
 
-      const baseSource = story().sources[0];
+      const baseSource = story().sources[0]!;
       store.getState().setStories([
         story({
           story_id: 'empty-config-1',
@@ -250,7 +250,7 @@ describe('news store', () => {
       const { createNewsStore } = await import('./index');
       const store = createNewsStore({ resolveClient: () => null });
 
-      const baseSource = story().sources[0];
+      const baseSource = story().sources[0]!;
       const allowed = story({
         story_id: 'allowed',
         sources: [{ ...baseSource, source_id: 'source-allowed', url_hash: '55ee66ff' }]
@@ -470,6 +470,65 @@ describe('news store', () => {
     expect(store.getState().loading).toBe(false);
     expect(readNewsLatestIndexMock).not.toHaveBeenCalled();
     expect(readNewsHotIndexMock).not.toHaveBeenCalled();
+  });
+
+  it('ensureStory reads a persisted story by id and mirrors it into discovery', async () => {
+    const client = { id: 'client-direct-story' };
+    const directStory = story({
+      story_id: 'story-direct',
+      topic_id: 'b'.repeat(64),
+      headline: 'Direct story headline',
+      cluster_window_end: 555,
+    });
+    readNewsStoryMock.mockResolvedValue(directStory);
+
+    const { createNewsStore } = await import('./index');
+    const { useDiscoveryStore } = await import('../discovery');
+    useDiscoveryStore.getState().reset();
+
+    const store = createNewsStore({ resolveClient: () => client as never });
+
+    await expect(store.getState().ensureStory(' story-direct ')).resolves.toBe(true);
+
+    expect(readNewsStoryMock).toHaveBeenCalledWith(client, 'story-direct');
+    expect(store.getState().stories.map((item) => item.story_id)).toEqual(['story-direct']);
+    expect(store.getState().latestIndex).toEqual({ 'story-direct': 555 });
+    expect(useDiscoveryStore.getState().items).toEqual([
+      expect.objectContaining({
+        kind: 'NEWS_STORY',
+        story_id: 'story-direct',
+        topic_id: directStory.topic_id,
+        title: 'Direct story headline',
+      }),
+    ]);
+  });
+
+  it('ensureStory remirrors an already loaded story without rereading the mesh', async () => {
+    const directStory = story({
+      story_id: 'story-existing',
+      topic_id: 'c'.repeat(64),
+      headline: 'Existing story headline',
+      cluster_window_end: 777,
+    });
+
+    const { createNewsStore } = await import('./index');
+    const { useDiscoveryStore } = await import('../discovery');
+    useDiscoveryStore.getState().reset();
+
+    const store = createNewsStore({ resolveClient: () => ({ id: 'client' }) as never });
+    store.getState().setStories([directStory]);
+
+    await expect(store.getState().ensureStory('story-existing')).resolves.toBe(true);
+
+    expect(readNewsStoryMock).not.toHaveBeenCalled();
+    expect(store.getState().latestIndex).toEqual({ 'story-existing': 777 });
+    expect(useDiscoveryStore.getState().items).toEqual([
+      expect.objectContaining({
+        kind: 'NEWS_STORY',
+        story_id: 'story-existing',
+        topic_id: directStory.topic_id,
+      }),
+    ]);
   });
 
   it('refreshLatest loads latest/hot indexes + stories and clears loading', async () => {

--- a/apps/web-pwa/src/store/news/index.test.ts
+++ b/apps/web-pwa/src/store/news/index.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { StoryBundle } from '@vh/data-model';
+import type { StoryBundle, StorylineGroup } from '@vh/data-model';
 
 const hydrateNewsStoreMock = vi.fn<(...args: unknown[]) => boolean>();
 const hasForbiddenNewsPayloadFieldsMock = vi.fn<(payload: unknown) => boolean>();
@@ -50,6 +50,23 @@ function story(overrides: Partial<StoryBundle> = {}): StoryBundle {
     },
     provenance_hash: 'hash-1',
     created_at: 100,
+    ...overrides
+  };
+}
+
+function storyline(overrides: Partial<StorylineGroup> = {}): StorylineGroup {
+  return {
+    schemaVersion: 'storyline-group-v0',
+    storyline_id: 'storyline-direct',
+    topic_id: CANONICAL_TOPIC_ID,
+    canonical_story_id: 'story-direct',
+    story_ids: ['story-direct'],
+    headline: 'Direct storyline',
+    related_coverage: [],
+    entity_keys: ['policy'],
+    time_bucket: 'tb-1',
+    created_at: 100,
+    updated_at: 200,
     ...overrides
   };
 }
@@ -500,6 +517,78 @@ describe('news store', () => {
         topic_id: directStory.topic_id,
         title: 'Direct story headline',
       }),
+    ]);
+  });
+
+  it('ensureStory rejects empty ids and missing clients without mesh reads', async () => {
+    const { createNewsStore } = await import('./index');
+    const storeWithoutClient = createNewsStore({ resolveClient: () => null });
+
+    await expect(storeWithoutClient.getState().ensureStory('   ')).resolves.toBe(false);
+    await expect(storeWithoutClient.getState().ensureStory('story-without-client')).resolves.toBe(false);
+
+    expect(readNewsStoryMock).not.toHaveBeenCalled();
+  });
+
+  it('ensureStory rejects missing, unconfigured, and failed direct reads', async () => {
+    const previousSources = process.env.VITE_NEWS_FEED_SOURCES;
+    process.env.VITE_NEWS_FEED_SOURCES = JSON.stringify([{ id: 'admitted-source' }]);
+    vi.resetModules();
+    try {
+      const client = { id: 'client-direct-story-failures' };
+      const { createNewsStore } = await import('./index');
+      const store = createNewsStore({ resolveClient: () => client as never });
+
+      readNewsStoryMock
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(story({ story_id: 'story-unconfigured' }))
+        .mockRejectedValueOnce(new Error('mesh-read-failed'));
+
+      await expect(store.getState().ensureStory('story-missing')).resolves.toBe(false);
+      await expect(store.getState().ensureStory('story-unconfigured')).resolves.toBe(false);
+      await expect(store.getState().ensureStory('story-error')).resolves.toBe(false);
+
+      expect(store.getState().stories).toEqual([]);
+      expect(readNewsStoryMock.mock.calls.map(([, storyId]) => storyId)).toEqual([
+        'story-missing',
+        'story-unconfigured',
+        'story-error',
+      ]);
+    } finally {
+      if (previousSources === undefined) {
+        delete process.env.VITE_NEWS_FEED_SOURCES;
+      } else {
+        process.env.VITE_NEWS_FEED_SOURCES = previousSources;
+      }
+      vi.resetModules();
+    }
+  });
+
+  it('ensureStory loads referenced storylines but keeps direct hydration resilient to slow storyline reads', async () => {
+    const client = { id: 'client-direct-storyline' };
+    const directStory = story({
+      story_id: 'story-direct',
+      storyline_id: 'storyline-direct',
+      topic_id: 'd'.repeat(64),
+    });
+
+    readNewsStoryMock.mockResolvedValueOnce(directStory).mockResolvedValueOnce({
+      ...directStory,
+      story_id: 'story-direct-with-slow-storyline',
+      headline: 'Direct story with slow storyline',
+    });
+    readNewsStorylineMock.mockResolvedValueOnce(storyline()).mockRejectedValueOnce(new Error('storyline-read-timeout'));
+
+    const { createNewsStore } = await import('./index');
+    const store = createNewsStore({ resolveClient: () => client as never });
+
+    await expect(store.getState().ensureStory('story-direct')).resolves.toBe(true);
+    expect(store.getState().storylinesById).toEqual({ 'storyline-direct': storyline() });
+
+    await expect(store.getState().ensureStory('story-direct-with-slow-storyline')).resolves.toBe(true);
+    expect(store.getState().stories.map((item) => item.story_id).sort()).toEqual([
+      'story-direct',
+      'story-direct-with-slow-storyline',
     ]);
   });
 

--- a/apps/web-pwa/src/store/news/index.ts
+++ b/apps/web-pwa/src/store/news/index.ts
@@ -107,6 +107,11 @@ export function createNewsStore(overrides?: Partial<NewsDeps>): StoreApi<NewsSta
   let storeRef!: StoreApi<NewsState>;
   let refreshGeneration = 0;
 
+  const mirrorCurrentStories = async () => {
+    const state = storeRef.getState();
+    await mirrorStoriesIntoDiscovery([...state.stories], state.hotIndex, state.storylinesById);
+  };
+
   const startHydration = () => {
     const started = hydrateNewsStore(deps.resolveClient, storeRef);
     if (started && !storeRef.getState().hydrated) {
@@ -301,6 +306,51 @@ export function createNewsStore(overrides?: Partial<NewsDeps>): StoreApi<NewsSta
         delete nextStorylines[normalizedStorylineId];
         return { storylinesById: nextStorylines };
       });
+    },
+
+    async ensureStory(storyId: string) {
+      const normalizedStoryId = storyId.trim();
+      if (!normalizedStoryId) {
+        return false;
+      }
+
+      const existingStory = get().stories.find((story) => story.story_id === normalizedStoryId);
+      if (existingStory) {
+        get().upsertLatestIndex(existingStory.story_id, existingStory.cluster_window_end);
+        await mirrorCurrentStories();
+        return true;
+      }
+
+      const client = deps.resolveClient();
+      if (!client) {
+        return false;
+      }
+
+      get().startHydration();
+
+      try {
+        const story = parseStory(await readNewsStory(client, normalizedStoryId));
+        if (!story || !isStoryFromConfiguredSources(story)) {
+          return false;
+        }
+
+        get().upsertLatestIndex(story.story_id, story.cluster_window_end);
+        get().upsertStory(story);
+
+        try {
+          const storylines = await loadStorylinesForStories(client, [story]);
+          for (const storyline of storylines) {
+            get().upsertStoryline(storyline);
+          }
+        } catch {
+          // Direct story hydration should not fail just because related coverage is slow.
+        }
+
+        await mirrorCurrentStories();
+        return true;
+      } catch {
+        return false;
+      }
     },
 
     async refreshLatest(limit = 50) {

--- a/apps/web-pwa/src/store/news/types.ts
+++ b/apps/web-pwa/src/store/news/types.ts
@@ -40,6 +40,7 @@ export interface NewsState {
   setStorylines(storylines: StorylineGroup[]): void;
   upsertStoryline(storyline: StorylineGroup): void;
   removeStoryline(storylineId: string): void;
+  ensureStory(storyId: string): Promise<boolean>;
   refreshLatest(limit?: number): Promise<void>;
   startHydration(): void;
   setLoading(loading: boolean): void;

--- a/apps/web-pwa/src/store/synthesis/index.test.ts
+++ b/apps/web-pwa/src/store/synthesis/index.test.ts
@@ -359,6 +359,43 @@ describe('synthesis store', () => {
     expect(topic.error).toBeNull();
   });
 
+  it('refreshTopic preserves an accepted synthesis across transient null latest reads', async () => {
+    readTopicLatestSynthesisMock.mockResolvedValue(null);
+    readTopicLatestSynthesisCorrectionMock.mockResolvedValue(null);
+
+    const { createSynthesisStore } = await import('./index');
+    const store = createSynthesisStore({ enabled: true, resolveClient: () => ({}) as never });
+    store.getState().setTopicSynthesis('topic-1', synthesis({ epoch: 4, synthesis_id: 'synth-4' }));
+
+    await store.getState().refreshTopic('topic-1');
+
+    const topic = store.getState().getTopicState('topic-1');
+    expect(topic.synthesis?.synthesis_id).toBe('synth-4');
+    expect(topic.epoch).toBe(4);
+    expect(topic.effectiveStatus).toBe('accepted_available');
+    expect(topic.loading).toBe(false);
+    expect(topic.error).toBeNull();
+  });
+
+  it('refreshTopic preserves durable corrections across transient null correction reads', async () => {
+    readTopicLatestSynthesisMock.mockResolvedValue(null);
+    readTopicLatestSynthesisCorrectionMock.mockResolvedValue(null);
+
+    const { createSynthesisStore } = await import('./index');
+    const store = createSynthesisStore({ enabled: true, resolveClient: () => ({}) as never });
+    store.getState().setTopicSynthesis('topic-1', synthesis());
+    store.getState().setTopicCorrection('topic-1', correction());
+
+    await store.getState().refreshTopic('topic-1');
+
+    const topic = store.getState().getTopicState('topic-1');
+    expect(topic.synthesis?.synthesis_id).toBe('synth-1');
+    expect(topic.correction?.correction_id).toBe('correction-1');
+    expect(topic.effectiveStatus).toBe('synthesis_suppressed');
+    expect(topic.loading).toBe(false);
+    expect(topic.error).toBeNull();
+  });
+
   it('refreshTopic drops invalid latest payloads after defensive parse', async () => {
     readTopicLatestSynthesisMock.mockResolvedValue({ invalid: true } as unknown as TopicSynthesisV2);
 

--- a/apps/web-pwa/src/store/synthesis/index.ts
+++ b/apps/web-pwa/src/store/synthesis/index.ts
@@ -243,15 +243,19 @@ export function createSynthesisStore(overrides?: Partial<InternalDeps>): StoreAp
         const topicCorrection = validatedCorrection?.topic_id === normalizedTopicId ? validatedCorrection : null;
 
         set((state) => ({
-          topics: upsertTopicState(state.topics, normalizedTopicId, (current) => ({
-            ...current,
-            synthesis: topicLatest,
-            epoch: topicLatest?.epoch ?? null,
-            correction: topicCorrection,
-            effectiveStatus: resolveEffectiveStatus(topicLatest, topicCorrection),
-            loading: false,
-            error: null
-          }))
+          topics: upsertTopicState(state.topics, normalizedTopicId, (current) => {
+            const nextSynthesis = topicLatest ?? current.synthesis;
+            const nextCorrection = topicCorrection ?? current.correction;
+            return {
+              ...current,
+              synthesis: nextSynthesis,
+              epoch: nextSynthesis?.epoch ?? null,
+              correction: nextCorrection,
+              effectiveStatus: resolveEffectiveStatus(nextSynthesis, nextCorrection),
+              loading: false,
+              error: null
+            };
+          })
         }));
       } catch (error: unknown) {
         set((state) => ({

--- a/infra/relay/server.js
+++ b/infra/relay/server.js
@@ -49,14 +49,626 @@ const port = Number(process.env.GUN_PORT || 7777);
 const host = process.env.GUN_HOST || '127.0.0.1';
 const radiskEnabled = process.env.GUN_RADISK !== 'false';
 const gunFile = radiskEnabled ? process.env.GUN_FILE || 'data' : false;
+const COMMENT_JSON_FIELD = '__comment_json';
+const COMMENT_INDEX_SCHEMA_VERSION = 'hermes-comment-index-v1';
+
+function sendJson(res, status, body) {
+  res.statusCode = status;
+  res.setHeader('Content-Type', 'application/json');
+  res.end(JSON.stringify(body));
+}
+
+function readJsonBody(req, limitBytes = 1_000_000) {
+  return new Promise((resolve, reject) => {
+    let body = '';
+    req.setEncoding('utf8');
+    req.on('data', (chunk) => {
+      body += chunk;
+      if (body.length > limitBytes) {
+        reject(new Error('body-too-large'));
+        req.destroy();
+      }
+    });
+    req.on('end', () => {
+      try {
+        resolve(body.trim() ? JSON.parse(body) : {});
+      } catch {
+        reject(new Error('invalid-json'));
+      }
+    });
+    req.on('error', reject);
+  });
+}
+
+function putWithTimeout(chain, value, timeoutMs = 1_500) {
+  return new Promise((resolve) => {
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      resolve({ timedOut: true });
+    }, timeoutMs);
+    chain.put(value, (ack) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve({ ack });
+    });
+  });
+}
+
+function readOnce(chain, timeoutMs = 1_500) {
+  return new Promise((resolve) => {
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      resolve(null);
+    }, timeoutMs);
+    chain.once((data) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(data ?? null);
+    });
+  });
+}
+
+function stripGunMetadata(value) {
+  if (!value || typeof value !== 'object') return value;
+  const { _, ...rest } = value;
+  return rest;
+}
+
+function parseThreadEnvelope(value) {
+  if (typeof value !== 'string' || value.trim().length === 0) return null;
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === 'object' ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function parseTopicSynthesisEnvelope(value) {
+  if (typeof value !== 'string' || value.trim().length === 0) return null;
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === 'object' ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function stateNode(node, field, state, value, soul) {
+  return Gun.state.ify(node || {}, field, state, value, soul);
+}
+
+function linkNode(graph, soul, field, childSoul, state) {
+  graph[soul] = stateNode(graph[soul], field, state, { '#': childSoul }, soul);
+}
+
+function buildThreadGraph(thread) {
+  const state = Gun.state();
+  const threadSoul = `vh/forum/threads/${thread.id}`;
+  const graph = {};
+  linkNode(graph, 'vh', 'forum', 'vh/forum', state);
+  linkNode(graph, 'vh/forum', 'threads', 'vh/forum/threads', state);
+  linkNode(graph, 'vh/forum/threads', thread.id, threadSoul, state);
+  for (const [key, value] of Object.entries(thread)) {
+    if (value === undefined) continue;
+    graph[threadSoul] = stateNode(graph[threadSoul], key, state, value, threadSoul);
+  }
+  return graph;
+}
+
+function buildCommentGraph(comment) {
+  const state = Gun.state();
+  const threadSoul = `vh/forum/threads/${comment.threadId}`;
+  const commentsSoul = `${threadSoul}/comments`;
+  const commentSoul = `${commentsSoul}/${comment.id}`;
+  const indexKey = encodeURIComponent(comment.threadId);
+  const indexRootSoul = `vh/forum/indexes/comment_ids/${indexKey}`;
+  const indexCurrentSoul = `${indexRootSoul}/current`;
+  const indexEntriesSoul = `${indexRootSoul}/entries`;
+  const indexEntrySoul = `${indexEntriesSoul}/${comment.id}`;
+  const updatedAt = Date.now();
+  const indexEntry = {
+    schemaVersion: COMMENT_INDEX_SCHEMA_VERSION,
+    threadId: comment.threadId,
+    commentId: comment.id,
+    updatedAt,
+  };
+  const indexCurrent = {
+    schemaVersion: COMMENT_INDEX_SCHEMA_VERSION,
+    threadId: comment.threadId,
+    idsJson: JSON.stringify([comment.id]),
+    updatedAt,
+  };
+  const encodedComment = {
+    ...comment,
+    [COMMENT_JSON_FIELD]: JSON.stringify(comment),
+  };
+  const graph = {};
+
+  linkNode(graph, 'vh', 'forum', 'vh/forum', state);
+  linkNode(graph, 'vh/forum', 'threads', 'vh/forum/threads', state);
+  linkNode(graph, 'vh/forum/threads', comment.threadId, threadSoul, state);
+  linkNode(graph, threadSoul, 'comments', commentsSoul, state);
+  linkNode(graph, commentsSoul, comment.id, commentSoul, state);
+  linkNode(graph, 'vh/forum', 'indexes', 'vh/forum/indexes', state);
+  linkNode(graph, 'vh/forum/indexes', 'comment_ids', 'vh/forum/indexes/comment_ids', state);
+  linkNode(graph, 'vh/forum/indexes/comment_ids', indexKey, indexRootSoul, state);
+  linkNode(graph, indexRootSoul, 'current', indexCurrentSoul, state);
+  linkNode(graph, indexRootSoul, 'entries', indexEntriesSoul, state);
+  linkNode(graph, indexEntriesSoul, comment.id, indexEntrySoul, state);
+
+  for (const [key, value] of Object.entries(encodedComment)) {
+    if (value === undefined) continue;
+    graph[commentSoul] = stateNode(graph[commentSoul], key, state, value, commentSoul);
+  }
+  for (const [key, value] of Object.entries(indexEntry)) {
+    graph[indexEntrySoul] = stateNode(graph[indexEntrySoul], key, state, value, indexEntrySoul);
+  }
+  for (const [key, value] of Object.entries(indexCurrent)) {
+    graph[indexCurrentSoul] = stateNode(graph[indexCurrentSoul], key, state, value, indexCurrentSoul);
+  }
+
+  return graph;
+}
+
+function encodeTopicSynthesis(synthesis) {
+  return {
+    __topic_synthesis_json: JSON.stringify(synthesis),
+    schemaVersion: synthesis.schemaVersion,
+    topic_id: synthesis.topic_id,
+    epoch: synthesis.epoch,
+    synthesis_id: synthesis.synthesis_id,
+    created_at: synthesis.created_at,
+  };
+}
+
+function buildTopicSynthesisGraph(synthesis) {
+  const state = Gun.state();
+  const topicId = String(synthesis.topic_id);
+  const epoch = String(synthesis.epoch);
+  const latestSoul = `vh/topics/${topicId}/latest`;
+  const epochRootSoul = `vh/topics/${topicId}/epochs`;
+  const epochSoul = `${epochRootSoul}/${epoch}`;
+  const epochSynthesisSoul = `${epochSoul}/synthesis`;
+  const encoded = encodeTopicSynthesis(synthesis);
+  const graph = {};
+
+  linkNode(graph, 'vh', 'topics', 'vh/topics', state);
+  linkNode(graph, 'vh/topics', topicId, `vh/topics/${topicId}`, state);
+  linkNode(graph, `vh/topics/${topicId}`, 'latest', latestSoul, state);
+  linkNode(graph, `vh/topics/${topicId}`, 'epochs', epochRootSoul, state);
+  linkNode(graph, epochRootSoul, epoch, epochSoul, state);
+  linkNode(graph, epochSoul, 'synthesis', epochSynthesisSoul, state);
+
+  for (const [key, value] of Object.entries(encoded)) {
+    if (value === undefined) continue;
+    graph[latestSoul] = stateNode(graph[latestSoul], key, state, value, latestSoul);
+    graph[epochSynthesisSoul] = stateNode(graph[epochSynthesisSoul], key, state, value, epochSynthesisSoul);
+  }
+
+  return graph;
+}
+
+function buildAggregateVoterGraph(write) {
+  const state = Gun.state();
+  const topicRootSoul = `vh/aggregates/topics/${write.topic_id}`;
+  const synthesesSoul = `${topicRootSoul}/syntheses`;
+  const synthesisSoul = `${synthesesSoul}/${write.synthesis_id}`;
+  const epochsSoul = `${synthesisSoul}/epochs`;
+  const epochSoul = `${epochsSoul}/${write.epoch}`;
+  const votersSoul = `${epochSoul}/voters`;
+  const voterSoul = `${votersSoul}/${write.voter_id}`;
+  const pointSoul = `${voterSoul}/${write.node.point_id}`;
+  const graph = {};
+
+  linkNode(graph, 'vh', 'aggregates', 'vh/aggregates', state);
+  linkNode(graph, 'vh/aggregates', 'topics', 'vh/aggregates/topics', state);
+  linkNode(graph, 'vh/aggregates/topics', write.topic_id, topicRootSoul, state);
+  linkNode(graph, topicRootSoul, 'syntheses', synthesesSoul, state);
+  linkNode(graph, synthesesSoul, write.synthesis_id, synthesisSoul, state);
+  linkNode(graph, synthesisSoul, 'epochs', epochsSoul, state);
+  linkNode(graph, epochsSoul, String(write.epoch), epochSoul, state);
+  linkNode(graph, epochSoul, 'voters', votersSoul, state);
+  linkNode(graph, votersSoul, write.voter_id, voterSoul, state);
+  linkNode(graph, voterSoul, write.node.point_id, pointSoul, state);
+
+  for (const [key, value] of Object.entries(write.node)) {
+    if (value === undefined) continue;
+    graph[pointSoul] = stateNode(graph[pointSoul], key, state, value, pointSoul);
+  }
+
+  return graph;
+}
+
+function buildAggregatePointSnapshotGraph(snapshot) {
+  const state = Gun.state();
+  const topicRootSoul = `vh/aggregates/topics/${snapshot.topic_id}`;
+  const synthesesSoul = `${topicRootSoul}/syntheses`;
+  const synthesisSoul = `${synthesesSoul}/${snapshot.synthesis_id}`;
+  const epochsSoul = `${synthesisSoul}/epochs`;
+  const epochSoul = `${epochsSoul}/${snapshot.epoch}`;
+  const pointsSoul = `${epochSoul}/points`;
+  const pointSoul = `${pointsSoul}/${snapshot.point_id}`;
+  const sourceWindowSoul = `${pointSoul}/source_window`;
+  const graph = {};
+
+  linkNode(graph, 'vh', 'aggregates', 'vh/aggregates', state);
+  linkNode(graph, 'vh/aggregates', 'topics', 'vh/aggregates/topics', state);
+  linkNode(graph, 'vh/aggregates/topics', snapshot.topic_id, topicRootSoul, state);
+  linkNode(graph, topicRootSoul, 'syntheses', synthesesSoul, state);
+  linkNode(graph, synthesesSoul, snapshot.synthesis_id, synthesisSoul, state);
+  linkNode(graph, synthesisSoul, 'epochs', epochsSoul, state);
+  linkNode(graph, epochsSoul, String(snapshot.epoch), epochSoul, state);
+  linkNode(graph, epochSoul, 'points', pointsSoul, state);
+  linkNode(graph, pointsSoul, snapshot.point_id, pointSoul, state);
+  linkNode(graph, pointSoul, 'source_window', sourceWindowSoul, state);
+
+  for (const [key, value] of Object.entries(snapshot)) {
+    if (key === 'source_window' || value === undefined) continue;
+    graph[pointSoul] = stateNode(graph[pointSoul], key, state, value, pointSoul);
+  }
+
+  graph[sourceWindowSoul] = stateNode(
+    graph[sourceWindowSoul],
+    'from_seq',
+    state,
+    snapshot.source_window.from_seq,
+    sourceWindowSoul
+  );
+  graph[sourceWindowSoul] = stateNode(
+    graph[sourceWindowSoul],
+    'to_seq',
+    state,
+    snapshot.source_window.to_seq,
+    sourceWindowSoul
+  );
+
+  return graph;
+}
+
+function injectGraph(gun, graph) {
+  gun._.on('in', {
+    '#': `vh-relay-http-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    put: graph,
+    $: gun,
+    _: { faith: true },
+  });
+}
+
+async function pollThreadBack(threadChain, threadId, timeoutMs = 5_000) {
+  const deadline = Date.now() + timeoutMs;
+  let latest = null;
+  while (Date.now() < deadline) {
+    latest = await readThreadBack(threadChain, threadId);
+    if (latest) return latest;
+    await new Promise((resolve) => setTimeout(resolve, 150));
+  }
+  return latest;
+}
+
+async function readThreadBack(threadChain, threadId) {
+  const direct = stripGunMetadata(await readOnce(threadChain));
+  if (direct && typeof direct === 'object' && direct.id === threadId) {
+    return direct;
+  }
+  const envelope = parseThreadEnvelope(await readOnce(threadChain.get('__thread_json')));
+  if (envelope?.id === threadId) {
+    return envelope;
+  }
+  return null;
+}
+
+async function readTopicSynthesisBack(gun, topicId, synthesisId) {
+  const latestChain = gun.get('vh').get('topics').get(topicId).get('latest');
+  const direct = stripGunMetadata(await readOnce(latestChain));
+  const envelope = direct && typeof direct === 'object'
+    ? parseTopicSynthesisEnvelope(direct.__topic_synthesis_json)
+    : null;
+  if (envelope?.topic_id === topicId && envelope?.synthesis_id === synthesisId) {
+    return envelope;
+  }
+  const scalar = parseTopicSynthesisEnvelope(await readOnce(latestChain.get('__topic_synthesis_json')));
+  if (scalar?.topic_id === topicId && scalar?.synthesis_id === synthesisId) {
+    return scalar;
+  }
+  return null;
+}
+
+function readTopicSynthesisFromGraph(gun, topicId, synthesisId) {
+  const latestSoul = `vh/topics/${topicId}/latest`;
+  const node = gun?._?.graph?.[latestSoul];
+  const envelope = parseTopicSynthesisEnvelope(node?.__topic_synthesis_json);
+  return envelope?.topic_id === topicId && envelope?.synthesis_id === synthesisId ? envelope : null;
+}
+
+function sanitizeThread(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('thread-required');
+  }
+  const id = typeof value.id === 'string' ? value.id.trim() : '';
+  if (!id) {
+    throw new Error('thread-id-required');
+  }
+  const clean = {};
+  for (const [key, raw] of Object.entries(value)) {
+    if (raw === undefined || key === '_') continue;
+    if (
+      raw === null ||
+      typeof raw === 'string' ||
+      typeof raw === 'number' ||
+      typeof raw === 'boolean'
+    ) {
+      clean[key] = raw;
+    }
+  }
+  clean.id = id;
+  return clean;
+}
+
+function sanitizeComment(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('comment-required');
+  }
+  const id = typeof value.id === 'string' ? value.id.trim() : '';
+  const threadId = typeof value.threadId === 'string' ? value.threadId.trim() : '';
+  if (!id) throw new Error('comment-id-required');
+  if (!threadId) throw new Error('comment-thread-required');
+  const clean = {};
+  for (const [key, raw] of Object.entries(value)) {
+    if (raw === undefined || key === '_' || key === COMMENT_JSON_FIELD) continue;
+    if (
+      raw === null ||
+      typeof raw === 'string' ||
+      typeof raw === 'number' ||
+      typeof raw === 'boolean'
+    ) {
+      clean[key] = raw;
+    }
+  }
+  clean.id = id;
+  clean.threadId = threadId;
+  if (typeof clean.schemaVersion !== 'string') {
+    clean.schemaVersion = 'hermes-comment-v1';
+  }
+  if (!Number.isFinite(clean.upvotes)) {
+    clean.upvotes = 0;
+  }
+  if (!Number.isFinite(clean.downvotes)) {
+    clean.downvotes = 0;
+  }
+  return clean;
+}
+
+function sanitizeTopicSynthesis(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('synthesis-required');
+  }
+  const topicId = typeof value.topic_id === 'string' ? value.topic_id.trim() : '';
+  const synthesisId = typeof value.synthesis_id === 'string' ? value.synthesis_id.trim() : '';
+  if (!topicId) throw new Error('synthesis-topic-required');
+  if (!synthesisId) throw new Error('synthesis-id-required');
+  if (!Number.isFinite(value.epoch)) throw new Error('synthesis-epoch-required');
+  return {
+    ...value,
+    topic_id: topicId,
+    synthesis_id: synthesisId,
+  };
+}
+
+function normalizeRequiredString(value, name) {
+  const normalized = typeof value === 'string' ? value.trim() : '';
+  if (!normalized) throw new Error(`${name}-required`);
+  return normalized;
+}
+
+function normalizeFiniteNumber(value, name) {
+  if (!Number.isFinite(value)) throw new Error(`${name}-required`);
+  return value;
+}
+
+function normalizeFiniteNonNegativeInteger(value, name) {
+  const normalized = normalizeFiniteNumber(value, name);
+  if (normalized < 0) throw new Error(`${name}-non-negative-required`);
+  return Math.floor(normalized);
+}
+
+function sanitizeAggregateVoterWrite(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('aggregate-voter-required');
+  }
+  const node = value.node;
+  if (!node || typeof node !== 'object' || Array.isArray(node)) {
+    throw new Error('aggregate-voter-node-required');
+  }
+
+  const agreement = normalizeFiniteNumber(node.agreement, 'agreement');
+  if (![ -1, 0, 1 ].includes(agreement)) {
+    throw new Error('agreement-invalid');
+  }
+
+  return {
+    topic_id: normalizeRequiredString(value.topic_id, 'topic-id'),
+    synthesis_id: normalizeRequiredString(value.synthesis_id, 'synthesis-id'),
+    epoch: normalizeFiniteNonNegativeInteger(value.epoch, 'epoch'),
+    voter_id: normalizeRequiredString(value.voter_id, 'voter-id'),
+    node: {
+      point_id: normalizeRequiredString(node.point_id, 'point-id'),
+      agreement,
+      weight: normalizeFiniteNumber(node.weight, 'weight'),
+      updated_at: normalizeRequiredString(node.updated_at, 'updated-at'),
+    },
+  };
+}
+
+function sanitizeAggregatePointSnapshot(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('aggregate-snapshot-required');
+  }
+  const sourceWindow = value.source_window;
+  if (!sourceWindow || typeof sourceWindow !== 'object' || Array.isArray(sourceWindow)) {
+    throw new Error('source-window-required');
+  }
+
+  return {
+    schema_version: normalizeRequiredString(value.schema_version, 'schema-version'),
+    topic_id: normalizeRequiredString(value.topic_id, 'topic-id'),
+    synthesis_id: normalizeRequiredString(value.synthesis_id, 'synthesis-id'),
+    epoch: normalizeFiniteNonNegativeInteger(value.epoch, 'epoch'),
+    point_id: normalizeRequiredString(value.point_id, 'point-id'),
+    agree: normalizeFiniteNonNegativeInteger(value.agree, 'agree'),
+    disagree: normalizeFiniteNonNegativeInteger(value.disagree, 'disagree'),
+    weight: normalizeFiniteNumber(value.weight, 'weight'),
+    participants: normalizeFiniteNonNegativeInteger(value.participants, 'participants'),
+    version: normalizeFiniteNonNegativeInteger(value.version, 'version'),
+    computed_at: normalizeFiniteNonNegativeInteger(value.computed_at, 'computed-at'),
+    source_window: {
+      from_seq: normalizeFiniteNonNegativeInteger(sourceWindow.from_seq, 'source-window-from-seq'),
+      to_seq: normalizeFiniteNonNegativeInteger(sourceWindow.to_seq, 'source-window-to-seq'),
+    },
+  };
+}
+
+async function writeForumThread(gun, thread) {
+  const clean = sanitizeThread(thread);
+  const threadChain = gun.get('vh').get('forum').get('threads').get(clean.id);
+  const writes = [putWithTimeout(threadChain, clean)];
+  for (const [key, value] of Object.entries(clean)) {
+    writes.push(putWithTimeout(threadChain.get(key), value, 750));
+  }
+  await Promise.allSettled(writes);
+  let readback = await pollThreadBack(threadChain, clean.id, 2_000);
+  if (!readback) {
+    injectGraph(gun, buildThreadGraph(clean));
+    readback = await pollThreadBack(threadChain, clean.id, 5_000);
+  }
+  if (!readback) {
+    throw new Error('thread-readback-failed');
+  }
+  return readback;
+}
+
+async function writeForumComment(gun, comment) {
+  const clean = sanitizeComment(comment);
+  injectGraph(gun, buildCommentGraph(clean));
+  return clean;
+}
+
+async function writeTopicSynthesis(gun, synthesis) {
+  const clean = sanitizeTopicSynthesis(synthesis);
+  injectGraph(gun, buildTopicSynthesisGraph(clean));
+  return clean;
+}
+
+async function writeAggregateVoter(gun, write) {
+  const clean = sanitizeAggregateVoterWrite(write);
+  injectGraph(gun, buildAggregateVoterGraph(clean));
+  return clean;
+}
+
+async function writeAggregatePointSnapshot(gun, snapshot) {
+  const clean = sanitizeAggregatePointSnapshot(snapshot);
+  injectGraph(gun, buildAggregatePointSnapshotGraph(clean));
+  return clean;
+}
 
 const server = http.createServer((req, res) => {
   res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Headers', 'content-type');
+  res.setHeader('Access-Control-Allow-Methods', 'GET,POST,OPTIONS');
+
+  if (req.method === 'OPTIONS') {
+    res.statusCode = 204;
+    res.end();
+    return;
+  }
+
+  if (req.method === 'POST' && req.url === '/vh/forum/thread') {
+    readJsonBody(req)
+      .then((body) => writeForumThread(gun, body.thread))
+      .then((thread) => sendJson(res, 200, { ok: true, thread_id: thread.id }))
+      .catch((error) => sendJson(res, 500, {
+        ok: false,
+        error: error instanceof Error ? error.message : String(error)
+      }));
+    return;
+  }
+
+  if (req.method === 'POST' && req.url === '/vh/forum/comment') {
+    readJsonBody(req)
+      .then((body) => writeForumComment(gun, body.comment))
+      .then((comment) => sendJson(res, 200, {
+        ok: true,
+        thread_id: comment.threadId,
+        comment_id: comment.id
+      }))
+      .catch((error) => sendJson(res, 500, {
+        ok: false,
+        error: error instanceof Error ? error.message : String(error)
+      }));
+    return;
+  }
+
+  if (req.method === 'POST' && req.url === '/vh/topics/synthesis') {
+    readJsonBody(req)
+      .then((body) => writeTopicSynthesis(gun, body.synthesis))
+      .then((synthesis) => sendJson(res, 200, {
+        ok: true,
+        topic_id: synthesis.topic_id,
+        synthesis_id: synthesis.synthesis_id
+      }))
+      .catch((error) => sendJson(res, 500, {
+        ok: false,
+        error: error instanceof Error ? error.message : String(error)
+      }));
+    return;
+  }
+
+  if (req.method === 'POST' && req.url === '/vh/aggregates/voter') {
+    readJsonBody(req)
+      .then((body) => writeAggregateVoter(gun, body))
+      .then((write) => sendJson(res, 200, {
+        ok: true,
+        topic_id: write.topic_id,
+        synthesis_id: write.synthesis_id,
+        epoch: write.epoch,
+        voter_id: write.voter_id,
+        point_id: write.node.point_id
+      }))
+      .catch((error) => sendJson(res, 500, {
+        ok: false,
+        error: error instanceof Error ? error.message : String(error)
+      }));
+    return;
+  }
+
+  if (req.method === 'POST' && req.url === '/vh/aggregates/point-snapshot') {
+    readJsonBody(req)
+      .then((body) => writeAggregatePointSnapshot(gun, body.snapshot))
+      .then((snapshot) => sendJson(res, 200, {
+        ok: true,
+        topic_id: snapshot.topic_id,
+        synthesis_id: snapshot.synthesis_id,
+        epoch: snapshot.epoch,
+        point_id: snapshot.point_id
+      }))
+      .catch((error) => sendJson(res, 500, {
+        ok: false,
+        error: error instanceof Error ? error.message : String(error)
+      }));
+    return;
+  }
+
   res.end('vh relay alive\n');
 });
 
 // Minimal, stable Gun relay (no custom hooks)
-Gun({
+const gun = Gun({
   web: server,
   radisk: radiskEnabled,
   file: gunFile,

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -31,6 +31,9 @@
     "codegen": "playwright codegen",
     "typecheck": "tsc --noEmit"
   },
+  "dependencies": {
+    "@vh/gun-client": "workspace:*"
+  },
   "devDependencies": {
     "@playwright/test": "^1.42.1",
     "@types/node": "^20.11.30",

--- a/packages/e2e/src/live/five-user-news-engagement.live.spec.ts
+++ b/packages/e2e/src/live/five-user-news-engagement.live.spec.ts
@@ -1,14 +1,20 @@
+import { execFile } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { promisify } from 'node:util';
 import { test, expect, type BrowserContext, type Locator, type Page } from '@playwright/test';
 
 const LIVE_BASE_URL = process.env.VH_LIVE_BASE_URL ?? 'http://127.0.0.1:2048/';
 const SHOULD_RUN = process.env.VH_RUN_FULL_PRODUCT_MOCK_USERS === 'true';
 const NAV_TIMEOUT_MS = 90_000;
 const FEED_TIMEOUT_MS = 180_000;
-const ANALYSIS_TIMEOUT_MS = 180_000;
+const ANALYSIS_TIMEOUT_MS = readPositiveIntEnv('VH_FULL_PRODUCT_ANALYSIS_TIMEOUT_MS', 360_000);
+const DISCOVERY_ANALYSIS_PROBE_MS = readPositiveIntEnv('VH_FULL_PRODUCT_DISCOVERY_ANALYSIS_PROBE_MS', 10_000);
 const AGGREGATE_TIMEOUT_MS = 90_000;
 const COMMENT_TIMEOUT_MS = 120_000;
 const DEFAULT_LABELS = ['alice', 'bruno', 'chandra', 'devon', 'elena'];
 const RUN_ID = process.env.VH_FULL_PRODUCT_MOCK_USERS_RUN_ID ?? `mock-users-${Date.now().toString(36)}`;
+const execFileAsync = promisify(execFile);
 
 function readPositiveIntEnv(name: string, fallback: number): number {
   const value = Number.parseInt(process.env[name] ?? '', 10);
@@ -18,6 +24,7 @@ function readPositiveIntEnv(name: string, fallback: number): number {
 const USER_COUNT = readPositiveIntEnv('VH_FULL_PRODUCT_MOCK_USER_COUNT', 5);
 const REQUIRED_SINGLETON_STORIES = readPositiveIntEnv('VH_FULL_PRODUCT_REQUIRED_SINGLETON_STORIES', 2);
 const REQUIRED_BUNDLED_STORIES = readPositiveIntEnv('VH_FULL_PRODUCT_REQUIRED_BUNDLED_STORIES', 2);
+const MESH_SYNTHESIS_READ_TIMEOUT_MS = readPositiveIntEnv('VH_FULL_PRODUCT_MESH_SYNTHESIS_READ_TIMEOUT_MS', 6_000);
 
 type StoryKind = 'singleton' | 'bundle';
 
@@ -49,6 +56,77 @@ interface VoteCounts {
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function parseGunPeers(): string[] {
+  const raw = process.env.VH_GUN_PEERS ?? process.env.VITE_GUN_PEERS ?? '["http://127.0.0.1:7777/gun"]';
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return ['http://127.0.0.1:7777/gun'];
+  }
+  if (trimmed.startsWith('[')) {
+    const parsed = JSON.parse(trimmed);
+    return Array.isArray(parsed) ? parsed.map(String).filter(Boolean) : ['http://127.0.0.1:7777/gun'];
+  }
+  return trimmed.split(',').map((peer) => peer.trim()).filter(Boolean);
+}
+
+function resolveRepoRoot(): string {
+  let current = process.cwd();
+  for (let depth = 0; depth < 5; depth += 1) {
+    if (fs.existsSync(path.join(current, 'pnpm-workspace.yaml'))) {
+      return current;
+    }
+    const parent = path.dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+  return path.resolve(process.cwd(), '../..');
+}
+
+async function meshAcceptedRows(
+  rows: ReadonlyArray<Omit<StoryTarget, 'pointId'> & { kind: StoryKind }>,
+): Promise<Array<Omit<StoryTarget, 'pointId'> & { kind: StoryKind }>> {
+  if (rows.length === 0) {
+    return [];
+  }
+  const repoRoot = resolveRepoRoot();
+  const e2eRoot = path.join(repoRoot, 'packages/e2e');
+  const scriptPath = path.join(e2eRoot, 'src/live/mesh-synthesis-prefilter.mjs');
+  const loaderPath = path.join(repoRoot, 'tools/node/esm-resolve-loader.mjs');
+  const topicIds = [...new Set(rows.map((row) => row.topicId))];
+  const { stdout } = await execFileAsync(
+    process.execPath,
+    [
+      '--loader',
+      loaderPath,
+      scriptPath,
+      '--peers',
+      JSON.stringify(parseGunPeers()),
+      ...topicIds,
+    ],
+    {
+      cwd: e2eRoot,
+      env: {
+        ...process.env,
+        VH_FULL_PRODUCT_MESH_SYNTHESIS_READ_TIMEOUT_MS: String(MESH_SYNTHESIS_READ_TIMEOUT_MS),
+      },
+      maxBuffer: 1024 * 1024,
+      timeout: MESH_SYNTHESIS_READ_TIMEOUT_MS + 8_000,
+    },
+  );
+  const payload = JSON.parse(stdout.trim().split('\n').at(-1) ?? '{}') as {
+    accepted?: Record<string, boolean>;
+  };
+  return rows.filter((row) => payload.accepted?.[row.topicId] === true);
+}
+
+function isRecoverablePageError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.includes('Page crashed')
+    || message.includes('Target crashed')
+    || message.includes('Target page')
+    || message.includes('has been closed');
 }
 
 async function waitFor(condition: () => Promise<boolean>, timeoutMs: number, stepMs = 500): Promise<boolean> {
@@ -91,9 +169,9 @@ async function gotoUserFeed(user: UserSession): Promise<Page> {
     if (
       !user.page.isClosed()
       && !message.includes('Page crashed')
-      && !message.includes('Target crashed')
       && !message.includes('Target page')
       && !message.includes('feed-not-ready')
+      && !isRecoverablePageError(error)
     ) {
       throw error;
     }
@@ -187,6 +265,18 @@ async function openStory(page: Page, target: { topicId: string; storyId: string 
     await gotoFeed(page);
     await nudgeFeed(page);
   }
+  const detailUrl = new URL(LIVE_BASE_URL);
+  detailUrl.searchParams.set('detail', `news:${target.storyId}`);
+  await page.goto(detailUrl.toString(), { waitUntil: 'domcontentloaded', timeout: NAV_TIMEOUT_MS });
+  const detail = page.locator(`[data-testid="news-card-detail-${target.topicId}"]`).first();
+  const opened = await waitFor(
+    async () => detail.isVisible().catch(() => false),
+    15_000,
+    250,
+  );
+  if (opened) {
+    return detail.locator('xpath=ancestor::article[1]');
+  }
   throw new Error(`story-open-failed:${target.storyId}`);
 }
 
@@ -205,73 +295,167 @@ async function closeStory(card: Locator, topicId: string): Promise<void> {
 }
 
 async function firstVotePointId(card: Locator): Promise<string | null> {
-  const button = card.locator('[data-testid^="cell-vote-agree-"]').first();
-  if (!(await button.count())) return null;
-  const testId = await button.getAttribute('data-testid');
-  return testId?.replace('cell-vote-agree-', '') ?? null;
+  const prefix = 'cell-vote-agree-';
+  const testIds = await card.locator(`[data-testid^="${prefix}"]`)
+    .evaluateAll((nodes, expectedPrefix) =>
+      nodes
+        .map((node) => node.getAttribute('data-testid') ?? '')
+        .filter((testId) => testId.length > expectedPrefix.length),
+      prefix
+    )
+    .catch((error: unknown) => {
+      if (isRecoverablePageError(error)) {
+        throw error;
+      }
+      return [];
+    });
+  return testIds[0]?.slice(prefix.length) ?? null;
 }
 
-async function waitForAnalysisReady(card: Locator, topicId: string): Promise<string> {
+async function textContentOrEmpty(locator: Locator): Promise<string> {
+  try {
+    return ((await locator.textContent()) ?? '').trim();
+  } catch (error) {
+    if (isRecoverablePageError(error)) {
+      throw error;
+    }
+    return '';
+  }
+}
+
+async function countOrZero(locator: Locator): Promise<number> {
+  try {
+    return await locator.count();
+  } catch (error) {
+    if (isRecoverablePageError(error)) {
+      throw error;
+    }
+    return 0;
+  }
+}
+
+async function waitForAnalysisReady(
+  card: Locator,
+  topicId: string,
+  timeoutMs = ANALYSIS_TIMEOUT_MS,
+): Promise<string> {
+  let readyPointId: string | null = null;
   const ready = await waitFor(async () => {
-    const basis = ((await card.getByTestId(`news-card-summary-basis-${topicId}`).textContent().catch(() => '')) ?? '').trim();
-    const rows = await card.locator('[data-testid^="bias-table-row-"]').count().catch(() => 0);
-    const votes = await card.locator('[data-testid^="cell-vote-agree-"]').count().catch(() => 0);
-    const correction = await card.locator(`[data-testid="news-card-synthesis-correction-state-${topicId}"]`).count().catch(() => 0);
-    return correction === 0 && basis.includes('Topic synthesis v2') && rows > 0 && votes > 0;
-  }, ANALYSIS_TIMEOUT_MS);
+    const basis = await textContentOrEmpty(card.getByTestId(`news-card-summary-basis-${topicId}`));
+    const rows = await countOrZero(card.locator('[data-testid^="bias-table-row-"]'));
+    const correction = await countOrZero(card.locator(`[data-testid="news-card-synthesis-correction-state-${topicId}"]`));
+    const pointId = await firstVotePointId(card);
+    if (correction === 0 && basis.includes('Topic synthesis v2') && rows > 0 && pointId) {
+      readyPointId = pointId;
+      return true;
+    }
+    return false;
+  }, timeoutMs);
   if (!ready) {
-    const basis = ((await card.getByTestId(`news-card-summary-basis-${topicId}`).textContent().catch(() => '')) ?? '').trim();
-    const rowCount = await card.locator('[data-testid^="bias-table-row-"]').count().catch(() => 0);
-    const voteCount = await card.locator('[data-testid^="cell-vote-agree-"]').count().catch(() => 0);
+    const basis = await textContentOrEmpty(card.getByTestId(`news-card-summary-basis-${topicId}`));
+    const rowCount = await countOrZero(card.locator('[data-testid^="bias-table-row-"]'));
+    const voteCount = await countOrZero(card.locator('[data-testid^="cell-vote-agree-"]'));
     throw new Error(`analysis-not-ready:${topicId}:basis=${basis}:rows=${rowCount}:votes=${voteCount}`);
   }
 
-  const pointId = await firstVotePointId(card);
-  if (!pointId) {
+  if (!readyPointId) {
     throw new Error(`analysis-ready-without-point:${topicId}`);
   }
-  return pointId;
+  return readyPointId;
 }
 
-async function discoverTargets(page: Page): Promise<StoryTarget[]> {
+async function discoverTargets(user: UserSession): Promise<StoryTarget[]> {
   const targets: StoryTarget[] = [];
-  const seen = new Set<string>();
+  const selectedStoryIds = new Set<string>();
+  const nextProbeAtByStoryId = new Map<string, number>();
   const enough = () =>
     targets.filter((target) => target.kind === 'singleton').length >= REQUIRED_SINGLETON_STORIES
     && targets.filter((target) => target.kind === 'bundle').length >= REQUIRED_BUNDLED_STORIES;
 
+  let page = await gotoUserFeed(user);
   const startedAt = Date.now();
   while (Date.now() - startedAt < ANALYSIS_TIMEOUT_MS && !enough()) {
-    await gotoFeed(page);
-    const rows = await visibleStoryRows(page);
-    for (const row of rows) {
-      if (seen.has(row.storyId)) continue;
+    page = await gotoUserFeed(user);
+    let rows: Array<Omit<StoryTarget, 'kind' | 'pointId'> & { kind: StoryKind }>;
+    try {
+      rows = await visibleStoryRows(page);
+    } catch (error) {
+      if (isRecoverablePageError(error)) {
+        page = await replaceUserPage(user);
+        continue;
+      }
+      throw error;
+    }
+
+    const eligibleRows = rows.filter((row) => {
+      if (selectedStoryIds.has(row.storyId)) {
+        return false;
+      }
       if (
         row.kind === 'singleton'
         && targets.filter((target) => target.kind === 'singleton').length >= REQUIRED_SINGLETON_STORIES
       ) {
-        continue;
+        return false;
       }
       if (
         row.kind === 'bundle'
         && targets.filter((target) => target.kind === 'bundle').length >= REQUIRED_BUNDLED_STORIES
       ) {
-        continue;
+        return false;
       }
-      seen.add(row.storyId);
-      const card = await openStory(page, row);
-      try {
-        const pointId = await waitForAnalysisReady(card, row.topicId);
-        targets.push({ ...row, pointId });
-        if (enough()) break;
-      } catch {
-        // Keep scanning until the daemon has enough accepted syntheses.
-      } finally {
-        await closeStory(card, row.topicId).catch(() => undefined);
+      const nextProbeAt = nextProbeAtByStoryId.get(row.storyId) ?? 0;
+      return nextProbeAt <= Date.now();
+    });
+    const acceptedRows = await meshAcceptedRows(eligibleRows);
+    const acceptedStoryIds = new Set(acceptedRows.map((row) => row.storyId));
+    for (const row of eligibleRows) {
+      if (!acceptedStoryIds.has(row.storyId)) {
+        nextProbeAtByStoryId.set(row.storyId, Date.now() + 5_000);
       }
     }
+
+    let restartedAfterPageRecovery = false;
+    for (const row of acceptedRows) {
+      let card: Locator | null = null;
+      try {
+        card = await openStory(page, row);
+        const pointId = await waitForAnalysisReady(card, row.topicId, DISCOVERY_ANALYSIS_PROBE_MS);
+        targets.push({ ...row, pointId });
+        selectedStoryIds.add(row.storyId);
+        nextProbeAtByStoryId.delete(row.storyId);
+        if (enough()) break;
+      } catch (error) {
+        if (isRecoverablePageError(error)) {
+          nextProbeAtByStoryId.set(row.storyId, Date.now() + 5_000);
+          page = await replaceUserPage(user);
+          restartedAfterPageRecovery = true;
+          break;
+        }
+        // Keep scanning; live public syntheses can land after the first card probe.
+        nextProbeAtByStoryId.set(row.storyId, Date.now() + 5_000);
+      } finally {
+        if (card && !restartedAfterPageRecovery) {
+          await closeStory(card, row.topicId).catch((error: unknown) => {
+            if (isRecoverablePageError(error)) {
+              restartedAfterPageRecovery = true;
+            }
+          });
+        }
+      }
+    }
+    if (restartedAfterPageRecovery) {
+      continue;
+    }
     if (!enough()) {
-      await nudgeFeed(page);
+      try {
+        await nudgeFeed(page);
+      } catch (error) {
+        if (isRecoverablePageError(error)) {
+          page = await replaceUserPage(user);
+          continue;
+        }
+        throw error;
+      }
       await sleep(2_000);
     }
   }
@@ -528,7 +712,7 @@ test.describe('full product mock-user news engagement', () => {
         users.push({ label, context, page });
       }
 
-      const targets = await discoverTargets(users[0]!.page);
+      const targets = await discoverTargets(users[0]!);
       const storyResults: Array<{
         target: StoryTarget;
         expectedMinimumVotes: VoteCounts;

--- a/packages/e2e/src/live/mesh-synthesis-prefilter.mjs
+++ b/packages/e2e/src/live/mesh-synthesis-prefilter.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+const DEFAULT_PEERS = ['http://127.0.0.1:7777/gun'];
+const DEFAULT_READ_TIMEOUT_MS = 6_000;
+
+function readPositiveIntEnv(name, fallback) {
+  const value = Number.parseInt(process.env[name] ?? '', 10);
+  return Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+function parseArgs(argv) {
+  const parsed = {
+    peers: process.env.VH_GUN_PEERS ?? process.env.VITE_GUN_PEERS ?? JSON.stringify(DEFAULT_PEERS),
+    topics: [],
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--peers') {
+      parsed.peers = argv[index + 1] ?? parsed.peers;
+      index += 1;
+      continue;
+    }
+    parsed.topics.push(arg);
+  }
+  return parsed;
+}
+
+function parsePeers(raw) {
+  const trimmed = raw.trim();
+  if (!trimmed) return DEFAULT_PEERS;
+  if (trimmed.startsWith('[')) {
+    const parsed = JSON.parse(trimmed);
+    return Array.isArray(parsed) ? parsed.map(String).filter(Boolean) : DEFAULT_PEERS;
+  }
+  return trimmed.split(',').map((peer) => peer.trim()).filter(Boolean);
+}
+
+function withTimeout(promise, timeoutMs) {
+  let timer;
+  return Promise.race([
+    promise.finally(() => clearTimeout(timer)),
+    new Promise((resolve) => {
+      timer = setTimeout(() => resolve(null), timeoutMs);
+    }),
+  ]);
+}
+
+function hasVoteableAcceptedSynthesis(synthesis) {
+  return Boolean(
+    synthesis?.facts_summary?.trim?.()
+      && synthesis?.frames?.some?.((frame) =>
+        Boolean(frame?.frame_point_id?.trim?.() || frame?.reframe_point_id?.trim?.())
+      )
+  );
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const timeoutMs = readPositiveIntEnv(
+    'VH_FULL_PRODUCT_MESH_SYNTHESIS_READ_TIMEOUT_MS',
+    DEFAULT_READ_TIMEOUT_MS,
+  );
+  const peers = parsePeers(options.peers);
+  const accepted = {};
+
+  // Gun writes noisy startup messages to stdout. Keep stdout machine-readable
+  // and emit only the final JSON payload from this short-lived helper process.
+  console.log = () => {};
+  const { createClient, readTopicLatestSynthesis } = await import('@vh/gun-client');
+  const client = createClient({ requireSession: false, peers, gunRadisk: false });
+  client.markSessionReady();
+  await new Promise((resolve) => setTimeout(resolve, 500));
+
+  await Promise.all([...new Set(options.topics)].map(async (topicId) => {
+    const synthesis = await withTimeout(readTopicLatestSynthesis(client, topicId), timeoutMs);
+    accepted[topicId] = hasVoteableAcceptedSynthesis(synthesis);
+  }));
+
+  client.shutdown?.();
+  process.stdout.write(`${JSON.stringify({ accepted })}\n`);
+  setTimeout(() => process.exit(0), 50).unref();
+}
+
+main().catch((error) => {
+  process.stderr.write(`[vh:mesh-synthesis-prefilter] ${error instanceof Error ? error.stack ?? error.message : String(error)}\n`);
+  process.exit(1);
+});

--- a/packages/gun-client/src/aggregateAdapters.test.ts
+++ b/packages/gun-client/src/aggregateAdapters.test.ts
@@ -115,12 +115,12 @@ function createFakeMesh(): FakeMesh {
   };
 }
 
-function createClient(mesh: FakeMesh, guard: TopologyGuard): VennClient {
+function createClient(mesh: FakeMesh, guard: TopologyGuard, peers: string[] = []): VennClient {
   const barrier = new HydrationBarrier();
   barrier.markReady();
 
   return {
-    config: { peers: [] },
+    config: { peers },
     hydrationBarrier: barrier,
     storage: {} as VennClient['storage'],
     topologyGuard: guard,
@@ -410,6 +410,168 @@ describe('aggregateAdapters', () => {
     }
   });
 
+  it('readPointAggregateSnapshot resolves Gun-linked source_window child nodes', async () => {
+    const path = 'aggregates/topics/topic-1/syntheses/synth-1/epochs/4/points/point-1';
+    const mesh = createFakeMesh();
+    mesh.setRead(path, {
+      schema_version: 'point-aggregate-snapshot-v1',
+      topic_id: 'topic-1',
+      synthesis_id: 'synth-1',
+      epoch: 4,
+      point_id: 'point-1',
+      agree: 1,
+      disagree: 0,
+      weight: 1,
+      participants: 1,
+      version: 1,
+      computed_at: 1,
+      source_window: { '#': `${path}/source_window` },
+    });
+    mesh.setRead(`${path}/source_window`, { from_seq: 1, to_seq: 1 });
+    const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+    const client = createClient(mesh, guard);
+
+    await expect(
+      readPointAggregateSnapshot(client, 'topic-1', 'synth-1', 4, 'point-1'),
+    ).resolves.toEqual({
+      schema_version: 'point-aggregate-snapshot-v1',
+      topic_id: 'topic-1',
+      synthesis_id: 'synth-1',
+      epoch: 4,
+      point_id: 'point-1',
+      agree: 1,
+      disagree: 0,
+      weight: 1,
+      participants: 1,
+      version: 1,
+      computed_at: 1,
+      source_window: { from_seq: 1, to_seq: 1 },
+    });
+  });
+
+  it('writePointAggregateSnapshot recovers timed-out writes with Gun-linked source_window readback', async () => {
+    vi.useFakeTimers();
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+
+    try {
+      const path = 'aggregates/topics/topic-1/syntheses/synth-1/epochs/4/points/point-1';
+      const mesh = createFakeMesh();
+      mesh.setPutHang(path);
+      mesh.setRead(path, {
+        schema_version: 'point-aggregate-snapshot-v1',
+        topic_id: 'topic-1',
+        synthesis_id: 'synth-1',
+        epoch: 4,
+        point_id: 'point-1',
+        agree: 1,
+        disagree: 0,
+        weight: 1,
+        participants: 1,
+        version: 1,
+        computed_at: 1,
+        source_window: { '#': `${path}/source_window` },
+      });
+      mesh.setRead(`${path}/source_window`, { from_seq: 1, to_seq: 1 });
+      const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+      const client = createClient(mesh, guard);
+
+      const pending = writePointAggregateSnapshot(client, {
+        schema_version: 'point-aggregate-snapshot-v1',
+        topic_id: 'topic-1',
+        synthesis_id: 'synth-1',
+        epoch: 4,
+        point_id: 'point-1',
+        agree: 1,
+        disagree: 0,
+        weight: 1,
+        participants: 1,
+        version: 1,
+        computed_at: 1,
+        source_window: { from_seq: 1, to_seq: 1 },
+      });
+
+      await vi.advanceTimersByTimeAsync(3_000);
+
+      await expect(pending).resolves.toEqual({
+        schema_version: 'point-aggregate-snapshot-v1',
+        topic_id: 'topic-1',
+        synthesis_id: 'synth-1',
+        epoch: 4,
+        point_id: 'point-1',
+        agree: 1,
+        disagree: 0,
+        weight: 1,
+        participants: 1,
+        version: 1,
+        computed_at: 1,
+        source_window: { from_seq: 1, to_seq: 1 },
+      });
+
+      expect(infoSpy).toHaveBeenCalledWith(
+        '[vh:aggregate:point-snapshot-write]',
+        expect.objectContaining({
+          point_id: 'point-1',
+          timed_out: true,
+          readback_confirmed: true,
+        }),
+      );
+    } finally {
+      infoSpy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
+  it('writePointAggregateSnapshot falls back to the relay aggregate endpoint when ack and readback time out', async () => {
+    vi.useFakeTimers();
+    try {
+      const mesh = createFakeMesh();
+      mesh.setPutHang('aggregates/topics/topic-1/syntheses/synth-1/epochs/4/points/point-1');
+      const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+      const client = createClient(mesh, guard, ['http://127.0.0.1:7777/gun']);
+      const snapshot = {
+        schema_version: 'point-aggregate-snapshot-v1' as const,
+        topic_id: 'topic-1',
+        synthesis_id: 'synth-1',
+        epoch: 4,
+        point_id: 'point-1',
+        agree: 1,
+        disagree: 0,
+        weight: 1,
+        participants: 1,
+        version: 1,
+        computed_at: 1,
+        source_window: { from_seq: 1, to_seq: 1 },
+      };
+      const fetchMock = vi.fn(async () => ({
+        ok: true,
+        json: async () => ({
+          ok: true,
+          topic_id: 'topic-1',
+          synthesis_id: 'synth-1',
+          epoch: 4,
+          point_id: 'point-1',
+        }),
+      }));
+      vi.stubGlobal('fetch', fetchMock);
+
+      const pending = writePointAggregateSnapshot(client, snapshot);
+      await vi.advanceTimersByTimeAsync(8_000);
+
+      await expect(pending).resolves.toEqual(snapshot);
+      expect(fetchMock).toHaveBeenCalledWith(
+        'http://127.0.0.1:7777/vh/aggregates/point-snapshot',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ snapshot }),
+        }),
+      );
+    } finally {
+      vi.unstubAllGlobals();
+      vi.useRealTimers();
+    }
+  });
+
   it('writePointAggregateSnapshot surfaces non-timeout put errors', async () => {
     const mesh = createFakeMesh();
     mesh.setPutError('aggregates/topics/topic-1/syntheses/synth-1/epochs/4/points/point-1', 'boom');
@@ -533,6 +695,56 @@ describe('aggregateAdapters', () => {
       );
     } finally {
       infoSpy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
+  it('writeVoterNode falls back to the relay aggregate endpoint when ack and readback time out', async () => {
+    vi.useFakeTimers();
+    try {
+      const mesh = createFakeMesh();
+      mesh.setPutHang('aggregates/topics/topic-1/syntheses/synth-1/epochs/4/voters/voter-1/point-1');
+      const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+      const client = createClient(mesh, guard, ['http://127.0.0.1:7777/gun']);
+      const node = {
+        point_id: 'point-1',
+        agreement: 1 as const,
+        weight: 1,
+        updated_at: '2026-02-18T22:20:00.000Z',
+      };
+      const fetchMock = vi.fn(async () => ({
+        ok: true,
+        json: async () => ({
+          ok: true,
+          topic_id: 'topic-1',
+          synthesis_id: 'synth-1',
+          epoch: 4,
+          voter_id: 'voter-1',
+          point_id: 'point-1',
+        }),
+      }));
+      vi.stubGlobal('fetch', fetchMock);
+
+      const pending = writeVoterNode(client, 'topic-1', 'synth-1', 4, 'voter-1', node);
+      await vi.advanceTimersByTimeAsync(8_000);
+
+      await expect(pending).resolves.toEqual(node);
+      expect(fetchMock).toHaveBeenCalledWith(
+        'http://127.0.0.1:7777/vh/aggregates/voter',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            topic_id: 'topic-1',
+            synthesis_id: 'synth-1',
+            epoch: 4,
+            voter_id: 'voter-1',
+            node,
+          }),
+        }),
+      );
+    } finally {
+      vi.unstubAllGlobals();
       vi.useRealTimers();
     }
   });
@@ -1397,6 +1609,31 @@ describe('aggregateAdapters', () => {
       await vi.advanceTimersByTimeAsync(2_500);
       callback?.({ later: true });
 
+      await expect(pending).resolves.toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('readOnce honors a per-call timeout override', async () => {
+    vi.useFakeTimers();
+    try {
+      const chain = {
+        once(_cb: (data: unknown) => void) {
+          // Simulate a Gun node that never answers.
+        },
+      } as ChainWithGet<unknown>;
+
+      const pending = aggregateAdapterInternal.readOnce(chain, 100);
+      await vi.advanceTimersByTimeAsync(99);
+      let settled = false;
+      void pending.then(() => {
+        settled = true;
+      });
+      await Promise.resolve();
+      expect(settled).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(1);
       await expect(pending).resolves.toBeNull();
     } finally {
       vi.useRealTimers();

--- a/packages/gun-client/src/aggregateAdapters.test.ts
+++ b/packages/gun-client/src/aggregateAdapters.test.ts
@@ -572,6 +572,83 @@ describe('aggregateAdapters', () => {
     }
   });
 
+  it('writePointAggregateSnapshot rejects when relay fallback is unavailable or declines the write', async () => {
+    vi.useFakeTimers();
+    try {
+      const snapshot = {
+        schema_version: 'point-aggregate-snapshot-v1' as const,
+        topic_id: 'topic-1',
+        synthesis_id: 'synth-1',
+        epoch: 4,
+        point_id: 'point-1',
+        agree: 1,
+        disagree: 0,
+        weight: 1,
+        participants: 1,
+        version: 1,
+        computed_at: 1,
+        source_window: { from_seq: 1, to_seq: 1 },
+      };
+      const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+
+      const invalidPeerMesh = createFakeMesh();
+      invalidPeerMesh.setPutHang('aggregates/topics/topic-1/syntheses/synth-1/epochs/4/points/point-1');
+      const invalidPeerClient = createClient(invalidPeerMesh, guard, ['http://[']);
+      const invalidPeerWrite = writePointAggregateSnapshot(invalidPeerClient, snapshot);
+      const invalidPeerAssertion = expect(invalidPeerWrite).rejects.toThrow('aggregate-put-ack-timeout');
+      await vi.advanceTimersByTimeAsync(8_000);
+      await invalidPeerAssertion;
+
+      const declinedMesh = createFakeMesh();
+      declinedMesh.setPutHang('aggregates/topics/topic-1/syntheses/synth-1/epochs/4/points/point-1');
+      const declinedClient = createClient(declinedMesh, guard, ['http://127.0.0.1:7777/gun']);
+      const fetchMock = vi.fn(async () => ({ ok: false }));
+      vi.stubGlobal('fetch', fetchMock);
+      const declinedWrite = writePointAggregateSnapshot(declinedClient, snapshot);
+      const declinedAssertion = expect(declinedWrite).rejects.toThrow('aggregate-put-ack-timeout');
+      await vi.advanceTimersByTimeAsync(8_000);
+      await declinedAssertion;
+    } finally {
+      vi.unstubAllGlobals();
+      vi.useRealTimers();
+    }
+  });
+
+  it('writePointAggregateSnapshot rejects when relay fallback fetch throws', async () => {
+    vi.useFakeTimers();
+    try {
+      const mesh = createFakeMesh();
+      mesh.setPutHang('aggregates/topics/topic-1/syntheses/synth-1/epochs/4/points/point-1');
+      const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+      const client = createClient(mesh, guard, ['http://127.0.0.1:7777/gun']);
+      vi.stubGlobal('fetch', vi.fn(async () => {
+        throw new Error('relay unavailable');
+      }));
+
+      const pending = writePointAggregateSnapshot(client, {
+        schema_version: 'point-aggregate-snapshot-v1',
+        topic_id: 'topic-1',
+        synthesis_id: 'synth-1',
+        epoch: 4,
+        point_id: 'point-1',
+        agree: 1,
+        disagree: 0,
+        weight: 1,
+        participants: 1,
+        version: 1,
+        computed_at: 1,
+        source_window: { from_seq: 1, to_seq: 1 },
+      });
+      const assertion = expect(pending).rejects.toThrow('aggregate-put-ack-timeout');
+      await vi.advanceTimersByTimeAsync(8_000);
+
+      await assertion;
+    } finally {
+      vi.unstubAllGlobals();
+      vi.useRealTimers();
+    }
+  });
+
   it('writePointAggregateSnapshot surfaces non-timeout put errors', async () => {
     const mesh = createFakeMesh();
     mesh.setPutError('aggregates/topics/topic-1/syntheses/synth-1/epochs/4/points/point-1', 'boom');
@@ -747,6 +824,68 @@ describe('aggregateAdapters', () => {
       vi.unstubAllGlobals();
       vi.useRealTimers();
     }
+  });
+
+  it('writeVoterNode rejects when relay fallback declines or throws', async () => {
+    vi.useFakeTimers();
+    try {
+      const node = {
+        point_id: 'point-1',
+        agreement: 1 as const,
+        weight: 1,
+        updated_at: '2026-02-18T22:20:00.000Z',
+      };
+      const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+
+      const declinedMesh = createFakeMesh();
+      declinedMesh.setPutHang('aggregates/topics/topic-1/syntheses/synth-1/epochs/4/voters/voter-1/point-1');
+      const declinedClient = createClient(declinedMesh, guard, ['http://127.0.0.1:7777/gun']);
+      vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false })));
+      const declinedWrite = writeVoterNode(declinedClient, 'topic-1', 'synth-1', 4, 'voter-1', node);
+      const declinedAssertion = expect(declinedWrite).rejects.toThrow('aggregate-put-ack-timeout');
+      await vi.advanceTimersByTimeAsync(8_000);
+      await declinedAssertion;
+
+      const throwingMesh = createFakeMesh();
+      throwingMesh.setPutHang('aggregates/topics/topic-1/syntheses/synth-1/epochs/4/voters/voter-1/point-1');
+      const throwingClient = createClient(throwingMesh, guard, ['http://127.0.0.1:7777/gun']);
+      vi.stubGlobal('fetch', vi.fn(async () => {
+        throw new Error('relay unavailable');
+      }));
+      const throwingWrite = writeVoterNode(throwingClient, 'topic-1', 'synth-1', 4, 'voter-1', node);
+      const throwingAssertion = expect(throwingWrite).rejects.toThrow('aggregate-put-ack-timeout');
+      await vi.advanceTimersByTimeAsync(8_000);
+      await throwingAssertion;
+    } finally {
+      vi.unstubAllGlobals();
+      vi.useRealTimers();
+    }
+  });
+
+  it('readPointAggregateSnapshot returns null when nested source_window readback is invalid', async () => {
+    const mesh = createFakeMesh();
+    mesh.setRead('aggregates/topics/topic-1/syntheses/synth-1/epochs/4/points/point-1', {
+      schema_version: 'point-aggregate-snapshot-v1',
+      topic_id: 'topic-1',
+      synthesis_id: 'synth-1',
+      epoch: 4,
+      point_id: 'point-1',
+      agree: 1,
+      disagree: 0,
+      weight: 1,
+      participants: 1,
+      version: 1,
+      computed_at: 1,
+      source_window: { '#': 'aggregates/topics/topic-1/syntheses/synth-1/epochs/4/points/point-1/source_window' },
+    });
+    mesh.setRead('aggregates/topics/topic-1/syntheses/synth-1/epochs/4/points/point-1/source_window', {
+      from_seq: 'bad',
+      to_seq: 1,
+    });
+    const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+    const client = createClient(mesh, guard);
+
+    await expect(readPointAggregateSnapshot(client, 'topic-1', 'synth-1', 4, 'point-1')).resolves.toBeNull();
   });
 
   it('writeVoterNode ignores timeout/late ack callbacks after successful settlement', async () => {

--- a/packages/gun-client/src/aggregateAdapters.ts
+++ b/packages/gun-client/src/aggregateAdapters.ts
@@ -160,7 +160,7 @@ const READ_ONCE_TIMEOUT_MS = readGunTimeoutMs(
   2_500,
 );
 
-function readOnce<T>(chain: ChainWithGet<T>): Promise<T | null> {
+function readOnce<T>(chain: ChainWithGet<T>, timeoutMs = READ_ONCE_TIMEOUT_MS): Promise<T | null> {
   return new Promise<T | null>((resolve) => {
     let settled = false;
     const timeout = setTimeout(() => {
@@ -169,7 +169,7 @@ function readOnce<T>(chain: ChainWithGet<T>): Promise<T | null> {
       }
       settled = true;
       resolve(null);
-    }, READ_ONCE_TIMEOUT_MS);
+    }, timeoutMs);
 
     chain.once((data) => {
       if (settled) {
@@ -192,6 +192,13 @@ const PUT_ACK_TIMEOUT_MS = readGunTimeoutMs(
 );
 const WRITE_READBACK_ATTEMPTS = 4;
 const WRITE_READBACK_RETRY_MS = 250;
+const WRITE_READBACK_READ_TIMEOUT_MS = readGunTimeoutMs(
+  [
+    'VITE_VH_GUN_AGGREGATE_WRITE_READBACK_TIMEOUT_MS',
+    'VH_GUN_AGGREGATE_WRITE_READBACK_TIMEOUT_MS',
+  ],
+  Math.min(READ_ONCE_TIMEOUT_MS, 1_000),
+);
 const STALE_ZERO_READ_ATTEMPTS = 4;
 const STALE_ZERO_READ_RETRY_MS = 500;
 
@@ -239,6 +246,101 @@ async function putWithAck<T>(chain: ChainWithGet<T>, value: T): Promise<PutAckRe
       });
     });
   });
+}
+
+function resolveRelayAggregateEndpoint(client: VennClient, path: 'voter' | 'point-snapshot'): string | null {
+  const peer = client.config?.peers?.[0];
+  if (!peer || typeof fetch !== 'function') {
+    return null;
+  }
+  try {
+    const url = new URL(peer, 'http://127.0.0.1/');
+    return `${url.origin}/vh/aggregates/${path}`;
+  } catch {
+    return null;
+  }
+}
+
+async function writeVoterNodeViaRelayFallback(
+  client: VennClient,
+  params: {
+    readonly topicId: string;
+    readonly synthesisId: string;
+    readonly epoch: number;
+    readonly voterId: string;
+    readonly node: AggregateVoterNode;
+  },
+): Promise<boolean> {
+  const endpoint = resolveRelayAggregateEndpoint(client, 'voter');
+  if (!endpoint) {
+    return false;
+  }
+  try {
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        topic_id: params.topicId,
+        synthesis_id: params.synthesisId,
+        epoch: params.epoch,
+        voter_id: params.voterId,
+        node: params.node,
+      }),
+    });
+    if (!response.ok) {
+      return false;
+    }
+    const payload = await response.json().catch(() => null) as {
+      ok?: unknown;
+      topic_id?: unknown;
+      synthesis_id?: unknown;
+      epoch?: unknown;
+      voter_id?: unknown;
+      point_id?: unknown;
+    } | null;
+    return payload?.ok === true
+      && payload.topic_id === params.topicId
+      && payload.synthesis_id === params.synthesisId
+      && payload.epoch === params.epoch
+      && payload.voter_id === params.voterId
+      && payload.point_id === params.node.point_id;
+  } catch {
+    return false;
+  }
+}
+
+async function writePointSnapshotViaRelayFallback(
+  client: VennClient,
+  snapshot: PointAggregateSnapshotV1,
+): Promise<boolean> {
+  const endpoint = resolveRelayAggregateEndpoint(client, 'point-snapshot');
+  if (!endpoint) {
+    return false;
+  }
+  try {
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ snapshot }),
+    });
+    if (!response.ok) {
+      return false;
+    }
+    const payload = await response.json().catch(() => null) as {
+      ok?: unknown;
+      topic_id?: unknown;
+      synthesis_id?: unknown;
+      epoch?: unknown;
+      point_id?: unknown;
+    } | null;
+    return payload?.ok === true
+      && payload.topic_id === snapshot.topic_id
+      && payload.synthesis_id === snapshot.synthesis_id
+      && payload.epoch === snapshot.epoch
+      && payload.point_id === snapshot.point_id;
+  } catch {
+    return false;
+  }
 }
 
 function aggregateVoterNodeMatches(left: AggregateVoterNode, right: AggregateVoterNode): boolean {
@@ -680,6 +782,29 @@ export async function writeVoterNode(
         });
         return recovered;
       }
+
+      const relayed = await writeVoterNodeViaRelayFallback(client, {
+        topicId: normalizedTopicId,
+        synthesisId: normalizedSynthesisId,
+        epoch: Number(normalizedEpoch),
+        voterId: normalizedVoterId,
+        node: sanitized,
+      });
+      if (relayed) {
+        console.info('[vh:aggregate:voter-write]', {
+          topic_id: normalizedTopicId,
+          synthesis_id: normalizedSynthesisId,
+          epoch: Number(normalizedEpoch),
+          voter_id: normalizedVoterId,
+          point_id: normalizedPointId,
+          acknowledged: false,
+          timed_out: true,
+          latency_ms: undefined,
+          path,
+          relay_fallback: true,
+        });
+        return sanitized;
+      }
     }
 
     console.warn('[vh:aggregate:voter-write]', {
@@ -767,6 +892,27 @@ export async function writePointAggregateSnapshot(
         });
         return recovered;
       }
+
+      const relayed = await writePointSnapshotViaRelayFallback(client, sanitized);
+      if (relayed) {
+        console.info('[vh:aggregate:point-snapshot-write]', {
+          topic_id: normalizedTopicId,
+          synthesis_id: normalizedSynthesisId,
+          epoch: Number(normalizedEpoch),
+          point_id: normalizedPointId,
+          acknowledged: false,
+          timed_out: true,
+          latency_ms: undefined,
+          path,
+          agree: sanitized.agree,
+          disagree: sanitized.disagree,
+          participants: sanitized.participants,
+          weight: sanitized.weight,
+          version: sanitized.version,
+          relay_fallback: true,
+        });
+        return sanitized;
+      }
     }
 
     console.warn('[vh:aggregate:point-snapshot-write]', {
@@ -810,6 +956,7 @@ export async function readAggregateVoterNode(
   epoch: number,
   voterId: string,
   pointId: string,
+  options?: { readonly readTimeoutMs?: number },
 ): Promise<AggregateVoterNode | null> {
   const normalizedTopicId = normalizeRequiredId(topicId, 'topicId');
   const normalizedSynthesisId = normalizeRequiredId(synthesisId, 'synthesisId');
@@ -826,7 +973,7 @@ export async function readAggregateVoterNode(
     .get(normalizedVoterId)
     .get(normalizedPointId) as unknown as ChainWithGet<unknown>;
 
-  const raw = await readOnce(chain);
+  const raw = await readOnce(chain, options?.readTimeoutMs);
   const parsed = AggregateVoterNodeSchema.safeParse(stripGunMetadata(raw));
   return parsed.success ? parsed.data : null;
 }
@@ -848,6 +995,7 @@ async function confirmAggregateVoterNodeReadback(
       epoch,
       voterId,
       pointId,
+      { readTimeoutMs: WRITE_READBACK_READ_TIMEOUT_MS },
     );
     if (recovered && aggregateVoterNodeMatches(recovered, expected)) {
       return recovered;
@@ -915,6 +1063,7 @@ export async function readPointAggregateSnapshot(
   synthesisId: string,
   epoch: number,
   pointId: string,
+  options?: { readonly readTimeoutMs?: number },
 ): Promise<PointAggregateSnapshotV1 | null> {
   const normalizedTopicId = normalizeRequiredId(topicId, 'topicId');
   const normalizedSynthesisId = normalizeRequiredId(synthesisId, 'synthesisId');
@@ -928,11 +1077,25 @@ export async function readPointAggregateSnapshot(
     normalizedEpoch,
   ).get(normalizedPointId) as unknown as ChainWithGet<unknown>;
 
-  const raw = await readOnce(pointChain);
+  const raw = await readOnce(pointChain, options?.readTimeoutMs);
+  const stripped = stripGunMetadata(raw);
 
-  const parsed = PointAggregateSnapshotV1Schema.safeParse(stripGunMetadata(raw));
+  const parsed = PointAggregateSnapshotV1Schema.safeParse(stripped);
   if (!parsed.success) {
-    return null;
+    if (!isRecord(stripped)) {
+      return null;
+    }
+
+    const rawSourceWindow = await readOnce(
+      pointChain.get('source_window') as unknown as ChainWithGet<unknown>,
+      options?.readTimeoutMs,
+    );
+    const withResolvedSourceWindow = {
+      ...stripped,
+      source_window: stripGunMetadata(rawSourceWindow),
+    };
+    const resolved = PointAggregateSnapshotV1Schema.safeParse(withResolvedSourceWindow);
+    return resolved.success ? resolved.data : null;
   }
 
   return parsed.data;
@@ -953,6 +1116,7 @@ async function confirmPointAggregateSnapshotReadback(
       synthesisId,
       epoch,
       pointId,
+      { readTimeoutMs: WRITE_READBACK_READ_TIMEOUT_MS },
     );
     if (recovered && aggregateSnapshotMatches(recovered, expected)) {
       return recovered;

--- a/packages/gun-client/src/chain.test.ts
+++ b/packages/gun-client/src/chain.test.ts
@@ -66,4 +66,24 @@ describe('createGuardedChain', () => {
 
     expect(mockGuard.validateWrite).toHaveBeenCalledWith('root/child/', { baz: 'qux' });
   });
+
+  it('does not adopt a Gun thenable returned from put', async () => {
+    const gunThenable = { then: vi.fn() };
+    const mockNode = {
+      once: vi.fn((cb: () => void) => cb()),
+      get: vi.fn().mockReturnThis(),
+      put: vi.fn((_val: any, cb?: () => void) => {
+        cb?.();
+        return gunThenable;
+      })
+    };
+    const mockBarrier = { prepare: vi.fn().mockResolvedValue(undefined) };
+    const mockGuard = { validateWrite: vi.fn() };
+
+    const guarded = createGuardedChain(mockNode as any, mockBarrier as any, mockGuard as any, 'test/path');
+    await guarded.put({ foo: 'bar' } as any);
+
+    expect(mockNode.put).toHaveBeenCalledWith({ foo: 'bar' }, undefined);
+    expect(gunThenable.then).not.toHaveBeenCalled();
+  });
 });

--- a/packages/gun-client/src/chain.ts
+++ b/packages/gun-client/src/chain.ts
@@ -83,7 +83,9 @@ export function createGuardedChain<T>(
       },
       put(value: T, callback?: (ack?: ChainAck) => void) {
         guard.validateWrite(currentPath, value);
-        return waitForRemote(node, barrier).then(() => node.put(value, callback));
+        return waitForRemote(node, barrier).then(() => {
+          node.put(value, callback);
+        });
       },
       // Passthrough subscription methods from the underlying Gun chain
       on: typeof rawNode.on === 'function' ? rawNode.on.bind(rawNode) : undefined,

--- a/packages/gun-client/src/synthesisAdapters.test.ts
+++ b/packages/gun-client/src/synthesisAdapters.test.ts
@@ -45,12 +45,14 @@ interface FakeMesh {
   setRead: (path: string, value: unknown) => void;
   setDelayedRead: (path: string) => (value: unknown) => void;
   setPendingRead: (path: string) => void;
+  setPendingPut: (path: string) => void;
   setPutError: (path: string, err: string) => void;
 }
 
 function createFakeMesh(): FakeMesh {
   const reads = new Map<string, unknown>();
   const pendingReads = new Set<string>();
+  const pendingPuts = new Set<string>();
   const delayedReads = new Map<string, (data: unknown) => void>();
   const putErrors = new Map<string, string>();
   const writes: Array<{ path: string; value: unknown }> = [];
@@ -70,6 +72,9 @@ function createFakeMesh(): FakeMesh {
       }),
       put: vi.fn((value: unknown, cb?: (ack?: { err?: string }) => void) => {
         writes.push({ path, value });
+        if (pendingPuts.has(path)) {
+          return;
+        }
         const err = putErrors.get(path);
         cb?.(err ? { err } : {});
       }),
@@ -100,18 +105,21 @@ function createFakeMesh(): FakeMesh {
       delayedReads.delete(path);
       pendingReads.add(path);
     },
+    setPendingPut(path: string) {
+      pendingPuts.add(path);
+    },
     setPutError(path: string, err: string) {
       putErrors.set(path, err);
     }
   };
 }
 
-function createClient(mesh: FakeMesh, guard: TopologyGuard): VennClient {
+function createClient(mesh: FakeMesh, guard: TopologyGuard, peers: string[] = []): VennClient {
   const barrier = new HydrationBarrier();
   barrier.markReady();
 
   return {
-    config: { peers: [] },
+    config: { peers },
     hydrationBarrier: barrier,
     storage: {} as VennClient['storage'],
     topologyGuard: guard,
@@ -544,6 +552,41 @@ describe('synthesisAdapters', () => {
     await expect(readTopicLatestSynthesis(client, 'topic-1')).resolves.toBeNull();
   });
 
+  it('falls back to relay synthesis writes when latest synthesis put acknowledgements time out', async () => {
+    vi.useFakeTimers();
+    try {
+      const mesh = createFakeMesh();
+      mesh.setPendingPut('topics/topic-1/latest');
+      const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+      const client = createClient(mesh, guard, ['http://127.0.0.1:7777/gun']);
+      const fetchMock = vi.fn(async () => ({
+        ok: true,
+        json: async () => ({
+          ok: true,
+          topic_id: SYNTHESIS.topic_id,
+          synthesis_id: SYNTHESIS.synthesis_id
+        })
+      }));
+      vi.stubGlobal('fetch', fetchMock);
+
+      const writePromise = writeTopicLatestSynthesis(client, SYNTHESIS);
+      await vi.advanceTimersByTimeAsync(5_000);
+
+      await expect(writePromise).resolves.toEqual(SYNTHESIS);
+      expect(fetchMock).toHaveBeenCalledWith(
+        'http://127.0.0.1:7777/vh/topics/synthesis',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ synthesis: SYNTHESIS })
+        })
+      );
+    } finally {
+      vi.unstubAllGlobals();
+      vi.useRealTimers();
+    }
+  });
+
   it('writes and reads synthesis correction payloads with audit metadata', async () => {
     const mesh = createFakeMesh();
     mesh.setRead('topics/topic-1/synthesis_corrections/correction-1', {
@@ -868,6 +911,24 @@ describe('synthesisAdapters', () => {
     const client = createClient(mesh, guard);
 
     await expect(writeTopicEpochSynthesis(client, SYNTHESIS)).rejects.toThrow('synthesis write failed');
+  });
+
+  it('rejects synthesis writes when the put acknowledgement never arrives', async () => {
+    vi.useFakeTimers();
+    try {
+      const mesh = createFakeMesh();
+      mesh.setPendingPut('topics/topic-1/latest');
+
+      const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+      const client = createClient(mesh, guard);
+
+      const writePromise = writeTopicLatestSynthesis(client, SYNTHESIS);
+      const assertion = expect(writePromise).rejects.toThrow('synthesis-put-ack-timeout');
+      await vi.advanceTimersByTimeAsync(5_000);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('writes and reads digest payloads', async () => {

--- a/packages/gun-client/src/synthesisAdapters.test.ts
+++ b/packages/gun-client/src/synthesisAdapters.test.ts
@@ -46,6 +46,7 @@ interface FakeMesh {
   setDelayedRead: (path: string) => (value: unknown) => void;
   setPendingRead: (path: string) => void;
   setPendingPut: (path: string) => void;
+  setLatePutAck: (path: string, delayMs: number) => void;
   setPutError: (path: string, err: string) => void;
 }
 
@@ -53,6 +54,7 @@ function createFakeMesh(): FakeMesh {
   const reads = new Map<string, unknown>();
   const pendingReads = new Set<string>();
   const pendingPuts = new Set<string>();
+  const latePutAcks = new Map<string, number>();
   const delayedReads = new Map<string, (data: unknown) => void>();
   const putErrors = new Map<string, string>();
   const writes: Array<{ path: string; value: unknown }> = [];
@@ -72,6 +74,11 @@ function createFakeMesh(): FakeMesh {
       }),
       put: vi.fn((value: unknown, cb?: (ack?: { err?: string }) => void) => {
         writes.push({ path, value });
+        const lateAckDelay = latePutAcks.get(path);
+        if (lateAckDelay !== undefined) {
+          setTimeout(() => cb?.({}), lateAckDelay);
+          return;
+        }
         if (pendingPuts.has(path)) {
           return;
         }
@@ -107,6 +114,9 @@ function createFakeMesh(): FakeMesh {
     },
     setPendingPut(path: string) {
       pendingPuts.add(path);
+    },
+    setLatePutAck(path: string, delayMs: number) {
+      latePutAcks.set(path, delayMs);
     },
     setPutError(path: string, err: string) {
       putErrors.set(path, err);
@@ -581,6 +591,72 @@ describe('synthesisAdapters', () => {
           body: JSON.stringify({ synthesis: SYNTHESIS })
         })
       );
+    } finally {
+      vi.unstubAllGlobals();
+      vi.useRealTimers();
+    }
+  });
+
+  it('ignores late synthesis put acknowledgements after the bounded timeout fires', async () => {
+    vi.useFakeTimers();
+    try {
+      const mesh = createFakeMesh();
+      mesh.setLatePutAck('topics/topic-1/latest', 6_000);
+      const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+      const client = createClient(mesh, guard);
+
+      const writePromise = writeTopicLatestSynthesis(client, SYNTHESIS);
+      const assertion = expect(writePromise).rejects.toThrow('synthesis-put-ack-timeout');
+      await vi.advanceTimersByTimeAsync(6_000);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('rejects latest synthesis writes when relay fallback is unavailable or declines the write', async () => {
+    vi.useFakeTimers();
+    try {
+      const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+
+      const invalidPeerMesh = createFakeMesh();
+      invalidPeerMesh.setPendingPut('topics/topic-1/latest');
+      const invalidPeerClient = createClient(invalidPeerMesh, guard, ['http://[']);
+      const invalidPeerWrite = writeTopicLatestSynthesis(invalidPeerClient, SYNTHESIS);
+      const invalidPeerAssertion = expect(invalidPeerWrite).rejects.toThrow('synthesis-put-ack-timeout');
+      await vi.advanceTimersByTimeAsync(5_000);
+      await invalidPeerAssertion;
+
+      const declinedMesh = createFakeMesh();
+      declinedMesh.setPendingPut('topics/topic-1/latest');
+      const declinedClient = createClient(declinedMesh, guard, ['http://127.0.0.1:7777/gun']);
+      vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false })));
+      const declinedWrite = writeTopicLatestSynthesis(declinedClient, SYNTHESIS);
+      const declinedAssertion = expect(declinedWrite).rejects.toThrow('synthesis-put-ack-timeout');
+      await vi.advanceTimersByTimeAsync(5_000);
+      await declinedAssertion;
+    } finally {
+      vi.unstubAllGlobals();
+      vi.useRealTimers();
+    }
+  });
+
+  it('rejects latest synthesis writes when relay fallback fetch throws', async () => {
+    vi.useFakeTimers();
+    try {
+      const mesh = createFakeMesh();
+      mesh.setPendingPut('topics/topic-1/latest');
+      const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+      const client = createClient(mesh, guard, ['http://127.0.0.1:7777/gun']);
+      vi.stubGlobal('fetch', vi.fn(async () => {
+        throw new Error('relay unavailable');
+      }));
+
+      const writePromise = writeTopicLatestSynthesis(client, SYNTHESIS);
+      const assertion = expect(writePromise).rejects.toThrow('synthesis-put-ack-timeout');
+      await vi.advanceTimersByTimeAsync(5_000);
+
+      await assertion;
     } finally {
       vi.unstubAllGlobals();
       vi.useRealTimers();

--- a/packages/gun-client/src/synthesisAdapters.ts
+++ b/packages/gun-client/src/synthesisAdapters.ts
@@ -39,6 +39,10 @@ const READ_ONCE_TIMEOUT_MS = readGunTimeoutMs(
   ['VITE_VH_GUN_SYNTHESIS_READ_TIMEOUT_MS', 'VH_GUN_SYNTHESIS_READ_TIMEOUT_MS', 'VITE_VH_GUN_READ_TIMEOUT_MS', 'VH_GUN_READ_TIMEOUT_MS'],
   2_500,
 );
+const PUT_ACK_TIMEOUT_MS = readGunTimeoutMs(
+  ['VITE_VH_GUN_SYNTHESIS_PUT_ACK_TIMEOUT_MS', 'VH_GUN_SYNTHESIS_PUT_ACK_TIMEOUT_MS', 'VITE_VH_GUN_PUT_ACK_TIMEOUT_MS', 'VH_GUN_PUT_ACK_TIMEOUT_MS'],
+  5_000,
+);
 function topicEpochCandidatesPath(topicId: string, epoch: string): string {
   return `vh/topics/${topicId}/epochs/${epoch}/candidates/`;
 }
@@ -318,7 +322,18 @@ function readOnce<T>(chain: ChainWithGet<T>): Promise<T | null> {
 
 async function putWithAck<T>(chain: ChainWithGet<T>, value: T): Promise<void> {
   await new Promise<void>((resolve, reject) => {
+    let settled = false;
+    const timeout = setTimeout(() => {
+      settled = true;
+      reject(new Error('synthesis-put-ack-timeout'));
+    }, PUT_ACK_TIMEOUT_MS);
+
     chain.put(value, (ack?: ChainAck) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeout);
       if (ack?.err) {
         reject(new Error(ack.err));
         return;
@@ -326,6 +341,66 @@ async function putWithAck<T>(chain: ChainWithGet<T>, value: T): Promise<void> {
       resolve();
     });
   });
+}
+
+function resolveRelaySynthesisEndpoint(client: VennClient): string | null {
+  const peer = client.config?.peers?.[0];
+  if (!peer || typeof fetch !== 'function') {
+    return null;
+  }
+  try {
+    const url = new URL(peer, 'http://127.0.0.1/');
+    return `${url.origin}/vh/topics/synthesis`;
+  } catch {
+    return null;
+  }
+}
+
+async function writeSynthesisViaRelayFallback(client: VennClient, synthesis: TopicSynthesisV2): Promise<boolean> {
+  const endpoint = resolveRelaySynthesisEndpoint(client);
+  if (!endpoint) {
+    return false;
+  }
+  try {
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ synthesis }),
+    });
+    if (!response.ok) {
+      return false;
+    }
+    const payload = await response.json().catch(() => null) as {
+      ok?: unknown;
+      topic_id?: unknown;
+      synthesis_id?: unknown;
+    } | null;
+    return payload?.ok === true
+      && payload.topic_id === synthesis.topic_id
+      && payload.synthesis_id === synthesis.synthesis_id;
+  } catch {
+    return false;
+  }
+}
+
+async function putSynthesisWithAckOrRelayFallback(
+  client: VennClient,
+  chain: ChainWithGet<Record<string, unknown>>,
+  encoded: Record<string, unknown>,
+  synthesis: TopicSynthesisV2
+): Promise<void> {
+  try {
+    await putWithAck(chain, encoded);
+    return;
+  } catch (error) {
+    if (!(error instanceof Error) || error.message !== 'synthesis-put-ack-timeout') {
+      throw error;
+    }
+    if (await writeSynthesisViaRelayFallback(client, synthesis)) {
+      return;
+    }
+    throw error;
+  }
 }
 
 export function getTopicEpochCandidatesChain(
@@ -486,13 +561,15 @@ export async function readTopicEpochSynthesis(client: VennClient, topicId: strin
 export async function writeTopicEpochSynthesis(client: VennClient, synthesis: unknown): Promise<TopicSynthesisV2> {
   assertNoForbiddenSynthesisFields(synthesis);
   const sanitized = TopicSynthesisV2Schema.parse(synthesis);
-  await putWithAck(
+  await putSynthesisWithAckOrRelayFallback(
+    client,
     getTopicEpochSynthesisChain(
       client,
       normalizeTopicId(sanitized.topic_id),
       normalizeEpoch(sanitized.epoch)
     ) as unknown as ChainWithGet<Record<string, unknown>>,
-    encodeSynthesisForGun(sanitized)
+    encodeSynthesisForGun(sanitized),
+    sanitized
   );
   return sanitized;
 }
@@ -512,9 +589,11 @@ export async function readTopicLatestSynthesis(client: VennClient, topicId: stri
 export async function writeTopicLatestSynthesis(client: VennClient, synthesis: unknown): Promise<TopicSynthesisV2> {
   assertNoForbiddenSynthesisFields(synthesis);
   const sanitized = TopicSynthesisV2Schema.parse(synthesis);
-  await putWithAck(
+  await putSynthesisWithAckOrRelayFallback(
+    client,
     getTopicLatestSynthesisChain(client, normalizeTopicId(sanitized.topic_id)) as unknown as ChainWithGet<Record<string, unknown>>,
-    encodeSynthesisForGun(sanitized)
+    encodeSynthesisForGun(sanitized),
+    sanitized
   );
   return sanitized;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -277,6 +277,10 @@ importers:
         version: 5.9.3
 
   packages/e2e:
+    dependencies:
+      '@vh/gun-client':
+        specifier: workspace:*
+        version: link:../gun-client
     devDependencies:
       '@playwright/test':
         specifier: ^1.42.1
@@ -3188,16 +3192,16 @@ packages:
 
   glob@7.1.7:
     resolution: {integrity: sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
     engines: {node: '>=12'}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   global-modules@2.0.0:
     resolution: {integrity: sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==}

--- a/services/news-aggregator/src/daemonUtils.test.ts
+++ b/services/news-aggregator/src/daemonUtils.test.ts
@@ -110,7 +110,7 @@ describe('daemonUtils', () => {
     expect(worker).not.toHaveBeenCalled();
   });
 
-  it('drops enrichment candidates when bounded queue is full', async () => {
+  it('evicts oldest pending enrichment candidates when bounded queue is full', async () => {
     const worker = vi.fn(async () => undefined);
     const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
     const onDrop = vi.fn();
@@ -125,19 +125,41 @@ describe('daemonUtils', () => {
     queue.enqueue({ ...CANDIDATE, story_id: 'story-3' });
 
     expect(onDrop).toHaveBeenCalledWith(
-      expect.objectContaining({ story_id: 'story-3' }),
+      expect.objectContaining({ story_id: 'story-1' }),
       { reason: 'queue_full', maxDepth: 2 },
     );
     expect(logger.warn).toHaveBeenCalledWith(
-      '[vh:news-daemon] enrichment queue full; dropped candidate',
-      { story_id: 'story-3', max_depth: 2 },
+      '[vh:news-daemon] enrichment queue full; evicted oldest candidate',
+      { story_id: 'story-1', replacement_story_id: 'story-3', max_depth: 2 },
     );
 
     await flushMicrotasks();
     await flushMicrotasks();
 
     expect(worker).toHaveBeenCalledTimes(2);
+    expect(worker).toHaveBeenNthCalledWith(1, expect.objectContaining({ story_id: 'story-2' }));
+    expect(worker).toHaveBeenNthCalledWith(2, expect.objectContaining({ story_id: 'story-3' }));
     expect(queue.size()).toBe(0);
+  });
+
+  it('deduplicates pending enrichment candidates by story id', async () => {
+    const worker = vi.fn(async () => undefined);
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    const queue = createAsyncEnrichmentQueue(worker, logger);
+
+    queue.enqueue({ ...CANDIDATE, request: { ...CANDIDATE.request, prompt: 'stale' } });
+    queue.enqueue({ ...CANDIDATE, request: { ...CANDIDATE.request, prompt: 'fresh' } });
+
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    expect(worker).toHaveBeenCalledTimes(1);
+    expect(worker).toHaveBeenCalledWith(
+      expect.objectContaining({
+        story_id: 'story-1',
+        request: expect.objectContaining({ prompt: 'fresh' }),
+      }),
+    );
   });
 
   it('derives StoryCluster health URLs across pathname shapes', () => {

--- a/services/news-aggregator/src/enrichmentQueue.ts
+++ b/services/news-aggregator/src/enrichmentQueue.ts
@@ -61,13 +61,28 @@ export function createAsyncEnrichmentQueue(
         return;
       }
 
+      const candidateStoryId =
+        typeof candidate === 'object' && candidate !== null
+          ? (candidate as Partial<NewsRuntimeSynthesisCandidate>).story_id
+          : undefined;
+      const existingIndex = candidateStoryId
+        ? pending.findIndex((queued) => queued?.story_id === candidateStoryId)
+        : -1;
+      if (existingIndex >= 0) {
+        pending[existingIndex] = candidate;
+        return;
+      }
+
       if (maxDepth !== undefined && pending.length >= maxDepth) {
-        options.onDrop?.(candidate, { reason: 'queue_full', maxDepth });
-        logger.warn('[vh:news-daemon] enrichment queue full; dropped candidate', {
-          story_id: candidate.story_id,
+        const dropped = pending.shift();
+        if (dropped) {
+          options.onDrop?.(dropped, { reason: 'queue_full', maxDepth });
+        }
+        logger.warn('[vh:news-daemon] enrichment queue full; evicted oldest candidate', {
+          story_id: dropped?.story_id ?? null,
+          replacement_story_id: candidateStoryId ?? null,
           max_depth: maxDepth,
         });
-        return;
       }
 
       pending.push(candidate);

--- a/tools/scripts/backfill-analysis-eval-artifacts.mjs
+++ b/tools/scripts/backfill-analysis-eval-artifacts.mjs
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+import { readdir, readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { createClient, readTopicLatestSynthesis, writeTopicSynthesis } from '@vh/gun-client';
+
+function parseArgs(argv) {
+  const parsed = {
+    artifactDir: process.env.VH_ANALYSIS_EVAL_ARTIFACT_DIR ?? '.tmp/analysis-eval-artifacts',
+    peers: process.env.VH_GUN_PEERS ?? process.env.VITE_GUN_PEERS ?? '["http://127.0.0.1:7777/gun"]',
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--artifact-dir') {
+      parsed.artifactDir = argv[index + 1] ?? parsed.artifactDir;
+      index += 1;
+    } else if (arg === '--peers') {
+      parsed.peers = argv[index + 1] ?? parsed.peers;
+      index += 1;
+    }
+  }
+
+  return parsed;
+}
+
+function parsePeers(raw) {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return ['http://127.0.0.1:7777/gun'];
+  }
+  if (trimmed.startsWith('[')) {
+    const parsed = JSON.parse(trimmed);
+    return Array.isArray(parsed) ? parsed.map(String).filter(Boolean) : ['http://127.0.0.1:7777/gun'];
+  }
+  return trimmed.split(',').map((peer) => peer.trim()).filter(Boolean);
+}
+
+function synthesisRank(entry) {
+  const synthesis = entry.synthesis;
+  return [
+    Number.isFinite(synthesis.epoch) ? synthesis.epoch : 0,
+    Number.isFinite(synthesis.created_at) ? synthesis.created_at : 0,
+    Number.isFinite(entry.capturedAt) ? entry.capturedAt : 0,
+  ];
+}
+
+function compareRank(a, b) {
+  const left = synthesisRank(a);
+  const right = synthesisRank(b);
+  for (let index = 0; index < left.length; index += 1) {
+    if (left[index] !== right[index]) {
+      return left[index] - right[index];
+    }
+  }
+  return 0;
+}
+
+function withTimeout(promise, timeoutMs, label) {
+  let timeout;
+  return Promise.race([
+    promise.finally(() => clearTimeout(timeout)),
+    new Promise((_resolve, reject) => {
+      timeout = setTimeout(() => reject(new Error(`${label}-timeout`)), timeoutMs);
+    }),
+  ]);
+}
+
+async function loadAcceptedSyntheses(artifactRoot) {
+  const artifactDir = path.join(artifactRoot, 'artifacts');
+  const names = await readdir(artifactDir);
+  const latestByTopic = new Map();
+
+  for (const name of names) {
+    if (!name.endsWith('.json')) {
+      continue;
+    }
+    const filePath = path.join(artifactDir, name);
+    const artifact = JSON.parse(await readFile(filePath, 'utf8'));
+    if (artifact.lifecycle_status !== 'accepted' || !artifact.final_accepted_synthesis) {
+      continue;
+    }
+    const synthesis = artifact.final_accepted_synthesis;
+    if (!synthesis.topic_id || !synthesis.synthesis_id) {
+      continue;
+    }
+
+    const entry = {
+      filePath,
+      storyId: artifact.story?.story_id ?? null,
+      capturedAt: artifact.captured_at ?? 0,
+      synthesis,
+    };
+    const existing = latestByTopic.get(synthesis.topic_id);
+    if (!existing || compareRank(existing, entry) <= 0) {
+      latestByTopic.set(synthesis.topic_id, entry);
+    }
+  }
+
+  return [...latestByTopic.values()].sort((a, b) => String(a.storyId).localeCompare(String(b.storyId)));
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const peers = parsePeers(options.peers);
+  const entries = await loadAcceptedSyntheses(options.artifactDir);
+  const client = createClient({ requireSession: false, peers, gunRadisk: false });
+  client.markSessionReady();
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+
+  let written = 0;
+  let alreadyCurrent = 0;
+  let failed = 0;
+
+  for (const entry of entries) {
+    const current = await withTimeout(
+      readTopicLatestSynthesis(client, entry.synthesis.topic_id),
+      10_000,
+      'current-read',
+    ).catch(() => null);
+    if (current?.synthesis_id === entry.synthesis.synthesis_id) {
+      alreadyCurrent += 1;
+      continue;
+    }
+
+    try {
+      await withTimeout(writeTopicSynthesis(client, entry.synthesis), 15_000, 'synthesis-write');
+      const readback = await withTimeout(
+        readTopicLatestSynthesis(client, entry.synthesis.topic_id),
+        10_000,
+        'readback',
+      );
+      if (readback?.synthesis_id !== entry.synthesis.synthesis_id) {
+        throw new Error('readback mismatch');
+      }
+      written += 1;
+      console.info('[vh:analysis-eval-backfill] synthesis written', {
+        topic_id: entry.synthesis.topic_id,
+        story_id: entry.storyId,
+        synthesis_id: entry.synthesis.synthesis_id,
+      });
+    } catch (error) {
+      failed += 1;
+      console.warn('[vh:analysis-eval-backfill] synthesis write failed', {
+        topic_id: entry.synthesis.topic_id,
+        story_id: entry.storyId,
+        synthesis_id: entry.synthesis.synthesis_id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  console.info('[vh:analysis-eval-backfill] complete', {
+    artifact_dir: options.artifactDir,
+    peers,
+    candidates: entries.length,
+    written,
+    already_current: alreadyCurrent,
+    failed,
+  });
+
+  if (failed > 0) {
+    process.exitCode = 1;
+  }
+  client.shutdown?.();
+  setTimeout(() => process.exit(process.exitCode ?? 0), 250).unref();
+}
+
+main().catch((error) => {
+  console.error('[vh:analysis-eval-backfill] failed', error);
+  process.exit(1);
+});

--- a/tools/scripts/live-local-stack.sh
+++ b/tools/scripts/live-local-stack.sh
@@ -182,7 +182,7 @@ load_profile_env() {
     else
       unset VH_STORYCLUSTER_REMOTE_MAX_ITEMS_PER_REQUEST
     fi
-    export VITE_NEWS_POLL_INTERVAL_MS="${VITE_NEWS_POLL_INTERVAL_MS:-10000}"
+    export VITE_NEWS_POLL_INTERVAL_MS="${VITE_NEWS_POLL_INTERVAL_MS:-300000}"
   fi
 
   if [[ "$STACK_MODE" == 'validated-snapshot' ]]; then
@@ -266,14 +266,18 @@ start_analysis_stub() {
 
 start_relay() {
   mkdir -p "$(dirname "$RELAY_DATA_PATH")"
-  rm -rf \
-    "$RELAY_DATA_PATH" \
-    "$RELAY_DATA_PATH"-* \
-    "$ROOT/data" \
-    "$ROOT/radata" \
-    "$ROOT/packages/gun-client/radata" \
-    "$ROOT/packages/e2e/radata" \
-    "$ROOT/services/news-aggregator/radata"
+  if [[ "$STACK_MODE" == 'public' && "${VH_LOCAL_STACK_RESET_RELAY:-false}" != 'true' ]]; then
+    info "Preserving public relay data at $RELAY_DATA_PATH (set VH_LOCAL_STACK_RESET_RELAY=true to reset)"
+  else
+    rm -rf \
+      "$RELAY_DATA_PATH" \
+      "$RELAY_DATA_PATH"-* \
+      "$ROOT/data" \
+      "$ROOT/radata" \
+      "$ROOT/packages/gun-client/radata" \
+      "$ROOT/packages/e2e/radata" \
+      "$ROOT/services/news-aggregator/radata"
+  fi
   info "Starting local Gun relay on :${RELAY_PORT}"
   : > "$RELAY_LOG"
   env GUN_PORT="$RELAY_PORT" GUN_FILE="$RELAY_DATA_PATH" GUN_RADISK="${GUN_RADISK:-true}" \


### PR DESCRIPTION
## Summary
- hardens public live-stack/news pipeline validation after the 24-article remote-analysis run
- preserves public relay state on local stack restarts and adds accepted analysis-artifact synthesis backfill tooling
- makes synthesis, aggregate vote, forum thread, and comment writes bounded/readback-confirmed with relay fallbacks for local Gun ack stalls
- improves feed/detail hydration and live e2e discovery so analyzed singleton and bundled stories are tested through the actual UI
- dedupes/evicts stale enrichment queue work instead of dropping current stories when public polling outruns synthesis

## Live evidence
- `pnpm test:live:two-user-engagement` passed against public/remote stack on `http://127.0.0.1:2048/` in 16.9m
- public source health: `readinessStatus=ready`, `releaseEvidence.status=pass`, `recommendedAction=release_ready`, 28/28 sources kept
- analysis eval artifacts under `.tmp/merged-main-public-24-20260501-182005/analysis-eval-artifacts`: 120 total, 101 accepted, 11 bundle syntheses, 90 singleton syntheses, 125 raw extracted article-text records, 101 prompt-bearing syntheses
- backfill: 46 accepted synthesis candidates, 0 failures after restart

## Local verification
- `pnpm exec vitest run apps/web-pwa/src/store/hermesForum.test.ts --config vitest.config.ts`
- `pnpm exec vitest run apps/web-pwa/src/store/news/index.test.ts apps/web-pwa/src/store/news/hydration.test.ts apps/web-pwa/src/store/news/hydration.identity.test.ts apps/web-pwa/src/store/news/hydration.storylines.test.ts --config vitest.config.ts`
- `pnpm exec vitest run apps/web-pwa/src/hooks/voteIntentMaterializer.test.ts --config vitest.config.ts`
- `pnpm --filter @vh/gun-client test`
- `pnpm --filter @vh/news-aggregator test`
- `pnpm --filter @vh/web-pwa typecheck`
- `pnpm --filter @vh/e2e typecheck`
- `pnpm --filter @vh/web-pwa build`
- `pnpm report:news-sources:health`

## Known unrelated caveat
- `pnpm --filter @vh/web-pwa typecheck:test` remains red on existing broad test strictness debt outside this patch; touched-file diagnostics were fixed before push.
