### PR TITLE
Generalize mesh durable writes

### DIFF
--- a/apps/web-pwa/src/hooks/intentQueue.test.ts
+++ b/apps/web-pwa/src/hooks/intentQueue.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createIntentQueue } from './intentQueue';
+
+const storage = new Map<string, string>();
+
+vi.mock('../utils/safeStorage', () => ({
+  safeGetItem: (key: string) => storage.get(key) ?? null,
+  safeSetItem: (key: string, value: string) => storage.set(key, value),
+}));
+
+interface TestIntent {
+  readonly intent_id: string;
+  readonly seq: number;
+}
+
+function createQueue(storageKey = 'vh_test_intent_queue_v1') {
+  return createIntentQueue<TestIntent>({
+    storageKey,
+    maxQueueSize: 3,
+    getId: (record) => record.intent_id,
+    compareReplayOrder: (a, b) => a.seq - b.seq || a.intent_id.localeCompare(b.intent_id),
+  });
+}
+
+describe('createIntentQueue', () => {
+  beforeEach(() => {
+    storage.clear();
+  });
+
+  it('dedupes by deterministic id and evicts oldest records at the cap', () => {
+    const queue = createQueue();
+    queue.enqueue({ intent_id: 'a', seq: 1 });
+    queue.enqueue({ intent_id: 'a', seq: 99 });
+    queue.enqueue({ intent_id: 'b', seq: 2 });
+    queue.enqueue({ intent_id: 'c', seq: 3 });
+    queue.enqueue({ intent_id: 'd', seq: 4 });
+
+    expect(queue.getPending()).toEqual([
+      { intent_id: 'b', seq: 2 },
+      { intent_id: 'c', seq: 3 },
+      { intent_id: 'd', seq: 4 },
+    ]);
+  });
+
+  it('replays in deterministic order, clears successes, and keeps failures pending', async () => {
+    const queue = createQueue();
+    queue.enqueue({ intent_id: 'c', seq: 30 });
+    queue.enqueue({ intent_id: 'a', seq: 10 });
+    queue.enqueue({ intent_id: 'b', seq: 20 });
+
+    const projected: string[] = [];
+    const result = await queue.replay(async (record) => {
+      projected.push(record.intent_id);
+      if (record.intent_id === 'b') {
+        throw new Error('retry later');
+      }
+    });
+
+    expect(result).toEqual({ replayed: 2, failed: 1 });
+    expect(projected).toEqual(['a', 'b', 'c']);
+    expect(queue.getPending()).toEqual([{ intent_id: 'b', seq: 20 }]);
+  });
+
+  it('survives malformed persisted data and storage write failures', () => {
+    storage.set('vh_corrupt_intent_queue_v1', '{bad json');
+    const corruptQueue = createQueue('vh_corrupt_intent_queue_v1');
+    expect(corruptQueue.getPending()).toEqual([]);
+
+    const setItemSpy = vi.spyOn(storage, 'set').mockImplementation(() => {
+      throw new Error('quota');
+    });
+    const queue = createQueue('vh_storage_failure_intent_queue_v1');
+    expect(() => queue.enqueue({ intent_id: 'safe', seq: 1 })).not.toThrow();
+    setItemSpy.mockRestore();
+  });
+});

