### PR TITLE
LUMA M0.B identifier registry foundation

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "check:launch-content-snapshot": "node ./packages/e2e/src/launch-content-snapshot.mjs",
     "check:public-beta-compliance": "node ./tools/scripts/check-public-beta-compliance.mjs",
     "check:public-beta-launch-closeout": "node ./tools/scripts/check-public-beta-launch-closeout.mjs",
+    "check:linkability-domain-registry": "node ./tools/scripts/check-linkability-domain-registry.mjs",
     "report:news-sources:admission": "pnpm --filter @vh/news-aggregator report:source-admission",
     "report:news-sources:health": "NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter @vh/news-aggregator report:source-health",
     "scout:news-sources:candidates": "NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter @vh/news-aggregator report:source-scout",

--- a/packages/luma-sdk/package.json
+++ b/packages/luma-sdk/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@vh/luma-sdk",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run --config ./vitest.config.ts",
+    "lint": "echo 'No lint yet'"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.5",
+    "vitest": "^2.1.4"
+  }
+}

--- a/packages/luma-sdk/src/index.ts
+++ b/packages/luma-sdk/src/index.ts
@@ -1,0 +1,17 @@
+export {
+  createLinkabilityDomainRegistry,
+  getLinkabilityDomain,
+  INITIAL_LINKABILITY_DOMAINS,
+  isRegisteredLinkabilityDomainName,
+  LINKABILITY_DOMAIN_NAMES,
+  linkabilityDomainRegistry,
+  LinkabilityDomainRegistryError,
+  type LinkabilityDomain,
+  type LinkabilityDomainName,
+  type LinkabilityDomainRegistry,
+  type LinkabilityProfile,
+  type LinkabilityPublicVisibility,
+  type LinkabilityRotationPolicy,
+  type LinkabilitySaltSource,
+  type LinkabilityScope
+} from './linkabilityDomains';

--- a/packages/luma-sdk/src/linkabilityDomains.test.ts
+++ b/packages/luma-sdk/src/linkabilityDomains.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  createLinkabilityDomainRegistry,
+  getLinkabilityDomain,
+  INITIAL_LINKABILITY_DOMAINS,
+  isRegisteredLinkabilityDomainName,
+  LINKABILITY_DOMAIN_NAMES,
+  LinkabilityDomainRegistryError,
+  linkabilityDomainRegistry
+} from './linkabilityDomains';
+
+describe('LUMA linkability-domain registry', () => {
+  it('exposes exactly the initial LUMA §9.3 domains', () => {
+    expect(LINKABILITY_DOMAIN_NAMES).toEqual([
+      'forum-author-v1',
+      'identity-directory-v1',
+      'voter-v1'
+    ]);
+    expect(linkabilityDomainRegistry.names).toEqual(LINKABILITY_DOMAIN_NAMES);
+    expect(linkabilityDomainRegistry.domains).toEqual(INITIAL_LINKABILITY_DOMAINS);
+  });
+
+  it('preserves the §9.3 metadata for every initial domain', () => {
+    expect(getLinkabilityDomain('forum-author-v1')).toEqual({
+      name: 'forum-author-v1',
+      scope: 'global',
+      saltSource: 'none',
+      info: 'vh:forum-author:v1',
+      linkabilityProfile: 'global',
+      publicVisibility: 'public-mesh',
+      rotationPolicy: 'on-reset-identity',
+      ownerSpec: 'spec-hermes-forum-v0.md'
+    });
+    expect(getLinkabilityDomain('identity-directory-v1')).toEqual({
+      name: 'identity-directory-v1',
+      scope: 'global',
+      saltSource: 'none',
+      info: 'vh:identity-directory:v1',
+      linkabilityProfile: 'global',
+      publicVisibility: 'public-mesh',
+      rotationPolicy: 'on-reset-identity',
+      ownerSpec: 'spec-luma-service-v0.md'
+    });
+    expect(getLinkabilityDomain('voter-v1')).toEqual({
+      name: 'voter-v1',
+      scope: 'topic-epoch-scoped',
+      saltSource: 'topic-id+epoch',
+      info: 'vh:voter:v1',
+      linkabilityProfile: 'unlinkable-across-scope',
+      publicVisibility: 'public-mesh',
+      rotationPolicy: 'on-reset-identity',
+      ownerSpec: 'spec-civic-sentiment.md'
+    });
+  });
+
+  it('fails closed for unregistered domain lookup', () => {
+    expect(() => getLinkabilityDomain('legacy-nullifier')).toThrow(LinkabilityDomainRegistryError);
+    expect(isRegisteredLinkabilityDomainName('legacy-nullifier')).toBe(false);
+  });
+
+  it('fails closed on duplicate domain registration', () => {
+    expect(() => createLinkabilityDomainRegistry([
+      ...INITIAL_LINKABILITY_DOMAINS,
+      {
+        ...INITIAL_LINKABILITY_DOMAINS[0],
+        info: 'vh:forum-author:v1-duplicate'
+      }
+    ])).toThrow(LinkabilityDomainRegistryError);
+  });
+});

