### PR TITLE
Mesh signed peer-config browser canary

### DIFF
--- a/apps/web-pwa/src/env.d.ts
+++ b/apps/web-pwa/src/env.d.ts
@@ -3,6 +3,13 @@
 interface ImportMetaEnv {
   readonly VITE_E2E_MODE?: 'true' | 'false';
   readonly VITE_GUN_PEERS?: string;
+  readonly VITE_GUN_PEER_CONFIG_URL?: string;
+  readonly VITE_GUN_PEER_CONFIG_PUBLIC_KEY?: string;
+  readonly VITE_GUN_PEER_MINIMUM?: string;
+  readonly VITE_GUN_PEER_QUORUM_REQUIRED?: string;
+  readonly VITE_VH_STRICT_PEER_CONFIG?: 'true' | 'false';
+  readonly VITE_VH_ALLOW_LOCAL_MESH_PEERS?: 'true' | 'false';
+  readonly VITE_VH_EXPOSE_PEER_TOPOLOGY?: 'true' | 'false';
   readonly VITE_ATTESTATION_URL?: string;
   readonly VITE_ATTESTATION_TIMEOUT_MS?: string;
   readonly VITE_REMOTE_ENGINE_URL?: string;

--- a/apps/web-pwa/src/store/index.ts
+++ b/apps/web-pwa/src/store/index.ts
@@ -11,11 +11,12 @@ import { safeGetItem, safeSetItem } from '../utils/safeStorage';
 import { loadIdentityRecord } from '../utils/vaultTyped';
 import { createMockClient } from './mockClient';
 import { setClientResolver } from './clientResolver';
-import { resolveGunPeerTopology } from './peerConfig';
+import { resolveGunPeerTopology, type GunPeerTopology } from './peerConfig';
 export { resolveGunPeers, resolveGunPeerTopology, resolveGunPeerTopologySync } from './peerConfig';
 
 const PROFILE_KEY = 'vh_profile';
 const E2E_OVERRIDE_KEY = '__VH_E2E_OVERRIDE__';
+const PEER_TOPOLOGY_PROOF_KEY = '__VH_PEER_TOPOLOGY_PROOF__';
 type IdentityStatus = 'idle' | 'creating' | 'ready' | 'error';
 
 interface AppState {
@@ -30,6 +31,36 @@ interface AppState {
 }
 
 let initInFlight: Promise<void> | null = null;
+
+type PeerTopologyProof =
+  | {
+      status: 'resolved';
+      resolver: 'resolveGunPeerTopology';
+      topology: GunPeerTopology;
+      clientPeers: string[];
+    }
+  | {
+      status: 'failed';
+      resolver: 'resolveGunPeerTopology';
+      error: string;
+      clientPeers: [];
+    };
+
+function shouldExposePeerTopologyProof(): boolean {
+  const viteEnv = (import.meta as unknown as { env?: Record<string, string | boolean | undefined> }).env;
+  const raw = viteEnv?.VITE_VH_EXPOSE_PEER_TOPOLOGY;
+  if (typeof raw === 'boolean') return raw;
+  return typeof raw === 'string' && ['1', 'true', 'yes', 'on'].includes(raw.trim().toLowerCase());
+}
+
+function exposePeerTopologyProof(proof: PeerTopologyProof): void {
+  if (!shouldExposePeerTopologyProof()) {
+    return;
+  }
+  (globalThis as typeof globalThis & { [PEER_TOPOLOGY_PROOF_KEY]?: PeerTopologyProof })[
+    PEER_TOPOLOGY_PROOF_KEY
+  ] = proof;
+}
 
 function loadProfile(): Profile | null {
   try {
@@ -226,6 +257,12 @@ export const useAppStore = create<AppState>((set, get) => ({
           gunLocalStorage: resolveGunLocalStorage(),
           requireSession: true
         });
+        exposePeerTopologyProof({
+          status: 'resolved',
+          resolver: 'resolveGunPeerTopology',
+          topology: peerTopology,
+          clientPeers: client.config.peers,
+        });
         console.info('[vh:web-pwa] using Gun peers', {
           peers: client.config.peers,
           source: peerTopology.source,
@@ -263,6 +300,12 @@ export const useAppStore = create<AppState>((set, get) => ({
 
         await bootstrapRuntimeFeatures(client, 'default');
       } catch (err) {
+        exposePeerTopologyProof({
+          status: 'failed',
+          resolver: 'resolveGunPeerTopology',
+          error: (err as Error).message,
+          clientPeers: [],
+        });
         set({ initializing: false, identityStatus: 'error', error: (err as Error).message });
       }
     };

--- a/apps/web-pwa/src/store/peerConfig.test.ts
+++ b/apps/web-pwa/src/store/peerConfig.test.ts
@@ -8,6 +8,21 @@ vi.mock('@vh/gun-client', () => ({
   },
 }));
 
+function canonicalize(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => canonicalize(entry)).join(',')}]`;
+  }
+  if (value && typeof value === 'object') {
+    const record = value as Record<string, unknown>;
+    return `{${Object.keys(record)
+      .filter((key) => record[key] !== undefined && key !== 'signature' && key !== 'signerPub')
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonicalize(record[key])}`)
+      .join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
 beforeEach(() => {
   vi.unstubAllEnvs();
   vi.unstubAllGlobals();
@@ -107,8 +122,7 @@ describe('peerConfig', () => {
       peers: ['https://a.example/gun', 'https://b.example/gun', 'https://c.example/gun'],
       quorumRequired: 2,
     };
-    const canonical = `{"configId":"local-three-relay-signed-canary","expiresAt":${expiresAt},"issuedAt":${issuedAt},"minimumPeerCount":3,"peers":["https://a.example/gun","https://b.example/gun","https://c.example/gun"],"quorumRequired":2,"schemaVersion":"mesh-peer-config-v1"}`;
-    verifyMock.mockResolvedValue(canonical);
+    verifyMock.mockResolvedValue(canonicalize(payload));
     vi.stubEnv('VITE_VH_STRICT_PEER_CONFIG', 'true');
     vi.stubEnv('VITE_GUN_PEER_CONFIG_URL', 'https://config.example/peers.json');
     vi.stubEnv('VITE_GUN_PEER_CONFIG_PUBLIC_KEY', 'peer-config-pub');
@@ -133,15 +147,18 @@ describe('peerConfig', () => {
   });
 
   it('rejects local signed peer configs in strict mode unless the harness explicitly allows them', async () => {
+    const issuedAt = Date.now() - 1_000;
+    const expiresAt = issuedAt + 86_400_000;
     const payload = {
+      schemaVersion: 'mesh-peer-config-v1',
       configId: 'local-three-relay-signed-canary',
+      issuedAt,
+      expiresAt,
       minimumPeerCount: 3,
       peers: ['http://127.0.0.1:7788/gun', 'http://127.0.0.1:7789/gun', 'http://127.0.0.1:7790/gun'],
       quorumRequired: 2,
     };
-    verifyMock.mockResolvedValue(
-      '{"configId":"local-three-relay-signed-canary","minimumPeerCount":3,"peers":["http://127.0.0.1:7788/gun","http://127.0.0.1:7789/gun","http://127.0.0.1:7790/gun"],"quorumRequired":2}',
-    );
+    verifyMock.mockResolvedValue(canonicalize(payload));
     vi.stubEnv('VITE_VH_STRICT_PEER_CONFIG', 'true');
     vi.stubEnv('VITE_GUN_PEER_CONFIG_URL', 'https://config.example/peers.json');
     vi.stubEnv('VITE_GUN_PEER_CONFIG_PUBLIC_KEY', 'peer-config-pub');
@@ -163,6 +180,47 @@ describe('peerConfig', () => {
       peers: payload.peers,
       quorumRequired: 2,
     });
+  });
+
+  it('rejects strict signed peer configs with missing lifecycle fields or impossible quorum', async () => {
+    const { resolveGunPeerTopology } = await import('./peerConfig');
+    const issuedAt = Date.now() - 1_000;
+    const expiresAt = issuedAt + 86_400_000;
+    const basePayload = {
+      schemaVersion: 'mesh-peer-config-v1',
+      configId: 'local-three-relay-signed-canary',
+      issuedAt,
+      expiresAt,
+      minimumPeerCount: 3,
+      peers: ['https://a.example/gun', 'https://b.example/gun', 'https://c.example/gun'],
+      quorumRequired: 2,
+    };
+    const cases: Array<[Record<string, unknown>, string]> = [
+      [{ ...basePayload, configId: '' }, 'strict signed peer config requires configId'],
+      [{ ...basePayload, issuedAt: undefined }, 'strict signed peer config requires issuedAt'],
+      [{ ...basePayload, expiresAt: undefined }, 'strict signed peer config requires expiresAt'],
+      [{ ...basePayload, minimumPeerCount: undefined }, 'strict signed peer config requires minimumPeerCount'],
+      [{ ...basePayload, quorumRequired: undefined }, 'strict signed peer config requires quorumRequired'],
+      [{ ...basePayload, expiresAt: issuedAt }, 'strict signed peer config expiresAt must be after issuedAt'],
+      [{ ...basePayload, quorumRequired: 4 }, 'strict signed peer config quorumRequired cannot exceed configured peers'],
+    ];
+
+    vi.stubEnv('VITE_VH_STRICT_PEER_CONFIG', 'true');
+    vi.stubEnv('VITE_GUN_PEER_CONFIG_URL', 'https://config.example/peers.json');
+    vi.stubEnv('VITE_GUN_PEER_CONFIG_PUBLIC_KEY', 'peer-config-pub');
+
+    for (const [payload, expectedError] of cases) {
+      verifyMock.mockResolvedValueOnce(canonicalize(payload));
+      vi.stubGlobal('fetch', vi.fn(async () => ({
+        ok: true,
+        text: async () => JSON.stringify({
+          payload,
+          signature: 'signed-peer-config',
+        }),
+      })));
+
+      await expect(resolveGunPeerTopology('app.example')).rejects.toThrow(expectedError);
+    }
   });
 
   it('parses inline peer-config payload variants and rejects bad signatures', async () => {

--- a/apps/web-pwa/src/store/peerConfig.test.ts
+++ b/apps/web-pwa/src/store/peerConfig.test.ts
@@ -96,11 +96,18 @@ describe('peerConfig', () => {
   });
 
   it('requires and verifies signed remote peer config in strict mode', async () => {
+    const issuedAt = Date.now() - 1_000;
+    const expiresAt = issuedAt + 86_400_000;
     const payload = {
+      schemaVersion: 'mesh-peer-config-v1',
+      configId: 'local-three-relay-signed-canary',
+      issuedAt,
+      expiresAt,
       minimumPeerCount: 3,
       peers: ['https://a.example/gun', 'https://b.example/gun', 'https://c.example/gun'],
+      quorumRequired: 2,
     };
-    const canonical = '{"minimumPeerCount":3,"peers":["https://a.example/gun","https://b.example/gun","https://c.example/gun"]}';
+    const canonical = `{"configId":"local-three-relay-signed-canary","expiresAt":${expiresAt},"issuedAt":${issuedAt},"minimumPeerCount":3,"peers":["https://a.example/gun","https://b.example/gun","https://c.example/gun"],"quorumRequired":2,"schemaVersion":"mesh-peer-config-v1"}`;
     verifyMock.mockResolvedValue(canonical);
     vi.stubEnv('VITE_VH_STRICT_PEER_CONFIG', 'true');
     vi.stubEnv('VITE_GUN_PEER_CONFIG_URL', 'https://config.example/peers.json');
@@ -119,9 +126,43 @@ describe('peerConfig', () => {
       source: 'remote-config',
       strict: true,
       signed: true,
+      configId: 'local-three-relay-signed-canary',
       quorumRequired: 2,
     });
     expect(verifyMock).toHaveBeenCalledWith('signed-peer-config', 'peer-config-pub');
+  });
+
+  it('rejects local signed peer configs in strict mode unless the harness explicitly allows them', async () => {
+    const payload = {
+      configId: 'local-three-relay-signed-canary',
+      minimumPeerCount: 3,
+      peers: ['http://127.0.0.1:7788/gun', 'http://127.0.0.1:7789/gun', 'http://127.0.0.1:7790/gun'],
+      quorumRequired: 2,
+    };
+    verifyMock.mockResolvedValue(
+      '{"configId":"local-three-relay-signed-canary","minimumPeerCount":3,"peers":["http://127.0.0.1:7788/gun","http://127.0.0.1:7789/gun","http://127.0.0.1:7790/gun"],"quorumRequired":2}',
+    );
+    vi.stubEnv('VITE_VH_STRICT_PEER_CONFIG', 'true');
+    vi.stubEnv('VITE_GUN_PEER_CONFIG_URL', 'https://config.example/peers.json');
+    vi.stubEnv('VITE_GUN_PEER_CONFIG_PUBLIC_KEY', 'peer-config-pub');
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      text: async () => JSON.stringify({
+        payload,
+        signature: 'signed-peer-config',
+      }),
+    })));
+    const { resolveGunPeerTopology } = await import('./peerConfig');
+
+    await expect(resolveGunPeerTopology('app.example')).rejects.toThrow('rejects insecure peer');
+
+    vi.stubEnv('VITE_VH_ALLOW_LOCAL_MESH_PEERS', 'true');
+    await expect(resolveGunPeerTopology('app.example')).resolves.toMatchObject({
+      allowLocalPeers: true,
+      configId: 'local-three-relay-signed-canary',
+      peers: payload.peers,
+      quorumRequired: 2,
+    });
   });
 
   it('parses inline peer-config payload variants and rejects bad signatures', async () => {

--- a/apps/web-pwa/src/store/peerConfig.ts
+++ b/apps/web-pwa/src/store/peerConfig.ts
@@ -3,6 +3,7 @@ export interface GunPeerTopology {
   readonly source: 'env-peers' | 'env-config' | 'remote-config' | 'runtime-global' | 'local-dev-fallback';
   readonly strict: boolean;
   readonly signed: boolean;
+  readonly configId?: string;
   readonly minimumPeerCount: number;
   readonly quorumRequired: number;
   readonly allowLocalPeers: boolean;
@@ -10,6 +11,7 @@ export interface GunPeerTopology {
 
 interface PeerConfigPayload {
   readonly schemaVersion?: string;
+  readonly configId?: unknown;
   readonly peers?: readonly unknown[];
   readonly minimumPeerCount?: unknown;
   readonly quorumRequired?: unknown;
@@ -141,10 +143,12 @@ function validateTopology(params: {
   strict: boolean;
   allowLocalPeers: boolean;
   minimumPeerCount: number;
+  quorumRequired?: number;
+  configId?: string;
   source: GunPeerTopology['source'];
   signed: boolean;
 }): GunPeerTopology {
-  const { peers, strict, allowLocalPeers, minimumPeerCount, source, signed } = params;
+  const { peers, strict, allowLocalPeers, minimumPeerCount, quorumRequired, configId, source, signed } = params;
   if (peers.length === 0) {
     if (!strict && source === 'runtime-global') {
       return {
@@ -173,8 +177,9 @@ function validateTopology(params: {
     source,
     strict,
     signed,
+    ...(configId ? { configId } : {}),
     minimumPeerCount,
-    quorumRequired: resolveQuorumRequired(peers.length),
+    quorumRequired: quorumRequired ?? resolveQuorumRequired(peers.length),
     allowLocalPeers,
   };
 }
@@ -282,9 +287,15 @@ function topologyFromPayload(params: {
 }): GunPeerTopology {
   const { payload, signed, source, strict, allowLocalPeers } = params;
   const peers = normalizeGunPeerList(payload.peers ?? []);
+  const configId = typeof payload.configId === 'string' && payload.configId.trim()
+    ? payload.configId.trim()
+    : undefined;
   const minimumPeerCount = typeof payload.minimumPeerCount === 'number' && payload.minimumPeerCount > 0
     ? Math.floor(payload.minimumPeerCount)
     : resolveMinimumPeerCount(strict);
+  const quorumRequired = typeof payload.quorumRequired === 'number' && payload.quorumRequired > 0
+    ? Math.min(peers.length, Math.floor(payload.quorumRequired))
+    : undefined;
   const now = Date.now();
   if (typeof payload.expiresAt === 'number' && payload.expiresAt <= now) {
     throw new Error('[vh:gun] peer config is expired');
@@ -294,6 +305,8 @@ function topologyFromPayload(params: {
     strict,
     allowLocalPeers,
     minimumPeerCount,
+    quorumRequired,
+    configId,
     source,
     signed,
   });

--- a/apps/web-pwa/src/store/peerConfig.ts
+++ b/apps/web-pwa/src/store/peerConfig.ts
@@ -240,6 +240,14 @@ function canonicalize(value: unknown): string {
   return JSON.stringify(value);
 }
 
+function positiveIntegerPayloadField(value: unknown): number | null {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value > 0 ? value : null;
+}
+
+function timestampPayloadField(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : null;
+}
+
 function parseInlinePeerConfig(raw: string): {
   payload: PeerConfigPayload;
   signature: string | null;
@@ -290,14 +298,39 @@ function topologyFromPayload(params: {
   const configId = typeof payload.configId === 'string' && payload.configId.trim()
     ? payload.configId.trim()
     : undefined;
-  const minimumPeerCount = typeof payload.minimumPeerCount === 'number' && payload.minimumPeerCount > 0
-    ? Math.floor(payload.minimumPeerCount)
-    : resolveMinimumPeerCount(strict);
-  const quorumRequired = typeof payload.quorumRequired === 'number' && payload.quorumRequired > 0
-    ? Math.min(peers.length, Math.floor(payload.quorumRequired))
-    : undefined;
+  const signedMinimumPeerCount = positiveIntegerPayloadField(payload.minimumPeerCount);
+  const signedQuorumRequired = positiveIntegerPayloadField(payload.quorumRequired);
+  const issuedAt = timestampPayloadField(payload.issuedAt);
+  const expiresAt = timestampPayloadField(payload.expiresAt);
+
+  if (strict && signed) {
+    if (!configId) {
+      throw new Error('[vh:gun] strict signed peer config requires configId');
+    }
+    if (!issuedAt) {
+      throw new Error('[vh:gun] strict signed peer config requires issuedAt');
+    }
+    if (!expiresAt) {
+      throw new Error('[vh:gun] strict signed peer config requires expiresAt');
+    }
+    if (expiresAt <= issuedAt) {
+      throw new Error('[vh:gun] strict signed peer config expiresAt must be after issuedAt');
+    }
+    if (!signedMinimumPeerCount) {
+      throw new Error('[vh:gun] strict signed peer config requires minimumPeerCount');
+    }
+    if (!signedQuorumRequired) {
+      throw new Error('[vh:gun] strict signed peer config requires quorumRequired');
+    }
+    if (signedQuorumRequired > peers.length) {
+      throw new Error('[vh:gun] strict signed peer config quorumRequired cannot exceed configured peers');
+    }
+  }
+
+  const minimumPeerCount = signedMinimumPeerCount ?? resolveMinimumPeerCount(strict);
+  const quorumRequired = signedQuorumRequired ?? undefined;
   const now = Date.now();
-  if (typeof payload.expiresAt === 'number' && payload.expiresAt <= now) {
+  if (expiresAt !== null && expiresAt <= now) {
     throw new Error('[vh:gun] peer config is expired');
   }
   return validateTopology({

--- a/docs/ops/mesh-production-topology-drills.md
+++ b/docs/ops/mesh-production-topology-drills.md
@@ -10,7 +10,7 @@ It runs under `schema_epoch: pre_luma_m0b` and `luma_profile: none`.
 
 ## Command
 
-Run:
+Run the transport drill:
 
 ```sh
 pnpm test:mesh:topology-drills
@@ -31,6 +31,25 @@ Each run also writes the same report under:
 ```text
 .tmp/mesh-production-readiness/<run_id>/mesh-production-readiness-report.json
 ```
+
+Run the signed browser peer-config canary:
+
+```sh
+pnpm test:mesh:signed-peer-config-canary
+```
+
+That command generates a local signed peer-config fixture with `schemaVersion`,
+`configId`, `issuedAt`, `expiresAt`, `peers`, `minimumPeerCount`, and
+`quorumRequired`; builds/previews the Web PWA with
+`VITE_VH_STRICT_PEER_CONFIG=true`, `VITE_GUN_PEER_CONFIG_URL`,
+`VITE_GUN_PEER_CONFIG_PUBLIC_KEY`, and
+`VITE_VH_ALLOW_LOCAL_MESH_PEERS=true`; and asserts app boot used
+`resolveGunPeerTopology` with `source: remote-config`, `strict: true`,
+`signed: true`, three peers, and quorum two.
+
+The signed canary writes its report to the same latest report path only when the
+signed browser proof actually ran. Standalone `pnpm test:mesh:topology-drills`
+remains transport-only and must not report `signed_peer_config: true`.
 
 ## Drill Scope
 
@@ -53,6 +72,16 @@ The current drill proves:
 - relay-peer auth negative coverage for unauthorized WebSocket peer upgrades;
 - TTL and tombstone cleanup accounting for the drill namespace.
 
+The signed browser canary separately proves:
+
+- strict app boot from a signed remote peer-config fixture, not direct
+  `VITE_GUN_PEERS` injection;
+- deterministic fail-closed behavior for unsigned config, expired config,
+  fewer than three peers, bad signature, missing public key, and local peers
+  without `VITE_VH_ALLOW_LOCAL_MESH_PEERS=true`;
+- no usable Gun client is initialized for those negative cases, as observed by
+  the e2e-only topology proof hook.
+
 `VH_RELAY_PEER_AUTH_MODE=private_network_allowlist` is a local/private-network
 harness mode. Because Gun relay and browser clients share the `/gun` WebSocket
 path in this server, public production WSS rollout still needs a trust path
@@ -62,10 +91,11 @@ client-compatible signed peer handshake.
 ## Review Boundary
 
 The report status remains `review_required` for Slice 6A/7A because this command
-does not claim restarted-relay catch-up, deployed WSS topology, browser signed
-peer-config boot, state-resolution drills, clock-skew drills, partition/heal
-drills, soak budgets, evidence scrub promotion, or post-M0.B LUMA-gated write
-coverage.
+does not claim restarted-relay catch-up, deployed WSS topology,
+state-resolution drills, clock-skew drills, partition/heal drills, soak budgets,
+evidence scrub promotion, or post-M0.B LUMA-gated write coverage. The transport
+drill and signed browser canary may each pass while the overall readiness status
+still remains `review_required`.
 
 If direct restarted-relay readback is added later and remains brittle after the
 bounded proof attempt, record the failure in the report instead of tuning Gun

--- a/docs/ops/mesh-production-topology-drills.md
+++ b/docs/ops/mesh-production-topology-drills.md
@@ -77,8 +77,9 @@ The signed browser canary separately proves:
 - strict app boot from a signed remote peer-config fixture, not direct
   `VITE_GUN_PEERS` injection;
 - deterministic fail-closed behavior for unsigned config, expired config,
-  fewer than three peers, bad signature, missing public key, and local peers
-  without `VITE_VH_ALLOW_LOCAL_MESH_PEERS=true`;
+  missing lifecycle fields, impossible quorum, fewer than three peers, bad
+  signature, missing public key, and local peers without
+  `VITE_VH_ALLOW_LOCAL_MESH_PEERS=true`;
 - no usable Gun client is initialized for those negative cases, as observed by
   the e2e-only topology proof hook.
 

--- a/docs/specs/spec-mesh-production-readiness.md
+++ b/docs/specs/spec-mesh-production-readiness.md
@@ -596,8 +596,9 @@ Acceptance gates:
   `strict: true`, `signed: true`, the expected `configId`, three peers, and
   quorum two.
 - Signed app boot negative cases fail closed before a usable Gun client is
-  initialized: unsigned config, expired config, fewer than three peers, bad
-  signature, missing public key, and local peers without
+  initialized: unsigned config, expired config, missing lifecycle fields,
+  impossible quorum, fewer than three peers, bad signature, missing public key,
+  and local peers without
   `VITE_VH_ALLOW_LOCAL_MESH_PEERS=true`.
 - Slice 6B browser app boot accepts a signed three-peer WSS config with local
   peer allowance disabled.

--- a/docs/specs/spec-mesh-production-readiness.md
+++ b/docs/specs/spec-mesh-production-readiness.md
@@ -101,9 +101,13 @@ Current head at closeout:
   validates app boot/health against those healthy relays, and separately
   validates a raw browser Gun write/readback path with one intentionally
   unavailable peer in that test client's peer list.
-- Full production relay topology drills remain queued because they require a
-  real multi-relay deployment and relay-to-relay persistence/catch-up behavior,
-  not just three local standalone relays.
+- `pnpm test:mesh:topology-drills` proves the first local three-relay transport
+  path and one-peer-kill remaining-quorum readback under
+  `schema_epoch: pre_luma_m0b`.
+- `pnpm test:mesh:signed-peer-config-canary` is the app-facing companion proof:
+  it must build/preview the Web PWA with strict signed peer-config env and
+  assert boot consumed `resolveGunPeerTopology` with `source: remote-config`,
+  not direct `VITE_GUN_PEERS` injection.
 
 Important boundary:
 
@@ -573,6 +577,8 @@ Acceptance gates:
 
 - Slice 6A local harness command exists:
   `pnpm test:mesh:topology-drills`
+- Slice 6A signed app boot command exists:
+  `pnpm test:mesh:signed-peer-config-canary`
 - The harness starts three production-mode local relays with distinct radata
   directories and non-empty relay peer lists.
 - Relay-to-relay auth rejects an unauthorized peer connection without weakening
@@ -585,7 +591,14 @@ Acceptance gates:
   - `GET /metrics`
 - Browser app boot rejects unsigned or insufficient peer config in strict mode.
 - Slice 6A browser app boot accepts a signed three-peer local config only when
-  local mesh peers are explicitly allowed for the harness.
+  local mesh peers are explicitly allowed for the harness. This proof must
+  assert the app used `resolveGunPeerTopology` with `source: remote-config`,
+  `strict: true`, `signed: true`, the expected `configId`, three peers, and
+  quorum two.
+- Signed app boot negative cases fail closed before a usable Gun client is
+  initialized: unsigned config, expired config, fewer than three peers, bad
+  signature, missing public key, and local peers without
+  `VITE_VH_ALLOW_LOCAL_MESH_PEERS=true`.
 - Slice 6B browser app boot accepts a signed three-peer WSS config with local
   peer allowance disabled.
 - Health panel reports quorum with actual peer health, not configured URL count.
@@ -959,7 +972,10 @@ interface MeshProductionReadinessReport {
     dirty: boolean;
   };
   run: {
-    mode: 'local_production_topology' | 'deployed_wss_topology';
+    mode:
+      | 'local_production_topology'
+      | 'local_signed_peer_config_browser_boot'
+      | 'deployed_wss_topology';
     started_at: string;
     completed_at: string;
     duration_ms: number;
@@ -982,6 +998,15 @@ interface MeshProductionReadinessReport {
     peer_config_id: string;
     peer_config_issued_at: string;
     peer_config_expires_at: string;
+    app_peer_config?: {
+      source: 'remote-config';
+      strict: true;
+      signed: boolean;
+      config_id: string;
+      minimum_peer_count: number;
+      quorum_required: number;
+      local_mesh_peers_allowed: boolean;
+    };
   };
   gates: Array<{
     name: string;
@@ -1833,37 +1858,26 @@ match and LUMA profile gates per §5.8.
 
 ## 9. Immediate Next Slice
 
-The next implementation slice is Slice 6A plus Slice 7A:
+The current Slice 6A/7A local proof is intentionally split into two commands:
 
-1. Add a local production-shaped three-relay topology harness with production
-   relay env, persistent per-relay radata dirs, auth/origin/limit settings, and
-   explicit relay peer lists.
-2. Add relay-to-relay auth for the harness and a negative unauthorized-peer
-   test.
-3. Add signed peer-config generation and verification for that harness,
-   including `configId`, `issuedAt`, and `expiresAt`.
-4. Add `run_id`, `write_id`, and `trace_id` propagation in the drill harness
-   and report skeleton.
-5. Write all drill data under `vh/__mesh_drills/<run_id>/...` using the mesh
-   drill test writer contract (§5.9). Drill records carry
-   `_drillWriterKind: 'mesh-drill'` and `_drillSignature` only; they do not
-   carry LUMA `_writerKind` or `SignedWriteEnvelope`.
-6. Add cleanup accounting for the drill namespace (§5.9.1).
-7. Add `pnpm test:mesh:topology-drills`.
-8. Prove one-peer-kill write/readback behavior through the remaining quorum.
-9. Record direct per-relay readback evidence, even if restarted-peer catch-up is
-   not claimed yet.
-10. Stub the state-resolution, clock-skew, and LUMA-gated-write report sections
-    as `skipped` with explicit reasons until Slice 7C/Slice 9 and LUMA M0.B
-    implement them; do not allow those skipped sections to produce
-    `release_ready`.
-11. Set `schema_epoch: 'pre_luma_m0b'`, `luma_profile: 'none'`, and record
-    `luma_dependency_status` reflecting the actual LUMA milestone state at
-    the time of the run (§5.13).
-12. Record the result in a new ops runbook and readiness report skeleton.
+1. `pnpm test:mesh:topology-drills` is the transport proof. It starts the local
+   three-relay harness, writes synthetic drill records under
+   `vh/__mesh_drills/<run_id>/...`, proves one-peer-kill write/readback through
+   the remaining quorum, records direct per-relay readback evidence, and keeps
+   restarted-peer catch-up unclaimed.
+2. `pnpm test:mesh:signed-peer-config-canary` is the browser boot proof. It
+   generates and serves a signed local peer-config fixture with `configId`,
+   `issuedAt`, and `expiresAt`, builds/previews the Web PWA in strict mode, and
+   proves the app consumed `resolveGunPeerTopology` with `source:
+   remote-config`.
 
-This is the narrowest next step because it tests the only major unproven claim
-left after PR #564: real distributed topology behavior beyond the local
-three-peer preview canary. Do not start with a cloud WSS deployment until the
-local harness produces the first report packet; otherwise the team will be
-debugging deployment, signing, topology, and convergence at the same time.
+The next implementation slice after both local commands are green is either
+Slice 7B direct restarted-relay catch-up evidence or Slice 6B deployed WSS
+topology. Do not start a production WSS readiness claim until the local signed
+peer-config browser canary is green.
+
+Both local commands must keep state-resolution, clock-skew, and LUMA-gated-write
+report sections as `skipped` with explicit reasons until Slice 7C/Slice 9 and
+LUMA M0.B implement them. Skipped sections must not produce `release_ready`.
+Reports stay under `schema_epoch: 'pre_luma_m0b'` and `luma_profile: 'none'`
+until the LUMA schema epoch changes.

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test:storycluster:publisher-canary": "pnpm --filter @vh/e2e test:live:daemon-feed:build && pnpm --filter @vh/e2e test:live:daemon-feed:publisher-canary",
     "test:storycluster:consumer-smoke": "pnpm --filter @vh/e2e test:live:daemon-feed:consumer-smoke",
     "test:mesh:browser-canary": "VITE_GUN_PEERS='[\"http://127.0.0.1:7788/gun\",\"http://127.0.0.1:7789/gun\",\"http://127.0.0.1:7790/gun\"]' VITE_GUN_PEER_MINIMUM=3 VITE_GUN_PEER_QUORUM_REQUIRED=2 VITE_VH_ALLOW_LOCAL_MESH_PEERS=true VITE_VH_GUN_LOCAL_STORAGE=false VITE_VH_SHOW_HEALTH=true pnpm --filter @vh/web-pwa build && pnpm --filter @vh/e2e test:mesh:browser-canary",
+    "test:mesh:signed-peer-config-canary": "node ./packages/e2e/src/mesh/signed-peer-config-canary.mjs",
     "test:mesh:topology-drills": "pnpm --filter @vh/e2e test:mesh:topology-drills",
     "test:storycluster:smoke": "pnpm --filter @vh/e2e test:live:daemon-feed:build && pnpm --filter @vh/e2e test:live:daemon-feed:semantic-soak",
     "test:storycluster:smoke:readiness": "pnpm --filter @vh/e2e test:live:daemon-feed:build && (pnpm --filter @vh/e2e test:live:daemon-feed:semantic-soak || true) && pnpm --filter @vh/e2e test:live:daemon-feed:semantic-soak:readiness",

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -24,6 +24,7 @@
     "test:live:daemon-feed:semantic-soak": "node ./src/live/daemon-feed-semantic-soak.mjs",
     "test:live:daemon-feed:semantic-soak:readiness": "node ./src/live/daemon-feed-semantic-soak-readiness.mjs",
     "test:mesh:browser-canary": "playwright test --config=playwright.mesh-canary.config.ts src/mesh/browser-mesh-canary.spec.ts",
+    "test:mesh:signed-peer-config-canary": "node ./src/mesh/signed-peer-config-canary.mjs",
     "test:mesh:topology-drills": "node ./src/mesh/production-topology-drills.mjs",
     "report:live:daemon-feed:fixture-candidate-intake": "node ./src/live/daemon-feed-fixture-candidate-intake.mjs",
     "report:offline-cluster-replay": "node ./src/live/daemon-feed-semantic-soak-offline-replay-report.mjs",

--- a/packages/e2e/playwright.mesh-signed-peer-config.config.ts
+++ b/packages/e2e/playwright.mesh-signed-peer-config.config.ts
@@ -1,0 +1,75 @@
+import { defineConfig, devices } from '@playwright/test';
+import * as path from 'node:path';
+
+const firstRelayPort = Number.parseInt(process.env.VH_MESH_SIGNED_CANARY_RELAY_PORT ?? '7888', 10);
+const relayPorts = (process.env.VH_MESH_SIGNED_CANARY_RELAY_PORTS ?? `${firstRelayPort},${firstRelayPort + 1},${firstRelayPort + 2}`)
+  .split(',')
+  .map((value) => Number.parseInt(value.trim(), 10))
+  .filter((value) => Number.isFinite(value));
+const relayIds = ['signed-relay-a', 'signed-relay-b', 'signed-relay-c'];
+const appPort = Number.parseInt(process.env.VH_MESH_SIGNED_CANARY_APP_PORT ?? '2248', 10);
+const configPort = Number.parseInt(process.env.VH_MESH_SIGNED_CANARY_CONFIG_PORT ?? '2249', 10);
+const peerUrls = relayPorts.map((port) => `http://127.0.0.1:${port}/gun`);
+const appUrl = process.env.VH_MESH_SIGNED_CANARY_APP_URL ?? `http://127.0.0.1:${appPort}/`;
+const appOrigin = new URL(appUrl).origin;
+const repoRoot = path.resolve(__dirname, '../..');
+const fixturePath = process.env.VH_MESH_SIGNED_PEER_CONFIG_PATH
+  ?? path.join(repoRoot, '.tmp/mesh-production-readiness/latest/signed-peer-config.json');
+
+export default defineConfig({
+  testDir: '.',
+  timeout: 90_000,
+  expect: { timeout: 10_000 },
+  use: {
+    ...devices['Desktop Chrome'],
+    baseURL: appUrl,
+    trace: 'retain-on-failure',
+  },
+  reporter: [['list']],
+  webServer: [
+    ...relayPorts.map((port, index) => ({
+      command: [
+        'env',
+        'NODE_ENV=production',
+        `GUN_PORT=${port}`,
+        'GUN_HOST=127.0.0.1',
+        `GUN_FILE=${repoRoot}/.tmp/mesh-signed-peer-config-relay-${port}`,
+        'GUN_RADISK=true',
+        `VH_RELAY_ID=${relayIds[index] ?? `signed-relay-${index + 1}`}`,
+        `VH_RELAY_PEERS='${JSON.stringify(peerUrls.filter((_, peerIndex) => peerIndex !== index))}'`,
+        'VH_RELAY_AUTH_REQUIRED=true',
+        'VH_RELAY_DAEMON_TOKEN=local-mesh-signed-canary-daemon-token',
+        `VH_RELAY_ALLOWED_ORIGINS=${appOrigin}`,
+        'VH_RELAY_PEER_AUTH_MODE=private_network_allowlist',
+        'VH_RELAY_PEER_ALLOWLIST=loopback',
+        'VH_RELAY_HTTP_RATE_LIMIT_PER_MIN=1200',
+        'VH_RELAY_WS_BYTES_PER_SEC=1000000',
+        'VH_RELAY_MAX_ACTIVE_CONNECTIONS=5000',
+        `node ${repoRoot}/infra/relay/server.js`,
+      ].join(' '),
+      url: `http://127.0.0.1:${port}/readyz`,
+      timeout: 30_000,
+      reuseExistingServer: false,
+      cwd: repoRoot,
+    })),
+    {
+      command: `env VH_MESH_SIGNED_CANARY_CONFIG_PORT=${configPort} VH_MESH_SIGNED_PEER_CONFIG_PATH=${fixturePath} node ${repoRoot}/packages/e2e/src/mesh/signed-peer-config-server.mjs`,
+      url: `http://127.0.0.1:${configPort}/healthz`,
+      timeout: 15_000,
+      reuseExistingServer: false,
+      cwd: repoRoot,
+    },
+    {
+      command: `pnpm --filter @vh/web-pwa exec vite preview --host 127.0.0.1 --port ${appPort} --strictPort`,
+      url: appUrl,
+      timeout: 45_000,
+      reuseExistingServer: false,
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        VITE_VH_GUN_LOCAL_STORAGE: 'false',
+        VITE_VH_SHOW_HEALTH: 'true',
+      },
+    },
+  ],
+});

--- a/packages/e2e/src/mesh/signed-peer-config-canary.mjs
+++ b/packages/e2e/src/mesh/signed-peer-config-canary.mjs
@@ -168,11 +168,23 @@ async function main() {
     configId: `${configId}-insufficient-peers`,
     peers: peerUrls.slice(0, 2),
   };
+  const missingExpiresAtPayload = {
+    ...positivePayload,
+    configId: `${configId}-missing-expires-at`,
+  };
+  delete missingExpiresAtPayload.expiresAt;
+  const impossibleQuorumPayload = {
+    ...positivePayload,
+    configId: `${configId}-impossible-quorum`,
+    quorumRequired: peerUrls.length + 1,
+  };
 
   const positiveFixturePath = path.join(fixtureDir, 'signed-peer-config.json');
   const unsignedFixturePath = path.join(fixtureDir, 'unsigned-peer-config.json');
   const expiredFixturePath = path.join(fixtureDir, 'expired-peer-config.json');
   const insufficientPeersFixturePath = path.join(fixtureDir, 'insufficient-peers-peer-config.json');
+  const missingExpiresAtFixturePath = path.join(fixtureDir, 'missing-expires-at-peer-config.json');
+  const impossibleQuorumFixturePath = path.join(fixtureDir, 'impossible-quorum-peer-config.json');
   const badSignatureFixturePath = path.join(fixtureDir, 'bad-signature-peer-config.json');
   const manifestPath = path.join(artifactDir, 'signed-peer-config-manifest.json');
   const browserEvidencePath = path.join(artifactDir, 'signed-peer-config-browser-evidence.json');
@@ -182,6 +194,8 @@ async function main() {
   writeJson(unsignedFixturePath, { payload: positivePayload });
   writeJson(expiredFixturePath, await signPayload(expiredPayload, pair));
   writeJson(insufficientPeersFixturePath, await signPayload(insufficientPeersPayload, pair));
+  writeJson(missingExpiresAtFixturePath, await signPayload(missingExpiresAtPayload, pair));
+  writeJson(impossibleQuorumFixturePath, await signPayload(impossibleQuorumPayload, pair));
   writeJson(badSignatureFixturePath, {
     ...positiveFixture,
     signature: `bad-${positiveFixture.signature}`,
@@ -202,6 +216,8 @@ async function main() {
       unsigned: unsignedFixturePath,
       expired: expiredFixturePath,
       insufficientPeers: insufficientPeersFixturePath,
+      missingExpiresAt: missingExpiresAtFixturePath,
+      impossibleQuorum: impossibleQuorumFixturePath,
       badSignature: badSignatureFixturePath,
     },
   };
@@ -402,7 +418,7 @@ async function main() {
       allowed: allPassed
         ? [
             'The local Web PWA can boot in strict mode from a signed three-relay local peer-config fixture when local mesh peers are explicitly allowed.',
-            'Unsigned, expired, insufficient-peer, bad-signature, missing-public-key, and local-peers-without-allowance configurations fail closed before a usable Gun client is initialized.',
+            'Unsigned, expired, missing-lifecycle-field, impossible-quorum, insufficient-peer, bad-signature, missing-public-key, and local-peers-without-allowance configurations fail closed before a usable Gun client is initialized.',
           ]
         : [],
       forbidden: [

--- a/packages/e2e/src/mesh/signed-peer-config-canary.mjs
+++ b/packages/e2e/src/mesh/signed-peer-config-canary.mjs
@@ -1,0 +1,450 @@
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import net from 'node:net';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '../../../..');
+const gunRequire = createRequire(path.join(repoRoot, 'packages/gun-client/package.json'));
+const SEA = gunRequire('gun/sea');
+
+const DEFAULT_TTL_MS = 60 * 60 * 1000;
+
+function makeId(prefix) {
+  return `${prefix}-${Date.now()}-${Math.random().toString(16).slice(2, 10)}`;
+}
+
+function canonicalize(value) {
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => canonicalize(entry)).join(',')}]`;
+  }
+  if (value && typeof value === 'object') {
+    return `{${Object.keys(value)
+      .filter((key) => value[key] !== undefined && key !== 'signature' && key !== 'signerPub')
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonicalize(value[key])}`)
+      .join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function findFreePort() {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        server.close(() => reject(new Error('failed to allocate free port')));
+        return;
+      }
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve(address.port);
+      });
+    });
+  });
+}
+
+async function allocatePorts(count) {
+  const ports = new Set();
+  while (ports.size < count) {
+    ports.add(await findFreePort());
+  }
+  return Array.from(ports);
+}
+
+function runGit(args) {
+  const result = spawnSync('git', args, {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  });
+  return result.status === 0 ? result.stdout.trim() : '';
+}
+
+function runStep(steps, name, command, args, env) {
+  const startedAt = Date.now();
+  const result = spawnSync(command, args, {
+    cwd: repoRoot,
+    env,
+    stdio: 'inherit',
+  });
+  const completedAt = Date.now();
+  const exitCode = typeof result.status === 'number' ? result.status : 1;
+  steps.push({
+    name,
+    command: [command, ...args].join(' '),
+    duration_ms: completedAt - startedAt,
+    exit_code: exitCode,
+    status: exitCode === 0 ? 'pass' : 'fail',
+    reason: exitCode === 0 ? undefined : result.error?.message ?? `exit ${exitCode}`,
+  });
+  return exitCode === 0;
+}
+
+async function signPayload(payload, pair) {
+  const signature = await SEA.sign(canonicalize(payload), pair);
+  return {
+    payload,
+    signature,
+    signerPub: pair.pub,
+  };
+}
+
+function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function redactedRelayUrl(peerUrl) {
+  const url = new URL(peerUrl);
+  return `${url.protocol}//${url.hostname}:<redacted>/gun`;
+}
+
+function copyIfExists(source, destination) {
+  if (fs.existsSync(source)) {
+    fs.copyFileSync(source, destination);
+  }
+}
+
+function writeReport({ artifactDir, report, positiveFixturePath, manifestPath, browserEvidencePath }) {
+  const latestDir = path.join(repoRoot, '.tmp/mesh-production-readiness/latest');
+  fs.rmSync(latestDir, { recursive: true, force: true });
+  fs.mkdirSync(latestDir, { recursive: true });
+
+  const reportPath = path.join(artifactDir, 'mesh-production-readiness-report.json');
+  const latestReportPath = path.join(latestDir, 'mesh-production-readiness-report.json');
+  writeJson(reportPath, report);
+  writeJson(latestReportPath, report);
+  copyIfExists(positiveFixturePath, path.join(latestDir, 'signed-peer-config.json'));
+  copyIfExists(manifestPath, path.join(latestDir, 'signed-peer-config-manifest.json'));
+  copyIfExists(browserEvidencePath, path.join(latestDir, 'signed-peer-config-browser-evidence.json'));
+  return { reportPath, latestReportPath };
+}
+
+async function main() {
+  const startedAtMs = Date.now();
+  const startedAt = new Date(startedAtMs).toISOString();
+  const runId = makeId('mesh-signed-peer-config');
+  const traceId = makeId('trace');
+  const artifactDir = path.join(repoRoot, '.tmp/mesh-production-readiness', runId);
+  const fixtureDir = path.join(artifactDir, 'fixtures');
+  fs.mkdirSync(fixtureDir, { recursive: true });
+
+  const ports = await allocatePorts(5);
+  const relayPorts = ports.slice(0, 3);
+  const appPort = ports[3];
+  const configPort = ports[4];
+  const peerUrls = relayPorts.map((port) => `http://127.0.0.1:${port}/gun`);
+  const configUrl = `http://127.0.0.1:${configPort}/mesh-peer-config.json`;
+  const issuedAt = Date.now();
+  const expiresAt = issuedAt + DEFAULT_TTL_MS;
+  const configId = `local-three-relay-${runId}`;
+  const pair = await SEA.pair();
+
+  const positivePayload = {
+    schemaVersion: 'mesh-peer-config-v1',
+    configId,
+    issuedAt,
+    expiresAt,
+    peers: peerUrls,
+    minimumPeerCount: 3,
+    quorumRequired: 2,
+  };
+  const expiredPayload = {
+    ...positivePayload,
+    configId: `${configId}-expired`,
+    issuedAt: issuedAt - (2 * DEFAULT_TTL_MS),
+    expiresAt: issuedAt - 1,
+  };
+  const insufficientPeersPayload = {
+    ...positivePayload,
+    configId: `${configId}-insufficient-peers`,
+    peers: peerUrls.slice(0, 2),
+  };
+
+  const positiveFixturePath = path.join(fixtureDir, 'signed-peer-config.json');
+  const unsignedFixturePath = path.join(fixtureDir, 'unsigned-peer-config.json');
+  const expiredFixturePath = path.join(fixtureDir, 'expired-peer-config.json');
+  const insufficientPeersFixturePath = path.join(fixtureDir, 'insufficient-peers-peer-config.json');
+  const badSignatureFixturePath = path.join(fixtureDir, 'bad-signature-peer-config.json');
+  const manifestPath = path.join(artifactDir, 'signed-peer-config-manifest.json');
+  const browserEvidencePath = path.join(artifactDir, 'signed-peer-config-browser-evidence.json');
+
+  const positiveFixture = await signPayload(positivePayload, pair);
+  writeJson(positiveFixturePath, positiveFixture);
+  writeJson(unsignedFixturePath, { payload: positivePayload });
+  writeJson(expiredFixturePath, await signPayload(expiredPayload, pair));
+  writeJson(insufficientPeersFixturePath, await signPayload(insufficientPeersPayload, pair));
+  writeJson(badSignatureFixturePath, {
+    ...positiveFixture,
+    signature: `bad-${positiveFixture.signature}`,
+  });
+
+  const manifest = {
+    runId,
+    traceId,
+    configId,
+    configUrl,
+    peerUrls,
+    relayIds: ['signed-relay-a', 'signed-relay-b', 'signed-relay-c'],
+    publicKey: pair.pub,
+    issuedAt,
+    expiresAt,
+    fixtures: {
+      positive: positiveFixturePath,
+      unsigned: unsignedFixturePath,
+      expired: expiredFixturePath,
+      insufficientPeers: insufficientPeersFixturePath,
+      badSignature: badSignatureFixturePath,
+    },
+  };
+  writeJson(manifestPath, manifest);
+
+  const sharedEnv = {
+    ...process.env,
+    VH_MESH_SIGNED_CANARY_RELAY_PORTS: relayPorts.join(','),
+    VH_MESH_SIGNED_CANARY_APP_PORT: String(appPort),
+    VH_MESH_SIGNED_CANARY_CONFIG_PORT: String(configPort),
+    VH_MESH_SIGNED_CANARY_MANIFEST_PATH: manifestPath,
+    VH_MESH_SIGNED_CANARY_BROWSER_EVIDENCE_PATH: browserEvidencePath,
+    VH_MESH_SIGNED_PEER_CONFIG_PATH: positiveFixturePath,
+    VITE_GUN_PEER_CONFIG_URL: configUrl,
+    VITE_GUN_PEER_MINIMUM: '3',
+    VITE_GUN_PEER_QUORUM_REQUIRED: '2',
+    VITE_VH_STRICT_PEER_CONFIG: 'true',
+    VITE_VH_EXPOSE_PEER_TOPOLOGY: 'true',
+    VITE_VH_GUN_LOCAL_STORAGE: 'false',
+    VITE_VH_SHOW_HEALTH: 'true',
+  };
+  const steps = [];
+  const playwrightArgs = [
+    '--filter',
+    '@vh/e2e',
+    'exec',
+    'playwright',
+    'test',
+    '--config=playwright.mesh-signed-peer-config.config.ts',
+    'src/mesh/signed-peer-config-canary.spec.ts',
+  ];
+
+  const commonEnv = {
+    ...sharedEnv,
+    VH_MESH_SIGNED_CANARY_MODE: 'common',
+    VITE_GUN_PEER_CONFIG_PUBLIC_KEY: pair.pub,
+    VITE_VH_ALLOW_LOCAL_MESH_PEERS: 'true',
+  };
+  if (runStep(steps, 'build-common-signed-peer-config', 'pnpm', ['--filter', '@vh/web-pwa', 'build'], commonEnv)) {
+    runStep(steps, 'playwright-common-signed-peer-config', 'pnpm', [...playwrightArgs, '--grep', '@common'], commonEnv);
+  }
+
+  const missingPublicKeyEnv = {
+    ...sharedEnv,
+    VH_MESH_SIGNED_CANARY_MODE: 'missing-public-key',
+    VH_MESH_SIGNED_CANARY_EXPECT_FAILURE: 'strict signed peer config requires VITE_GUN_PEER_CONFIG_PUBLIC_KEY',
+    VITE_GUN_PEER_CONFIG_PUBLIC_KEY: '',
+    VITE_VH_ALLOW_LOCAL_MESH_PEERS: 'true',
+  };
+  if (runStep(steps, 'build-missing-public-key', 'pnpm', ['--filter', '@vh/web-pwa', 'build'], missingPublicKeyEnv)) {
+    runStep(steps, 'playwright-missing-public-key', 'pnpm', [...playwrightArgs, '--grep', '@build-failure'], missingPublicKeyEnv);
+  }
+
+  const localPeersDisallowedEnv = {
+    ...sharedEnv,
+    VH_MESH_SIGNED_CANARY_MODE: 'local-peers-disallowed',
+    VH_MESH_SIGNED_CANARY_EXPECT_FAILURE: 'strict peer config rejects insecure peer',
+    VITE_GUN_PEER_CONFIG_PUBLIC_KEY: pair.pub,
+    VITE_VH_ALLOW_LOCAL_MESH_PEERS: 'false',
+  };
+  if (runStep(steps, 'build-local-peers-disallowed', 'pnpm', ['--filter', '@vh/web-pwa', 'build'], localPeersDisallowedEnv)) {
+    runStep(steps, 'playwright-local-peers-disallowed', 'pnpm', [...playwrightArgs, '--grep', '@build-failure'], localPeersDisallowedEnv);
+  }
+
+  const completedAtMs = Date.now();
+  const allPassed = steps.every((step) => step.status === 'pass');
+  const report = {
+    schema_version: 'mesh-production-readiness-v1',
+    generated_at: new Date(completedAtMs).toISOString(),
+    run_id: runId,
+    repo: {
+      branch: runGit(['rev-parse', '--abbrev-ref', 'HEAD']),
+      commit: runGit(['rev-parse', 'HEAD']),
+      base_ref: 'origin/main',
+      dirty: runGit(['status', '--short']).length > 0,
+    },
+    run: {
+      mode: 'local_signed_peer_config_browser_boot',
+      started_at: startedAt,
+      completed_at: new Date(completedAtMs).toISOString(),
+      duration_ms: completedAtMs - startedAtMs,
+      command: 'pnpm test:mesh:signed-peer-config-canary',
+    },
+    status: 'review_required',
+    status_reason: allPassed
+      ? 'Slice 6A signed local peer-config browser boot proof passed; full mesh production readiness remains review_required because deployed WSS, restarted catch-up, state-resolution, clock-skew, partition/heal, soak, evidence scrub, and post-M0.B LUMA-gated write sections remain pending.'
+      : 'Slice 6A signed local peer-config browser boot proof failed; inspect gates and Playwright traces.',
+    schema_epoch: 'pre_luma_m0b',
+    luma_profile: 'none',
+    luma_dependency_status: {
+      luma_m0b_schema_epoch: 'pending',
+      luma_gated_write_drills: 'n/a',
+      luma_profile_gates: 'n/a',
+    },
+    drill_writer_kind_by_class: {
+      'synthetic mesh drill object': 'mesh-drill',
+    },
+    topology: {
+      strategy: 'relay_peer_fanout',
+      configured_peer_count: 3,
+      quorum_required: 2,
+      signed_peer_config: allPassed,
+      relay_urls_redacted: peerUrls.map(redactedRelayUrl),
+      relay_ids: manifest.relayIds,
+      relay_to_relay_peers_configured: true,
+      relay_to_relay_auth_mode: 'private_network_allowlist',
+      relay_to_relay_auth_negative_test: 'skipped',
+      relay_to_relay_auth_negative_test_reason: 'covered by pnpm test:mesh:topology-drills; this canary exercises app signed peer-config consumption',
+      peer_config_id: configId,
+      peer_config_issued_at: new Date(issuedAt).toISOString(),
+      peer_config_expires_at: new Date(expiresAt).toISOString(),
+      app_peer_config: {
+        source: 'remote-config',
+        strict: true,
+        signed: allPassed,
+        config_id: configId,
+        minimum_peer_count: 3,
+        quorum_required: 2,
+        local_mesh_peers_allowed: true,
+      },
+    },
+    gates: [
+      {
+        name: 'local-signed-peer-config-browser-boot',
+        status: allPassed ? 'pass' : 'fail',
+        command: 'pnpm test:mesh:signed-peer-config-canary',
+        duration_ms: completedAtMs - startedAtMs,
+        exit_code: allPassed ? 0 : 1,
+        artifact_path: browserEvidencePath,
+        reason: allPassed
+          ? 'Web PWA boot used resolveGunPeerTopology with source remote-config, strict true, signed true, three local relays, quorum two, and deterministic fail-closed negative cases.'
+          : steps.filter((step) => step.status !== 'pass').map((step) => `${step.name}:${step.reason}`).join('; '),
+      },
+      {
+        name: 'local-three-relay-peer-kill-write-readback',
+        status: 'skipped',
+        command: 'pnpm test:mesh:topology-drills',
+        duration_ms: 0,
+        exit_code: null,
+        reason: 'standalone transport proof remains owned by pnpm test:mesh:topology-drills and must not be counted as signed browser peer-config evidence',
+      },
+    ],
+    gate_steps: steps,
+    write_class_slos: [],
+    resource_slos: [],
+    per_relay_readback: [],
+    peer_failure_drills: [
+      {
+        name: 'one-peer-kill-write-readback',
+        status: 'skipped',
+        reason: 'covered by pnpm test:mesh:topology-drills; this command is app signed peer-config boot proof only',
+      },
+    ],
+    state_resolution_drills: [
+      {
+        object_id: 'state-resolution-matrix-skip-pre-luma-m0b',
+        object_class: 'state-resolution matrix',
+        state_rule: 'last-write-wins-deterministic-id',
+        expected_winner_write_id: 'skipped',
+        observed_winner_write_id: null,
+        competing_write_ids: [],
+        down_relay_id: null,
+        violation_reason: null,
+        status: 'skipped',
+        reason: 'Slice 7C state-resolution matrix is out of scope for the signed peer-config browser boot proof.',
+      },
+    ],
+    clock_skew: {
+      skewed_actor: null,
+      skewed_layer: null,
+      skew_ms: 0,
+      named_failure: 'skipped: Slice 9 clock-skew drill is out of scope for the signed peer-config browser boot proof.',
+      lww_diverged: false,
+      status: 'skipped',
+    },
+    luma_gated_write_drills: [
+      {
+        write_class: 'LUMA-gated public mesh writes',
+        trace_id: traceId,
+        status: 'skipped',
+        reason: 'schema_epoch is pre_luma_m0b and luma_profile is none; no LUMA _writerKind, _authorScheme, SignedWriteEnvelope, or adapter migration work was exercised.',
+      },
+    ],
+    cleanup: {
+      namespace: 'no vh/__mesh_drills writes in signed peer-config browser canary',
+      ttl_ms: DEFAULT_TTL_MS,
+      objects_written: 0,
+      objects_cleaned_or_tombstoned: 0,
+      retained_objects: 0,
+      status: 'pass',
+    },
+    health: {
+      peer_quorum_minimum_observed: allPassed ? 3 : 0,
+      sustained_message_rate_max_per_sec: 0,
+      degradation_reasons_seen: allPassed ? [] : ['signed-peer-config-browser-canary-failed'],
+    },
+    release_claims: {
+      allowed: allPassed
+        ? [
+            'The local Web PWA can boot in strict mode from a signed three-relay local peer-config fixture when local mesh peers are explicitly allowed.',
+            'Unsigned, expired, insufficient-peer, bad-signature, missing-public-key, and local-peers-without-allowance configurations fail closed before a usable Gun client is initialized.',
+          ]
+        : [],
+      forbidden: [
+        'The standalone topology drill proves signed browser peer-config consumption.',
+        'The mesh has production WSS signed peer-config readiness.',
+        'Restarted peers catch up automatically.',
+        'LUMA-gated write classes have mesh transport readiness under the current LUMA schema epoch.',
+      ],
+      invalidated_by_luma_epoch_change: true,
+    },
+    downstream_canary: {
+      command: 'pnpm check:mesh:production-readiness',
+      status: 'skipped',
+      reason: 'full downstream production-readiness gate is not wired in this slice',
+    },
+  };
+
+  const reportPaths = writeReport({
+    artifactDir,
+    report,
+    positiveFixturePath,
+    manifestPath,
+    browserEvidencePath,
+  });
+
+  console.log(JSON.stringify({
+    ok: allPassed,
+    status: report.status,
+    run_id: runId,
+    config_id: configId,
+    report_path: reportPaths.reportPath,
+    latest_report_path: reportPaths.latestReportPath,
+    signed_peer_config: report.topology.signed_peer_config,
+    health_reasons: report.health.degradation_reasons_seen,
+  }, null, 2));
+
+  if (!allPassed) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  console.error(`[vh:mesh-signed-peer-config-canary] fatal: ${error instanceof Error ? error.stack ?? error.message : String(error)}`);
+  process.exitCode = 1;
+});

--- a/packages/e2e/src/mesh/signed-peer-config-canary.spec.ts
+++ b/packages/e2e/src/mesh/signed-peer-config-canary.spec.ts
@@ -212,6 +212,18 @@ test('fails closed for fewer than three signed peers @common', async ({ page }) 
   await expectFailClosed(page, 'strict peer config requires at least 3 peers');
 });
 
+test('fails closed for signed config missing lifecycle fields @common', async ({ page }) => {
+  test.skip(mode !== 'common', `mode ${mode} runs a build-time fail-closed case`);
+  await routeConfig(page, readFixture('missingExpiresAt'));
+  await expectFailClosed(page, 'strict signed peer config requires expiresAt');
+});
+
+test('fails closed for signed config with impossible quorum @common', async ({ page }) => {
+  test.skip(mode !== 'common', `mode ${mode} runs a build-time fail-closed case`);
+  await routeConfig(page, readFixture('impossibleQuorum'));
+  await expectFailClosed(page, 'strict signed peer config quorumRequired cannot exceed configured peers');
+});
+
 test('fails closed for a bad peer-config signature @common', async ({ page }) => {
   test.skip(mode !== 'common', `mode ${mode} runs a build-time fail-closed case`);
   await routeConfig(page, readFixture('badSignature'));

--- a/packages/e2e/src/mesh/signed-peer-config-canary.spec.ts
+++ b/packages/e2e/src/mesh/signed-peer-config-canary.spec.ts
@@ -1,0 +1,225 @@
+import { test, expect, type Page } from '@playwright/test';
+import * as fs from 'node:fs';
+
+interface SignedPeerConfigManifest {
+  runId: string;
+  traceId: string;
+  configId: string;
+  peerUrls: string[];
+  configUrl: string;
+  publicKey: string;
+  fixtures: Record<string, string>;
+}
+
+type PeerTopologyProof =
+  | {
+      status: 'resolved';
+      resolver: 'resolveGunPeerTopology';
+      topology: {
+        source: string;
+        strict: boolean;
+        signed: boolean;
+        configId?: string;
+        peers: string[];
+        minimumPeerCount: number;
+        quorumRequired: number;
+        allowLocalPeers: boolean;
+      };
+      clientPeers: string[];
+    }
+  | {
+      status: 'failed';
+      resolver: 'resolveGunPeerTopology';
+      error: string;
+      clientPeers: [];
+    };
+
+type SignedCanaryWindow = Window & {
+  __VH_PEER_TOPOLOGY_PROOF__?: PeerTopologyProof;
+  __VH_GUN_PEERS__?: unknown;
+  __VH_SIGNED_CONFIG_CANARY__?: {
+    openedUrls: () => string[];
+  };
+};
+
+const manifestPath = process.env.VH_MESH_SIGNED_CANARY_MANIFEST_PATH;
+if (!manifestPath) {
+  throw new Error('VH_MESH_SIGNED_CANARY_MANIFEST_PATH is required');
+}
+
+const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as SignedPeerConfigManifest;
+const mode = process.env.VH_MESH_SIGNED_CANARY_MODE ?? 'common';
+const expectedBuildFailure = process.env.VH_MESH_SIGNED_CANARY_EXPECT_FAILURE ?? '';
+const browserEvidencePath = process.env.VH_MESH_SIGNED_CANARY_BROWSER_EVIDENCE_PATH;
+
+function readFixture(name: string): unknown {
+  const filePath = manifest.fixtures[name];
+  if (!filePath) {
+    throw new Error(`missing signed peer-config fixture path: ${name}`);
+  }
+  return JSON.parse(fs.readFileSync(filePath, 'utf8')) as unknown;
+}
+
+async function routeConfig(page: Page, body: unknown): Promise<void> {
+  await page.route(manifest.configUrl, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      headers: {
+        'cache-control': 'no-store',
+        'access-control-allow-origin': '*',
+      },
+      body: JSON.stringify(body),
+    });
+  });
+}
+
+async function waitForProof(page: Page, status: PeerTopologyProof['status']): Promise<PeerTopologyProof> {
+  const handle = await page.waitForFunction(
+    (expected) => {
+      const proof = (window as SignedCanaryWindow).__VH_PEER_TOPOLOGY_PROOF__;
+      return proof?.status === expected ? proof : false;
+    },
+    status,
+    { timeout: 20_000 },
+  );
+  return await handle.jsonValue() as PeerTopologyProof;
+}
+
+function expectedSocketHosts(): string[] {
+  return manifest.peerUrls.map((peerUrl) => new URL(peerUrl).host);
+}
+
+async function openedPeerSocketHosts(page: Page): Promise<string[]> {
+  const urls = await page.evaluate(() => {
+    return (window as SignedCanaryWindow).__VH_SIGNED_CONFIG_CANARY__?.openedUrls() ?? [];
+  });
+  const hosts = urls
+    .map((url) => {
+      try {
+        return new URL(url).host;
+      } catch {
+        return null;
+      }
+    })
+    .filter((host): host is string => Boolean(host));
+  return Array.from(new Set(hosts));
+}
+
+async function expectFailClosed(page: Page, expectedError: string): Promise<PeerTopologyProof> {
+  await page.goto('/');
+  const proof = await waitForProof(page, 'failed');
+  if (proof.status !== 'failed') {
+    throw new Error(`expected fail-closed peer topology proof, got ${proof.status}`);
+  }
+  expect(proof.resolver).toBe('resolveGunPeerTopology');
+  expect(proof.clientPeers).toEqual([]);
+  expect(proof.error).toContain(expectedError);
+  const peerHosts = expectedSocketHosts();
+  const openedHosts = await openedPeerSocketHosts(page);
+  expect(openedHosts.filter((host) => peerHosts.includes(host))).toEqual([]);
+  return proof;
+}
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    const nativeWebSocket = window.WebSocket;
+    const openedUrls: string[] = [];
+
+    class TrackingWebSocket extends nativeWebSocket {
+      constructor(url: string | URL, protocols?: string | string[]) {
+        openedUrls.push(String(url));
+        super(url, protocols);
+      }
+    }
+
+    Object.defineProperties(TrackingWebSocket, {
+      CONNECTING: { value: nativeWebSocket.CONNECTING },
+      OPEN: { value: nativeWebSocket.OPEN },
+      CLOSING: { value: nativeWebSocket.CLOSING },
+      CLOSED: { value: nativeWebSocket.CLOSED },
+    });
+
+    window.WebSocket = TrackingWebSocket as typeof WebSocket;
+    (window as SignedCanaryWindow).__VH_SIGNED_CONFIG_CANARY__ = {
+      openedUrls: () => [...openedUrls],
+    };
+  });
+});
+
+test('accepts signed remote config through the app peer resolver @common', async ({ page }) => {
+  test.skip(mode !== 'common', `mode ${mode} runs a build-time fail-closed case`);
+
+  for (const peerUrl of manifest.peerUrls) {
+    const health = await page.request.get(new URL('/healthz', peerUrl.replace('/gun', '/')).toString());
+    expect(health.ok()).toBe(true);
+    await expect(health.json()).resolves.toMatchObject({ ok: true, service: 'vh-relay' });
+  }
+
+  await page.goto('/');
+  const proof = await waitForProof(page, 'resolved');
+  expect(proof).toMatchObject({
+    status: 'resolved',
+    resolver: 'resolveGunPeerTopology',
+    topology: {
+      source: 'remote-config',
+      strict: true,
+      signed: true,
+      configId: manifest.configId,
+      peers: manifest.peerUrls,
+      minimumPeerCount: 3,
+      quorumRequired: 2,
+      allowLocalPeers: true,
+    },
+    clientPeers: manifest.peerUrls,
+  });
+  await expect(page.locator('[data-testid="feed-shell"]')).toBeVisible({ timeout: 20_000 });
+  await expect
+    .poll(() => openedPeerSocketHosts(page), { timeout: 15_000 })
+    .toEqual(expect.arrayContaining(expectedSocketHosts()));
+  await expect(page.evaluate(() => (window as SignedCanaryWindow).__VH_GUN_PEERS__)).resolves.toBeUndefined();
+
+  if (browserEvidencePath) {
+    fs.writeFileSync(
+      browserEvidencePath,
+      `${JSON.stringify({
+        gate: 'local-signed-peer-config-browser-boot',
+        run_id: manifest.runId,
+        trace_id: manifest.traceId,
+        config_id: manifest.configId,
+        proof,
+        opened_socket_hosts: await openedPeerSocketHosts(page),
+      }, null, 2)}\n`,
+    );
+  }
+});
+
+test('fails closed for unsigned peer config @common', async ({ page }) => {
+  test.skip(mode !== 'common', `mode ${mode} runs a build-time fail-closed case`);
+  await routeConfig(page, readFixture('unsigned'));
+  await expectFailClosed(page, 'strict peer config requires a signed peer config envelope');
+});
+
+test('fails closed for expired signed peer config @common', async ({ page }) => {
+  test.skip(mode !== 'common', `mode ${mode} runs a build-time fail-closed case`);
+  await routeConfig(page, readFixture('expired'));
+  await expectFailClosed(page, 'peer config is expired');
+});
+
+test('fails closed for fewer than three signed peers @common', async ({ page }) => {
+  test.skip(mode !== 'common', `mode ${mode} runs a build-time fail-closed case`);
+  await routeConfig(page, readFixture('insufficientPeers'));
+  await expectFailClosed(page, 'strict peer config requires at least 3 peers');
+});
+
+test('fails closed for a bad peer-config signature @common', async ({ page }) => {
+  test.skip(mode !== 'common', `mode ${mode} runs a build-time fail-closed case`);
+  await routeConfig(page, readFixture('badSignature'));
+  await expectFailClosed(page, 'signed peer config verification failed');
+});
+
+test('fails closed for build-time strict peer-config guardrails @build-failure', async ({ page }) => {
+  test.skip(mode === 'common', 'common mode covers signed-config content failures');
+  expect(expectedBuildFailure).not.toBe('');
+  await expectFailClosed(page, expectedBuildFailure);
+});

--- a/packages/e2e/src/mesh/signed-peer-config-server.mjs
+++ b/packages/e2e/src/mesh/signed-peer-config-server.mjs
@@ -1,0 +1,52 @@
+import fs from 'node:fs';
+import http from 'node:http';
+
+const port = Number.parseInt(process.env.VH_MESH_SIGNED_CANARY_CONFIG_PORT ?? '0', 10);
+const host = process.env.VH_MESH_SIGNED_CANARY_CONFIG_HOST ?? '127.0.0.1';
+const fixturePath = process.env.VH_MESH_SIGNED_PEER_CONFIG_PATH;
+
+if (!Number.isFinite(port) || port <= 0) {
+  throw new Error('VH_MESH_SIGNED_CANARY_CONFIG_PORT must be a positive integer');
+}
+if (!fixturePath) {
+  throw new Error('VH_MESH_SIGNED_PEER_CONFIG_PATH is required');
+}
+
+function applyCors(res) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET,OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'content-type');
+  res.setHeader('Cache-Control', 'no-store');
+}
+
+const server = http.createServer((req, res) => {
+  applyCors(res);
+  if (req.method === 'OPTIONS') {
+    res.writeHead(204);
+    res.end();
+    return;
+  }
+  const url = new URL(req.url ?? '/', `http://${host}:${port}`);
+  if (req.method === 'GET' && url.pathname === '/healthz') {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ ok: true, service: 'vh-mesh-signed-peer-config' }));
+    return;
+  }
+  if (req.method === 'GET' && url.pathname === '/mesh-peer-config.json') {
+    try {
+      const body = fs.readFileSync(fixturePath, 'utf8');
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(body);
+    } catch (error) {
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ ok: false, error: error instanceof Error ? error.message : String(error) }));
+    }
+    return;
+  }
+  res.writeHead(404, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify({ ok: false, error: 'not-found' }));
+});
+
+server.listen(port, host, () => {
+  console.log(`[vh:mesh-signed-peer-config] serving ${fixturePath} on http://${host}:${port}`);
+});