--- a/apps/web-pwa/src/hooks/intentQueue.ts
+++ b/apps/web-pwa/src/hooks/intentQueue.ts
@@ -1,0 +1,93 @@
+import { safeGetItem, safeSetItem } from '../utils/safeStorage';
+
+export interface IntentQueueOptions<T> {
+  readonly storageKey: string;
+  readonly maxQueueSize: number;
+  readonly getId: (record: T) => string;
+  readonly compareReplayOrder: (a: T, b: T) => number;
+}
+
+export interface IntentQueue<T> {
+  enqueue(record: T): void;
+  markProjected(intentId: string): void;
+  getPending(): T[];
+  replay(
+    project: (record: T) => Promise<void>,
+    options?: { readonly limit?: number },
+  ): Promise<{ replayed: number; failed: number }>;
+}
+
+function loadQueue<T>(storageKey: string): T[] {
+  try {
+    const raw = safeGetItem(storageKey);
+    return raw ? (JSON.parse(raw) as T[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function persistQueue<T>(storageKey: string, queue: readonly T[]): void {
+  try {
+    safeSetItem(storageKey, JSON.stringify(queue));
+  } catch {
+    /* ignore — quota exceeded, disabled storage, etc. */
+  }
+}
+
+export function createIntentQueue<T>(options: IntentQueueOptions<T>): IntentQueue<T> {
+  const load = () => loadQueue<T>(options.storageKey);
+  const persist = (queue: readonly T[]) => persistQueue(options.storageKey, queue);
+
+  return {
+    enqueue(record: T): void {
+      const queue = load();
+      const intentId = options.getId(record);
+      if (queue.some((queued) => options.getId(queued) === intentId)) {
+        return;
+      }
+
+      queue.push(record);
+      while (queue.length > options.maxQueueSize) {
+        queue.shift();
+      }
+      persist(queue);
+    },
+
+    markProjected(intentId: string): void {
+      const queue = load();
+      const filtered = queue.filter((record) => options.getId(record) !== intentId);
+      if (filtered.length !== queue.length) {
+        persist(filtered);
+      }
+    },
+
+    getPending(): T[] {
+      return load();
+    },
+
+    async replay(
+      project: (record: T) => Promise<void>,
+      replayOptions?: { readonly limit?: number },
+    ): Promise<{ replayed: number; failed: number }> {
+      const pending = load().sort(options.compareReplayOrder);
+      const normalizedLimit = replayOptions?.limit && replayOptions.limit > 0
+        ? Math.floor(replayOptions.limit)
+        : pending.length;
+      const replayBatch = pending.slice(0, normalizedLimit);
+
+      let replayed = 0;
+      let failed = 0;
+      for (const record of replayBatch) {
+        try {
+          await project(record);
+          this.markProjected(options.getId(record));
+          replayed += 1;
+        } catch {
+          failed += 1;
+        }
+      }
+
+      return { replayed, failed };
+    },
+  };
+}

--- a/apps/web-pwa/src/hooks/voteIntentQueue.ts
+++ b/apps/web-pwa/src/hooks/voteIntentQueue.ts
@@ -1,5 +1,5 @@
 import type { VoteIntentRecord } from '@vh/data-model';
-import { safeGetItem, safeSetItem } from '../utils/safeStorage';
+import { createIntentQueue } from './intentQueue';
 
 /**
  * Durable local intent queue for vote intents.
@@ -40,63 +40,33 @@ function compareReplayOrder(a: VoteIntentRecord, b: VoteIntentRecord): number {
   return a.intent_id.localeCompare(b.intent_id);
 }
 
-function loadQueue(): VoteIntentRecord[] {
-  try {
-    const raw = safeGetItem(STORAGE_KEY);
-    return raw ? (JSON.parse(raw) as VoteIntentRecord[]) : [];
-  } catch {
-    return [];
-  }
-}
-
-function persistQueue(queue: VoteIntentRecord[]): void {
-  try {
-    safeSetItem(STORAGE_KEY, JSON.stringify(queue));
-  } catch {
-    /* ignore — quota exceeded, etc. */
-  }
-}
+const queue = createIntentQueue<VoteIntentRecord>({
+  storageKey: STORAGE_KEY,
+  maxQueueSize: MAX_QUEUE_SIZE,
+  getId: (record) => record.intent_id,
+  compareReplayOrder,
+});
 
 /**
  * Enqueue a vote intent record. Idempotent: duplicate intent_ids are silently deduped.
  * When the queue exceeds MAX_QUEUE_SIZE, the oldest intent is evicted.
  */
 export function enqueueIntent(record: VoteIntentRecord): void {
-  const queue = loadQueue();
-
-  // Dedup by intent_id
-  if (queue.some((r) => r.intent_id === record.intent_id)) {
-    return;
-  }
-
-  queue.push(record);
-
-  // Evict oldest if over cap
-  while (queue.length > MAX_QUEUE_SIZE) {
-    queue.shift();
-  }
-
-  persistQueue(queue);
+  queue.enqueue(record);
 }
 
 /**
  * Mark a vote intent as projected (remove from pending queue).
  */
 export function markIntentProjected(intentId: string): void {
-  const queue = loadQueue();
-  const filtered = queue.filter((r) => r.intent_id !== intentId);
-
-  // Only persist if something changed
-  if (filtered.length !== queue.length) {
-    persistQueue(filtered);
-  }
+  queue.markProjected(intentId);
 }
 
 /**
  * Get all un-projected (pending) intents.
  */
 export function getPendingIntents(): VoteIntentRecord[] {
-  return loadQueue();
+  return queue.getPending();
 }
 
 /**
@@ -112,24 +82,5 @@ export async function replayPendingIntents(
     limit?: number;
   },
 ): Promise<{ replayed: number; failed: number }> {
-  const pending = loadQueue().sort(compareReplayOrder);
-  const normalizedLimit = options?.limit && options.limit > 0
-    ? Math.floor(options.limit)
-    : pending.length;
-  const replayBatch = pending.slice(0, normalizedLimit);
-
-  let replayed = 0;
-  let failed = 0;
-
-  for (const record of replayBatch) {
-    try {
-      await project(record);
-      markIntentProjected(record.intent_id);
-      replayed++;
-    } catch {
-      failed++;
-    }
-  }
-
-  return { replayed, failed };
+  return queue.replay(project, options);
 }

--- a/docs/reports/MESH_HARDENING_PR2_2026-05-02.md
+++ b/docs/reports/MESH_HARDENING_PR2_2026-05-02.md
@@ -1,0 +1,104 @@
+# Mesh Hardening PR2 Review Ledger
+
+Date: 2026-05-02
+Branch: `coord/mesh-durable-write-contract-pr2`
+Base: merged `main` after PR #560 (`17dcbb04`)
+
+## Completed And Verified
+
+### PR1 — Diagnostic Clarity And Bounded Pressure
+
+Status: Done and merged.
+
+Verified implementation:
+- `createGuardedChain.put` no longer starts caller ack timers before the physical `node.put(...)`.
+- Health monitoring starts from app bootstrap and reports named degradation reasons instead of vacuous green states.
+- Health probe uses deterministic browser slots with write plus readback validation.
+- News, forum, and synthesis hydration are bounded and expose teardown.
+- Built-preview mesh canary exists and is outside the default E2E suite.
+- Service worker has a build-version update path.
+
+Verification evidence:
+- PR #560 merged to `main`.
+- GitHub checks were green before merge: Change Detection, Ownership Scope, Quality Guard, Source Health, StoryCluster Correctness, Test & Build, Bundle Size, Lighthouse, E2E Tests.
+- Local post-merge `main` was clean at `17dcbb04`.
+
+### PR2 — Durable Write Contract
+
+Status: Done locally on `coord/mesh-durable-write-contract-pr2`; ready for PR/CI.
+
+Verified implementation:
+- Added `packages/gun-client/src/durableWrite.ts` with bounded ack, timeout telemetry, readback confirmation after timeout, relay fallback, and terminal failure.
+- Migrated previously best-effort or partially hardened write paths:
+  - news stories, latest/hot indexes, ingestion leases
+  - storylines
+  - analysis latest pointer
+  - topic engagement actor and summary
+  - encrypted sentiment outbox
+  - directory publish
+  - synthesis latest pointer readback before relay fallback
+  - news reports and status index
+  - forum moderation writes
+  - namespace initialization writes
+- Added `apps/web-pwa/src/hooks/intentQueue.ts` and rewired `voteIntentQueue.ts` to use the generic safeStorage-backed intent queue.
+- Preserved vote-intent API compatibility while making the generic queue reusable for the next migrated intent classes.
+
+Verification evidence:
+- `pnpm --filter @vh/gun-client test` — 29 files, 347 tests passed.
+- `pnpm --filter @vh/gun-client typecheck` — passed.
+- `pnpm exec vitest run apps/web-pwa/src/hooks/intentQueue.test.ts apps/web-pwa/src/hooks/voteIntentQueue.test.ts apps/web-pwa/src/hooks/useSentimentState.test.ts apps/web-pwa/src/hooks/voteIntentMaterializer.test.ts --reporter=dot` — 4 files, 114 tests passed.
+- `pnpm --filter @vh/web-pwa typecheck` — passed.
+- `pnpm --filter @vh/e2e typecheck` — passed.
+- `pnpm typecheck` — passed across the workspace.
+- `pnpm --filter @vh/news-aggregator test` — 32 files, 396 tests passed.
+- `pnpm test:mesh:browser-canary` — built preview canary passed.
+- `git diff --check` — passed.
+- `node tools/scripts/check-diff-coverage.mjs` — 295 files, 4,293 tests passed; every changed source file reached 100% diff line and branch coverage.
+
+Known unrelated test debt:
+- `pnpm --filter @vh/web-pwa typecheck:test` still fails on broad pre-existing fixture strictness issues across bridge/feed/forum/discovery tests. The production web typecheck and focused tests affected by this PR are green.
+
+## Queued
+
+### PR3 — Daemon-Side Hardening
+
+Queue next.
+
+Scope:
+- Enable daemon `gunRadisk: true` with a per-process journal path.
+- Split daemon write lanes by class with bounded concurrency.
+- Persist enrichment queue state and DLQ displaced candidates instead of dropping on overflow.
+- Replay queue, DLQ, and accepted-but-unwritten work on restart.
+- Surface queue depth and DLQ counts through daemon health.
+
+Acceptance target:
+- `kill -9` mid-synthesis does not lose accepted work; restart replays to terminal state.
+
+### PR4 — Production Relay
+
+Queue after PR3.
+
+Scope:
+- Add `/healthz`, `/readyz`, and `/metrics`.
+- Auth-gate graph-injection HTTP endpoints.
+- Split user-callable signed endpoints from daemon-only bearer-auth endpoints.
+- Add WS rate limits, body size caps, per-client backpressure, origin allowlist, and structured drop reasons.
+- Add compaction strategy for utility namespaces.
+
+Acceptance target:
+- Auth failures are rejected, noisy peers are dropped with structured reasons, and metrics expose write/ack/drop/radata signals.
+
+### PR5 — Topology And Quorum
+
+Queue after PR4.
+
+Scope:
+- Three-peer WSS topology.
+- Signed peer config fetched at boot.
+- Remove hardcoded Tailscale fallback from production code paths.
+- Strip or reject runtime peer mutation in production builds.
+- Health reports quorum, not configured peer count.
+- Add failover, network partition, WS reconnect, and soak drills.
+
+Acceptance target:
+- One-peer kill and restart drill converges within SLA with no duplicate writes.

--- a/packages/gun-client/src/analysisAdapters.test.ts
+++ b/packages/gun-client/src/analysisAdapters.test.ts
@@ -266,7 +266,7 @@ describe('analysisAdapters', () => {
       await expect(writePromise).resolves.toEqual(ARTIFACT);
 
       expect(mesh.writes).toHaveLength(2);
-      expect(warnSpy).toHaveBeenCalledWith('[vh:gun-client] analysis put ack timed out, proceeding best-effort');
+      expect(warnSpy).toHaveBeenCalledWith('[vh:gun-client] analysis put ack timed out, requiring readback confirmation');
     } finally {
       warnSpy.mockRestore();
       vi.useRealTimers();
@@ -288,7 +288,35 @@ describe('analysisAdapters', () => {
       );
       await vi.advanceTimersByTimeAsync(5000);
       await rejected;
-      expect(warnSpy).toHaveBeenCalledWith('[vh:gun-client] analysis put ack timed out, proceeding best-effort');
+      expect(warnSpy).toHaveBeenCalledWith('[vh:gun-client] analysis put ack timed out, requiring readback confirmation');
+    } finally {
+      warnSpy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
+  it('writeAnalysis resolves when latest pointer ack times out but readback confirms persistence', async () => {
+    vi.useFakeTimers();
+    const mesh = createFakeMesh();
+    mesh.setPutDelay('news/stories/story-1/analysis_latest', 1100);
+    mesh.setRead('news/stories/story-1/analysis_latest', {
+      analysisKey: ARTIFACT.analysisKey,
+      provenance_hash: ARTIFACT.provenance_hash,
+      model_scope: ARTIFACT.model_scope,
+      created_at: ARTIFACT.created_at,
+      bundle_identity: ARTIFACT.bundle_identity,
+    });
+    const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+    const client = createClient(mesh, guard);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      const writePromise = writeAnalysis(client, ARTIFACT);
+      await vi.advanceTimersByTimeAsync(2500);
+      await expect(writePromise).resolves.toEqual(ARTIFACT);
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[vh:gun-client] analysis latest pointer ack timed out, requiring readback confirmation',
+      );
     } finally {
       warnSpy.mockRestore();
       vi.useRealTimers();
@@ -307,7 +335,7 @@ describe('analysisAdapters', () => {
       await expect(writeAnalysis(client, ARTIFACT)).resolves.toEqual(ARTIFACT);
       await vi.advanceTimersByTimeAsync(1000);
 
-      expect(warnSpy).not.toHaveBeenCalledWith('[vh:gun-client] analysis put ack timed out, proceeding best-effort');
+      expect(warnSpy).not.toHaveBeenCalledWith('[vh:gun-client] analysis put ack timed out, requiring readback confirmation');
       expect(clearTimeoutSpy).toHaveBeenCalled();
     } finally {
       clearTimeoutSpy.mockRestore();

--- a/packages/gun-client/src/analysisAdapters.ts
+++ b/packages/gun-client/src/analysisAdapters.ts
@@ -5,6 +5,7 @@ import {
   type StoryAnalysisLatestPointer,
 } from '@vh/data-model';
 import { createGuardedChain, putWithAckTimeout, type ChainWithGet, type PutAckResult } from './chain';
+import { writeWithDurability } from './durableWrite';
 import { readGunTimeoutMs } from './runtimeConfig';
 import type { VennClient } from './types';
 
@@ -238,7 +239,7 @@ const WRITE_READBACK_RETRY_MS = 250;
 async function putWithAck<T>(chain: ChainWithGet<T>, value: T): Promise<PutAckResult> {
   return putWithAckTimeout(chain, value, {
     timeoutMs: PUT_ACK_TIMEOUT_MS,
-    onTimeout: () => console.warn('[vh:gun-client] analysis put ack timed out, proceeding best-effort'),
+    onTimeout: () => console.warn('[vh:gun-client] analysis put ack timed out, requiring readback confirmation'),
   });
 }
 
@@ -357,7 +358,24 @@ export async function writeAnalysis(
     ...(sanitized.bundle_identity ? { bundle_identity: sanitized.bundle_identity } : {}),
   };
 
-  await putWithAck(getStoryAnalysisLatestChain(client, normalizedStoryId), pointer);
+  await writeWithDurability({
+    chain: getStoryAnalysisLatestChain(client, normalizedStoryId),
+    value: pointer,
+    writeClass: 'analysis-latest-pointer',
+    timeoutMs: PUT_ACK_TIMEOUT_MS,
+    timeoutError: 'analysis latest pointer write timed out and readback did not confirm persistence',
+    onAckTimeout: () => console.warn('[vh:gun-client] analysis latest pointer ack timed out, requiring readback confirmation'),
+    readback: async () => parseLatestPointer(await readOnce(getStoryAnalysisLatestChain(client, normalizedStoryId))),
+    readbackPredicate: (observed) => {
+      const candidate = observed as StoryAnalysisLatestPointer | null;
+      return Boolean(
+        candidate
+        && candidate.analysisKey === pointer.analysisKey
+        && candidate.provenance_hash === pointer.provenance_hash
+        && candidate.model_scope === pointer.model_scope
+      );
+    },
+  });
   return sanitized;
 }
 

--- a/packages/gun-client/src/client.test.ts
+++ b/packages/gun-client/src/client.test.ts
@@ -133,14 +133,13 @@ describe('createClient', () => {
     await expect(client.linkDevice('dev')).rejects.toThrow('Session not ready');
   });
 
-  it('user.write resolves even when put callback never fires (offline)', async () => {
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  it('user.write rejects when put callback never fires instead of silently dropping the write', async () => {
     const client = createClient({ requireSession: false });
     (userChain.put as any).mockImplementationOnce((_value: any, _cb?: (ack?: any) => void) => {
       /* no ack */
     });