--- a/packages/luma-sdk/src/linkabilityDomains.ts
+++ b/packages/luma-sdk/src/linkabilityDomains.ts
@@ -1,0 +1,125 @@
+export type LinkabilityScope =
+  | 'global'
+  | 'topic-scoped'
+  | 'topic-epoch-scoped'
+  | 'thread-scoped'
+  | 'session-scoped';
+
+export type LinkabilitySaltSource =
+  | 'none'
+  | 'topic-id'
+  | 'topic-id+epoch'
+  | 'thread-id'
+  | 'session-id';
+
+export type LinkabilityProfile = 'global' | 'scoped' | 'unlinkable-across-scope';
+export type LinkabilityPublicVisibility = 'public-mesh' | 'sensitive' | 'local';
+export type LinkabilityRotationPolicy = 'never' | 'on-reset-identity' | 'per-session';
+
+export interface LinkabilityDomain {
+  name: string;
+  scope: LinkabilityScope;
+  saltSource: LinkabilitySaltSource;
+  info: string;
+  linkabilityProfile: LinkabilityProfile;
+  publicVisibility: LinkabilityPublicVisibility;
+  rotationPolicy: LinkabilityRotationPolicy;
+  ownerSpec: string;
+}
+
+export const INITIAL_LINKABILITY_DOMAINS = Object.freeze([
+  Object.freeze({
+    name: 'forum-author-v1',
+    scope: 'global',
+    saltSource: 'none',
+    info: 'vh:forum-author:v1',
+    linkabilityProfile: 'global',
+    publicVisibility: 'public-mesh',
+    rotationPolicy: 'on-reset-identity',
+    ownerSpec: 'spec-hermes-forum-v0.md'
+  }),
+  Object.freeze({
+    name: 'identity-directory-v1',
+    scope: 'global',
+    saltSource: 'none',
+    info: 'vh:identity-directory:v1',
+    linkabilityProfile: 'global',
+    publicVisibility: 'public-mesh',
+    rotationPolicy: 'on-reset-identity',
+    ownerSpec: 'spec-luma-service-v0.md'
+  }),
+  Object.freeze({
+    name: 'voter-v1',
+    scope: 'topic-epoch-scoped',
+    saltSource: 'topic-id+epoch',
+    info: 'vh:voter:v1',
+    linkabilityProfile: 'unlinkable-across-scope',
+    publicVisibility: 'public-mesh',
+    rotationPolicy: 'on-reset-identity',
+    ownerSpec: 'spec-civic-sentiment.md'
+  })
+] as const satisfies readonly LinkabilityDomain[]);
+
+export type LinkabilityDomainName = (typeof INITIAL_LINKABILITY_DOMAINS)[number]['name'];
+
+export const LINKABILITY_DOMAIN_NAMES = Object.freeze(
+  INITIAL_LINKABILITY_DOMAINS.map((domain) => domain.name)
+) as readonly LinkabilityDomainName[];
+
+type LinkabilityDomainMap = ReadonlyMap<LinkabilityDomainName, Readonly<LinkabilityDomain>>;
+
+export interface LinkabilityDomainRegistry {
+  domains: readonly Readonly<LinkabilityDomain>[];
+  names: readonly LinkabilityDomainName[];
+  get(name: string): Readonly<LinkabilityDomain>;
+  has(name: string): name is LinkabilityDomainName;
+}
+
+export class LinkabilityDomainRegistryError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'LinkabilityDomainRegistryError';
+  }
+}
+
+export function createLinkabilityDomainRegistry(
+  domains: readonly LinkabilityDomain[]
+): LinkabilityDomainRegistry {
+  const domainMap = new Map<LinkabilityDomainName, Readonly<LinkabilityDomain>>();
+
+  for (const domain of domains) {
+    if (domainMap.has(domain.name as LinkabilityDomainName)) {
+      throw new LinkabilityDomainRegistryError(`Duplicate LUMA linkability domain: ${domain.name}`);
+    }
+    domainMap.set(domain.name as LinkabilityDomainName, Object.freeze({ ...domain }));
+  }
+
+  const names = Object.freeze(Array.from(domainMap.keys()));
+  const domainList = Object.freeze(Array.from(domainMap.values()));
+  const readonlyMap: LinkabilityDomainMap = domainMap;
+
+  return Object.freeze({
+    domains: domainList,
+    names,
+    get(name: string): Readonly<LinkabilityDomain> {
+      const domain = readonlyMap.get(name as LinkabilityDomainName);
+      if (!domain) {
+        throw new LinkabilityDomainRegistryError(`Unregistered LUMA linkability domain: ${name}`);
+      }
+      return domain;
+    },
+    has(name: string): name is LinkabilityDomainName {
+      return readonlyMap.has(name as LinkabilityDomainName);
+    }
+  });
+}
+
+export const linkabilityDomainRegistry = createLinkabilityDomainRegistry(INITIAL_LINKABILITY_DOMAINS);
+
+export function getLinkabilityDomain(name: string): Readonly<LinkabilityDomain> {
+  return linkabilityDomainRegistry.get(name);
+}
+
+export function isRegisteredLinkabilityDomainName(name: string): name is LinkabilityDomainName {
+  return linkabilityDomainRegistry.has(name);
+}

