### PR TITLE
Harden news daemon durability

### DIFF
--- a/docs/reports/MESH_HARDENING_PR2_2026-05-02.md
+++ b/docs/reports/MESH_HARDENING_PR2_2026-05-02.md
@@ -1,8 +1,8 @@
 # Mesh Hardening PR2 Review Ledger
 
 Date: 2026-05-02
-Branch: `coord/mesh-durable-write-contract-pr2`
-Base: merged `main` after PR #560 (`17dcbb04`)
+Branch: `coord/mesh-daemon-durability-pr3`
+Base: merged `main` after PR #561 (`77567bed`)
 
 ## Completed And Verified
 
@@ -25,7 +25,7 @@ Verification evidence:
 
 ### PR2 — Durable Write Contract
 
-Status: Done locally on `coord/mesh-durable-write-contract-pr2`; ready for PR/CI.
+Status: Done and merged.
 
 Verified implementation:
 - Added `packages/gun-client/src/durableWrite.ts` with bounded ack, timeout telemetry, readback confirmation after timeout, relay fallback, and terminal failure.
@@ -44,6 +44,7 @@ Verified implementation:
 - Preserved vote-intent API compatibility while making the generic queue reusable for the next migrated intent classes.
 
 Verification evidence:
+- PR #561 merged to `main`.
 - `pnpm --filter @vh/gun-client test` — 29 files, 347 tests passed.
 - `pnpm --filter @vh/gun-client typecheck` — passed.
 - `pnpm exec vitest run apps/web-pwa/src/hooks/intentQueue.test.ts apps/web-pwa/src/hooks/voteIntentQueue.test.ts apps/web-pwa/src/hooks/useSentimentState.test.ts apps/web-pwa/src/hooks/voteIntentMaterializer.test.ts --reporter=dot` — 4 files, 114 tests passed.
@@ -62,17 +63,37 @@ Known unrelated test debt:
 
 ### PR3 — Daemon-Side Hardening
 
-Queue next.
+Status: Done locally on `coord/mesh-daemon-durability-pr3`; ready for PR/CI.
 
-Scope:
-- Enable daemon `gunRadisk: true` with a per-process journal path.
-- Split daemon write lanes by class with bounded concurrency.
-- Persist enrichment queue state and DLQ displaced candidates instead of dropping on overflow.
-- Replay queue, DLQ, and accepted-but-unwritten work on restart.
-- Surface queue depth and DLQ counts through daemon health.
+Verified implementation:
+- Daemon `createNodeMeshClient` now defaults to `gunRadisk: true` with a deterministic per-daemon journal path from `VH_NEWS_DAEMON_GUN_FILE`, `VH_NEWS_DAEMON_STATE_DIR`, `VH_DAEMON_FEED_ARTIFACT_ROOT`, or `/tmp/vh-news-daemon/node-mesh-radisk/...`; hermetic tests can disable it with `VH_NEWS_DAEMON_GUN_RADISK=false`.
+- Added named bounded daemon write lanes with structured `enqueued`, `started`, `completed`, and `failed` events plus rolling p95 latency. Runtime bundle, stale-bundle removal, storyline, stale-storyline removal, lease, and bundle-synthesis candidate/epoch/latest writes now flow through lanes.
+- Enrichment queue state is persisted to `pending.json`; in-flight candidates remain in that replay file until worker completion, so `kill -9` mid-synthesis does not remove the candidate from durable replay state.
+- Queue overflow candidates are written to `dead-letter.jsonl` with reason `queue_full`, then replayed into pending on restart. Terminal worker failures are also dead-lettered with reason `worker_failed`.
+- The bundle-synthesis queue persists by default under `VH_BUNDLE_SYNTHESIS_QUEUE_DIR`, or under the daemon artifact/state root when explicit queue dir is absent.
+- Accepted analysis eval artifacts can replay once after daemon leadership is acquired, republishing the latest accepted synthesis per topic through the write-lane telemetry path.
+- Daemon handle now exposes `enrichmentQueueStats()`, `enrichmentQueueDeadLetterCount()`, and `writeLaneStats()` for local health/inspection surfaces.
+
+Verification evidence:
+- `pnpm --filter @vh/news-aggregator exec vitest run src/daemonUtils.test.ts src/daemonWriteLane.test.ts src/analysisEvalReplay.test.ts src/bundleSynthesisDaemonConfig.test.ts src/bundleSynthesisWorker.test.ts src/daemon.test.ts src/daemon.env.test.ts src/daemon.production.test.ts src/daemon.storylines.test.ts --reporter=dot` — 9 files, 48 tests passed.
+- `pnpm --filter @vh/news-aggregator typecheck` — passed.
+- `pnpm --filter @vh/news-aggregator exec vitest run src/daemon.coverage.test.ts --reporter=dot` — 6 tests passed after updating the stopped-daemon expectation.
+- `pnpm --filter @vh/news-aggregator exec vitest run src/sourceHealthReport.test.ts --reporter=dot` — 25 tests passed in isolation after an initial parallel timeout.
+- `pnpm --filter @vh/news-aggregator test` — 34 files, 407 tests passed.
+- `pnpm typecheck` — passed across the workspace.
+- `pnpm lint` — passed across the workspace.
+- `node tools/scripts/check-diff-coverage.mjs` — passed; the guard reported no coverage-eligible service files, so the daemon package tests above are the primary coverage evidence.
+- `pnpm test:mesh:browser-canary` — built-preview mesh canary passed.
+- `pnpm test:storycluster:correctness` — passed after fixing daemon radisk parent-directory creation for the daemon-first fixture lane.
+- `git diff --check` — passed.
 
 Acceptance target:
-- `kill -9` mid-synthesis does not lose accepted work; restart replays to terminal state.
+- `kill -9` mid-synthesis does not lose candidate work because the in-flight synthesis candidate remains in `pending.json` until worker completion.
+- Accepted-but-unwritten syntheses can be replayed from eval artifacts after leadership acquisition.
+
+Remaining PR3 packaging work:
+- Run broad workspace gates and CI.
+- Open PR, merge on green, and refresh local `main`.
 
 ### PR4 — Production Relay
 

--- a/services/news-aggregator/src/analysisEvalReplay.test.ts
+++ b/services/news-aggregator/src/analysisEvalReplay.test.ts
@@ -1,0 +1,156 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { TopicSynthesisV2 } from '@vh/data-model';
+import type { VennClient } from '@vh/gun-client';
+import {
+  loadAcceptedAnalysisEvalSyntheses,
+  replayAcceptedAnalysisEvalSyntheses,
+  resolveAnalysisEvalReplayArtifactDirFromEnv,
+} from './analysisEvalReplay';
+
+function synthesis(overrides: Partial<TopicSynthesisV2> = {}): TopicSynthesisV2 {
+  return {
+    schemaVersion: 'topic-synthesis-v2',
+    topic_id: 'topic-1',
+    epoch: 0,
+    synthesis_id: 'synthesis-1',
+    inputs: { story_bundle_ids: ['story-1'] },
+    quorum: {
+      required: 1,
+      received: 1,
+      reached_at: 100,
+      timed_out: false,
+      selection_rule: 'deterministic',
+    },
+    facts_summary: 'Fact summary.',
+    frames: [
+      {
+        frame: 'Frame',
+        reframe: 'Reframe',
+        frame_point_id: 'synth-point:synthesis-1:0:frame',
+        reframe_point_id: 'synth-point:synthesis-1:0:reframe',
+      },
+    ],
+    warnings: [],
+    divergence_metrics: {
+      disagreement_score: 0,
+      source_dispersion: 0,
+      candidate_count: 1,
+    },
+    provenance: {
+      candidate_ids: ['candidate-1'],
+      provider_mix: [{ provider_id: 'openai', count: 1 }],
+    },
+    created_at: 100,
+    ...overrides,
+  };
+}
+
+function writeArtifact(root: string, name: string, artifact: unknown): void {
+  const artifactDir = path.join(root, 'artifacts');
+  mkdirSync(artifactDir, { recursive: true });
+  writeFileSync(path.join(artifactDir, name), `${JSON.stringify(artifact, null, 2)}\n`, 'utf8');
+}
+
+describe('analysisEvalReplay', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('loads the latest accepted synthesis per topic from eval artifacts', async () => {
+    const tmpDir = mkdtempSync(path.join(os.tmpdir(), 'vh-analysis-eval-replay-'));
+    try {
+      writeArtifact(tmpDir, 'old.json', {
+        lifecycle_status: 'accepted',
+        captured_at: 100,
+        story: { story_id: 'story-old' },
+        final_accepted_synthesis: synthesis({ synthesis_id: 'synthesis-old', created_at: 100 }),
+      });
+      writeArtifact(tmpDir, 'new.json', {
+        lifecycle_status: 'accepted',
+        captured_at: 200,
+        story: { story_id: 'story-new' },
+        final_accepted_synthesis: synthesis({ synthesis_id: 'synthesis-new', created_at: 200 }),
+      });
+      writeArtifact(tmpDir, 'rejected.json', {
+        lifecycle_status: 'rejected',
+        final_accepted_synthesis: synthesis({ topic_id: 'topic-rejected' }),
+      });
+
+      const entries = await loadAcceptedAnalysisEvalSyntheses(tmpDir, {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      });
+
+      expect(entries).toHaveLength(1);
+      expect(entries[0]).toMatchObject({
+        story_id: 'story-new',
+        synthesis: {
+          synthesis_id: 'synthesis-new',
+        },
+      });
+    } finally {
+      rmSync(tmpDir, { force: true, recursive: true });
+    }
+  });
+
+  it('replays missing accepted syntheses and skips already-current topics', async () => {
+    const tmpDir = mkdtempSync(path.join(os.tmpdir(), 'vh-analysis-eval-write-'));
+    try {
+      const missing = synthesis({ topic_id: 'topic-missing', synthesis_id: 'synthesis-missing' });
+      const current = synthesis({ topic_id: 'topic-current', synthesis_id: 'synthesis-current' });
+      writeArtifact(tmpDir, 'missing.json', {
+        lifecycle_status: 'accepted',
+        captured_at: 100,
+        story: { story_id: 'story-missing' },
+        final_accepted_synthesis: missing,
+      });
+      writeArtifact(tmpDir, 'current.json', {
+        lifecycle_status: 'accepted',
+        captured_at: 100,
+        story: { story_id: 'story-current' },
+        final_accepted_synthesis: current,
+      });
+
+      const writeSynthesis = vi.fn(async (_client: VennClient, next: unknown) => next as TopicSynthesisV2);
+      const runWrite = vi.fn(async <T,>(_className: string, _attrs: Record<string, unknown>, task: () => Promise<T>) =>
+        task(),
+      );
+      const result = await replayAcceptedAnalysisEvalSyntheses({
+        client: {} as VennClient,
+        artifactDir: tmpDir,
+        logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+        readLatest: vi.fn(async (_client, topicId) => (topicId === 'topic-current' ? current : null)),
+        writeSynthesis,
+        runWrite,
+      });
+
+      expect(result).toEqual({
+        candidates: 2,
+        written: 1,
+        already_current: 1,
+        failed: 0,
+      });
+      expect(writeSynthesis).toHaveBeenCalledWith({}, missing);
+      expect(runWrite).toHaveBeenCalledWith(
+        'analysis_eval_replay',
+        expect.objectContaining({ topic_id: 'topic-missing', synthesis_id: 'synthesis-missing' }),
+        expect.any(Function),
+      );
+    } finally {
+      rmSync(tmpDir, { force: true, recursive: true });
+    }
+  });
+
+  it('resolves replay env only when replay or eval artifacts are enabled', () => {
+    expect(resolveAnalysisEvalReplayArtifactDirFromEnv()).toBeNull();
+
+    vi.stubEnv('VH_ANALYSIS_EVAL_REPLAY_ON_START', 'true');
+    vi.stubEnv('VH_ANALYSIS_EVAL_ARTIFACT_DIR', '/tmp/vh-artifacts');
+
+    expect(resolveAnalysisEvalReplayArtifactDirFromEnv()).toBe('/tmp/vh-artifacts');
+  });
+});

