### PR TITLE
LUMA M0.D multi-device link stubs

### DIFF
--- a/apps/web-pwa/src/hooks/useIdentity.test.ts
+++ b/apps/web-pwa/src/hooks/useIdentity.test.ts
@@ -42,6 +42,11 @@ function deleteDatabase(name: string): Promise<void> {
 }
 
 async function loadHook(e2eMode = false) {
+  const freshMod = await loadIdentityModule(e2eMode);
+  return freshMod.useIdentity;
+}
+
+async function loadIdentityModule(e2eMode = false) {
   vi.resetModules();
   vi.stubGlobal('import.meta', {
     env: {
@@ -50,8 +55,7 @@ async function loadHook(e2eMode = false) {
     }
   });
 
-  const freshMod = await import('./useIdentity');
-  return freshMod.useIdentity;
+  return import('./useIdentity');
 }
 
 function mockVerifierByDeviceCredential(trustScore = 0.83) {
@@ -303,6 +307,48 @@ describe('useIdentity', () => {
     } finally {
       warning.mockRestore();
     }
+  });
+
+  it('fails closed for deferred multi-device link methods without mutating identity state', async () => {
+    mockVerifierByDeviceCredential();
+    const identityModule = await loadIdentityModule();
+    const { MULTI_DEVICE_LINK_DEFERRED_CODE, useIdentity } = identityModule;
+    const { result } = renderHook(() => useIdentity());
+
+    await waitFor(() => expect(result.current.status).toBe('anonymous'));
+    await act(async () => {
+      await result.current.createIdentity();
+    });
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+
+    const originalIdentity = result.current.identity;
+    expect(originalIdentity).toBeTruthy();
+    expect(originalIdentity?.linkedDevices).toBeUndefined();
+    expect(originalIdentity?.pendingLinkCode).toBeUndefined();
+
+    await expect(result.current.linkDevice()).rejects.toMatchObject({
+      code: MULTI_DEVICE_LINK_DEFERRED_CODE,
+      capability: 'multi-device-link',
+      phase: 'Phase 3+'
+    });
+    await expect(result.current.startLinkSession()).rejects.toMatchObject({
+      code: MULTI_DEVICE_LINK_DEFERRED_CODE,
+      capability: 'multi-device-link',
+      phase: 'Phase 3+'
+    });
+    await expect(result.current.completeLinkSession('legacy-code')).rejects.toMatchObject({
+      code: MULTI_DEVICE_LINK_DEFERRED_CODE,
+      capability: 'multi-device-link',
+      phase: 'Phase 3+'
+    });
+
+    expect(result.current.identity).toEqual(originalIdentity);
+    expect(result.current.identity?.linkedDevices).toBeUndefined();
+    expect(result.current.identity?.pendingLinkCode).toBeUndefined();
+
+    const fromVault = await vaultLoad();
+    expect((fromVault as any)?.linkedDevices).toBeUndefined();
+    expect((fromVault as any)?.pendingLinkCode).toBeUndefined();
   });
 
   it('promotes legacy attestation/device pair into stable vault compartments', async () => {

--- a/apps/web-pwa/src/hooks/useIdentity.ts
+++ b/apps/web-pwa/src/hooks/useIdentity.ts
@@ -32,6 +32,19 @@ export type SessionExpiryCheck =
   | { valid: true; warning?: 'near-expiry' }
   | { valid: false; reason: 'expired' };
 
+export const MULTI_DEVICE_LINK_DEFERRED_CODE = 'luma.multidevice.deferred' as const;
+
+export class MultiDeviceLinkDeferredError extends Error {
+  readonly code = MULTI_DEVICE_LINK_DEFERRED_CODE;
+  readonly capability = 'multi-device-link';
+  readonly phase = 'Phase 3+';
+
+  constructor(method: 'linkDevice' | 'startLinkSession' | 'completeLinkSession') {
+    super(`${method} is deferred until LUMA Phase 3+ multi-device identity linking lands`);
+    this.name = 'MultiDeviceLinkDeferredError';
+  }
+}
+
 /** Module-level migration guard — runs at most once. */
 let migrationPromise: Promise<void> | null = null;
 
@@ -59,6 +72,10 @@ function randomToken(): string {
     return crypto.randomUUID();
   }
   return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+function rejectMultiDeviceLink(method: 'linkDevice' | 'startLinkSession' | 'completeLinkSession'): never {
+  throw new MultiDeviceLinkDeferredError(method);
 }
 
 export function useIdentity() {
@@ -203,40 +220,23 @@ export function useIdentity() {
     if (!identity) {
       throw new Error('Identity not ready');
     }
-    const newDevice = `device-${randomToken()}`;
-    const updated: IdentityRecord = {
-      ...identity,
-      linkedDevices: [...(identity.linkedDevices ?? []), newDevice]
-    };
-    await persistIdentity(updated);
-    setIdentity(updated);
-    return newDevice;
+    rejectMultiDeviceLink('linkDevice');
   }, [identity]);
 
   const startLinkSession = useCallback(async () => {
     if (!identity) {
       throw new Error('Identity not ready');
     }
-    const code = `link-${randomToken()}`;
-    const updated: IdentityRecord = { ...identity, pendingLinkCode: code };
-    await persistIdentity(updated);
-    setIdentity(updated);
-    return code;
+    rejectMultiDeviceLink('startLinkSession');
   }, [identity]);
 
   const completeLinkSession = useCallback(
     async (code: string) => {
-      if (!identity || !identity.pendingLinkCode) {
-        throw new Error('No pending link');
+      void code;
+      if (!identity) {
+        throw new Error('Identity not ready');
       }
-      if (code !== identity.pendingLinkCode) {
-        throw new Error('Invalid link code');
-      }
-      const linked = [...(identity.linkedDevices ?? []), `linked-${randomToken()}`];
-      const updated: IdentityRecord = { ...identity, linkedDevices: linked, pendingLinkCode: undefined };
-      await persistIdentity(updated);
-      setIdentity(updated);
-      return linked;
+      rejectMultiDeviceLink('completeLinkSession');
     },
     [identity]
   );

--- a/apps/web-pwa/src/routes/dashboardContent.test.tsx
+++ b/apps/web-pwa/src/routes/dashboardContent.test.tsx
@@ -1,0 +1,100 @@
+/* @vitest-environment jsdom */
+
+import { cleanup, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import type React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const dashboardMocks = vi.hoisted(() => ({
+  createIdentityRecord: vi.fn(),
+  startLinkSession: vi.fn(),
+  completeLinkSession: vi.fn(),
+  analyze: vi.fn(),
+  reset: vi.fn(),
+  createProfile: vi.fn()
+}));
+
+vi.mock('@vh/ui', () => ({
+  Button: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  )
+}));
+
+vi.mock('@vh/ai-engine', () => ({
+  useAI: () => ({
+    state: {
+      status: 'idle',
+      progress: 0,
+      result: null,
+      message: null
+    },
+    analyze: dashboardMocks.analyze,
+    reset: dashboardMocks.reset
+  })
+}));
+
+vi.mock('@vh/ai-engine/worker?worker', () => ({
+  default: class MockWorker {}
+}), { virtual: true });
+
+vi.mock('../components/HandleEditor', () => ({
+  HandleEditor: () => <div data-testid="handle-editor" />
+}));
+
+vi.mock('./AnalysisFeed', () => ({
+  AnalysisFeed: () => <div data-testid="analysis-feed" />
+}));
+
+vi.mock('../store', () => ({
+  useAppStore: () => ({
+    profile: { username: 'Alice' },
+    createIdentity: dashboardMocks.createProfile,
+    identityStatus: 'ready',
+    client: {},
+    error: undefined
+  })
+}));
+
+vi.mock('../hooks/useIdentity', () => ({
+  useIdentity: () => ({
+    identity: {
+      session: {
+        trustScore: 0.91,
+        scaledTrustScore: 9100
+      },
+      linkedDevices: ['legacy-linked-device'],
+      pendingLinkCode: 'legacy-link-code'
+    },
+    status: 'ready',
+    createIdentity: dashboardMocks.createIdentityRecord,
+    startLinkSession: dashboardMocks.startLinkSession,
+    completeLinkSession: dashboardMocks.completeLinkSession
+  })
+}));
+
+describe('DashboardContent multi-device deferral', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  afterEach(() => cleanup());
+
+  it('renders link-device as deferred without exposing fake link controls', async () => {
+    const { DashboardContent } = await import('./dashboardContent');
+    render(<DashboardContent />);
+
+    expect(screen.getByTestId('linked-count')).toHaveTextContent('Device linking: deferred');
+    expect(screen.getByTestId('link-device-btn')).toBeDisabled();
+    expect(screen.getByTestId('link-device-btn')).toHaveTextContent('Link Device Deferred');
+    expect(screen.getByTestId('link-device-deferred')).toHaveTextContent(
+      'Multi-device identity linking is deferred to LUMA Phase 3+.'
+    );
+
+    expect(screen.queryByTestId('link-code')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('link-input')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('link-complete-btn')).not.toBeInTheDocument();
+    expect(dashboardMocks.startLinkSession).not.toHaveBeenCalled();
+    expect(dashboardMocks.completeLinkSession).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web-pwa/src/routes/dashboardContent.tsx
+++ b/apps/web-pwa/src/routes/dashboardContent.tsx
@@ -18,16 +18,11 @@ export const DashboardContent: React.FC = () => {
   const {
     identity,
     status: identityRecordStatus,
-    createIdentity: createIdentityRecord,
-    startLinkSession,
-    completeLinkSession
+    createIdentity: createIdentityRecord
   } = useIdentity();
   const [username, setUsername] = useState('');
   const [handleInput, setHandleInput] = useState('');
   const [handleErrorMsg, setHandleErrorMsg] = useState<string | null>(null);
-  const [linkModalOpen, setLinkModalOpen] = useState(false);
-  const [generatedCode, setGeneratedCode] = useState<string | null>(null);
-  const [incomingCode, setIncomingCode] = useState('');
   const [workerFactory, setWorkerFactory] = useState<(() => Worker) | undefined>();
   const {
     state: { status, progress, result, message },
@@ -89,26 +84,6 @@ export const DashboardContent: React.FC = () => {
     const demo = `A local-first stack powers civic analysis. The system processes text on-device to surface bias and provide balanced counterpoints.`;
     if (!profile) return;
     analyze(demo);
-  };
-
-  const handleStartLink = async () => {
-    try {
-      const code = await startLinkSession();
-      setGeneratedCode(code);
-      setLinkModalOpen(true);
-    } catch (err) {
-      console.error(err);
-    }
-  };
-
-  const handleCompleteLink = async () => {
-    try {
-      await completeLinkSession(incomingCode.trim());
-      setLinkModalOpen(false);
-      setIncomingCode('');
-    } catch (err) {
-      console.error(err);
-    }
   };
 
   return (
@@ -200,7 +175,7 @@ export const DashboardContent: React.FC = () => {
               </span>
             )}
             <span className="text-slate-500" data-testid="linked-count">
-              Linked devices: {(identity?.linkedDevices ?? []).length}
+              Device linking: deferred
             </span>
           </div>
 
@@ -209,9 +184,17 @@ export const DashboardContent: React.FC = () => {
             <Button variant="secondary" onClick={() => console.log('open settings')}>
               Open Settings
             </Button>
-            <Button variant="ghost" onClick={handleStartLink} data-testid="link-device-btn">
-              Link Device
+            <Button
+              variant="ghost"
+              disabled
+              aria-describedby="link-device-deferred"
+              data-testid="link-device-btn"
+            >
+              Link Device Deferred
             </Button>
+            <span id="link-device-deferred" className="sr-only" data-testid="link-device-deferred">
+              Multi-device identity linking is deferred to LUMA Phase 3+.
+            </span>
             <Button
               variant="ghost"
               onClick={handleAnalyze}
@@ -228,39 +211,6 @@ export const DashboardContent: React.FC = () => {
           </div>
 
           <HandleEditor />
-
-          {linkModalOpen && (
-            <div className="rounded-lg border border-slate-200 bg-card p-4 shadow-lg dark:border-slate-700">
-              <p className="font-semibold text-slate-900">Link Device</p>
-              <p className="text-sm text-slate-700">Share this link code with the device you want to link.</p>
-              {generatedCode && (
-                <div className="mt-2 rounded border border-dashed border-slate-300 bg-card-muted px-3 py-2 text-sm font-mono text-slate-800" data-testid="link-code">
-                  {generatedCode}
-                </div>
-              )}
-              <div className="mt-3 space-y-2">
-                <label className="text-xs uppercase tracking-wide text-slate-500">Simulate incoming link</label>
-                <div className="flex gap-2">
-                  <input
-                    className="w-full rounded border border-slate-200 px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none"
-                    placeholder="Paste code here"
-                    value={incomingCode}
-                    onChange={(e) => setIncomingCode(e.target.value)}
-                    data-testid="link-input"
-                  />
-                  <Button onClick={handleCompleteLink} data-testid="link-complete-btn">
-                    Complete
-                  </Button>
-                </div>
-              </div>
-              <div className="mt-3 flex items-center justify-between text-xs text-slate-600">
-                <span>Linked devices: {(identity?.linkedDevices ?? []).length}</span>
-                <Button variant="ghost" onClick={() => setLinkModalOpen(false)}>
-                  Close
-                </Button>
-              </div>
-            </div>
-          )}
 
           <Suspense fallback={<div className="rounded-lg border border-slate-200 bg-card p-4 text-sm text-slate-700 dark:border-slate-700">Loading analyses…</div>}>
             <AnalysisFeed />

--- a/docs/foundational/STATUS.md
+++ b/docs/foundational/STATUS.md
@@ -458,6 +458,7 @@ Operational live profiles intentionally override selected flags to enable the fu
 | Session lifecycle | ✅ Feature-flagged | `packages/types/src/session-lifecycle.ts` — expiry, near-expiry, migration (`VITE_SESSION_LIFECYCLE_ENABLED`) |
 | Constituency proof verification | ✅ Feature-flagged | `packages/types/src/constituency-verification.ts` — nullifier/district/freshness checks (`VITE_CONSTITUENCY_PROOF_REAL`) |
 | Identity lifecycle controls | ✅ Active (no flag) | `useIdentity.ts` — `signOut()` preserves device-bound compartments; `resetIdentity()` rotates them; `revokeSession()` is a deprecated shim |
+| Multi-device identity linking | ⏸️ Deferred | `useIdentity.ts` — `linkDevice()`, `startLinkSession()`, and `completeLinkSession()` fail closed; no fake linked-device state is written |
 | Hardware TEE binding | ❌ Not implemented | No Secure Enclave/StrongBox code (Season 0 deferred §9.2) |
 | VIO liveness detection | ❌ Not implemented | No sensor fusion code (Season 0 deferred §9.2) |
 | Trust score calculation | ⚠️ Hardened stub | `main.rs` — structured validation, rate limiting; no real chain validation |

--- a/docs/plans/LUMA_SERVICE_V0_ROADMAP_2026-05-02.md
+++ b/docs/plans/LUMA_SERVICE_V0_ROADMAP_2026-05-02.md
@@ -279,7 +279,7 @@ Deliverables:
 - `packages/identity-vault/src/compartments/` typed accessors per spec §11.2.
 - `useIdentity.createIdentity()` reads `deviceCredential.loadOrCreate()`.
 - Split `useIdentity.revokeSession()` into `signOut()` and `resetIdentity()` per spec §13.2. `revokeSession` becomes a deprecation shim calling `signOut()`.
-- Multi-device link flow (`linkDevice` / `startLinkSession` / `completeLinkSession`) explicitly stub-marked.
+- Multi-device link flow (`linkDevice` / `startLinkSession` / `completeLinkSession`) explicitly stub-marked: fail closed with no fake link codes, no `pendingLinkCode` persistence, and no `linkedDevices` mutation.
 - `delegationSigningKey` Ed25519 generation and persistence; public component published in directory entry per spec §11.4.
 - `walletBinding` semantics implemented per spec §11.5 (LUMA never holds wallet signing keys).
 - Constant-time HMAC for verifier-side and any client-side nullifier derivation per spec §6.4 and §11.3.
@@ -289,6 +289,7 @@ Acceptance criteria:
 - Unit test: `createIdentity → signOut → createIdentity` yields the same `principalNullifier`.
 - Unit test: `createIdentity → resetIdentity → createIdentity` yields a different `principalNullifier`.
 - Unit test: `signOut` preserves `seaDevicePair`; `resetIdentity` rotates it.
+- Unit test: multi-device link stubs fail closed and do not mutate identity state.
 - Unit test: vault v1 → v2 migration is idempotent.
 - Unit test: `delegationSigningKey` public component appears in the directory entry; familiar `OnBehalfOfAssertion` validates against it.
 - Unit test: `walletBinding` Reset Identity clears the binding and a re-bind prompt is surfaced.

--- a/docs/specs/spec-identity-trust-constituency.md
+++ b/docs/specs/spec-identity-trust-constituency.md
@@ -127,6 +127,18 @@ device-bound compartments and clears old-principal delegation storage.
 - Reset Identity MUST rotate device-bound nullifier derivation material, SEA device material, and delegation signing material; clear old-principal delegation storage; and preserve historical public artifacts without implying deletion or repudiation.
 - Remote revocation (e.g., revoking a lost device's session from another device) is DEFERRED to multi-device recovery (§5) + Gold assurance.
 
+### 2.1.3.1 Multi-Device Link Deferral
+
+**Current state:** `useIdentity.linkDevice()`, `useIdentity.startLinkSession()`,
+and `useIdentity.completeLinkSession()` are compatibility stubs. They MUST fail
+closed with `luma.multidevice.deferred`, MUST NOT generate link codes, MUST NOT
+persist `pendingLinkCode`, and MUST NOT mutate `linkedDevices`.
+
+Real multi-device identity linking remains Phase 3+ work because it requires a
+cross-device identity graph and higher-assurance proof that two device-bound
+credentials belong to the same human. Product surfaces MAY show a disabled or
+deferred state, but MUST NOT present simulated linking as functional.
+
 ### 2.1.4 Timeout Semantics
 
 **Current state:** `useIdentity.checkSessionExpiry()` checks expiry at action

--- a/docs/specs/spec-luma-service-v0.md
+++ b/docs/specs/spec-luma-service-v0.md
@@ -951,7 +951,7 @@ A recorded full-product engagement run is replayed; every emitted `LumaEvent` is
 | Lazarus social recovery | Phase 2 | `recoveryKey` compartment (reserved in §11.2) |
 | Canary System | Phase 4+ | Verifier-side; outside this spec |
 | Per-human nullifier binding (cross-device) | Phase 3+ | `PrincipalId` projection rule (§3) |
-| Real multi-device linking cryptography | Phase 3+ | New SDK surface; `linkDevice` stub today |
+| Real multi-device linking cryptography | Phase 3+ | New SDK surface; current `linkDevice` / link-session app stubs fail closed and write no fake linked-device state |
 | Dynamic trust adjustment | Season 1+ | Mid-session envelope mutation (§12.6 already permits degradation) |
 | Remote session revocation | Phase 3+ | Extension of §13 + safety bulletin (§18 already supports `revokedVerifierIds` and `revokedPolicyHashes`) |
 | Federation / multi-verifier | Season 1+ | Verifier-pin set rather than single pin |
@@ -961,4 +961,4 @@ A recorded full-product engagement run is replayed; every emitted `LumaEvent` is
 | Account merging across devices | Phase 3+ | Out of scope |
 | Username squatting reclaim | Season 1+ | Out of scope |
 
-Implementations MUST NOT build features from this list without a successor spec or RFC that resolves prerequisites.
+Implementations MUST NOT build features from this list without a successor spec or RFC that resolves prerequisites. Compatibility stubs for deferred capabilities MUST fail closed and MUST NOT create fake public state, fake vault state, or UI evidence that implies the capability works.

--- a/docs/sprints/MANUAL_TEST_CHECKLIST_SPRINT3.md
+++ b/docs/sprints/MANUAL_TEST_CHECKLIST_SPRINT3.md
@@ -372,16 +372,16 @@
 
 ## Part 7: Multi-Device Sync (If Applicable)
 
-> ✅ **PARTIALLY READY:**
+> ⏸️ **DEFERRED:**
 > - Outbox subscription implemented — messages sent from other devices should sync
-> - Device linking flow exists
+> - Multi-device identity linking is deferred to LUMA Phase 3+; the current app must show a disabled/deferred state only
 > 
-> ⚠️ **Note:** Cross-device sync depends on Gun relay being online and identity propagation
+> ⚠️ **Note:** Cross-device sync depends on future identity-graph work, Gun relay availability, and identity propagation
 
-### 7.1 Device Linking
-- [ ] On primary device, locate "Link Device" option
-- [ ] On secondary device, scan QR or enter code
-- [ ] Verify devices are linked
+### 7.1 Device Linking Deferred State
+- [ ] On primary device, locate the disabled "Link Device Deferred" control
+- [ ] Verify no QR code, link code, paste-code input, or "complete link" action is exposed
+- [ ] Verify the UI states that multi-device identity linking is deferred
 
 ### 7.2 Cross-Device Message Sync
 - [ ] Send message from Device A

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "check:luma-vault-compartments": "node ./tools/scripts/check-luma-vault-compartments.mjs",
     "check:luma-delegation-signer-surface": "node ./tools/scripts/check-luma-delegation-signer-surface.mjs",
     "check:luma-identity-lifecycle": "node ./tools/scripts/check-luma-identity-lifecycle.mjs",
+    "check:luma-multidevice-stubs": "node ./tools/scripts/check-luma-multidevice-stubs.mjs",
     "report:news-sources:admission": "pnpm --filter @vh/news-aggregator report:source-admission",
     "report:news-sources:health": "NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter @vh/news-aggregator report:source-health",
     "scout:news-sources:candidates": "NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter @vh/news-aggregator report:source-scout",

--- a/packages/e2e/src/full-flow.spec.ts
+++ b/packages/e2e/src/full-flow.spec.ts
@@ -20,7 +20,7 @@ async function ensureIdentity(page: Page, username: string) {
 }
 
 test.describe('Golden Path E2E', () => {
-  test('Identity -> Attestation -> Wallet -> UBE -> Analysis -> Device Link', async ({ page }) => {
+  test('Identity -> Attestation -> Wallet -> UBE -> Analysis -> Device Link Deferred', async ({ page }) => {
     page.on('console', (msg) => console.error(`BROWSER LOG: ${msg.text()}`));
     page.on('pageerror', (err) => console.error(`BROWSER ERROR: ${err.message}`));
 
@@ -46,12 +46,9 @@ test.describe('Golden Path E2E', () => {
     await expect(page.getByText('Summary', { exact: true })).toBeVisible();
     await expect(page.getByText('Biases', { exact: true })).toBeVisible();
 
-    // Device linking (single-page flow)
-    await page.getByTestId('link-device-btn').click();
-    const linkCode = (await page.getByTestId('link-code').innerText()).trim();
-    expect(linkCode).toBeTruthy();
-    await page.getByTestId('link-input').fill(linkCode);
-    await page.getByTestId('link-complete-btn').click();
-    await expect(page.getByTestId('linked-count')).toContainText('1', { timeout: 5_000 });
+    // Multi-device linking is explicitly deferred until the LUMA Phase 3+ identity graph.
+    await expect(page.getByTestId('link-device-btn')).toBeDisabled();
+    await expect(page.getByTestId('linked-count')).toContainText('Device linking: deferred');
+    await expect(page.getByTestId('link-code')).toHaveCount(0);
   });
 });

--- a/packages/e2e/src/tracer-bullet.spec.ts
+++ b/packages/e2e/src/tracer-bullet.spec.ts
@@ -47,12 +47,10 @@ test.describe('The Tracer Bullet: E2E Integration', () => {
         await expect(page.getByText('Summary', { exact: true })).toBeVisible();
         await expect(page.getByText('Biases', { exact: true })).toBeVisible();
 
-        // 7. Link Device UI Flow
-        await page.getByTestId('link-device-btn').click();
-        const code = await page.getByTestId('link-code').innerText();
-        await page.fill('[data-testid="link-input"]', code);
-        await page.getByTestId('link-complete-btn').click();
-        await expect(page.getByTestId('linked-count')).toContainText(/Linked devices: 1/);
+        // 7. Multi-device linking is explicitly deferred until the LUMA Phase 3+ identity graph.
+        await expect(page.getByTestId('link-device-btn')).toBeDisabled();
+        await expect(page.getByTestId('linked-count')).toContainText(/Device linking: deferred/);
+        await expect(page.getByTestId('link-code')).toHaveCount(0);
 
         // 8. Verify Persistence (Reload)
         await page.reload();
@@ -60,6 +58,6 @@ test.describe('The Tracer Bullet: E2E Integration', () => {
         await expect(createIdentityBtn).not.toBeVisible();
         // Mesh should reconnect
         await expect(page.getByText(/Peers:?\s+\d+/)).toBeVisible();
-        await expect(page.getByTestId('linked-count')).toContainText(/Linked devices: 1/);
+        await expect(page.getByTestId('linked-count')).toContainText(/Device linking: deferred/);
     });
 });

--- a/tools/scripts/check-luma-multidevice-stubs.mjs
+++ b/tools/scripts/check-luma-multidevice-stubs.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const failures = [];
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(rootDir, relativePath), 'utf8');
+}
+
+function requireToken(source, token, label) {
+  if (!source.includes(token)) {
+    failures.push(`${label} is missing ${token}`);
+  }
+}
+
+function forbidToken(source, token, label) {
+  if (source.includes(token)) {
+    failures.push(`${label} still contains ${token}`);
+  }
+}
+
+const useIdentitySource = read('apps/web-pwa/src/hooks/useIdentity.ts');
+const dashboardSource = read('apps/web-pwa/src/routes/dashboardContent.tsx');
+const fullFlowSource = read('packages/e2e/src/full-flow.spec.ts');
+const tracerBulletSource = read('packages/e2e/src/tracer-bullet.spec.ts');
+const lumaSpecSource = read('docs/specs/spec-luma-service-v0.md');
+const identitySpecSource = read('docs/specs/spec-identity-trust-constituency.md');
+const statusSource = read('docs/foundational/STATUS.md');
+const sprintManualTestSource = read('docs/sprints/MANUAL_TEST_CHECKLIST_SPRINT3.md');
+
+for (const token of [
+  "MULTI_DEVICE_LINK_DEFERRED_CODE = 'luma.multidevice.deferred'",
+  'class MultiDeviceLinkDeferredError extends Error',
+  "rejectMultiDeviceLink('linkDevice')",
+  "rejectMultiDeviceLink('startLinkSession')",
+  "rejectMultiDeviceLink('completeLinkSession')"
+]) {
+  requireToken(useIdentitySource, token, 'apps/web-pwa/src/hooks/useIdentity.ts');
+}
+
+for (const token of [
+  'linkedDevices: [...',
+  'pendingLinkCode:',
+  '`link-${randomToken()}`',
+  '`device-${randomToken()}`',
+  '`linked-${randomToken()}`'
+]) {
+  forbidToken(useIdentitySource, token, 'apps/web-pwa/src/hooks/useIdentity.ts');
+}
+
+for (const token of [
+  'Device linking: deferred',
+  'data-testid="link-device-btn"',
+  'disabled',
+  'Multi-device identity linking is deferred to LUMA Phase 3+.'
+]) {
+  requireToken(dashboardSource, token, 'apps/web-pwa/src/routes/dashboardContent.tsx');
+}
+
+for (const token of [
+  'startLinkSession',
+  'completeLinkSession',
+  'data-testid="link-code"',
+  'data-testid="link-input"',
+  'data-testid="link-complete-btn"',
+  'setGeneratedCode',
+  'setIncomingCode'
+]) {
+  forbidToken(dashboardSource, token, 'apps/web-pwa/src/routes/dashboardContent.tsx');
+}
+
+for (const [label, source] of [
+  ['packages/e2e/src/full-flow.spec.ts', fullFlowSource],
+  ['packages/e2e/src/tracer-bullet.spec.ts', tracerBulletSource]
+]) {
+  requireToken(source, "getByTestId('link-device-btn')).toBeDisabled()", label);
+  requireToken(source, 'Device linking: deferred', label);
+  forbidToken(source, "getByTestId('link-complete-btn').click()", label);
+  forbidToken(source, "getByTestId('link-code').innerText()", label);
+  forbidToken(source, 'Linked devices: 1', label);
+}
+
+requireToken(lumaSpecSource, 'current `linkDevice` / link-session app stubs fail closed', 'LUMA spec deferred capability table');
+requireToken(identitySpecSource, '`luma.multidevice.deferred`', 'identity spec multi-device deferral section');
+requireToken(identitySpecSource, 'MUST NOT mutate `linkedDevices`', 'identity spec multi-device deferral section');
+requireToken(statusSource, 'Multi-device identity linking', 'foundational status LUMA table');
+requireToken(statusSource, 'fail closed; no fake linked-device state is written', 'foundational status LUMA table');
+requireToken(sprintManualTestSource, 'Device Linking Deferred State', 'Sprint 3 manual test checklist');
+requireToken(sprintManualTestSource, 'disabled "Link Device Deferred" control', 'Sprint 3 manual test checklist');
+requireToken(sprintManualTestSource, 'Verify no QR code, link code, paste-code input, or "complete link" action is exposed', 'Sprint 3 manual test checklist');
+forbidToken(sprintManualTestSource, 'Device linking flow exists', 'Sprint 3 manual test checklist');
+forbidToken(sprintManualTestSource, 'Verify devices are linked', 'Sprint 3 manual test checklist');
+
+if (failures.length > 0) {
+  console.error('[check:luma-multidevice-stubs] failed');
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log('[check:luma-multidevice-stubs] multi-device stubs fail closed');

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
       '@vh/crypto/primitives': resolve(__dirname, 'packages/crypto/src/primitives.ts'),
       '@vh/crypto/provider': resolve(__dirname, 'packages/crypto/src/provider.ts'),
       '@vh/data-model': resolve(__dirname, 'packages/data-model/src/index.ts'),
+      '@vh/ai-engine/worker?worker': resolve(__dirname, 'packages/ai-engine/src/worker.ts'),
       '@vh/ai-engine': resolve(__dirname, 'packages/ai-engine/src/index.ts'),
       '@vh/gun-client': resolve(__dirname, 'packages/gun-client/src/index.ts'),
       '@vh/identity-vault': resolve(__dirname, 'packages/identity-vault/src/index.ts'),


### PR DESCRIPTION
## Summary
- make useIdentity multi-device link methods fail closed with stable luma.multidevice.deferred errors instead of writing fake linked-device state
- replace the Dashboard Link Device flow with a disabled/deferred state and update E2E expectations
- document Phase 3+ multi-device deferral and add check:luma-multidevice-stubs guard

## Verification
- pnpm install --frozen-lockfile
- pnpm exec vitest run apps/web-pwa/src/hooks/useIdentity.test.ts apps/web-pwa/src/routes/dashboardContent.test.tsx --reporter=verbose
- pnpm check:linkability-domain-registry
- pnpm check:luma-provider-surface
- pnpm check:luma-signed-write-surface
- pnpm check:luma-vault-compartments
- pnpm check:luma-delegation-signer-surface
- pnpm check:luma-identity-lifecycle
- pnpm check:luma-multidevice-stubs
- pnpm --filter @vh/web-pwa typecheck
- pnpm --filter @vh/web-pwa build
- VITE_E2E_MODE=true pnpm --filter @vh/web-pwa build
- pnpm --filter @vh/identity-vault typecheck
- pnpm --filter @vh/identity-vault build
- pnpm --filter @vh/identity-vault test
- pnpm --filter @vh/e2e typecheck
- pnpm --filter @vh/e2e exec playwright test src/full-flow.spec.ts src/tracer-bullet.spec.ts
- pnpm docs:check
- git diff --check / git diff --check origin/main...HEAD
- node tools/scripts/check-diff-coverage.mjs

## Scope confirmations
- no public schemas or adapter write paths migrated
- no voteIntentMaterializer, mesh drill harness, relay, services, LUMA provider behavior, signed-write behavior, public identifier derivation, vault rotation semantics, or wallet binding changes
- packages/gun-client client-level linkDevice API intentionally untouched