--- a/packages/luma-sdk/tsconfig.json
+++ b/packages/luma-sdk/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tools/ts-config/base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "declaration": true,
+    "emitDeclarationOnly": false,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "node_modules", "dist"]
+}

--- a/packages/luma-sdk/vitest.config.ts
+++ b/packages/luma-sdk/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.ts'],
+    watch: false
+  }
+});

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc --noEmit",
-    "test": "echo 'No tests yet'",
+    "test": "vitest run --config ../../vitest.config.ts --dir ../../ packages/types/src",
     "lint": "echo 'No lint yet'"
   },
   "dependencies": {

--- a/packages/types/src/identifiers.test.ts
+++ b/packages/types/src/identifiers.test.ts
@@ -1,0 +1,99 @@
+import { hkdfSync } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+
+import {
+  deriveForumAuthorId,
+  deriveIdentityDirectoryKey,
+  deriveVoterId,
+  LUMA_IDENTIFIER_INFO
+} from './identifiers';
+
+const PRINCIPAL_NULLIFIER = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+const ZERO_HKDF_SHA256_SALT = Buffer.alloc(32, 0);
+const LOWER_64_CHAR_HEX = /^[0-9a-f]{64}$/;
+
+function nodeHkdfHex(principalNullifier: string, salt: Buffer, info: string): string {
+  return Buffer.from(
+    hkdfSync(
+      'sha256',
+      Buffer.from(principalNullifier, 'utf8'),
+      salt,
+      Buffer.from(info, 'utf8'),
+      32
+    )
+  ).toString('hex');
+}
+
+describe('LUMA public id derivation', () => {
+  it('matches frozen Node hkdfSync vectors through the WebCrypto implementation', async () => {
+    const vectors = [
+      {
+        label: 'forumAuthorId',
+        expected: '7cf7ce7f3c163105e9b9a40a95d4cfb36fdcd8e8835df9012398fd3aed838639',
+        actual: await deriveForumAuthorId(PRINCIPAL_NULLIFIER),
+        node: nodeHkdfHex(
+          PRINCIPAL_NULLIFIER,
+          ZERO_HKDF_SHA256_SALT,
+          LUMA_IDENTIFIER_INFO['forum-author-v1']
+        )
+      },
+      {
+        label: 'identityDirectoryKey',
+        expected: 'a11763992fbdbffb23a5275426fcc648918eeafff98090155fad1b43beade0f6',
+        actual: await deriveIdentityDirectoryKey(PRINCIPAL_NULLIFIER),
+        node: nodeHkdfHex(
+          PRINCIPAL_NULLIFIER,
+          ZERO_HKDF_SHA256_SALT,
+          LUMA_IDENTIFIER_INFO['identity-directory-v1']
+        )
+      },
+      {
+        label: 'voterId',
+        expected: '3da82b3ff8a431e591492e313ff4f34d28c142227ad8c6c7e7132fe420a19c2d',
+        actual: await deriveVoterId(PRINCIPAL_NULLIFIER, { topicId: 'topic-alpha', epoch: 7 }),
+        node: nodeHkdfHex(
+          PRINCIPAL_NULLIFIER,
+          Buffer.from('topic-alpha:7', 'utf8'),
+          LUMA_IDENTIFIER_INFO['voter-v1']
+        )
+      }
+    ];
+
+    for (const vector of vectors) {
+      expect(vector.actual, vector.label).toBe(vector.expected);
+      expect(vector.node, vector.label).toBe(vector.expected);
+    }
+  });
+
+  it('returns lowercase 64-char hex ids that do not expose the raw principalNullifier', async () => {
+    const ids = [
+      await deriveForumAuthorId(PRINCIPAL_NULLIFIER),
+      await deriveIdentityDirectoryKey(PRINCIPAL_NULLIFIER),
+      await deriveVoterId(PRINCIPAL_NULLIFIER, { topicId: 'topic-alpha', epoch: 7 })
+    ];
+
+    for (const id of ids) {
+      expect(id).toMatch(LOWER_64_CHAR_HEX);
+      expect(id).not.toBe(PRINCIPAL_NULLIFIER);
+    }
+  });
+
+  it('does not collide across the initial linkability domains for the same principal', async () => {
+    const ids = new Set([
+      await deriveForumAuthorId(PRINCIPAL_NULLIFIER),
+      await deriveIdentityDirectoryKey(PRINCIPAL_NULLIFIER),
+      await deriveVoterId(PRINCIPAL_NULLIFIER, { topicId: 'topic-alpha', epoch: 7 })
+    ]);
+
+    expect(ids.size).toBe(3);
+  });
+
+  it('scopes voterId by topic and epoch', async () => {
+    await expect(deriveVoterId(PRINCIPAL_NULLIFIER, { topicId: 'topic-alpha', epoch: 7 }))
+      .resolves.toBe('3da82b3ff8a431e591492e313ff4f34d28c142227ad8c6c7e7132fe420a19c2d');
+    await expect(deriveVoterId(PRINCIPAL_NULLIFIER, { topicId: 'topic-alpha', epoch: 8 }))
+      .resolves.toBe('f8e51c913cf5a5705873dd7ef7b12cc3d03a6b06ff315c6f128a7fb727e69960');
+    await expect(deriveVoterId(PRINCIPAL_NULLIFIER, { topicId: 'topic-beta', epoch: 7 }))
+      .resolves.toBe('83210d493c373ce63d11498a2b648961cde5318b418bb8ce91f0cc78f615c1ec');
+  });
+});

--- a/packages/types/src/identifiers.test.ts
+++ b/packages/types/src/identifiers.test.ts
@@ -1,11 +1,12 @@
 import { hkdfSync } from 'node:crypto';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import {
   deriveForumAuthorId,
   deriveIdentityDirectoryKey,
   deriveVoterId,
   LUMA_IDENTIFIER_INFO,
+  type LumaIdentifierDerivationOptions,
   type VoterIdScope
 } from './identifiers';
 
@@ -23,6 +24,10 @@ function nodeHkdfHex(principalNullifier: string, salt: Buffer, info: string): st
       32
     )
   ).toString('hex');