--- a/services/news-aggregator/src/analysisEvalReplay.ts
+++ b/services/news-aggregator/src/analysisEvalReplay.ts
@@ -1,0 +1,194 @@
+import { readdir, readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { TopicSynthesisV2Schema, type TopicSynthesisV2 } from '@vh/data-model';
+import {
+  readTopicLatestSynthesis,
+  writeTopicSynthesis,
+  type VennClient,
+} from '@vh/gun-client';
+import type { LoggerLike } from './daemonUtils';
+
+const DEFAULT_ARTIFACT_DIR = '.tmp/analysis-eval-artifacts';
+
+export interface AcceptedAnalysisEvalSynthesis {
+  artifact_path: string;
+  captured_at: number;
+  story_id: string | null;
+  synthesis: TopicSynthesisV2;
+}
+
+export interface AnalysisEvalReplayResult {
+  candidates: number;
+  written: number;
+  already_current: number;
+  failed: number;
+}
+
+export interface AnalysisEvalReplayOptions {
+  client: VennClient;
+  artifactDir: string;
+  logger?: LoggerLike;
+  readLatest?: typeof readTopicLatestSynthesis;
+  writeSynthesis?: typeof writeTopicSynthesis;
+  runWrite?: <T>(
+    writeClass: string,
+    attributes: Record<string, unknown>,
+    task: () => Promise<T>,
+  ) => Promise<T>;
+}
+
+function synthesisRank(entry: AcceptedAnalysisEvalSynthesis): [number, number, number] {
+  return [
+    Number.isFinite(entry.synthesis.epoch) ? entry.synthesis.epoch : 0,
+    Number.isFinite(entry.synthesis.created_at) ? entry.synthesis.created_at : 0,
+    Number.isFinite(entry.captured_at) ? entry.captured_at : 0,
+  ];
+}
+
+function compareRank(leftEntry: AcceptedAnalysisEvalSynthesis, rightEntry: AcceptedAnalysisEvalSynthesis): number {
+  const left = synthesisRank(leftEntry);
+  const right = synthesisRank(rightEntry);
+  for (let index = 0; index < left.length; index += 1) {
+    const leftValue = left[index] ?? 0;
+    const rightValue = right[index] ?? 0;
+    if (leftValue !== rightValue) {
+      return leftValue - rightValue;
+    }
+  }
+  return 0;
+}
+
+export async function loadAcceptedAnalysisEvalSyntheses(
+  artifactRoot: string,
+  logger: LoggerLike = console,
+): Promise<AcceptedAnalysisEvalSynthesis[]> {
+  const artifactDir = path.join(artifactRoot, 'artifacts');
+  let names: string[];
+  try {
+    names = await readdir(artifactDir);
+  } catch (error) {
+    logger.warn('[vh:analysis-eval-replay] artifact directory unavailable', {
+      artifact_dir: artifactDir,
+      error,
+    });
+    return [];
+  }
+
+  const latestByTopic = new Map<string, AcceptedAnalysisEvalSynthesis>();
+  for (const name of names) {
+    if (!name.endsWith('.json')) {
+      continue;
+    }
+    const artifactPath = path.join(artifactDir, name);
+    try {
+      const artifact = JSON.parse(await readFile(artifactPath, 'utf8')) as {
+        lifecycle_status?: unknown;
+        captured_at?: unknown;
+        story?: { story_id?: unknown };
+        final_accepted_synthesis?: unknown;
+      };
+      if (artifact.lifecycle_status !== 'accepted') {
+        continue;
+      }
+      const parsed = TopicSynthesisV2Schema.safeParse(artifact.final_accepted_synthesis);
+      if (!parsed.success) {
+        continue;
+      }
+      const entry: AcceptedAnalysisEvalSynthesis = {
+        artifact_path: artifactPath,
+        captured_at: typeof artifact.captured_at === 'number' ? artifact.captured_at : 0,
+        story_id: typeof artifact.story?.story_id === 'string' ? artifact.story.story_id : null,
+        synthesis: parsed.data,
+      };
+      const existing = latestByTopic.get(entry.synthesis.topic_id);
+      if (!existing || compareRank(existing, entry) <= 0) {
+        latestByTopic.set(entry.synthesis.topic_id, entry);
+      }
+    } catch (error) {
+      logger.warn('[vh:analysis-eval-replay] artifact parse failed', {
+        artifact_path: artifactPath,
+        error,
+      });
+    }
+  }
+
+  return [...latestByTopic.values()].sort((left, right) =>
+    left.synthesis.topic_id.localeCompare(right.synthesis.topic_id),
+  );
+}
+
+export async function replayAcceptedAnalysisEvalSyntheses(
+  options: AnalysisEvalReplayOptions,
+): Promise<AnalysisEvalReplayResult> {
+  const logger = options.logger ?? console;
+  const readLatest = options.readLatest ?? readTopicLatestSynthesis;
+  const writeSynthesisAdapter = options.writeSynthesis ?? writeTopicSynthesis;
+  const runWrite =
+    options.runWrite ??
+    (<T,>(_writeClass: string, _attributes: Record<string, unknown>, task: () => Promise<T>) => task());
+  const entries = await loadAcceptedAnalysisEvalSyntheses(options.artifactDir, logger);
+  const result: AnalysisEvalReplayResult = {
+    candidates: entries.length,
+    written: 0,
+    already_current: 0,
+    failed: 0,
+  };
+
+  for (const entry of entries) {
+    try {
+      const current = await readLatest(options.client, entry.synthesis.topic_id);
+      if (current?.synthesis_id === entry.synthesis.synthesis_id) {
+        result.already_current += 1;
+        continue;
+      }
+      await runWrite(
+        'analysis_eval_replay',
+        {
+          topic_id: entry.synthesis.topic_id,
+          synthesis_id: entry.synthesis.synthesis_id,
+          story_id: entry.story_id,
+        },
+        () => writeSynthesisAdapter(options.client, entry.synthesis),
+      );
+      result.written += 1;
+      logger.info('[vh:analysis-eval-replay] synthesis replayed', {
+        topic_id: entry.synthesis.topic_id,
+        story_id: entry.story_id,
+        synthesis_id: entry.synthesis.synthesis_id,
+      });
+    } catch (error) {
+      result.failed += 1;
+      logger.warn('[vh:analysis-eval-replay] synthesis replay failed', {
+        topic_id: entry.synthesis.topic_id,
+        story_id: entry.story_id,
+        synthesis_id: entry.synthesis.synthesis_id,
+        error,
+      });
+    }
+  }
+
+  logger.info('[vh:analysis-eval-replay] complete', {
+    artifact_dir: options.artifactDir,
+    ...result,
+  });
+  return result;
+}
+
+function isTruthyFlag(value: string | undefined): boolean {
+  if (!value) {
+    return false;
+  }
+  const normalized = value.trim().toLowerCase();
+  return normalized.length > 0 && !['0', 'false', 'off', 'no'].includes(normalized);
+}
+
+export function resolveAnalysisEvalReplayArtifactDirFromEnv(): string | null {
+  if (
+    !isTruthyFlag(process.env.VH_ANALYSIS_EVAL_REPLAY_ON_START) &&
+    !isTruthyFlag(process.env.VH_ANALYSIS_EVAL_ARTIFACTS_ENABLED)
+  ) {
+    return null;
+  }
+  const configuredDir = process.env.VH_ANALYSIS_EVAL_ARTIFACT_DIR?.trim();
+  return configuredDir || path.resolve(process.cwd(), DEFAULT_ARTIFACT_DIR);
+}

--- a/services/news-aggregator/src/bundleSynthesisDaemonConfig.test.ts
+++ b/services/news-aggregator/src/bundleSynthesisDaemonConfig.test.ts
@@ -26,11 +26,13 @@ describe('bundleSynthesisDaemonConfig', () => {
     const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
     vi.stubEnv('VH_BUNDLE_SYNTHESIS_ENABLED', 'true');
     vi.stubEnv('VH_BUNDLE_SYNTHESIS_QUEUE_DEPTH', '7');
+    vi.stubEnv('VH_DAEMON_FEED_ARTIFACT_ROOT', '/tmp/vh-artifacts');
 
     const enrichment = createBundleSynthesisEnrichmentFromEnv({} as VennClient, logger);
 
     expect(typeof enrichment.enrichmentWorker).toBe('function');
     expect(enrichment.enrichmentQueueOptions?.maxDepth).toBe(7);
+    expect(enrichment.enrichmentQueueOptions?.persistenceDir).toBe('/tmp/vh-artifacts/bundle-synthesis-queue');
 
     enrichment.enrichmentQueueOptions?.onDrop?.(
       {
@@ -43,7 +45,7 @@ describe('bundleSynthesisDaemonConfig', () => {
     );
 
     expect(logger.warn).toHaveBeenCalledWith(
-      '[vh:bundle-synthesis] queue full; candidate dropped',
+      '[vh:bundle-synthesis] queue full; candidate dead-lettered for replay',
       { story_id: 'story-1', max_depth: 7 },
     );
   });

--- a/services/news-aggregator/src/bundleSynthesisDaemonConfig.ts
+++ b/services/news-aggregator/src/bundleSynthesisDaemonConfig.ts
@@ -1,3 +1,5 @@
+import os from 'node:os';
+import path from 'node:path';
 import type { VennClient } from '@vh/gun-client';
 import {
   parsePositiveInt,
@@ -21,6 +23,14 @@ export interface BundleSynthesisDaemonEnrichment {
   enrichmentQueueOptions?: AsyncEnrichmentQueueOptions;
 }
 
+export interface BundleSynthesisDaemonOptions {
+  runWrite?: <T>(
+    writeClass: string,
+    attributes: Record<string, unknown>,
+    task: () => Promise<T>,
+  ) => Promise<T>;
+}
+
 export function isTruthyFlag(value: string | undefined): boolean {
   if (!value) {
     return false;
@@ -40,6 +50,7 @@ function parseFiniteNumber(raw: string | undefined, fallback: number): number {
 export function createBundleSynthesisEnrichmentFromEnv(
   client: VennClient,
   logger: LoggerLike = console,
+  options: BundleSynthesisDaemonOptions = {},
 ): BundleSynthesisDaemonEnrichment {
   const enabled = isTruthyFlag(readEnvVar('VH_BUNDLE_SYNTHESIS_ENABLED'));
   if (!enabled) {
@@ -62,7 +73,16 @@ export function createBundleSynthesisEnrichmentFromEnv(
     ),
     pipelineVersion: readEnvVar('VH_BUNDLE_SYNTHESIS_PIPELINE_VERSION') ?? DEFAULT_BUNDLE_SYNTHESIS_PIPELINE_VERSION,
     logger,
+    runWrite: options.runWrite,
   });
+  const artifactRoot = readEnvVar('VH_DAEMON_FEED_ARTIFACT_ROOT');
+  const stateRoot = readEnvVar('VH_NEWS_DAEMON_STATE_DIR');
+  const queuePersistenceDir =
+    readEnvVar('VH_BUNDLE_SYNTHESIS_QUEUE_DIR') ??
+    path.join(
+      (stateRoot?.trim() || artifactRoot?.trim() || path.join(os.tmpdir(), 'vh-news-daemon')),
+      'bundle-synthesis-queue',
+    );
 
   return {
     enrichmentWorker: async (candidate) => {
@@ -70,8 +90,9 @@ export function createBundleSynthesisEnrichmentFromEnv(
     },
     enrichmentQueueOptions: {
       maxDepth: queueDepth,
+      persistenceDir: queuePersistenceDir,
       onDrop(candidate) {
-        logger.warn('[vh:bundle-synthesis] queue full; candidate dropped', {
+        logger.warn('[vh:bundle-synthesis] queue full; candidate dead-lettered for replay', {
           story_id: candidate.story_id,
           max_depth: queueDepth,
         });

--- a/services/news-aggregator/src/bundleSynthesisWorker.test.ts
+++ b/services/news-aggregator/src/bundleSynthesisWorker.test.ts
@@ -3,7 +3,7 @@ import type { NewsRuntimeSynthesisCandidate } from '@vh/ai-engine';
 import type { CandidateSynthesis, StoryBundle, TopicSynthesisV2 } from '@vh/data-model';
 import type { VennClient } from '@vh/gun-client';
 import type { AnalysisEvalArtifact } from './analysisEvalArtifacts';
-import { createBundleSynthesisWorker } from './bundleSynthesisWorker';
+import { createBundleSynthesisWorker, type BundleSynthesisWorkerConfig } from './bundleSynthesisWorker';
 
 const BUNDLE: StoryBundle = {
   schemaVersion: 'story-bundle-v0',
@@ -228,6 +228,10 @@ describe('bundleSynthesisWorker', () => {
       expect(options?.canOverwriteExisting?.({ ...synthesis, synthesis_id: 'news-bundle:old' }, synthesis)).toBe(true);
       return { status: 'written' as const, synthesis, previous: null };
     });
+    const runWriteMock = vi.fn(
+      async <T,>(_writeClass: string, _attributes: Record<string, unknown>, task: () => Promise<T>) => task(),
+    );
+    const runWrite: NonNullable<BundleSynthesisWorkerConfig['runWrite']> = runWriteMock;
 
     const worker = createBundleSynthesisWorker({
       client: {} as VennClient,
@@ -243,6 +247,7 @@ describe('bundleSynthesisWorker', () => {
         return synthesis;
       }),
       writeLatest,
+      runWrite,
       analysisEvalArtifactWriter: {
         write: vi.fn(async (artifact) => {
           artifacts.push(artifact);
@@ -293,6 +298,11 @@ describe('bundleSynthesisWorker', () => {
     expect(writtenSyntheses[0]?.frames[0]?.frame_point_id).toMatch(/^synth-point:/);
     expect(writtenSyntheses[0]?.synthesis_id).toMatch(/^news-bundle:story-1:/);
     expect(writeLatest).toHaveBeenCalledTimes(1);
+    expect(runWriteMock.mock.calls.map((call) => call[0])).toEqual([
+      'synthesis_candidate',
+      'synthesis_epoch',
+      'synthesis_latest',
+    ]);
     expect(artifacts).toHaveLength(1);
     expect(artifacts[0]).toMatchObject({
       schema_version: 'analysis-eval-artifact-v1',

--- a/services/news-aggregator/src/bundleSynthesisWorker.ts
+++ b/services/news-aggregator/src/bundleSynthesisWorker.ts
@@ -76,6 +76,11 @@ export interface BundleSynthesisWorkerConfig {
   writeCandidate?: (client: VennClient, candidate: CandidateSynthesis) => Promise<CandidateSynthesis>;
   writeSynthesis?: (client: VennClient, synthesis: TopicSynthesisV2) => Promise<TopicSynthesisV2>;
   writeLatest?: typeof writeTopicLatestSynthesisIfNotDowngrade;
+  runWrite?: <T>(
+    writeClass: string,
+    attributes: Record<string, unknown>,
+    task: () => Promise<T>,
+  ) => Promise<T>;
 }
 
 export function createBundleSynthesisWorker(
@@ -99,6 +104,37 @@ export function createBundleSynthesisWorker(
   const writeCandidate = config.writeCandidate ?? writeTopicEpochCandidate;
   const writeSynthesis = config.writeSynthesis ?? writeTopicEpochSynthesis;
   const writeLatest = config.writeLatest ?? writeTopicLatestSynthesisIfNotDowngrade;
+  const runWrite = config.runWrite ?? (<T>(_: string, __: Record<string, unknown>, task: () => Promise<T>) => task());
+  const writeCandidateWithLane = (client: VennClient, candidatePayload: CandidateSynthesis) =>
+    runWrite(
+      'synthesis_candidate',
+      {
+        topic_id: candidatePayload.topic_id,
+        candidate_id: candidatePayload.candidate_id,
+      },
+      () => writeCandidate(client, candidatePayload),
+    );
+  const writeSynthesisWithLane = (client: VennClient, synthesis: TopicSynthesisV2) =>
+    runWrite(
+      'synthesis_epoch',
+      {
+        topic_id: synthesis.topic_id,
+        synthesis_id: synthesis.synthesis_id,
+      },
+      () => writeSynthesis(client, synthesis),
+    );
+  const writeLatestWithLane: typeof writeTopicLatestSynthesisIfNotDowngrade = (client, synthesis, options) =>
+    {
+      const candidateSynthesis = synthesis as Partial<TopicSynthesisV2>;
+      return runWrite(
+        'synthesis_latest',
+        {
+          topic_id: candidateSynthesis.topic_id ?? null,
+          synthesis_id: candidateSynthesis.synthesis_id ?? null,
+        },
+        () => writeLatest(client, synthesis, options),
+      );
+    };
 
   return async (candidate) => {
     const storyId = candidate.story_id;
@@ -176,8 +212,8 @@ export function createBundleSynthesisWorker(
         frames: existingCandidate.frames,
         warnings: existingCandidate.warnings,
         createdAt: existingCandidate.created_at,
-        writeSynthesis,
-        writeLatest,
+        writeSynthesis: writeSynthesisWithLane,
+        writeLatest: writeLatestWithLane,
       });
       logger.info('[vh:bundle-synthesis] duplicate candidate recovered synthesis; skipped model call', {
         story_id: storyId,
@@ -297,7 +333,7 @@ export function createBundleSynthesisWorker(
       model: response.model,
       now: createdAt,
     });
-    await writeCandidate(config.client, candidatePayload);
+    await writeCandidateWithLane(config.client, candidatePayload);
     const { latestStatus, synthesis } = await writeAcceptedSynthesis({
       client: config.client,
       bundle,
@@ -307,8 +343,8 @@ export function createBundleSynthesisWorker(
       frames,
       warnings,
       createdAt,
-      writeSynthesis,
-      writeLatest,
+      writeSynthesis: writeSynthesisWithLane,
+      writeLatest: writeLatestWithLane,
     });
     await persistAcceptedBundleSynthesisEvalArtifact({
       context: artifactContext,

--- a/services/news-aggregator/src/daemon.coverage.test.ts
+++ b/services/news-aggregator/src/daemon.coverage.test.ts
@@ -64,6 +64,12 @@ async function flushMicrotasks(): Promise<void> {
   await Promise.resolve();
 }
 
+async function flushAsyncTasks(): Promise<void> {
+  await flushMicrotasks();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await flushMicrotasks();
+}
+
 describe('news daemon coverage guards', () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -267,7 +273,7 @@ describe('news daemon coverage guards', () => {
     await daemon.start();
     const heartbeatTick = timers.ticks[0];
     heartbeatTick?.();
-    await flushMicrotasks();
+    await flushAsyncTasks();
 
     expect(runtimeHandle.stop).toHaveBeenCalledTimes(1);
     expect(logger.warn).toHaveBeenCalledWith('[vh:news-daemon] lease heartbeat failed', expect.any(Error));
@@ -278,7 +284,7 @@ describe('news daemon coverage guards', () => {
 
     const writesAfterStop = writeLease.mock.calls.length;
     heartbeatTick?.();
-    await flushMicrotasks();
+    await flushAsyncTasks();
     expect(writeLease).toHaveBeenCalledTimes(writesAfterStop);
   });
 

--- a/services/news-aggregator/src/daemon.env.test.ts
+++ b/services/news-aggregator/src/daemon.env.test.ts
@@ -145,6 +145,8 @@ describe('startNewsAggregatorDaemonFromEnv', () => {
     expect(createNodeMeshClient).toHaveBeenCalledWith({
       peers: ['http://127.0.0.1:7777/gun'],
       requireSession: false,
+      gunRadisk: true,
+      gunFile: expect.stringContaining('vh-news-daemon:test'),
     });
     expect(startNewsRuntime).toHaveBeenCalledWith(
       expect.objectContaining<Partial<NewsRuntimeConfig>>({
@@ -191,12 +193,47 @@ describe('startNewsAggregatorDaemonFromEnv', () => {
     expect(createNodeMeshClient).toHaveBeenCalledWith({
       peers: undefined,
       requireSession: false,
+      gunRadisk: true,
+      gunFile: expect.stringContaining('default'),
     });
     expect(startNewsRuntime).toHaveBeenCalledWith(
       expect.objectContaining<Partial<NewsRuntimeConfig>>({
         pollIntervalMs: undefined,
       }),
     );
+
+    await processHandle.stop();
+  });
+
+  it('allows daemon radisk to be explicitly disabled for hermetic tests', async () => {
+    const {
+      subject,
+      createNodeMeshClient,
+    } = await loadSubject({
+      env: {
+        VITE_NEWS_FEED_SOURCES: '[]',
+        VITE_NEWS_TOPIC_MAPPING: '{}',
+        VITE_NEWS_POLL_INTERVAL_MS: null,
+        VH_NEWS_RUNTIME_LEASE_TTL_MS: null,
+        VITE_NEWS_RUNTIME_LEASE_TTL_MS: '60000',
+        VH_GUN_PEERS: null,
+        VITE_GUN_PEERS: null,
+        VH_NEWS_DAEMON_HOLDER_ID: null,
+        VH_NEWS_DAEMON_GUN_RADISK: 'false',
+      },
+      gunPeers: [],
+      pollIntervalMs: undefined,
+      leaseTtlMs: 60_000,
+    });
+
+    const processHandle = await subject.startNewsAggregatorDaemonFromEnv();
+
+    expect(createNodeMeshClient).toHaveBeenCalledWith({
+      peers: undefined,
+      requireSession: false,
+      gunRadisk: false,
+      gunFile: false,
+    });
 
     await processHandle.stop();
   });

--- a/services/news-aggregator/src/daemon.production.test.ts
+++ b/services/news-aggregator/src/daemon.production.test.ts
@@ -174,6 +174,8 @@ describe('news daemon production wiring', () => {
       expect(mocks.createNodeMeshClient).toHaveBeenCalledWith({
         peers: ['https://peer-a.example/gun', 'https://peer-b.example/gun'],
         requireSession: false,
+        gunRadisk: true,
+        gunFile: expect.any(String),
       });
     } finally {
       await handle.stop();

--- a/services/news-aggregator/src/daemon.test.ts
+++ b/services/news-aggregator/src/daemon.test.ts
@@ -188,6 +188,50 @@ describe('news aggregator daemon', () => {
     await daemon.stop();
   });
 
+  it('replays accepted synthesis artifacts once after acquiring leadership', async () => {
+    const logger = makeLogger();
+    const runtimeHandle = makeRuntimeHandle();
+    const timers = makeTimerControls();
+    const replayAcceptedSynthesis = vi.fn().mockResolvedValue({ written: 1 });
+
+    const startRuntime = vi.fn(() => runtimeHandle);
+    const readLease = vi.fn().mockResolvedValue(null);
+    const writeLease = vi.fn(async (_client: VennClient, lease: unknown) => lease as NewsIngestionLease);
+
+    const daemon = createNewsAggregatorDaemon({
+      client: { id: 'client-replay' } as VennClient,
+      feedSources: [...FEED_SOURCES],
+      topicMapping: { ...TOPIC_MAPPING },
+      startRuntime,
+      readLease,
+      writeLease,
+      replayAcceptedSynthesis,
+      logger,
+      setIntervalFn: timers.setIntervalFn,
+      clearIntervalFn: timers.clearIntervalFn,
+      now: () => 1_700_000_000_000,
+      random: () => 0.12345,
+      leaseHolderId: 'vh-news-daemon:test',
+    });
+
+    await daemon.start();
+
+    expect(replayAcceptedSynthesis).toHaveBeenCalledTimes(1);
+    expect(replayAcceptedSynthesis).toHaveBeenCalledWith({ id: 'client-replay' });
+    expect(replayAcceptedSynthesis.mock.invocationCallOrder[0]).toBeLessThan(
+      startRuntime.mock.invocationCallOrder[0],
+    );
+
+    const heartbeatTick = timers.ticks[0];
+    heartbeatTick?.();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(replayAcceptedSynthesis).toHaveBeenCalledTimes(1);
+
+    await daemon.stop();
+  });
+
   it('refuses publish writes when daemon lease is no longer held', async () => {
     const logger = makeLogger();
     const runtimeHandle = makeRuntimeHandle();

--- a/services/news-aggregator/src/daemon.ts
+++ b/services/news-aggregator/src/daemon.ts
@@ -1,3 +1,6 @@
+import { mkdirSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import {
   startNewsRuntime,
   type FeedSource,
@@ -31,6 +34,7 @@ import {
   resolveLeaseHolderId,
   verifyStoryClusterHealth,
   type AsyncEnrichmentQueueOptions,
+  type EnrichmentQueueSnapshot,
   type EnrichmentWorker,
   type LoggerLike,
 } from './daemonUtils';
@@ -41,6 +45,15 @@ import {
   isTruthyFlag,
 } from './bundleSynthesisDaemonConfig';
 import { isDirectExecution, runFromCli } from './daemonCli';
+import {
+  createDaemonWriteLaneRegistry,
+  type DaemonWriteLaneRegistry,
+  type DaemonWriteLaneSnapshot,
+} from './daemonWriteLane';
+import {
+  replayAcceptedAnalysisEvalSyntheses,
+  resolveAnalysisEvalReplayArtifactDirFromEnv,
+} from './analysisEvalReplay';
 type RuntimeStarter = (config: NewsRuntimeConfig) => NewsRuntimeHandle;
 type RuntimeOrchestratorOptions = NonNullable<NewsRuntimeConfig['orchestratorOptions']> & {
   remoteClusterMaxItemsPerRequest?: number;
@@ -60,6 +73,8 @@ export interface NewsAggregatorDaemonConfig {
   removeBundle?: (client: VennClient, storyId: string) => Promise<unknown>;
   enrichmentWorker?: EnrichmentWorker;
   enrichmentQueueOptions?: AsyncEnrichmentQueueOptions;
+  writeLanes?: DaemonWriteLaneRegistry;
+  replayAcceptedSynthesis?: (client: VennClient) => Promise<unknown>;
   runtimeOrchestratorOptions?: NewsRuntimeConfig['orchestratorOptions'];
   now?: () => number;
   random?: () => number;
@@ -74,6 +89,9 @@ export interface NewsAggregatorDaemonHandle {
   isRunning(): boolean;
   currentLease(): NewsIngestionLease | null;
   enrichmentQueueDepth(): number;
+  enrichmentQueueDeadLetterCount(): number;
+  enrichmentQueueStats(): EnrichmentQueueSnapshot;
+  writeLaneStats(): DaemonWriteLaneSnapshot[];
 }
 export function createNewsAggregatorDaemon(config: NewsAggregatorDaemonConfig): NewsAggregatorDaemonHandle {
   const logger = config.logger ?? console;
@@ -90,10 +108,14 @@ export function createNewsAggregatorDaemon(config: NewsAggregatorDaemonConfig): 
   const leaseRenewIntervalMs = Math.max(5_000, Math.floor(leaseTtlMs / 2));
   const leaseVerificationWindowMs = Math.max(500, Math.min(5_000, Math.floor(leaseTtlMs / 6)));
   const holderId = resolveLeaseHolderId(config.leaseHolderId);
+  const writeLanes = config.writeLanes ?? createDaemonWriteLaneRegistry({ logger, now: nowFn });
   const queue = createAsyncEnrichmentQueue(
     config.enrichmentWorker ?? (() => undefined),
     logger,
-    config.enrichmentQueueOptions,
+    {
+      ...(config.enrichmentQueueOptions ?? {}),
+      autoStart: false,
+    },
   );
   const clusterCaptureRecorder = createDaemonFeedClusterCaptureRecorder(
     readEnvVar('VH_DAEMON_FEED_RUN_ID'),
@@ -102,6 +124,7 @@ export function createNewsAggregatorDaemon(config: NewsAggregatorDaemonConfig): 
   let runtimeHandle: NewsRuntimeHandle | null = null;
   let leaseHeartbeatTimer: ReturnType<typeof setInterval> | null = null;
   let leadershipTickPromise: Promise<void> | null = null;
+  let acceptedSynthesisReplayAttempted = false;
   const leaseGuard = createLeaseGuard({ client: config.client, readLease, verificationWindowMs: leaseVerificationWindowMs });
   const stopRuntime = () => {
     if (!runtimeHandle) {
@@ -133,23 +156,40 @@ export function createNewsAggregatorDaemon(config: NewsAggregatorDaemonConfig): 
       gunClient: config.client,
       pollIntervalMs: config.pollIntervalMs,
       writeStoryBundle: async (runtimeClient: unknown, bundle: unknown) => {
+        const storyId = typeof bundle === 'object' && bundle !== null ? (bundle as { story_id?: unknown }).story_id : null;
         await leaseGuard.assertHeld(nowFn());
-        return writeBundle(runtimeClient as VennClient, bundle);
+        return writeLanes.run('news_bundle', { story_id: storyId ?? null }, async () => {
+          return writeBundle(runtimeClient as VennClient, bundle);
+        });
       },
       removeStoryBundle: async (runtimeClient: unknown, storyId: string) => {
         await leaseGuard.assertHeld(nowFn());
-        return removeBundle(runtimeClient as VennClient, storyId);
+        return writeLanes.run('news_bundle_remove', { story_id: storyId }, async () => {
+          return removeBundle(runtimeClient as VennClient, storyId);
+        });
       },
       writeStorylineGroup: async (runtimeClient: unknown, storyline: unknown) => {
+        const storylineId =
+          typeof storyline === 'object' && storyline !== null
+            ? (storyline as { storyline_id?: unknown }).storyline_id
+            : null;
         await leaseGuard.assertHeld(nowFn());
-        return writeNewsStoryline(runtimeClient as VennClient, storyline);
+        return writeLanes.run('storyline', { storyline_id: storylineId ?? null }, async () => {
+          return writeNewsStoryline(runtimeClient as VennClient, storyline);
+        });
       },
       removeStorylineGroup: async (runtimeClient: unknown, storylineId: string) => {
         await leaseGuard.assertHeld(nowFn());
-        return removeNewsStoryline(runtimeClient as VennClient, storylineId);
+        return writeLanes.run('storyline_remove', { storyline_id: storylineId }, async () => {
+          return removeNewsStoryline(runtimeClient as VennClient, storylineId);
+        });
       },
       onSynthesisCandidate(candidate) {
         queue.enqueue(candidate);
+        logger.info('[vh:news-daemon] enrichment candidate enqueued', {
+          story_id: candidate.story_id,
+          ...queue.snapshot(),
+        });
       },
       onError(error) {
         logger.warn('[vh:news-daemon] runtime tick failed', error);
@@ -157,7 +197,12 @@ export function createNewsAggregatorDaemon(config: NewsAggregatorDaemonConfig): 
       orchestratorOptions,
     });
     if (runtimeHandle.isRunning()) {
-      logger.info('[vh:news-daemon] runtime started', { holder_id: holderId, poll_interval_ms: config.pollIntervalMs ?? null });
+      queue.start();
+      logger.info('[vh:news-daemon] runtime started', {
+        holder_id: holderId,
+        poll_interval_ms: config.pollIntervalMs ?? null,
+        enrichment_queue: queue.snapshot(),
+      });
       return;
     }
     runtimeHandle = null;
@@ -178,6 +223,7 @@ export function createNewsAggregatorDaemon(config: NewsAggregatorDaemonConfig): 
     if (currentLease && currentLease.holder_id !== holderId && currentLease.expires_at > nowMs) {
       logger.warn('[vh:news-daemon] lease held by another writer; runtime stays stopped', { holder_id: holderId, observed_lease_holder_id: currentLease.holder_id, observed_lease_expires_at: currentLease.expires_at });
       leaseGuard.clear();
+      queue.pause();
       stopRuntime();
       return;
     }
@@ -188,9 +234,19 @@ export function createNewsAggregatorDaemon(config: NewsAggregatorDaemonConfig): 
       leaseTtlMs,
       randomFn,
     );
-    const lease = await writeLease(config.client, nextLease);
+    const lease = await writeLanes.run('lease', { holder_id: holderId, operation: 'heartbeat' }, async () =>
+      writeLease(config.client, nextLease),
+    );
     leaseGuard.accept(lease, nowMs);
     logger.info('[vh:news-daemon] lease acquired', { holder_id: holderId, lease_holder_id: lease.holder_id, lease_token: lease.lease_token, expires_at: lease.expires_at });
+    if (!acceptedSynthesisReplayAttempted && config.replayAcceptedSynthesis) {
+      acceptedSynthesisReplayAttempted = true;
+      try {
+        await config.replayAcceptedSynthesis(config.client);
+      } catch (error) {
+        logger.warn('[vh:news-daemon] accepted synthesis replay failed', error);
+      }
+    }
     startRuntimeIfNeeded();
   };
   const runLeadershipTick = async (): Promise<void> => {
@@ -216,7 +272,9 @@ export function createNewsAggregatorDaemon(config: NewsAggregatorDaemonConfig): 
       return;
     }
     try {
-      await writeLease(config.client, releaseLease);
+      await writeLanes.run('lease', { holder_id: holderId, operation: 'release' }, async () =>
+        writeLease(config.client, releaseLease),
+      );
     } catch (error) {
       logger.warn('[vh:news-daemon] failed to release lease', error);
     } finally {
@@ -248,6 +306,7 @@ export function createNewsAggregatorDaemon(config: NewsAggregatorDaemonConfig): 
       queue.stop();
       stopRuntime();
       await releaseLease();
+      writeLanes.stop();
       logger.info('[vh:news-daemon] stopped', { holder_id: holderId });
     },
     isRunning() {
@@ -259,12 +318,49 @@ export function createNewsAggregatorDaemon(config: NewsAggregatorDaemonConfig): 
     enrichmentQueueDepth() {
       return queue.size();
     },
+    enrichmentQueueDeadLetterCount() {
+      return queue.deadLetterCount();
+    },
+    enrichmentQueueStats() {
+      return queue.snapshot();
+    },
+    writeLaneStats() {
+      return writeLanes.snapshot();
+    },
   };
 }
 export interface NewsAggregatorDaemonProcessHandle {
   daemon: NewsAggregatorDaemonHandle;
   client: VennClient;
   stop(): Promise<void>;
+}
+
+function firstNonEmpty(...values: Array<string | undefined>): string | undefined {
+  for (const value of values) {
+    const trimmed = value?.trim();
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+  return undefined;
+}
+
+function isDisabledFlag(value: string | undefined): boolean {
+  const normalized = value?.trim().toLowerCase();
+  return normalized === '0' || normalized === 'false' || normalized === 'off' || normalized === 'no';
+}
+
+function safePathToken(value: string): string {
+  return value.trim().replace(/[^a-zA-Z0-9._:-]+/g, '_') || 'default';
+}
+
+function resolveNewsDaemonGunFile(holderId: string | undefined): string {
+  const stateRoot =
+    firstNonEmpty(
+      readEnvVar('VH_NEWS_DAEMON_STATE_DIR'),
+      readEnvVar('VH_DAEMON_FEED_ARTIFACT_ROOT'),
+    ) ?? path.join(os.tmpdir(), 'vh-news-daemon');
+  return path.join(stateRoot, 'node-mesh-radisk', safePathToken(holderId ?? 'default'));
 }
 
 export async function startNewsAggregatorDaemonFromEnv(): Promise<NewsAggregatorDaemonProcessHandle> {
@@ -291,18 +387,42 @@ export async function startNewsAggregatorDaemonFromEnv(): Promise<NewsAggregator
       reportPath: feedSourceResolution.sourceHealth.reportPath,
     });
   }
+  const holderId = readEnvVar('VH_NEWS_DAEMON_HOLDER_ID');
+  const gunRadisk = !isDisabledFlag(readEnvVar('VH_NEWS_DAEMON_GUN_RADISK'));
+  const gunFile = gunRadisk
+    ? firstNonEmpty(readEnvVar('VH_NEWS_DAEMON_GUN_FILE')) ?? resolveNewsDaemonGunFile(holderId)
+    : false;
+  if (typeof gunFile === 'string') {
+    mkdirSync(path.dirname(gunFile), { recursive: true });
+  }
+  const writeLanes = createDaemonWriteLaneRegistry({ logger: console });
   const client = createNodeMeshClient({
     peers: gunPeers.length > 0 ? gunPeers : undefined,
     requireSession: false,
+    gunRadisk,
+    gunFile,
   });
-  const bundleSynthesisEnrichment = createBundleSynthesisEnrichmentFromEnv(client, console);
+  const bundleSynthesisEnrichment = createBundleSynthesisEnrichmentFromEnv(client, console, {
+    runWrite: writeLanes.run,
+  });
+  const replayArtifactDir = resolveAnalysisEvalReplayArtifactDirFromEnv();
   const daemon = createNewsAggregatorDaemon({
     client,
     feedSources,
     topicMapping,
     pollIntervalMs,
     leaseTtlMs,
-    leaseHolderId: readEnvVar('VH_NEWS_DAEMON_HOLDER_ID'),
+    leaseHolderId: holderId,
+    writeLanes,
+    replayAcceptedSynthesis: replayArtifactDir
+      ? (runtimeClient) =>
+          replayAcceptedAnalysisEvalSyntheses({
+            client: runtimeClient,
+            artifactDir: replayArtifactDir,
+            logger: console,
+            runWrite: writeLanes.run,
+          })
+      : undefined,
     ...bundleSynthesisEnrichment,
     runtimeOrchestratorOptions: {
       productionMode: true,

--- a/services/news-aggregator/src/daemonUtils.test.ts
+++ b/services/news-aggregator/src/daemonUtils.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -160,6 +160,141 @@ describe('daemonUtils', () => {
         request: expect.objectContaining({ prompt: 'fresh' }),
       }),
     );
+  });
+
+  it('persists pending enrichment candidates and replays them on restart', async () => {
+    const tmpDir = mkdtempSync(path.join(os.tmpdir(), 'vh-enrichment-queue-'));
+    try {
+      const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+      const firstWorker = vi.fn(async () => undefined);
+      const firstQueue = createAsyncEnrichmentQueue(firstWorker, logger, {
+        autoStart: false,
+        persistenceDir: tmpDir,
+      });
+
+      firstQueue.enqueue({ ...CANDIDATE, story_id: 'story-persisted' });
+      expect(firstQueue.size()).toBe(1);
+      firstQueue.stop();
+
+      const replayWorker = vi.fn(async () => undefined);
+      const replayQueue = createAsyncEnrichmentQueue(replayWorker, logger, {
+        autoStart: false,
+        persistenceDir: tmpDir,
+      });
+
+      expect(replayQueue.size()).toBe(1);
+      replayQueue.start();
+      await flushMicrotasks();
+      await flushMicrotasks();
+
+      expect(replayWorker).toHaveBeenCalledWith(expect.objectContaining({ story_id: 'story-persisted' }));
+      expect(replayQueue.size()).toBe(0);
+    } finally {
+      rmSync(tmpDir, { force: true, recursive: true });
+    }
+  });
+
+  it('keeps in-flight enrichment candidates in the persisted replay file until completion', async () => {
+    const tmpDir = mkdtempSync(path.join(os.tmpdir(), 'vh-enrichment-inflight-'));
+    try {
+      const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+      let resolveWorker: (() => void) | null = null;
+      const queue = createAsyncEnrichmentQueue(
+        vi.fn(
+          () =>
+            new Promise<void>((resolve) => {
+              resolveWorker = resolve;
+            }),
+        ),
+        logger,
+        {
+          persistenceDir: tmpDir,
+        },
+      );
+
+      queue.enqueue({ ...CANDIDATE, story_id: 'story-in-flight' });
+      await flushMicrotasks();
+      await flushMicrotasks();
+
+      expect(queue.snapshot()).toMatchObject({ pending_depth: 0, in_flight: 1 });
+      const pendingDuringWork = readFileSync(path.join(tmpDir, 'pending.json'), 'utf8');
+      expect(pendingDuringWork).toContain('"story_id": "story-in-flight"');
+
+      resolveWorker?.();
+      await flushMicrotasks();
+      await flushMicrotasks();
+
+      const pendingAfterWork = readFileSync(path.join(tmpDir, 'pending.json'), 'utf8');
+      expect(pendingAfterWork).not.toContain('"story_id": "story-in-flight"');
+    } finally {
+      rmSync(tmpDir, { force: true, recursive: true });
+    }
+  });
+
+  it('dead-letters queue overflow candidates and replays them on restart', async () => {
+    const tmpDir = mkdtempSync(path.join(os.tmpdir(), 'vh-enrichment-dlq-'));
+    try {
+      const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+      const firstQueue = createAsyncEnrichmentQueue(vi.fn(async () => undefined), logger, {
+        autoStart: false,
+        maxDepth: 1,
+        persistenceDir: tmpDir,
+        now: () => 1_700_000_000_000,
+      });
+
+      firstQueue.enqueue({ ...CANDIDATE, story_id: 'story-overflow' });
+      firstQueue.enqueue({ ...CANDIDATE, story_id: 'story-current' });
+
+      expect(firstQueue.size()).toBe(1);
+      expect(firstQueue.deadLetterCount()).toBe(1);
+      firstQueue.stop();
+
+      const replayWorker = vi.fn(async () => undefined);
+      const replayQueue = createAsyncEnrichmentQueue(replayWorker, logger, {
+        autoStart: false,
+        persistenceDir: tmpDir,
+      });
+
+      expect(replayQueue.size()).toBe(2);
+      expect(replayQueue.deadLetterCount()).toBe(0);
+      replayQueue.start();
+      await flushMicrotasks();
+      await flushMicrotasks();
+
+      expect(replayWorker).toHaveBeenCalledWith(expect.objectContaining({ story_id: 'story-current' }));
+      expect(replayWorker).toHaveBeenCalledWith(expect.objectContaining({ story_id: 'story-overflow' }));
+      expect(replayQueue.size()).toBe(0);
+    } finally {
+      rmSync(tmpDir, { force: true, recursive: true });
+    }
+  });
+
+  it('records terminal worker failures in the enrichment DLQ', async () => {
+    const tmpDir = mkdtempSync(path.join(os.tmpdir(), 'vh-enrichment-failed-'));
+    try {
+      const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+      const queue = createAsyncEnrichmentQueue(
+        vi.fn(async () => {
+          throw new Error('permanent worker failure');
+        }),
+        logger,
+        {
+          persistenceDir: tmpDir,
+          now: () => 1_700_000_000_000,
+        },
+      );
+
+      queue.enqueue({ ...CANDIDATE, story_id: 'story-failed' });
+      await flushMicrotasks();
+      await flushMicrotasks();
+
+      expect(queue.deadLetterCount()).toBe(1);
+      const deadLetter = readFileSync(path.join(tmpDir, 'dead-letter.jsonl'), 'utf8');
+      expect(deadLetter).toContain('"reason":"worker_failed"');
+      expect(deadLetter).toContain('"story_id":"story-failed"');
+    } finally {
+      rmSync(tmpDir, { force: true, recursive: true });
+    }
   });
 
   it('derives StoryCluster health URLs across pathname shapes', () => {

--- a/services/news-aggregator/src/daemonUtils.ts
+++ b/services/news-aggregator/src/daemonUtils.ts
@@ -11,6 +11,7 @@ export {
   createAsyncEnrichmentQueue,
   type AsyncEnrichmentQueue,
   type AsyncEnrichmentQueueOptions,
+  type EnrichmentQueueSnapshot,
   type EnrichmentWorker,
   type LoggerLike,
 } from './enrichmentQueue';

--- a/services/news-aggregator/src/daemonWriteLane.test.ts
+++ b/services/news-aggregator/src/daemonWriteLane.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createDaemonWriteLaneRegistry } from './daemonWriteLane';
+
+function flushMicrotasks(): Promise<void> {
+  return Promise.resolve().then(() => undefined);
+}
+
+describe('daemonWriteLane', () => {
+  it('bounds concurrent writes per class and records p95 latency', async () => {
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    let now = 1_000;
+    let releaseFirst: (() => void) | null = null;
+    const lane = createDaemonWriteLaneRegistry({
+      logger,
+      now: () => now,
+      defaultConcurrency: 1,
+    });
+
+    const first = lane.run('news_bundle', { story_id: 'story-1' }, () =>
+      new Promise<string>((resolve) => {
+        releaseFirst = () => resolve('first');
+      }),
+    );
+    const secondTask = vi.fn(async () => 'second');
+    const second = lane.run('news_bundle', { story_id: 'story-2' }, secondTask);
+
+    await flushMicrotasks();
+    expect(secondTask).not.toHaveBeenCalled();
+    expect(lane.snapshot()).toContainEqual(
+      expect.objectContaining({
+        write_class: 'news_bundle',
+        pending_depth: 1,
+        in_flight: 1,
+      }),
+    );
+
+    now += 40;
+    releaseFirst?.();
+    await expect(first).resolves.toBe('first');
+    await flushMicrotasks();
+    await expect(second).resolves.toBe('second');
+
+    expect(secondTask).toHaveBeenCalledTimes(1);
+    expect(lane.snapshot()).toContainEqual(
+      expect.objectContaining({
+        write_class: 'news_bundle',
+        pending_depth: 0,
+        in_flight: 0,
+        completed_count: 2,
+        failed_count: 0,
+        p95_ms: expect.any(Number),
+      }),
+    );
+  });
+
+  it('rejects queued writes when stopped', async () => {
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    const lane = createDaemonWriteLaneRegistry({ logger, defaultConcurrency: 1 });
+    const first = lane.run('storyline', {}, () => new Promise(() => undefined));
+    const second = lane.run('storyline', {}, async () => 'unreached');
+
+    await flushMicrotasks();
+    lane.stop();
+
+    await expect(second).rejects.toThrow('daemon write lane stopped: storyline');
+    await expect(lane.run('storyline', {}, async () => 'late')).rejects.toThrow(
+      'daemon write lane stopped: storyline',
+    );
+    void first.catch(() => undefined);
+  });
+});

--- a/services/news-aggregator/src/daemonWriteLane.ts
+++ b/services/news-aggregator/src/daemonWriteLane.ts
@@ -1,0 +1,204 @@
+export type LoggerLike = Pick<Console, 'info' | 'warn' | 'error'>;
+
+export interface DaemonWriteLaneSnapshot {
+  write_class: string;
+  pending_depth: number;
+  in_flight: number;
+  completed_count: number;
+  failed_count: number;
+  p95_ms: number | null;
+}
+
+export interface DaemonWriteLaneRegistry {
+  run<T>(
+    writeClass: string,
+    attributes: Record<string, unknown>,
+    task: () => Promise<T>,
+  ): Promise<T>;
+  snapshot(): DaemonWriteLaneSnapshot[];
+  stop(): void;
+}
+
+interface QueuedWrite<T> {
+  attributes: Record<string, unknown>;
+  resolve: (value: T) => void;
+  reject: (error: unknown) => void;
+  task: () => Promise<T>;
+}
+
+interface LaneState {
+  pending: Array<QueuedWrite<unknown>>;
+  inFlight: number;
+  completedCount: number;
+  failedCount: number;
+  durations: number[];
+}
+
+export interface DaemonWriteLaneOptions {
+  logger?: LoggerLike;
+  now?: () => number;
+  defaultConcurrency?: number;
+  classConcurrency?: Record<string, number | undefined>;
+  maxSamples?: number;
+}
+
+function normalizeConcurrency(value: number | undefined, fallback: number): number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+    return fallback;
+  }
+  return Math.floor(value);
+}
+
+function p95(values: number[]): number | null {
+  if (values.length === 0) {
+    return null;
+  }
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = Math.min(sorted.length - 1, Math.ceil(sorted.length * 0.95) - 1);
+  return sorted[index] ?? null;
+}
+
+export function createDaemonWriteLaneRegistry(
+  options: DaemonWriteLaneOptions = {},
+): DaemonWriteLaneRegistry {
+  const logger = options.logger ?? console;
+  const now = options.now ?? Date.now;
+  const defaultConcurrency = normalizeConcurrency(options.defaultConcurrency, 2);
+  const maxSamples = normalizeConcurrency(options.maxSamples, 100);
+  const lanes = new Map<string, LaneState>();
+  let stopped = false;
+
+  const stateFor = (writeClass: string): LaneState => {
+    const existing = lanes.get(writeClass);
+    if (existing) {
+      return existing;
+    }
+    const created: LaneState = {
+      pending: [],
+      inFlight: 0,
+      completedCount: 0,
+      failedCount: 0,
+      durations: [],
+    };
+    lanes.set(writeClass, created);
+    return created;
+  };
+
+  const concurrencyFor = (writeClass: string): number =>
+    normalizeConcurrency(options.classConcurrency?.[writeClass], defaultConcurrency);
+
+  const recordDuration = (state: LaneState, durationMs: number): number | null => {
+    state.durations.push(durationMs);
+    if (state.durations.length > maxSamples) {
+      state.durations.splice(0, state.durations.length - maxSamples);
+    }
+    return p95(state.durations);
+  };
+
+  const drain = (writeClass: string): void => {
+    if (stopped) {
+      return;
+    }
+    const state = stateFor(writeClass);
+    const maxInFlight = concurrencyFor(writeClass);
+    while (state.inFlight < maxInFlight && state.pending.length > 0) {
+      const item = state.pending.shift();
+      if (!item) {
+        continue;
+      }
+      state.inFlight += 1;
+      const startedAt = now();
+      logger.info('[vh:news-daemon] write lane started', {
+        write_class: writeClass,
+        pending_depth: state.pending.length,
+        in_flight: state.inFlight,
+        ...item.attributes,
+      });
+      void item.task()
+        .then((value) => {
+          const durationMs = Math.max(0, now() - startedAt);
+          state.completedCount += 1;
+          const p95Ms = recordDuration(state, durationMs);
+          logger.info('[vh:news-daemon] write lane completed', {
+            write_class: writeClass,
+            duration_ms: durationMs,
+            p95_ms: p95Ms,
+            pending_depth: state.pending.length,
+            in_flight: Math.max(0, state.inFlight - 1),
+            completed_count: state.completedCount,
+            failed_count: state.failedCount,
+            ...item.attributes,
+          });
+          item.resolve(value);
+        })
+        .catch((error) => {
+          const durationMs = Math.max(0, now() - startedAt);
+          state.failedCount += 1;
+          const p95Ms = recordDuration(state, durationMs);
+          logger.warn('[vh:news-daemon] write lane failed', {
+            write_class: writeClass,
+            duration_ms: durationMs,
+            p95_ms: p95Ms,
+            pending_depth: state.pending.length,
+            in_flight: Math.max(0, state.inFlight - 1),
+            completed_count: state.completedCount,
+            failed_count: state.failedCount,
+            ...item.attributes,
+            error,
+          });
+          item.reject(error);
+        })
+        .finally(() => {
+          state.inFlight = Math.max(0, state.inFlight - 1);
+          drain(writeClass);
+        });
+    }
+  };
+
+  return {
+    run<T>(writeClass: string, attributes: Record<string, unknown>, task: () => Promise<T>): Promise<T> {
+      if (stopped) {
+        return Promise.reject(new Error(`daemon write lane stopped: ${writeClass}`));
+      }
+      const state = stateFor(writeClass);
+      return new Promise<T>((resolve, reject) => {
+        state.pending.push({
+          attributes,
+          resolve: resolve as (value: unknown) => void,
+          reject,
+          task: task as () => Promise<unknown>,
+        });
+        logger.info('[vh:news-daemon] write lane enqueued', {
+          write_class: writeClass,
+          pending_depth: state.pending.length,
+          in_flight: state.inFlight,
+          ...attributes,
+        });
+        queueMicrotask(() => drain(writeClass));
+      });
+    },
+
+    snapshot(): DaemonWriteLaneSnapshot[] {
+      return [...lanes.entries()]
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([writeClass, state]) => ({
+          write_class: writeClass,
+          pending_depth: state.pending.length,
+          in_flight: state.inFlight,
+          completed_count: state.completedCount,
+          failed_count: state.failedCount,
+          p95_ms: p95(state.durations),
+        }));
+    },
+
+    stop() {
+      stopped = true;
+      for (const [writeClass, state] of lanes) {
+        const pending = state.pending.splice(0);
+        for (const item of pending) {
+          item.reject(new Error(`daemon write lane stopped: ${writeClass}`));
+        }
+      }
+    },
+  };
+}

--- a/services/news-aggregator/src/enrichmentQueue.ts
+++ b/services/news-aggregator/src/enrichmentQueue.ts
@@ -1,10 +1,41 @@
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from 'node:fs';
+import path from 'node:path';
 import type { NewsRuntimeSynthesisCandidate } from '@vh/ai-engine';
 
 export type LoggerLike = Pick<Console, 'info' | 'warn' | 'error'>;
 export type EnrichmentWorker = (candidate: NewsRuntimeSynthesisCandidate) => Promise<void> | void;
+export type EnrichmentDeadLetterReason = 'queue_full' | 'worker_failed';
+
+export interface EnrichmentQueueDeadLetterRecord {
+  schemaVersion: 'vh-news-enrichment-dlq-v1';
+  recorded_at: number;
+  reason: EnrichmentDeadLetterReason;
+  max_depth?: number;
+  error?: string;
+  candidate: NewsRuntimeSynthesisCandidate;
+}
+
+export interface EnrichmentQueueSnapshot {
+  pending_depth: number;
+  in_flight: number;
+  dead_letter_count: number;
+  active: boolean;
+  draining: boolean;
+}
 
 export interface AsyncEnrichmentQueueOptions {
   maxDepth?: number;
+  autoStart?: boolean;
+  persistenceDir?: string;
+  now?: () => number;
+  replayDeadLettersOnStart?: boolean;
   onDrop?: (
     candidate: NewsRuntimeSynthesisCandidate,
     detail: { reason: 'queue_full'; maxDepth: number },
@@ -12,9 +43,146 @@ export interface AsyncEnrichmentQueueOptions {
 }
 
 export interface AsyncEnrichmentQueue {
+  start(): void;
+  pause(): void;
   enqueue(candidate: NewsRuntimeSynthesisCandidate): void;
   size(): number;
+  deadLetterCount(): number;
+  snapshot(): EnrichmentQueueSnapshot;
   stop(): void;
+}
+
+interface PersistenceState {
+  pendingFile: string;
+  deadLetterFile: string;
+}
+
+function isCandidateLike(value: unknown): value is NewsRuntimeSynthesisCandidate {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as Partial<NewsRuntimeSynthesisCandidate>).story_id === 'string'
+  );
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function resolvePersistence(options: AsyncEnrichmentQueueOptions): PersistenceState | null {
+  const persistenceDir = options.persistenceDir?.trim();
+  if (!persistenceDir) {
+    return null;
+  }
+  return {
+    pendingFile: path.join(persistenceDir, 'pending.json'),
+    deadLetterFile: path.join(persistenceDir, 'dead-letter.jsonl'),
+  };
+}
+
+function ensureParent(filePath: string): void {
+  mkdirSync(path.dirname(filePath), { recursive: true });
+}
+
+function writeJsonAtomic(filePath: string, value: unknown): void {
+  ensureParent(filePath);
+  const tmpFile = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+  writeFileSync(tmpFile, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+  renameSync(tmpFile, filePath);
+}
+
+function readPendingFile(filePath: string, logger: LoggerLike): NewsRuntimeSynthesisCandidate[] {
+  if (!existsSync(filePath)) {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(readFileSync(filePath, 'utf8')) as unknown;
+    const candidates = Array.isArray(parsed)
+      ? parsed
+      : Array.isArray((parsed as { pending?: unknown }).pending)
+        ? (parsed as { pending: unknown[] }).pending
+        : [];
+    return candidates.filter(isCandidateLike);
+  } catch (error) {
+    logger.warn('[vh:news-daemon] enrichment queue pending replay failed', {
+      file: filePath,
+      error,
+    });
+    return [];
+  }
+}
+
+function readDeadLetterFile(filePath: string, logger: LoggerLike): EnrichmentQueueDeadLetterRecord[] {
+  if (!existsSync(filePath)) {
+    return [];
+  }
+  const content = readFileSync(filePath, 'utf8').trim();
+  if (!content) {
+    return [];
+  }
+  const records: EnrichmentQueueDeadLetterRecord[] = [];
+  for (const line of content.split('\n')) {
+    try {
+      const parsed = JSON.parse(line) as Partial<EnrichmentQueueDeadLetterRecord>;
+      if (
+        parsed?.schemaVersion === 'vh-news-enrichment-dlq-v1' &&
+        (parsed.reason === 'queue_full' || parsed.reason === 'worker_failed') &&
+        isCandidateLike(parsed.candidate)
+      ) {
+        records.push(parsed as EnrichmentQueueDeadLetterRecord);
+      }
+    } catch (error) {
+      logger.warn('[vh:news-daemon] enrichment queue dead-letter replay parse failed', {
+        file: filePath,
+        error,
+      });
+    }
+  }
+  return records;
+}
+
+function persistPending(
+  persistence: PersistenceState | null,
+  pending: NewsRuntimeSynthesisCandidate[],
+  logger: LoggerLike,
+  now: () => number,
+): void {
+  if (!persistence) {
+    return;
+  }
+  try {
+    writeJsonAtomic(persistence.pendingFile, {
+      schemaVersion: 'vh-news-enrichment-pending-v1',
+      updated_at: now(),
+      pending,
+    });
+  } catch (error) {
+    logger.warn('[vh:news-daemon] enrichment queue pending persist failed', {
+      file: persistence.pendingFile,
+      error,
+    });
+  }
+}
+
+function rewriteDeadLetters(
+  persistence: PersistenceState,
+  records: EnrichmentQueueDeadLetterRecord[],
+  logger: LoggerLike,
+): void {
+  try {
+    ensureParent(persistence.deadLetterFile);
+    writeFileSync(
+      persistence.deadLetterFile,
+      records.map((record) => JSON.stringify(record)).join(records.length > 0 ? '\n' : '') +
+        (records.length > 0 ? '\n' : ''),
+      'utf8',
+    );
+  } catch (error) {
+    logger.warn('[vh:news-daemon] enrichment queue dead-letter rewrite failed', {
+      file: persistence.deadLetterFile,
+      error,
+    });
+  }
 }
 
 export function createAsyncEnrichmentQueue(
@@ -22,32 +190,109 @@ export function createAsyncEnrichmentQueue(
   logger: LoggerLike,
   options: AsyncEnrichmentQueueOptions = {},
 ): AsyncEnrichmentQueue {
-  const pending: NewsRuntimeSynthesisCandidate[] = [];
+  const now = options.now ?? Date.now;
+  const persistence = resolvePersistence(options);
+  const initialPending = persistence ? readPendingFile(persistence.pendingFile, logger) : [];
+  const initialDeadLetters = persistence ? readDeadLetterFile(persistence.deadLetterFile, logger) : [];
+  const replayDeadLettersOnStart = options.replayDeadLettersOnStart !== false;
+  const replayableDeadLetters = replayDeadLettersOnStart
+    ? initialDeadLetters.filter((record) => record.reason === 'queue_full')
+    : [];
+  const retainedDeadLetters = replayDeadLettersOnStart
+    ? initialDeadLetters.filter((record) => record.reason !== 'queue_full')
+    : initialDeadLetters;
+  const pending: NewsRuntimeSynthesisCandidate[] = [...initialPending];
+  const inFlight: NewsRuntimeSynthesisCandidate[] = [];
+  for (const record of replayableDeadLetters) {
+    const existingIndex = pending.findIndex((candidate) => candidate.story_id === record.candidate.story_id);
+    if (existingIndex >= 0) {
+      pending[existingIndex] = record.candidate;
+    } else {
+      pending.push(record.candidate);
+    }
+  }
+  if (persistence && replayableDeadLetters.length > 0) {
+    rewriteDeadLetters(persistence, retainedDeadLetters, logger);
+  }
+  if (persistence && (initialPending.length > 0 || replayableDeadLetters.length > 0)) {
+    logger.info('[vh:news-daemon] enrichment queue replay loaded', {
+      pending_count: initialPending.length,
+      replayed_dead_letter_count: replayableDeadLetters.length,
+      file: persistence.pendingFile,
+    });
+  }
   const maxDepth =
     typeof options.maxDepth === 'number' && Number.isFinite(options.maxDepth) && options.maxDepth > 0
       ? Math.floor(options.maxDepth)
       : undefined;
   let draining = false;
   let stopped = false;
+  let active = options.autoStart !== false;
   let drainScheduled = false;
+  let deadLetterCount = retainedDeadLetters.length;
+
+  const persistDurableState = () => {
+    persistPending(persistence, [...inFlight, ...pending], logger, now);
+  };
+
+  const appendDeadLetter = (
+    candidate: NewsRuntimeSynthesisCandidate,
+    reason: EnrichmentDeadLetterReason,
+    detail: { maxDepth?: number; error?: unknown } = {},
+  ) => {
+    const record: EnrichmentQueueDeadLetterRecord = {
+      schemaVersion: 'vh-news-enrichment-dlq-v1',
+      recorded_at: now(),
+      reason,
+      candidate,
+      ...(detail.maxDepth !== undefined ? { max_depth: detail.maxDepth } : {}),
+      ...(detail.error !== undefined ? { error: errorMessage(detail.error) } : {}),
+    };
+    deadLetterCount += 1;
+    if (!persistence) {
+      return;
+    }
+    try {
+      ensureParent(persistence.deadLetterFile);
+      appendFileSync(persistence.deadLetterFile, `${JSON.stringify(record)}\n`, 'utf8');
+    } catch (error) {
+      logger.warn('[vh:news-daemon] enrichment queue dead-letter persist failed', {
+        file: persistence.deadLetterFile,
+        reason,
+        story_id: candidate.story_id,
+        error,
+      });
+    }
+  };
 
   const drain = async (): Promise<void> => {
-    if (draining || stopped) {
+    if (draining || stopped || !active) {
       return;
     }
 
     draining = true;
     try {
-      while (!stopped && pending.length > 0) {
+      while (!stopped && active && pending.length > 0) {
         const next = pending.shift();
         if (!next) {
           continue;
         }
+        inFlight.push(next);
+        persistDurableState();
 
         try {
           await worker(next);
         } catch (error) {
           logger.warn('[vh:news-daemon] enrichment worker failed', error);
+          appendDeadLetter(next, 'worker_failed', { error });
+        } finally {
+          const inFlightIndex = inFlight.indexOf(next);
+          if (inFlightIndex >= 0) {
+            inFlight.splice(inFlightIndex, 1);
+          }
+          if (!stopped) {
+            persistDurableState();
+          }
         }
       }
     } finally {
@@ -55,7 +300,37 @@ export function createAsyncEnrichmentQueue(
     }
   };
 
+  const scheduleDrain = () => {
+    if (drainScheduled || draining || stopped || !active) {
+      return;
+    }
+
+    drainScheduled = true;
+    queueMicrotask(() => {
+      drainScheduled = false;
+      void drain();
+    });
+  };
+
+  if (pending.length > 0) {
+    persistDurableState();
+    scheduleDrain();
+  }
+
   return {
+    start() {
+      if (stopped) {
+        return;
+      }
+      active = true;
+      scheduleDrain();
+    },
+
+    pause() {
+      active = false;
+      persistDurableState();
+    },
+
     enqueue(candidate: NewsRuntimeSynthesisCandidate) {
       if (stopped) {
         return;
@@ -70,12 +345,14 @@ export function createAsyncEnrichmentQueue(
         : -1;
       if (existingIndex >= 0) {
         pending[existingIndex] = candidate;
+        persistDurableState();
         return;
       }
 
       if (maxDepth !== undefined && pending.length >= maxDepth) {
         const dropped = pending.shift();
         if (dropped) {
+          appendDeadLetter(dropped, 'queue_full', { maxDepth });
           options.onDrop?.(dropped, { reason: 'queue_full', maxDepth });
         }
         logger.warn('[vh:news-daemon] enrichment queue full; evicted oldest candidate', {
@@ -86,24 +363,34 @@ export function createAsyncEnrichmentQueue(
       }
 
       pending.push(candidate);
-      if (drainScheduled || draining) {
-        return;
-      }
-
-      drainScheduled = true;
-      queueMicrotask(() => {
-        drainScheduled = false;
-        void drain();
-      });
+      persistDurableState();
+      scheduleDrain();
     },
 
     size() {
       return pending.length;
     },
 
+    deadLetterCount() {
+      return deadLetterCount;
+    },
+
+    snapshot() {
+      return {
+        pending_depth: pending.length,
+        in_flight: inFlight.length,
+        dead_letter_count: deadLetterCount,
+        active,
+        draining,
+      };
+    },
+
     stop() {
       stopped = true;
+      active = false;
+      persistDurableState();
       pending.length = 0;
+      inFlight.length = 0;
     },
   };
 }


### PR DESCRIPTION
## Summary
- enable stateful daemon mesh writes with default Node radisk journaling and an explicit disable switch for hermetic tests
- add named bounded daemon write lanes with structured enqueue/start/complete/fail telemetry and rolling p95 latency snapshots
- persist bundle-synthesis enrichment queue state, keep in-flight candidates durable until completion, dead-letter overflow/terminal failures, and replay queue-full DLQ records on restart
- replay accepted analysis-eval syntheses once after daemon leadership acquisition so accepted artifacts can repair missing relay state
- update the mesh hardening ledger to mark PR1/PR2 done and PR3 locally verified, with PR4/PR5 still queued

## Verification
- `pnpm --filter @vh/news-aggregator exec vitest run src/daemonUtils.test.ts src/daemonWriteLane.test.ts src/analysisEvalReplay.test.ts src/bundleSynthesisDaemonConfig.test.ts src/bundleSynthesisWorker.test.ts src/daemon.test.ts src/daemon.env.test.ts src/daemon.production.test.ts src/daemon.storylines.test.ts --reporter=dot`
- `pnpm --filter @vh/news-aggregator typecheck`
- `pnpm --filter @vh/news-aggregator exec vitest run src/daemon.coverage.test.ts --reporter=dot`
- `pnpm --filter @vh/news-aggregator exec vitest run src/sourceHealthReport.test.ts --reporter=dot`
- `pnpm --filter @vh/news-aggregator test`
- `pnpm typecheck`
- `pnpm lint`
- `node tools/scripts/check-diff-coverage.mjs`
- `pnpm test:mesh:browser-canary`

## Notes
- `node tools/scripts/check-diff-coverage.mjs` passed but reported no coverage-eligible service files, so the package-specific daemon tests are the meaningful local coverage signal for this PR.
- Local Node is v23.10.0, so pnpm prints the repo's expected `>=20 <23` engine warning; commands completed successfully.
