### PR TITLE
LUMA M0.D wallet binding vault semantics

### DIFF
--- a/apps/web-pwa/src/hooks/useIdentity.test.ts
+++ b/apps/web-pwa/src/hooks/useIdentity.test.ts
@@ -9,6 +9,7 @@ import {
   loadIdentity as vaultLoad,
   clearIdentity as vaultClear,
   LEGACY_STORAGE_KEY,
+  walletBinding,
 } from '@vh/identity-vault';
 import type { Identity } from '@vh/identity-vault';
 import type { AttestationPayload } from '@vh/types';
@@ -205,6 +206,13 @@ describe('useIdentity', () => {
     useXpLedger.getState().addXp('civic', 4);
     localStorage.setItem(delegationStorageKey(firstNullifier!), '{"grants":[{"grantId":"g-1"}]}');
     useDelegationStore.getState().setActivePrincipal(firstNullifier!);
+    const firstWalletBinding = await walletBinding.save({
+      address: '0x1111111111111111111111111111111111111111',
+      chainId: '1',
+      providerKind: 'browser-injected',
+      boundPrincipalNullifier: firstNullifier!,
+      now: 1000
+    });
 
     await act(async () => {
       await result.current.signOut();
@@ -215,6 +223,7 @@ describe('useIdentity', () => {
     expect(useXpLedger.getState().activeNullifier).toBeNull();
     expect(await deviceCredential.loadOrCreate()).toEqual(firstDeviceCredential);
     expect(await delegationSigningKey.publicKey()).toEqual(firstDelegationPublicKey);
+    expect(await walletBinding.load()).toEqual(firstWalletBinding);
 
     await act(async () => {
       await result.current.createIdentity();
@@ -256,6 +265,13 @@ describe('useIdentity', () => {
     const firstDelegationPublicKey = await delegationSigningKey.publicKey();
     localStorage.setItem(delegationStorageKey(firstNullifier), '{"grants":[{"grantId":"old"}]}');
     useDelegationStore.getState().setActivePrincipal(firstNullifier);
+    await walletBinding.save({
+      address: '0x2222222222222222222222222222222222222222',
+      chainId: '31337',
+      providerKind: 'e2e-mock',
+      boundPrincipalNullifier: firstNullifier,
+      now: 1000
+    });
 
     await act(async () => {
       await result.current.resetIdentity();
@@ -265,6 +281,7 @@ describe('useIdentity', () => {
     expect(localStorage.getItem(delegationStorageKey(firstNullifier))).toBeNull();
     expect(useDelegationStore.getState().activePrincipal).toBeNull();
     expect(await vaultLoad()).toBeNull();
+    expect(await walletBinding.load()).toBeNull();
     expect(await deviceCredential.loadOrCreate()).not.toEqual(firstDeviceCredential);
     expect(await delegationSigningKey.publicKey()).not.toEqual(firstDelegationPublicKey);
     expect(pairMock).toHaveBeenCalledTimes(2);

--- a/apps/web-pwa/src/hooks/useIdentity.ts
+++ b/apps/web-pwa/src/hooks/useIdentity.ts
@@ -7,6 +7,7 @@ import { authenticateGunUser, publishDirectoryEntry, useAppStore } from '../stor
 import { getHandleError, isValidHandle } from '../utils/handle';
 import {
   clearIdentity as vaultClear,
+  clearWalletBinding,
   delegationSigningKey,
   deviceCredential,
   migrateLegacyLocalStorage,
@@ -288,6 +289,7 @@ export function useIdentity() {
     }
 
     await vaultClear().catch(() => {});
+    await clearWalletBinding().catch(() => {});
     await deviceCredential.rotate();
     await seaDevicePair.rotate(() => SEA.pair());
     await delegationSigningKey.rotateStored();

--- a/apps/web-pwa/src/hooks/useWallet.test.ts
+++ b/apps/web-pwa/src/hooks/useWallet.test.ts
@@ -9,8 +9,28 @@ const storeMock = vi.hoisted(() => ({
   isE2EMode: vi.fn()
 }));
 
+const identityProviderMock = vi.hoisted(() => ({
+  current: null as null | { session: { nullifier: string } },
+  getPublishedIdentity: vi.fn()
+}));
+
+const identityVaultMock = vi.hoisted(() => ({
+  walletBinding: {
+    load: vi.fn(),
+    save: vi.fn()
+  }
+}));
+
 vi.mock('../store', () => ({
   isE2EMode: storeMock.isE2EMode
+}));
+
+vi.mock('../store/identityProvider', () => ({
+  getPublishedIdentity: identityProviderMock.getPublishedIdentity
+}));
+
+vi.mock('@vh/identity-vault', () => ({
+  walletBinding: identityVaultMock.walletBinding
 }));
 
 const ethersHoist = vi.hoisted(() => {
@@ -21,7 +41,8 @@ const ethersHoist = vi.hoisted(() => {
   };
   const send = vi.fn();
   const getSigner = vi.fn();
-  return { contract, send, getSigner };
+  const getNetwork = vi.fn();
+  return { contract, send, getSigner, getNetwork };
 });
 
 vi.mock('ethers', async () => {
@@ -35,6 +56,7 @@ vi.mock('ethers', async () => {
     }
     send = (...args: unknown[]) => mocks.send(...args);
     getSigner = (...args: unknown[]) => mocks.getSigner(...args);
+    getNetwork = (...args: unknown[]) => mocks.getNetwork(...args);
   }
 
   class FakeJsonRpcProvider {
@@ -135,6 +157,19 @@ async function getWalletTestHelpers() {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  identityProviderMock.current = null;
+  identityProviderMock.getPublishedIdentity.mockImplementation(() => identityProviderMock.current);
+  identityVaultMock.walletBinding.load.mockResolvedValue(null);
+  identityVaultMock.walletBinding.save.mockImplementation(async (input: any) => ({
+    schemaVersion: 1,
+    address: String(input.address).toLowerCase(),
+    chainId: String(input.chainId),
+    providerKind: input.providerKind,
+    boundPrincipalNullifier: input.boundPrincipalNullifier,
+    boundAt: 1000,
+    updatedAt: 1000
+  }));
+  ethersHoist.getNetwork.mockResolvedValue({ chainId: 1n });
 });
 
 afterEach(() => {
@@ -190,6 +225,7 @@ describe('useWallet', () => {
     });
     expect(ethersMocks.send).toHaveBeenCalledWith('eth_requestAccounts', []);
     expect(result.current.account).toBe('0xabc');
+    expect(identityVaultMock.walletBinding.save).not.toHaveBeenCalled();
 
     await act(async () => {
       await result.current.refresh();
@@ -204,6 +240,45 @@ describe('useWallet', () => {
     expect(ethersMocks.contract.claim).toHaveBeenCalled();
     expect(claimWait).toHaveBeenCalled();
     await waitFor(() => expect(result.current.claimStatus?.eligible).toBe(true));
+  });
+
+  it('persists a vault wallet binding only when an active identity is published', async () => {
+    const useWallet = await loadHook({}, false);
+    const ethersMocks = await getEthersMocks();
+    const address = '0xABCDEFabcdefABCDEFabcdefABCDEFabcdefABCD';
+    identityProviderMock.current = { session: { nullifier: 'principal-1' } };
+    ethersMocks.send.mockResolvedValue([address]);
+    ethersMocks.getNetwork.mockResolvedValue({ chainId: 31337n });
+    Object.defineProperty(window, 'ethereum', { value: { ok: true }, configurable: true });
+
+    const { result } = renderHook(() => useWallet());
+
+    await waitFor(() => expect(identityVaultMock.walletBinding.load).toHaveBeenCalled());
+    await act(async () => {
+      await result.current.connect();
+    });
+
+    expect(identityVaultMock.walletBinding.save).toHaveBeenCalledWith({
+      address,
+      chainId: 31337n,
+      providerKind: 'browser-injected',
+      boundPrincipalNullifier: 'principal-1'
+    });
+    expect(result.current.walletBinding).toMatchObject({
+      address: address.toLowerCase(),
+      chainId: '31337',
+      boundPrincipalNullifier: 'principal-1'
+    });
+  });
+
+  it('fails closed when the stored wallet binding cannot be validated', async () => {
+    identityVaultMock.walletBinding.load.mockRejectedValue(new Error('Invalid walletBinding compartment'));
+    const useWallet = await loadHook({}, false);
+
+    const { result } = renderHook(() => useWallet());
+
+    await waitFor(() => expect(result.current.error).toBe('Invalid walletBinding compartment'));
+    expect(result.current.walletBinding).toBeNull();
   });
 
   it('handles connection and refresh errors gracefully', async () => {

--- a/apps/web-pwa/src/hooks/useWallet.ts
+++ b/apps/web-pwa/src/hooks/useWallet.ts
@@ -1,6 +1,9 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { BrowserProvider, Contract, JsonRpcProvider, formatUnits, parseUnits } from 'ethers';
+import { walletBinding } from '@vh/identity-vault';
 import { isE2EMode } from '../store';
+import { getPublishedIdentity } from '../store/identityProvider';
+import type { WalletBindingCompartment, WalletProviderKind } from '@vh/identity-vault';
 
 const RVU_ABI = ['function balanceOf(address account) view returns (uint256)'];
 const UBE_ABI = [
@@ -51,6 +54,7 @@ export function useWallet() {
   const [provider, setProvider] = useState<BrowserProvider | null>(null);
   const [balance, setBalance] = useState<bigint | null>(null);
   const [claimStatus, setClaimStatus] = useState<ClaimStatus | null>(null);
+  const [boundWallet, setBoundWallet] = useState<WalletBindingCompartment | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [claiming, setClaiming] = useState(false);
@@ -64,10 +68,39 @@ export function useWallet() {
 
   const hasConfig = useMemo(() => Boolean(UBE_ADDRESS && RVU_ADDRESS), []);
 
+  const refreshBinding = useCallback(async () => {
+    try {
+      setBoundWallet(await walletBinding.load());
+    } catch (err) {
+      setBoundWallet(null);
+      setError((err as Error).message);
+    }
+  }, []);
+
+  const bindCurrentIdentity = useCallback(async (input: {
+    address: string;
+    chainId: string | number | bigint;
+    providerKind: WalletProviderKind;
+  }) => {
+    const principalNullifier = getPublishedIdentity()?.session.nullifier;
+    if (!principalNullifier) {
+      setBoundWallet(null);
+      return null;
+    }
+
+    const binding = await walletBinding.save({
+      ...input,
+      boundPrincipalNullifier: principalNullifier
+    });
+    setBoundWallet(binding);
+    return binding;
+  }, []);
+
   const connect = useCallback(async () => {
     if (e2e) {
       const now = Math.floor(Date.now() / 1000);
-      setAccount('0xE2E0000000000000000000000000000000000000');
+      const address = '0xE2E0000000000000000000000000000000000000';
+      setAccount(address);
       setBalance(parseUnits('250', 18));
       setClaimStatus({
         eligible: true,
@@ -75,6 +108,11 @@ export function useWallet() {
         trustScore: 9500,
         expiresAt: now + 7 * 24 * 60 * 60,
         nullifier: MOCK_NULLIFIER
+      });
+      await bindCurrentIdentity({
+        address,
+        chainId: '31337',
+        providerKind: 'e2e-mock'
       });
       setError(null);
       return;
@@ -88,6 +126,14 @@ export function useWallet() {
       const [address] = await browserProvider.send('eth_requestAccounts', []);
       setProvider(browserProvider);
       setAccount(address);
+      if (getPublishedIdentity()?.session.nullifier) {
+        const network = await browserProvider.getNetwork();
+        await bindCurrentIdentity({
+          address,
+          chainId: network.chainId,
+          providerKind: 'browser-injected'
+        });
+      }
       setError(null);
     } catch (err) {
       setError((err as Error).message);
@@ -181,6 +227,10 @@ export function useWallet() {
     }
   }, [account, provider, refresh]);
 
+  useEffect(() => {
+    void refreshBinding();
+  }, [refreshBinding]);
+
   const formattedBalance = useMemo(() => {
     if (balance === null) return null;
     const value = Number.parseFloat(formatUnits(balance, 18));
@@ -191,6 +241,7 @@ export function useWallet() {
   return {
     account,
     balance,
+    walletBinding: boundWallet,
     formattedBalance,
     claimStatus,
     loading,
@@ -198,6 +249,7 @@ export function useWallet() {
     error,
     connect,
     refresh,
+    refreshBinding,
     claimUBE
   };
 }

--- a/apps/web-pwa/src/routes/WalletPanel.test.tsx
+++ b/apps/web-pwa/src/routes/WalletPanel.test.tsx
@@ -8,6 +8,7 @@ import '@testing-library/jest-dom/vitest';
 const lastOnClickRef = vi.hoisted(() => ({ handler: null as any }));
 const connect = vi.fn();
 const refresh = vi.fn();
+const refreshBinding = vi.fn();
 const claimUBE = vi.fn();
 
 const mockUseWallet = vi.fn();
@@ -50,8 +51,10 @@ function setupWalletState(state: Partial<ReturnType<typeof mockUseWallet>>) {
     loading: false,
     claiming: false,
     error: null,
+    walletBinding: null,
     connect,
     refresh,
+    refreshBinding,
     claimUBE,
     ...state
   });
@@ -80,8 +83,65 @@ describe('WalletPanel', () => {
   it('renders disconnected state and triggers connect', () => {
     render(<WalletPanel />);
     expect(screen.getByText(/Wallet not connected/)).toBeInTheDocument();
+    expect(screen.getByTestId('wallet-binding-status')).toHaveTextContent('Create identity before binding');
 
     fireEvent.click(screen.getByText('Connect Wallet'));
+    expect(connect).toHaveBeenCalled();
+  });
+
+  it('shows bound wallet state for the current identity', () => {
+    identityMock.identity = {
+      id: 'id',
+      createdAt: Date.now(),
+      attestation: { platform: 'web', integrityToken: 't', deviceKey: 'd', nonce: 'n' },
+      session: { token: 'tok', trustScore: 0.9, scaledTrustScore: 9000, nullifier: 'principal-1' }
+    };
+    identityMock.status = 'ready';
+    setupWalletState({
+      account: '0xABCDEFabcdefABCDEFabcdefABCDEFabcdefABCD',
+      walletBinding: {
+        schemaVersion: 1,
+        address: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd',
+        chainId: '31337',
+        providerKind: 'browser-injected',
+        boundPrincipalNullifier: 'principal-1',
+        boundAt: 1000,
+        updatedAt: 1000
+      }
+    });
+
+    render(<WalletPanel />);
+
+    expect(refreshBinding).toHaveBeenCalled();
+    expect(screen.getByTestId('wallet-binding-status')).toHaveTextContent('Bound to this identity');
+    expect(screen.queryByText('Re-bind Wallet')).not.toBeInTheDocument();
+  });
+
+  it('surfaces a re-bind prompt when wallet binding is missing or belongs to an old principal', () => {
+    identityMock.identity = {
+      id: 'id',
+      createdAt: Date.now(),
+      attestation: { platform: 'web', integrityToken: 't', deviceKey: 'd', nonce: 'n' },
+      session: { token: 'tok', trustScore: 0.9, scaledTrustScore: 9000, nullifier: 'new-principal' }
+    };
+    identityMock.status = 'ready';
+    setupWalletState({
+      account: '0x1111111111111111111111111111111111111111',
+      walletBinding: {
+        schemaVersion: 1,
+        address: '0x1111111111111111111111111111111111111111',
+        chainId: '1',
+        providerKind: 'browser-injected',
+        boundPrincipalNullifier: 'old-principal',
+        boundAt: 1000,
+        updatedAt: 1000
+      }
+    });
+
+    render(<WalletPanel />);
+
+    expect(screen.getByTestId('wallet-binding-status')).toHaveTextContent('Re-bind wallet to current identity');
+    fireEvent.click(screen.getByText('Re-bind Wallet'));
     expect(connect).toHaveBeenCalled();
   });
 

--- a/apps/web-pwa/src/routes/WalletPanel.tsx
+++ b/apps/web-pwa/src/routes/WalletPanel.tsx
@@ -37,6 +37,8 @@ export const WalletPanel: React.FC = () => {
     connect: connectWallet,
     refresh: refreshWallet,
     claimUBE,
+    walletBinding,
+    refreshBinding,
     loading: walletLoading,
     claiming: claimingUBE,
     error: walletError
@@ -46,6 +48,7 @@ export const WalletPanel: React.FC = () => {
   const { slideToPostEnabled, setSlideToPostEnabled } = useForumPreferences();
   const [localNextClaimAt, setLocalNextClaimAt] = useState<number>(0);
   const [localBalanceDelta, setLocalBalanceDelta] = useState<bigint>(0n);
+  const activePrincipal = identity?.session.nullifier ?? null;
 
   // Persist local cooldown per device to avoid accidental spam
   useEffect(() => {
@@ -64,6 +67,10 @@ export const WalletPanel: React.FC = () => {
     }
   }, [localNextClaimAt]);
 
+  useEffect(() => {
+    void refreshBinding();
+  }, [activePrincipal, refreshBinding]);
+
   const trustScoreFloat =
     identity?.session?.trustScore ??
     (identity?.session?.scaledTrustScore != null ? identity.session.scaledTrustScore / 10000 : undefined);
@@ -80,6 +87,20 @@ export const WalletPanel: React.FC = () => {
   }, [identity, claimStatus]);
   const slideToPostActive = slideToPostEnabled === true;
   const slideToPostLabel = slideToPostEnabled === null ? 'Off (default)' : slideToPostActive ? 'On' : 'Off';
+  const normalizedAccount = account ? account.toLowerCase() : null;
+  const walletBoundToCurrentIdentity = Boolean(
+    activePrincipal
+    && walletBinding?.boundPrincipalNullifier === activePrincipal
+    && (!normalizedAccount || walletBinding.address === normalizedAccount)
+  );
+  const walletBindingLabel = !activePrincipal
+    ? 'Create identity before binding'
+    : !account
+      ? 'Connect wallet to bind'
+      : walletBoundToCurrentIdentity
+        ? 'Bound to this identity'
+        : 'Re-bind wallet to current identity';
+  const walletBindingNeedsRebind = Boolean(activePrincipal && account && !walletBoundToCurrentIdentity);
 
   return (
     <div className="rounded-2xl border border-slate-200/80 bg-card p-5 shadow-sm shadow-slate-900/5 dark:border-slate-700">
@@ -89,15 +110,22 @@ export const WalletPanel: React.FC = () => {
           <p className="text-xs text-slate-600">{shortAddress(account)}</p>
         </div>
         <div className="flex gap-2">
-          {!account && (
+          {(!account || walletBindingNeedsRebind) && (
             <Button onClick={() => void connectWallet()} disabled={walletLoading}>
-              Connect Wallet
+              {account ? 'Re-bind Wallet' : 'Connect Wallet'}
             </Button>
           )}
           <Button variant="ghost" onClick={() => void refreshWallet()} disabled={walletLoading || !account}>
             {walletLoading ? 'Refreshing…' : 'Refresh'}
           </Button>
         </div>
+      </div>
+
+      <div className="mt-3 rounded-xl border border-slate-100 bg-card-muted px-3 py-2 dark:border-slate-700/70">
+        <p className="text-xs uppercase tracking-wide text-slate-500">Wallet Binding</p>
+        <p className="text-sm font-semibold text-slate-900" data-testid="wallet-binding-status">
+          {walletBindingLabel}
+        </p>
       </div>
 
       <div className="mt-3 grid gap-3 sm:grid-cols-3">

--- a/docs/foundational/STATUS.md
+++ b/docs/foundational/STATUS.md
@@ -458,6 +458,7 @@ Operational live profiles intentionally override selected flags to enable the fu
 | Session lifecycle | ✅ Feature-flagged | `packages/types/src/session-lifecycle.ts` — expiry, near-expiry, migration (`VITE_SESSION_LIFECYCLE_ENABLED`) |
 | Constituency proof verification | ✅ Feature-flagged | `packages/types/src/constituency-verification.ts` — nullifier/district/freshness checks (`VITE_CONSTITUENCY_PROOF_REAL`) |
 | Identity lifecycle controls | ✅ Active (no flag) | `useIdentity.ts` — `signOut()` preserves device-bound compartments; `resetIdentity()` rotates them; `revokeSession()` is a deprecated shim |
+| Wallet binding lifecycle | ✅ Active (no flag) | `identity-vault` + `useWallet.ts` — vault-only binding record, preserved on Sign Out, cleared on Reset Identity, re-bind prompt surfaced |
 | Multi-device identity linking | ⏸️ Deferred | `useIdentity.ts` — `linkDevice()`, `startLinkSession()`, and `completeLinkSession()` fail closed; no fake linked-device state is written |
 | Hardware TEE binding | ❌ Not implemented | No Secure Enclave/StrongBox code (Season 0 deferred §9.2) |
 | VIO liveness detection | ❌ Not implemented | No sensor fusion code (Season 0 deferred §9.2) |

--- a/docs/plans/LUMA_SERVICE_V0_ROADMAP_2026-05-02.md
+++ b/docs/plans/LUMA_SERVICE_V0_ROADMAP_2026-05-02.md
@@ -281,7 +281,7 @@ Deliverables:
 - Split `useIdentity.revokeSession()` into `signOut()` and `resetIdentity()` per spec §13.2. `revokeSession` becomes a deprecation shim calling `signOut()`.
 - Multi-device link flow (`linkDevice` / `startLinkSession` / `completeLinkSession`) explicitly stub-marked: fail closed with no fake link codes, no `pendingLinkCode` persistence, and no `linkedDevices` mutation.
 - `delegationSigningKey` Ed25519 generation and persistence; public component published in directory entry per spec §11.4.
-- `walletBinding` semantics implemented per spec §11.5 (LUMA never holds wallet signing keys).
+- `walletBinding` semantics implemented per spec §11.5: vault-only binding record, Sign Out preservation, Reset Identity clearing, and re-bind prompt (LUMA never holds wallet signing keys).
 - Constant-time HMAC for verifier-side and any client-side nullifier derivation per spec §6.4 and §11.3.
 
 Acceptance criteria:
@@ -293,6 +293,7 @@ Acceptance criteria:
 - Unit test: vault v1 → v2 migration is idempotent.
 - Unit test: `delegationSigningKey` public component appears in the directory entry; familiar `OnBehalfOfAssertion` validates against it.
 - Unit test: `walletBinding` Reset Identity clears the binding and a re-bind prompt is surfaced.
+- `pnpm check:luma-wallet-binding` confirms the typed binding surface, lifecycle wiring, UI prompt, and no wallet key/provider persistence.
 - `pnpm check:luma-production-profile` confirms only v2 vault in non-`dev` profiles.
 
 Forbidden during M0.D: cross-device per-human nullifier binding; verifier-side derivation algorithm change beyond constant-time enforcement; persisting credentials outside the vault.

--- a/docs/specs/spec-identity-trust-constituency.md
+++ b/docs/specs/spec-identity-trust-constituency.md
@@ -139,6 +139,19 @@ cross-device identity graph and higher-assurance proof that two device-bound
 credentials belong to the same human. Product surfaces MAY show a disabled or
 deferred state, but MUST NOT present simulated linking as functional.
 
+### 2.1.3.2 Wallet Binding Current State
+
+**Current state:** Wallet connection state remains in `useWallet`, but the
+identity binding record is vault-owned. `walletBinding` stores normalized
+address, decimal-string chain id, closed provider kind, bound principal
+nullifier, and timestamps. It MUST NOT store wallet private keys, signers,
+provider objects, balances, claim status, or external wallet capabilities.
+
+Sign Out preserves the binding because it preserves device-bound identity
+continuity. Reset Identity clears the binding because the previous wallet
+address was bound to the old `principalNullifier`; the wallet panel MUST surface
+a re-bind state for the new identity.
+
 ### 2.1.4 Timeout Semantics
 
 **Current state:** `useIdentity.checkSessionExpiry()` checks expiry at action

--- a/docs/specs/spec-luma-service-v0.md
+++ b/docs/specs/spec-luma-service-v0.md
@@ -482,6 +482,8 @@ Ed25519 keypair generated at first identity creation, persisted in the vault. Si
 
 `walletBinding` stores the address and connection metadata, not the wallet's signing key. External wallets (MetaMask, WalletConnect, etc.) hold their own keys; LUMA "rotate" means clear the binding record and prompt the user to re-bind on next claim. Internal wallets (if any) follow the same external-key principle: LUMA never holds wallet signing keys.
 
+Current M0.D implementation stores the binding as a typed v2 vault compartment with normalized wallet address, decimal-string `chainId`, closed provider kind, `boundPrincipalNullifier`, `boundAt`, and `updatedAt`. No wallet private key, signer, provider object, balance, claim status, or external-wallet capability is stored. `useWallet` may refresh or replace the vault record only when an active published identity exists; `WalletPanel` treats a connected wallet without a current-principal binding as "Re-bind wallet to current identity."
+
 ### 11.6 Evidence retention and zeroization
 
 | Stage | Retention | Notes |

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "check:luma-delegation-signer-surface": "node ./tools/scripts/check-luma-delegation-signer-surface.mjs",
     "check:luma-identity-lifecycle": "node ./tools/scripts/check-luma-identity-lifecycle.mjs",
     "check:luma-multidevice-stubs": "node ./tools/scripts/check-luma-multidevice-stubs.mjs",
+    "check:luma-wallet-binding": "node ./tools/scripts/check-luma-wallet-binding.mjs",
     "report:news-sources:admission": "pnpm --filter @vh/news-aggregator report:source-admission",
     "report:news-sources:health": "NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter @vh/news-aggregator report:source-health",
     "scout:news-sources:candidates": "NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter @vh/news-aggregator report:source-scout",

--- a/packages/identity-vault/src/compartments/index.ts
+++ b/packages/identity-vault/src/compartments/index.ts
@@ -26,6 +26,17 @@ export {
   type SeaDevicePairInput
 } from './seaDevicePair';
 export {
+  clearWalletBinding,
+  loadWalletBinding,
+  normalizeWalletAddress,
+  normalizeWalletChainId,
+  saveWalletBinding,
+  validateWalletBinding,
+  walletBinding,
+  walletBindingMatchesPrincipal,
+  type WalletBindingInput
+} from './walletBinding';
+export {
   base64UrlToBytes,
   bytesToBase64Url,
   randomBase64Url,

--- a/packages/identity-vault/src/compartments/walletBinding.ts
+++ b/packages/identity-vault/src/compartments/walletBinding.ts
@@ -1,0 +1,183 @@
+import type {
+  WalletBindingCompartment,
+  WalletProviderKind
+} from '../types';
+import { loadVaultV2, saveVaultV2 } from '../vault';
+import { VaultCompartmentError } from './encoding';
+
+export interface WalletBindingInput {
+  address: string;
+  chainId: string | number | bigint;
+  providerKind: WalletProviderKind;
+  boundPrincipalNullifier: string;
+  now?: number;
+}
+
+const WALLET_BINDING_KEYS = new Set([
+  'schemaVersion',
+  'address',
+  'chainId',
+  'providerKind',
+  'boundPrincipalNullifier',
+  'boundAt',
+  'updatedAt'
+]);
+
+const PROVIDER_KINDS = new Set<WalletProviderKind>([
+  'browser-injected',
+  'e2e-mock'
+]);
+
+export async function loadWalletBinding(): Promise<WalletBindingCompartment | null> {
+  const vault = await loadVaultV2();
+  if (!vault?.walletBinding) return null;
+  return validateWalletBinding(vault.walletBinding);
+}
+
+export async function saveWalletBinding(
+  input: WalletBindingInput
+): Promise<WalletBindingCompartment> {
+  const vault = await loadVaultV2();
+  const existing = vault?.walletBinding ? validateWalletBinding(vault.walletBinding) : null;
+  const now = normalizeTimestamp(input.now ?? Date.now(), 'walletBinding timestamp');
+  const candidate = buildWalletBinding(input, now, existing);
+
+  await saveVaultV2({
+    ...(vault ?? {}),
+    schemaVersion: 2,
+    walletBinding: candidate
+  });
+
+  return candidate;
+}
+
+export async function clearWalletBinding(): Promise<void> {
+  const vault = await loadVaultV2();
+  if (!vault?.walletBinding) return;
+
+  const { walletBinding: _walletBinding, ...remaining } = vault;
+  await saveVaultV2({
+    ...remaining,
+    schemaVersion: 2
+  });
+}
+
+export function walletBindingMatchesPrincipal(
+  binding: WalletBindingCompartment | null | undefined,
+  principalNullifier: string | null | undefined
+): boolean {
+  if (!binding || typeof principalNullifier !== 'string' || principalNullifier.length === 0) {
+    return false;
+  }
+  return validateWalletBinding(binding).boundPrincipalNullifier === principalNullifier;
+}
+
+export function validateWalletBinding(value: unknown): WalletBindingCompartment {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new VaultCompartmentError('Invalid walletBinding compartment');
+  }
+
+  for (const key of Object.keys(value)) {
+    if (!WALLET_BINDING_KEYS.has(key)) {
+      throw new VaultCompartmentError('Invalid walletBinding compartment');
+    }
+  }
+
+  const record = value as WalletBindingCompartment;
+  if (
+    record.schemaVersion !== 1
+    || record.address !== normalizeWalletAddress(record.address)
+    || record.chainId !== normalizeChainId(record.chainId)
+    || !PROVIDER_KINDS.has(record.providerKind)
+    || typeof record.boundPrincipalNullifier !== 'string'
+    || record.boundPrincipalNullifier.length === 0
+    || record.boundAt !== normalizeTimestamp(record.boundAt, 'walletBinding boundAt')
+    || record.updatedAt !== normalizeTimestamp(record.updatedAt, 'walletBinding updatedAt')
+    || record.updatedAt < record.boundAt
+  ) {
+    throw new VaultCompartmentError('Invalid walletBinding compartment');
+  }
+
+  return record;
+}
+
+export function normalizeWalletAddress(address: unknown): string {
+  if (typeof address !== 'string' || !/^0x[0-9a-fA-F]{40}$/.test(address)) {
+    throw new VaultCompartmentError('Invalid wallet address');
+  }
+  return address.toLowerCase();
+}
+
+export function normalizeWalletChainId(chainId: unknown): string {
+  return normalizeChainId(chainId);
+}
+
+function buildWalletBinding(
+  input: WalletBindingInput,
+  now: number,
+  existing: WalletBindingCompartment | null
+): WalletBindingCompartment {
+  const address = normalizeWalletAddress(input.address);
+  const chainId = normalizeChainId(input.chainId);
+  if (!PROVIDER_KINDS.has(input.providerKind)) {
+    throw new VaultCompartmentError('Unsupported wallet provider kind');
+  }
+  if (typeof input.boundPrincipalNullifier !== 'string' || input.boundPrincipalNullifier.length === 0) {
+    throw new VaultCompartmentError('Invalid wallet binding principal');
+  }
+
+  const sameBinding = existing
+    && existing.address === address
+    && existing.chainId === chainId
+    && existing.providerKind === input.providerKind
+    && existing.boundPrincipalNullifier === input.boundPrincipalNullifier;
+
+  return {
+    schemaVersion: 1,
+    address,
+    chainId,
+    providerKind: input.providerKind,
+    boundPrincipalNullifier: input.boundPrincipalNullifier,
+    boundAt: sameBinding ? existing.boundAt : now,
+    updatedAt: now
+  };
+}
+
+function normalizeChainId(chainId: unknown): string {
+  if (typeof chainId === 'bigint') {
+    if (chainId < 0n) {
+      throw new VaultCompartmentError('Invalid wallet chain id');
+    }
+    return chainId.toString(10);
+  }
+
+  if (typeof chainId === 'number') {
+    if (!Number.isSafeInteger(chainId) || chainId < 0) {
+      throw new VaultCompartmentError('Invalid wallet chain id');
+    }
+    return String(chainId);
+  }
+
+  if (typeof chainId === 'string' && /^(0|[1-9][0-9]*)$/.test(chainId)) {
+    return chainId;
+  }
+
+  throw new VaultCompartmentError('Invalid wallet chain id');
+}
+
+function normalizeTimestamp(value: unknown, label: string): number {
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < 0) {
+    throw new VaultCompartmentError(`Invalid ${label}`);
+  }
+  return value;
+}
+
+export const walletBinding = Object.freeze({
+  load: loadWalletBinding,
+  save: saveWalletBinding,
+  clear: clearWalletBinding,
+  matchesPrincipal: walletBindingMatchesPrincipal,
+  normalizeAddress: normalizeWalletAddress,
+  normalizeChainId: normalizeWalletChainId,
+  validate: validateWalletBinding
+});

--- a/packages/identity-vault/src/index.ts
+++ b/packages/identity-vault/src/index.ts
@@ -6,11 +6,14 @@ export type {
   JsonSafeByteEncoding,
   SeaDevicePairCompartment,
   VaultRecord,
-  VaultV2
+  VaultV2,
+  WalletBindingCompartment,
+  WalletProviderKind
 } from './types';
 export {
   LEGACY_STORAGE_KEY,
   LEGACY_VAULT_VERSION,
+  isWalletBindingCompartment,
   isValidIdentity,
   isVaultV2,
   VAULT_VERSION
@@ -27,18 +30,23 @@ export { migrateLegacyLocalStorage } from './migrate';
 export {
   base64UrlToBytes,
   bytesToBase64Url,
+  clearWalletBinding,
   delegationSigningKey,
   deviceCredential,
   getDelegationSigningPublicKey,
   loadOrCreateDelegationSigningKey,
   loadOrCreateDeviceCredential,
   loadOrCreateSeaDevicePair,
+  loadWalletBinding,
+  normalizeWalletAddress,
+  normalizeWalletChainId,
   publicDelegationSigningKey,
   randomBase64Url,
   rotateDelegationSigningKey,
   rotateDeviceCredential,
   rotateSeaDevicePair,
   rotateStoredDelegationSigningKey,
+  saveWalletBinding,
   seaDevicePair,
   signWithDelegationSigningKey,
   signWithStoredDelegationSigningKey,
@@ -47,8 +55,12 @@ export {
   validateDelegationSigningPublicKey,
   validateDeviceCredential,
   validateSeaDevicePair,
+  validateWalletBinding,
   VaultCompartmentError,
   verifyWithDelegationSigningKey,
   verifyWithDelegationSigningPublicKey,
-  type SeaDevicePairInput
+  walletBinding,
+  walletBindingMatchesPrincipal,
+  type SeaDevicePairInput,
+  type WalletBindingInput
 } from './compartments';

--- a/packages/identity-vault/src/types.ts
+++ b/packages/identity-vault/src/types.ts
@@ -45,12 +45,25 @@ export interface DelegationSigningPublicKey {
   createdAt: number;
 }
 
+export type WalletProviderKind = 'browser-injected' | 'e2e-mock';
+
+export interface WalletBindingCompartment {
+  schemaVersion: 1;
+  address: string;
+  chainId: string;
+  providerKind: WalletProviderKind;
+  boundPrincipalNullifier: string;
+  boundAt: number;
+  updatedAt: number;
+}
+
 export interface VaultV2 {
   schemaVersion: 2;
   identityRecord?: Identity;
   deviceCredential?: DeviceCredentialCompartment;
   seaDevicePair?: SeaDevicePairCompartment;
   delegationSigningKey?: DelegationSigningKeyCompartment;
+  walletBinding?: WalletBindingCompartment;
 }
 
 /**
@@ -95,6 +108,44 @@ export function isValidIdentity(value: unknown): value is Identity {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
+export function isWalletBindingCompartment(value: unknown): value is WalletBindingCompartment {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false;
+  }
+
+  const keys = Object.keys(value);
+  const allowedKeys = new Set([
+    'schemaVersion',
+    'address',
+    'chainId',
+    'providerKind',
+    'boundPrincipalNullifier',
+    'boundAt',
+    'updatedAt'
+  ]);
+  if (keys.some((key) => !allowedKeys.has(key))) {
+    return false;
+  }
+
+  const record = value as WalletBindingCompartment;
+  return (
+    record.schemaVersion === 1
+    && typeof record.address === 'string'
+    && /^0x[0-9a-f]{40}$/.test(record.address)
+    && typeof record.chainId === 'string'
+    && /^(0|[1-9][0-9]*)$/.test(record.chainId)
+    && (record.providerKind === 'browser-injected' || record.providerKind === 'e2e-mock')
+    && typeof record.boundPrincipalNullifier === 'string'
+    && record.boundPrincipalNullifier.length > 0
+    && typeof record.boundAt === 'number'
+    && Number.isSafeInteger(record.boundAt)
+    && record.boundAt >= 0
+    && typeof record.updatedAt === 'number'
+    && Number.isSafeInteger(record.updatedAt)
+    && record.updatedAt >= record.boundAt
+  );
+}
+
 export function isVaultV2(value: unknown): value is VaultV2 {
   if (
     !isValidIdentity(value)
@@ -104,5 +155,9 @@ export function isVaultV2(value: unknown): value is VaultV2 {
   }
 
   const identityRecord = (value as { identityRecord?: unknown }).identityRecord;
-  return identityRecord === undefined || isValidIdentity(identityRecord);
+  const walletBinding = (value as { walletBinding?: unknown }).walletBinding;
+  return (
+    (identityRecord === undefined || isValidIdentity(identityRecord))
+    && (walletBinding === undefined || isWalletBindingCompartment(walletBinding))
+  );
 }

--- a/packages/identity-vault/src/vault.test.ts
+++ b/packages/identity-vault/src/vault.test.ts
@@ -17,6 +17,7 @@ import {
   IDENTITY_KEY,
   MASTER_KEY,
   LEGACY_STORAGE_KEY,
+  isWalletBindingCompartment,
   LEGACY_VAULT_VERSION,
   VAULT_VERSION
 } from './types';
@@ -28,10 +29,12 @@ import {
   deviceCredential,
   randomBase64Url,
   seaDevicePair,
+  validateWalletBinding,
   validateDelegationSigningKey,
   validateDelegationSigningPublicKey,
   validateDeviceCredential,
   validateSeaDevicePair,
+  walletBinding,
   VaultCompartmentError
 } from './compartments';
 
@@ -707,6 +710,165 @@ describe('M0.D-1 vault v2 compartments', () => {
       ...key,
       createdAt: -1
     })).toThrow(VaultCompartmentError);
+  });
+
+  it('saves, loads, updates, and clears JSON-safe wallet binding records', async () => {
+    await expect(walletBinding.clear()).resolves.toBeUndefined();
+
+    await saveIdentity(LEGACY_IDENTITY);
+    await expect(walletBinding.clear()).resolves.toBeUndefined();
+
+    const first = await walletBinding.save({
+      address: '0xABCDEFabcdefABCDEFabcdefABCDEFabcdefABCD',
+      chainId: 31337n,
+      providerKind: 'browser-injected',
+      boundPrincipalNullifier: 'principal-1',
+      now: 1000
+    });
+
+    expect(first).toEqual({
+      schemaVersion: 1,
+      address: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd',
+      chainId: '31337',
+      providerKind: 'browser-injected',
+      boundPrincipalNullifier: 'principal-1',
+      boundAt: 1000,
+      updatedAt: 1000
+    });
+    expect(await walletBinding.load()).toEqual(first);
+    expect(walletBinding.matchesPrincipal(first, 'principal-1')).toBe(true);
+    expect(JSON.parse(JSON.stringify(await loadVaultV2()))?.walletBinding).toEqual(first);
+
+    const updated = await walletBinding.save({
+      address: first.address,
+      chainId: first.chainId,
+      providerKind: first.providerKind,
+      boundPrincipalNullifier: first.boundPrincipalNullifier,
+      now: 1500
+    });
+    expect(updated.boundAt).toBe(1000);
+    expect(updated.updatedAt).toBe(1500);
+
+    await walletBinding.clear();
+    const vault = await loadVaultV2();
+    expect(vault?.identityRecord).toEqual(LEGACY_IDENTITY);
+    expect(vault?.walletBinding).toBeUndefined();
+    expect(await walletBinding.load()).toBeNull();
+  });
+
+  it('rejects invalid wallet binding shape and private-key-shaped records', async () => {
+    const valid = await walletBinding.save({
+      address: '0x1111111111111111111111111111111111111111',
+      chainId: '1',
+      providerKind: 'e2e-mock',
+      boundPrincipalNullifier: 'principal-wallet',
+      now: 2000
+    });
+
+    expect(() => validateWalletBinding({
+      ...valid,
+      privateKey: 'do-not-store'
+    })).toThrow(VaultCompartmentError);
+    expect(() => validateWalletBinding({
+      ...valid,
+      provider: { request() {} }
+    })).toThrow(VaultCompartmentError);
+    expect(() => validateWalletBinding({
+      ...valid,
+      signer: { signMessage() {} }
+    })).toThrow(VaultCompartmentError);
+    expect(() => validateWalletBinding(null)).toThrow(VaultCompartmentError);
+    expect(() => validateWalletBinding([])).toThrow(VaultCompartmentError);
+    expect(() => validateWalletBinding({
+      ...valid,
+      updatedAt: valid.boundAt - 1
+    })).toThrow(VaultCompartmentError);
+    expect(walletBinding.matchesPrincipal(null, 'principal-wallet')).toBe(false);
+    expect(walletBinding.matchesPrincipal(valid, null)).toBe(false);
+    expect(walletBinding.normalizeChainId('31337')).toBe('31337');
+    expect(walletBinding.normalizeChainId(31337)).toBe('31337');
+    expect(() => walletBinding.normalizeChainId(-1n)).toThrow(VaultCompartmentError);
+    expect(() => walletBinding.normalizeChainId(-1)).toThrow(VaultCompartmentError);
+    expect(() => walletBinding.normalizeChainId(1.5)).toThrow(VaultCompartmentError);
+    expect(() => validateWalletBinding({
+      ...valid,
+      boundAt: -1
+    })).toThrow(VaultCompartmentError);
+    await expect(walletBinding.save({
+      address: '0xabc',
+      chainId: '1',
+      providerKind: 'browser-injected',
+      boundPrincipalNullifier: 'principal-wallet'
+    })).rejects.toThrow(VaultCompartmentError);
+    await expect(walletBinding.save({
+      address: valid.address,
+      chainId: '01',
+      providerKind: 'browser-injected',
+      boundPrincipalNullifier: 'principal-wallet'
+    })).rejects.toThrow(VaultCompartmentError);
+    await expect(walletBinding.save({
+      address: valid.address,
+      chainId: '1',
+      providerKind: 'wallet-connect' as never,
+      boundPrincipalNullifier: 'principal-wallet'
+    })).rejects.toThrow(VaultCompartmentError);
+    await expect(walletBinding.save({
+      address: valid.address,
+      chainId: '1',
+      providerKind: 'browser-injected',
+      boundPrincipalNullifier: ''
+    })).rejects.toThrow(VaultCompartmentError);
+    await expect(walletBinding.save({
+      address: valid.address,
+      chainId: '1',
+      providerKind: 'browser-injected',
+      boundPrincipalNullifier: 'principal-wallet',
+      now: -1
+    })).rejects.toThrow(VaultCompartmentError);
+  });
+
+  it('fails closed when a v2 vault contains a malformed wallet binding compartment', async () => {
+    await writeEncryptedVaultRecord(VAULT_VERSION, {
+      schemaVersion: 2,
+      identityRecord: LEGACY_IDENTITY,
+      walletBinding: {
+        schemaVersion: 1,
+        address: '0x2222222222222222222222222222222222222222',
+        chainId: '1',
+        providerKind: 'browser-injected',
+        boundPrincipalNullifier: 'principal-wallet',
+        boundAt: 1,
+        updatedAt: 1,
+        privateKey: 'leak'
+      }
+    });
+
+    await expect(loadVaultV2()).resolves.toBeNull();
+
+    const db = await openVaultDb();
+    const remaining = await idbGet<VaultRecord>(db, VAULT_STORE, IDENTITY_KEY);
+    db.close();
+    expect(remaining).toBeUndefined();
+  });
+
+  it('rejects malformed wallet binding compartments through v2 shape guards and public writers', async () => {
+    expect(isWalletBindingCompartment(null)).toBe(false);
+    expect(isWalletBindingCompartment([])).toBe(false);
+
+    await writeEncryptedVaultRecord(VAULT_VERSION, {
+      schemaVersion: 2,
+      identityRecord: LEGACY_IDENTITY,
+      walletBinding: []
+    });
+    await expect(loadVaultV2()).resolves.toBeNull();
+
+    await saveIdentity(LEGACY_IDENTITY);
+    await expect(saveVaultV2({
+      schemaVersion: 2,
+      identityRecord: LEGACY_IDENTITY,
+      walletBinding: [] as never
+    })).resolves.toBeUndefined();
+    expect(await loadIdentity()).toEqual(LEGACY_IDENTITY);
   });
 
   it('fails closed when Ed25519 key generation returns an invalid shape', async () => {

--- a/packages/identity-vault/src/vault.ts
+++ b/packages/identity-vault/src/vault.ts
@@ -14,13 +14,15 @@ import {
   LEGACY_VAULT_VERSION,
   isValidIdentity,
   isVaultV2,
+  isWalletBindingCompartment,
 } from './types';
 import type {
   DeviceCredentialCompartment,
   Identity,
   SeaDevicePairCompartment,
   VaultRecord,
-  VaultV2
+  VaultV2,
+  WalletBindingCompartment
 } from './types';
 
 const encoder = new TextEncoder();
@@ -259,13 +261,18 @@ function normalizeVaultV2(vault: VaultV2): VaultV2 {
   if (identityRecord !== undefined && !isValidIdentity(identityRecord)) {
     throw new Error('Invalid v2 identityRecord compartment');
   }
+  const walletBinding = vault.walletBinding;
+  if (walletBinding !== undefined && !isWalletBindingCompartment(walletBinding)) {
+    throw new Error('Invalid v2 walletBinding compartment');
+  }
 
   return {
     schemaVersion: VAULT_VERSION,
     ...(identityRecord !== undefined ? { identityRecord } : {}),
     ...(vault.deviceCredential ? { deviceCredential: vault.deviceCredential } : {}),
     ...(vault.seaDevicePair ? { seaDevicePair: vault.seaDevicePair } : {}),
-    ...(vault.delegationSigningKey ? { delegationSigningKey: vault.delegationSigningKey } : {})
+    ...(vault.delegationSigningKey ? { delegationSigningKey: vault.delegationSigningKey } : {}),
+    ...(walletBinding ? { walletBinding: walletBinding as WalletBindingCompartment } : {})
   };
 }
 

--- a/tools/scripts/check-luma-wallet-binding.mjs
+++ b/tools/scripts/check-luma-wallet-binding.mjs
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const failures = [];
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(rootDir, relativePath), 'utf8');
+}
+
+function requireToken(source, token, label) {
+  if (!source.includes(token)) {
+    failures.push(`${label} is missing ${token}`);
+  }
+}
+
+const typesSource = read('packages/identity-vault/src/types.ts');
+const vaultSource = read('packages/identity-vault/src/vault.ts');
+const indexSource = read('packages/identity-vault/src/index.ts');
+const walletBindingSource = read('packages/identity-vault/src/compartments/walletBinding.ts');
+const compartmentsIndexSource = read('packages/identity-vault/src/compartments/index.ts');
+const useWalletSource = read('apps/web-pwa/src/hooks/useWallet.ts');
+const walletPanelSource = read('apps/web-pwa/src/routes/WalletPanel.tsx');
+const useIdentitySource = read('apps/web-pwa/src/hooks/useIdentity.ts');
+const vaultTestSource = read('packages/identity-vault/src/vault.test.ts');
+const useWalletTestSource = read('apps/web-pwa/src/hooks/useWallet.test.ts');
+const walletPanelTestSource = read('apps/web-pwa/src/routes/WalletPanel.test.tsx');
+const useIdentityTestSource = read('apps/web-pwa/src/hooks/useIdentity.test.ts');
+const lumaSpecSource = read('docs/specs/spec-luma-service-v0.md');
+const identitySpecSource = read('docs/specs/spec-identity-trust-constituency.md');
+const roadmapSource = read('docs/plans/LUMA_SERVICE_V0_ROADMAP_2026-05-02.md');
+const statusSource = read('docs/foundational/STATUS.md');
+
+for (const token of [
+  'WalletBindingCompartment',
+  'WalletProviderKind',
+  'walletBinding?: WalletBindingCompartment',
+  'isWalletBindingCompartment'
+]) {
+  requireToken(typesSource, token, 'packages/identity-vault/src/types.ts');
+}
+
+const walletBindingInterface = typesSource.slice(
+  typesSource.indexOf('export interface WalletBindingCompartment'),
+  typesSource.indexOf('export interface VaultV2')
+);
+for (const forbidden of ['privateKey', 'signer', 'provider:', 'balance', 'claimStatus']) {
+  if (walletBindingInterface.includes(forbidden)) {
+    failures.push(`WalletBindingCompartment includes forbidden wallet custody/runtime field ${forbidden}`);
+  }
+}
+
+for (const token of [
+  'loadWalletBinding',
+  'saveWalletBinding',
+  'clearWalletBinding',
+  'validateWalletBinding',
+  'normalizeWalletAddress',
+  'normalizeWalletChainId'
+]) {
+  requireToken(walletBindingSource, token, 'walletBinding compartment helper');
+  requireToken(compartmentsIndexSource, token, 'compartment index exports');
+}
+
+for (const token of [
+  'boundPrincipalNullifier',
+  "'browser-injected'",
+  "'e2e-mock'"
+]) {
+  requireToken(walletBindingSource, token, 'walletBinding compartment helper');
+}
+
+for (const token of [
+  'walletBinding',
+  'loadWalletBinding',
+  'saveWalletBinding',
+  'clearWalletBinding',
+  'WalletBindingCompartment',
+  'WalletProviderKind'
+]) {
+  requireToken(indexSource, token, 'packages/identity-vault/src/index.ts');
+}
+
+requireToken(vaultSource, 'isWalletBindingCompartment', 'vault v2 validation');
+requireToken(vaultSource, 'walletBinding: walletBinding as WalletBindingCompartment', 'vault v2 normalization');
+requireToken(vaultSource, 'const { identityRecord: _identityRecord, ...stableCompartments } = vault', 'clearIdentity stable-compartment preservation');
+
+for (const token of [
+  "import { walletBinding } from '@vh/identity-vault'",
+  "import { getPublishedIdentity } from '../store/identityProvider'",
+  'boundPrincipalNullifier: principalNullifier',
+  "providerKind: 'browser-injected'",
+  "providerKind: 'e2e-mock'",
+  'setBoundWallet(binding)'
+]) {
+  requireToken(useWalletSource, token, 'apps/web-pwa/src/hooks/useWallet.ts');
+}
+
+for (const forbiddenPattern of [
+  /safeSetItem\([^)]*wallet/i,
+  /localStorage\.setItem\([^)]*wallet/i,
+  /privateKey/i,
+  /getSigner\(\)[\s\S]*walletBinding\.save/
+]) {
+  if (forbiddenPattern.test(useWalletSource)) {
+    failures.push(`useWallet contains forbidden wallet binding persistence/custody pattern ${forbiddenPattern}`);
+  }
+}
+
+for (const token of [
+  'clearWalletBinding',
+  'await clearWalletBinding().catch(() => {})'
+]) {
+  requireToken(useIdentitySource, token, 'apps/web-pwa/src/hooks/useIdentity.ts');
+}
+
+for (const token of [
+  'wallet-binding-status',
+  'Re-bind wallet to current identity',
+  'Re-bind Wallet',
+  'refreshBinding()'
+]) {
+  requireToken(walletPanelSource, token, 'apps/web-pwa/src/routes/WalletPanel.tsx');
+}
+
+for (const token of [
+  'saves, loads, updates, and clears JSON-safe wallet binding records',
+  'rejects invalid wallet binding shape and private-key-shaped records',
+  'fails closed when a v2 vault contains a malformed wallet binding compartment'
+]) {
+  requireToken(vaultTestSource, token, 'identity-vault wallet binding tests');
+}
+
+for (const token of [
+  'persists a vault wallet binding only when an active identity is published',
+  'fails closed when the stored wallet binding cannot be validated'
+]) {
+  requireToken(useWalletTestSource, token, 'useWallet wallet binding tests');
+}
+
+for (const token of [
+  'shows bound wallet state for the current identity',
+  'surfaces a re-bind prompt when wallet binding is missing or belongs to an old principal'
+]) {
+  requireToken(walletPanelTestSource, token, 'WalletPanel wallet binding tests');
+}
+
+for (const token of [
+  'walletBinding.save',
+  'expect(await walletBinding.load()).toEqual(firstWalletBinding)',
+  'expect(await walletBinding.load()).toBeNull()'
+]) {
+  requireToken(useIdentityTestSource, token, 'useIdentity wallet binding lifecycle tests');
+}
+
+for (const token of [
+  'decimal-string `chainId`',
+  'No wallet private key, signer, provider object, balance, claim status, or external-wallet capability is stored',
+  'Re-bind wallet to current identity'
+]) {
+  requireToken(lumaSpecSource, token, 'LUMA wallet binding spec');
+}
+
+requireToken(identitySpecSource, 'Wallet Binding Current State', 'identity spec wallet binding section');
+requireToken(roadmapSource, 'check:luma-wallet-binding', 'LUMA roadmap wallet binding gate');
+requireToken(statusSource, 'Wallet binding lifecycle', 'foundational status wallet binding row');
+
+if (failures.length > 0) {
+  console.error('[check:luma-wallet-binding] failed');
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log('[check:luma-wallet-binding] wallet binding surface ok');


### PR DESCRIPTION
## Summary
- add a typed vault v2 walletBinding compartment with closed provider kinds, normalized addresses, decimal-string chain IDs, and fail-closed validation
- wire useWallet/WalletPanel to bind only against an active published identity, preserve binding on Sign Out, clear it on Reset Identity, and surface re-bind state
- add check:luma-wallet-binding plus docs/tests for the M0.D wallet binding lifecycle contract

## Verification
- pnpm exec vitest run packages/identity-vault/src/vault.test.ts apps/web-pwa/src/hooks/useWallet.test.ts apps/web-pwa/src/routes/WalletPanel.test.tsx apps/web-pwa/src/hooks/useIdentity.test.ts --reporter=verbose
- pnpm --filter @vh/identity-vault test
- pnpm --filter @vh/identity-vault typecheck
- pnpm --filter @vh/identity-vault build
- pnpm --filter @vh/web-pwa typecheck
- pnpm --filter @vh/web-pwa build
- VITE_E2E_MODE=true pnpm --filter @vh/web-pwa build
- pnpm check:linkability-domain-registry
- pnpm check:luma-provider-surface
- pnpm check:luma-signed-write-surface
- pnpm check:luma-vault-compartments
- pnpm check:luma-delegation-signer-surface
- pnpm check:luma-identity-lifecycle
- pnpm check:luma-multidevice-stubs
- pnpm check:luma-wallet-binding
- pnpm docs:check
- git diff --check
- git diff --check origin/main...HEAD
- node tools/scripts/check-diff-coverage.mjs

## Scope confirmation
- no public schemas or adapter write paths migrated
- no changes to packages/data-model, packages/gun-client, voteIntentMaterializer, mesh drills, relay, services, LUMA provider behavior, signed-write behavior, public identifier derivation, multi-device stubs, verifier derivation, or wallet private-key custody