+}
+
+function hexToArrayBuffer(hex: string): ArrayBuffer {
+  return Uint8Array.from(hex.match(/.{2}/g) ?? [], (byte) => Number.parseInt(byte, 16)).buffer;
 }
 
 describe('LUMA public id derivation', () => {
@@ -111,5 +116,36 @@ describe('LUMA public id derivation', () => {
       PRINCIPAL_NULLIFIER,
       { topicId: 'topic-alpha', epoch: '7' } as unknown as VoterIdScope
     )).rejects.toThrow('epoch must be a nonnegative integer');
+  });
+
+  it('uses an injected WebCrypto implementation when provided', async () => {
+    await expect(deriveForumAuthorId(
+      PRINCIPAL_NULLIFIER,
+      { crypto: { subtle: globalThis.crypto.subtle } }
+    )).resolves.toBe('7cf7ce7f3c163105e9b9a40a95d4cfb36fdcd8e8835df9012398fd3aed838639');
+  });
+
+  it('fails closed when WebCrypto is unavailable', async () => {
+    const originalCrypto = globalThis.crypto;
+    vi.stubGlobal('crypto', undefined);
+
+    try {
+      await expect(deriveForumAuthorId(PRINCIPAL_NULLIFIER, { crypto: {} }))
+        .rejects.toThrow('WebCrypto SubtleCrypto is required');
+    } finally {
+      vi.stubGlobal('crypto', originalCrypto);
+    }
+  });
+
+  it('fails closed if derivation collides with the raw principalNullifier', async () => {
+    const collidingCrypto = {
+      subtle: {
+        importKey: async () => ({}),
+        deriveBits: async () => hexToArrayBuffer(PRINCIPAL_NULLIFIER)
+      }
+    } satisfies LumaIdentifierDerivationOptions['crypto'];
+
+    await expect(deriveForumAuthorId(PRINCIPAL_NULLIFIER, { crypto: collidingCrypto }))
+      .rejects.toThrow('collided with the raw principalNullifier');
   });
 });