-    await expect(client.user.write({ foo: 'bar' } as any)).resolves.toBeUndefined();
-    expect(warn).toHaveBeenCalledWith('[vh:gun-client] put timed out, proceeding without ack');
-    warn.mockRestore();
+    await expect(client.user.write({ foo: 'bar' } as any)).rejects.toThrow(
+      'namespace write timed out before Gun acknowledged persistence',
+    );
   });
 });

--- a/packages/gun-client/src/directoryAdapters.test.ts
+++ b/packages/gun-client/src/directoryAdapters.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { getDirectoryChain, lookupByNullifier, publishToDirectory } from './directoryAdapters';
+import { HydrationBarrier } from './sync/barrier';
 import type { VennClient } from './types';
 
 function createMockChain() {
@@ -18,8 +19,12 @@ function createMockChain() {
 }
 
 function createClient(chain: any): VennClient {
+  const hydrationBarrier = new HydrationBarrier();
+  hydrationBarrier.markReady();
   return {
-    gun: { get: vi.fn((key: string) => chain.get(key)) } as any
+    gun: { get: vi.fn((key: string) => chain.get(key)) } as any,
+    hydrationBarrier,
+    topologyGuard: { validateWrite: vi.fn() } as any,
   } as VennClient;
 }
 
@@ -53,7 +58,7 @@ describe('directoryAdapters', () => {
   it('propagates errors from publish', async () => {
     const failingChain: any = {
       get: vi.fn(() => failingChain),
-      once: vi.fn(),
+      once: vi.fn((cb?: (data: unknown) => void) => cb?.(undefined)),
       put: vi.fn((_value: any, cb?: (ack?: { err?: string }) => void) => cb?.({ err: 'boom' }))
     };
     const client = createClient(failingChain);
@@ -69,17 +74,21 @@ describe('directoryAdapters', () => {
     ).rejects.toThrow('boom');
   });
 
-  it('resolves when publish ack times out', async () => {
+  it('resolves when publish ack times out but readback confirms persistence', async () => {
     vi.useFakeTimers();
     const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
 
     try {
-      const hangingChain: any = {
-        get: vi.fn(() => hangingChain),
-        once: vi.fn(),
-        put: vi.fn((_value: any, _cb?: (ack?: { err?: string }) => void) => undefined)
-      };
-      const client = createClient(hangingChain);
+      const store = new Map<string, unknown>();
+      const makeChain = (path: string[]): any => ({
+        get: vi.fn((key: string) => makeChain([...path, key])),
+        once: vi.fn((cb?: (data: unknown) => void) => cb?.(store.get(path.join('/')))),
+        put: vi.fn((value: unknown) => {
+          store.set(path.join('/'), value);
+        }),
+      });
+      const chain = makeChain([]);
+      const client = createClient(chain);
       const publishPromise = publishToDirectory(client, {
         schemaVersion: 'hermes-directory-v0',
         nullifier: 'timeout-case',
@@ -91,7 +100,7 @@ describe('directoryAdapters', () => {
 
       await vi.advanceTimersByTimeAsync(1000);
       await expect(publishPromise).resolves.toBeUndefined();
-      expect(warning).toHaveBeenCalledWith('[vh:directory] publish ack timed out, proceeding without ack');
+      expect(warning).toHaveBeenCalledWith('[vh:directory] publish ack timed out, requiring readback confirmation');
     } finally {
       warning.mockRestore();
       vi.useRealTimers();
@@ -108,7 +117,7 @@ describe('directoryAdapters', () => {
     try {
       const duplicateAckChain: any = {
         get: vi.fn(() => duplicateAckChain),
-        once: vi.fn(),
+        once: vi.fn((cb?: (data: unknown) => void) => cb?.(undefined)),
         put: vi.fn((_value: any, cb?: (ack?: { err?: string }) => void) => {
           cb?.({});
           cb?.({});

--- a/packages/gun-client/src/directoryAdapters.ts
+++ b/packages/gun-client/src/directoryAdapters.ts
@@ -1,9 +1,20 @@
 import type { DirectoryEntry } from '@vh/data-model';
-import { putWithAckTimeout, type ChainWithGet } from './chain';
+import { createGuardedChain, type ChainWithGet } from './chain';
+import { writeWithDurability } from './durableWrite';
 import type { VennClient } from './types';
 
+function directoryPath(nullifier: string): string {
+  return `vh/directory/${nullifier}/`;
+}
+
 export function getDirectoryChain(client: VennClient, nullifier: string) {
-  return client.gun.get('vh').get('directory').get(nullifier);
+  const chain = client.gun.get('vh').get('directory').get(nullifier) as unknown as ChainWithGet<DirectoryEntry>;
+  return createGuardedChain(
+    chain,
+    client.hydrationBarrier,
+    client.topologyGuard,
+    directoryPath(nullifier),
+  );
 }
 
 export async function lookupByNullifier(client: VennClient, nullifier: string): Promise<DirectoryEntry | null> {
@@ -23,12 +34,23 @@ export async function lookupByNullifier(client: VennClient, nullifier: string): 
 const DIRECTORY_PUT_ACK_TIMEOUT_MS = 1000;
 
 export function publishToDirectory(client: VennClient, entry: DirectoryEntry): Promise<void> {
-  return putWithAckTimeout(
-    getDirectoryChain(client, entry.nullifier) as unknown as ChainWithGet<DirectoryEntry>,
-    entry,
-    {
+  return writeWithDurability({
+      chain: getDirectoryChain(client, entry.nullifier) as unknown as ChainWithGet<DirectoryEntry>,
+      value: entry,
+      writeClass: 'directory',
       timeoutMs: DIRECTORY_PUT_ACK_TIMEOUT_MS,
-      onTimeout: () => console.warn('[vh:directory] publish ack timed out, proceeding without ack'),
-    },
-  ).then(() => undefined);
+      timeoutError: 'directory publish timed out and readback did not confirm persistence',
+      onAckTimeout: () => console.warn('[vh:directory] publish ack timed out, requiring readback confirmation'),
+      readback: () => lookupByNullifier(client, entry.nullifier),
+      readbackPredicate: (observed) => {
+        const candidate = observed as DirectoryEntry | null;
+        return Boolean(
+          candidate
+          && candidate.nullifier === entry.nullifier
+          && candidate.devicePub === entry.devicePub
+          && candidate.epub === entry.epub
+        );
+      },
+    })
+    .then(() => undefined);
 }

--- a/packages/gun-client/src/durableWrite.test.ts
+++ b/packages/gun-client/src/durableWrite.test.ts
@@ -1,0 +1,252 @@
+import { describe, expect, it, vi } from 'vitest';
+import { writeWithDurability } from './durableWrite';
+import type { ChainAck, ChainWithGet } from './chain';
+
+function makeChain<T>(
+  putImpl: (value: T, callback?: (ack?: ChainAck) => void) => void,
+): ChainWithGet<T> {
+  return {
+    once: vi.fn(),
+    get: vi.fn(() => makeChain(putImpl)),
+    put: vi.fn((value: T, callback?: (ack?: ChainAck) => void) => {
+      putImpl(value, callback);
+      return undefined;
+    }),
+  };
+}
+
+describe('writeWithDurability', () => {
+  it('returns acked writes without readback overhead', async () => {
+    const readback = vi.fn();
+    const chain = makeChain<Record<string, unknown>>((_value, callback) => callback?.({}));
+
+    await expect(writeWithDurability({
+      chain,
+      value: { id: 'ok' },
+      writeClass: 'test',
+      timeoutMs: 100,
+      readback,
+      readbackPredicate: () => true,
+      onEvent: vi.fn(),
+    })).resolves.toMatchObject({
+      ack: { acknowledged: true, timedOut: false },
+      readback_confirmed: false,
+      relay_fallback: false,
+    });
+    expect(readback).not.toHaveBeenCalled();
+  });
+
+  it('recovers a timed-out write when readback confirms persistence', async () => {
+    vi.useFakeTimers();
+    const events: string[] = [];
+    const chain = makeChain<Record<string, unknown>>(() => undefined);
+    const promise = writeWithDurability({
+      chain,
+      value: { id: 'durable' },
+      writeClass: 'test-readback',
+      timeoutMs: 100,
+      readbackRetryMs: 1,
+      readback: async () => ({ id: 'durable' }),
+      readbackPredicate: (observed) => (observed as { id?: string } | null)?.id === 'durable',
+      onEvent: (event) => events.push(event.stage),
+    });
+
+    await vi.advanceTimersByTimeAsync(101);
+    await expect(promise).resolves.toMatchObject({
+      ack: { acknowledged: false, timedOut: true },
+      readback_confirmed: true,
+      relay_fallback: false,
+    });
+    expect(events).toEqual(['ack-timeout', 'readback-confirmed']);
+    vi.useRealTimers();
+  });
+
+  it('uses relay fallback after timeout and failed readback', async () => {
+    vi.useFakeTimers();
+    const events: string[] = [];
+    const chain = makeChain<Record<string, unknown>>(() => undefined);
+    const relayFallback = vi.fn(async () => true);
+    const promise = writeWithDurability({
+      chain,
+      value: { id: 'relay' },
+      writeClass: 'test-relay',
+      timeoutMs: 100,
+      readbackAttempts: 1,
+      readback: async () => null,
+      readbackPredicate: () => false,
+      relayFallback,
+      onEvent: (event) => events.push(event.stage),
+    });
+
+    await vi.advanceTimersByTimeAsync(101);
+    await expect(promise).resolves.toMatchObject({
+      ack: { acknowledged: false, timedOut: true },
+      readback_confirmed: false,
+      relay_fallback: true,
+    });
+    expect(relayFallback).toHaveBeenCalledTimes(1);
+    expect(events).toEqual(['ack-timeout', 'relay-fallback']);
+    vi.useRealTimers();
+  });
+
+  it('rejects when timeout, readback, and fallback all fail', async () => {
+    vi.useFakeTimers();
+    const events: string[] = [];
+    const chain = makeChain<Record<string, unknown>>(() => undefined);
+    const promise = writeWithDurability({
+      chain,
+      value: { id: 'fail' },
+      writeClass: 'test-fail',
+      timeoutMs: 100,
+      timeoutError: 'durability failed',
+      readbackAttempts: 1,
+      readback: async () => null,
+      readbackPredicate: () => false,
+      relayFallback: async () => false,
+      onEvent: (event) => events.push(event.stage),
+    });
+
+    const assertion = expect(promise).rejects.toThrow('durability failed');
+    await vi.advanceTimersByTimeAsync(101);
+    await assertion;
+    expect(events).toEqual(['ack-timeout', 'failed']);
+    vi.useRealTimers();
+  });
+
+  it('uses default telemetry and default timeout errors when no recovery contract is provided', async () => {
+    vi.useFakeTimers();
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const chain = makeChain<Record<string, unknown>>(() => undefined);
+
+    try {
+      const promise = writeWithDurability({
+        chain,
+        value: { id: 'no-contract' },
+        writeClass: 'default-contract',
+        timeoutMs: 100,
+      });
+
+      const assertion = expect(promise).rejects.toThrow(
+        'default-contract write timed out and readback did not confirm persistence',
+      );
+      await vi.advanceTimersByTimeAsync(101);
+      await assertion;
+      expect(infoSpy).toHaveBeenCalledWith(
+        '[vh:mesh:durable-write]',
+        expect.objectContaining({ write_class: 'default-contract', stage: 'ack-timeout' }),
+      );
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[vh:mesh:durable-write]',
+        expect.objectContaining({
+          write_class: 'default-contract',
+          stage: 'failed',
+          error: 'default-contract write timed out and readback did not confirm persistence',
+        }),
+      );
+    } finally {
+      infoSpy.mockRestore();
+      warnSpy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
+  it('retries readback misses before confirming persistence', async () => {
+    vi.useFakeTimers();
+    const chain = makeChain<Record<string, unknown>>(() => undefined);
+    const readback = vi
+      .fn<() => Promise<unknown>>()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ id: 'eventual' });
+
+    try {
+      const promise = writeWithDurability({
+        chain,
+        value: { id: 'eventual' },
+        writeClass: 'retry-readback',
+        timeoutMs: 100,
+        readbackAttempts: 2,
+        readbackRetryMs: 10,
+        readback,
+        readbackPredicate: (observed) => (observed as { id?: string } | null)?.id === 'eventual',
+        onEvent: vi.fn(),
+      });
+
+      await vi.advanceTimersByTimeAsync(101);
+      await vi.advanceTimersByTimeAsync(10);
+      await expect(promise).resolves.toMatchObject({
+        readback_confirmed: true,
+        relay_fallback: false,
+      });
+      expect(readback).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('records final readback exceptions in telemetry', async () => {
+    vi.useFakeTimers();
+    const chain = makeChain<Record<string, unknown>>(() => undefined);
+    const events: Array<{ stage: string; error?: string }> = [];
+
+    try {
+      const promise = writeWithDurability({
+        chain,
+        value: { id: 'throws' },
+        writeClass: 'throwing-readback',
+        timeoutMs: 100,
+        readbackAttempts: 1,
+        readback: async () => {
+          throw 'readback-string-failure';
+        },
+        readbackPredicate: () => false,
+        relayFallback: async () => false,
+        onEvent: (event) => events.push({ stage: event.stage, error: event.error }),
+      });
+
+      const assertion = expect(promise).rejects.toThrow(
+        'throwing-readback write timed out and readback did not confirm persistence',
+      );
+      await vi.advanceTimersByTimeAsync(101);
+      await assertion;
+      expect(events).toContainEqual({ stage: 'failed', error: 'readback-string-failure' });
+      expect(events.at(-1)).toEqual({
+        stage: 'failed',
+        error: 'throwing-readback write timed out and readback did not confirm persistence',
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('records Error instances from final readback exceptions', async () => {
+    vi.useFakeTimers();
+    const chain = makeChain<Record<string, unknown>>(() => undefined);
+    const events: Array<{ stage: string; error?: string }> = [];
+
+    try {
+      const promise = writeWithDurability({
+        chain,
+        value: { id: 'throws-error' },
+        writeClass: 'throwing-error-readback',
+        timeoutMs: 100,
+        readbackAttempts: 1,
+        readback: async () => {
+          throw new Error('readback-error-instance');
+        },
+        readbackPredicate: () => false,
+        relayFallback: async () => false,
+        onEvent: (event) => events.push({ stage: event.stage, error: event.error }),
+      });
+
+      const assertion = expect(promise).rejects.toThrow(
+        'throwing-error-readback write timed out and readback did not confirm persistence',
+      );
+      await vi.advanceTimersByTimeAsync(101);
+      await assertion;
+      expect(events).toContainEqual({ stage: 'failed', error: 'readback-error-instance' });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/packages/gun-client/src/durableWrite.ts
+++ b/packages/gun-client/src/durableWrite.ts
@@ -1,0 +1,175 @@
+import { putWithAckTimeout, type ChainWithGet, type PutAckResult } from './chain';
+import { readGunTimeoutMs } from './runtimeConfig';
+
+export type DurableWriteEventStage =
+  | 'acked'
+  | 'ack-timeout'
+  | 'readback-confirmed'
+  | 'relay-fallback'
+  | 'failed';
+
+export interface DurableWriteEvent {
+  readonly writeClass: string;
+  readonly stage: DurableWriteEventStage;
+  readonly attempt?: number;
+  readonly ack?: PutAckResult;
+  readonly error?: string;
+}
+
+export interface DurableWriteResult {
+  readonly ack: PutAckResult;
+  readonly readback_confirmed: boolean;
+  readonly relay_fallback: boolean;
+}
+
+export interface DurableWriteOptions<T> {
+  readonly chain: ChainWithGet<T>;
+  readonly value: T;
+  readonly writeClass: string;
+  readonly timeoutMs: number;
+  readonly timeoutError?: string;
+  readonly readback?: () => Promise<unknown>;
+  readonly readbackPredicate?: (observed: unknown) => boolean;
+  readonly readbackAttempts?: number;
+  readonly readbackRetryMs?: number;
+  readonly relayFallback?: () => Promise<boolean>;
+  readonly onAckTimeout?: () => void;
+  readonly onEvent?: (event: DurableWriteEvent) => void;
+}
+
+const DEFAULT_READBACK_ATTEMPTS = 6;
+const DEFAULT_READBACK_RETRY_MS = readGunTimeoutMs(
+  ['VITE_VH_GUN_DURABLE_WRITE_READBACK_RETRY_MS', 'VH_GUN_DURABLE_WRITE_READBACK_RETRY_MS'],
+  250,
+  25,
+);
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function toErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function emitDefaultDurableWriteEvent(event: DurableWriteEvent): void {
+  if (event.stage === 'acked') {
+    return;
+  }
+  const payload = {
+    write_class: event.writeClass,
+    stage: event.stage,
+    attempt: event.attempt,
+    acknowledged: event.ack?.acknowledged,
+    timed_out: event.ack?.timedOut,
+    latency_ms: event.ack?.latencyMs,
+    error: event.error,
+  };
+  const label = '[vh:mesh:durable-write]';
+  if (event.stage === 'failed') {
+    console.warn(label, payload);
+    return;
+  }
+  console.info(label, payload);
+}
+
+function emitEvent(options: DurableWriteOptions<unknown>, event: DurableWriteEvent): void {
+  if (options.onEvent) {
+    options.onEvent(event);
+    return;
+  }
+  emitDefaultDurableWriteEvent(event);
+}
+
+async function confirmReadback<T>(options: DurableWriteOptions<T>): Promise<boolean> {
+  if (!options.readback || !options.readbackPredicate) {
+    return false;
+  }
+
+  const attempts = Math.max(1, Math.floor(options.readbackAttempts ?? DEFAULT_READBACK_ATTEMPTS));
+  const retryMs = Math.max(0, Math.floor(options.readbackRetryMs ?? DEFAULT_READBACK_RETRY_MS));
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      const observed = await options.readback();
+      if (options.readbackPredicate(observed)) {
+        emitEvent(options as DurableWriteOptions<unknown>, {
+          writeClass: options.writeClass,
+          stage: 'readback-confirmed',
+          attempt,
+        });
+        return true;
+      }
+    } catch (error) {
+      if (attempt === attempts) {
+        emitEvent(options as DurableWriteOptions<unknown>, {
+          writeClass: options.writeClass,
+          stage: 'failed',
+          attempt,
+          error: toErrorMessage(error),
+        });
+      }
+    }
+
+    if (attempt < attempts && retryMs > 0) {
+      await sleep(retryMs);
+    }
+  }
+  return false;
+}
+
+export async function writeWithDurability<T>(options: DurableWriteOptions<T>): Promise<DurableWriteResult> {
+  const ack = await putWithAckTimeout(options.chain, options.value, {
+    timeoutMs: options.timeoutMs,
+    onTimeout: options.onAckTimeout,
+  });
+
+  if (!ack.timedOut) {
+    emitEvent(options as DurableWriteOptions<unknown>, {
+      writeClass: options.writeClass,
+      stage: 'acked',
+      ack,
+    });
+    return {
+      ack,
+      readback_confirmed: false,
+      relay_fallback: false,
+    };
+  }
+
+  emitEvent(options as DurableWriteOptions<unknown>, {
+    writeClass: options.writeClass,
+    stage: 'ack-timeout',
+    ack,
+  });
+
+  if (await confirmReadback(options)) {
+    return {
+      ack,
+      readback_confirmed: true,
+      relay_fallback: false,
+    };
+  }
+
+  if (options.relayFallback && await options.relayFallback()) {
+    emitEvent(options as DurableWriteOptions<unknown>, {
+      writeClass: options.writeClass,
+      stage: 'relay-fallback',
+      ack,
+    });
+    return {
+      ack,
+      readback_confirmed: false,
+      relay_fallback: true,
+    };
+  }
+
+  const errorMessage = options.timeoutError
+    ?? `${options.writeClass} write timed out and readback did not confirm persistence`;
+  emitEvent(options as DurableWriteOptions<unknown>, {
+    writeClass: options.writeClass,
+    stage: 'failed',
+    ack,
+    error: errorMessage,
+  });
+  throw new Error(errorMessage);
+}

--- a/packages/gun-client/src/forumAdapters.test.ts
+++ b/packages/gun-client/src/forumAdapters.test.ts
@@ -266,6 +266,27 @@ describe('forumAdapters', () => {
     await expect(writeForumCommentModeration(client, MODERATION, OPERATOR_AUTHORIZATION)).rejects.toThrow('boom');
   });
 
+  it('recovers moderation writes from ack timeout when readback confirms persistence', async () => {
+    vi.useFakeTimers();
+    const chain = createMockChain();
+    chain.put.mockImplementation((_value: any, _cb?: (ack?: any) => void) => undefined);
+    chain.once.mockImplementation((cb?: (data: unknown) => void) => cb?.(MODERATION));
+    const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+    const client = createClient(chain, guard);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      const writePromise = writeForumCommentModeration(client, MODERATION, OPERATOR_AUTHORIZATION);
+      await vi.advanceTimersByTimeAsync(6_000);
+      await expect(writePromise).resolves.toEqual(MODERATION);
+      expect(warnSpy).toHaveBeenCalledWith('[vh:forum] moderation put ack timed out, requiring readback confirmation');
+      expect(warnSpy).toHaveBeenCalledWith('[vh:forum] latest moderation put ack timed out, requiring readback confirmation');
+    } finally {
+      warnSpy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
   it('requires trusted operator authorization for comment moderation writes', async () => {
     const chain = createMockChain();
     const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;

--- a/packages/gun-client/src/forumAdapters.ts
+++ b/packages/gun-client/src/forumAdapters.ts
@@ -4,7 +4,8 @@ import {
   HermesCommentModerationSchema,
   type TrustedOperatorAuthorization,
 } from '@vh/data-model';
-import { createGuardedChain, putWithAckTimeout, type ChainWithGet } from './chain';
+import { createGuardedChain, type ChainWithGet } from './chain';
+import { writeWithDurability } from './durableWrite';
 import type { VennClient } from './types';
 
 function threadPath(threadId: string): string {
@@ -181,10 +182,6 @@ function readOnce<T>(chain: ChainWithGet<T>): Promise<T | null> {
   });
 }
 
-async function putWithAck<T>(chain: ChainWithGet<T>, value: T): Promise<void> {
-  await putWithAckTimeout(chain, value, { timeoutMs: 2_500 });
-}
-
 export async function readForumCommentModeration(
   client: VennClient,
   threadId: string,
@@ -229,7 +226,43 @@ export async function writeForumCommentModeration(
   const moderationId = normalizeId(sanitized.moderation_id, 'moderationId');
   const operatorId = normalizeId(sanitized.operator_id, 'operatorId');
   assertTrustedOperatorAuthorization(operatorAuthorization, operatorId, 'moderate_story_thread');
-  await putWithAck(getForumCommentModerationChain(client, threadId, moderationId), sanitized);
-  await putWithAck(getForumLatestCommentModerationChain(client, threadId, commentId), sanitized);
+  await writeWithDurability({
+    chain: getForumCommentModerationChain(client, threadId, moderationId),
+    value: sanitized,
+    writeClass: 'forum-comment-moderation',
+    timeoutMs: 2_500,
+    timeoutError: 'forum comment moderation write timed out and readback did not confirm persistence',
+    onAckTimeout: () => console.warn('[vh:forum] moderation put ack timed out, requiring readback confirmation'),
+    readback: () => readForumCommentModeration(client, threadId, moderationId),
+    readbackPredicate: (observed) => {
+      const candidate = observed as HermesCommentModeration | null;
+      return Boolean(
+        candidate
+        && candidate.thread_id === threadId
+        && candidate.comment_id === commentId
+        && candidate.moderation_id === moderationId
+        && candidate.status === sanitized.status
+      );
+    },
+  });
+  await writeWithDurability({
+    chain: getForumLatestCommentModerationChain(client, threadId, commentId),
+    value: sanitized,
+    writeClass: 'forum-latest-comment-moderation',
+    timeoutMs: 2_500,
+    timeoutError: 'forum latest comment moderation write timed out and readback did not confirm persistence',
+    onAckTimeout: () => console.warn('[vh:forum] latest moderation put ack timed out, requiring readback confirmation'),
+    readback: () => readForumLatestCommentModeration(client, threadId, commentId),
+    readbackPredicate: (observed) => {
+      const candidate = observed as HermesCommentModeration | null;
+      return Boolean(
+        candidate
+        && candidate.thread_id === threadId
+        && candidate.comment_id === commentId
+        && candidate.moderation_id === moderationId
+        && candidate.status === sanitized.status
+      );
+    },
+  });
   return sanitized;
 }

--- a/packages/gun-client/src/index.ts
+++ b/packages/gun-client/src/index.ts
@@ -73,8 +73,7 @@ function createNamespace<T>(
         const timer = setTimeout(() => {
           if (settled) return;
           settled = true;
-          console.warn('[vh:gun-client] put timed out, proceeding without ack');
-          resolve();
+          reject(new Error('namespace write timed out before Gun acknowledged persistence'));
         }, 1000);
 
         chain.put(value, (ack?: ChainAck) => {
@@ -217,6 +216,7 @@ export * from './sentimentEventAdapters';
 export * from './aggregateAdapters';
 export * from './sentimentAdapters';
 export * from './bridgeAdapters';
+export * from './durableWrite';
 export type { ChainWithGet } from './chain';
 export { default as SEA } from 'gun/sea';
 export const __internal = {

--- a/packages/gun-client/src/newsAdapters.test.ts
+++ b/packages/gun-client/src/newsAdapters.test.ts
@@ -409,7 +409,7 @@ describe('newsAdapters', () => {
     await expect(writeNewsStory(client, STORY)).rejects.toThrow('write failed');
   });
 
-  it('writeNewsStory resolves when put ack times out', async () => {
+  it('writeNewsStory resolves when put ack times out and readback confirms persistence', async () => {
     vi.useFakeTimers();
     const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
     const identityGuard = vi.spyOn(dataModel, 'assertCanonicalNewsTopicId').mockResolvedValue();
@@ -417,13 +417,14 @@ describe('newsAdapters', () => {
     try {
       const mesh = createFakeMesh();
       mesh.setPutHang('news/stories/story-123');
+      mesh.setRead('news/stories/story-123', STORY);
       const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
       const client = createClient(mesh, guard);
 
       const writePromise = writeNewsStory(client, STORY);
       await vi.advanceTimersByTimeAsync(1000);
       await expect(writePromise).resolves.toEqual(STORY);
-      expect(warning).toHaveBeenCalledWith('[vh:news] put ack timed out, proceeding without ack');
+      expect(warning).toHaveBeenCalledWith('[vh:news] put ack timed out, requiring readback confirmation');
     } finally {
       identityGuard.mockRestore();
       warning.mockRestore();
@@ -461,6 +462,10 @@ describe('newsAdapters', () => {
         topic_id: '59512f69ced0a62872ec237f8f7ddbe3c33b407fca881e92b0829d9493ae79ff',
       };
 
+      mesh.setRead('news/stories/story-timeout-1', storyOne);
+      mesh.setRead('news/stories/story-timeout-2', storyTwo);
+      mesh.setRead('news/stories/story-timeout-3', storyThree);
+
       const firstWrite = writeNewsStory(client, storyOne);
       await vi.advanceTimersByTimeAsync(1000);
       await expect(firstWrite).resolves.toEqual(storyOne);
@@ -477,7 +482,7 @@ describe('newsAdapters', () => {
       await vi.advanceTimersByTimeAsync(1000);
       await expect(thirdWrite).resolves.toEqual(storyThree);
       expect(warning).toHaveBeenLastCalledWith(
-        '[vh:news] put ack timed out, proceeding without ack (suppressed 1 repeats)',
+        '[vh:news] put ack timed out, requiring readback confirmation (suppressed 1 repeats)',
       );
     } finally {
       identityGuard.mockRestore();
@@ -1075,6 +1080,30 @@ describe('newsAdapters', () => {
         expires_at: 40,
       },
     });
+  });
+
+  it('recovers ingestion lease writes from ack timeout when readback confirms persistence', async () => {
+    vi.useFakeTimers();
+    const mesh = createFakeMesh();
+    const lease = {
+      holder_id: 'holder-timeout',
+      lease_token: 'token-timeout',
+      acquired_at: 20,
+      heartbeat_at: 21,
+      expires_at: 40,
+    };
+    mesh.setPutHang('news/runtime/lease/ingester');
+    mesh.setRead('news/runtime/lease/ingester', lease);
+    const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+    const client = createClient(mesh, guard);
+
+    try {
+      const writePromise = writeNewsIngestionLease(client, lease);
+      await vi.advanceTimersByTimeAsync(1_001);
+      await expect(writePromise).resolves.toEqual(lease);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('rejects malformed ingestion lease writes and ignores malformed reads', async () => {

--- a/packages/gun-client/src/newsAdapters.ts
+++ b/packages/gun-client/src/newsAdapters.ts
@@ -4,7 +4,8 @@ import {
   StoryBundleSchema,
   type StoryBundle,
 } from '@vh/data-model';
-import { createGuardedChain, putWithAckTimeout, type ChainWithGet } from './chain';
+import { createGuardedChain, type ChainWithGet } from './chain';
+import { writeWithDurability, type DurableWriteResult } from './durableWrite';
 import { readGunTimeoutMs } from './runtimeConfig';
 import type { VennClient } from './types';
 
@@ -309,25 +310,50 @@ function warnNewsAckTimeout(): void {
       : '';
   suppressedNewsAckWarns = 0;
   lastNewsAckWarnAt = now;
-  console.warn(`[vh:news] put ack timed out, proceeding without ack${suffix}`);
+  console.warn(`[vh:news] put ack timed out, requiring readback confirmation${suffix}`);
 }
 
-async function putWithAck<T>(chain: ChainWithGet<T>, value: T): Promise<void> {
-  await putWithAckTimeout(chain, value, {
+async function putWithAck<T>(
+  chain: ChainWithGet<T>,
+  value: T,
+  options: {
+    readonly writeClass: string;
+    readonly timeoutError?: string;
+    readonly readback?: () => Promise<unknown>;
+    readonly readbackPredicate?: (observed: unknown) => boolean;
+  },
+): Promise<DurableWriteResult> {
+  return writeWithDurability({
+    chain,
+    value,
+    writeClass: options.writeClass,
     timeoutMs: NEWS_PUT_ACK_TIMEOUT_MS,
-    onTimeout: warnNewsAckTimeout,
+    timeoutError: options.timeoutError,
+    readback: options.readback,
+    readbackPredicate: options.readbackPredicate,
+    onAckTimeout: warnNewsAckTimeout,
   });
 }
 
 async function clearWithAck<T>(chain: ChainWithGet<T>): Promise<void> {
-  await putWithAck(chain as unknown as ChainWithGet<T | null>, null as T | null);
+  await putWithAck(chain as unknown as ChainWithGet<T | null>, null as T | null, {
+    writeClass: 'news-clear',
+    timeoutError: 'news clear timed out and readback did not confirm removal',
+    readback: () => readOnce(chain as unknown as ChainWithGet<T | null>),
+    readbackPredicate: (observed) => observed === null,
+  });
 }
 
 async function clearMapEntryWithAck(
   chain: ChainWithGet<Record<string, unknown>>,
   storyId: string,
 ): Promise<void> {
-  await putWithAck(chain, { [storyId]: null });
+  await putWithAck(chain, { [storyId]: null }, {
+    writeClass: 'news-map-clear',
+    timeoutError: 'news map clear timed out and readback did not confirm removal',
+    readback: () => readOnce(chain.get(storyId) as unknown as ChainWithGet<unknown>),
+    readbackPredicate: (observed) => observed === null,
+  });
 }
 
 /**
@@ -641,7 +667,22 @@ export async function writeNewsIngestionLease(
   lease: NewsIngestionLease,
 ): Promise<NewsIngestionLease> {
   const sanitized = sanitizeNewsIngestionLease(lease);
-  await putWithAck(getNewsIngestionLeaseChain(client), sanitized);
+  await putWithAck(getNewsIngestionLeaseChain(client), sanitized, {
+    writeClass: 'news-ingestion-lease',
+    timeoutError: 'news ingestion lease write timed out and readback did not confirm persistence',
+    readback: () => readNewsIngestionLease(client),
+    readbackPredicate: (observed) => {
+      const candidate = observed as NewsIngestionLease | null;
+      return Boolean(
+        candidate
+        && candidate.holder_id === sanitized.holder_id
+        && candidate.lease_token === sanitized.lease_token
+        && candidate.acquired_at === sanitized.acquired_at
+        && candidate.heartbeat_at === sanitized.heartbeat_at
+        && candidate.expires_at === sanitized.expires_at
+      );
+    },
+  });
   return sanitized;
 }
 
@@ -678,7 +719,21 @@ export async function writeNewsStory(client: VennClient, story: unknown): Promis
   const encoded = encodeStoryBundleForGun(normalized);
   await putWithAck(
     getNewsStoryChain(client, normalized.story_id) as unknown as ChainWithGet<Record<string, unknown>>,
-    encoded
+    encoded,
+    {
+      writeClass: 'news-story',
+      timeoutError: 'news story write timed out and readback did not confirm persistence',
+      readback: () => readNewsStory(client, normalized.story_id),
+      readbackPredicate: (observed) => {
+        const candidate = observed as StoryBundle | null;
+        return Boolean(
+          candidate
+          && candidate.story_id === normalized.story_id
+          && candidate.provenance_hash === normalized.provenance_hash
+          && candidate.cluster_window_end === normalized.cluster_window_end
+        );
+      },
+    }
   );
   return normalized;
 }
@@ -775,7 +830,13 @@ export async function writeNewsLatestIndexEntry(
     throw new Error('storyId is required');
   }
   const normalizedLatestTimestamp = Math.max(0, Math.floor(latestTimestamp));
-  await putWithAck(getNewsLatestIndexChain(client).get(normalizedId), normalizedLatestTimestamp);
+  const chain = getNewsLatestIndexChain(client).get(normalizedId);
+  await putWithAck(chain, normalizedLatestTimestamp, {
+    writeClass: 'news-latest-index',
+    timeoutError: 'news latest-index write timed out and readback did not confirm persistence',
+    readback: () => readOnce(chain as unknown as ChainWithGet<unknown>),
+    readbackPredicate: (observed) => parseLatestTimestamp(observed) === normalizedLatestTimestamp,
+  });
 }
 
 /**
@@ -810,7 +871,13 @@ export async function writeNewsHotIndexEntry(
   }
 
   const normalizedHotness = parseHotnessScore(hotnessScore) ?? 0;
-  await putWithAck(getNewsHotIndexChain(client).get(normalizedId), normalizedHotness);
+  const chain = getNewsHotIndexChain(client).get(normalizedId);
+  await putWithAck(chain, normalizedHotness, {
+    writeClass: 'news-hot-index',
+    timeoutError: 'news hot-index write timed out and readback did not confirm persistence',
+    readback: () => readOnce(chain as unknown as ChainWithGet<unknown>),
+    readbackPredicate: (observed) => parseHotnessScore(observed) === normalizedHotness,
+  });
   return normalizedHotness;
 }
 

--- a/packages/gun-client/src/newsReportAdapters.test.ts
+++ b/packages/gun-client/src/newsReportAdapters.test.ts
@@ -294,6 +294,26 @@ describe('newsReportAdapters', () => {
     await expect(writeNewsReport(client, REPORT)).rejects.toThrow('boom');
   });
 
+  it('recovers report writes from ack timeout when readback confirms persistence', async () => {
+    vi.useFakeTimers();
+    const chain = createMockChain();
+    chain.put.mockImplementationOnce((_value: unknown, _cb?: (ack?: { err?: string }) => void) => undefined);
+    chain.once.mockImplementation((cb?: (data: unknown) => void) => cb?.(REPORT));
+    const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+    const client = createClient(chain, guard);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      const writePromise = writeNewsReport(client, REPORT);
+      await vi.advanceTimersByTimeAsync(2_501);
+      await expect(writePromise).resolves.toEqual(REPORT);
+      expect(warnSpy).toHaveBeenCalledWith('[vh:news-report] report put ack timed out, requiring readback confirmation');
+    } finally {
+      warnSpy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
   it('surfaces status index write ack failures', async () => {
     const chain = createMockChain();
     chain.put

--- a/packages/gun-client/src/newsReportAdapters.ts
+++ b/packages/gun-client/src/newsReportAdapters.ts
@@ -6,7 +6,8 @@ import {
   type HermesNewsReportStatus,
   type TrustedOperatorAuthorization,
 } from '@vh/data-model';
-import { createGuardedChain, putWithAckTimeout, type ChainWithGet } from './chain';
+import { createGuardedChain, type ChainWithGet } from './chain';
+import { writeWithDurability } from './durableWrite';
 import type { VennClient } from './types';
 
 function newsReportPath(reportId: string): string {
@@ -73,10 +74,6 @@ function readOnce<T>(chain: ChainWithGet<T>): Promise<T | null> {
       resolve((data ?? null) as T | null);
     });
   });
-}
-
-async function putWithAck<T>(chain: ChainWithGet<T>, value: T): Promise<void> {
-  await putWithAckTimeout(chain, value, { timeoutMs: 2_500 });
 }
 
 export function getNewsReportChain(client: VennClient, reportId: string): ChainWithGet<HermesNewsReport> {
@@ -175,11 +172,38 @@ export async function writeNewsReport(
       assertTrustedOperatorAuthorization(operatorAuthorization, operatorId, 'moderate_story_thread');
     }
   }
-  await putWithAck(getNewsReportChain(client, reportId), sanitized);
-  await putWithAck(getNewsReportStatusIndexEntryChain(client, sanitized.status, reportId), {
+  await writeWithDurability({
+    chain: getNewsReportChain(client, reportId),
+    value: sanitized,
+    writeClass: 'news-report',
+    timeoutMs: 2_500,
+    timeoutError: 'news report write timed out and readback did not confirm persistence',
+    onAckTimeout: () => console.warn('[vh:news-report] report put ack timed out, requiring readback confirmation'),
+    readback: () => readNewsReport(client, reportId),
+    readbackPredicate: (observed) => {
+      const candidate = observed as HermesNewsReport | null;
+      return Boolean(
+        candidate
+        && candidate.report_id === reportId
+        && candidate.status === sanitized.status
+        && candidate.created_at === sanitized.created_at
+      );
+    },
+  });
+  const indexValue = {
     report_id: reportId,
     created_at: sanitized.created_at,
     target_type: sanitized.target.type,
+  };
+  await writeWithDurability({
+    chain: getNewsReportStatusIndexEntryChain(client, sanitized.status, reportId),
+    value: indexValue,
+    writeClass: 'news-report-index',
+    timeoutMs: 2_500,
+    timeoutError: 'news report status-index write timed out and readback did not confirm persistence',
+    onAckTimeout: () => console.warn('[vh:news-report] status-index put ack timed out, requiring readback confirmation'),
+    readback: () => readOnce(getNewsReportStatusIndexEntryChain(client, sanitized.status, reportId)),
+    readbackPredicate: (observed) => parseQueuePointer(observed, reportId) === reportId,
   });
   return sanitized;
 }

--- a/packages/gun-client/src/sentimentEventAdapters.test.ts
+++ b/packages/gun-client/src/sentimentEventAdapters.test.ts
@@ -267,7 +267,9 @@ describe('sentimentEventAdapters', () => {
       point_id: EVENT.point_id,
     });
     userNode.setPutHang(`outbox/sentiment/${eventId}`);
+    userNode.setRead(`outbox/sentiment/${eventId}`, { __encrypted: true, ciphertext: 'encrypted-payload' });
     encryptMock.mockResolvedValueOnce('encrypted-payload');
+    decryptMock.mockResolvedValueOnce(JSON.stringify(EVENT));
 
     await expect(writeSentimentEvent(client, EVENT)).resolves.toEqual({
       eventId,

--- a/packages/gun-client/src/sentimentEventAdapters.ts
+++ b/packages/gun-client/src/sentimentEventAdapters.ts
@@ -4,7 +4,8 @@ import {
   deriveSentimentEventId,
   type SentimentEvent,
 } from '@vh/data-model';
-import { createGuardedChain, putWithAckTimeout, type ChainWithGet, type PutAckResult } from './chain';
+import { createGuardedChain, type ChainWithGet, type PutAckResult } from './chain';
+import { writeWithDurability } from './durableWrite';
 import { readGunTimeoutMs } from './runtimeConfig';
 import type { VennClient } from './types';
 
@@ -121,11 +122,27 @@ const PUT_ACK_TIMEOUT_MS = readGunTimeoutMs(
   1_000,
 );
 
-async function putWithAck<T>(chain: ChainWithGet<T>, value: T): Promise<PutAckResult> {
-  return putWithAckTimeout(chain, value, {
+async function putWithAck<T>(
+  chain: ChainWithGet<T>,
+  value: T,
+  options: {
+    readonly writeClass: string;
+    readonly timeoutError?: string;
+    readonly readback?: () => Promise<unknown>;
+    readonly readbackPredicate?: (observed: unknown) => boolean;
+  },
+): Promise<PutAckResult> {
+  const result = await writeWithDurability({
+    chain,
+    value,
+    writeClass: options.writeClass,
     timeoutMs: PUT_ACK_TIMEOUT_MS,
-    onTimeout: () => console.warn('[vh:gun-client] sentiment outbox put ack timed out, proceeding best-effort'),
+    timeoutError: options.timeoutError,
+    readback: options.readback,
+    readbackPredicate: options.readbackPredicate,
+    onAckTimeout: () => console.warn('[vh:gun-client] sentiment outbox put ack timed out, requiring readback confirmation'),
   });
+  return result.ack;
 }
 
 export function getSentimentOutboxChain(client: VennClient): ChainWithGet<EncryptedSentimentEnvelope> {
@@ -155,7 +172,22 @@ export async function writeSentimentEvent(
   });
 
   const envelope = await encryptSentimentEvent(client, sanitized);
-  const ack = await putWithAck(getSentimentOutboxChain(client).get(eventId), envelope);
+  const eventChain = getSentimentOutboxChain(client).get(eventId);
+  const ack = await putWithAck(eventChain, envelope, {
+    writeClass: 'sentiment-outbox',
+    timeoutError: 'sentiment outbox write timed out and readback did not confirm persistence',
+    readback: async () => decryptSentimentEvent(client, stripGunMetadata(await readOnce(eventChain))),
+    readbackPredicate: (observed) => {
+      const candidate = observed as SentimentEvent | null;
+      return Boolean(
+        candidate
+        && candidate.topic_id === sanitized.topic_id
+        && candidate.synthesis_id === sanitized.synthesis_id
+        && candidate.epoch === sanitized.epoch
+        && candidate.point_id === sanitized.point_id
+      );
+    },
+  });
 
   return { eventId, event: sanitized, ack };
 }

--- a/packages/gun-client/src/storylineAdapters.test.ts
+++ b/packages/gun-client/src/storylineAdapters.test.ts
@@ -198,11 +198,12 @@ describe('storylineAdapters', () => {
     timedReadMesh.triggerOnce('news/storylines/storyline-1', STORYLINE);
 
     const timeoutMesh = createFakeMesh({ putAck: 'skip' });
+    timeoutMesh.setRead('news/storylines/storyline-1', STORYLINE);
     const timeoutClient = createClient(timeoutMesh, { validateWrite: vi.fn() } as unknown as TopologyGuard);
     const pendingWrite = writeNewsStoryline(timeoutClient, STORYLINE);
     await vi.advanceTimersByTimeAsync(1_000);
     await expect(pendingWrite).resolves.toEqual(STORYLINE);
-    expect(warnSpy).toHaveBeenCalledWith('[vh:storylines] put ack timed out, proceeding without ack');
+    expect(warnSpy).toHaveBeenCalledWith('[vh:storylines] put ack timed out, requiring readback confirmation');
     timeoutMesh.triggerAck('news/storylines/storyline-1', {});
 
     const errorClient = createClient(

--- a/packages/gun-client/src/storylineAdapters.ts
+++ b/packages/gun-client/src/storylineAdapters.ts
@@ -1,5 +1,6 @@
 import { StorylineGroupSchema, type StorylineGroup } from '@vh/data-model';
-import { createGuardedChain, putWithAckTimeout, type ChainWithGet } from './chain';
+import { createGuardedChain, type ChainWithGet } from './chain';
+import { writeWithDurability } from './durableWrite';
 import { readGunTimeoutMs } from './runtimeConfig';
 import type { VennClient } from './types';
 
@@ -37,22 +38,47 @@ function readOnce<T>(chain: ChainWithGet<T>): Promise<T | null> {
   });
 }
 
-async function putWithAck<T>(chain: ChainWithGet<T>, value: T): Promise<void> {
-  await putWithAckTimeout(chain, value, {
+async function putWithAck<T>(
+  chain: ChainWithGet<T>,
+  value: T,
+  options: {
+    readonly writeClass: string;
+    readonly timeoutError?: string;
+    readonly readback?: () => Promise<unknown>;
+    readonly readbackPredicate?: (observed: unknown) => boolean;
+  },
+): Promise<void> {
+  await writeWithDurability({
+    chain,
+    value,
+    writeClass: options.writeClass,
     timeoutMs: STORYLINE_ACK_TIMEOUT_MS,
-    onTimeout: () => console.warn('[vh:storylines] put ack timed out, proceeding without ack'),
+    timeoutError: options.timeoutError,
+    readback: options.readback,
+    readbackPredicate: options.readbackPredicate,
+    onAckTimeout: () => console.warn('[vh:storylines] put ack timed out, requiring readback confirmation'),
   });
 }
 
 async function clearWithAck<T>(chain: ChainWithGet<T>): Promise<void> {
-  await putWithAck(chain as unknown as ChainWithGet<T | null>, null as T | null);
+  await putWithAck(chain as unknown as ChainWithGet<T | null>, null as T | null, {
+    writeClass: 'storyline-clear',
+    timeoutError: 'storyline clear timed out and readback did not confirm removal',
+    readback: () => readOnce(chain as unknown as ChainWithGet<T | null>),
+    readbackPredicate: (observed) => observed === null,
+  });
 }
 
 async function clearMapEntryWithAck(
   chain: ChainWithGet<Record<string, unknown>>,
   storylineId: string,
 ): Promise<void> {
-  await putWithAck(chain, { [storylineId]: null });
+  await putWithAck(chain, { [storylineId]: null }, {
+    writeClass: 'storyline-map-clear',
+    timeoutError: 'storyline map clear timed out and readback did not confirm removal',
+    readback: () => readOnce(chain.get(storylineId) as unknown as ChainWithGet<unknown>),
+    readbackPredicate: (observed) => observed === null,
+  });
 }
 
 function encodeStorylineGroup(group: StorylineGroup): Record<string, unknown> {
@@ -139,6 +165,20 @@ export async function writeNewsStoryline(
   await putWithAck(
     getNewsStorylineChain(client, sanitized.storyline_id),
     encodeStorylineGroup(sanitized),
+    {
+      writeClass: 'storyline',
+      timeoutError: 'storyline write timed out and readback did not confirm persistence',
+      readback: () => readNewsStoryline(client, sanitized.storyline_id),
+      readbackPredicate: (observed) => {
+        const candidate = observed as StorylineGroup | null;
+        return Boolean(
+          candidate
+          && candidate.storyline_id === sanitized.storyline_id
+          && candidate.canonical_story_id === sanitized.canonical_story_id
+          && candidate.updated_at === sanitized.updated_at
+        );
+      },
+    },
   );
   return sanitized;
 }

--- a/packages/gun-client/src/synthesisAdapters.test.ts
+++ b/packages/gun-client/src/synthesisAdapters.test.ts
@@ -597,6 +597,31 @@ describe('synthesisAdapters', () => {
     }
   });
 
+  it('recovers latest synthesis writes from epoch readback before relay fallback', async () => {
+    vi.useFakeTimers();
+    try {
+      const mesh = createFakeMesh();
+      mesh.setPendingPut('topics/topic-1/latest');
+      mesh.setRead('topics/topic-1/epochs/2/synthesis', {
+        _: { '#': 'meta' },
+        ...SYNTHESIS,
+      });
+      const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+      const client = createClient(mesh, guard, ['http://127.0.0.1:7777/gun']);
+      const fetchMock = vi.fn();
+      vi.stubGlobal('fetch', fetchMock);
+
+      const writePromise = writeTopicLatestSynthesis(client, SYNTHESIS);
+      await vi.advanceTimersByTimeAsync(5_000);
+
+      await expect(writePromise).resolves.toEqual(SYNTHESIS);
+      expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      vi.unstubAllGlobals();
+      vi.useRealTimers();
+    }
+  });
+
   it('ignores late synthesis put acknowledgements after the bounded timeout fires', async () => {
     vi.useFakeTimers();
     try {
@@ -606,7 +631,9 @@ describe('synthesisAdapters', () => {
       const client = createClient(mesh, guard);
 
       const writePromise = writeTopicLatestSynthesis(client, SYNTHESIS);
-      const assertion = expect(writePromise).rejects.toThrow('synthesis-put-ack-timeout');
+      const assertion = expect(writePromise).rejects.toThrow(
+        'synthesis write timed out and readback/fallback did not confirm persistence',
+      );
       await vi.advanceTimersByTimeAsync(6_000);
       await assertion;
     } finally {
@@ -623,7 +650,9 @@ describe('synthesisAdapters', () => {
       invalidPeerMesh.setPendingPut('topics/topic-1/latest');
       const invalidPeerClient = createClient(invalidPeerMesh, guard, ['http://[']);
       const invalidPeerWrite = writeTopicLatestSynthesis(invalidPeerClient, SYNTHESIS);
-      const invalidPeerAssertion = expect(invalidPeerWrite).rejects.toThrow('synthesis-put-ack-timeout');
+      const invalidPeerAssertion = expect(invalidPeerWrite).rejects.toThrow(
+        'synthesis write timed out and readback/fallback did not confirm persistence',
+      );
       await vi.advanceTimersByTimeAsync(5_000);
       await invalidPeerAssertion;
 
@@ -632,7 +661,9 @@ describe('synthesisAdapters', () => {
       const declinedClient = createClient(declinedMesh, guard, ['http://127.0.0.1:7777/gun']);
       vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false })));
       const declinedWrite = writeTopicLatestSynthesis(declinedClient, SYNTHESIS);
-      const declinedAssertion = expect(declinedWrite).rejects.toThrow('synthesis-put-ack-timeout');
+      const declinedAssertion = expect(declinedWrite).rejects.toThrow(
+        'synthesis write timed out and readback/fallback did not confirm persistence',
+      );
       await vi.advanceTimersByTimeAsync(5_000);
       await declinedAssertion;
     } finally {
@@ -653,7 +684,9 @@ describe('synthesisAdapters', () => {
       }));
 
       const writePromise = writeTopicLatestSynthesis(client, SYNTHESIS);
-      const assertion = expect(writePromise).rejects.toThrow('synthesis-put-ack-timeout');
+      const assertion = expect(writePromise).rejects.toThrow(
+        'synthesis write timed out and readback/fallback did not confirm persistence',
+      );
       await vi.advanceTimersByTimeAsync(5_000);
 
       await assertion;
@@ -989,6 +1022,23 @@ describe('synthesisAdapters', () => {
     await expect(writeTopicEpochSynthesis(client, SYNTHESIS)).rejects.toThrow('synthesis write failed');
   });
 
+  it('surfaces candidate write acknowledgement timeouts', async () => {
+    vi.useFakeTimers();
+    try {
+      const mesh = createFakeMesh();
+      mesh.setPendingPut('topics/topic-1/epochs/2/candidates/candidate-1');
+      const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+      const client = createClient(mesh, guard);
+
+      const writePromise = writeTopicEpochCandidate(client, CANDIDATE);
+      const assertion = expect(writePromise).rejects.toThrow('synthesis-put-ack-timeout');
+      await vi.advanceTimersByTimeAsync(5_000);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('rejects synthesis writes when the put acknowledgement never arrives', async () => {
     vi.useFakeTimers();
     try {
@@ -999,7 +1049,9 @@ describe('synthesisAdapters', () => {
       const client = createClient(mesh, guard);
 
       const writePromise = writeTopicLatestSynthesis(client, SYNTHESIS);
-      const assertion = expect(writePromise).rejects.toThrow('synthesis-put-ack-timeout');
+      const assertion = expect(writePromise).rejects.toThrow(
+        'synthesis write timed out and readback/fallback did not confirm persistence',
+      );
       await vi.advanceTimersByTimeAsync(5_000);
       await assertion;
     } finally {

--- a/packages/gun-client/src/synthesisAdapters.ts
+++ b/packages/gun-client/src/synthesisAdapters.ts
@@ -11,6 +11,7 @@ import {
   type TrustedOperatorAuthorization
 } from '@vh/data-model';
 import { createGuardedChain, putWithAckTimeout, type ChainWithGet } from './chain';
+import { writeWithDurability } from './durableWrite';
 import { readGunTimeoutMs } from './runtimeConfig';
 import type { VennClient } from './types';
 const FORBIDDEN_SYNTHESIS_KEYS = new Set<string>([
@@ -373,18 +374,32 @@ async function putSynthesisWithAckOrRelayFallback(
   encoded: Record<string, unknown>,
   synthesis: TopicSynthesisV2
 ): Promise<void> {
-  try {
-    await putWithAck(chain, encoded);
-    return;
-  } catch (error) {
-    if (!(error instanceof Error) || error.message !== 'synthesis-put-ack-timeout') {
-      throw error;
-    }
-    if (await writeSynthesisViaRelayFallback(client, synthesis)) {
-      return;
-    }
-    throw error;
-  }
+  await writeWithDurability({
+    chain,
+    value: encoded,
+    writeClass: 'topic-synthesis',
+    timeoutMs: PUT_ACK_TIMEOUT_MS,
+    timeoutError: 'synthesis write timed out and readback/fallback did not confirm persistence',
+    readback: async () => {
+      const byEpoch = await readTopicEpochSynthesis(client, synthesis.topic_id, synthesis.epoch);
+      if (byEpoch?.synthesis_id === synthesis.synthesis_id) {
+        return byEpoch;
+      }
+      return readTopicLatestSynthesis(client, synthesis.topic_id);
+    },
+    readbackAttempts: 1,
+    readbackPredicate: (observed) => {
+      const candidate = observed as TopicSynthesisV2 | null;
+      return Boolean(
+        candidate
+        && candidate.topic_id === synthesis.topic_id
+        && candidate.synthesis_id === synthesis.synthesis_id
+        && candidate.epoch === synthesis.epoch
+      );
+    },
+    relayFallback: () => writeSynthesisViaRelayFallback(client, synthesis),
+    onAckTimeout: () => console.warn('[vh:synthesis] put ack timed out, requiring readback or relay fallback'),
+  });
 }
 
 export function getTopicEpochCandidatesChain(

--- a/packages/gun-client/src/topicEngagementAdapters.test.ts
+++ b/packages/gun-client/src/topicEngagementAdapters.test.ts
@@ -403,6 +403,7 @@ describe('topicEngagementAdapters', () => {
     });
     mesh.setPutHandler((path, value, cb) => {
       mesh.writes.push({ path, value });
+      mesh.setRead(path, value);
       setTimeout(() => cb?.({}), 1_100);
     });
     const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;

--- a/packages/gun-client/src/topicEngagementAdapters.ts
+++ b/packages/gun-client/src/topicEngagementAdapters.ts
@@ -6,7 +6,8 @@ import {
   type TopicEngagementActorNode,
   type TopicEngagementAggregateV1,
 } from '@vh/data-model';
-import { createGuardedChain, putWithAckTimeout, type ChainWithGet, type PutAckResult } from './chain';
+import { createGuardedChain, type ChainWithGet } from './chain';
+import { writeWithDurability, type DurableWriteResult } from './durableWrite';
 import { readGunTimeoutMs } from './runtimeConfig';
 import type { VennClient } from './types';
 
@@ -100,8 +101,26 @@ function readOnce<T>(chain: ChainWithGet<T>): Promise<T | null> {
   });
 }
 
-function putWithAck<T>(chain: ChainWithGet<T>, value: T): Promise<PutAckResult> {
-  return putWithAckTimeout(chain, value, { timeoutMs: PUT_ACK_TIMEOUT_MS });
+function putWithAck<T>(
+  chain: ChainWithGet<T>,
+  value: T,
+  options: {
+    readonly writeClass: string;
+    readonly timeoutError?: string;
+    readonly readback?: () => Promise<unknown>;
+    readonly readbackPredicate?: (observed: unknown) => boolean;
+  },
+): Promise<DurableWriteResult> {
+  return writeWithDurability({
+    chain,
+    value,
+    writeClass: options.writeClass,
+    timeoutMs: PUT_ACK_TIMEOUT_MS,
+    timeoutError: options.timeoutError,
+    readback: options.readback,
+    readbackPredicate: options.readbackPredicate,
+    onAckTimeout: () => console.warn('[vh:topic-engagement] put ack timed out, requiring readback confirmation'),
+  });
 }
 
 function parseActorNode(raw: unknown): TopicEngagementActorNode | null {
@@ -329,7 +348,21 @@ export async function writeTopicEngagementActorNode(
   };
 
   TopicEngagementActorNodeSchema.parse(actorNode);
-  await putWithAck(getTopicEngagementActorChain(client, normalizedTopicId, normalizedActorId), actorNode);
+  await putWithAck(getTopicEngagementActorChain(client, normalizedTopicId, normalizedActorId), actorNode, {
+    writeClass: 'topic-engagement-actor',
+    timeoutError: 'topic engagement actor write timed out and readback did not confirm persistence',
+    readback: () => readTopicEngagementActorNode(client, normalizedTopicId, normalizedActorId),
+    readbackPredicate: (observed) => {
+      const candidate = observed as TopicEngagementActorNode | null;
+      return Boolean(
+        candidate
+        && candidate.topic_id === actorNode.topic_id
+        && candidate.updated_at === actorNode.updated_at
+        && candidate.eye_weight === actorNode.eye_weight
+        && candidate.lightbulb_weight === actorNode.lightbulb_weight
+      );
+    },
+  });
 
   const actorsChain = getTopicEngagementActorsChain(client, normalizedTopicId) as unknown as ChainWithGet<unknown>;
   const rawActors = await readOnce(actorsChain);
@@ -343,6 +376,23 @@ export async function writeTopicEngagementActorNode(
     actorNodes,
   });
 
-  await putWithAck(getTopicEngagementSummaryChain(client, normalizedTopicId), aggregate);
+  await putWithAck(getTopicEngagementSummaryChain(client, normalizedTopicId), aggregate, {
+    writeClass: 'topic-engagement-summary',
+    timeoutError: 'topic engagement summary write timed out and readback did not confirm persistence',
+    readback: () => readTopicEngagementSummary(client, normalizedTopicId),
+    readbackPredicate: (observed) => {
+      const candidate = observed as TopicEngagementAggregateV1 | null;
+      return Boolean(
+        candidate
+        && candidate.topic_id === aggregate.topic_id
+        && candidate.eye_weight === aggregate.eye_weight
+        && candidate.lightbulb_weight === aggregate.lightbulb_weight
+        && candidate.readers === aggregate.readers
+        && candidate.engagers === aggregate.engagers
+        && candidate.version === aggregate.version
+        && candidate.computed_at === aggregate.computed_at
+      );
+    },
+  });
   return aggregate;
 }


### PR DESCRIPTION
## Summary

- add shared `writeWithDurability` for bounded Gun ack, timeout telemetry, readback recovery, relay fallback, and terminal failure
- migrate previously best-effort mesh write paths: news bundles/indexes/leases, storylines, analysis latest pointer, topic engagement, encrypted sentiment outbox, directory publish, synthesis latest pointer, news reports, forum moderation, and namespace initialization
- add generic safeStorage-backed `intentQueue<T>` and rewire the existing vote-intent queue onto it
- add `docs/reports/MESH_HARDENING_PR2_2026-05-02.md` marking PR1/PR2 done and queuing PR3-PR5

## Verification

- `pnpm --filter @vh/gun-client test` — 29 files, 347 tests passed
- `pnpm --filter @vh/gun-client typecheck`
- `pnpm exec vitest run apps/web-pwa/src/hooks/intentQueue.test.ts apps/web-pwa/src/hooks/voteIntentQueue.test.ts apps/web-pwa/src/hooks/useSentimentState.test.ts apps/web-pwa/src/hooks/voteIntentMaterializer.test.ts --reporter=dot` — 4 files, 114 tests passed
- `pnpm --filter @vh/web-pwa typecheck`
- `pnpm --filter @vh/e2e typecheck`
- `pnpm typecheck`
- `pnpm --filter @vh/news-aggregator test` — 32 files, 396 tests passed
- `pnpm lint`
- `pnpm test:mesh:browser-canary` — built preview canary passed
- `node tools/scripts/check-diff-coverage.mjs` — 295 files, 4,293 tests passed; every changed source file reached 100% diff line and branch coverage
- `git diff --check`

## Known unrelated local debt

`pnpm --filter @vh/web-pwa typecheck:test` still fails on broad pre-existing fixture strictness debt across bridge/feed/forum/discovery test files. The production web typecheck and focused affected tests are green.