### PR TITLE
LUMA M0.D-1 vault compartment foundation

### DIFF
--- a/apps/web-pwa/src/hooks/useIdentity.test.ts
+++ b/apps/web-pwa/src/hooks/useIdentity.test.ts
@@ -159,6 +159,107 @@ describe('useIdentity', () => {
     expect((snapshot as any).session.token).toBeUndefined();
   });
 
+  it('reuses vault-owned device credential and SEA pair across session revocation', async () => {
+    createSessionMock
+      .mockResolvedValueOnce({
+        token: 'srv-token-1',
+        trustScore: 0.82,
+        nullifier: 'stable-nullifier-1'
+      })
+      .mockResolvedValueOnce({
+        token: 'srv-token-2',
+        trustScore: 0.83,
+        nullifier: 'stable-nullifier-2'
+      });
+
+    const useIdentity = await loadHook();
+    const { result } = renderHook(() => useIdentity());
+
+    await waitFor(() => expect(result.current.status).toBe('anonymous'));
+
+    await act(async () => {
+      await result.current.createIdentity();
+    });
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+
+    const firstDeviceKey = createSessionMock.mock.calls[0]?.[0]?.deviceKey;
+    const firstDevicePair = result.current.identity?.devicePair;
+    expect(firstDeviceKey).toEqual(expect.any(String));
+    expect(firstDevicePair).toEqual({ pub: 'pub', priv: 'priv', epub: 'epub', epriv: 'epriv' });
+    expect(pairMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await result.current.revokeSession();
+    });
+    await waitFor(() => expect(result.current.status).toBe('anonymous'));
+
+    await act(async () => {
+      await result.current.createIdentity();
+    });
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+
+    expect(createSessionMock.mock.calls[1]?.[0]?.deviceKey).toBe(firstDeviceKey);
+    expect(result.current.identity?.devicePair).toEqual(firstDevicePair);
+    expect(pairMock).toHaveBeenCalledTimes(1);
+
+    const fromVault = await vaultLoad();
+    expect((fromVault as any)?.attestation.deviceKey).toBe(firstDeviceKey);
+    expect((fromVault as any)?.devicePair).toEqual(firstDevicePair);
+  });
+
+  it('promotes legacy attestation/device pair into stable vault compartments', async () => {
+    const legacyDevicePair = {
+      pub: 'legacy-pub',
+      priv: 'legacy-priv',
+      epub: 'legacy-epub',
+      epriv: 'legacy-epriv'
+    };
+    const legacy = {
+      id: 'legacy-id',
+      createdAt: 500,
+      attestation: {
+        platform: 'web',
+        integrityToken: 'lt',
+        deviceKey: 'legacy-device-key',
+        nonce: 'ln'
+      },
+      session: {
+        token: 'lt',
+        trustScore: 0.8,
+        scaledTrustScore: 8000,
+        nullifier: 'legacy-null'
+      },
+      devicePair: legacyDevicePair,
+      handle: 'legacy_user'
+    };
+    localStorage.setItem(LEGACY_STORAGE_KEY, JSON.stringify(legacy));
+    createSessionMock.mockResolvedValue({
+      token: 'srv-token',
+      trustScore: 0.84,
+      nullifier: 'fresh-nullifier'
+    });
+
+    const useIdentity = await loadHook();
+    const { result } = renderHook(() => useIdentity());
+
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+    expect(result.current.identity?.session.nullifier).toBe('legacy-null');
+
+    await act(async () => {
+      await result.current.revokeSession();
+    });
+    await waitFor(() => expect(result.current.status).toBe('anonymous'));
+
+    await act(async () => {
+      await result.current.createIdentity();
+    });
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+
+    expect(createSessionMock.mock.calls[0]?.[0]?.deviceKey).toBe('legacy-device-key');
+    expect(result.current.identity?.devicePair).toEqual(legacyDevicePair);
+    expect(pairMock).not.toHaveBeenCalled();
+  });
+
   it('clamps scaled trust score to 10000 when verifier reports >1', async () => {
     createSessionMock.mockResolvedValue({
       token: 'srv-token',

--- a/apps/web-pwa/src/hooks/useIdentity.ts
+++ b/apps/web-pwa/src/hooks/useIdentity.ts
@@ -5,7 +5,12 @@ import { TRUST_MINIMUM } from '@vh/data-model';
 import { SEA, createSession } from '@vh/gun-client';
 import { authenticateGunUser, publishDirectoryEntry, useAppStore } from '../store';
 import { getHandleError, isValidHandle } from '../utils/handle';
-import { migrateLegacyLocalStorage, clearIdentity as vaultClear } from '@vh/identity-vault';
+import {
+  clearIdentity as vaultClear,
+  deviceCredential,
+  migrateLegacyLocalStorage,
+  seaDevicePair
+} from '@vh/identity-vault';
 import { publishIdentity, clearPublishedIdentity } from '../store/identityProvider';
 import { useXpLedger } from '../store/xpLedger';
 import { loadIdentityRecord, saveIdentityRecord } from '../utils/vaultTyped';
@@ -101,7 +106,8 @@ export function useIdentity() {
   const createIdentity = useCallback(async (handle?: string) => {
     try {
       setStatus('creating');
-      const attestation = buildAttestation();
+      const deviceCredentialCompartment = await deviceCredential.loadOrCreate();
+      const attestation = buildAttestation(deviceCredentialCompartment.material);
       const trimmedHandle = handle?.trim();
       if (trimmedHandle) {
         const validationError = getHandleError(trimmedHandle);
@@ -111,7 +117,7 @@ export function useIdentity() {
       }
 
       let session: { token: string; trustScore: number; nullifier: string };
-      const devicePair = await SEA.pair();
+      const devicePair = await seaDevicePair.loadOrCreate(() => SEA.pair());
 
       if (E2E_MODE) {
         session = { token: `mock-session-${randomToken()}`, trustScore: 1, nullifier: `mock-nullifier-${randomToken()}` };
@@ -252,8 +258,8 @@ export function useIdentity() {
    * Revoke the current session (spec §2.1.3).
    *
    * Always available regardless of feature flag — this is a user-initiated
-   * security action. Clears session, vault, published identity, and
-   * delegation grants. Preserves nullifier derivation material.
+   * security action. Clears session/identity state, published identity, and
+   * delegation grants. Stable vault key compartments are preserved.
    */
   const revokeSession = useCallback(async () => {
     setIdentity(null);
@@ -301,12 +307,12 @@ export function useIdentity() {
   };
 }
 
-function buildAttestation(): IdentityRecord['attestation'] {
+function buildAttestation(deviceKey: string): IdentityRecord['attestation'] {
   if (E2E_MODE) {
     return {
       platform: 'web',
       integrityToken: 'test-token',
-      deviceKey: 'mock-device',
+      deviceKey,
       nonce: 'mock-nonce'
     };
   }
@@ -314,7 +320,7 @@ function buildAttestation(): IdentityRecord['attestation'] {
   return {
     platform: 'web',
     integrityToken: randomToken(),
-    deviceKey: randomToken(),
+    deviceKey,
     nonce: randomToken()
   };
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "check:linkability-domain-registry": "node ./tools/scripts/check-linkability-domain-registry.mjs",
     "check:luma-provider-surface": "node ./tools/scripts/check-luma-provider-surface.mjs",
     "check:luma-signed-write-surface": "node ./tools/scripts/check-luma-signed-write-surface.mjs",
+    "check:luma-vault-compartments": "node ./tools/scripts/check-luma-vault-compartments.mjs",
     "report:news-sources:admission": "pnpm --filter @vh/news-aggregator report:source-admission",
     "report:news-sources:health": "NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter @vh/news-aggregator report:source-health",
     "scout:news-sources:candidates": "NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter @vh/news-aggregator report:source-scout",

--- a/packages/e2e/src/helpers/vault-identity.ts
+++ b/packages/e2e/src/helpers/vault-identity.ts
@@ -7,7 +7,8 @@ const VAULT_CONFIG = {
   keysStore: 'keys',
   identityKey: 'identity',
   masterKey: 'master',
-  vaultVersion: 1,
+  legacyVaultVersion: 1,
+  currentVaultVersion: 2,
   aesGcmIvBytes: 12,
 } as const;
 
@@ -24,6 +25,12 @@ export interface VaultIdentity {
     [key: string]: unknown;
   };
   [key: string]: unknown;
+}
+
+interface VaultRecord {
+  version?: unknown;
+  iv?: unknown;
+  ciphertext?: unknown;
 }
 
 function isObject(value: unknown): value is Record<string, unknown> {
@@ -91,13 +98,12 @@ export async function readVaultIdentity(page: Page): Promise<VaultIdentity | nul
         return null;
       }
 
-      const record = rawRecord as {
-        version?: unknown;
-        iv?: unknown;
-        ciphertext?: unknown;
-      };
+      const record = rawRecord as VaultRecord;
 
-      if (record.version !== config.vaultVersion) {
+      if (
+        record.version !== config.legacyVaultVersion
+        && record.version !== config.currentVaultVersion
+      ) {
         return null;
       }
 
@@ -123,6 +129,13 @@ export async function readVaultIdentity(page: Page): Promise<VaultIdentity | nul
 
       if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
         return null;
+      }
+
+      if (record.version === config.currentVaultVersion) {
+        const identityRecord = (parsed as { identityRecord?: unknown }).identityRecord;
+        return identityRecord && typeof identityRecord === 'object' && !Array.isArray(identityRecord)
+          ? identityRecord
+          : null;
       }
 
       return parsed;
@@ -179,6 +192,52 @@ export async function writeVaultIdentity(page: Page, identity: VaultIdentity): P
         tx.onerror = () => reject(tx.error ?? new Error(`Failed to write ${storeName}/${key}`));
       });
 
+    const asArrayBuffer = (value: unknown): ArrayBuffer | null => {
+      if (value instanceof ArrayBuffer) {
+        return value;
+      }
+
+      if (ArrayBuffer.isView(value)) {
+        const view = value as ArrayBufferView;
+        const bytes = new Uint8Array(view.byteLength);
+        bytes.set(new Uint8Array(view.buffer, view.byteOffset, view.byteLength));
+        return bytes.buffer;
+      }
+
+      return null;
+    };
+
+    const asUint8Array = (value: unknown): Uint8Array | null => {
+      if (value instanceof Uint8Array) {
+        return value;
+      }
+
+      const buffer = asArrayBuffer(value);
+      return buffer ? new Uint8Array(buffer) : null;
+    };
+
+    const decryptRecord = async (
+      key: CryptoKey,
+      record: { iv?: unknown; ciphertext?: unknown },
+    ): Promise<unknown | null> => {
+      const iv = asUint8Array(record.iv);
+      const ciphertext = asArrayBuffer(record.ciphertext);
+      if (!iv || !ciphertext) {
+        return null;
+      }
+
+      try {
+        const decrypted = await crypto.subtle.decrypt(
+          { name: 'AES-GCM', iv: iv as unknown as BufferSource },
+          key,
+          ciphertext as ArrayBuffer,
+        );
+        return JSON.parse(new TextDecoder().decode(decrypted));
+      } catch {
+        return null;
+      }
+    };
+
     const db = await openDb();
 
     try {
@@ -188,12 +247,37 @@ export async function writeVaultIdentity(page: Page, identity: VaultIdentity): P
       }
 
       const rawRecord = await idbGet(db, config.vaultStore, config.identityKey);
+      const existingRecord =
+        rawRecord && typeof rawRecord === 'object'
+          ? rawRecord as { version?: unknown; iv?: unknown; ciphertext?: unknown }
+          : null;
       const existingVersion =
-        rawRecord && typeof rawRecord === 'object' && typeof (rawRecord as { version?: unknown }).version === 'number'
-          ? (rawRecord as { version: number }).version
-          : config.vaultVersion;
+        existingRecord && existingRecord.version === config.currentVaultVersion
+          ? config.currentVaultVersion
+          : config.legacyVaultVersion;
 
-      const plaintext = new TextEncoder().encode(JSON.stringify(nextIdentity));
+      let nextVaultPayload: unknown = nextIdentity;
+      if (existingVersion === config.currentVaultVersion && existingRecord) {
+        const existingPayload = await decryptRecord(rawMasterKey, existingRecord);
+        const stableCompartments =
+          existingPayload && typeof existingPayload === 'object' && !Array.isArray(existingPayload)
+            ? existingPayload as {
+                deviceCredential?: unknown;
+                seaDevicePair?: unknown;
+                delegationSigningKey?: unknown;
+              }
+            : {};
+
+        nextVaultPayload = {
+          schemaVersion: config.currentVaultVersion,
+          identityRecord: nextIdentity,
+          ...(stableCompartments.deviceCredential ? { deviceCredential: stableCompartments.deviceCredential } : {}),
+          ...(stableCompartments.seaDevicePair ? { seaDevicePair: stableCompartments.seaDevicePair } : {}),
+          ...(stableCompartments.delegationSigningKey ? { delegationSigningKey: stableCompartments.delegationSigningKey } : {}),
+        };
+      }
+
+      const plaintext = new TextEncoder().encode(JSON.stringify(nextVaultPayload));
       const iv = crypto.getRandomValues(new Uint8Array(config.aesGcmIvBytes));
       const ciphertext = await crypto.subtle.encrypt(
         { name: 'AES-GCM', iv },

--- a/packages/e2e/src/tracer-bullet.spec.ts
+++ b/packages/e2e/src/tracer-bullet.spec.ts
@@ -24,8 +24,10 @@ test.describe('The Tracer Bullet: E2E Integration', () => {
             // Handle is now required for identity creation
             await page.fill('input[placeholder="Choose a handle (letters, numbers, _)"]', 'trinitytester');
             await createIdentityBtn.click();
+            await expect(welcomeMsg).toContainText('TrinityTester', { timeout: 10000 });
+        } else {
+            await expect(welcomeMsg).toBeVisible({ timeout: 10000 });
         }
-        await expect(page.getByTestId('welcome-msg')).toContainText('TrinityTester', { timeout: 10000 });
 
         // 3. Verify Mesh Connection
         // Note: Codex needs to ensure this text appears when connected

--- a/packages/identity-vault/src/compartments/delegationSigningKey.ts
+++ b/packages/identity-vault/src/compartments/delegationSigningKey.ts
@@ -1,0 +1,168 @@
+import type { DelegationSigningKeyCompartment } from '../types';
+import { loadVaultV2, saveVaultV2 } from '../vault';
+import {
+  base64UrlToBytes,
+  bytesToBase64Url,
+  utf8,
+  VaultCompartmentError
+} from './encoding';
+
+const SIGNATURE_SUITE = 'jcs-ed25519-sha256-v1';
+const ED25519 = 'Ed25519';
+
+export async function loadOrCreateDelegationSigningKey(): Promise<DelegationSigningKeyCompartment> {
+  const vault = await loadVaultV2();
+  const existing = vault?.delegationSigningKey;
+  if (existing) return validateDelegationSigningKey(existing);
+
+  const created = await createDelegationSigningKey();
+  await saveVaultV2({
+    schemaVersion: 2,
+    ...(vault ?? {}),
+    delegationSigningKey: created
+  });
+  return created;
+}
+
+export async function rotateDelegationSigningKey(): Promise<DelegationSigningKeyCompartment> {
+  const vault = await loadVaultV2();
+  const rotated = await createDelegationSigningKey();
+  await saveVaultV2({
+    schemaVersion: 2,
+    ...(vault ?? {}),
+    delegationSigningKey: rotated
+  });
+  return rotated;
+}
+
+export async function signWithDelegationSigningKey(
+  message: string | Uint8Array,
+  key: DelegationSigningKeyCompartment
+): Promise<string> {
+  const validKey = validateDelegationSigningKey(key);
+  const privateKey = await importPrivateKey(validKey.privateKey.material);
+  const signature = await crypto.subtle.sign(ED25519, privateKey, bytesFor(message));
+  return bytesToBase64Url(new Uint8Array(signature));
+}
+
+export async function verifyWithDelegationSigningKey(input: {
+  message: string | Uint8Array;
+  signature: string;
+  key: Pick<DelegationSigningKeyCompartment, 'publicKey' | 'signatureSuite'>;
+}): Promise<boolean> {
+  if (input.key.signatureSuite !== SIGNATURE_SUITE) {
+    throw new VaultCompartmentError('Unsupported delegation signing suite');
+  }
+
+  const publicKey = await importPublicKey(input.key.publicKey.material);
+  return crypto.subtle.verify(
+    ED25519,
+    publicKey,
+    bytesToCryptoBufferSource(base64UrlToBytes(input.signature)),
+    bytesFor(input.message)
+  );
+}
+
+export function validateDelegationSigningKey(
+  value: unknown
+): DelegationSigningKeyCompartment {
+  if (
+    typeof value !== 'object'
+    || value === null
+    || (value as { schemaVersion?: unknown }).schemaVersion !== 1
+    || (value as { signatureSuite?: unknown }).signatureSuite !== SIGNATURE_SUITE
+    || !encodedMaterial((value as { publicKey?: unknown }).publicKey)
+    || !encodedMaterial((value as { privateKey?: unknown }).privateKey)
+    || typeof (value as { createdAt?: unknown }).createdAt !== 'number'
+    || !Number.isSafeInteger((value as { createdAt: number }).createdAt)
+    || (value as { createdAt: number }).createdAt < 0
+  ) {
+    throw new VaultCompartmentError('Invalid delegationSigningKey compartment');
+  }
+
+  return value as DelegationSigningKeyCompartment;
+}
+
+async function createDelegationSigningKey(): Promise<DelegationSigningKeyCompartment> {
+  const keyPair = await crypto.subtle.generateKey(ED25519, true, ['sign', 'verify']);
+  if (!('privateKey' in keyPair) || !('publicKey' in keyPair)) {
+    throw new VaultCompartmentError('Ed25519 key generation failed');
+  }
+
+  const privateKey = await crypto.subtle.exportKey('pkcs8', keyPair.privateKey);
+  const publicKey = await crypto.subtle.exportKey('spki', keyPair.publicKey);
+
+  return {
+    schemaVersion: 1,
+    signatureSuite: SIGNATURE_SUITE,
+    publicKey: {
+      encoding: 'base64url',
+      material: bytesToBase64Url(new Uint8Array(publicKey))
+    },
+    privateKey: {
+      encoding: 'base64url',
+      material: bytesToBase64Url(new Uint8Array(privateKey))
+    },
+    createdAt: Date.now()
+  };
+}
+
+async function importPrivateKey(material: string): Promise<CryptoKey> {
+  return crypto.subtle.importKey(
+    'pkcs8',
+    bytesToCryptoBufferSource(base64UrlToBytes(material)),
+    ED25519,
+    false,
+    ['sign']
+  );
+}
+
+async function importPublicKey(material: string): Promise<CryptoKey> {
+  return crypto.subtle.importKey(
+    'spki',
+    bytesToCryptoBufferSource(base64UrlToBytes(material)),
+    ED25519,
+    false,
+    ['verify']
+  );
+}
+
+function encodedMaterial(value: unknown): boolean {
+  return typeof value === 'object'
+    && value !== null
+    && (value as { encoding?: unknown }).encoding === 'base64url'
+    && typeof (value as { material?: unknown }).material === 'string'
+    && (value as { material: string }).material.length > 0;
+}
+
+function bytesFor(message: string | Uint8Array): BufferSource {
+  if (typeof message === 'string') {
+    return bytesToCryptoBufferSource(utf8(message));
+  }
+  return bytesToCryptoBufferSource(message);
+}
+
+function bytesToArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  const buffer = new ArrayBuffer(bytes.byteLength);
+  new Uint8Array(buffer).set(bytes);
+  return buffer;
+}
+
+function bytesToCryptoBufferSource(bytes: Uint8Array): BufferSource {
+  const NodeBuffer = (globalThis as typeof globalThis & {
+    Buffer?: { from(value: Uint8Array): Uint8Array };
+  }).Buffer;
+
+  if (NodeBuffer) {
+    return NodeBuffer.from(bytes) as unknown as BufferSource;
+  }
+
+  return bytesToArrayBuffer(bytes);
+}
+
+export const delegationSigningKey = Object.freeze({
+  loadOrCreate: loadOrCreateDelegationSigningKey,
+  rotate: rotateDelegationSigningKey,
+  sign: signWithDelegationSigningKey,
+  verify: verifyWithDelegationSigningKey
+});

--- a/packages/identity-vault/src/compartments/deviceCredential.ts
+++ b/packages/identity-vault/src/compartments/deviceCredential.ts
@@ -1,0 +1,66 @@
+import type { DeviceCredentialCompartment } from '../types';
+import { loadVaultV2, saveVaultV2 } from '../vault';
+import { randomBase64Url, VaultCompartmentError } from './encoding';
+
+const DEVICE_CREDENTIAL_BYTES = 32;
+
+export async function loadOrCreateDeviceCredential(): Promise<DeviceCredentialCompartment> {
+  const vault = await loadVaultV2();
+  const existing = vault?.deviceCredential;
+  if (existing) return validateDeviceCredential(existing);
+
+  const created = createDeviceCredential('generated');
+  await saveVaultV2({
+    schemaVersion: 2,
+    ...(vault ?? {}),
+    deviceCredential: created
+  });
+  return created;
+}
+
+export async function rotateDeviceCredential(): Promise<DeviceCredentialCompartment> {
+  const vault = await loadVaultV2();
+  const rotated = createDeviceCredential('generated');
+  await saveVaultV2({
+    schemaVersion: 2,
+    ...(vault ?? {}),
+    deviceCredential: rotated
+  });
+  return rotated;
+}
+
+export function validateDeviceCredential(
+  value: unknown
+): DeviceCredentialCompartment {
+  if (
+    typeof value !== 'object'
+    || value === null
+    || (value as { schemaVersion?: unknown }).schemaVersion !== 1
+    || typeof (value as { material?: unknown }).material !== 'string'
+    || (value as { material: string }).material.length === 0
+    || typeof (value as { createdAt?: unknown }).createdAt !== 'number'
+    || !Number.isSafeInteger((value as { createdAt: number }).createdAt)
+    || (value as { createdAt: number }).createdAt < 0
+    || !['generated', 'legacy-v1'].includes((value as { source?: string }).source ?? '')
+  ) {
+    throw new VaultCompartmentError('Invalid deviceCredential compartment');
+  }
+
+  return value as DeviceCredentialCompartment;
+}
+
+function createDeviceCredential(
+  source: DeviceCredentialCompartment['source']
+): DeviceCredentialCompartment {
+  return {
+    schemaVersion: 1,
+    material: randomBase64Url(DEVICE_CREDENTIAL_BYTES),
+    createdAt: Date.now(),
+    source
+  };
+}
+
+export const deviceCredential = Object.freeze({
+  loadOrCreate: loadOrCreateDeviceCredential,
+  rotate: rotateDeviceCredential
+});

--- a/packages/identity-vault/src/compartments/encoding.ts
+++ b/packages/identity-vault/src/compartments/encoding.ts
@@ -1,0 +1,45 @@
+export class VaultCompartmentError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'VaultCompartmentError';
+  }
+}
+
+export function randomBase64Url(byteLength: number): string {
+  if (!globalThis.crypto?.getRandomValues) {
+    throw new VaultCompartmentError('WebCrypto random source is unavailable');
+  }
+
+  const bytes = crypto.getRandomValues(new Uint8Array(byteLength));
+  return bytesToBase64Url(bytes);
+}
+
+export function bytesToBase64Url(bytes: Uint8Array): string {
+  const chunks: string[] = [];
+  for (let offset = 0; offset < bytes.length; offset += 0x8000) {
+    const chunk = bytes.subarray(offset, offset + 0x8000);
+    chunks.push(String.fromCharCode(...chunk));
+  }
+
+  const base64 = btoa(chunks.join(''));
+  return base64.replaceAll('+', '-').replaceAll('/', '_').replace(/=+$/u, '');
+}
+
+export function base64UrlToBytes(value: string): Uint8Array {
+  if (!/^[A-Za-z0-9_-]*$/u.test(value)) {
+    throw new VaultCompartmentError('Invalid base64url material');
+  }
+
+  const padded = value.replaceAll('-', '+').replaceAll('_', '/')
+    .padEnd(Math.ceil(value.length / 4) * 4, '=');
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return bytes;
+}
+
+export function utf8(value: string): Uint8Array {
+  return new TextEncoder().encode(value);
+}

--- a/packages/identity-vault/src/compartments/index.ts
+++ b/packages/identity-vault/src/compartments/index.ts
@@ -1,0 +1,28 @@
+export {
+  deviceCredential,
+  loadOrCreateDeviceCredential,
+  rotateDeviceCredential,
+  validateDeviceCredential
+} from './deviceCredential';
+export {
+  delegationSigningKey,
+  loadOrCreateDelegationSigningKey,
+  rotateDelegationSigningKey,
+  signWithDelegationSigningKey,
+  validateDelegationSigningKey,
+  verifyWithDelegationSigningKey
+} from './delegationSigningKey';
+export {
+  loadOrCreateSeaDevicePair,
+  rotateSeaDevicePair,
+  seaDevicePair,
+  validateSeaDevicePair,
+  type SeaDevicePairInput
+} from './seaDevicePair';
+export {
+  base64UrlToBytes,
+  bytesToBase64Url,
+  randomBase64Url,
+  utf8,
+  VaultCompartmentError
+} from './encoding';

--- a/packages/identity-vault/src/compartments/seaDevicePair.ts
+++ b/packages/identity-vault/src/compartments/seaDevicePair.ts
@@ -1,0 +1,85 @@
+import type { SeaDevicePairCompartment } from '../types';
+import { loadVaultV2, saveVaultV2 } from '../vault';
+import { VaultCompartmentError } from './encoding';
+
+export type SeaDevicePairInput = Pick<
+  SeaDevicePairCompartment,
+  'pub' | 'priv' | 'epub' | 'epriv'
+>;
+
+export async function loadOrCreateSeaDevicePair(
+  createPair: () => Promise<SeaDevicePairInput> | SeaDevicePairInput
+): Promise<SeaDevicePairCompartment> {
+  const vault = await loadVaultV2();
+  const existing = vault?.seaDevicePair;
+  if (existing) return validateSeaDevicePair(existing);
+
+  const created = normalizeSeaDevicePair(await createPair());
+  await saveVaultV2({
+    schemaVersion: 2,
+    ...(vault ?? {}),
+    seaDevicePair: created
+  });
+  return created;
+}
+
+export async function rotateSeaDevicePair(
+  createPair: () => Promise<SeaDevicePairInput> | SeaDevicePairInput
+): Promise<SeaDevicePairCompartment> {
+  const vault = await loadVaultV2();
+  const rotated = normalizeSeaDevicePair(await createPair());
+  await saveVaultV2({
+    schemaVersion: 2,
+    ...(vault ?? {}),
+    seaDevicePair: rotated
+  });
+  return rotated;
+}
+
+export function validateSeaDevicePair(value: unknown): SeaDevicePairCompartment {
+  if (
+    typeof value !== 'object'
+    || value === null
+    || (value as { schemaVersion?: unknown }).schemaVersion !== 1
+    || !nonEmptyString((value as { pub?: unknown }).pub)
+    || !nonEmptyString((value as { priv?: unknown }).priv)
+    || !nonEmptyString((value as { epub?: unknown }).epub)
+    || !nonEmptyString((value as { epriv?: unknown }).epriv)
+    || typeof (value as { createdAt?: unknown }).createdAt !== 'number'
+    || !Number.isSafeInteger((value as { createdAt: number }).createdAt)
+    || (value as { createdAt: number }).createdAt < 0
+  ) {
+    throw new VaultCompartmentError('Invalid seaDevicePair compartment');
+  }
+
+  return value as SeaDevicePairCompartment;
+}
+
+function normalizeSeaDevicePair(pair: SeaDevicePairInput): SeaDevicePairCompartment {
+  if (
+    !nonEmptyString(pair.pub)
+    || !nonEmptyString(pair.priv)
+    || !nonEmptyString(pair.epub)
+    || !nonEmptyString(pair.epriv)
+  ) {
+    throw new VaultCompartmentError('SEA device pair must contain all key fields');
+  }
+
+  return {
+    schemaVersion: 1,
+    pub: pair.pub,
+    priv: pair.priv,
+    epub: pair.epub,
+    epriv: pair.epriv,
+    createdAt: Date.now()
+  };
+}
+
+function nonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+export const seaDevicePair = Object.freeze({
+  loadOrCreate: loadOrCreateSeaDevicePair,
+  rotate: rotateSeaDevicePair
+});

--- a/packages/identity-vault/src/index.ts
+++ b/packages/identity-vault/src/index.ts
@@ -1,4 +1,47 @@
-export type { Identity, VaultRecord } from './types';
-export { LEGACY_STORAGE_KEY, isValidIdentity } from './types';
-export { loadIdentity, saveIdentity, clearIdentity } from './vault';
+export type {
+  DelegationSigningKeyCompartment,
+  DeviceCredentialCompartment,
+  Identity,
+  JsonSafeByteEncoding,
+  SeaDevicePairCompartment,
+  VaultRecord,
+  VaultV2
+} from './types';
+export {
+  LEGACY_STORAGE_KEY,
+  LEGACY_VAULT_VERSION,
+  isValidIdentity,
+  isVaultV2,
+  VAULT_VERSION
+} from './types';
+export {
+  clearIdentity,
+  loadIdentity,
+  loadVaultV2,
+  saveIdentity,
+  saveVaultV2,
+  updateVaultV2
+} from './vault';
 export { migrateLegacyLocalStorage } from './migrate';
+export {
+  base64UrlToBytes,
+  bytesToBase64Url,
+  delegationSigningKey,
+  deviceCredential,
+  loadOrCreateDelegationSigningKey,
+  loadOrCreateDeviceCredential,
+  loadOrCreateSeaDevicePair,
+  randomBase64Url,
+  rotateDelegationSigningKey,
+  rotateDeviceCredential,
+  rotateSeaDevicePair,
+  seaDevicePair,
+  signWithDelegationSigningKey,
+  utf8,
+  validateDelegationSigningKey,
+  validateDeviceCredential,
+  validateSeaDevicePair,
+  VaultCompartmentError,
+  verifyWithDelegationSigningKey,
+  type SeaDevicePairInput
+} from './compartments';

--- a/packages/identity-vault/src/types.ts
+++ b/packages/identity-vault/src/types.ts
@@ -4,6 +4,46 @@
  */
 export type Identity = Record<string, unknown>;
 
+export type JsonSafeByteEncoding = 'base64url';
+
+export interface DeviceCredentialCompartment {
+  schemaVersion: 1;
+  material: string;
+  createdAt: number;
+  source: 'generated' | 'legacy-v1';
+}
+
+export interface SeaDevicePairCompartment {
+  schemaVersion: 1;
+  pub: string;
+  priv: string;
+  epub: string;
+  epriv: string;
+  createdAt: number;
+}
+
+export interface DelegationSigningKeyCompartment {
+  schemaVersion: 1;
+  signatureSuite: 'jcs-ed25519-sha256-v1';
+  publicKey: {
+    encoding: JsonSafeByteEncoding;
+    material: string;
+  };
+  privateKey: {
+    encoding: JsonSafeByteEncoding;
+    material: string;
+  };
+  createdAt: number;
+}
+
+export interface VaultV2 {
+  schemaVersion: 2;
+  identityRecord?: Identity;
+  deviceCredential?: DeviceCredentialCompartment;
+  seaDevicePair?: SeaDevicePairCompartment;
+  delegationSigningKey?: DelegationSigningKeyCompartment;
+}
+
 /**
  * Record stored in IndexedDB "vault" object store.
  */
@@ -29,7 +69,10 @@ export const IDENTITY_KEY = 'identity';
 export const MASTER_KEY = 'master';
 
 /** Current vault record version. */
-export const VAULT_VERSION = 1;
+export const VAULT_VERSION = 2;
+
+/** Legacy opaque identity vault record version. */
+export const LEGACY_VAULT_VERSION = 1;
 
 /** Legacy localStorage key consumed during migration. */
 export const LEGACY_STORAGE_KEY = 'vh_identity';
@@ -41,4 +84,8 @@ export const LEGACY_STORAGE_KEY = 'vh_identity';
  */
 export function isValidIdentity(value: unknown): value is Identity {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function isVaultV2(value: unknown): value is VaultV2 {
+  return isValidIdentity(value) && (value as { schemaVersion?: unknown }).schemaVersion === 2;
 }

--- a/packages/identity-vault/src/types.ts
+++ b/packages/identity-vault/src/types.ts
@@ -87,5 +87,13 @@ export function isValidIdentity(value: unknown): value is Identity {
 }
 
 export function isVaultV2(value: unknown): value is VaultV2 {
-  return isValidIdentity(value) && (value as { schemaVersion?: unknown }).schemaVersion === 2;
+  if (
+    !isValidIdentity(value)
+    || (value as { schemaVersion?: unknown }).schemaVersion !== VAULT_VERSION
+  ) {
+    return false;
+  }
+
+  const identityRecord = (value as { identityRecord?: unknown }).identityRecord;
+  return identityRecord === undefined || isValidIdentity(identityRecord);
 }

--- a/packages/identity-vault/src/vault.test.ts
+++ b/packages/identity-vault/src/vault.test.ts
@@ -1,11 +1,38 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import 'fake-indexeddb/auto';
-import { loadIdentity, saveIdentity, clearIdentity } from './vault';
+import {
+  loadIdentity,
+  loadVaultV2,
+  saveIdentity,
+  saveVaultV2,
+  updateVaultV2,
+  clearIdentity
+} from './vault';
 import { migrateLegacyLocalStorage } from './migrate';
 import { openVaultDb, idbGet, idbPut, idbDelete } from './db';
-import { VAULT_STORE, KEYS_STORE, IDENTITY_KEY, MASTER_KEY, LEGACY_STORAGE_KEY, VAULT_VERSION } from './types';
-import type { Identity, VaultRecord } from './types';
+import {
+  VAULT_STORE,
+  KEYS_STORE,
+  IDENTITY_KEY,
+  MASTER_KEY,
+  LEGACY_STORAGE_KEY,
+  LEGACY_VAULT_VERSION,
+  VAULT_VERSION
+} from './types';
+import type { DelegationSigningKeyCompartment, Identity, VaultRecord } from './types';
+import { encrypt, generateMasterKey } from './crypto';
+import {
+  base64UrlToBytes,
+  delegationSigningKey,
+  deviceCredential,
+  randomBase64Url,
+  seaDevicePair,
+  validateDelegationSigningKey,
+  validateDeviceCredential,
+  validateSeaDevicePair,
+  VaultCompartmentError
+} from './compartments';
 
 const TEST_IDENTITY: Identity = {
   displayName: 'Alice Nakamoto',
@@ -13,6 +40,26 @@ const TEST_IDENTITY: Identity = {
   priv: 'sk_secret_private_key_data',
   session: { nullifier: 'test-null', trustScore: 0.9 },
   customField: 42,
+};
+
+const LEGACY_DEVICE_KEY = 'legacy-device-key-exact';
+const LEGACY_SEA_PAIR = Object.freeze({
+  pub: 'legacy-pub',
+  priv: 'legacy-priv',
+  epub: 'legacy-epub',
+  epriv: 'legacy-epriv'
+});
+const LEGACY_IDENTITY: Identity = {
+  ...TEST_IDENTITY,
+  id: 'legacy-id',
+  createdAt: 1700000000000,
+  attestation: {
+    platform: 'web',
+    integrityToken: 'legacy-integrity',
+    deviceKey: LEGACY_DEVICE_KEY,
+    nonce: 'legacy-nonce'
+  },
+  devicePair: LEGACY_SEA_PAIR
 };
 
 /**
@@ -24,6 +71,20 @@ function deleteDatabase(name: string): Promise<void> {
     req.onsuccess = () => resolve();
     req.onerror = () => reject(req.error);
   });
+}
+
+async function writeLegacyVaultRecord(identity: unknown): Promise<void> {
+  const db = await openVaultDb();
+  const key = await generateMasterKey();
+  await idbPut(db, KEYS_STORE, MASTER_KEY, key);
+  const plaintext = new TextEncoder().encode(JSON.stringify(identity));
+  const { iv, ciphertext } = await encrypt(key, plaintext);
+  await idbPut(db, VAULT_STORE, IDENTITY_KEY, {
+    version: LEGACY_VAULT_VERSION,
+    iv,
+    ciphertext
+  } satisfies VaultRecord);
+  db.close();
 }
 
 beforeEach(async () => {
@@ -426,5 +487,378 @@ describe('Edge cases', () => {
     const updated: Identity = { displayName: 'Bob', pub: 'pk2', priv: 'sk2' };
     await saveIdentity(updated);
     expect(await loadIdentity()).toEqual(updated);
+  });
+});
+
+describe('M0.D-1 vault v2 compartments', () => {
+  it('migrates a v1 vault record to v2 idempotently and preserves legacy key material', async () => {
+    await writeLegacyVaultRecord(LEGACY_IDENTITY);
+
+    await expect(loadIdentity()).resolves.toEqual(LEGACY_IDENTITY);
+    const migrated = await loadVaultV2();
+    expect(migrated).toMatchObject({
+      schemaVersion: 2,
+      identityRecord: LEGACY_IDENTITY,
+      deviceCredential: {
+        schemaVersion: 1,
+        material: LEGACY_DEVICE_KEY,
+        createdAt: LEGACY_IDENTITY.createdAt,
+        source: 'legacy-v1'
+      },
+      seaDevicePair: {
+        schemaVersion: 1,
+        ...LEGACY_SEA_PAIR,
+        createdAt: LEGACY_IDENTITY.createdAt
+      }
+    });
+
+    const db = await openVaultDb();
+    const rawRecord = await idbGet<VaultRecord>(db, VAULT_STORE, IDENTITY_KEY);
+    db.close();
+    expect(rawRecord?.version).toBe(VAULT_VERSION);
+
+    await expect(loadIdentity()).resolves.toEqual(LEGACY_IDENTITY);
+    await expect(loadVaultV2()).resolves.toEqual(migrated);
+  });
+
+  it('migrates legacy localStorage into v2 and reuses attestation.deviceKey exactly', async () => {
+    localStorage.setItem(LEGACY_STORAGE_KEY, JSON.stringify(LEGACY_IDENTITY));
+
+    await expect(migrateLegacyLocalStorage()).resolves.toBe('migrated');
+    const vault = await loadVaultV2();
+
+    expect(vault?.identityRecord).toEqual(LEGACY_IDENTITY);
+    expect(vault?.deviceCredential?.material).toBe(LEGACY_DEVICE_KEY);
+    expect(vault?.deviceCredential?.source).toBe('legacy-v1');
+  });
+
+  it('loadOrCreate keeps generated device credentials stable until rotation', async () => {
+    const first = await deviceCredential.loadOrCreate();
+    const second = await deviceCredential.loadOrCreate();
+    const rotated = await deviceCredential.rotate();
+
+    expect(first.material).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(second).toEqual(first);
+    expect(rotated.material).not.toBe(first.material);
+    expect(rotated.source).toBe('generated');
+  });
+
+  it('rejects malformed device credential compartments without replacement', async () => {
+    const valid = await deviceCredential.rotate();
+
+    expect(() => validateDeviceCredential({
+      ...valid,
+      source: 'unknown'
+    })).toThrow(VaultCompartmentError);
+    expect(() => validateDeviceCredential({
+      ...valid,
+      source: undefined
+    })).toThrow(VaultCompartmentError);
+  });
+
+  it('loadOrCreate keeps SEA device pairs stable and rotates only through the helper', async () => {
+    const first = await seaDevicePair.loadOrCreate(() => LEGACY_SEA_PAIR);
+    const second = await seaDevicePair.loadOrCreate(() => {
+      throw new Error('should not create a second SEA pair');
+    });
+    const rotated = await seaDevicePair.rotate(() => ({
+      pub: 'rotated-pub',
+      priv: 'rotated-priv',
+      epub: 'rotated-epub',
+      epriv: 'rotated-epriv'
+    }));
+
+    expect(second).toEqual(first);
+    expect(rotated).toMatchObject({
+      pub: 'rotated-pub',
+      priv: 'rotated-priv',
+      epub: 'rotated-epub',
+      epriv: 'rotated-epriv'
+    });
+  });
+
+  it('fails closed on malformed SEA compartment creation and validation', async () => {
+    await expect(seaDevicePair.rotate(() => ({
+      pub: 'missing-epriv-pub',
+      priv: 'missing-epriv-priv',
+      epub: 'missing-epriv-epub',
+      epriv: ''
+    }))).rejects.toThrow(VaultCompartmentError);
+
+    expect(() => validateSeaDevicePair({
+      schemaVersion: 1,
+      pub: 'pub',
+      priv: 'priv',
+      epub: 'epub',
+      epriv: '',
+      createdAt: 0
+    })).toThrow(VaultCompartmentError);
+  });
+
+  it('keeps delegation signing keys stable and signs/verifies the frozen M0.D vector', async () => {
+    const vector = 'vh:luma:m0d-vault-compartment-vector:v1';
+    const first = await delegationSigningKey.loadOrCreate();
+    const firstSignature = await delegationSigningKey.sign(vector, first);
+    const second = await delegationSigningKey.loadOrCreate();
+    const secondSignature = await delegationSigningKey.sign(vector, second);
+
+    expect(second).toEqual(first);
+    expect(secondSignature).toBe(firstSignature);
+    await expect(delegationSigningKey.verify({
+      key: first,
+      message: vector,
+      signature: firstSignature
+    })).resolves.toBe(true);
+    await expect(delegationSigningKey.verify({
+      key: first,
+      message: `${vector}:tampered`,
+      signature: firstSignature
+    })).resolves.toBe(false);
+
+    const rotated = await delegationSigningKey.rotate();
+    expect(rotated.publicKey.material).not.toBe(first.publicKey.material);
+  });
+
+  it('handles delegation signing Uint8Array messages and rejects unsupported suites', async () => {
+    const vector = new Uint8Array([1, 2, 3, 4]);
+    const key = await delegationSigningKey.rotate();
+    const signature = await delegationSigningKey.sign(vector, key);
+
+    await expect(delegationSigningKey.verify({
+      key,
+      message: vector,
+      signature
+    })).resolves.toBe(true);
+
+    await expect(delegationSigningKey.verify({
+      key: { publicKey: key.publicKey, signatureSuite: 'bad-suite' as never },
+      message: vector,
+      signature
+    })).rejects.toThrow(VaultCompartmentError);
+
+    expect(() => validateDelegationSigningKey({
+      ...key,
+      createdAt: -1
+    })).toThrow(VaultCompartmentError);
+  });
+
+  it('fails closed when Ed25519 key generation returns an invalid shape', async () => {
+    const originalSubtle = crypto.subtle;
+    Object.defineProperty(crypto, 'subtle', {
+      value: { generateKey: vi.fn().mockResolvedValue({}) },
+      configurable: true
+    });
+
+    try {
+      await expect(delegationSigningKey.rotate()).rejects.toThrow(VaultCompartmentError);
+    } finally {
+      Object.defineProperty(crypto, 'subtle', { value: originalSubtle, configurable: true });
+    }
+  });
+
+  it('uses standard ArrayBuffer sources when the Node Buffer helper is absent', async () => {
+    const originalBuffer = (globalThis as typeof globalThis & { Buffer?: unknown }).Buffer;
+    const originalSubtle = crypto.subtle;
+    const fakePrivateKey = {} as CryptoKey;
+    const fakePublicKey = {} as CryptoKey;
+    const fakeSubtle = {
+      importKey: vi.fn()
+        .mockResolvedValueOnce(fakePrivateKey)
+        .mockResolvedValueOnce(fakePublicKey),
+      sign: vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3]).buffer),
+      verify: vi.fn().mockResolvedValue(true)
+    };
+    const key: DelegationSigningKeyCompartment = {
+      schemaVersion: 1,
+      signatureSuite: 'jcs-ed25519-sha256-v1',
+      publicKey: { encoding: 'base64url', material: 'AQID' },
+      privateKey: { encoding: 'base64url', material: 'BAUG' },
+      createdAt: 0
+    };
+
+    Object.defineProperty(globalThis, 'Buffer', { value: undefined, configurable: true });
+    Object.defineProperty(crypto, 'subtle', { value: fakeSubtle, configurable: true });
+
+    try {
+      await expect(delegationSigningKey.sign(new Uint8Array([9]), key)).resolves.toBe('AQID');
+      await expect(delegationSigningKey.verify({
+        key,
+        message: new Uint8Array([9]),
+        signature: 'AQID'
+      })).resolves.toBe(true);
+      expect(fakeSubtle.importKey.mock.calls[0]?.[1]).toBeInstanceOf(ArrayBuffer);
+      expect(fakeSubtle.importKey.mock.calls[1]?.[1]).toBeInstanceOf(ArrayBuffer);
+    } finally {
+      Object.defineProperty(globalThis, 'Buffer', { value: originalBuffer, configurable: true });
+      Object.defineProperty(crypto, 'subtle', { value: originalSubtle, configurable: true });
+    }
+  });
+
+  it('exposes JSON-safe base64url helpers that fail closed on invalid runtime inputs', () => {
+    expect(base64UrlToBytes('AQID')).toEqual(new Uint8Array([1, 2, 3]));
+    expect(() => base64UrlToBytes('AQ+')).toThrow(VaultCompartmentError);
+
+    const originalGetRandomValues = crypto.getRandomValues;
+    Object.defineProperty(crypto, 'getRandomValues', { value: undefined, configurable: true });
+    try {
+      expect(() => randomBase64Url(4)).toThrow(VaultCompartmentError);
+    } finally {
+      Object.defineProperty(crypto, 'getRandomValues', {
+        value: originalGetRandomValues,
+        configurable: true
+      });
+    }
+  });
+
+  it('rotation helpers can initialize fresh material from an empty v2 vault', async () => {
+    const emptyVaultPair = await seaDevicePair.rotate(() => LEGACY_SEA_PAIR);
+    await clearIdentity();
+    const rotatedCredential = await deviceCredential.rotate();
+    await clearIdentity();
+    const rotatedPair = await seaDevicePair.rotate(() => LEGACY_SEA_PAIR);
+    await clearIdentity();
+    const rotatedDelegationKey = await delegationSigningKey.rotate();
+
+    expect(emptyVaultPair).toMatchObject(LEGACY_SEA_PAIR);
+    expect(rotatedCredential.material).toEqual(expect.any(String));
+    expect(rotatedPair).toMatchObject(LEGACY_SEA_PAIR);
+    expect(rotatedDelegationKey.publicKey.material).toEqual(expect.any(String));
+  });
+
+  it('clears identity/session data without deleting stable v2 compartments', async () => {
+    const firstCredential = await deviceCredential.loadOrCreate();
+    const firstPair = await seaDevicePair.loadOrCreate(() => LEGACY_SEA_PAIR);
+    const firstDelegationKey = await delegationSigningKey.loadOrCreate();
+    await saveIdentity(LEGACY_IDENTITY);
+
+    await clearIdentity();
+
+    expect(await loadIdentity()).toBeNull();
+    expect(await deviceCredential.loadOrCreate()).toEqual(firstCredential);
+    expect(await seaDevicePair.loadOrCreate(() => {
+      throw new Error('SEA pair should have been preserved');
+    })).toEqual(firstPair);
+    expect(await delegationSigningKey.loadOrCreate()).toEqual(firstDelegationKey);
+  });
+
+  it('persists compartment byte material as JSON-safe strings', async () => {
+    await deviceCredential.loadOrCreate();
+    await delegationSigningKey.loadOrCreate();
+
+    const vault = await loadVaultV2();
+    expect(vault?.deviceCredential?.material).toEqual(expect.any(String));
+    expect(vault?.delegationSigningKey?.publicKey.material).toEqual(expect.any(String));
+    expect(vault?.delegationSigningKey?.privateKey.material).toEqual(expect.any(String));
+    expect(JSON.parse(JSON.stringify(vault))).toEqual(vault);
+  });
+
+  it('fails closed instead of regenerating over malformed v2 compartments', async () => {
+    await saveIdentity({
+      ...LEGACY_IDENTITY,
+      deviceCredential: {
+        schemaVersion: 1,
+        material: '',
+        createdAt: 0,
+        source: 'legacy-v1'
+      }
+    });
+    const vault = await loadVaultV2();
+    await saveVaultV2({
+      schemaVersion: 2,
+      identityRecord: LEGACY_IDENTITY,
+      deviceCredential: {
+        schemaVersion: 1,
+        material: '',
+        createdAt: 0,
+        source: 'legacy-v1'
+      } as never
+    });
+
+    expect(vault?.deviceCredential?.material).toBe(LEGACY_DEVICE_KEY);
+    await expect(deviceCredential.loadOrCreate()).rejects.toThrow(VaultCompartmentError);
+  });
+
+  it('preserves fail-closed semantics for malformed v2 SEA compartments', async () => {
+    await saveVaultV2({
+      schemaVersion: 2,
+      identityRecord: LEGACY_IDENTITY,
+      seaDevicePair: {
+        schemaVersion: 1,
+        pub: 'pub',
+        priv: 'priv',
+        epub: 'epub',
+        epriv: '',
+        createdAt: 0
+      } as never
+    });
+
+    await expect(seaDevicePair.loadOrCreate(() => LEGACY_SEA_PAIR))
+      .rejects.toThrow(VaultCompartmentError);
+  });
+
+  it('updates v2 vault records through the typed mutator', async () => {
+    await expect(updateVaultV2((vault) => ({
+      ...vault,
+      identityRecord: LEGACY_IDENTITY
+    }))).resolves.toMatchObject({
+      schemaVersion: 2,
+      identityRecord: LEGACY_IDENTITY
+    });
+
+    await expect(loadIdentity()).resolves.toEqual(LEGACY_IDENTITY);
+  });
+
+  it('typed v2 accessors fail closed when IndexedDB is unavailable', async () => {
+    const original = globalThis.indexedDB;
+    try {
+      // @ts-expect-error — intentionally removing for test
+      delete globalThis.indexedDB;
+      await expect(loadVaultV2()).resolves.toBeNull();
+      await expect(saveVaultV2({ schemaVersion: 2 })).resolves.toBeUndefined();
+      await expect(updateVaultV2((vault) => vault)).resolves.toBeNull();
+    } finally {
+      globalThis.indexedDB = original;
+    }
+  });
+
+  it('clearIdentity is a no-op when only stable compartments are absent', async () => {
+    await expect(clearIdentity()).resolves.toBeUndefined();
+    expect(await loadVaultV2()).toBeNull();
+  });
+
+  it('rejects invalid legacy v1 vault payloads before v2 migration', async () => {
+    await writeLegacyVaultRecord(['not-an-identity']);
+
+    await expect(loadVaultV2()).resolves.toBeNull();
+
+    const db = await openVaultDb();
+    const remaining = await idbGet<VaultRecord>(db, VAULT_STORE, IDENTITY_KEY);
+    db.close();
+    expect(remaining).toBeUndefined();
+  });
+
+  it('does not promote invalid legacy device or SEA material into v2 compartments', async () => {
+    const legacyWithInvalidCompartments: Identity = {
+      ...TEST_IDENTITY,
+      attestation: {
+        platform: 'web',
+        integrityToken: 'tok',
+        deviceKey: '',
+        nonce: 'nonce'
+      },
+      devicePair: {
+        pub: 'pub',
+        priv: 'priv',
+        epub: 'epub',
+        epriv: ''
+      }
+    };
+
+    await saveIdentity(legacyWithInvalidCompartments);
+    const vault = await loadVaultV2();
+
+    expect(vault?.identityRecord).toEqual(legacyWithInvalidCompartments);
+    expect(vault?.deviceCredential).toBeUndefined();
+    expect(vault?.seaDevicePair).toBeUndefined();
   });
 });

--- a/packages/identity-vault/src/vault.test.ts
+++ b/packages/identity-vault/src/vault.test.ts
@@ -73,18 +73,22 @@ function deleteDatabase(name: string): Promise<void> {
   });
 }
 
-async function writeLegacyVaultRecord(identity: unknown): Promise<void> {
+async function writeEncryptedVaultRecord(version: number, payload: unknown): Promise<void> {
   const db = await openVaultDb();
   const key = await generateMasterKey();
   await idbPut(db, KEYS_STORE, MASTER_KEY, key);
-  const plaintext = new TextEncoder().encode(JSON.stringify(identity));
+  const plaintext = new TextEncoder().encode(JSON.stringify(payload));
   const { iv, ciphertext } = await encrypt(key, plaintext);
   await idbPut(db, VAULT_STORE, IDENTITY_KEY, {
-    version: LEGACY_VAULT_VERSION,
+    version,
     iv,
     ciphertext
   } satisfies VaultRecord);
   db.close();
+}
+
+async function writeLegacyVaultRecord(identity: unknown): Promise<void> {
+  await writeEncryptedVaultRecord(LEGACY_VAULT_VERSION, identity);
 }
 
 beforeEach(async () => {
@@ -401,6 +405,21 @@ describe('Error branches', () => {
     const db2 = await openVaultDb();
     const remaining = await idbGet<VaultRecord>(db2, VAULT_STORE, IDENTITY_KEY);
     db2.close();
+    expect(remaining).toBeUndefined();
+  });
+
+  it('loadIdentity rejects v2 vault records with invalid identityRecord compartments', async () => {
+    await writeEncryptedVaultRecord(VAULT_VERSION, {
+      schemaVersion: VAULT_VERSION,
+      identityRecord: 'not-an-identity-record'
+    });
+
+    await expect(loadIdentity()).resolves.toBeNull();
+    await expect(loadVaultV2()).resolves.toBeNull();
+
+    const db = await openVaultDb();
+    const remaining = await idbGet<VaultRecord>(db, VAULT_STORE, IDENTITY_KEY);
+    db.close();
     expect(remaining).toBeUndefined();
   });
 
@@ -804,6 +823,17 @@ describe('M0.D-1 vault v2 compartments', () => {
       schemaVersion: 2,
       identityRecord: LEGACY_IDENTITY
     });
+
+    await expect(loadIdentity()).resolves.toEqual(LEGACY_IDENTITY);
+  });
+
+  it('does not save invalid v2 identityRecord compartments through public writers', async () => {
+    await saveIdentity(LEGACY_IDENTITY);
+
+    await expect(saveVaultV2({
+      schemaVersion: 2,
+      identityRecord: 'not-an-identity-record' as never
+    })).resolves.toBeUndefined();
 
     await expect(loadIdentity()).resolves.toEqual(LEGACY_IDENTITY);
   });

--- a/packages/identity-vault/src/vault.ts
+++ b/packages/identity-vault/src/vault.ts
@@ -11,9 +11,17 @@ import {
   IDENTITY_KEY,
   MASTER_KEY,
   VAULT_VERSION,
+  LEGACY_VAULT_VERSION,
   isValidIdentity,
+  isVaultV2,
 } from './types';
-import type { Identity, VaultRecord } from './types';
+import type {
+  DeviceCredentialCompartment,
+  Identity,
+  SeaDevicePairCompartment,
+  VaultRecord,
+  VaultV2
+} from './types';
 
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
@@ -100,32 +108,8 @@ export async function loadIdentity(): Promise<Identity | null> {
   if (!isVaultAvailable()) return null;
 
   return withDb(null, async (db) => {
-    const record = await idbGet<VaultRecord>(db, VAULT_STORE, IDENTITY_KEY);
-    if (!record) return null;
-
-    // M2: version gate — reject records from incompatible future versions
-    if (record.version !== VAULT_VERSION) return null;
-
-    const key = await getMasterKey(db);
-    if (!key) return null;
-
-    const plaintext = await decrypt(key, record.iv, record.ciphertext);
-    if (!plaintext) {
-      // Tamper detected — wipe corrupt record
-      await idbDelete(db, VAULT_STORE, IDENTITY_KEY).catch(() => {});
-      return null;
-    }
-
-    const json = decoder.decode(plaintext);
-    const parsed: unknown = JSON.parse(json);
-
-    // M1: runtime shape validation — zero-trust on stored data
-    if (!isValidIdentity(parsed)) {
-      await idbDelete(db, VAULT_STORE, IDENTITY_KEY).catch(() => {});
-      return null;
-    }
-
-    return parsed;
+    const vault = await loadVaultV2FromDb(db);
+    return vault?.identityRecord ?? null;
   });
 }
 
@@ -137,27 +121,194 @@ export async function saveIdentity(identity: Identity): Promise<void> {
   if (!isVaultAvailable()) return;
 
   return withDb(undefined, async (db) => {
-    const key = await ensureMasterKey(db);
-    const plaintext = encoder.encode(JSON.stringify(identity));
-    const { iv, ciphertext } = await encrypt(key, plaintext);
-
-    const record: VaultRecord = {
-      version: VAULT_VERSION,
-      iv,
-      ciphertext,
-    };
-
-    await idbPut(db, VAULT_STORE, IDENTITY_KEY, record);
+    const existing = await loadVaultV2FromDb(db);
+    const next = mergeIdentityIntoVault(existing ?? emptyVaultV2(), identity);
+    await saveVaultV2ToDb(db, next);
   });
 }
 
 /**
- * Remove the identity from the vault (keeps the master key).
+ * Remove the identity/session compartment from the vault (keeps the master key
+ * and stable v2 key compartments).
  */
 export async function clearIdentity(): Promise<void> {
   if (!isVaultAvailable()) return;
 
   return withDb(undefined, async (db) => {
-    await idbDelete(db, VAULT_STORE, IDENTITY_KEY);
+    const vault = await loadVaultV2FromDb(db);
+    if (!vault) return;
+
+    const { identityRecord: _identityRecord, ...stableCompartments } = vault;
+    await saveVaultV2ToDb(db, stableCompartments);
   });
+}
+
+export async function loadVaultV2(): Promise<VaultV2 | null> {
+  if (!isVaultAvailable()) return null;
+
+  return withDb(null, async (db) => loadVaultV2FromDb(db));
+}
+
+export async function saveVaultV2(vault: VaultV2): Promise<void> {
+  if (!isVaultAvailable()) return;
+
+  return withDb(undefined, async (db) => {
+    await saveVaultV2ToDb(db, normalizeVaultV2(vault));
+  });
+}
+
+export async function updateVaultV2(mutator: (vault: VaultV2) => VaultV2): Promise<VaultV2 | null> {
+  if (!isVaultAvailable()) return null;
+
+  return withDb(null, async (db) => {
+    const current = await loadVaultV2FromDb(db) ?? emptyVaultV2();
+    const next = normalizeVaultV2(mutator(current));
+    await saveVaultV2ToDb(db, next);
+    return next;
+  });
+}
+
+function emptyVaultV2(): VaultV2 {
+  return { schemaVersion: VAULT_VERSION };
+}
+
+async function loadVaultV2FromDb(db: IDBDatabase): Promise<VaultV2 | null> {
+  const record = await idbGet<VaultRecord>(db, VAULT_STORE, IDENTITY_KEY);
+  if (!record) return null;
+
+  const parsed = await decryptVaultRecord(db, record);
+  if (!parsed) return null;
+
+  if (record.version === VAULT_VERSION) {
+    if (!isVaultV2(parsed)) {
+      await idbDelete(db, VAULT_STORE, IDENTITY_KEY).catch(() => {});
+      return null;
+    }
+    return normalizeVaultV2(parsed);
+  }
+
+  if (record.version === LEGACY_VAULT_VERSION) {
+    if (!isValidIdentity(parsed)) {
+      await idbDelete(db, VAULT_STORE, IDENTITY_KEY).catch(() => {});
+      return null;
+    }
+
+    const migrated = migrateIdentityToVaultV2(parsed);
+    await saveVaultV2ToDb(db, migrated);
+    return migrated;
+  }
+
+  return null;
+}
+
+async function decryptVaultRecord(
+  db: IDBDatabase,
+  record: VaultRecord
+): Promise<unknown | null> {
+  const key = await getMasterKey(db);
+  if (!key) return null;
+
+  const plaintext = await decrypt(key, record.iv, record.ciphertext);
+  if (!plaintext) {
+    await idbDelete(db, VAULT_STORE, IDENTITY_KEY).catch(() => {});
+    return null;
+  }
+
+  try {
+    return JSON.parse(decoder.decode(plaintext));
+  } catch {
+    await idbDelete(db, VAULT_STORE, IDENTITY_KEY).catch(() => {});
+    return null;
+  }
+}
+
+async function saveVaultV2ToDb(db: IDBDatabase, vault: VaultV2): Promise<void> {
+  const key = await ensureMasterKey(db);
+  const plaintext = encoder.encode(JSON.stringify(normalizeVaultV2(vault)));
+  const { iv, ciphertext } = await encrypt(key, plaintext);
+
+  const record: VaultRecord = {
+    version: VAULT_VERSION,
+    iv,
+    ciphertext,
+  };
+
+  await idbPut(db, VAULT_STORE, IDENTITY_KEY, record);
+}
+
+function mergeIdentityIntoVault(vault: VaultV2, identity: Identity): VaultV2 {
+  return normalizeVaultV2({
+    ...vault,
+    identityRecord: identity,
+    deviceCredential: vault.deviceCredential ?? legacyDeviceCredential(identity),
+    seaDevicePair: vault.seaDevicePair ?? legacySeaDevicePair(identity)
+  });
+}
+
+function migrateIdentityToVaultV2(identity: Identity): VaultV2 {
+  return normalizeVaultV2({
+    ...emptyVaultV2(),
+    identityRecord: identity,
+    deviceCredential: legacyDeviceCredential(identity),
+    seaDevicePair: legacySeaDevicePair(identity)
+  });
+}
+
+function normalizeVaultV2(vault: VaultV2): VaultV2 {
+  return {
+    schemaVersion: VAULT_VERSION,
+    ...(vault.identityRecord ? { identityRecord: vault.identityRecord } : {}),
+    ...(vault.deviceCredential ? { deviceCredential: vault.deviceCredential } : {}),
+    ...(vault.seaDevicePair ? { seaDevicePair: vault.seaDevicePair } : {}),
+    ...(vault.delegationSigningKey ? { delegationSigningKey: vault.delegationSigningKey } : {})
+  };
+}
+
+function legacyDeviceCredential(identity: Identity): DeviceCredentialCompartment | undefined {
+  const attestation = identity.attestation;
+  if (!isValidIdentity(attestation)) return undefined;
+
+  const material = attestation.deviceKey;
+  if (typeof material !== 'string' || material.length === 0) return undefined;
+
+  return {
+    schemaVersion: 1,
+    material,
+    createdAt: createdAtFromIdentity(identity),
+    source: 'legacy-v1'
+  };
+}
+
+function legacySeaDevicePair(identity: Identity): SeaDevicePairCompartment | undefined {
+  const pair = identity.devicePair;
+  if (!isValidIdentity(pair)) return undefined;
+
+  const { pub, priv, epub, epriv } = pair;
+  if (
+    typeof pub !== 'string'
+    || typeof priv !== 'string'
+    || typeof epub !== 'string'
+    || typeof epriv !== 'string'
+    || pub.length === 0
+    || priv.length === 0
+    || epub.length === 0
+    || epriv.length === 0
+  ) {
+    return undefined;
+  }
+
+  return {
+    schemaVersion: 1,
+    pub,
+    priv,
+    epub,
+    epriv,
+    createdAt: createdAtFromIdentity(identity)
+  };
+}
+
+function createdAtFromIdentity(identity: Identity): number {
+  return typeof identity.createdAt === 'number' && Number.isSafeInteger(identity.createdAt)
+    ? identity.createdAt
+    : Date.now();
 }

--- a/packages/identity-vault/src/vault.ts
+++ b/packages/identity-vault/src/vault.ts
@@ -255,9 +255,14 @@ function migrateIdentityToVaultV2(identity: Identity): VaultV2 {
 }
 
 function normalizeVaultV2(vault: VaultV2): VaultV2 {
+  const identityRecord = vault.identityRecord;
+  if (identityRecord !== undefined && !isValidIdentity(identityRecord)) {
+    throw new Error('Invalid v2 identityRecord compartment');
+  }
+
   return {
     schemaVersion: VAULT_VERSION,
-    ...(vault.identityRecord ? { identityRecord: vault.identityRecord } : {}),
+    ...(identityRecord !== undefined ? { identityRecord } : {}),
     ...(vault.deviceCredential ? { deviceCredential: vault.deviceCredential } : {}),
     ...(vault.seaDevicePair ? { seaDevicePair: vault.seaDevicePair } : {}),
     ...(vault.delegationSigningKey ? { delegationSigningKey: vault.delegationSigningKey } : {})

--- a/tools/scripts/check-luma-vault-compartments.mjs
+++ b/tools/scripts/check-luma-vault-compartments.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const identityVaultSrc = path.join(rootDir, 'packages/identity-vault/src');
+const typesPath = path.join(identityVaultSrc, 'types.ts');
+const vaultPath = path.join(identityVaultSrc, 'vault.ts');
+const indexPath = path.join(identityVaultSrc, 'index.ts');
+const useIdentityPath = path.join(rootDir, 'apps/web-pwa/src/hooks/useIdentity.ts');
+
+const failures = [];
+
+for (const relativePath of [
+  'packages/identity-vault/src/compartments/deviceCredential.ts',
+  'packages/identity-vault/src/compartments/seaDevicePair.ts',
+  'packages/identity-vault/src/compartments/delegationSigningKey.ts',
+  'packages/identity-vault/src/compartments/index.ts'
+]) {
+  if (!fs.existsSync(path.join(rootDir, relativePath))) {
+    failures.push(`missing ${relativePath}`);
+  }
+}
+
+const typesSource = fs.readFileSync(typesPath, 'utf8');
+const vaultSource = fs.readFileSync(vaultPath, 'utf8');
+const indexSource = fs.readFileSync(indexPath, 'utf8');
+const useIdentitySource = fs.readFileSync(useIdentityPath, 'utf8');
+
+const requiredTypeTokens = [
+  'DeviceCredentialCompartment',
+  'SeaDevicePairCompartment',
+  'DelegationSigningKeyCompartment',
+  'VaultV2',
+  'export const VAULT_VERSION = 2',
+  'export const LEGACY_VAULT_VERSION = 1'
+];
+
+for (const token of requiredTypeTokens) {
+  if (!typesSource.includes(token)) {
+    failures.push(`packages/identity-vault/src/types.ts is missing ${token}`);
+  }
+}
+
+const requiredIndexExports = [
+  'deviceCredential',
+  'seaDevicePair',
+  'delegationSigningKey',
+  'loadVaultV2',
+  'saveVaultV2',
+  'updateVaultV2'
+];
+
+for (const exportName of requiredIndexExports) {
+  if (!indexSource.includes(exportName)) {
+    failures.push(`packages/identity-vault/src/index.ts does not export ${exportName}`);
+  }
+}
+
+if (!vaultSource.includes('identityRecord: identity')) {
+  failures.push('saveIdentity no longer stores identity data in the v2 identityRecord compartment');
+}
+
+if (!vaultSource.includes('deviceCredential: vault.deviceCredential ?? legacyDeviceCredential(identity)')) {
+  failures.push('saveIdentity does not preserve or promote deviceCredential compartment material');
+}
+
+if (!vaultSource.includes('seaDevicePair: vault.seaDevicePair ?? legacySeaDevicePair(identity)')) {
+  failures.push('saveIdentity does not preserve or promote seaDevicePair compartment material');
+}
+
+if (!vaultSource.includes('const { identityRecord: _identityRecord, ...stableCompartments } = vault')) {
+  failures.push('clearIdentity does not preserve stable vault compartments');
+}
+
+if (!useIdentitySource.includes('deviceCredential.loadOrCreate()')) {
+  failures.push('useIdentity.createIdentity does not load the vault-owned deviceCredential');
+}
+
+if (!useIdentitySource.includes('buildAttestation(deviceCredentialCompartment.material)')) {
+  failures.push('useIdentity.createIdentity does not pass stable deviceCredential material into attestation');
+}
+
+if (!useIdentitySource.includes('seaDevicePair.loadOrCreate(() => SEA.pair())')) {
+  failures.push('useIdentity.createIdentity does not load SEA device pair through the vault compartment');
+}
+
+if (/deviceKey:\s*randomToken\(\)/.test(useIdentitySource)) {
+  failures.push('useIdentity still generates attestation.deviceKey with randomToken()');
+}
+
+if (/const\s+devicePair\s*=\s*await\s+SEA\.pair\(\)/.test(useIdentitySource)) {
+  failures.push('useIdentity still creates a fresh SEA pair outside the vault compartment');
+}
+
+if (failures.length > 0) {
+  console.error('[check:luma-vault-compartments] failed');
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log('[check:luma-vault-compartments] vault compartment surface ok');


### PR DESCRIPTION
## Summary
- Add identity-vault v2 typed compartments for stable `deviceCredential`, `seaDevicePair`, and durable Ed25519 `delegationSigningKey` material.
- Migrate v1 opaque vault records to v2 on read while preserving valid legacy `attestation.deviceKey` and SEA `devicePair` material.
- Wire `useIdentity.createIdentity()` to use vault-owned `deviceCredential` and `seaDevicePair` instead of fresh per-create material.
- Add `pnpm check:luma-vault-compartments` to guard the M0.D-1 surface.

## Scope fence
No public schemas or adapter write paths were migrated. This PR does not touch `packages/gun-client`, `packages/data-model`, `apps/web-pwa/src/hooks/voteIntentMaterializer.ts`, mesh drills, relay, services, LUMA provider behavior, or signed-write behavior.

## Verification
- `pnpm --filter @vh/identity-vault typecheck`
- `pnpm --filter @vh/identity-vault build`
- `pnpm --filter @vh/identity-vault test`
- `pnpm exec vitest run packages/identity-vault/src/vault.test.ts --reporter=verbose`
- `pnpm exec vitest run apps/web-pwa/src/hooks/useIdentity.test.ts --reporter=verbose`
- `pnpm exec vitest run packages/identity-vault/src/vault.test.ts apps/web-pwa/src/hooks/useIdentity.test.ts --reporter=verbose`
- `pnpm check:linkability-domain-registry`
- `pnpm check:luma-provider-surface`
- `pnpm check:luma-signed-write-surface`
- `pnpm check:luma-vault-compartments`
- `pnpm docs:check`
- `git diff --check HEAD~1..HEAD`
- `node tools/scripts/check-diff-coverage.mjs`
- protected-surface grep over adapter/schema/materializer/mesh/relay/service/LUMA SDK excluded paths

Note: local PNPM emits the existing Node engine warning for Node `v23.10.0` against repo requirement `>=20 <23`; commands completed successfully.