--- a/packages/types/src/identifiers.test.ts
+++ b/packages/types/src/identifiers.test.ts
@@ -5,7 +5,8 @@ import {
   deriveForumAuthorId,
   deriveIdentityDirectoryKey,
   deriveVoterId,
-  LUMA_IDENTIFIER_INFO
+  LUMA_IDENTIFIER_INFO,
+  type VoterIdScope
 } from './identifiers';
 
 const PRINCIPAL_NULLIFIER = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
@@ -95,5 +96,20 @@ describe('LUMA public id derivation', () => {
       .resolves.toBe('f8e51c913cf5a5705873dd7ef7b12cc3d03a6b06ff315c6f128a7fb727e69960');
     await expect(deriveVoterId(PRINCIPAL_NULLIFIER, { topicId: 'topic-beta', epoch: 7 }))
       .resolves.toBe('83210d493c373ce63d11498a2b648961cde5318b418bb8ce91f0cc78f615c1ec');
+  });
+
+  it('rejects ambiguous voterId scopes', async () => {
+    await expect(deriveVoterId(PRINCIPAL_NULLIFIER, { topicId: '', epoch: 7 }))
+      .rejects.toThrow('topicId is required');
+    await expect(deriveVoterId(PRINCIPAL_NULLIFIER, { topicId: '   ', epoch: 7 }))
+      .rejects.toThrow('topicId is required');
+    await expect(deriveVoterId(PRINCIPAL_NULLIFIER, { topicId: 'topic-alpha', epoch: -1 }))
+      .rejects.toThrow('epoch must be a nonnegative integer');
+    await expect(deriveVoterId(PRINCIPAL_NULLIFIER, { topicId: 'topic-alpha', epoch: 7.5 }))
+      .rejects.toThrow('epoch must be a nonnegative integer');
+    await expect(deriveVoterId(
+      PRINCIPAL_NULLIFIER,
+      { topicId: 'topic-alpha', epoch: '7' } as unknown as VoterIdScope
+    )).rejects.toThrow('epoch must be a nonnegative integer');
   });
 });