### PR DESCRIPTION
## Summary
- add `pnpm test:mesh:signed-peer-config-canary` for strict Web PWA boot from a signed three-relay local peer-config fixture
- expose an e2e-only app topology proof hook so the canary verifies `resolveGunPeerTopology` with `source: remote-config`, not direct peer injection
- cover fail-closed browser cases for unsigned, expired, insufficient-peer, bad-signature, missing-public-key, and local-peers-without-allowance configs
- keep standalone `pnpm test:mesh:topology-drills` transport-only and document the signed-vs-transport report boundary

## Verification
- `pnpm exec vitest run apps/web-pwa/src/store/peerConfig.test.ts apps/web-pwa/src/store/store.test.ts --config vitest.config.ts --reporter=dot`
- `pnpm test:mesh:signed-peer-config-canary`
- `pnpm test:mesh:topology-drills`
- `pnpm docs:check`
- `git diff --check origin/main..HEAD`
- `pnpm --filter @vh/web-pwa typecheck`

## Evidence
- latest signed canary report: `/Users/bldt/Desktop/VHC/VHC-mesh-signed-peer-config-canary/.tmp/mesh-production-readiness/latest/mesh-production-readiness-report.json`
- report status remains `review_required`; `schema_epoch: pre_luma_m0b`; `luma_profile: none`; LUMA-gated writes skipped

No LUMA `_writerKind`, `_authorScheme`, adapters, envelopes, or schema migration work was done.