### PR TITLE
Harden mesh topology quorum

### DIFF
--- a/apps/web-pwa/src/components/dev/HealthIndicator.test.tsx
+++ b/apps/web-pwa/src/components/dev/HealthIndicator.test.tsx
@@ -11,6 +11,9 @@ const state = {
   meshWriteAckSamples: 0,
   analysisRelayAvailable: true,
   convergenceLagP95Ms: null,
+  peerQuorumConfigured: 0,
+  peerQuorumHealthy: 0,
+  peerQuorumRequired: 0,
   degradationMode: 'none',
   degradationReasons: [] as readonly string[],
   lastHealthCheck: null,
@@ -28,6 +31,9 @@ describe('HealthIndicator', () => {
     state.meshWriteAckSamples = 0;
     state.analysisRelayAvailable = true;
     state.convergenceLagP95Ms = null;
+    state.peerQuorumConfigured = 0;
+    state.peerQuorumHealthy = 0;
+    state.peerQuorumRequired = 0;
     state.degradationMode = 'none';
     state.degradationReasons = [];
     state.lastHealthCheck = null;
@@ -57,5 +63,19 @@ describe('HealthIndicator', () => {
 
     expect(screen.getByText('unknown (0 samples)')).toBeInTheDocument();
     expect(screen.getByText('Probe ack timeout, Gun message rate high')).toBeInTheDocument();
+  });
+
+  it('renders peer quorum counts and reason', () => {
+    state.degradationMode = 'mesh-degraded';
+    state.degradationReasons = ['peer-quorum-missing'];
+    state.peerQuorumConfigured = 3;
+    state.peerQuorumHealthy = 1;
+    state.peerQuorumRequired = 2;
+
+    render(<HealthIndicator />);
+    fireEvent.click(screen.getByLabelText('Health: Mesh Degraded'));
+
+    expect(screen.getByText('1/3 (need 2)')).toBeInTheDocument();
+    expect(screen.getByText('Peer quorum missing')).toBeInTheDocument();
   });
 });

--- a/apps/web-pwa/src/components/dev/HealthIndicator.tsx
+++ b/apps/web-pwa/src/components/dev/HealthIndicator.tsx
@@ -62,6 +62,9 @@ export const HealthIndicator: React.FC = () => {
   const meshWriteAckSamples = useHealthStore((s) => s.meshWriteAckSamples);
   const analysisRelayAvailable = useHealthStore((s) => s.analysisRelayAvailable);
   const convergenceLagP95Ms = useHealthStore((s) => s.convergenceLagP95Ms);
+  const peerQuorumConfigured = useHealthStore((s) => s.peerQuorumConfigured);
+  const peerQuorumHealthy = useHealthStore((s) => s.peerQuorumHealthy);
+  const peerQuorumRequired = useHealthStore((s) => s.peerQuorumRequired);
   const degradationMode = useHealthStore((s) => s.degradationMode);
   const degradationReasons = useHealthStore((s) => s.degradationReasons);
   const lastHealthCheck = useHealthStore((s) => s.lastHealthCheck);
@@ -108,6 +111,14 @@ export const HealthIndicator: React.FC = () => {
               <tr>
                 <td className="pr-2 text-slate-500">Convergence p95</td>
                 <td>{convergenceLagP95Ms !== null ? `${convergenceLagP95Ms}ms` : 'n/a'}</td>
+              </tr>
+              <tr>
+                <td className="pr-2 text-slate-500">Peer quorum</td>
+                <td>
+                  {peerQuorumConfigured > 0
+                    ? `${peerQuorumHealthy}/${peerQuorumConfigured} (need ${peerQuorumRequired})`
+                    : 'unknown'}
+                </td>
               </tr>
               <tr>
                 <td className="pr-2 text-slate-500">Last check</td>

--- a/apps/web-pwa/src/hooks/useHealthMonitor.test.ts
+++ b/apps/web-pwa/src/hooks/useHealthMonitor.test.ts
@@ -109,6 +109,9 @@ describe('useHealthMonitor', () => {
         meshWriteAckSamples: 0,
         analysisRelayAvailable: true,
         convergenceLagP95Ms: null,
+        peerQuorumConfigured: 0,
+        peerQuorumHealthy: 0,
+        peerQuorumRequired: 0,
         degradationReasons: [],
         degradationMode: 'none',
         lastHealthCheck: null,
@@ -167,6 +170,9 @@ describe('useHealthMonitor', () => {
 
     useHealthStore.getState().recordMessageRateHigh(true);
     expect(useHealthStore.getState().degradationReasons).toContain('message-rate-high');
+
+    useHealthStore.getState().recordPeerQuorum(3, 1, 2);
+    expect(useHealthStore.getState().degradationReasons).toContain('peer-quorum-missing');
 
     useHealthStore.getState().tick();
     expect(useHealthStore.getState().lastHealthCheck).not.toBeNull();
@@ -574,6 +580,93 @@ describe('useHealthMonitor', () => {
     await flushPromises();
 
     expect(useHealthStore.getState().analysisRelayAvailable).toBe(false);
+
+    stop();
+  });
+
+  it('checks peer quorum with relay health endpoints', async () => {
+    const client = {
+      ...createMockClient((_payload, ack) => {
+        ack({ ok: { '': 1 } });
+      }),
+      config: {
+        peers: [
+          'http://127.0.0.1:7788/gun',
+          'http://127.0.0.1:7789/gun',
+          'http://127.0.0.1:7790/gun',
+        ],
+      },
+    };
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === '/api/analyze/config') {
+        return {
+          ok: true,
+          json: async () => ({ configured: true }),
+        };
+      }
+      return {
+        ok: url.includes(':7788') || url.includes(':7789'),
+        json: async () => ({ ok: true }),
+      };
+    });
+
+    const { startHealthMonitor, useHealthStore } = await loadHealthMonitorHarness({
+      client,
+      fetchImpl: fetchImpl as unknown as () => Promise<{ ok: boolean; json?: () => Promise<unknown> }>,
+    });
+
+    const stop = startHealthMonitor();
+    await flushPromises();
+
+    expect(useHealthStore.getState()).toMatchObject({
+      peerQuorumConfigured: 3,
+      peerQuorumHealthy: 2,
+      peerQuorumRequired: 2,
+    });
+    expect(useHealthStore.getState().degradationReasons).not.toContain('peer-quorum-missing');
+
+    stop();
+  });
+
+  it('marks peer quorum missing when peer health URLs are invalid or throw', async () => {
+    const client = {
+      ...createMockClient((_payload, ack) => {
+        ack({ ok: { '': 1 } });
+      }),
+      config: {
+        peers: [
+          'not a url',
+          'http://127.0.0.1:7788/gun',
+          'http://127.0.0.1:7789/gun',
+        ],
+      },
+    };
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === '/api/analyze/config') {
+        return {
+          ok: true,
+          json: async () => ({ configured: true }),
+        };
+      }
+      throw new Error(`peer health failed: ${url}`);
+    });
+
+    const { startHealthMonitor, useHealthStore } = await loadHealthMonitorHarness({
+      client,
+      fetchImpl: fetchImpl as unknown as () => Promise<{ ok: boolean; json?: () => Promise<unknown> }>,
+    });
+
+    const stop = startHealthMonitor();
+    await flushPromises();
+
+    expect(useHealthStore.getState()).toMatchObject({
+      peerQuorumConfigured: 3,
+      peerQuorumHealthy: 0,
+      peerQuorumRequired: 2,
+    });
+    expect(useHealthStore.getState().degradationReasons).toContain('peer-quorum-missing');
 
     stop();
   });

--- a/apps/web-pwa/src/hooks/useHealthMonitor.ts
+++ b/apps/web-pwa/src/hooks/useHealthMonitor.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { resolveClientFromAppStore } from '../store/clientResolver';
+import { peerHealthUrl, resolveQuorumRequired } from '../store/peerConfig';
 import { onMeshWriteResult, onConvergenceLag } from '../utils/sentimentTelemetry';
 
 type GunPeerState = 'connected' | 'degraded' | 'disconnected' | 'unknown';
@@ -23,6 +24,9 @@ export interface HealthState {
   readonly meshWriteAckSamples: number;
   readonly analysisRelayAvailable: boolean;
   readonly convergenceLagP95Ms: number | null;
+  readonly peerQuorumConfigured: number;
+  readonly peerQuorumHealthy: number;
+  readonly peerQuorumRequired: number;
   readonly degradationMode: DegradationMode;
   readonly degradationReasons: readonly DegradationReason[];
   readonly lastHealthCheck: string | null;
@@ -32,6 +36,7 @@ interface HealthStore extends HealthState {
   recordMeshWrite: (success: boolean) => void;
   recordConvergenceLag: (lagMs: number) => void;
   recordGunProbe: (state: GunPeerState, reason?: GunProbeFailureReason | null) => void;
+  recordPeerQuorum: (configured: number, healthy: number, required: number) => void;
   recordLocalStorageHydrationFailed: () => void;
   recordClientOutOfDate: () => void;
   recordMessageRateHigh: (high: boolean) => void;
@@ -46,6 +51,7 @@ const MESH_WRITE_ACK_RATE_THRESHOLD = 0.95;
 const CONVERGENCE_LAG_DEGRADED_MS = 10_000;
 const MESSAGE_RATE_DEGRADED_PER_SEC = readPositiveIntEnv('VITE_VH_GUN_MESSAGE_RATE_DEGRADED_PER_SEC', 200);
 const PROBE_TIMEOUT_MS = readPositiveIntEnv('VITE_VH_HEALTH_PROBE_TIMEOUT_MS', 3_000);
+const PEER_QUORUM_TIMEOUT_MS = readPositiveIntEnv('VITE_VH_PEER_QUORUM_TIMEOUT_MS', 2_000);
 const HEALTH_BROWSER_ID_KEY = 'vh_health_probe_browser_id_v1';
 
 const meshWriteResults: boolean[] = [];
@@ -83,7 +89,7 @@ function computeP95(samples: readonly number[]): number {
 }
 
 function deriveHealth(
-  state: Pick<HealthState, 'gunPeerState' | 'meshWriteAckRate' | 'meshWriteAckSamples' | 'analysisRelayAvailable' | 'convergenceLagP95Ms'>,
+  state: Pick<HealthState, 'gunPeerState' | 'meshWriteAckRate' | 'meshWriteAckSamples' | 'analysisRelayAvailable' | 'convergenceLagP95Ms' | 'peerQuorumConfigured' | 'peerQuorumHealthy' | 'peerQuorumRequired'>,
 ): Pick<HealthState, 'degradationMode' | 'degradationReasons'> {
   const reasons = new Set<DegradationReason>();
 
@@ -102,6 +108,9 @@ function deriveHealth(
   }
   if (state.convergenceLagP95Ms !== null && state.convergenceLagP95Ms > CONVERGENCE_LAG_DEGRADED_MS) {
     reasons.add('convergence-lagging');
+  }
+  if (state.peerQuorumConfigured > 0 && state.peerQuorumHealthy < state.peerQuorumRequired) {
+    reasons.add('peer-quorum-missing');
   }
   if (localStorageHydrationFailed) {
     reasons.add('local-storage-hydration-failed');
@@ -135,6 +144,9 @@ export const useHealthStore = create<HealthStore>((set, get) => ({
   meshWriteAckSamples: 0,
   analysisRelayAvailable: true,
   convergenceLagP95Ms: null,
+  peerQuorumConfigured: 0,
+  peerQuorumHealthy: 0,
+  peerQuorumRequired: 0,
   degradationMode: 'none',
   degradationReasons: [],
   lastHealthCheck: null,
@@ -181,6 +193,26 @@ export const useHealthStore = create<HealthStore>((set, get) => ({
     set((state) => {
       const next = { ...state, gunPeerState };
       return { gunPeerState, ...deriveHealth(next) };
+    });
+  },
+
+  recordPeerQuorum(configured: number, healthy: number, required: number) {
+    const peerQuorumConfigured = Math.max(0, Math.floor(configured));
+    const peerQuorumHealthy = Math.max(0, Math.min(peerQuorumConfigured, Math.floor(healthy)));
+    const peerQuorumRequired = Math.max(0, Math.min(peerQuorumConfigured, Math.floor(required)));
+    set((state) => {
+      const next = {
+        ...state,
+        peerQuorumConfigured,
+        peerQuorumHealthy,
+        peerQuorumRequired,
+      };
+      return {
+        peerQuorumConfigured,
+        peerQuorumHealthy,
+        peerQuorumRequired,
+        ...deriveHealth(next),
+      };
     });
   },
 
@@ -265,6 +297,30 @@ function readOnceWithTimeout<T>(chain: { once?: (cb: (data: T | undefined) => vo
       resolve((data ?? null) as T | null);
     });
   });
+}
+
+// ── Peer quorum probe ───────────────────────────────────────────────────
+async function probePeerQuorum(): Promise<void> {
+  const client = resolveClientFromAppStore() as { config?: { peers?: string[] } } | null;
+  const peers = client?.config?.peers ?? [];
+  if (peers.length === 0) {
+    useHealthStore.getState().recordPeerQuorum(0, 0, 0);
+    return;
+  }
+  const required = resolveQuorumRequired(peers.length);
+  const checks = await Promise.all(peers.map(async (peer) => {
+    const healthUrl = peerHealthUrl(peer);
+    if (!healthUrl) {
+      return false;
+    }
+    try {
+      const response = await fetch(healthUrl, { signal: AbortSignal.timeout(PEER_QUORUM_TIMEOUT_MS) });
+      return response.ok;
+    } catch {
+      return false;
+    }
+  }));
+  useHealthStore.getState().recordPeerQuorum(peers.length, checks.filter(Boolean).length, required);
 }
 
 // ── Gun peer probe ──────────────────────────────────────────────────────
@@ -352,9 +408,11 @@ export function startHealthMonitor(): () => void {
   }
 
   probeGunPeer();
+  void probePeerQuorum();
   void probeAnalysisRelay();
 
   const gunProbeInterval = setInterval(probeGunPeer, 10_000);
+  const peerQuorumInterval = setInterval(() => void probePeerQuorum(), 10_000);
   const relayProbeInterval = setInterval(() => void probeAnalysisRelay(), 30_000);
   const tickInterval = setInterval(() => {
     useHealthStore.getState().tick();
@@ -379,6 +437,7 @@ export function startHealthMonitor(): () => void {
 
   activeHealthMonitorStop = () => {
     clearInterval(gunProbeInterval);
+    clearInterval(peerQuorumInterval);
     clearInterval(relayProbeInterval);
     clearInterval(tickInterval);
     unsubMeshWrite();

--- a/apps/web-pwa/src/store/index.ts
+++ b/apps/web-pwa/src/store/index.ts
@@ -11,11 +11,11 @@ import { safeGetItem, safeSetItem } from '../utils/safeStorage';
 import { loadIdentityRecord } from '../utils/vaultTyped';
 import { createMockClient } from './mockClient';
 import { setClientResolver } from './clientResolver';
+import { resolveGunPeerTopology } from './peerConfig';
+export { resolveGunPeers, resolveGunPeerTopology, resolveGunPeerTopologySync } from './peerConfig';
 
 const PROFILE_KEY = 'vh_profile';
 const E2E_OVERRIDE_KEY = '__VH_E2E_OVERRIDE__';
-const LOCAL_GUN_PEER = 'http://127.0.0.1:7777/gun';
-const TAILSCALE_GUN_PEER = 'http://100.75.18.26:7777/gun';
 type IdentityStatus = 'idle' | 'creating' | 'ready' | 'error';
 
 interface AppState {
@@ -125,34 +125,6 @@ async function bootstrapRuntimeFeatures(client: VennClient, context: string): Pr
   }
 }
 
-function normalizeGunPeer(peer: unknown): string | null {
-  if (typeof peer !== 'string') {
-    return null;
-  }
-  const trimmed = peer.trim();
-  if (!trimmed) {
-    return null;
-  }
-  return trimmed.endsWith('/gun') ? trimmed : `${trimmed.replace(/\/+$/, '')}/gun`;
-}
-
-function normalizeGunPeerList(peers: readonly unknown[]): string[] {
-  return peers
-    .map((peer) => normalizeGunPeer(peer))
-    .filter((peer): peer is string => Boolean(peer));
-}
-
-function isLocalHostname(hostname: string | undefined): boolean {
-  const normalized = hostname?.trim().toLowerCase();
-  return normalized === 'localhost' || normalized === '127.0.0.1' || normalized === '::1';
-}
-
-function getRuntimeHostname(): string | undefined {
-  return typeof globalThis.location?.hostname === 'string'
-    ? globalThis.location.hostname
-    : undefined;
-}
-
 export function resolveGunLocalStorage(): boolean | undefined {
   const raw = (import.meta as any).env?.VITE_VH_GUN_LOCAL_STORAGE
     ?? (typeof process !== 'undefined' ? process.env?.VITE_VH_GUN_LOCAL_STORAGE : undefined);
@@ -167,31 +139,6 @@ export function resolveGunLocalStorage(): boolean | undefined {
     return true;
   }
   return undefined;
-}
-
-export function resolveGunPeers(runtimeHostname = getRuntimeHostname()): string[] {
-  const globalOverride = (globalThis as { __VH_GUN_PEERS__?: unknown }).__VH_GUN_PEERS__;
-  if (Array.isArray(globalOverride)) {
-    return normalizeGunPeerList(globalOverride);
-  }
-
-  const raw = (import.meta as any).env?.VITE_GUN_PEERS;
-  if (raw && typeof raw === 'string') {
-    try {
-      const parsed = JSON.parse(raw);
-      if (Array.isArray(parsed)) {
-        return normalizeGunPeerList(parsed);
-      }
-    } catch {
-      const parts = normalizeGunPeerList(raw.split(','));
-      if (parts.length > 0) return parts;
-    }
-  }
-  if (isLocalHostname(runtimeHostname)) {
-    return [LOCAL_GUN_PEER];
-  }
-  // Non-local app hosts default to the Tailscale relay with localhost as a dev fallback.
-  return [TAILSCALE_GUN_PEER, LOCAL_GUN_PEER];
 }
 
 export async function authenticateGunUser(client: VennClient, devicePair: DevicePair): Promise<void> {
@@ -273,12 +220,18 @@ export const useAppStore = create<AppState>((set, get) => ({
           return;
         }
 
+        const peerTopology = await resolveGunPeerTopology();
         const client = createClient({
-          peers: resolveGunPeers(),
+          peers: peerTopology.peers,
           gunLocalStorage: resolveGunLocalStorage(),
           requireSession: true
         });
-        console.info('[vh:web-pwa] using Gun peers', client.config.peers);
+        console.info('[vh:web-pwa] using Gun peers', {
+          peers: client.config.peers,
+          source: peerTopology.source,
+          strict: peerTopology.strict,
+          quorumRequired: peerTopology.quorumRequired,
+        });
         await Promise.race([
           client.hydrationBarrier.prepare(),
           new Promise<void>((_, reject) =>

--- a/apps/web-pwa/src/store/peerConfig.test.ts
+++ b/apps/web-pwa/src/store/peerConfig.test.ts
@@ -1,0 +1,262 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const verifyMock = vi.fn();
+
+vi.mock('@vh/gun-client', () => ({
+  SEA: {
+    verify: (...args: unknown[]) => verifyMock(...args),
+  },
+}));
+
+beforeEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+  verifyMock.mockReset();
+});
+
+describe('peerConfig', () => {
+  it('covers normalizers and strict validation edge cases', async () => {
+    const {
+      normalizeGunPeer,
+      resolveGunPeers,
+      resolveGunPeerTopologySync,
+      resolveMinimumPeerCount,
+      resolveQuorumRequired,
+      isStrictPeerConfigMode,
+      isLocalMeshPeerAllowed,
+    } = await import('./peerConfig');
+
+    expect(normalizeGunPeer(null)).toBeNull();
+    expect(normalizeGunPeer('   ')).toBeNull();
+    expect(normalizeGunPeer('https://peer.example')).toBe('https://peer.example/gun');
+    expect(resolveQuorumRequired(0)).toBe(1);
+    vi.stubEnv('VITE_GUN_PEER_QUORUM_REQUIRED', 'bad');
+    expect(resolveQuorumRequired(3)).toBe(2);
+    vi.stubEnv('VITE_GUN_PEER_MINIMUM', '0');
+    expect(resolveMinimumPeerCount(true)).toBe(3);
+    vi.stubEnv('VITE_GUN_PEER_MINIMUM', '5');
+    expect(resolveMinimumPeerCount(true)).toBe(5);
+    vi.stubEnv('VITE_VH_STRICT_PEER_CONFIG', 'maybe');
+    vi.stubEnv('VITE_VH_ALLOW_LOCAL_MESH_PEERS', 'maybe');
+    expect(isStrictPeerConfigMode()).toBe(false);
+    expect(isLocalMeshPeerAllowed()).toBe(false);
+    vi.stubEnv('VITE_VH_ALLOW_LOCAL_MESH_PEERS', 'off');
+    expect(isLocalMeshPeerAllowed()).toBe(false);
+
+    vi.stubEnv('VITE_VH_STRICT_PEER_CONFIG', 'true');
+    vi.stubEnv('VITE_GUN_PEER_MINIMUM', '3');
+    vi.stubEnv('VITE_GUN_PEERS', JSON.stringify([
+      'https://a.example/gun',
+      'https://b.example/gun',
+      'not a url',
+    ]));
+    expect(() => resolveGunPeers('app.example')).toThrow('rejects insecure peer');
+
+    vi.unstubAllEnvs();
+    vi.stubEnv('VITE_GUN_PEER_CONFIG', JSON.stringify({ peers: [] }));
+    expect(() => resolveGunPeerTopologySync('app.example')).toThrow('no Gun peers configured');
+
+    vi.unstubAllEnvs();
+    vi.stubEnv('VITE_GUN_PEER_CONFIG_URL', 'https://config.example/peers.json');
+    expect(() => resolveGunPeerTopologySync('app.example')).toThrow('remote Gun peer config requires async');
+  });
+
+  it('accepts local insecure peers only when explicitly allowed in strict mode', async () => {
+    vi.stubEnv('VITE_VH_STRICT_PEER_CONFIG', 'true');
+    vi.stubEnv('VITE_VH_ALLOW_LOCAL_MESH_PEERS', 'true');
+    vi.stubEnv('VITE_GUN_PEERS', JSON.stringify([
+      'ws://localhost:7788/gun',
+      'http://127.0.0.1:7789/gun',
+      'http://[::1]:7790/gun',
+    ]));
+    const { resolveGunPeerTopologySync } = await import('./peerConfig');
+
+    expect(resolveGunPeerTopologySync('app.example')).toMatchObject({
+      peers: [
+        'ws://localhost:7788/gun',
+        'http://127.0.0.1:7789/gun',
+        'http://[::1]:7790/gun',
+      ],
+      strict: true,
+      allowLocalPeers: true,
+      quorumRequired: 2,
+    });
+  });
+
+  it('normalizes comma-separated peers and derives quorum', async () => {
+    vi.stubEnv('VITE_GUN_PEERS', 'https://a.example, https://b.example/gun, https://c.example');
+    const { resolveGunPeerTopology } = await import('./peerConfig');
+
+    await expect(resolveGunPeerTopology('app.example')).resolves.toMatchObject({
+      peers: ['https://a.example/gun', 'https://b.example/gun', 'https://c.example/gun'],
+      source: 'env-peers',
+      signed: false,
+      quorumRequired: 2,
+    });
+  });
+
+  it('requires and verifies signed remote peer config in strict mode', async () => {
+    const payload = {
+      minimumPeerCount: 3,
+      peers: ['https://a.example/gun', 'https://b.example/gun', 'https://c.example/gun'],
+    };
+    const canonical = '{"minimumPeerCount":3,"peers":["https://a.example/gun","https://b.example/gun","https://c.example/gun"]}';
+    verifyMock.mockResolvedValue(canonical);
+    vi.stubEnv('VITE_VH_STRICT_PEER_CONFIG', 'true');
+    vi.stubEnv('VITE_GUN_PEER_CONFIG_URL', 'https://config.example/peers.json');
+    vi.stubEnv('VITE_GUN_PEER_CONFIG_PUBLIC_KEY', 'peer-config-pub');
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      text: async () => JSON.stringify({
+        payload,
+        signature: 'signed-peer-config',
+      }),
+    })));
+    const { resolveGunPeerTopology } = await import('./peerConfig');
+
+    await expect(resolveGunPeerTopology('app.example')).resolves.toMatchObject({
+      peers: payload.peers,
+      source: 'remote-config',
+      strict: true,
+      signed: true,
+      quorumRequired: 2,
+    });
+    expect(verifyMock).toHaveBeenCalledWith('signed-peer-config', 'peer-config-pub');
+  });
+
+  it('parses inline peer-config payload variants and rejects bad signatures', async () => {
+    const { resolveGunPeerTopology } = await import('./peerConfig');
+
+    vi.stubEnv('VITE_GUN_PEER_CONFIG', JSON.stringify([
+      'https://array-a.example/gun',
+      'https://array-b.example/gun',
+      'https://array-c.example/gun',
+    ]));
+    await expect(resolveGunPeerTopology('app.example')).resolves.toMatchObject({
+      peers: [
+        'https://array-a.example/gun',
+        'https://array-b.example/gun',
+        'https://array-c.example/gun',
+      ],
+      source: 'env-config',
+    });
+
+    vi.stubEnv('VITE_GUN_PEER_CONFIG', JSON.stringify('bad-config'));
+    await expect(resolveGunPeerTopology('app.example')).rejects.toThrow('peer config must be an array or object');
+
+    const payload = {
+      peers: ['https://a.example/gun', 'https://b.example/gun', 'https://c.example/gun'],
+    };
+    vi.stubEnv('VITE_GUN_PEER_CONFIG', JSON.stringify({
+      payload: JSON.stringify(payload),
+      signature: 'bad-signature',
+      signerPub: 'dev-signer',
+    }));
+    verifyMock.mockResolvedValue('{"peers":["https://wrong.example/gun"]}');
+    await expect(resolveGunPeerTopology('app.example')).rejects.toThrow('signed peer config verification failed');
+
+    vi.stubEnv('VITE_GUN_PEER_CONFIG', JSON.stringify({
+      payload,
+      signature: 'signature-without-key',
+    }));
+    await expect(resolveGunPeerTopology('app.example')).rejects.toThrow('signed peer config is missing');
+
+    vi.stubEnv('VITE_GUN_PEER_CONFIG', JSON.stringify({
+      payload,
+      signature: 123,
+      signerPub: 456,
+    }));
+    await expect(resolveGunPeerTopology('app.example')).resolves.toMatchObject({
+      peers: payload.peers,
+      signed: false,
+    });
+
+    vi.stubEnv('VITE_GUN_PEER_CONFIG', JSON.stringify({
+      peers: payload.peers,
+      signature: 123,
+      signerPub: 456,
+    }));
+    await expect(resolveGunPeerTopology('app.example')).resolves.toMatchObject({
+      peers: payload.peers,
+      signed: false,
+    });
+
+    vi.stubEnv('VITE_GUN_PEER_CONFIG', JSON.stringify({
+      peers: payload.peers,
+      signature: 'plain-object-bad-signature',
+      signerPub: 'plain-object-signer',
+    }));
+    verifyMock.mockResolvedValue('{"peers":["https://wrong.example/gun"]}');
+    await expect(resolveGunPeerTopology('app.example')).rejects.toThrow('signed peer config verification failed');
+  });
+
+  it('requires async resolution for signed inline peer configs in sync mode', async () => {
+    vi.stubEnv('VITE_GUN_PEER_CONFIG', JSON.stringify({
+      payload: {
+        peers: ['https://a.example/gun', 'https://b.example/gun', 'https://c.example/gun'],
+      },
+      signature: 'signed-peer-config',
+      signerPub: 'dev-signer',
+    }));
+    const { resolveGunPeerTopologySync } = await import('./peerConfig');
+
+    expect(() => resolveGunPeerTopologySync('app.example')).toThrow('signed Gun peer config requires async resolution');
+  });
+
+  it('rejects peer config payloads that omit peers', async () => {
+    vi.stubEnv('VITE_GUN_PEER_CONFIG', JSON.stringify({
+      minimumPeerCount: 1,
+    }));
+    const { resolveGunPeerTopology } = await import('./peerConfig');
+
+    await expect(resolveGunPeerTopology('app.example')).rejects.toThrow('no Gun peers configured');
+  });
+
+  it('rejects unsigned or expired strict peer config envelopes', async () => {
+    vi.stubEnv('VITE_VH_STRICT_PEER_CONFIG', 'true');
+    vi.stubEnv('VITE_GUN_PEER_CONFIG', JSON.stringify({
+      peers: ['https://a.example/gun', 'https://b.example/gun', 'https://c.example/gun'],
+    }));
+    const first = await import('./peerConfig');
+    await expect(first.resolveGunPeerTopology('app.example')).rejects.toThrow('requires a signed peer config');
+
+    vi.stubEnv('VITE_VH_ALLOW_UNSIGNED_PEER_CONFIG', 'true');
+    vi.stubEnv('VITE_GUN_PEER_CONFIG', JSON.stringify({
+      expiresAt: Date.now() - 1,
+      peers: ['https://a.example/gun', 'https://b.example/gun', 'https://c.example/gun'],
+    }));
+    await expect(first.resolveGunPeerTopology('app.example')).rejects.toThrow('peer config is expired');
+
+    vi.stubEnv('VITE_VH_ALLOW_UNSIGNED_PEER_CONFIG', 'false');
+    vi.stubEnv('VITE_GUN_PEER_CONFIG', JSON.stringify({
+      payload: {
+        peers: ['https://a.example/gun', 'https://b.example/gun', 'https://c.example/gun'],
+      },
+      signature: 'signature',
+      signerPub: 'self-asserted-signer',
+    }));
+    await expect(first.resolveGunPeerTopology('app.example')).rejects.toThrow(
+      'strict signed peer config requires VITE_GUN_PEER_CONFIG_PUBLIC_KEY',
+    );
+  });
+
+  it('rejects failed remote peer-config fetches', async () => {
+    vi.stubEnv('VITE_GUN_PEER_CONFIG_URL', 'https://config.example/peers.json');
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: false,
+      status: 503,
+      text: async () => '',
+    })));
+    const { resolveGunPeerTopology } = await import('./peerConfig');
+
+    await expect(resolveGunPeerTopology('app.example')).rejects.toThrow('failed to fetch peer config: 503');
+  });
+
+  it('maps Gun peer URLs to relay health endpoints', async () => {
+    const { peerHealthUrl } = await import('./peerConfig');
+
+    expect(peerHealthUrl('wss://relay.example/gun')).toBe('https://relay.example/healthz');
+    expect(peerHealthUrl('ws://127.0.0.1:7788/gun')).toBe('http://127.0.0.1:7788/healthz');
+    expect(peerHealthUrl('not a url')).toBeNull();
+  });
+});

--- a/apps/web-pwa/src/store/peerConfig.ts
+++ b/apps/web-pwa/src/store/peerConfig.ts
@@ -1,0 +1,441 @@
+export interface GunPeerTopology {
+  readonly peers: string[];
+  readonly source: 'env-peers' | 'env-config' | 'remote-config' | 'runtime-global' | 'local-dev-fallback';
+  readonly strict: boolean;
+  readonly signed: boolean;
+  readonly minimumPeerCount: number;
+  readonly quorumRequired: number;
+  readonly allowLocalPeers: boolean;
+}
+
+interface PeerConfigPayload {
+  readonly schemaVersion?: string;
+  readonly peers?: readonly unknown[];
+  readonly minimumPeerCount?: unknown;
+  readonly quorumRequired?: unknown;
+  readonly issuedAt?: unknown;
+  readonly expiresAt?: unknown;
+}
+
+interface SignedPeerConfigEnvelope {
+  readonly payload?: unknown;
+  readonly signature?: unknown;
+  readonly signerPub?: unknown;
+}
+
+const LOCAL_GUN_PEER = 'http://127.0.0.1:7777/gun';
+const STRICT_PEER_CONFIG_ENV = 'VITE_VH_STRICT_PEER_CONFIG';
+const ALLOW_LOCAL_PEERS_ENV = 'VITE_VH_ALLOW_LOCAL_MESH_PEERS';
+const GUN_PEERS_ENV = 'VITE_GUN_PEERS';
+const GUN_PEER_CONFIG_ENV = 'VITE_GUN_PEER_CONFIG';
+const GUN_PEER_CONFIG_URL_ENV = 'VITE_GUN_PEER_CONFIG_URL';
+const GUN_PEER_CONFIG_PUBLIC_KEY_ENV = 'VITE_GUN_PEER_CONFIG_PUBLIC_KEY';
+const GUN_PEER_MINIMUM_ENV = 'VITE_GUN_PEER_MINIMUM';
+const GUN_PEER_QUORUM_REQUIRED_ENV = 'VITE_GUN_PEER_QUORUM_REQUIRED';
+const ALLOW_UNSIGNED_PEER_CONFIG_ENV = 'VITE_VH_ALLOW_UNSIGNED_PEER_CONFIG';
+
+/* c8 ignore start -- Vite import.meta env typing differs between browser bundles, vitest, and Node scripts. */
+function envValue(name: string): string | undefined {
+  const viteValue = (import.meta as unknown as { env?: Record<string, string | boolean | undefined> }).env?.[name];
+  if (typeof viteValue === 'string') {
+    return viteValue;
+  }
+  if (typeof viteValue === 'boolean') {
+    return viteValue ? 'true' : 'false';
+  }
+  return typeof process !== 'undefined' ? process.env?.[name] : undefined;
+}
+/* c8 ignore stop */
+
+function boolEnv(name: string, fallback = false): boolean {
+  const raw = envValue(name);
+  if (typeof raw !== 'string') {
+    return fallback;
+  }
+  const normalized = raw.trim().toLowerCase();
+  if (['1', 'true', 'yes', 'on'].includes(normalized)) return true;
+  if (['0', 'false', 'no', 'off'].includes(normalized)) return false;
+  return fallback;
+}
+
+function positiveIntEnv(name: string, fallback: number): number {
+  const raw = envValue(name);
+  if (typeof raw !== 'string' || raw.trim() === '') {
+    return fallback;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+/* c8 ignore start -- production flag source is runtime dependent; strict behavior is covered through env override tests. */
+function isProductionBuild(): boolean {
+  const viteProd = (import.meta as unknown as { env?: { PROD?: boolean } }).env?.PROD;
+  if (typeof viteProd === 'boolean') {
+    return viteProd;
+  }
+  return typeof process !== 'undefined' && process.env?.NODE_ENV === 'production';
+}
+/* c8 ignore stop */
+
+export function isStrictPeerConfigMode(): boolean {
+  return boolEnv(STRICT_PEER_CONFIG_ENV, isProductionBuild());
+}
+
+export function isLocalMeshPeerAllowed(): boolean {
+  return boolEnv(ALLOW_LOCAL_PEERS_ENV, false);
+}
+
+function defaultMinimumPeerCount(strict: boolean): number {
+  return strict ? 3 : 1;
+}
+
+export function resolveMinimumPeerCount(strict = isStrictPeerConfigMode()): number {
+  return positiveIntEnv(GUN_PEER_MINIMUM_ENV, defaultMinimumPeerCount(strict));
+}
+
+export function resolveQuorumRequired(peerCount: number): number {
+  const fallback = peerCount >= 3 ? 2 : Math.max(1, peerCount);
+  return Math.min(peerCount || fallback, positiveIntEnv(GUN_PEER_QUORUM_REQUIRED_ENV, fallback));
+}
+
+export function normalizeGunPeer(peer: unknown): string | null {
+  if (typeof peer !== 'string') {
+    return null;
+  }
+  const trimmed = peer.trim();
+  if (!trimmed) {
+    return null;
+  }
+  return trimmed.endsWith('/gun') ? trimmed : `${trimmed.replace(/\/+$/, '')}/gun`;
+}
+
+function normalizeGunPeerList(peers: readonly unknown[]): string[] {
+  const normalized = peers
+    .map((peer) => normalizeGunPeer(peer))
+    .filter((peer): peer is string => Boolean(peer));
+  return Array.from(new Set(normalized));
+}
+
+function isLocalHostname(hostname: string | undefined): boolean {
+  const normalized = hostname?.trim().toLowerCase().replace(/^\[(.*)\]$/, '$1');
+  return normalized === 'localhost' || normalized === '127.0.0.1' || normalized === '::1';
+}
+
+function isSecurePeerUrl(peer: string, allowLocalPeers: boolean): boolean {
+  try {
+    const url = new URL(peer);
+    if (url.protocol === 'https:' || url.protocol === 'wss:') {
+      return true;
+    }
+    if (allowLocalPeers && (url.protocol === 'http:' || url.protocol === 'ws:') && isLocalHostname(url.hostname)) {
+      return true;
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+function validateTopology(params: {
+  peers: string[];
+  strict: boolean;
+  allowLocalPeers: boolean;
+  minimumPeerCount: number;
+  source: GunPeerTopology['source'];
+  signed: boolean;
+}): GunPeerTopology {
+  const { peers, strict, allowLocalPeers, minimumPeerCount, source, signed } = params;
+  if (peers.length === 0) {
+    if (!strict && source === 'runtime-global') {
+      return {
+        peers,
+        source,
+        strict,
+        signed,
+        minimumPeerCount,
+        quorumRequired: 0,
+        allowLocalPeers,
+      };
+    }
+    throw new Error('[vh:gun] no Gun peers configured');
+  }
+  if (strict && peers.length < minimumPeerCount) {
+    throw new Error(`[vh:gun] strict peer config requires at least ${minimumPeerCount} peers; got ${peers.length}`);
+  }
+  if (strict) {
+    const insecurePeer = peers.find((peer) => !isSecurePeerUrl(peer, allowLocalPeers));
+    if (insecurePeer) {
+      throw new Error(`[vh:gun] strict peer config rejects insecure peer ${insecurePeer}`);
+    }
+  }
+  return {
+    peers,
+    source,
+    strict,
+    signed,
+    minimumPeerCount,
+    quorumRequired: resolveQuorumRequired(peers.length),
+    allowLocalPeers,
+  };
+}
+
+function parsePeerListEnv(raw: string): string[] {
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (Array.isArray(parsed)) {
+      return normalizeGunPeerList(parsed);
+    }
+  } catch {
+    // fall through to comma-separated parsing
+  }
+  return normalizeGunPeerList(raw.split(','));
+}
+
+function parsePeerConfigPayload(input: unknown): {
+  payload: PeerConfigPayload;
+  signature: string | null;
+  signerPub: string | null;
+} {
+  if (Array.isArray(input)) {
+    return { payload: { peers: input }, signature: null, signerPub: null };
+  }
+  if (!input || typeof input !== 'object') {
+    throw new Error('[vh:gun] peer config must be an array or object');
+  }
+  const record = input as SignedPeerConfigEnvelope & PeerConfigPayload;
+  if ('payload' in record) {
+    const payload = typeof record.payload === 'string'
+      ? JSON.parse(record.payload) as PeerConfigPayload
+      : record.payload as PeerConfigPayload;
+    return {
+      payload,
+      signature: typeof record.signature === 'string' ? record.signature : null,
+      signerPub: typeof record.signerPub === 'string' ? record.signerPub : null,
+    };
+  }
+  return {
+    payload: record as PeerConfigPayload,
+    signature: typeof record.signature === 'string' ? record.signature : null,
+    signerPub: typeof record.signerPub === 'string' ? record.signerPub : null,
+  };
+}
+
+function canonicalize(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => canonicalize(entry)).join(',')}]`;
+  }
+  if (value && typeof value === 'object') {
+    const record = value as Record<string, unknown>;
+    return `{${Object.keys(record)
+      .filter((key) => record[key] !== undefined && key !== 'signature' && key !== 'signerPub')
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonicalize(record[key])}`)
+      .join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function parseInlinePeerConfig(raw: string): {
+  payload: PeerConfigPayload;
+  signature: string | null;
+  signerPub: string | null;
+} {
+  return parsePeerConfigPayload(JSON.parse(raw) as unknown);
+}
+
+async function verifyPeerConfigIfNeeded(params: {
+  payload: PeerConfigPayload;
+  signature: string | null;
+  signerPub: string | null;
+  strict: boolean;
+}): Promise<boolean> {
+  const { payload, signature, signerPub, strict } = params;
+  if (!signature) {
+    if (strict && !boolEnv(ALLOW_UNSIGNED_PEER_CONFIG_ENV, false)) {
+      throw new Error('[vh:gun] strict peer config requires a signed peer config envelope');
+    }
+    return false;
+  }
+  const configuredPublicKey = envValue(GUN_PEER_CONFIG_PUBLIC_KEY_ENV)?.trim() || '';
+  if (strict && !configuredPublicKey) {
+    throw new Error('[vh:gun] strict signed peer config requires VITE_GUN_PEER_CONFIG_PUBLIC_KEY');
+  }
+  const publicKey = configuredPublicKey || signerPub || '';
+  if (!publicKey) {
+    throw new Error('[vh:gun] signed peer config is missing a verification public key');
+  }
+  const { SEA } = await import('@vh/gun-client');
+  const verified = await SEA.verify(signature, publicKey);
+  const canonicalPayload = canonicalize(payload);
+  if (verified !== canonicalPayload && canonicalize(verified) !== canonicalPayload) {
+    throw new Error('[vh:gun] signed peer config verification failed');
+  }
+  return true;
+}
+
+function topologyFromPayload(params: {
+  payload: PeerConfigPayload;
+  signed: boolean;
+  source: GunPeerTopology['source'];
+  strict: boolean;
+  allowLocalPeers: boolean;
+}): GunPeerTopology {
+  const { payload, signed, source, strict, allowLocalPeers } = params;
+  const peers = normalizeGunPeerList(payload.peers ?? []);
+  const minimumPeerCount = typeof payload.minimumPeerCount === 'number' && payload.minimumPeerCount > 0
+    ? Math.floor(payload.minimumPeerCount)
+    : resolveMinimumPeerCount(strict);
+  const now = Date.now();
+  if (typeof payload.expiresAt === 'number' && payload.expiresAt <= now) {
+    throw new Error('[vh:gun] peer config is expired');
+  }
+  return validateTopology({
+    peers,
+    strict,
+    allowLocalPeers,
+    minimumPeerCount,
+    source,
+    signed,
+  });
+}
+
+function runtimeGlobalPeers(strict: boolean): string[] | null {
+  if (strict) {
+    return null;
+  }
+  const globalOverride = (globalThis as { __VH_GUN_PEERS__?: unknown }).__VH_GUN_PEERS__;
+  return Array.isArray(globalOverride) ? normalizeGunPeerList(globalOverride) : null;
+}
+
+function getRuntimeHostname(): string | undefined {
+  return typeof globalThis.location?.hostname === 'string'
+    ? globalThis.location.hostname
+    : undefined;
+}
+
+export function peerHealthUrl(peer: string): string | null {
+  try {
+    const url = new URL(peer);
+    url.protocol = url.protocol === 'wss:' ? 'https:' : url.protocol === 'ws:' ? 'http:' : url.protocol;
+    url.pathname = '/healthz';
+    url.search = '';
+    url.hash = '';
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+export function resolveGunPeerTopologySync(runtimeHostname = getRuntimeHostname()): GunPeerTopology {
+  const strict = isStrictPeerConfigMode();
+  const allowLocalPeers = isLocalMeshPeerAllowed();
+  const minimumPeerCount = resolveMinimumPeerCount(strict);
+
+  const globalPeers = runtimeGlobalPeers(strict);
+  if (globalPeers) {
+    return validateTopology({
+      peers: globalPeers,
+      strict,
+      allowLocalPeers,
+      minimumPeerCount,
+      source: 'runtime-global',
+      signed: false,
+    });
+  }
+
+  const rawPeers = envValue(GUN_PEERS_ENV);
+  if (rawPeers && rawPeers.trim()) {
+    return validateTopology({
+      peers: parsePeerListEnv(rawPeers),
+      strict,
+      allowLocalPeers,
+      minimumPeerCount,
+      source: 'env-peers',
+      signed: false,
+    });
+  }
+
+  const rawConfig = envValue(GUN_PEER_CONFIG_ENV);
+  if (rawConfig && rawConfig.trim()) {
+    const parsed = parseInlinePeerConfig(rawConfig);
+    if (parsed.signature) {
+      throw new Error('[vh:gun] signed Gun peer config requires async resolution');
+    }
+    return topologyFromPayload({
+      payload: parsed.payload,
+      signed: false,
+      source: 'env-config',
+      strict,
+      allowLocalPeers,
+    });
+  }
+
+  if (envValue(GUN_PEER_CONFIG_URL_ENV)) {
+    throw new Error('[vh:gun] remote Gun peer config requires async resolution');
+  }
+
+  if (strict) {
+    throw new Error('[vh:gun] strict peer config requires explicit Gun peers or a signed peer config');
+  }
+
+  return validateTopology({
+    peers: [LOCAL_GUN_PEER],
+    strict,
+    allowLocalPeers,
+    minimumPeerCount,
+    source: 'local-dev-fallback',
+    signed: false,
+  });
+}
+
+export async function resolveGunPeerTopology(runtimeHostname = getRuntimeHostname()): Promise<GunPeerTopology> {
+  const strict = isStrictPeerConfigMode();
+  const allowLocalPeers = isLocalMeshPeerAllowed();
+
+  const remoteConfigUrl = envValue(GUN_PEER_CONFIG_URL_ENV);
+  if (remoteConfigUrl && remoteConfigUrl.trim()) {
+    const response = await fetch(remoteConfigUrl, { signal: AbortSignal.timeout(5_000) });
+    if (!response.ok) {
+      throw new Error(`[vh:gun] failed to fetch peer config: ${response.status}`);
+    }
+    const text = await response.text();
+    const parsed = parseInlinePeerConfig(text);
+    const signed = await verifyPeerConfigIfNeeded({
+      payload: parsed.payload,
+      signature: parsed.signature,
+      signerPub: parsed.signerPub,
+      strict,
+    });
+    return topologyFromPayload({
+      payload: parsed.payload,
+      signed,
+      source: 'remote-config',
+      strict,
+      allowLocalPeers,
+    });
+  }
+
+  const rawConfig = envValue(GUN_PEER_CONFIG_ENV);
+  if (rawConfig && rawConfig.trim()) {
+    const parsed = parseInlinePeerConfig(rawConfig);
+    const signed = await verifyPeerConfigIfNeeded({
+      payload: parsed.payload,
+      signature: parsed.signature,
+      signerPub: parsed.signerPub,
+      strict,
+    });
+    return topologyFromPayload({
+      payload: parsed.payload,
+      signed,
+      source: 'env-config',
+      strict,
+      allowLocalPeers,
+    });
+  }
+
+  return resolveGunPeerTopologySync(runtimeHostname);
+}
+
+export function resolveGunPeers(runtimeHostname = getRuntimeHostname()): string[] {
+  return resolveGunPeerTopologySync(runtimeHostname).peers;
+}

--- a/apps/web-pwa/src/store/store.test.ts
+++ b/apps/web-pwa/src/store/store.test.ts
@@ -1,7 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Mock } from 'vitest';
 
-import { useAppStore, isE2EMode, resolveGunPeers, resolveGunLocalStorage } from './index';
+import {
+  useAppStore,
+  isE2EMode,
+  resolveGunPeers,
+  resolveGunPeerTopologySync,
+  resolveGunLocalStorage,
+} from './index';
 import { createClient } from '@vh/gun-client';
 import * as storeModule from './index';
 
@@ -43,6 +49,10 @@ vi.mock('@vh/gun-client', () => ({
   })),
   publishToDirectory: (...args: unknown[]) => mockPublishDirectory(...(args as [])),
   writeStoryBundle: vi.fn(),
+}));
+
+vi.mock('./synthesis/commentRuntime', () => ({
+  bootstrapSynthesisCommentRuntime: vi.fn(),
 }));
 
 class MemoryStorage {
@@ -91,9 +101,8 @@ describe('useAppStore', () => {
     expect(resolveGunPeers('localhost')).toEqual(['http://127.0.0.1:7777/gun']);
   });
 
-  it('resolves Tailscale first for non-local UI hosts without overrides', () => {
+  it('does not fall back to a hard-coded Tailscale peer for non-local dev hosts', () => {
     expect(resolveGunPeers('ccibootstrap.tail6cc9b5.ts.net')).toEqual([
-      'http://100.75.18.26:7777/gun',
       'http://127.0.0.1:7777/gun',
     ]);
   });
@@ -107,6 +116,57 @@ describe('useAppStore', () => {
 
     (globalThis as any).__VH_GUN_PEERS__ = [];
     expect(resolveGunPeers('127.0.0.1')).toEqual([]);
+  });
+
+  it('rejects missing explicit peer config in strict mode and ignores runtime global peers', () => {
+    vi.stubEnv('VITE_VH_STRICT_PEER_CONFIG', 'true');
+    (globalThis as any).__VH_GUN_PEERS__ = [
+      'https://runtime-a.example/gun',
+      'https://runtime-b.example/gun',
+      'https://runtime-c.example/gun',
+    ];
+
+    expect(() => resolveGunPeers('app.example')).toThrow('strict peer config requires explicit Gun peers');
+  });
+
+  it('requires three secure peers by default in strict mode', () => {
+    vi.stubEnv('VITE_VH_STRICT_PEER_CONFIG', 'true');
+    vi.stubEnv('VITE_GUN_PEERS', JSON.stringify([
+      'https://peer-a.example/gun',
+      'https://peer-b.example/gun',
+    ]));
+
+    expect(() => resolveGunPeers('app.example')).toThrow('requires at least 3 peers');
+
+    vi.stubEnv('VITE_GUN_PEERS', JSON.stringify([
+      'https://peer-a.example/gun',
+      'https://peer-b.example/gun',
+      'http://peer-c.example/gun',
+    ]));
+
+    expect(() => resolveGunPeers('app.example')).toThrow('rejects insecure peer');
+  });
+
+  it('allows local three-peer topology only when explicitly enabled', () => {
+    vi.stubEnv('VITE_VH_STRICT_PEER_CONFIG', 'true');
+    vi.stubEnv('VITE_VH_ALLOW_LOCAL_MESH_PEERS', 'true');
+    vi.stubEnv('VITE_GUN_PEERS', JSON.stringify([
+      'http://127.0.0.1:7788/gun',
+      'http://127.0.0.1:7789/gun',
+      'http://127.0.0.1:7790/gun',
+    ]));
+
+    expect(resolveGunPeerTopologySync('127.0.0.1')).toMatchObject({
+      peers: [
+        'http://127.0.0.1:7788/gun',
+        'http://127.0.0.1:7789/gun',
+        'http://127.0.0.1:7790/gun',
+      ],
+      strict: true,
+      minimumPeerCount: 3,
+      quorumRequired: 2,
+      source: 'env-peers',
+    });
   });
 
   it('passes the locality-aware default peers into the Gun client', async () => {

--- a/docs/reports/MESH_HARDENING_PR2_2026-05-02.md
+++ b/docs/reports/MESH_HARDENING_PR2_2026-05-02.md
@@ -91,11 +91,9 @@ Acceptance target:
 Known unrelated test debt:
 - `pnpm --filter @vh/web-pwa typecheck:test` still fails on broad pre-existing fixture strictness issues across bridge/feed/forum/discovery tests. The production web typecheck and focused tests affected by PR2 were green.
 
-## Queued
-
 ### PR4 — Production Relay
 
-Status: Done locally on `coord/mesh-production-relay-pr4`; ready for PR/CI.
+Status: Done and merged.
 
 Verified implementation:
 - Relay exposes `/healthz`, `/readyz`, and Prometheus-shaped `/metrics`.
@@ -108,6 +106,8 @@ Verified implementation:
 - Historical `vh/__health/__vh_health_probe_*` compaction can run at startup and on interval, with compaction counters in `/metrics`.
 
 Verification evidence:
+- PR #563 merged to `main` at `af2db9e0`.
+- GitHub checks were green before merge: Change Detection, Ownership Scope, Quality Guard, Source Health, StoryCluster Correctness, Test & Build, Bundle Size, Lighthouse, E2E Tests.
 - `pnpm --filter @vh/e2e exec vitest run src/live/relay-server.vitest.mjs --reporter=dot` — 5 tests passed.
 - `pnpm exec vitest run apps/web-pwa/src/store/hermesForum.test.ts --config vitest.config.ts --reporter=dot` — 38 tests passed.
 - `pnpm --filter @vh/gun-client test` — 29 files, 348 tests passed.
@@ -126,15 +126,38 @@ Acceptance target:
 
 ### PR5 — Topology And Quorum
 
-Queued after PR4 merge.
+Status: Done locally on `coord/mesh-topology-quorum-pr5`; ready for PR/CI.
 
-Scope:
-- Three-peer WSS topology.
-- Signed peer config fetched at boot.
-- Remove hardcoded Tailscale fallback from production code paths.
-- Strip or reject runtime peer mutation in production builds.
-- Health reports quorum, not configured peer count.
-- Add failover, network partition, WS reconnect, and soak drills.
+Verified implementation:
+- Added `apps/web-pwa/src/store/peerConfig.ts` as the single peer-topology resolver.
+- Removed the hard-coded Tailscale fallback from web runtime peer resolution.
+- Strict production peer mode now requires explicit peer configuration, requires at least three peers by default, rejects insecure peers unless local mesh peers are explicitly allowed, and ignores the mutable `globalThis.__VH_GUN_PEERS__` escape hatch.
+- Added signed peer-config support for inline or remote JSON envelopes, verified through Gun SEA against `VITE_GUN_PEER_CONFIG_PUBLIC_KEY`.
+- Health monitoring now probes relay `/healthz` endpoints and reports `healthy/configured (need quorum)` instead of showing a vacuous peer URL count.
+- Built-preview mesh canary now runs three local relays, asserts health/readiness/metrics, and includes a one-peer-unavailable write/readback drill.
+- The root `pnpm test:mesh:browser-canary` command builds the app with an explicit three-peer local topology and local-peer permission for the production-preview artifact.
+
+Verification evidence:
+- `pnpm exec vitest run apps/web-pwa/src/store/peerConfig.test.ts apps/web-pwa/src/store/store.test.ts apps/web-pwa/src/hooks/useHealthMonitor.test.ts apps/web-pwa/src/components/dev/HealthIndicator.test.tsx --config vitest.config.ts --reporter=dot` — 4 files, 46 tests passed.
+- `pnpm --filter @vh/e2e typecheck` — passed.
+- `pnpm --filter @vh/web-pwa typecheck` — passed.
+- `pnpm typecheck` — passed across the workspace.
+- `pnpm lint` — passed across the workspace.
+- `node tools/scripts/check-diff-coverage.mjs` — passed; guard reported no coverage-eligible source files changed, so focused peer-config/health/e2e tests are the primary source evidence.
+- `git diff --check` — passed.
+- `pnpm test:mesh:browser-canary` — passed against three built-preview relays with one-peer-unavailable drill.
 
 Acceptance target:
-- One-peer kill and restart drill converges within SLA with no duplicate writes.
+- One-peer-unavailable write/readback drill converges within SLA; full peer kill/restart and network-partition drills remain queued for the production relay/topology environment where relay-to-relay persistence is available.
+
+## Queued
+
+### Production Topology Drills
+
+Scope:
+- Deploy three WSS relays with signed boot peer config.
+- Add peer kill/restart and network-partition drills against the hardened production relay environment.
+- Add 30-minute rolling-restart soak with no duplicate writes after forced WS reconnect.
+
+Acceptance target:
+- Kill one peer, write still confirms; restart peer catches up within SLA; forced WS disconnect does not duplicate user writes.

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test:storycluster:gates": "pnpm --filter @vh/e2e test:live:daemon-feed:build && pnpm --filter @vh/e2e test:live:daemon-feed:gates",
     "test:storycluster:publisher-canary": "pnpm --filter @vh/e2e test:live:daemon-feed:build && pnpm --filter @vh/e2e test:live:daemon-feed:publisher-canary",
     "test:storycluster:consumer-smoke": "pnpm --filter @vh/e2e test:live:daemon-feed:consumer-smoke",
-    "test:mesh:browser-canary": "VITE_GUN_PEERS=http://127.0.0.1:7788/gun VITE_VH_GUN_LOCAL_STORAGE=false VITE_VH_SHOW_HEALTH=true pnpm --filter @vh/web-pwa build && pnpm --filter @vh/e2e test:mesh:browser-canary",
+    "test:mesh:browser-canary": "VITE_GUN_PEERS='[\"http://127.0.0.1:7788/gun\",\"http://127.0.0.1:7789/gun\",\"http://127.0.0.1:7790/gun\"]' VITE_GUN_PEER_MINIMUM=3 VITE_GUN_PEER_QUORUM_REQUIRED=2 VITE_VH_ALLOW_LOCAL_MESH_PEERS=true VITE_VH_GUN_LOCAL_STORAGE=false VITE_VH_SHOW_HEALTH=true pnpm --filter @vh/web-pwa build && pnpm --filter @vh/e2e test:mesh:browser-canary",
     "test:storycluster:smoke": "pnpm --filter @vh/e2e test:live:daemon-feed:build && pnpm --filter @vh/e2e test:live:daemon-feed:semantic-soak",
     "test:storycluster:smoke:readiness": "pnpm --filter @vh/e2e test:live:daemon-feed:build && (pnpm --filter @vh/e2e test:live:daemon-feed:semantic-soak || true) && pnpm --filter @vh/e2e test:live:daemon-feed:semantic-soak:readiness",
     "collect:storycluster:headline-soak": "pnpm report:news-sources:health && pnpm test:storycluster:smoke:readiness",

--- a/packages/e2e/playwright.mesh-canary.config.ts
+++ b/packages/e2e/playwright.mesh-canary.config.ts
@@ -2,8 +2,12 @@ import { defineConfig, devices } from '@playwright/test';
 import * as path from 'node:path';
 
 const relayPort = Number.parseInt(process.env.VH_MESH_CANARY_RELAY_PORT ?? '7788', 10);
+const relayPorts = (process.env.VH_MESH_CANARY_RELAY_PORTS ?? `${relayPort},${relayPort + 1},${relayPort + 2}`)
+  .split(',')
+  .map((value) => Number.parseInt(value.trim(), 10))
+  .filter((value) => Number.isFinite(value));
 const appPort = Number.parseInt(process.env.VH_MESH_CANARY_APP_PORT ?? '2148', 10);
-const relayUrl = `http://127.0.0.1:${relayPort}`;
+const peerUrls = relayPorts.map((port) => `http://127.0.0.1:${port}/gun`);
 const appUrl = process.env.VH_MESH_CANARY_APP_URL ?? `http://127.0.0.1:${appPort}/`;
 const repoRoot = path.resolve(__dirname, '../..');
 
@@ -18,13 +22,13 @@ export default defineConfig({
   },
   reporter: [['list']],
   webServer: [
-    {
-      command: `env GUN_PORT=${relayPort} GUN_HOST=127.0.0.1 GUN_FILE=${repoRoot}/.tmp/mesh-browser-canary-relay GUN_RADISK=true node ${repoRoot}/infra/relay/server.js`,
-      url: relayUrl,
+    ...relayPorts.map((port) => ({
+      command: `env GUN_PORT=${port} GUN_HOST=127.0.0.1 GUN_FILE=${repoRoot}/.tmp/mesh-browser-canary-relay-${port} GUN_RADISK=true node ${repoRoot}/infra/relay/server.js`,
+      url: `http://127.0.0.1:${port}`,
       timeout: 30_000,
       reuseExistingServer: false,
       cwd: repoRoot,
-    },
+    })),
     {
       command: `pnpm --filter @vh/web-pwa exec vite preview --host 127.0.0.1 --port ${appPort} --strictPort`,
       url: appUrl,
@@ -33,7 +37,10 @@ export default defineConfig({
       cwd: repoRoot,
       env: {
         ...process.env,
-        VITE_GUN_PEERS: `http://127.0.0.1:${relayPort}/gun`,
+        VITE_GUN_PEERS: JSON.stringify(peerUrls),
+        VITE_GUN_PEER_MINIMUM: String(Math.min(3, peerUrls.length)),
+        VITE_GUN_PEER_QUORUM_REQUIRED: String(Math.min(2, peerUrls.length)),
+        VITE_VH_ALLOW_LOCAL_MESH_PEERS: 'true',
         VITE_VH_GUN_LOCAL_STORAGE: 'false',
         VITE_VH_SHOW_HEALTH: 'true',
       },

--- a/packages/e2e/src/mesh/browser-mesh-canary.spec.ts
+++ b/packages/e2e/src/mesh/browser-mesh-canary.spec.ts
@@ -2,7 +2,11 @@ import { test, expect } from '@playwright/test';
 import * as path from 'node:path';
 
 const relayPort = Number.parseInt(process.env.VH_MESH_CANARY_RELAY_PORT ?? '7788', 10);
-const peerUrl = `http://127.0.0.1:${relayPort}/gun`;
+const relayPorts = (process.env.VH_MESH_CANARY_RELAY_PORTS ?? `${relayPort},${relayPort + 1},${relayPort + 2}`)
+  .split(',')
+  .map((value) => Number.parseInt(value.trim(), 10))
+  .filter((value) => Number.isFinite(value));
+const peerUrls = relayPorts.map((port) => `http://127.0.0.1:${port}/gun`);
 const gunScriptPath = path.resolve(__dirname, '../../../gun-client/node_modules/gun/gun.js');
 
 type MeshCanaryWindow = Window & {
@@ -60,29 +64,31 @@ test.beforeEach(async ({ page }) => {
 });
 
 test('built preview mesh can write, read back, stay quiet, tear down, and reconnect', async ({ page }) => {
-  const health = await page.request.get(`http://127.0.0.1:${relayPort}/healthz`);
-  expect(health.ok()).toBe(true);
-  await expect(health.json()).resolves.toMatchObject({ ok: true, service: 'vh-relay' });
-  const ready = await page.request.get(`http://127.0.0.1:${relayPort}/readyz`);
-  expect(ready.ok()).toBe(true);
+  for (const port of relayPorts) {
+    const health = await page.request.get(`http://127.0.0.1:${port}/healthz`);
+    expect(health.ok()).toBe(true);
+    await expect(health.json()).resolves.toMatchObject({ ok: true, service: 'vh-relay' });
+    const ready = await page.request.get(`http://127.0.0.1:${port}/readyz`);
+    expect(ready.ok()).toBe(true);
+  }
 
   await page.goto('/');
   await expect(page.locator('[data-testid="feed-shell"]')).toBeVisible({ timeout: 20_000 });
 
-  const initial = await page.evaluate(async (peer) => {
+  const initial = await page.evaluate(async (peers) => {
     const win = window as MeshCanaryWindow;
     if (!win.Gun) {
       throw new Error('gun-script-missing');
     }
     const gun = win.Gun({
-      peers: [peer],
+      peers,
       localStorage: false,
       radisk: false,
       file: false,
       axe: false,
     });
     const writerGun = win.Gun({
-      peers: [peer],
+      peers,
       localStorage: false,
       radisk: false,
       file: false,
@@ -181,7 +187,7 @@ test('built preview mesh can write, read back, stay quiet, tear down, and reconn
     gun.off?.();
     writerGun.off?.();
     return { beforeOff, observedNonces, afterOffNonce, nonce };
-  }, peerUrl);
+  }, peerUrls);
 
   expect(initial.beforeOff).toBeGreaterThan(0);
   expect(initial.observedNonces).not.toContain(initial.afterOffNonce);
@@ -199,12 +205,12 @@ test('built preview mesh can write, read back, stay quiet, tear down, and reconn
   });
   expect(steadyStateMessageRate).toBeLessThan(200);
 
-  const reconnect = await page.evaluate(async ({ peer, expectedNonce }) => {
+  const reconnect = await page.evaluate(async ({ peers, expectedNonce }) => {
     const win = window as MeshCanaryWindow;
     win.__VH_MESH_CANARY__?.forceCloseSockets();
     await new Promise((resolve) => setTimeout(resolve, 500));
     const gun = win.Gun!({
-      peers: [peer],
+      peers,
       localStorage: false,
       radisk: false,
       file: false,
@@ -259,12 +265,57 @@ test('built preview mesh can write, read back, stay quiet, tear down, and reconn
       readPrevious: before.matched,
       readNext: after.matched,
     };
-  }, { peer: peerUrl, expectedNonce: initial.nonce });
+  }, { peers: peerUrls, expectedNonce: initial.nonce });
 
   expect(reconnect.readPrevious).toBe(true);
   expect(reconnect.readNext).toBe(true);
 
-  const metrics = await page.request.get(`http://127.0.0.1:${relayPort}/metrics`);
+  const failover = await page.evaluate(async (peers) => {
+    const win = window as MeshCanaryWindow;
+    const gun = win.Gun!({
+      peers,
+      localStorage: false,
+      radisk: false,
+      file: false,
+      axe: false,
+    });
+    type Chain = {
+      get: (key: string) => Chain;
+      once: (callback: (value: unknown) => void) => unknown;
+      put: (value: unknown, callback?: (ack?: { err?: string }) => void) => unknown;
+    };
+    const node = (gun.get('vh') as Chain).get('__canary').get('one-peer-unavailable');
+    const nonce = `one-peer-down-${Date.now()}`;
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error('failover-put-timeout')), 8_000);
+      node.put({ schemaVersion: 'mesh-canary-v1', nonce, t: Date.now() }, (ack?: { err?: string }) => {
+        clearTimeout(timer);
+        if (ack?.err) reject(new Error(ack.err));
+        else resolve();
+      });
+    });
+    const deadline = Date.now() + 8_000;
+    while (Date.now() < deadline) {
+      const observed = await new Promise<Record<string, unknown> | null>((resolve) => {
+        const timer = setTimeout(() => resolve(null), 1_000);
+        node.once((value: unknown) => {
+          clearTimeout(timer);
+          resolve(value && typeof value === 'object' ? value as Record<string, unknown> : null);
+        });
+      });
+      if (observed?.nonce === nonce) {
+        gun.off?.();
+        return { readNext: true };
+      }
+      await new Promise((resolve) => setTimeout(resolve, 150));
+    }
+    gun.off?.();
+    return { readNext: false };
+  }, [`http://127.0.0.1:9/gun`, ...peerUrls.slice(1)]);
+
+  expect(failover.readNext).toBe(true);
+
+  const metrics = await page.request.get(`http://127.0.0.1:${relayPorts[0]}/metrics`);
   expect(metrics.ok()).toBe(true);
   await expect(metrics.text()).resolves.toContain('vh_relay_http_requests_total');
 });


### PR DESCRIPTION
## Summary
- add a single web peer-topology resolver with strict production guardrails, signed peer-config support, and no hard-coded Tailscale fallback
- surface real peer quorum in the health store/panel by probing each relay health endpoint
- upgrade the built-preview mesh canary to three relays plus a one-peer-unavailable write/readback drill
- update the mesh hardening ledger to mark PR4 merged and PR5 locally verified

## Verification
- `pnpm exec vitest run apps/web-pwa/src/store/peerConfig.test.ts apps/web-pwa/src/store/store.test.ts apps/web-pwa/src/hooks/useHealthMonitor.test.ts apps/web-pwa/src/components/dev/HealthIndicator.test.tsx --config vitest.config.ts --reporter=dot`
- `pnpm --filter @vh/web-pwa typecheck`
- `pnpm --filter @vh/e2e typecheck`
- `pnpm typecheck`
- `pnpm lint`
- `node tools/scripts/check-diff-coverage.mjs`
- `git diff --check`
- `pnpm test:mesh:browser-canary`

## Notes
- `docs/plans/LUMA_SERVICE_V0_ROADMAP_2026-05-02.md` was already untracked and is intentionally not included.
- Full relay kill/restart, network partition, and rolling-soak drills remain queued for the production WSS topology environment where relay-to-relay persistence exists.