--- a/packages/types/src/identifiers.ts
+++ b/packages/types/src/identifiers.ts
@@ -1,0 +1,158 @@
+export type PrincipalNullifier = string;
+export type ForumAuthorId = string;
+export type IdentityDirectoryKey = string;
+export type VoterId = string;
+
+export type LumaIdentifierDomainName =
+  | 'forum-author-v1'
+  | 'identity-directory-v1'
+  | 'voter-v1';
+
+export const LUMA_IDENTIFIER_INFO: Record<LumaIdentifierDomainName, string> = Object.freeze({
+  'forum-author-v1': 'vh:forum-author:v1',
+  'identity-directory-v1': 'vh:identity-directory:v1',
+  'voter-v1': 'vh:voter:v1'
+});
+
+const HKDF_SHA256_OUTPUT_BYTES = 32;
+const ZERO_HKDF_SHA256_SALT = new Uint8Array(HKDF_SHA256_OUTPUT_BYTES);
+const textEncoder = new (globalThis as unknown as {
+  TextEncoder: { new (): { encode(input?: string): Uint8Array } };
+}).TextEncoder();
+
+type HkdfHash = 'SHA-256';
+
+interface HkdfParamsLike {
+  name: 'HKDF';
+  hash: HkdfHash;
+  salt: Uint8Array;
+  info: Uint8Array;
+}
+
+interface SubtleCryptoLike {
+  importKey(
+    format: 'raw',
+    keyData: Uint8Array,
+    algorithm: 'HKDF',
+    extractable: false,
+    keyUsages: ['deriveBits']
+  ): Promise<unknown>;
+  deriveBits(params: HkdfParamsLike, baseKey: unknown, length: number): Promise<ArrayBuffer>;
+}
+
+interface CryptoLike {
+  subtle?: SubtleCryptoLike;
+}
+
+export interface LumaIdentifierDerivationOptions {
+  crypto?: CryptoLike;
+}
+
+export interface VoterIdScope {
+  topicId: string;
+  epoch: number | string;
+}
+
+export async function deriveForumAuthorId(
+  principalNullifier: PrincipalNullifier,
+  options: LumaIdentifierDerivationOptions = {}
+): Promise<ForumAuthorId> {
+  return derivePublicId(principalNullifier, LUMA_IDENTIFIER_INFO['forum-author-v1'], null, options);
+}
+
+export async function deriveIdentityDirectoryKey(
+  principalNullifier: PrincipalNullifier,
+  options: LumaIdentifierDerivationOptions = {}
+): Promise<IdentityDirectoryKey> {
+  return derivePublicId(principalNullifier, LUMA_IDENTIFIER_INFO['identity-directory-v1'], null, options);
+}
+
+export async function deriveVoterId(
+  principalNullifier: PrincipalNullifier,
+  scope: VoterIdScope,
+  options: LumaIdentifierDerivationOptions = {}
+): Promise<VoterId> {
+  assertNonEmpty(scope.topicId, 'topicId');
+  assertValidEpoch(scope.epoch);
+
+  return derivePublicId(
+    principalNullifier,
+    LUMA_IDENTIFIER_INFO['voter-v1'],
+    `${scope.topicId}:${scope.epoch}`,
+    options
+  );
+}
+
+async function derivePublicId(
+  principalNullifier: PrincipalNullifier,
+  info: string,
+  scopeIdentifier: string | null,
+  options: LumaIdentifierDerivationOptions
+): Promise<string> {
+  assertNonEmpty(principalNullifier, 'principalNullifier');
+
+  const subtle = getSubtleCrypto(options);
+  const key = await subtle.importKey(
+    'raw',
+    textEncoder.encode(principalNullifier),
+    'HKDF',
+    false,
+    ['deriveBits']
+  );
+  const bits = await subtle.deriveBits(
+    {
+      name: 'HKDF',
+      hash: 'SHA-256',
+      salt: scopeIdentifier === null ? ZERO_HKDF_SHA256_SALT : textEncoder.encode(scopeIdentifier),
+      info: textEncoder.encode(info)
+    },
+    key,
+    HKDF_SHA256_OUTPUT_BYTES * 8
+  );
+  const derived = toLowerHex(new Uint8Array(bits));
+
+  if (matchesRawNullifier(derived, principalNullifier)) {
+    throw new Error('LUMA public id derivation collided with the raw principalNullifier');
+  }
+
+  return derived;
+}
+
+function getSubtleCrypto(options: LumaIdentifierDerivationOptions): SubtleCryptoLike {
+  const provided = options.crypto?.subtle;
+  if (provided) {
+    return provided;
+  }
+
+  const globalCrypto = (globalThis as unknown as { crypto?: CryptoLike }).crypto;
+  if (globalCrypto?.subtle) {
+    return globalCrypto.subtle;
+  }
+
+  throw new Error('WebCrypto SubtleCrypto is required for LUMA public id derivation');
+}
+
+function toLowerHex(bytes: Uint8Array): string {
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+function matchesRawNullifier(derived: string, principalNullifier: string): boolean {
+  return derived === principalNullifier || derived === principalNullifier.toLowerCase();
+}
+
+function assertNonEmpty(value: string, fieldName: string): void {
+  if (value.length === 0) {
+    throw new Error(`${fieldName} is required for LUMA public id derivation`);
+  }
+}
+
+function assertValidEpoch(epoch: number | string): void {
+  if (typeof epoch === 'number') {
+    if (!Number.isInteger(epoch) || epoch < 0) {
+      throw new Error('epoch must be a nonnegative integer for LUMA voter id derivation');
+    }
+    return;
+  }
+
+  assertNonEmpty(epoch, 'epoch');
+}

--- a/packages/types/src/identifiers.ts
+++ b/packages/types/src/identifiers.ts
@@ -50,7 +50,7 @@ export interface LumaIdentifierDerivationOptions {
 
 export interface VoterIdScope {
   topicId: string;
-  epoch: number | string;
+  epoch: number;
 }
 
 export async function deriveForumAuthorId(
@@ -141,18 +141,13 @@ function matchesRawNullifier(derived: string, principalNullifier: string): boole
 }
 
 function assertNonEmpty(value: string, fieldName: string): void {
-  if (value.length === 0) {
+  if (value.trim().length === 0) {
     throw new Error(`${fieldName} is required for LUMA public id derivation`);
   }
 }
 
-function assertValidEpoch(epoch: number | string): void {
-  if (typeof epoch === 'number') {
-    if (!Number.isInteger(epoch) || epoch < 0) {
-      throw new Error('epoch must be a nonnegative integer for LUMA voter id derivation');
-    }
-    return;
+function assertValidEpoch(epoch: number): void {
+  if (typeof epoch !== 'number' || !Number.isInteger(epoch) || epoch < 0) {
+    throw new Error('epoch must be a nonnegative integer for LUMA voter id derivation');
   }
-
-  assertNonEmpty(epoch, 'epoch');
 }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -25,6 +25,20 @@ export {
   verifyConstituencyProof,
 } from './constituency-verification';
 
+export {
+  deriveForumAuthorId,
+  deriveIdentityDirectoryKey,
+  deriveVoterId,
+  LUMA_IDENTIFIER_INFO,
+  type ForumAuthorId,
+  type IdentityDirectoryKey,
+  type LumaIdentifierDerivationOptions,
+  type LumaIdentifierDomainName,
+  type PrincipalNullifier,
+  type VoterId,
+  type VoterIdScope
+} from './identifiers';
+
 export interface RegionProof {
   proof: string;
   publicSignals: string[];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -335,6 +335,15 @@ importers:
         specifier: ^2.1.4
         version: 2.1.9(@types/node@20.17.19)(jsdom@24.1.3)
 
+  packages/luma-sdk:
+    devDependencies:
+      typescript:
+        specifier: ^5.4.5
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.4
+        version: 2.1.9(@types/node@20.17.19)(jsdom@24.1.3)
+
   packages/types:
     dependencies:
       zod:

--- a/tools/scripts/check-linkability-domain-registry.mjs
+++ b/tools/scripts/check-linkability-domain-registry.mjs
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import * as ts from 'typescript';
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const registryPath = path.join(rootDir, 'packages/luma-sdk/src/linkabilityDomains.ts');
+const specPath = path.join(rootDir, 'docs/specs/spec-luma-service-v0.md');
+
+const expectedDomains = [
+  {
+    name: 'forum-author-v1',
+    scope: 'global',
+    saltSource: 'none',
+    info: 'vh:forum-author:v1',
+    linkabilityProfile: 'global',
+    publicVisibility: 'public-mesh',
+    rotationPolicy: 'on-reset-identity',
+    ownerSpec: 'spec-hermes-forum-v0.md'
+  },
+  {
+    name: 'identity-directory-v1',
+    scope: 'global',
+    saltSource: 'none',
+    info: 'vh:identity-directory:v1',
+    linkabilityProfile: 'global',
+    publicVisibility: 'public-mesh',
+    rotationPolicy: 'on-reset-identity',
+    ownerSpec: 'spec-luma-service-v0.md'
+  },
+  {
+    name: 'voter-v1',
+    scope: 'topic-epoch-scoped',
+    saltSource: 'topic-id+epoch',
+    info: 'vh:voter:v1',
+    linkabilityProfile: 'unlinkable-across-scope',
+    publicVisibility: 'public-mesh',
+    rotationPolicy: 'on-reset-identity',
+    ownerSpec: 'spec-civic-sentiment.md'
+  }
+];
+
+const registrySource = fs.readFileSync(registryPath, 'utf8');
+const specSource = fs.readFileSync(specPath, 'utf8');
+const sourceFile = ts.createSourceFile(registryPath, registrySource, ts.ScriptTarget.Latest, true);
+
+const registry = extractInitialRegistry(sourceFile);
+const failures = [];
+
+if (registry.length !== expectedDomains.length) {
+  failures.push(`expected ${expectedDomains.length} registry domains, found ${registry.length}`);
+}
+
+const seen = new Set();
+for (const domain of registry) {
+  if (seen.has(domain.name)) {
+    failures.push(`duplicate registry domain: ${domain.name}`);
+  }
+  seen.add(domain.name);
+}
+
+for (const expected of expectedDomains) {
+  const actual = registry.find((domain) => domain.name === expected.name);
+  if (!actual) {
+    failures.push(`missing registry domain: ${expected.name}`);
+    continue;
+  }
+
+  for (const [key, expectedValue] of Object.entries(expected)) {
+    if (actual[key] !== expectedValue) {
+      failures.push(`${expected.name}.${key} expected ${expectedValue}, found ${actual[key]}`);
+    }
+  }
+
+  const specRow = [
+    `| \`${expected.name}\``,
+    `| ${expected.scope}`,
+    `| ${expected.saltSource}`,
+    `| \`${expected.info}\``,
+    `| ${expected.linkabilityProfile}`,
+    `| ${expected.publicVisibility}`,
+    `| ${expected.rotationPolicy}`,
+    `| \`${expected.ownerSpec}\` |`
+  ].join(' ');
+
+  if (!specSource.includes(specRow)) {
+    failures.push(`spec §9.3 row missing or drifted for ${expected.name}`);
+  }
+}
+
+for (const expected of expectedDomains) {
+  if (!seen.has(expected.name)) {
+    failures.push(`expected registry domain not present: ${expected.name}`);
+  }
+}
+
+for (const name of seen) {
+  if (!expectedDomains.some((domain) => domain.name === name)) {
+    failures.push(`unexpected registry domain: ${name}`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error('[check:linkability-domain-registry] failed');
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log('[check:linkability-domain-registry] registry integrity ok');
+
+function extractInitialRegistry(source) {
+  let initializer;
+
+  visit(source);
+
+  if (!initializer) {
+    throw new Error('INITIAL_LINKABILITY_DOMAINS was not found');
+  }
+
+  const arrayLiteral = unwrapArrayLiteral(initializer);
+  return arrayLiteral.elements.map((element) => extractDomainObject(element));
+
+  function visit(node) {
+    if (ts.isVariableDeclaration(node) && node.name.getText(source) === 'INITIAL_LINKABILITY_DOMAINS') {
+      initializer = node.initializer;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  }
+}
+
+function unwrapArrayLiteral(expression) {
+  const unwrapped = unwrapExpression(expression);
+
+  if (ts.isCallExpression(unwrapped) && unwrapped.expression.getText(sourceFile) === 'Object.freeze') {
+    return unwrapArrayLiteral(unwrapped.arguments[0]);
+  }
+
+  if (!ts.isArrayLiteralExpression(unwrapped)) {
+    throw new Error('INITIAL_LINKABILITY_DOMAINS is not an array literal');
+  }
+
+  return unwrapped;
+}
+
+function extractDomainObject(expression) {
+  const unwrapped = unwrapExpression(expression);
+  const objectLiteral =
+    ts.isCallExpression(unwrapped) && unwrapped.expression.getText(sourceFile) === 'Object.freeze'
+      ? unwrapExpression(unwrapped.arguments[0])
+      : unwrapped;
+
+  if (!ts.isObjectLiteralExpression(objectLiteral)) {
+    throw new Error('registry entry is not an object literal');
+  }
+
+  const entry = {};
+  for (const property of objectLiteral.properties) {
+    if (!ts.isPropertyAssignment(property)) {
+      continue;
+    }
+    const key = property.name.getText(sourceFile).replace(/^['"]|['"]$/g, '');
+    const value = unwrapExpression(property.initializer);
+    if (!ts.isStringLiteralLike(value)) {
+      throw new Error(`registry entry property ${key} is not a string literal`);
+    }
+    entry[key] = value.text;
+  }
+
+  return entry;
+}
+
+function unwrapExpression(expression) {
+  let current = expression;
+  while (
+    ts.isParenthesizedExpression(current) ||
+    ts.isAsExpression(current) ||
+    ts.isSatisfiesExpression(current) ||
+    ts.isTypeAssertionExpression(current)
+  ) {
+    current = current.expression;
+  }
+  return current;
+}


### PR DESCRIPTION
## Summary

- Add WebCrypto HKDF-SHA-256 LUMA public identifier derivation for forumAuthorId, identityDirectoryKey, and scoped voterId in @vh/types.
- Add frozen Node hkdfSync parity vectors and validation tests for lowercase 64-char derived ids, raw-nullifier non-exposure, cross-domain non-collision, voter topic/epoch scoping, and fail-closed invalid voter scopes.
- Create the @vh/luma-sdk shell with only the linkability-domain registry exports for the three initial LUMA §9.3 domains.
- Add the registry-integrity-only `pnpm check:linkability-domain-registry` gate.

## Review refinement

- Tightened `VoterIdScope.epoch` to a numeric nonnegative integer and reject blank topic IDs / string epochs so the `topicId:epoch` HKDF salt cannot become ambiguous.

## Scope guard

This PR does not migrate public schemas or adapters. It does not touch `packages/gun-client`, `packages/data-model`, `apps/web-pwa/src/hooks/voteIntentMaterializer.ts`, M0.C provider interfaces, M0.D vault files, mesh drill harness paths, `vh/__mesh_drills/*`, `infra/relay/server.js`, or relay code.

## Verification

- `pnpm --filter @vh/types test` — 280 tests
- `pnpm --filter @vh/luma-sdk test` — 4 tests
- `pnpm --filter @vh/types typecheck`
- `pnpm --filter @vh/luma-sdk typecheck`
- `pnpm --filter @vh/types build`
- `pnpm --filter @vh/luma-sdk build`
- `pnpm check:linkability-domain-registry`
- `pnpm docs:check`
- `git diff --check origin/main...HEAD`
- `git diff --check HEAD^..HEAD`

Note: local pnpm emits the existing engine warning because this shell is on Node v23.10.0 while the repo declares `>=20 <23`; the commands above passed.