### PR TITLE
LUMA M0.D-3 identity lifecycle split

### DIFF
--- a/apps/web-pwa/src/hooks/useIdentity.test.ts
+++ b/apps/web-pwa/src/hooks/useIdentity.test.ts
@@ -3,15 +3,21 @@ import 'fake-indexeddb/auto';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  delegationSigningKey,
+  deviceCredential,
   saveIdentity as vaultSave,
   loadIdentity as vaultLoad,
   clearIdentity as vaultClear,
   LEGACY_STORAGE_KEY,
 } from '@vh/identity-vault';
 import type { Identity } from '@vh/identity-vault';
+import type { AttestationPayload } from '@vh/types';
 
 const createSessionMock = vi.fn();
 const pairMock = vi.fn();
+
+const SEA_PAIR_1 = Object.freeze({ pub: 'pub', priv: 'priv', epub: 'epub', epriv: 'epriv' });
+const SEA_PAIR_2 = Object.freeze({ pub: 'pub-2', priv: 'priv-2', epub: 'epub-2', epriv: 'epriv-2' });
 
 vi.mock('@vh/gun-client', () => ({
   createSession: (...args: unknown[]) => createSessionMock(...(args as [])),
@@ -48,13 +54,21 @@ async function loadHook(e2eMode = false) {
   return freshMod.useIdentity;
 }
 
+function mockVerifierByDeviceCredential(trustScore = 0.83) {
+  createSessionMock.mockImplementation((attestation: AttestationPayload) => Promise.resolve({
+    token: `srv-token:${attestation.deviceKey}`,
+    trustScore,
+    nullifier: `nullifier:${attestation.deviceKey}`
+  }));
+}
+
 describe('useIdentity', () => {
   beforeEach(async () => {
     await deleteDatabase('vh-vault');
     localStorage.clear();
     createSessionMock.mockReset();
     pairMock.mockReset();
-    pairMock.mockResolvedValue({ pub: 'pub', priv: 'priv', epub: 'epub', epriv: 'epriv' });
+    pairMock.mockResolvedValue(SEA_PAIR_1);
   });
 
   it('starts in hydrating state and resolves to anonymous when vault is empty', async () => {
@@ -159,21 +173,13 @@ describe('useIdentity', () => {
     expect((snapshot as any).session.token).toBeUndefined();
   });
 
-  it('reuses vault-owned device credential and SEA pair across session revocation', async () => {
-    createSessionMock
-      .mockResolvedValueOnce({
-        token: 'srv-token-1',
-        trustScore: 0.82,
-        nullifier: 'stable-nullifier-1'
-      })
-      .mockResolvedValueOnce({
-        token: 'srv-token-2',
-        trustScore: 0.83,
-        nullifier: 'stable-nullifier-2'
-      });
+  it('signOut preserves device-bound compartments, delegation storage, and XP continuity', async () => {
+    mockVerifierByDeviceCredential();
 
     const useIdentity = await loadHook();
     const { result } = renderHook(() => useIdentity());
+    const { useXpLedger } = await import('../store/xpLedger');
+    const { delegationStorageKey, useDelegationStore } = await import('../store/delegation');
 
     await waitFor(() => expect(result.current.status).toBe('anonymous'));
 
@@ -182,29 +188,121 @@ describe('useIdentity', () => {
     });
     await waitFor(() => expect(result.current.status).toBe('ready'));
 
+    const firstNullifier = result.current.identity?.session.nullifier;
     const firstDeviceKey = createSessionMock.mock.calls[0]?.[0]?.deviceKey;
     const firstDevicePair = result.current.identity?.devicePair;
+    const firstDeviceCredential = await deviceCredential.loadOrCreate();
+    const firstDelegationPublicKey = await delegationSigningKey.publicKey();
     expect(firstDeviceKey).toEqual(expect.any(String));
-    expect(firstDevicePair).toEqual({ pub: 'pub', priv: 'priv', epub: 'epub', epriv: 'epriv' });
+    expect(firstNullifier).toBe(`nullifier:${firstDeviceKey}`);
+    expect(firstDevicePair).toEqual(SEA_PAIR_1);
     expect(pairMock).toHaveBeenCalledTimes(1);
 
+    useXpLedger.getState().addXp('civic', 4);
+    localStorage.setItem(delegationStorageKey(firstNullifier!), '{"grants":[{"grantId":"g-1"}]}');
+    useDelegationStore.getState().setActivePrincipal(firstNullifier!);
+
     await act(async () => {
-      await result.current.revokeSession();
+      await result.current.signOut();
     });
     await waitFor(() => expect(result.current.status).toBe('anonymous'));
+    expect(useDelegationStore.getState().activePrincipal).toBeNull();
+    expect(localStorage.getItem(delegationStorageKey(firstNullifier!))).toBe('{"grants":[{"grantId":"g-1"}]}');
+    expect(useXpLedger.getState().activeNullifier).toBeNull();
+    expect(await deviceCredential.loadOrCreate()).toEqual(firstDeviceCredential);
+    expect(await delegationSigningKey.publicKey()).toEqual(firstDelegationPublicKey);
 
     await act(async () => {
       await result.current.createIdentity();
     });
     await waitFor(() => expect(result.current.status).toBe('ready'));
 
+    expect(result.current.identity?.session.nullifier).toBe(firstNullifier);
     expect(createSessionMock.mock.calls[1]?.[0]?.deviceKey).toBe(firstDeviceKey);
     expect(result.current.identity?.devicePair).toEqual(firstDevicePair);
     expect(pairMock).toHaveBeenCalledTimes(1);
+    expect(useXpLedger.getState().activeNullifier).toBe(firstNullifier);
+    expect(useXpLedger.getState().civicXP).toBeGreaterThanOrEqual(4);
 
     const fromVault = await vaultLoad();
     expect((fromVault as any)?.attestation.deviceKey).toBe(firstDeviceKey);
     expect((fromVault as any)?.devicePair).toEqual(firstDevicePair);
+  });
+
+  it('resetIdentity rotates device-bound compartments and clears old-principal delegation storage', async () => {
+    mockVerifierByDeviceCredential(0.9);
+    pairMock
+      .mockResolvedValueOnce(SEA_PAIR_1)
+      .mockResolvedValueOnce(SEA_PAIR_2);
+
+    const useIdentity = await loadHook();
+    const { result } = renderHook(() => useIdentity());
+    const { delegationStorageKey, useDelegationStore } = await import('../store/delegation');
+
+    await waitFor(() => expect(result.current.status).toBe('anonymous'));
+
+    await act(async () => {
+      await result.current.createIdentity();
+    });
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+
+    const firstNullifier = result.current.identity!.session.nullifier;
+    const firstDeviceKey = createSessionMock.mock.calls[0]?.[0]?.deviceKey;
+    const firstDeviceCredential = await deviceCredential.loadOrCreate();
+    const firstDelegationPublicKey = await delegationSigningKey.publicKey();
+    localStorage.setItem(delegationStorageKey(firstNullifier), '{"grants":[{"grantId":"old"}]}');
+    useDelegationStore.getState().setActivePrincipal(firstNullifier);
+
+    await act(async () => {
+      await result.current.resetIdentity();
+    });
+    await waitFor(() => expect(result.current.status).toBe('anonymous'));
+
+    expect(localStorage.getItem(delegationStorageKey(firstNullifier))).toBeNull();
+    expect(useDelegationStore.getState().activePrincipal).toBeNull();
+    expect(await vaultLoad()).toBeNull();
+    expect(await deviceCredential.loadOrCreate()).not.toEqual(firstDeviceCredential);
+    expect(await delegationSigningKey.publicKey()).not.toEqual(firstDelegationPublicKey);
+    expect(pairMock).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      await result.current.createIdentity();
+    });
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+
+    const secondDeviceKey = createSessionMock.mock.calls[1]?.[0]?.deviceKey;
+    expect(secondDeviceKey).not.toBe(firstDeviceKey);
+    expect(result.current.identity?.session.nullifier).toBe(`nullifier:${secondDeviceKey}`);
+    expect(result.current.identity?.session.nullifier).not.toBe(firstNullifier);
+    expect(result.current.identity?.devicePair).toEqual(SEA_PAIR_2);
+  });
+
+  it('keeps revokeSession as a deprecated signOut shim', async () => {
+    mockVerifierByDeviceCredential();
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    try {
+      const useIdentity = await loadHook();
+      const { result } = renderHook(() => useIdentity());
+
+      await waitFor(() => expect(result.current.status).toBe('anonymous'));
+      await act(async () => {
+        await result.current.createIdentity();
+      });
+      await waitFor(() => expect(result.current.status).toBe('ready'));
+
+      const firstDeviceCredential = await deviceCredential.loadOrCreate();
+
+      await act(async () => {
+        await result.current.revokeSession();
+      });
+
+      await waitFor(() => expect(result.current.status).toBe('anonymous'));
+      expect(warning).toHaveBeenCalledWith('[vh:identity] useIdentity.revokeSession() is deprecated; use signOut() instead');
+      expect(await deviceCredential.loadOrCreate()).toEqual(firstDeviceCredential);
+    } finally {
+      warning.mockRestore();
+    }
   });
 
   it('promotes legacy attestation/device pair into stable vault compartments', async () => {
@@ -246,7 +344,7 @@ describe('useIdentity', () => {
     expect(result.current.identity?.session.nullifier).toBe('legacy-null');
 
     await act(async () => {
-      await result.current.revokeSession();
+      await result.current.signOut();
     });
     await waitFor(() => expect(result.current.status).toBe('anonymous'));
 

--- a/apps/web-pwa/src/hooks/useIdentity.ts
+++ b/apps/web-pwa/src/hooks/useIdentity.ts
@@ -7,6 +7,7 @@ import { authenticateGunUser, publishDirectoryEntry, useAppStore } from '../stor
 import { getHandleError, isValidHandle } from '../utils/handle';
 import {
   clearIdentity as vaultClear,
+  delegationSigningKey,
   deviceCredential,
   migrateLegacyLocalStorage,
   seaDevicePair
@@ -15,6 +16,7 @@ import { publishIdentity, clearPublishedIdentity } from '../store/identityProvid
 import { useXpLedger } from '../store/xpLedger';
 import { loadIdentityRecord, saveIdentityRecord } from '../utils/vaultTyped';
 import { useSentimentState } from './useSentimentState';
+import { clearDelegationStorageForPrincipal, useDelegationStore } from '../store/delegation';
 
 const E2E_MODE = (import.meta as any).env?.VITE_E2E_MODE === 'true';
 const DEV_MODE = (import.meta as any).env?.DEV === true || (import.meta as any).env?.MODE === 'development';
@@ -254,23 +256,51 @@ export function useIdentity() {
     [identity]
   );
 
-  /**
-   * Revoke the current session (spec §2.1.3).
-   *
-   * Always available regardless of feature flag — this is a user-initiated
-   * security action. Clears session/identity state, published identity, and
-   * delegation grants. Stable vault key compartments are preserved.
-   */
-  const revokeSession = useCallback(async () => {
+  const clearActiveIdentityRuntime = useCallback(() => {
     setIdentity(null);
     setStatus('anonymous');
     setError(undefined);
     clearPublishedIdentity();
     useXpLedger.getState().setActiveNullifier(null);
-    // Constituency proof is derived from identity — clearing identity invalidates all proofs (spec §2.1.3)
+    useDelegationStore.getState().setActivePrincipal(null);
+    // Constituency proof is derived from identity, so clearing identity invalidates all proofs.
     useSentimentState.setState({ signals: [] });
-    await vaultClear().catch(() => {});
   }, []);
+
+  /**
+   * End the current session while preserving device-bound identity compartments
+   * (LUMA §13 Sign Out).
+   */
+  const signOut = useCallback(async () => {
+    clearActiveIdentityRuntime();
+    await vaultClear().catch(() => {});
+  }, [clearActiveIdentityRuntime]);
+
+  /**
+   * Rotate the local device-bound identity and clear old-principal delegation
+   * storage (LUMA §13 Reset Identity).
+   */
+  const resetIdentity = useCallback(async () => {
+    const oldPrincipal = identity?.session.nullifier ?? null;
+    clearActiveIdentityRuntime();
+    if (oldPrincipal) {
+      clearDelegationStorageForPrincipal(oldPrincipal);
+    }
+
+    await vaultClear().catch(() => {});
+    await deviceCredential.rotate();
+    await seaDevicePair.rotate(() => SEA.pair());
+    await delegationSigningKey.rotateStored();
+  }, [clearActiveIdentityRuntime, identity?.session.nullifier]);
+
+  /**
+   * @deprecated Use signOut(). This compatibility shim preserves the pre-M0.D
+   * hook surface while the app migrates call sites.
+   */
+  const revokeSession = useCallback(async () => {
+    console.warn('[vh:identity] useIdentity.revokeSession() is deprecated; use signOut() instead');
+    await signOut();
+  }, [signOut]);
 
   /**
    * Check session validity at action boundaries (spec §2.1.4).
@@ -301,6 +331,8 @@ export function useIdentity() {
     startLinkSession,
     completeLinkSession,
     updateHandle,
+    signOut,
+    resetIdentity,
     revokeSession,
     checkSessionExpiry,
     validateHandle: isValidHandle

--- a/apps/web-pwa/src/store/delegation/index.test.ts
+++ b/apps/web-pwa/src/store/delegation/index.test.ts
@@ -3,6 +3,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { DelegationGrant } from '@vh/types';
 import {
+  clearDelegationStorageForPrincipal,
   createMockDelegationStore,
   delegationStorageKey,
   useDelegationStore,
@@ -187,6 +188,17 @@ describe('delegation persistence helpers', () => {
     };
     circular.familiarsById.self = circular;
     expect(() => persistForPrincipal(circular)).not.toThrow();
+  });
+
+  it('clears storage for one principal without touching other principals', () => {
+    localStorage.setItem(delegationStorageKey('principal-1'), '{"grants":[]}');
+    localStorage.setItem(delegationStorageKey('principal-2'), '{"grants":[]}');
+
+    clearDelegationStorageForPrincipal('principal-1');
+    clearDelegationStorageForPrincipal('');
+
+    expect(localStorage.getItem(delegationStorageKey('principal-1'))).toBeNull();
+    expect(localStorage.getItem(delegationStorageKey('principal-2'))).toBe('{"grants":[]}');
   });
 
   it('buildInitialState hydrates from published identity and storage', () => {

--- a/apps/web-pwa/src/store/delegation/index.ts
+++ b/apps/web-pwa/src/store/delegation/index.ts
@@ -38,6 +38,7 @@ export type {
 } from './types';
 
 export {
+  clearDelegationStorageForPrincipal,
   DELEGATION_STORAGE_KEY_PREFIX,
   delegationStorageKey
 } from './persistence';

--- a/apps/web-pwa/src/store/delegation/persistence.ts
+++ b/apps/web-pwa/src/store/delegation/persistence.ts
@@ -6,7 +6,7 @@ import {
   type DelegationTier
 } from '@vh/types';
 import { getPublishedIdentity } from '../identityProvider';
-import { safeGetItem, safeSetItem } from '../../utils/safeStorage';
+import { safeGetItem, safeRemoveItem, safeSetItem } from '../../utils/safeStorage';
 import type {
   DelegationStateData,
   SerializedDelegationState
@@ -16,6 +16,11 @@ export const DELEGATION_STORAGE_KEY_PREFIX = 'vh_delegation_v1:';
 
 export function delegationStorageKey(principalNullifier: string): string {
   return `${DELEGATION_STORAGE_KEY_PREFIX}${principalNullifier}`;
+}
+
+export function clearDelegationStorageForPrincipal(principalNullifier: string): void {
+  if (!principalNullifier) return;
+  safeRemoveItem(delegationStorageKey(principalNullifier));
 }
 
 export function readIdentityNullifier(): string | null {

--- a/docs/foundational/STATUS.md
+++ b/docs/foundational/STATUS.md
@@ -457,7 +457,7 @@ Operational live profiles intentionally override selected flags to enable the fu
 | Trust constants | ✅ Centralized | `packages/data-model/src/constants/trust.ts` — TRUST_MINIMUM (0.5), TRUST_ELEVATED (0.7) |
 | Session lifecycle | ✅ Feature-flagged | `packages/types/src/session-lifecycle.ts` — expiry, near-expiry, migration (`VITE_SESSION_LIFECYCLE_ENABLED`) |
 | Constituency proof verification | ✅ Feature-flagged | `packages/types/src/constituency-verification.ts` — nullifier/district/freshness checks (`VITE_CONSTITUENCY_PROOF_REAL`) |
-| Session revocation | ✅ Active (no flag) | `useIdentity.ts` — `revokeSession()` clears identity + proof state |
+| Identity lifecycle controls | ✅ Active (no flag) | `useIdentity.ts` — `signOut()` preserves device-bound compartments; `resetIdentity()` rotates them; `revokeSession()` is a deprecated shim |
 | Hardware TEE binding | ❌ Not implemented | No Secure Enclave/StrongBox code (Season 0 deferred §9.2) |
 | VIO liveness detection | ❌ Not implemented | No sensor fusion code (Season 0 deferred §9.2) |
 | Trust score calculation | ⚠️ Hardened stub | `main.rs` — structured validation, rate limiting; no real chain validation |

--- a/docs/specs/spec-identity-trust-constituency.md
+++ b/docs/specs/spec-identity-trust-constituency.md
@@ -106,20 +106,25 @@ interface SessionResponse {
 }
 ```
 
-### 2.1.3 Session Revocation
+### 2.1.3 Sign Out And Reset Identity
 
-**Current state:** Local session revocation is implemented. `useIdentity.revokeSession()`
-clears identity state, published identity, sentiment signal state, and the local
-identity vault. Remote lost-device revocation remains deferred.
+**Current state:** Local lifecycle controls are implemented. `useIdentity.signOut()`
+clears active session state, published identity, active XP nullifier, active
+delegation runtime principal, and sentiment signal state while preserving
+device-bound vault compartments. `useIdentity.resetIdentity()` rotates
+device-bound compartments and clears old-principal delegation storage.
+`useIdentity.revokeSession()` remains as a deprecated compatibility shim over
+`signOut()`. Remote lost-device revocation remains deferred.
 
 **Target contract:**
-- A user MAY revoke their own session via an explicit "Sign Out" / "Clear Identity" action.
-- Revocation MUST:
-  1. Clear `SessionResponse` from local state and IndexedDB vault.
+- A user MAY end their current session via an explicit Sign Out action.
+- Sign Out MUST:
+  1. Clear `SessionResponse` from local state and the vault `identityRecord`.
   2. Clear any cached `ConstituencyProof`.
-  3. Invalidate the session token (local-only; no server-side token list in Season 0).
-  4. Revoke all active `DelegationGrant` records for familiars bound to this session.
-- Revocation MUST NOT delete the nullifier derivation material (device key) - re-attestation should yield the same nullifier.
+  3. Invalidate the session token locally; no server-side token list exists in Season 0.
+  4. Preserve device-bound nullifier derivation material, SEA device material, delegation signing material, XP history, and old-principal delegation storage.
+- A user MAY rotate their local identity via an explicit Reset Identity action.
+- Reset Identity MUST rotate device-bound nullifier derivation material, SEA device material, and delegation signing material; clear old-principal delegation storage; and preserve historical public artifacts without implying deletion or repudiation.
 - Remote revocation (e.g., revoking a lost device's session from another device) is DEFERRED to multi-device recovery (§5) + Gold assurance.
 
 ### 2.1.4 Timeout Semantics
@@ -415,7 +420,7 @@ These items work in Season 0 but are explicitly marked as transitional and MUST 
 
 1. **Threshold consolidation still incomplete on older surfaces:** Shared trust constants exist, but some older docs/surfaces still reference raw `0.5` and `0.7` boundaries. Target: active code paths should import canonical constants where practical.
 2. **Session expiry is flag-gated:** lifecycle fields and lazy expiry checks exist, but lifecycle enforcement depends on `VITE_SESSION_LIFECYCLE_ENABLED=true`; lifecycle-disabled sessions remain transitional non-expiring sessions.
-3. **No session revocation UI:** `useIdentity.revokeSession()` exists, but a user-facing "Sign Out" or "Clear Identity" flow still needs product wiring.
+3. **No identity lifecycle UI:** `useIdentity.signOut()` and `useIdentity.resetIdentity()` exist, but user-facing account controls still need product wiring.
 4. **Beta-local constituency proof:** voting paths reject mock proof values and use deterministic proof derivation, but cryptographic residency proof acquisition is still deferred (see §4.4).
 5. **Device-bound nullifier:** Nullifier is per-device, not per-human. Target: multi-device linking with higher assurance (see §5).
 6. **Dev fallback trust score:** `0.95` fallback on attestation timeout is convenient but masks real verifier issues. Target: remove or gate behind explicit dev flag.

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "check:luma-signed-write-surface": "node ./tools/scripts/check-luma-signed-write-surface.mjs",
     "check:luma-vault-compartments": "node ./tools/scripts/check-luma-vault-compartments.mjs",
     "check:luma-delegation-signer-surface": "node ./tools/scripts/check-luma-delegation-signer-surface.mjs",
+    "check:luma-identity-lifecycle": "node ./tools/scripts/check-luma-identity-lifecycle.mjs",
     "report:news-sources:admission": "pnpm --filter @vh/news-aggregator report:source-admission",
     "report:news-sources:health": "NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter @vh/news-aggregator report:source-health",
     "scout:news-sources:candidates": "NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter @vh/news-aggregator report:source-scout",

--- a/tools/scripts/check-luma-identity-lifecycle.mjs
+++ b/tools/scripts/check-luma-identity-lifecycle.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const failures = [];
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(rootDir, relativePath), 'utf8');
+}
+
+function requireToken(source, token, label) {
+  if (!source.includes(token)) {
+    failures.push(`${label} is missing ${token}`);
+  }
+}
+
+const useIdentitySource = read('apps/web-pwa/src/hooks/useIdentity.ts');
+const delegationPersistenceSource = read('apps/web-pwa/src/store/delegation/persistence.ts');
+const delegationIndexSource = read('apps/web-pwa/src/store/delegation/index.ts');
+const statusSource = read('docs/foundational/STATUS.md');
+const identitySpecSource = read('docs/specs/spec-identity-trust-constituency.md');
+
+for (const token of [
+  'const signOut = useCallback',
+  'const resetIdentity = useCallback',
+  'await signOut()',
+  'deviceCredential.rotate()',
+  'seaDevicePair.rotate(() => SEA.pair())',
+  'delegationSigningKey.rotateStored()',
+  'clearDelegationStorageForPrincipal(oldPrincipal)',
+  'useDelegationStore.getState().setActivePrincipal(null)',
+  'useIdentity.revokeSession() is deprecated; use signOut() instead'
+]) {
+  requireToken(useIdentitySource, token, 'apps/web-pwa/src/hooks/useIdentity.ts');
+}
+
+requireToken(delegationPersistenceSource, 'clearDelegationStorageForPrincipal', 'delegation persistence helper');
+requireToken(delegationPersistenceSource, 'safeRemoveItem(delegationStorageKey(principalNullifier))', 'delegation storage clear path');
+requireToken(delegationIndexSource, 'clearDelegationStorageForPrincipal', 'delegation index exports');
+requireToken(statusSource, '`signOut()` preserves device-bound compartments; `resetIdentity()` rotates them', 'foundational status lifecycle row');
+requireToken(identitySpecSource, 'useIdentity.signOut()', 'identity spec lifecycle surface');
+requireToken(identitySpecSource, 'useIdentity.resetIdentity()', 'identity spec lifecycle surface');
+
+if (identitySpecSource.includes('`useIdentity.revokeSession()` exists, but')) {
+  failures.push('identity spec still presents revokeSession as the primary lifecycle surface');
+}
+
+if (statusSource.includes('`revokeSession()` clears identity + proof state')) {
+  failures.push('foundational status still presents revokeSession as the primary lifecycle surface');
+}
+
+if (failures.length > 0) {
+  console.error('[check:luma-identity-lifecycle] failed');
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log('[check:luma-identity-lifecycle] identity lifecycle surface ok');


### PR DESCRIPTION
## Summary
- Add explicit `signOut()` and `resetIdentity()` lifecycle surfaces to `useIdentity`.
- Keep `revokeSession()` as a deprecated compatibility shim over `signOut()`.
- Preserve device-bound identity compartments on sign out while rotating them on reset identity.
- Add old-principal delegation storage clearing for reset identity only.
- Add `pnpm check:luma-identity-lifecycle` and update identity lifecycle docs.

## Verification
- `pnpm exec vitest run apps/web-pwa/src/hooks/useIdentity.test.ts apps/web-pwa/src/store/delegation/index.test.ts packages/identity-vault/src/vault.test.ts --reporter=verbose`
- `pnpm --filter @vh/identity-vault test`
- `pnpm --filter @vh/identity-vault typecheck`
- `pnpm --filter @vh/identity-vault build`
- `pnpm --filter @vh/web-pwa typecheck`
- `pnpm --filter @vh/web-pwa build`
- `pnpm check:linkability-domain-registry`
- `pnpm check:luma-provider-surface`
- `pnpm check:luma-signed-write-surface`
- `pnpm check:luma-vault-compartments`
- `pnpm check:luma-delegation-signer-surface`
- `pnpm check:luma-identity-lifecycle`
- `pnpm docs:check`
- `git diff --check HEAD~1..HEAD`
- `node tools/scripts/check-diff-coverage.mjs`

## Scope Guard
No public schemas, adapter write paths, `voteIntentMaterializer`, mesh drills, relay, services, LUMA provider behavior, signed-write envelope behavior, or public identifier derivation were changed.

Local PNPM still emits the existing Node engine warning: local Node is `v23.10.0`, repo wants `>=20 <23`.
