### PR TITLE
LUMA M0.B signed write envelope foundation

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "check:public-beta-launch-closeout": "node ./tools/scripts/check-public-beta-launch-closeout.mjs",
     "check:linkability-domain-registry": "node ./tools/scripts/check-linkability-domain-registry.mjs",
     "check:luma-provider-surface": "node ./tools/scripts/check-luma-provider-surface.mjs",
+    "check:luma-signed-write-surface": "node ./tools/scripts/check-luma-signed-write-surface.mjs",
     "report:news-sources:admission": "pnpm --filter @vh/news-aggregator report:source-admission",
     "report:news-sources:health": "NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter @vh/news-aggregator report:source-health",
     "scout:news-sources:candidates": "NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter @vh/news-aggregator report:source-scout",

--- a/packages/luma-sdk/package.json
+++ b/packages/luma-sdk/package.json
@@ -18,7 +18,8 @@
     "lint": "echo 'No lint yet'"
   },
   "dependencies": {
-    "@vh/types": "workspace:*"
+    "@vh/types": "workspace:*",
+    "canonicalize": "^3.0.0"
   },
   "devDependencies": {
     "typescript": "^5.4.5",

--- a/packages/luma-sdk/src/index.ts
+++ b/packages/luma-sdk/src/index.ts
@@ -48,3 +48,35 @@ export {
   type LumaProviderName,
   type SignatureSuite
 } from './providers';
+
+export {
+  canonicalizeSignedWriteEnvelopeForSigning,
+  canonicalizeSignedWritePayload,
+  CLIENT_SIGNED_WRITE_SIGNATURE_SUITE,
+  createLumaPublicAuthorId,
+  createSignedWriteEnvelope,
+  deriveSignedWriteIdempotencyKey,
+  digestSignedWritePayload,
+  isLumaPublicAuthorId,
+  LUMA_SIGNED_WRITE_AUDIENCES,
+  LUMA_SIGNED_WRITE_ENVELOPE_VERSION,
+  LUMA_SIGNED_WRITE_PROFILES,
+  LUMA_SIGNED_WRITE_PROTOCOL_VERSION,
+  LUMA_SIGNED_WRITE_SIGNATURE_SUITES,
+  signedWriteEnvelopeSigningInput,
+  SignedWriteEnvelopeError,
+  verifySignedWriteEnvelope,
+  type ClientSignedWriteSignatureSuite,
+  type CreateSignedWriteEnvelopeInput,
+  type LumaPublicAuthorId,
+  type SignedWriteEnvelope,
+  type SignedWriteSessionRef,
+  type SignedWriteSignHook,
+  type SignedWriteSignHookInput,
+  type SignedWriteVerificationFailureReason,
+  type SignedWriteVerificationResult,
+  type SignedWriteVerifyHook,
+  type SignedWriteVerifyHookInput,
+  type UnsignedSignedWriteEnvelope,
+  type VerifySignedWriteEnvelopeInput
+} from './signedWrites';

--- a/packages/luma-sdk/src/signedWrites.test.ts
+++ b/packages/luma-sdk/src/signedWrites.test.ts
@@ -318,11 +318,122 @@ describe('LUMA SignedWriteEnvelope SDK surface', () => {
       'uncanonicalizable payload',
       { payload: undefined },
       'invalid_payload_digest'
+    ],
+    [
+      'payload with undefined object member',
+      { payload: { ...VECTOR_PAYLOAD, ignored: undefined } },
+      'invalid_payload_digest'
+    ],
+    [
+      'payload with function object member',
+      { payload: { ...VECTOR_PAYLOAD, callback: () => null } },
+      'invalid_payload_digest'
+    ],
+    [
+      'payload with undefined array member',
+      { payload: { ...VECTOR_PAYLOAD, tags: ['m0b', undefined, 'jcs'] } },
+      'invalid_payload_digest'
     ]
   ])('fails closed while creating on %s', async (_label, patch, reason) => {
     await expect(createSignedWriteEnvelope(baseCreateInput(
       patch as Partial<CreateSignedWriteEnvelopeInput<typeof VECTOR_PAYLOAD>>
     ))).rejects.toMatchObject({ reason });
+  });
+
+  it.each([
+    ['root undefined', () => undefined],
+    ['root function', () => () => null],
+    ['root symbol', () => Symbol('payload')],
+    ['root bigint', () => BigInt(1)],
+    ['NaN number', () => Number.NaN],
+    ['Infinity number', () => Infinity],
+    ['undefined object member', () => ({ ok: true, skipped: undefined })],
+    ['function object member', () => ({ ok: true, callback: () => null })],
+    ['symbol object member', () => ({ ok: true, value: Symbol('hidden') })],
+    ['symbol-keyed object member', () => {
+      const payload = { ok: true } as Record<string | symbol, unknown>;
+      payload[Symbol('hidden')] = 'secret';
+      return payload;
+    }],
+    ['class instance object', () => new Date('2026-05-06T00:00:00.000Z')],
+    ['object accessor', () => {
+      const payload = { ok: true } as Record<string, unknown>;
+      Object.defineProperty(payload, 'hidden', {
+        enumerable: true,
+        get: () => 'secret'
+      });
+      return payload;
+    }],
+    ['non-enumerable object field', () => {
+      const payload = { ok: true } as Record<string, unknown>;
+      Object.defineProperty(payload, 'hidden', {
+        enumerable: false,
+        value: 'secret'
+      });
+      return payload;
+    }],
+    ['sparse array hole', () => {
+      const payload = [1, 2, 3];
+      delete payload[1];
+      return payload;
+    }],
+    ['array extra property', () => {
+      const payload = [1, 2, 3] as unknown[] & { extra?: string };
+      payload.extra = 'ignored';
+      return payload;
+    }],
+    ['array non-enumerable property', () => {
+      const payload = [1, 2, 3];
+      Object.defineProperty(payload, 'hidden', {
+        enumerable: false,
+        value: 'secret'
+      });
+      return payload;
+    }],
+    ['array accessor index', () => {
+      const payload = [1, 2, 3];
+      Object.defineProperty(payload, '1', {
+        enumerable: true,
+        get: () => 'secret'
+      });
+      return payload;
+    }],
+    ['array non-index string key', () => {
+      const payload = [1, 2, 3] as unknown[] & { '01'?: string };
+      payload['01'] = 'ignored';
+      return payload;
+    }],
+    ['array symbol property', () => {
+      const payload = [1, 2, 3] as unknown[] & Record<symbol, unknown>;
+      payload[Symbol('hidden')] = 'secret';
+      return payload;
+    }],
+    ['circular object', () => {
+      const payload = { ok: true, self: null as unknown };
+      payload.self = payload;
+      return payload;
+    }],
+    ['circular array', () => {
+      const payload: unknown[] = [];
+      payload.push(payload);
+      return payload;
+    }]
+  ])('rejects non-JSON canonicalization input: %s', (_label, makePayload) => {
+    expect(() => canonicalizeSignedWritePayload(makePayload())).toThrow(SignedWriteEnvelopeError);
+  });
+
+  it('wraps canonicalizer failures in a signed-write error', () => {
+    const payload = new Proxy({ ok: true }, {
+      get(target, property, receiver) {
+        if (property === 'ok') {
+          throw new Error('canonicalizer read failure');
+        }
+        return Reflect.get(target, property, receiver);
+      }
+    });
+
+    expect(() => canonicalizeSignedWritePayload(payload)).toThrow(SignedWriteEnvelopeError);
+    expect(() => canonicalizeSignedWritePayload(payload)).toThrow(/canonicalizer read failure/);
   });
 
   it.each([
@@ -405,6 +516,11 @@ describe('LUMA SignedWriteEnvelope SDK surface', () => {
       'tampered payload',
       { payload: { ...VECTOR_PAYLOAD, body: 'tampered' } },
       'payload_digest_mismatch'
+    ],
+    [
+      'non-JSON payload',
+      { payload: { ...VECTOR_PAYLOAD, ignored: undefined } },
+      'invalid_payload_digest'
     ],
     [
       'mismatched payloadDigest',

--- a/packages/luma-sdk/src/signedWrites.test.ts
+++ b/packages/luma-sdk/src/signedWrites.test.ts
@@ -1,0 +1,492 @@
+import {
+  createPrivateKey,
+  createPublicKey,
+  sign as ed25519Sign,
+  verify as ed25519Verify
+} from 'node:crypto';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  canonicalizeSignedWriteEnvelopeForSigning,
+  canonicalizeSignedWritePayload,
+  CLIENT_SIGNED_WRITE_SIGNATURE_SUITE,
+  createLumaPublicAuthorId,
+  createSignedWriteEnvelope,
+  deriveSignedWriteIdempotencyKey,
+  digestSignedWritePayload,
+  isLumaPublicAuthorId,
+  LUMA_SIGNED_WRITE_PROTOCOL_VERSION,
+  signedWriteEnvelopeSigningInput,
+  SignedWriteEnvelopeError,
+  verifySignedWriteEnvelope,
+  type CreateSignedWriteEnvelopeInput,
+  type SignedWriteEnvelope,
+  type SignedWriteSignHook,
+  type SignedWriteVerifyHook
+} from './signedWrites';
+
+const PRIVATE_KEY_PEM = `-----BEGIN PRIVATE KEY-----
+MC4CAQAwBQYDK2VwBCIEIMhiE+oUkBP79LO/ed83g6I8s8VeivofrYTh8e1NQ8Ke
+-----END PRIVATE KEY-----
+`;
+
+const PUBLIC_KEY_PEM = `-----BEGIN PUBLIC KEY-----
+MCowBQYDK2VwAyEAkpHdKIlWs3Zn2QaVf3nO9SdMT9g5Vkzijghfm3uteLQ=
+-----END PUBLIC KEY-----
+`;
+
+const PUBLIC_AUTHOR_VALUE =
+  '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+const SESSION_REF = Object.freeze({
+  tokenHash: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+  envelopeDigest: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+});
+const NONCE = '00112233445566778899aabbccddeeff';
+const ISSUED_AT = 1777777777000;
+
+const VECTOR_PAYLOAD = Object.freeze({
+  title: 'LUMA launch',
+  body: 'signed write',
+  tags: ['m0b', 'jcs'],
+  metadata: {
+    count: 2,
+    active: true,
+    nested: {
+      a: null,
+      z: 'last'
+    }
+  }
+});
+
+const REORDERED_VECTOR_PAYLOAD = Object.freeze({
+  metadata: {
+    nested: {
+      z: 'last',
+      a: null
+    },
+    active: true,
+    count: 2
+  },
+  tags: ['m0b', 'jcs'],
+  body: 'signed write',
+  title: 'LUMA launch'
+});
+
+const EXPECTED_CANONICAL_PAYLOAD =
+  '{"body":"signed write","metadata":{"active":true,"count":2,"nested":{"a":null,"z":"last"}},"tags":["m0b","jcs"],"title":"LUMA launch"}';
+const EXPECTED_PAYLOAD_DIGEST =
+  '88904ae596dba42583755c10a239e1d3d9a12df9ee52188fd50ee52319e4dbf0';
+const EXPECTED_IDEMPOTENCY_KEY =
+  '3777e3e28dec03ac2df6ebdfca850a3b3d201449a2db95f9c2162471ebd2c829';
+const EXPECTED_CANONICAL_ENVELOPE =
+  '{"audience":"vh-forum-thread","envelopeVersion":1,"idempotencyKey":"3777e3e28dec03ac2df6ebdfca850a3b3d201449a2db95f9c2162471ebd2c829","issuedAt":1777777777000,"nonce":"00112233445566778899aabbccddeeff","origin":"https://vh.example","payload":{"body":"signed write","metadata":{"active":true,"count":2,"nested":{"a":null,"z":"last"}},"tags":["m0b","jcs"],"title":"LUMA launch"},"payloadDigest":"88904ae596dba42583755c10a239e1d3d9a12df9ee52188fd50ee52319e4dbf0","profile":"public-beta","protocolVersion":"luma-write-v1","publicAuthor":"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef","scheme":"forum-author-v1","sequence":7,"sessionRef":{"envelopeDigest":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","tokenHash":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},"signatureSuite":"jcs-ed25519-sha256-v1"}';
+const EXPECTED_SIGNATURE =
+  '7-tfl0mmIIDO33TXE30mmxWOIGPUn22M5Cyt57jyKxrMaZISs0sTV00Xh8lUlPkfFp80tMvTWqSrmOZqfXy9AQ';
+
+const privateKey = createPrivateKey(PRIVATE_KEY_PEM);
+const publicKey = createPublicKey(PUBLIC_KEY_PEM);
+
+function ed25519SignHook(): SignedWriteSignHook<typeof VECTOR_PAYLOAD> {
+  return ({ canonicalBytes }) => ed25519Sign(null, canonicalBytes, privateKey).toString('base64url');
+}
+
+function ed25519VerifyHook(): SignedWriteVerifyHook<typeof VECTOR_PAYLOAD> {
+  return ({ canonicalBytes, signature }) => ed25519Verify(
+    null,
+    canonicalBytes,
+    publicKey,
+    Buffer.from(signature, 'base64url')
+  );
+}
+
+function baseCreateInput(
+  overrides: Partial<CreateSignedWriteEnvelopeInput<typeof VECTOR_PAYLOAD>> = {}
+): CreateSignedWriteEnvelopeInput<typeof VECTOR_PAYLOAD> {
+  return {
+    profile: 'public-beta',
+    audience: 'vh-forum-thread',
+    origin: 'https://vh.example',
+    scheme: 'forum-author-v1',
+    publicAuthor: createLumaPublicAuthorId(PUBLIC_AUTHOR_VALUE, 'forum-author-v1'),
+    sessionRef: SESSION_REF,
+    payload: VECTOR_PAYLOAD,
+    sequence: 7,
+    nonce: NONCE,
+    issuedAt: ISSUED_AT,
+    sign: ed25519SignHook(),
+    ...overrides
+  };
+}
+
+async function createVectorEnvelope(
+  overrides: Partial<CreateSignedWriteEnvelopeInput<typeof VECTOR_PAYLOAD>> = {}
+): Promise<SignedWriteEnvelope<typeof VECTOR_PAYLOAD>> {
+  return createSignedWriteEnvelope(baseCreateInput(overrides));
+}
+
+function withEnvelopePatch(
+  envelope: SignedWriteEnvelope<typeof VECTOR_PAYLOAD>,
+  patch: Partial<SignedWriteEnvelope<typeof VECTOR_PAYLOAD>>
+): SignedWriteEnvelope<typeof VECTOR_PAYLOAD> {
+  return {
+    ...envelope,
+    ...patch
+  };
+}
+
+describe('LUMA SignedWriteEnvelope SDK surface', () => {
+  it('creates and verifies the frozen M0.B JCS/Ed25519 vector', async () => {
+    const envelope = await createVectorEnvelope();
+    const verification = await verifySignedWriteEnvelope({
+      envelope,
+      verify: ed25519VerifyHook()
+    });
+
+    expect(canonicalizeSignedWritePayload(VECTOR_PAYLOAD)).toBe(EXPECTED_CANONICAL_PAYLOAD);
+    await expect(digestSignedWritePayload(VECTOR_PAYLOAD))
+      .resolves.toBe(EXPECTED_PAYLOAD_DIGEST);
+    await expect(deriveSignedWriteIdempotencyKey({
+      payloadDigest: EXPECTED_PAYLOAD_DIGEST,
+      audience: 'vh-forum-thread',
+      sequence: 7
+    })).resolves.toBe(EXPECTED_IDEMPOTENCY_KEY);
+    expect(canonicalizeSignedWriteEnvelopeForSigning(envelope))
+      .toBe(EXPECTED_CANONICAL_ENVELOPE);
+    expect(Buffer.from(signedWriteEnvelopeSigningInput(envelope)).toString('utf8'))
+      .toBe(EXPECTED_CANONICAL_ENVELOPE);
+    expect(envelope).toEqual({
+      envelopeVersion: 1,
+      signatureSuite: CLIENT_SIGNED_WRITE_SIGNATURE_SUITE,
+      protocolVersion: LUMA_SIGNED_WRITE_PROTOCOL_VERSION,
+      profile: 'public-beta',
+      audience: 'vh-forum-thread',
+      origin: 'https://vh.example',
+      scheme: 'forum-author-v1',
+      publicAuthor: PUBLIC_AUTHOR_VALUE,
+      sessionRef: SESSION_REF,
+      payload: VECTOR_PAYLOAD,
+      payloadDigest: EXPECTED_PAYLOAD_DIGEST,
+      sequence: 7,
+      nonce: NONCE,
+      idempotencyKey: EXPECTED_IDEMPOTENCY_KEY,
+      issuedAt: ISSUED_AT,
+      signature: EXPECTED_SIGNATURE
+    });
+    expect(verification).toMatchObject({
+      valid: true,
+      payloadDigest: EXPECTED_PAYLOAD_DIGEST,
+      idempotencyKey: EXPECTED_IDEMPOTENCY_KEY,
+      canonicalEnvelope: EXPECTED_CANONICAL_ENVELOPE
+    });
+  });
+
+  it('keeps payloadDigest and signing input stable when object key order changes', async () => {
+    const first = await createVectorEnvelope();
+    const second = await createSignedWriteEnvelope(baseCreateInput({
+      payload: REORDERED_VECTOR_PAYLOAD as typeof VECTOR_PAYLOAD
+    }));
+
+    expect(second.payloadDigest).toBe(first.payloadDigest);
+    expect(second.idempotencyKey).toBe(first.idempotencyKey);
+    expect(second.signature).toBe(first.signature);
+    expect(canonicalizeSignedWriteEnvelopeForSigning(second))
+      .toBe(canonicalizeSignedWriteEnvelopeForSigning(first));
+  });
+
+  it('excludes signature from canonical signing bytes', async () => {
+    const envelope = await createVectorEnvelope();
+    const changedSignature = withEnvelopePatch(envelope, {
+      signature: 'different-signature'
+    });
+
+    expect(canonicalizeSignedWriteEnvelopeForSigning(envelope)).not.toContain('"signature":');
+    expect(canonicalizeSignedWriteEnvelopeForSigning(changedSignature))
+      .toBe(canonicalizeSignedWriteEnvelopeForSigning(envelope));
+    await expect(verifySignedWriteEnvelope({
+      envelope: changedSignature,
+      verify: ed25519VerifyHook()
+    })).resolves.toMatchObject({
+      valid: false,
+      reason: 'signature_verification_failed'
+    });
+  });
+
+  it('requires caller-provided public-author ids instead of direct raw strings', async () => {
+    const publicAuthor = createLumaPublicAuthorId(PUBLIC_AUTHOR_VALUE, 'forum-author-v1');
+
+    expect(publicAuthor).toEqual({
+      kind: 'luma-public-author-id',
+      scheme: 'forum-author-v1',
+      value: PUBLIC_AUTHOR_VALUE
+    });
+    expect(isLumaPublicAuthorId(publicAuthor)).toBe(true);
+    await expect(createSignedWriteEnvelope(baseCreateInput({
+      publicAuthor: PUBLIC_AUTHOR_VALUE as never
+    }))).rejects.toMatchObject({
+      reason: 'invalid_public_author'
+    });
+    await expect(createSignedWriteEnvelope(baseCreateInput({
+      publicAuthor: createLumaPublicAuthorId(PUBLIC_AUTHOR_VALUE, 'voter-v1')
+    }))).rejects.toMatchObject({
+      reason: 'public_author_scheme_mismatch'
+    });
+  });
+
+  it.each([
+    ['undefined', undefined],
+    ['null', null],
+    ['wrong object', {}],
+    ['wrong kind', { kind: 'raw-nullifier', scheme: 'forum-author-v1', value: PUBLIC_AUTHOR_VALUE }],
+    ['unregistered scheme', { kind: 'luma-public-author-id', scheme: 'legacy', value: PUBLIC_AUTHOR_VALUE }],
+    ['invalid value', { kind: 'luma-public-author-id', scheme: 'forum-author-v1', value: 'not-hex' }]
+  ])('rejects %s as a public author id guard', (_label, value) => {
+    expect(isLumaPublicAuthorId(value)).toBe(false);
+  });
+
+  it.each([
+    [
+      'unsupported audience',
+      { audience: 'vh-unknown' },
+      'unsupported_audience'
+    ],
+    [
+      'unregistered scheme',
+      { scheme: 'legacy-nullifier' },
+      'unregistered_scheme'
+    ],
+    [
+      'unsupported profile',
+      { profile: 'staging' },
+      'unsupported_profile'
+    ],
+    [
+      'unsupported signature suite',
+      { signatureSuite: 'jcs-ed25519-sha512-v1' },
+      'unsupported_signature_suite'
+    ],
+    [
+      'unsupported protocol',
+      { protocolVersion: 'luma-write-v2' },
+      'unsupported_protocol_version'
+    ],
+    [
+      'blank origin',
+      { origin: '' },
+      'invalid_origin'
+    ],
+    [
+      'missing sessionRef',
+      { sessionRef: null },
+      'invalid_session_ref'
+    ],
+    [
+      'blank session token hash',
+      { sessionRef: { tokenHash: '', envelopeDigest: SESSION_REF.envelopeDigest } },
+      'invalid_session_ref'
+    ],
+    [
+      'negative sequence',
+      { sequence: -1 },
+      'invalid_sequence'
+    ],
+    [
+      'fractional sequence',
+      { sequence: 1.25 },
+      'invalid_sequence'
+    ],
+    [
+      'short nonce',
+      { nonce: 'abc' },
+      'invalid_nonce'
+    ],
+    [
+      'uppercase nonce',
+      { nonce: '00112233445566778899AABBCCDDEEFF' },
+      'invalid_nonce'
+    ],
+    [
+      'negative issuedAt',
+      { issuedAt: -1 },
+      'invalid_issued_at'
+    ],
+    [
+      'empty signature',
+      { sign: () => '' },
+      'invalid_signature'
+    ],
+    [
+      'uncanonicalizable payload',
+      { payload: undefined },
+      'invalid_payload_digest'
+    ]
+  ])('fails closed while creating on %s', async (_label, patch, reason) => {
+    await expect(createSignedWriteEnvelope(baseCreateInput(
+      patch as Partial<CreateSignedWriteEnvelopeInput<typeof VECTOR_PAYLOAD>>
+    ))).rejects.toMatchObject({ reason });
+  });
+
+  it.each([
+    [
+      'invalid envelope version',
+      { envelopeVersion: 2 },
+      'invalid_envelope_version'
+    ],
+    [
+      'unsupported protocol',
+      { protocolVersion: 'luma-write-v2' },
+      'unsupported_protocol_version'
+    ],
+    [
+      'unsupported signature suite',
+      { signatureSuite: 'jcs-ed25519-sha512-v1' },
+      'unsupported_signature_suite'
+    ],
+    [
+      'unsupported profile',
+      { profile: 'staging' },
+      'unsupported_profile'
+    ],
+    [
+      'unsupported audience',
+      { audience: 'vh-unknown' },
+      'unsupported_audience'
+    ],
+    [
+      'unregistered scheme',
+      { scheme: 'legacy-nullifier' },
+      'unregistered_scheme'
+    ],
+    [
+      'invalid public author',
+      { publicAuthor: 'ABCDEF' },
+      'invalid_public_author'
+    ],
+    [
+      'blank origin',
+      { origin: '' },
+      'invalid_origin'
+    ],
+    [
+      'missing sessionRef',
+      { sessionRef: null },
+      'invalid_session_ref'
+    ],
+    [
+      'bad sequence',
+      { sequence: -1 },
+      'invalid_sequence'
+    ],
+    [
+      'bad nonce',
+      { nonce: 'bad-nonce' },
+      'invalid_nonce'
+    ],
+    [
+      'bad issuedAt',
+      { issuedAt: -1 },
+      'invalid_issued_at'
+    ],
+    [
+      'empty signature',
+      { signature: '' },
+      'invalid_signature'
+    ],
+    [
+      'invalid payloadDigest',
+      { payloadDigest: 'not-hex' },
+      'invalid_payload_digest'
+    ],
+    [
+      'invalid idempotencyKey',
+      { idempotencyKey: 'not-hex' },
+      'invalid_idempotency_key'
+    ],
+    [
+      'tampered payload',
+      { payload: { ...VECTOR_PAYLOAD, body: 'tampered' } },
+      'payload_digest_mismatch'
+    ],
+    [
+      'mismatched payloadDigest',
+      { payloadDigest: '0000000000000000000000000000000000000000000000000000000000000000' },
+      'payload_digest_mismatch'
+    ],
+    [
+      'mismatched idempotencyKey',
+      { idempotencyKey: 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff' },
+      'idempotency_key_mismatch'
+    ],
+    [
+      'tampered metadata',
+      { origin: 'https://evil.example' },
+      'signature_verification_failed'
+    ],
+    [
+      'failed signature',
+      { signature: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' },
+      'signature_verification_failed'
+    ]
+  ])('returns a structured verification failure for %s', async (_label, patch, reason) => {
+    const envelope = await createVectorEnvelope();
+
+    await expect(verifySignedWriteEnvelope({
+      envelope: withEnvelopePatch(envelope, patch as Partial<SignedWriteEnvelope<typeof VECTOR_PAYLOAD>>),
+      verify: ed25519VerifyHook()
+    })).resolves.toMatchObject({
+      valid: false,
+      reason
+    });
+  });
+
+  it('uses injected sign and verify hooks without owning key lifecycle', async () => {
+    const sign = vi.fn(ed25519SignHook());
+    const envelope = await createSignedWriteEnvelope(baseCreateInput({ sign }));
+    const verify = vi.fn(ed25519VerifyHook());
+    const result = await verifySignedWriteEnvelope({ envelope, verify });
+
+    expect(sign).toHaveBeenCalledWith(expect.objectContaining({
+      signatureSuite: CLIENT_SIGNED_WRITE_SIGNATURE_SUITE,
+      canonicalEnvelope: EXPECTED_CANONICAL_ENVELOPE
+    }));
+    expect(verify).toHaveBeenCalledWith(expect.objectContaining({
+      signatureSuite: CLIENT_SIGNED_WRITE_SIGNATURE_SUITE,
+      canonicalEnvelope: EXPECTED_CANONICAL_ENVELOPE,
+      signature: EXPECTED_SIGNATURE
+    }));
+    expect(result.valid).toBe(true);
+  });
+
+  it('reports missing WebCrypto SHA-256 as a closed failure', async () => {
+    vi.stubGlobal('crypto', undefined);
+
+    await expect(digestSignedWritePayload(VECTOR_PAYLOAD)).rejects.toMatchObject({
+      reason: 'invalid_payload_digest'
+    });
+
+    vi.unstubAllGlobals();
+  });
+
+  it('rethrows unexpected envelope validation errors', async () => {
+    const envelope = await createVectorEnvelope();
+    const throwingEnvelope = Object.create(envelope) as SignedWriteEnvelope<typeof VECTOR_PAYLOAD>;
+    Object.defineProperty(throwingEnvelope, 'envelopeVersion', {
+      get() {
+        throw new Error('unexpected getter failure');
+      }
+    });
+
+    await expect(verifySignedWriteEnvelope({
+      envelope: throwingEnvelope,
+      verify: ed25519VerifyHook()
+    })).rejects.toThrow(/unexpected getter failure/);
+  });
+
+  it('throws a signed-write error for invalid public author construction', () => {
+    expect(() => createLumaPublicAuthorId(
+      'ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789',
+      'forum-author-v1'
+    )).toThrow(SignedWriteEnvelopeError);
+    expect(() => createLumaPublicAuthorId(PUBLIC_AUTHOR_VALUE, 'legacy-nullifier'))
+      .toThrow(SignedWriteEnvelopeError);
+  });
+});

--- a/packages/luma-sdk/src/signedWrites.ts
+++ b/packages/luma-sdk/src/signedWrites.ts
@@ -352,7 +352,12 @@ async function validateSignedWriteEnvelope<TPayload>(
     return errorResult(error);
   }
 
-  const payloadDigest = await digestSignedWritePayload(envelope.payload);
+  let payloadDigest: string;
+  try {
+    payloadDigest = await digestSignedWritePayload(envelope.payload);
+  } catch (error) {
+    return errorResult(error);
+  }
   if (payloadDigest !== envelope.payloadDigest) {
     return invalidResult(
       'payload_digest_mismatch',
@@ -380,14 +385,110 @@ async function validateSignedWriteEnvelope<TPayload>(
 }
 
 function requireCanonicalJson(value: unknown, label: string): string {
-  const encoded = canonicalize(value);
-  if (typeof encoded !== 'string') {
+  try {
+    assertJsonCanonicalizable(value, label);
+    return canonicalize(value) as string;
+  } catch (error) {
+    if (error instanceof SignedWriteEnvelopeError) {
+      throw error;
+    }
     throw new SignedWriteEnvelopeError(
       'invalid_payload_digest',
-      `${label} must be RFC 8785 JSON-canonicalizable`
+      `${label} must be RFC 8785 JSON-canonicalizable: ${(error as Error).message}`
     );
   }
-  return encoded;
+}
+
+function assertJsonCanonicalizable(
+  value: unknown,
+  label: string,
+  seen: WeakSet<object> = new WeakSet()
+): void {
+  if (value === null || typeof value === 'string' || typeof value === 'boolean') {
+    return;
+  }
+
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      throwInvalidJsonValue(label);
+    }
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    if (seen.has(value)) {
+      throwInvalidJsonValue(label);
+    }
+    seen.add(value);
+
+    if (Object.getOwnPropertySymbols(value).length > 0) {
+      throwInvalidJsonValue(label);
+    }
+
+    const descriptors = Object.fromEntries(
+      Object.entries(Object.getOwnPropertyDescriptors(value))
+        .filter(([key]) => key !== 'length')
+    );
+
+    for (const [key, descriptor] of Object.entries(descriptors)) {
+      const index = Number(key);
+      if (
+        !Number.isInteger(index)
+        || String(index) !== key
+        || index < 0
+        || index >= value.length
+        || !descriptor.enumerable
+        || !('value' in descriptor)
+      ) {
+        throwInvalidJsonValue(label);
+      }
+    }
+
+    for (let index = 0; index < value.length; index += 1) {
+      const descriptor = descriptors[String(index)];
+      if (descriptor === undefined || !('value' in descriptor)) {
+        throwInvalidJsonValue(label);
+      }
+      assertJsonCanonicalizable(descriptor.value, label, seen);
+    }
+    seen.delete(value);
+    return;
+  }
+
+  if (typeof value === 'object' && value !== null) {
+    if (seen.has(value)) {
+      throwInvalidJsonValue(label);
+    }
+
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) {
+      throwInvalidJsonValue(label);
+    }
+
+    seen.add(value);
+    if (Object.getOwnPropertySymbols(value).length > 0) {
+      throwInvalidJsonValue(label);
+    }
+
+    const descriptors = Object.getOwnPropertyDescriptors(value);
+    for (const descriptor of Object.values(descriptors)) {
+      if (!descriptor.enumerable || !('value' in descriptor)) {
+        throwInvalidJsonValue(label);
+      }
+      assertJsonCanonicalizable(descriptor.value, label, seen);
+    }
+    seen.delete(value);
+    return;
+  }
+
+  throwInvalidJsonValue(label);
+}
+
+function throwInvalidJsonValue(label: string): never {
+  throw new SignedWriteEnvelopeError(
+    'invalid_payload_digest',
+    `${label} must be strict JSON data for RFC 8785 canonicalization`
+  );
 }
 
 function requireEnvelopeVersion(value: unknown): typeof LUMA_SIGNED_WRITE_ENVELOPE_VERSION {

--- a/packages/luma-sdk/src/signedWrites.ts
+++ b/packages/luma-sdk/src/signedWrites.ts
@@ -1,0 +1,631 @@
+import canonicalize from 'canonicalize';
+
+import {
+  isRegisteredLinkabilityDomainName,
+  type LinkabilityDomainName
+} from './linkabilityDomains';
+import type {
+  AudienceTag,
+  DeploymentProfile,
+  SignatureSuite
+} from './providers';
+
+export const LUMA_SIGNED_WRITE_ENVELOPE_VERSION = 1;
+export const LUMA_SIGNED_WRITE_PROTOCOL_VERSION = 'luma-write-v1';
+export const CLIENT_SIGNED_WRITE_SIGNATURE_SUITE = 'jcs-ed25519-sha256-v1';
+
+export const LUMA_SIGNED_WRITE_AUDIENCES = Object.freeze([
+  'vh-forum-thread',
+  'vh-forum-comment',
+  'vh-stance-vote',
+  'vh-stance-clear',
+  'vh-civic-action-draft',
+  'vh-civic-action-send',
+  'vh-delegation-grant',
+  'vh-delegation-revoke',
+  'vh-budget-consume',
+  'vh-onchain-bridge'
+] as const satisfies readonly AudienceTag[]);
+
+export const LUMA_SIGNED_WRITE_PROFILES = Object.freeze([
+  'dev',
+  'e2e',
+  'public-beta',
+  'production-attestation'
+] as const satisfies readonly DeploymentProfile[]);
+
+export const LUMA_SIGNED_WRITE_SIGNATURE_SUITES = Object.freeze([
+  CLIENT_SIGNED_WRITE_SIGNATURE_SUITE
+] as const satisfies readonly SignatureSuite[]);
+
+export type ClientSignedWriteSignatureSuite = typeof CLIENT_SIGNED_WRITE_SIGNATURE_SUITE;
+
+const PUBLIC_AUTHOR_KIND = 'luma-public-author-id';
+const LOWERCASE_HEX_64 = /^[0-9a-f]{64}$/;
+const LOWERCASE_HEX_32 = /^[0-9a-f]{32}$/;
+
+export interface LumaPublicAuthorId {
+  readonly kind: typeof PUBLIC_AUTHOR_KIND;
+  readonly scheme: LinkabilityDomainName;
+  readonly value: string;
+}
+
+export interface SignedWriteSessionRef {
+  tokenHash: string;
+  envelopeDigest: string;
+}
+
+export interface SignedWriteEnvelope<TPayload> {
+  envelopeVersion: typeof LUMA_SIGNED_WRITE_ENVELOPE_VERSION;
+  signatureSuite: ClientSignedWriteSignatureSuite;
+  protocolVersion: typeof LUMA_SIGNED_WRITE_PROTOCOL_VERSION;
+  profile: DeploymentProfile;
+  audience: AudienceTag;
+  origin: string;
+  scheme: LinkabilityDomainName;
+  publicAuthor: string;
+  sessionRef: SignedWriteSessionRef;
+  payload: TPayload;
+  payloadDigest: string;
+  sequence: number;
+  nonce: string;
+  idempotencyKey: string;
+  issuedAt: number;
+  signature: string;
+}
+
+export type UnsignedSignedWriteEnvelope<TPayload> = Omit<
+  SignedWriteEnvelope<TPayload>,
+  'signature'
+>;
+
+export interface SignedWriteSignHookInput<TPayload = unknown> {
+  signatureSuite: ClientSignedWriteSignatureSuite;
+  canonicalBytes: Uint8Array;
+  canonicalEnvelope: string;
+  envelope: UnsignedSignedWriteEnvelope<TPayload>;
+}
+
+export type SignedWriteSignHook<TPayload = unknown> = (
+  input: SignedWriteSignHookInput<TPayload>
+) => Promise<string> | string;
+
+export interface SignedWriteVerifyHookInput<TPayload = unknown>
+  extends SignedWriteSignHookInput<TPayload> {
+  signature: string;
+}
+
+export type SignedWriteVerifyHook<TPayload = unknown> = (
+  input: SignedWriteVerifyHookInput<TPayload>
+) => Promise<boolean> | boolean;
+
+export interface CreateSignedWriteEnvelopeInput<TPayload> {
+  profile: DeploymentProfile;
+  audience: AudienceTag;
+  origin: string;
+  scheme: string;
+  publicAuthor: LumaPublicAuthorId;
+  sessionRef: SignedWriteSessionRef;
+  payload: TPayload;
+  sequence: number;
+  nonce: string;
+  issuedAt: number;
+  sign: SignedWriteSignHook<TPayload>;
+  protocolVersion?: string;
+  signatureSuite?: SignatureSuite;
+}
+
+export interface VerifySignedWriteEnvelopeInput<TPayload> {
+  envelope: SignedWriteEnvelope<TPayload>;
+  verify: SignedWriteVerifyHook<TPayload>;
+}
+
+export type SignedWriteVerificationFailureReason =
+  | 'invalid_envelope_version'
+  | 'unsupported_protocol_version'
+  | 'unsupported_signature_suite'
+  | 'unsupported_profile'
+  | 'unsupported_audience'
+  | 'unregistered_scheme'
+  | 'invalid_public_author'
+  | 'public_author_scheme_mismatch'
+  | 'invalid_origin'
+  | 'invalid_session_ref'
+  | 'invalid_payload_digest'
+  | 'payload_digest_mismatch'
+  | 'invalid_idempotency_key'
+  | 'idempotency_key_mismatch'
+  | 'invalid_sequence'
+  | 'invalid_nonce'
+  | 'invalid_issued_at'
+  | 'invalid_signature'
+  | 'signature_verification_failed';
+
+export type SignedWriteVerificationResult<TPayload = unknown> =
+  | {
+    valid: true;
+    envelope: SignedWriteEnvelope<TPayload>;
+    payloadDigest: string;
+    idempotencyKey: string;
+    canonicalEnvelope: string;
+  }
+  | {
+    valid: false;
+    reason: SignedWriteVerificationFailureReason;
+    message: string;
+  };
+
+export class SignedWriteEnvelopeError extends Error {
+  constructor(
+    readonly reason: SignedWriteVerificationFailureReason,
+    message: string
+  ) {
+    super(message);
+    this.name = 'SignedWriteEnvelopeError';
+  }
+}
+
+export function createLumaPublicAuthorId(
+  value: string,
+  scheme: string
+): LumaPublicAuthorId {
+  const registeredScheme = requireRegisteredScheme(scheme);
+  requireLowercaseHex64(value, 'publicAuthor', 'invalid_public_author');
+
+  return Object.freeze({
+    kind: PUBLIC_AUTHOR_KIND,
+    scheme: registeredScheme,
+    value
+  });
+}
+
+export function isLumaPublicAuthorId(value: unknown): value is LumaPublicAuthorId {
+  return typeof value === 'object'
+    && value !== null
+    && (value as { kind?: unknown }).kind === PUBLIC_AUTHOR_KIND
+    && typeof (value as { scheme?: unknown }).scheme === 'string'
+    && typeof (value as { value?: unknown }).value === 'string'
+    && isRegisteredLinkabilityDomainName((value as { scheme: string }).scheme)
+    && LOWERCASE_HEX_64.test((value as { value: string }).value);
+}
+
+export function canonicalizeSignedWritePayload(payload: unknown): string {
+  return requireCanonicalJson(payload, 'payload');
+}
+
+export async function digestSignedWritePayload(payload: unknown): Promise<string> {
+  return sha256Hex(utf8(canonicalizeSignedWritePayload(payload)));
+}
+
+export function canonicalizeSignedWriteEnvelopeForSigning<TPayload>(
+  envelope: UnsignedSignedWriteEnvelope<TPayload> | SignedWriteEnvelope<TPayload>
+): string {
+  return requireCanonicalJson(unsignedEnvelope(envelope), 'signed write envelope');
+}
+
+export function signedWriteEnvelopeSigningInput<TPayload>(
+  envelope: UnsignedSignedWriteEnvelope<TPayload> | SignedWriteEnvelope<TPayload>
+): Uint8Array {
+  return utf8(canonicalizeSignedWriteEnvelopeForSigning(envelope));
+}
+
+export async function deriveSignedWriteIdempotencyKey(input: {
+  payloadDigest: string;
+  audience: AudienceTag;
+  sequence: number;
+}): Promise<string> {
+  requireLowercaseHex64(input.payloadDigest, 'payloadDigest', 'invalid_payload_digest');
+  requireAudience(input.audience);
+  requireSequence(input.sequence);
+
+  const material = `${input.payloadDigest}${input.audience}${input.sequence}`;
+  return sha256Hex(utf8(requireCanonicalJson(material, 'idempotency basis')));
+}
+
+export async function createSignedWriteEnvelope<TPayload>(
+  input: CreateSignedWriteEnvelopeInput<TPayload>
+): Promise<SignedWriteEnvelope<TPayload>> {
+  const signatureSuite = requireClientSignatureSuite(
+    input.signatureSuite ?? CLIENT_SIGNED_WRITE_SIGNATURE_SUITE
+  );
+  const protocolVersion = requireProtocolVersion(
+    input.protocolVersion ?? LUMA_SIGNED_WRITE_PROTOCOL_VERSION
+  );
+  const profile = requireProfile(input.profile);
+  const audience = requireAudience(input.audience);
+  const scheme = requireRegisteredScheme(input.scheme);
+  const publicAuthor = requirePublicAuthor(input.publicAuthor, scheme);
+  const origin = requireNonEmptyString(input.origin, 'origin', 'invalid_origin');
+  const sessionRef = requireSessionRef(input.sessionRef);
+  const sequence = requireSequence(input.sequence);
+  const nonce = requireNonce(input.nonce);
+  const issuedAt = requireIssuedAt(input.issuedAt);
+  const payloadDigest = await digestSignedWritePayload(input.payload);
+  const idempotencyKey = await deriveSignedWriteIdempotencyKey({
+    payloadDigest,
+    audience,
+    sequence
+  });
+
+  const unsigned: UnsignedSignedWriteEnvelope<TPayload> = {
+    envelopeVersion: LUMA_SIGNED_WRITE_ENVELOPE_VERSION,
+    signatureSuite,
+    protocolVersion,
+    profile,
+    audience,
+    origin,
+    scheme,
+    publicAuthor,
+    sessionRef,
+    payload: input.payload,
+    payloadDigest,
+    sequence,
+    nonce,
+    idempotencyKey,
+    issuedAt
+  };
+
+  const canonicalEnvelope = canonicalizeSignedWriteEnvelopeForSigning(unsigned);
+  const signature = await input.sign({
+    signatureSuite,
+    canonicalBytes: utf8(canonicalEnvelope),
+    canonicalEnvelope,
+    envelope: unsigned
+  });
+
+  requireNonEmptyString(signature, 'signature', 'invalid_signature');
+
+  return Object.freeze({
+    ...unsigned,
+    signature
+  });
+}
+
+export async function verifySignedWriteEnvelope<TPayload>(
+  input: VerifySignedWriteEnvelopeInput<TPayload>
+): Promise<SignedWriteVerificationResult<TPayload>> {
+  const validation = await validateSignedWriteEnvelope(input.envelope);
+  if (!validation.valid) {
+    return validation;
+  }
+
+  const canonicalEnvelope = canonicalizeSignedWriteEnvelopeForSigning(input.envelope);
+  const verified = await input.verify({
+    signatureSuite: input.envelope.signatureSuite,
+    canonicalBytes: utf8(canonicalEnvelope),
+    canonicalEnvelope,
+    envelope: unsignedEnvelope(input.envelope),
+    signature: input.envelope.signature
+  });
+
+  if (!verified) {
+    return invalidResult<TPayload>(
+      'signature_verification_failed',
+      'Signed write envelope signature verification failed'
+    );
+  }
+
+  return {
+    valid: true,
+    envelope: input.envelope,
+    payloadDigest: validation.payloadDigest,
+    idempotencyKey: validation.idempotencyKey,
+    canonicalEnvelope
+  };
+}
+
+async function validateSignedWriteEnvelope<TPayload>(
+  envelope: SignedWriteEnvelope<TPayload>
+): Promise<
+  | {
+    valid: true;
+    payloadDigest: string;
+    idempotencyKey: string;
+  }
+  | {
+    valid: false;
+    reason: SignedWriteVerificationFailureReason;
+    message: string;
+  }
+> {
+  try {
+    requireEnvelopeVersion(envelope.envelopeVersion);
+    requireClientSignatureSuite(envelope.signatureSuite);
+    requireProtocolVersion(envelope.protocolVersion);
+    requireProfile(envelope.profile);
+    requireAudience(envelope.audience);
+    requireRegisteredScheme(envelope.scheme);
+    requireLowercaseHex64(envelope.publicAuthor, 'publicAuthor', 'invalid_public_author');
+    requireNonEmptyString(envelope.origin, 'origin', 'invalid_origin');
+    requireSessionRef(envelope.sessionRef);
+    requireSequence(envelope.sequence);
+    requireNonce(envelope.nonce);
+    requireIssuedAt(envelope.issuedAt);
+    requireNonEmptyString(envelope.signature, 'signature', 'invalid_signature');
+    requireLowercaseHex64(envelope.payloadDigest, 'payloadDigest', 'invalid_payload_digest');
+    requireLowercaseHex64(
+      envelope.idempotencyKey,
+      'idempotencyKey',
+      'invalid_idempotency_key'
+    );
+  } catch (error) {
+    return errorResult(error);
+  }
+
+  const payloadDigest = await digestSignedWritePayload(envelope.payload);
+  if (payloadDigest !== envelope.payloadDigest) {
+    return invalidResult(
+      'payload_digest_mismatch',
+      'Signed write envelope payloadDigest does not match payload'
+    );
+  }
+
+  const idempotencyKey = await deriveSignedWriteIdempotencyKey({
+    payloadDigest,
+    audience: envelope.audience,
+    sequence: envelope.sequence
+  });
+  if (idempotencyKey !== envelope.idempotencyKey) {
+    return invalidResult(
+      'idempotency_key_mismatch',
+      'Signed write envelope idempotencyKey does not match payloadDigest, audience, and sequence'
+    );
+  }
+
+  return {
+    valid: true,
+    payloadDigest,
+    idempotencyKey
+  };
+}
+
+function requireCanonicalJson(value: unknown, label: string): string {
+  const encoded = canonicalize(value);
+  if (typeof encoded !== 'string') {
+    throw new SignedWriteEnvelopeError(
+      'invalid_payload_digest',
+      `${label} must be RFC 8785 JSON-canonicalizable`
+    );
+  }
+  return encoded;
+}
+
+function requireEnvelopeVersion(value: unknown): typeof LUMA_SIGNED_WRITE_ENVELOPE_VERSION {
+  if (value !== LUMA_SIGNED_WRITE_ENVELOPE_VERSION) {
+    throw new SignedWriteEnvelopeError(
+      'invalid_envelope_version',
+      `Signed write envelopeVersion must be ${LUMA_SIGNED_WRITE_ENVELOPE_VERSION}`
+    );
+  }
+  return value;
+}
+
+function requireProtocolVersion(value: unknown): typeof LUMA_SIGNED_WRITE_PROTOCOL_VERSION {
+  if (value !== LUMA_SIGNED_WRITE_PROTOCOL_VERSION) {
+    throw new SignedWriteEnvelopeError(
+      'unsupported_protocol_version',
+      `Signed write protocolVersion must be ${LUMA_SIGNED_WRITE_PROTOCOL_VERSION}`
+    );
+  }
+  return value;
+}
+
+function requireClientSignatureSuite(value: unknown): ClientSignedWriteSignatureSuite {
+  if (value !== CLIENT_SIGNED_WRITE_SIGNATURE_SUITE) {
+    throw new SignedWriteEnvelopeError(
+      'unsupported_signature_suite',
+      `Signed write signatureSuite must be ${CLIENT_SIGNED_WRITE_SIGNATURE_SUITE}`
+    );
+  }
+  return value;
+}
+
+function requireProfile(value: unknown): DeploymentProfile {
+  if (!LUMA_SIGNED_WRITE_PROFILES.includes(value as DeploymentProfile)) {
+    throw new SignedWriteEnvelopeError(
+      'unsupported_profile',
+      `Signed write profile is not supported: ${String(value)}`
+    );
+  }
+  return value as DeploymentProfile;
+}
+
+function requireAudience(value: unknown): AudienceTag {
+  if (!LUMA_SIGNED_WRITE_AUDIENCES.includes(value as AudienceTag)) {
+    throw new SignedWriteEnvelopeError(
+      'unsupported_audience',
+      `Signed write audience is not supported: ${String(value)}`
+    );
+  }
+  return value as AudienceTag;
+}
+
+function requireRegisteredScheme(value: unknown): LinkabilityDomainName {
+  if (typeof value !== 'string' || !isRegisteredLinkabilityDomainName(value)) {
+    throw new SignedWriteEnvelopeError(
+      'unregistered_scheme',
+      `Signed write scheme is not registered: ${String(value)}`
+    );
+  }
+  return value;
+}
+
+function requirePublicAuthor(
+  value: unknown,
+  scheme: LinkabilityDomainName
+): string {
+  if (!isLumaPublicAuthorId(value)) {
+    throw new SignedWriteEnvelopeError(
+      'invalid_public_author',
+      'Signed write publicAuthor must be a LUMA public author id'
+    );
+  }
+  if (value.scheme !== scheme) {
+    throw new SignedWriteEnvelopeError(
+      'public_author_scheme_mismatch',
+      'Signed write publicAuthor scheme must match the envelope scheme'
+    );
+  }
+  return value.value;
+}
+
+function requireSessionRef(value: unknown): SignedWriteSessionRef {
+  if (typeof value !== 'object' || value === null) {
+    throw new SignedWriteEnvelopeError(
+      'invalid_session_ref',
+      'Signed write sessionRef must be an object'
+    );
+  }
+
+  const tokenHash = requireNonEmptyString(
+    (value as { tokenHash?: unknown }).tokenHash,
+    'sessionRef.tokenHash',
+    'invalid_session_ref'
+  );
+  const envelopeDigest = requireNonEmptyString(
+    (value as { envelopeDigest?: unknown }).envelopeDigest,
+    'sessionRef.envelopeDigest',
+    'invalid_session_ref'
+  );
+
+  return Object.freeze({ tokenHash, envelopeDigest });
+}
+
+function requireSequence(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < 0) {
+    throw new SignedWriteEnvelopeError(
+      'invalid_sequence',
+      'Signed write sequence must be a nonnegative safe integer'
+    );
+  }
+  return value;
+}
+
+function requireNonce(value: unknown): string {
+  if (typeof value !== 'string' || !LOWERCASE_HEX_32.test(value)) {
+    throw new SignedWriteEnvelopeError(
+      'invalid_nonce',
+      'Signed write nonce must be a lowercase 128-bit hex string'
+    );
+  }
+  return value;
+}
+
+function requireIssuedAt(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < 0) {
+    throw new SignedWriteEnvelopeError(
+      'invalid_issued_at',
+      'Signed write issuedAt must be a nonnegative safe integer'
+    );
+  }
+  return value;
+}
+
+function requireLowercaseHex64(
+  value: unknown,
+  label: string,
+  reason: SignedWriteVerificationFailureReason
+): string {
+  if (typeof value !== 'string' || !LOWERCASE_HEX_64.test(value)) {
+    throw new SignedWriteEnvelopeError(
+      reason,
+      `Signed write ${label} must be lowercase 64-character hex`
+    );
+  }
+  return value;
+}
+
+function requireNonEmptyString(
+  value: unknown,
+  label: string,
+  reason: SignedWriteVerificationFailureReason
+): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new SignedWriteEnvelopeError(
+      reason,
+      `Signed write ${label} must be a non-empty string`
+    );
+  }
+  return value;
+}
+
+function unsignedEnvelope<TPayload>(
+  envelope: UnsignedSignedWriteEnvelope<TPayload> | SignedWriteEnvelope<TPayload>
+): UnsignedSignedWriteEnvelope<TPayload> {
+  const {
+    envelopeVersion,
+    signatureSuite,
+    protocolVersion,
+    profile,
+    audience,
+    origin,
+    scheme,
+    publicAuthor,
+    sessionRef,
+    payload,
+    payloadDigest,
+    sequence,
+    nonce,
+    idempotencyKey,
+    issuedAt
+  } = envelope;
+
+  return {
+    envelopeVersion,
+    signatureSuite,
+    protocolVersion,
+    profile,
+    audience,
+    origin,
+    scheme,
+    publicAuthor,
+    sessionRef,
+    payload,
+    payloadDigest,
+    sequence,
+    nonce,
+    idempotencyKey,
+    issuedAt
+  };
+}
+
+function utf8(value: string): Uint8Array {
+  return new TextEncoder().encode(value);
+}
+
+async function sha256Hex(bytes: Uint8Array): Promise<string> {
+  const subtle = globalThis.crypto?.subtle;
+  if (!subtle) {
+    throw new SignedWriteEnvelopeError(
+      'invalid_payload_digest',
+      'WebCrypto SHA-256 is unavailable'
+    );
+  }
+
+  const digestInput = new ArrayBuffer(bytes.byteLength);
+  new Uint8Array(digestInput).set(bytes);
+  const digest = await subtle.digest('SHA-256', digestInput);
+  return bytesToHex(new Uint8Array(digest));
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+function invalidResult<TPayload = unknown>(
+  reason: SignedWriteVerificationFailureReason,
+  message: string
+): SignedWriteVerificationResult<TPayload> {
+  return {
+    valid: false,
+    reason,
+    message
+  };
+}
+
+function errorResult<TPayload = unknown>(error: unknown): SignedWriteVerificationResult<TPayload> {
+  if (error instanceof SignedWriteEnvelopeError) {
+    return invalidResult(error.reason, error.message);
+  }
+  throw error;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -343,6 +343,9 @@ importers:
       '@vh/types':
         specifier: workspace:*
         version: link:../types
+      canonicalize:
+        specifier: ^3.0.0
+        version: 3.0.0
     devDependencies:
       typescript:
         specifier: ^5.4.5
@@ -2332,6 +2335,11 @@ packages:
 
   caniuse-lite@1.0.30001756:
     resolution: {integrity: sha512-4HnCNKbMLkLdhJz3TToeVWHSnfJvPaq6vu/eRP0Ahub/07n484XHhBF5AJoSGHdVrS8tKFauUQz8Bp9P7LVx7A==}
+
+  canonicalize@3.0.0:
+    resolution: {integrity: sha512-yYLfHyDMIXRyRqsKBRLX023riFLpXY2YOfdtqKXZRZy9qsfOJ9U+4F9YZL7MEzL5+ziN2x2nlBvY/Voi3EBljA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   cbor@8.1.0:
     resolution: {integrity: sha512-DwGjNW9omn6EwP70aXsn7FQJx5kO12tX0bZkaTjzdVFM6/7nhA4t0EENocKGx6D2Bch9PE2KzCUf5SceBdeijg==}
@@ -7489,6 +7497,8 @@ snapshots:
   camelcase@6.3.0: {}
 
   caniuse-lite@1.0.30001756: {}
+
+  canonicalize@3.0.0: {}
 
   cbor@8.1.0:
     dependencies:

--- a/tools/scripts/check-luma-signed-write-surface.mjs
+++ b/tools/scripts/check-luma-signed-write-surface.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const signedWritesPath = path.join(rootDir, 'packages/luma-sdk/src/signedWrites.ts');
+const sdkIndexPath = path.join(rootDir, 'packages/luma-sdk/src/index.ts');
+const packagePath = path.join(rootDir, 'packages/luma-sdk/package.json');
+
+const signedWritesSource = fs.readFileSync(signedWritesPath, 'utf8');
+const sdkIndexSource = fs.readFileSync(sdkIndexPath, 'utf8');
+const packageJson = JSON.parse(fs.readFileSync(packagePath, 'utf8'));
+const failures = [];
+
+const requiredExports = [
+  'SignedWriteEnvelope',
+  'UnsignedSignedWriteEnvelope',
+  'createSignedWriteEnvelope',
+  'verifySignedWriteEnvelope',
+  'canonicalizeSignedWritePayload',
+  'digestSignedWritePayload',
+  'canonicalizeSignedWriteEnvelopeForSigning',
+  'deriveSignedWriteIdempotencyKey',
+  'createLumaPublicAuthorId',
+  'CLIENT_SIGNED_WRITE_SIGNATURE_SUITE'
+];
+
+for (const exportName of requiredExports) {
+  if (!sdkIndexSource.includes(exportName)) {
+    failures.push(`packages/luma-sdk/src/index.ts does not export ${exportName}`);
+  }
+}
+
+if (!signedWritesSource.includes("import canonicalize from 'canonicalize'")) {
+  failures.push('signed write surface does not use the RFC 8785 canonicalize dependency');
+}
+
+if (!signedWritesSource.includes("CLIENT_SIGNED_WRITE_SIGNATURE_SUITE = 'jcs-ed25519-sha256-v1'")) {
+  failures.push('client signed-write signature suite is not closed to jcs-ed25519-sha256-v1');
+}
+
+if (/from ['"]node:crypto['"]/.test(signedWritesSource)) {
+  failures.push('signed write runtime imports node:crypto instead of browser-safe WebCrypto');
+}
+
+if (/\bprincipalNullifier\b/.test(signedWritesSource)) {
+  failures.push('signed write surface references principalNullifier');
+}
+
+if (packageJson.dependencies?.canonicalize !== '^3.0.0') {
+  failures.push('@vh/luma-sdk must depend on canonicalize ^3.0.0');
+}
+
+if (failures.length > 0) {
+  console.error('[check:luma-signed-write-surface] failed');
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log('[check:luma-signed-write-surface] signed write surface ok');


### PR DESCRIPTION
## Summary
- Adds the narrow M0.B SignedWriteEnvelope SDK foundation in `@vh/luma-sdk`.
- Implements RFC 8785 JCS canonical payload digesting, canonical envelope signing input, idempotency key derivation, closed audience/profile/scheme/suite validation, caller-provided public author IDs, and injected Ed25519 sign/verify hooks for `jcs-ed25519-sha256-v1`.
- Adds a signed-write surface guard without migrating any public schema or adapter write path.

## Scope Boundaries
- No changes to `packages/gun-client`, `packages/data-model`, public schemas, `apps/web-pwa/src/hooks/voteIntentMaterializer.ts`, mesh drills, relay, services, or vault migration.
- No adapter consumes the new envelope surface in this slice.
- `packages/luma-sdk/src/providers/**` behavior is untouched.

## Verification
- `pnpm --filter @vh/luma-sdk test`
- `pnpm --filter @vh/luma-sdk typecheck`
- `pnpm --filter @vh/luma-sdk build`
- `pnpm check:luma-signed-write-surface`
- `pnpm check:linkability-domain-registry`
- `pnpm check:luma-provider-surface`
- `pnpm docs:check`
- `git diff --check HEAD~1..HEAD`
- `node tools/scripts/check-diff-coverage.mjs` (100% line + branch coverage on `packages/luma-sdk/src/signedWrites.ts`)

Note: local PNPM emits the existing Node engine warning for Node `v23.10.0` vs repo `>=20 <23`.
