### PR TITLE
Mesh Slice 11A production-readiness gate

### DIFF
--- a/docs/ops/mesh-production-topology-drills.md
+++ b/docs/ops/mesh-production-topology-drills.md
@@ -293,6 +293,8 @@ pnpm check:mesh:production-readiness
 The aggregate command reruns the implemented mesh proof commands, copies each
 source `.tmp/mesh-production-readiness/latest/*` packet before the next command
 overwrites it, and writes a new aggregate packet to the stable latest path. The
+validator requires each copied source report to match the expected gate command,
+run mode, commit, clean-state policy, and current gate-run timestamp window. The
 packet includes `mesh-production-readiness-report.json`,
 `mesh-production-readiness-evidence.md`, and copied source reports under
 `source-reports/<gate>/`.

--- a/docs/ops/mesh-production-topology-drills.md
+++ b/docs/ops/mesh-production-topology-drills.md
@@ -284,6 +284,28 @@ This command proves only bounded local synthetic soak behavior under
 classes, public WSS infrastructure, evidence promotion, or the full
 `pnpm check:mesh:production-readiness` gate.
 
+Run the aggregate production-readiness gate with:
+
+```bash
+pnpm check:mesh:production-readiness
+```
+
+The aggregate command reruns the implemented mesh proof commands, copies each
+source `.tmp/mesh-production-readiness/latest/*` packet before the next command
+overwrites it, and writes a new aggregate packet to the stable latest path. The
+packet includes `mesh-production-readiness-report.json`,
+`mesh-production-readiness-evidence.md`, and copied source reports under
+`source-reports/<gate>/`.
+
+For Slice 11A, a successful aggregate command still reports
+`status: review_required` while release blockers remain. Expected blockers
+include the canonical 30-minute soak, public WSS deployment proof, full
+clock-skew matrix, conflict-resolution fixtures, evidence scrub promotion,
+downstream full-app canary, and LUMA-gated write coverage through the LUMA
+reader path. The command exits non-zero for missing, malformed, dirty, stale, or
+failed source evidence, and for any overclaiming packet that would emit
+`release_ready` before the blockers are gone.
+
 `VH_RELAY_PEER_AUTH_MODE=private_network_allowlist` is a local/private-network
 harness mode. Because Gun relay and browser clients share the `/gun` WebSocket
 path in this server, public production WSS rollout still needs a trust path
@@ -292,10 +314,10 @@ client-compatible signed peer handshake.
 
 ## Review Boundary
 
-The report status remains `review_required` for Slice 6B/7B/7C/8/9/9B/10 even when the
+The report status remains `review_required` for Slice 6B/7B/7C/8/9/9B/10/11A even when the
 local restarted-relay drill, deployed-WSS local TLS profile, state-resolution
 drill, disconnect drill, partition/heal drill, read-repair drill, and bounded
-rolling-restart soak pass. A passing
+rolling-restart soak pass and the aggregate evidence packet is well formed. A passing
 restarted-relay section means only that the restarted local relay directly read
 the missed synthetic drill write inside this bounded harness. A passing
 deployed-WSS section means only that the local TLS/WSS profile, signed WSS
@@ -314,7 +336,9 @@ synthetic drill records missed by relay B were repaired through explicit replay
 from surviving-quorum direct readback. A passing bounded soak section means only
 that deterministic synthetic local-harness restart/reconnect rows met their
 recorded budgets; if `soak.full_duration_satisfied` is false it is not the
-canonical 30-minute soak claim. Neither outcome proves public WSS
+canonical 30-minute soak claim. A passing aggregate section means only that the
+implemented source reports were collected, validated, copied, and summarized in
+one operator packet. None of these outcomes proves public WSS
 infrastructure, automatic peer-federation recovery, LUMA-gated write state
 resolution, the full clock-skew matrix, evidence scrub promotion, or post-M0.B
 LUMA-gated write coverage.

--- a/docs/specs/spec-mesh-production-readiness.md
+++ b/docs/specs/spec-mesh-production-readiness.md
@@ -482,7 +482,8 @@ Regression traps:
 
 ### Slice 6 - Production Topology Harness And Deployment
 
-Status: Queued.
+Status: Implemented through the local topology harness, signed peer-config
+canary, and local TLS/WSS deployment-shape proof commands.
 
 Purpose:
 
@@ -1040,7 +1041,9 @@ without replacing it with a more specific one.
 
 ### Slice 11 - Release Gate And Evidence Packet
 
-Status: Queued.
+Status: Implemented as an aggregate evidence-packet scaffold. The command
+produces a complete `review_required` packet when implemented proof commands
+pass but release-ready blockers remain.
 
 Purpose:
 
@@ -1085,7 +1088,8 @@ interface MeshProductionReadinessReport {
       | 'deployed_wss_topology'
       | 'local_partition_heal_topology'
       | 'local_read_repair_strategy'
-      | 'local_rolling_restart_soak';
+      | 'local_rolling_restart_soak'
+      | 'aggregate_production_readiness';
     deployment_scope?: 'local_tls_wss_profile' | 'public_wss_deployment';
     started_at: string;
     completed_at: string;
@@ -1326,6 +1330,9 @@ Acceptance gates:
 - New command: `pnpm check:mesh:production-readiness`
 - Report writes to a stable latest path, for example:
   `.tmp/mesh-production-readiness/latest/mesh-production-readiness-report.json`
+- The command exits `0` when all implemented source proof commands pass and the
+  aggregate truthfully records `review_required` blockers. It exits non-zero
+  for malformed, missing, stale, dirty, failed, or overclaiming source evidence.
 - Release-ready means:
   - report repo metadata identifies branch, commit, base ref, and dirty state
   - report has a `run_id` and every drill write has a joinable `write_id` and
@@ -1995,12 +2002,12 @@ Implemented mesh commands:
 - `pnpm test:mesh:partition-drills`
 - `pnpm test:mesh:read-repair-drills`
 - `pnpm test:mesh:soak`
+- `pnpm check:mesh:production-readiness`
 
 Required new commands:
 
 - `pnpm test:mesh:clock-skew-drills`
 - `pnpm test:mesh:conflict-drills`
-- `pnpm check:mesh:production-readiness`
 - `pnpm check:production-app-canary`
 - `pnpm check:mesh-evidence-scrub` (gates promotion of `.tmp` packets to
   `docs/reports/evidence/`; see §5.7.1)
@@ -2122,6 +2129,24 @@ Still not allowed after Slice 10 shortened rolling-restart soak proof:
 - "LUMA-gated production write classes are soak-proven."
 - "Public WSS infrastructure is soak-proven."
 - "The mesh has production-ready multi-relay failover."
+- "The app is ready for a test group."
+
+Allowed after Slice 11A aggregate evidence-packet proof:
+
+- "`pnpm check:mesh:production-readiness` can rerun the implemented mesh proof
+  commands and copy their source reports into one operator-facing aggregate
+  packet."
+- "The aggregate packet names the current `review_required` blockers instead of
+  relying on scattered one-off drill reports."
+
+Still not allowed after Slice 11A aggregate evidence-packet proof:
+
+- "The mesh is `release_ready`."
+- "The default shortened local command satisfies the canonical thirty-minute
+  soak claim."
+- "Public WSS infrastructure is production-proven."
+- "The full clock-skew matrix is production-ready."
+- "LUMA-gated production write classes are mesh-readiness-proven."
 - "The app is ready for a test group."
 
 Allowed after Slices 6B through 12 pass (under `schema_epoch:

--- a/docs/specs/spec-mesh-production-readiness.md
+++ b/docs/specs/spec-mesh-production-readiness.md
@@ -1166,6 +1166,27 @@ interface MeshProductionReadinessReport {
       post_repair_direct_readback_passed: boolean;
     };
   };
+  source_reports?: Array<{
+    id: string;
+    name: string;
+    command: string;
+    status: 'pass' | 'fail';
+    result_status: 'release_ready' | 'review_required' | 'blocked' | 'missing';
+    run_id: string | null;
+    run_mode: string | null;
+    run_command: string | null;
+    source_completed_at: string | null;
+    schema_epoch: string | null;
+    luma_profile: string | null;
+    repo_dirty: boolean | null;
+    report_path: string;
+    failures: string[];
+  }>;
+  release_readiness_blockers?: Array<{
+    id: string;
+    command: string;
+    reason: string;
+  }>;
   gates: Array<{
     name: string;
     status: 'pass' | 'fail' | 'skipped';
@@ -1333,6 +1354,9 @@ Acceptance gates:
 - The command exits `0` when all implemented source proof commands pass and the
   aggregate truthfully records `review_required` blockers. It exits non-zero
   for malformed, missing, stale, dirty, failed, or overclaiming source evidence.
+  Each copied source report must match the expected gate command, run mode,
+  current commit, clean-state policy, and the current aggregate gate-run
+  timestamp window.
 - Release-ready means:
   - report repo metadata identifies branch, commit, base ref, and dirty state
   - report has a `run_id` and every drill write has a joinable `write_id` and

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "test:mesh:partition-drills": "pnpm --filter @vh/e2e test:mesh:partition-drills",
     "test:mesh:read-repair-drills": "pnpm --filter @vh/e2e test:mesh:read-repair-drills",
     "test:mesh:soak": "pnpm --filter @vh/e2e test:mesh:soak",
+    "check:mesh:production-readiness": "pnpm --filter @vh/e2e check:mesh:production-readiness",
     "test:storycluster:smoke": "pnpm --filter @vh/e2e test:live:daemon-feed:build && pnpm --filter @vh/e2e test:live:daemon-feed:semantic-soak",
     "test:storycluster:smoke:readiness": "pnpm --filter @vh/e2e test:live:daemon-feed:build && (pnpm --filter @vh/e2e test:live:daemon-feed:semantic-soak || true) && pnpm --filter @vh/e2e test:live:daemon-feed:semantic-soak:readiness",
     "collect:storycluster:headline-soak": "pnpm report:news-sources:health && pnpm test:storycluster:smoke:readiness",

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -32,6 +32,7 @@
     "test:mesh:partition-drills": "node ./src/mesh/partition-drills.mjs",
     "test:mesh:read-repair-drills": "node ./src/mesh/read-repair-drills.mjs",
     "test:mesh:soak": "node ./src/mesh/soak-drills.mjs",
+    "check:mesh:production-readiness": "node ./src/mesh/production-readiness-check.mjs",
     "report:live:daemon-feed:fixture-candidate-intake": "node ./src/live/daemon-feed-fixture-candidate-intake.mjs",
     "report:offline-cluster-replay": "node ./src/live/daemon-feed-semantic-soak-offline-replay-report.mjs",
     "report:live:daemon-feed:production-readiness": "node ./src/live/storycluster-production-readiness.mjs",

--- a/packages/e2e/src/mesh/production-readiness-check.mjs
+++ b/packages/e2e/src/mesh/production-readiness-check.mjs
@@ -1,0 +1,654 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '../../../..');
+const latestDir = path.join(repoRoot, '.tmp/mesh-production-readiness/latest');
+
+const SOURCE_GATES = [
+  {
+    id: 'topology',
+    name: 'local production topology',
+    command: ['pnpm', 'test:mesh:topology-drills'],
+    expectedMode: 'local_production_topology',
+  },
+  {
+    id: 'signed_peer_config',
+    name: 'signed peer-config browser boot',
+    command: ['pnpm', 'test:mesh:signed-peer-config-canary'],
+    expectedMode: 'local_signed_peer_config_browser_boot',
+  },
+  {
+    id: 'deployed_wss',
+    name: 'deployed WSS local TLS profile',
+    command: ['pnpm', 'test:mesh:deployed-wss-peer-config'],
+    expectedMode: 'deployed_wss_topology',
+  },
+  {
+    id: 'state_resolution',
+    name: 'state-resolution matrix',
+    command: ['pnpm', 'test:mesh:state-resolution-drills'],
+    expectedMode: 'local_production_topology',
+  },
+  {
+    id: 'disconnect',
+    name: 'disconnect duplicate-write drills',
+    command: ['pnpm', 'test:mesh:disconnect-drills'],
+    expectedMode: 'local_production_topology',
+  },
+  {
+    id: 'partition',
+    name: 'partition/heal topology',
+    command: ['pnpm', 'test:mesh:partition-drills'],
+    expectedMode: 'local_partition_heal_topology',
+  },
+  {
+    id: 'read_repair',
+    name: 'explicit read-repair strategy',
+    command: ['pnpm', 'test:mesh:read-repair-drills'],
+    expectedMode: 'local_read_repair_strategy',
+  },
+  {
+    id: 'soak',
+    name: 'bounded rolling restart soak',
+    command: ['pnpm', 'test:mesh:soak'],
+    expectedMode: 'local_rolling_restart_soak',
+  },
+];
+
+function nowIsoCompact(date = new Date()) {
+  return date.toISOString().replaceAll('-', '').replaceAll(':', '').replace(/\.\d{3}Z$/, 'Z');
+}
+
+function makeId(prefix) {
+  return `${prefix}-${nowIsoCompact()}-${crypto.randomBytes(4).toString('hex')}`;
+}
+
+function runGit(args) {
+  const result = spawnSync('git', args, {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  });
+  return result.status === 0 ? result.stdout.trim() : '';
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function copyDir(src, dest) {
+  fs.rmSync(dest, { recursive: true, force: true });
+  if (!fs.existsSync(src)) return;
+  fs.mkdirSync(dest, { recursive: true });
+  for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
+    const sourcePath = path.join(src, entry.name);
+    const destPath = path.join(dest, entry.name);
+    if (entry.isDirectory()) {
+      copyDir(sourcePath, destPath);
+    } else if (entry.isFile()) {
+      fs.copyFileSync(sourcePath, destPath);
+    }
+  }
+}
+
+function commandText(command) {
+  return command.join(' ');
+}
+
+function hasScript(scriptName) {
+  try {
+    const rootPackage = readJson(path.join(repoRoot, 'package.json'));
+    return Boolean(rootPackage.scripts?.[scriptName]);
+  } catch {
+    return false;
+  }
+}
+
+function unique(values) {
+  return [...new Set(values.filter((value) => value !== undefined && value !== null && value !== ''))];
+}
+
+function mergeMaps(objects) {
+  return Object.assign({}, ...objects.filter((value) => value && typeof value === 'object'));
+}
+
+function maxFinite(values, fallback = 0) {
+  const finite = values.filter((value) => Number.isFinite(value));
+  return finite.length ? Math.max(...finite) : fallback;
+}
+
+function sumFinite(values) {
+  return values.filter((value) => Number.isFinite(value)).reduce((sum, value) => sum + value, 0);
+}
+
+function normalizeReportRows(sources, field) {
+  return sources.flatMap((source) => {
+    const rows = Array.isArray(source.report?.[field]) ? source.report[field] : [];
+    return rows.map((row) => ({
+      ...row,
+      source_gate: source.id,
+      source_run_id: source.report?.run_id || null,
+    }));
+  });
+}
+
+function reportPathForSource(sourceDir) {
+  return path.join(sourceDir, 'mesh-production-readiness-report.json');
+}
+
+function validationFailuresForSource({ gate, report, exitCode, currentCommit, sourceReportPath, requireClean }) {
+  const failures = [];
+  if (exitCode !== 0) {
+    failures.push(`command exited ${exitCode}`);
+  }
+  if (!report) {
+    failures.push('missing mesh-production-readiness-report.json');
+    return failures;
+  }
+  if (report.schema_version !== 'mesh-production-readiness-v1') {
+    failures.push(`unexpected schema_version ${report.schema_version || 'missing'}`);
+  }
+  if (!report.run_id) {
+    failures.push('missing run_id');
+  }
+  if (gate.expectedMode && report.run?.mode !== gate.expectedMode) {
+    failures.push(`expected run.mode ${gate.expectedMode}, observed ${report.run?.mode || 'missing'}`);
+  }
+  if (report.repo?.commit !== currentCommit) {
+    failures.push(`report commit ${report.repo?.commit || 'missing'} does not match ${currentCommit}`);
+  }
+  if (requireClean && report.repo?.dirty) {
+    failures.push('source report repo.dirty is true');
+  }
+  if (report.status === 'blocked') {
+    failures.push('source report status is blocked');
+  }
+  if (report.cleanup?.status === 'fail') {
+    failures.push('source cleanup failed');
+  }
+  for (const row of report.write_class_slos || []) {
+    if ((row.terminal_failures || 0) > 0) {
+      failures.push(`${row.write_class || 'write class'} has terminal failures`);
+    }
+    if ((row.duplicate_count || 0) > 0) {
+      failures.push(`${row.write_class || 'write class'} has duplicate canonical writes`);
+    }
+    if (row.status === 'fail') {
+      failures.push(`${row.write_class || 'write class'} SLO failed`);
+    }
+  }
+  for (const row of report.resource_slos || []) {
+    if (row.status === 'fail') {
+      failures.push(`${row.resource || 'resource'} budget failed`);
+    }
+  }
+  if ((report.soak?.terminal_failures || 0) > 0) {
+    failures.push('soak terminal failures are non-zero');
+  }
+  if ((report.soak?.duplicate_canonical_writes || 0) > 0) {
+    failures.push('soak duplicate canonical writes are non-zero');
+  }
+  if ((report.soak?.silent_drops || 0) > 0) {
+    failures.push('soak silent drops are non-zero');
+  }
+  if (!fs.existsSync(sourceReportPath)) {
+    failures.push('source report was not copied into aggregate packet');
+  }
+  return unique(failures);
+}
+
+function runSourceGate({ gate, artifactDir, currentCommit, requireClean }) {
+  const startedAt = Date.now();
+  const result = spawnSync(gate.command[0], gate.command.slice(1), {
+    cwd: repoRoot,
+    env: process.env,
+    stdio: 'inherit',
+  });
+  const completedAt = Date.now();
+  const exitCode = typeof result.status === 'number' ? result.status : 1;
+  const sourceDir = path.join(artifactDir, 'source-reports', gate.id);
+  copyDir(latestDir, sourceDir);
+  const sourceReportPath = reportPathForSource(sourceDir);
+  let report = null;
+  let parseError = null;
+  if (fs.existsSync(sourceReportPath)) {
+    try {
+      report = readJson(sourceReportPath);
+    } catch (error) {
+      parseError = error instanceof Error ? error.message : String(error);
+    }
+  }
+  const failures = validationFailuresForSource({
+    gate,
+    report,
+    exitCode,
+    currentCommit,
+    sourceReportPath,
+    requireClean,
+  });
+  if (parseError) failures.push(`failed to parse source report: ${parseError}`);
+  return {
+    id: gate.id,
+    name: gate.name,
+    command: commandText(gate.command),
+    expected_mode: gate.expectedMode,
+    started_at: new Date(startedAt).toISOString(),
+    completed_at: new Date(completedAt).toISOString(),
+    duration_ms: completedAt - startedAt,
+    exit_code: exitCode,
+    report,
+    source_dir: sourceDir,
+    report_path: sourceReportPath,
+    source_status: report?.status || 'missing',
+    status: failures.length === 0 ? 'pass' : 'fail',
+    failures,
+  };
+}
+
+function buildReleaseBlockers(sources) {
+  const blockers = [];
+  const sourceById = new Map(sources.map((source) => [source.id, source]));
+  const soak = sourceById.get('soak')?.report;
+  const deployed = sourceById.get('deployed_wss')?.report;
+
+  if (!soak?.soak?.full_duration_satisfied) {
+    blockers.push({
+      id: 'canonical-30-minute-soak',
+      command: 'VH_MESH_SOAK_DURATION_MS=1800000 pnpm test:mesh:soak',
+      reason: 'latest soak evidence is bounded/shortened and does not satisfy the canonical 30-minute soak claim',
+    });
+  }
+  if (deployed?.run?.deployment_scope !== 'public_wss_deployment') {
+    blockers.push({
+      id: 'public-wss-deployment-proof',
+      command: 'pnpm test:mesh:deployed-wss-peer-config',
+      reason: 'current WSS evidence is the hermetic local TLS profile, not public WSS infrastructure',
+    });
+  }
+  if (!hasScript('test:mesh:clock-skew-drills')) {
+    blockers.push({
+      id: 'full-clock-skew-matrix',
+      command: 'pnpm test:mesh:clock-skew-drills',
+      reason: 'full clock-skew/auth-window matrix command is not implemented',
+    });
+  }
+  if (!hasScript('test:mesh:conflict-drills')) {
+    blockers.push({
+      id: 'conflict-resolution-fixtures',
+      command: 'pnpm test:mesh:conflict-drills',
+      reason: 'conflict-resolution fixture command is not implemented',
+    });
+  }
+  if (!hasScript('check:mesh-evidence-scrub')) {
+    blockers.push({
+      id: 'evidence-scrub-promotion',
+      command: 'pnpm check:mesh-evidence-scrub',
+      reason: 'evidence scrub gate for promoted docs/reports/evidence packets is not implemented',
+    });
+  }
+  if (!hasScript('check:production-app-canary')) {
+    blockers.push({
+      id: 'downstream-full-app-production-canary',
+      command: 'pnpm check:production-app-canary',
+      reason: 'downstream full-app production canary is not implemented',
+    });
+  }
+
+  const lumaRows = sources.flatMap((source) => source.report?.luma_gated_write_drills || []);
+  const lumaPassed = lumaRows.some((row) => row.status === 'pass');
+  const drillWriterKinds = mergeMaps(sources.map((source) => source.report?.drill_writer_kind_by_class));
+  const hasLumaWriter = Object.values(drillWriterKinds).includes('luma');
+  if (!lumaPassed || !hasLumaWriter) {
+    blockers.push({
+      id: 'luma-gated-write-coverage',
+      command: 'future LUMA-gated mesh write drill through the LUMA reader path',
+      reason: 'current mesh packet uses synthetic mesh-drill records and does not prove LUMA-gated production write classes',
+    });
+  }
+
+  return blockers;
+}
+
+function pickTopology(sources) {
+  const reports = sources.map((source) => source.report).filter(Boolean);
+  const deployed = sources.find((source) => source.id === 'deployed_wss')?.report;
+  const topology = sources.find((source) => source.id === 'topology')?.report;
+  const readRepair = sources.find((source) => source.id === 'read_repair')?.report;
+  const soak = sources.find((source) => source.id === 'soak')?.report;
+  const signed = sources.find((source) => source.id === 'signed_peer_config')?.report;
+  const topologies = reports.map((report) => report.topology).filter(Boolean);
+  return {
+    strategy: readRepair?.topology?.strategy || soak?.topology?.strategy || 'explicit_replication',
+    selected_strategy: readRepair?.topology?.selected_strategy || soak?.topology?.selected_strategy || 'explicit_read_repair',
+    selected_strategy_scope:
+      readRepair?.topology?.selected_strategy_scope ||
+      soak?.topology?.selected_strategy_scope ||
+      'aggregate of existing synthetic mesh drill proof paths only',
+    deployment_scope: deployed?.run?.deployment_scope || deployed?.topology?.deployment_scope || 'local_tls_wss_profile',
+    configured_peer_count: maxFinite(topologies.map((entry) => entry.configured_peer_count), 3),
+    quorum_required: maxFinite(topologies.map((entry) => entry.quorum_required), 2),
+    signed_peer_config: topologies.some((entry) => entry.signed_peer_config === true),
+    relay_urls_redacted: unique(topologies.flatMap((entry) => entry.relay_urls_redacted || [])),
+    relay_to_relay_peers_configured: topologies.some((entry) => entry.relay_to_relay_peers_configured === true),
+    relay_to_relay_auth_mode:
+      readRepair?.topology?.relay_to_relay_auth_mode ||
+      soak?.topology?.relay_to_relay_auth_mode ||
+      topology?.topology?.relay_to_relay_auth_mode ||
+      'private_network_allowlist',
+    relay_to_relay_auth_negative_test:
+      topology?.topology?.relay_to_relay_auth_negative_test ||
+      readRepair?.topology?.relay_to_relay_auth_negative_test ||
+      'skipped',
+    peer_config_id: deployed?.topology?.peer_config_id || signed?.topology?.peer_config_id || soak?.topology?.peer_config_id || 'aggregate',
+    peer_config_issued_at:
+      deployed?.topology?.peer_config_issued_at ||
+      signed?.topology?.peer_config_issued_at ||
+      soak?.topology?.peer_config_issued_at ||
+      new Date().toISOString(),
+    peer_config_expires_at:
+      deployed?.topology?.peer_config_expires_at ||
+      signed?.topology?.peer_config_expires_at ||
+      soak?.topology?.peer_config_expires_at ||
+      new Date().toISOString(),
+    app_peer_config: deployed?.topology?.app_peer_config || signed?.topology?.app_peer_config,
+    csp: deployed?.topology?.csp,
+    service_worker_peer_config_rollover: deployed?.topology?.service_worker_peer_config_rollover,
+    restarted_relay_catchup: topology?.topology?.restarted_relay_catchup,
+    read_repair: readRepair?.topology?.read_repair || soak?.topology?.read_repair,
+  };
+}
+
+function buildClockSkew(sources) {
+  const partitionClockSkew = sources.find((source) => source.id === 'partition')?.report?.clock_skew;
+  return {
+    skewed_actor: partitionClockSkew?.skewed_actor || null,
+    skewed_layer: partitionClockSkew?.skewed_layer || null,
+    skew_ms: partitionClockSkew?.skew_ms || 0,
+    named_failure: partitionClockSkew?.named_failure || null,
+    lww_diverged: Boolean(partitionClockSkew?.lww_diverged),
+    status: 'skipped',
+    reason:
+      partitionClockSkew?.status === 'pass'
+        ? 'bounded partition drill classified one stale timestamp; full clock-skew matrix command is still missing'
+        : 'full clock-skew matrix command is still missing',
+    bounded_partition_evidence: partitionClockSkew || null,
+  };
+}
+
+function buildCleanup(sources) {
+  const cleanups = sources.map((source) => source.report?.cleanup).filter(Boolean);
+  return {
+    namespace: '.tmp/mesh-production-readiness/source-reports/* plus source drill namespaces',
+    objects_written: sumFinite(cleanups.map((cleanup) => cleanup.objects_written)),
+    objects_cleaned_or_tombstoned: sumFinite(cleanups.map((cleanup) => cleanup.objects_cleaned_or_tombstoned)),
+    retained_objects: sumFinite(cleanups.map((cleanup) => cleanup.retained_objects)),
+    status: cleanups.every((cleanup) => cleanup.status === 'pass') ? 'pass' : 'fail',
+    source_cleanups: sources.map((source) => ({
+      source_gate: source.id,
+      namespace: source.report?.cleanup?.namespace || null,
+      status: source.report?.cleanup?.status || 'missing',
+      retained_objects: source.report?.cleanup?.retained_objects ?? null,
+    })),
+  };
+}
+
+function buildGates(sources, blockers) {
+  const sourceGates = sources.map((source) => ({
+    name: source.name,
+    status: source.status,
+    result_status:
+      source.source_status === 'release_ready'
+        ? 'pass'
+        : ['pass', 'review_required', 'blocked'].includes(source.source_status)
+          ? source.source_status
+          : 'blocked',
+    command: source.command,
+    duration_ms: source.duration_ms,
+    exit_code: source.exit_code,
+    artifact_path: source.report_path,
+    reason: source.failures.length > 0 ? source.failures.join('; ') : undefined,
+  }));
+  const blockerGates = blockers.map((blocker) => ({
+    name: blocker.id,
+    status: 'skipped',
+    result_status: 'review_required',
+    command: blocker.command,
+    duration_ms: 0,
+    exit_code: null,
+    reason: blocker.reason,
+  }));
+  return [...sourceGates, ...blockerGates];
+}
+
+function buildManifest({ report, sources, blockers, reportPath }) {
+  const sourceRows = sources
+    .map((source) => `| ${source.id} | ${source.status} | ${source.source_status} | \`${source.command}\` | \`${path.relative(repoRoot, source.report_path)}\` |`)
+    .join('\n');
+  const blockerRows = blockers
+    .map((blocker) => `| ${blocker.id} | \`${blocker.command}\` | ${blocker.reason} |`)
+    .join('\n');
+  return `# Mesh Production Readiness Evidence Packet
+
+- Run ID: \`${report.run_id}\`
+- Status: \`${report.status}\`
+- Commit: \`${report.repo.commit}\`
+- Dirty: \`${report.repo.dirty}\`
+- Schema epoch: \`${report.schema_epoch}\`
+- LUMA profile: \`${report.luma_profile}\`
+- Report: \`${reportPath}\`
+
+## Source Reports
+
+| Gate | Gate status | Source report status | Command | Copied report |
+|---|---|---|---|---|
+${sourceRows}
+
+## Release-Ready Blockers
+
+| Blocker | Command / future gate | Reason |
+|---|---|---|
+${blockerRows}
+
+## Allowed Claims
+
+${report.release_claims.allowed.map((claim) => `- ${claim}`).join('\n')}
+
+## Forbidden Claims
+
+${report.release_claims.forbidden.map((claim) => `- ${claim}`).join('\n')}
+`;
+}
+
+function writeAggregatePacket({ report, manifest, artifactDir }) {
+  fs.mkdirSync(artifactDir, { recursive: true });
+  const reportPath = path.join(artifactDir, 'mesh-production-readiness-report.json');
+  const manifestPath = path.join(artifactDir, 'mesh-production-readiness-evidence.md');
+  writeJson(reportPath, report);
+  fs.writeFileSync(manifestPath, manifest);
+
+  fs.rmSync(latestDir, { recursive: true, force: true });
+  fs.mkdirSync(latestDir, { recursive: true });
+  fs.copyFileSync(reportPath, path.join(latestDir, 'mesh-production-readiness-report.json'));
+  fs.copyFileSync(manifestPath, path.join(latestDir, 'mesh-production-readiness-evidence.md'));
+  copyDir(path.join(artifactDir, 'source-reports'), path.join(latestDir, 'source-reports'));
+  return { reportPath, manifestPath, latestReportPath: path.join(latestDir, 'mesh-production-readiness-report.json') };
+}
+
+function buildReport({ runId, startedAt, completedAt, sources, blockers, commandPassed }) {
+  const currentCommit = runGit(['rev-parse', 'HEAD']);
+  const dirty = runGit(['status', '--short']).length > 0;
+  const sourceReports = sources.map((source) => source.report).filter(Boolean);
+  const status = !commandPassed ? 'blocked' : blockers.length > 0 ? 'review_required' : 'release_ready';
+  const sourceSchemaEpochs = unique(sourceReports.map((report) => report.schema_epoch));
+  const aggregateSchemaEpoch = sourceSchemaEpochs.includes('post_luma_m0b') ? 'post_luma_m0b' : sourceSchemaEpochs[0] || 'post_luma_m0b';
+  const writeClassSlos = normalizeReportRows(sources, 'write_class_slos');
+  const resourceSlos = normalizeReportRows(sources, 'resource_slos');
+  const perRelayReadback = normalizeReportRows(sources, 'per_relay_readback');
+  const conflictRows = normalizeReportRows(sources, 'conflict_fixtures');
+  const stateResolutionRows = normalizeReportRows(sources, 'state_resolution_drills');
+  const readRepairRows = normalizeReportRows(sources, 'read_repair_drills');
+  const lumaRows = normalizeReportRows(sources, 'luma_gated_write_drills');
+  const degradationReasons = unique(sourceReports.flatMap((report) => report.health?.degradation_reasons_seen || []));
+  const soakReport = sources.find((source) => source.id === 'soak')?.report;
+
+  return {
+    schema_version: 'mesh-production-readiness-v1',
+    generated_at: new Date(completedAt).toISOString(),
+    run_id: runId,
+    repo: {
+      branch: runGit(['rev-parse', '--abbrev-ref', 'HEAD']),
+      commit: currentCommit,
+      base_ref: 'origin/main',
+      dirty,
+    },
+    run: {
+      mode: 'aggregate_production_readiness',
+      started_at: new Date(startedAt).toISOString(),
+      completed_at: new Date(completedAt).toISOString(),
+      duration_ms: completedAt - startedAt,
+      command: 'pnpm check:mesh:production-readiness',
+    },
+    status,
+    status_reason:
+      status === 'blocked'
+        ? 'one or more implemented mesh proof commands failed, produced invalid evidence, or produced dirty/stale reports'
+        : status === 'review_required'
+          ? 'implemented mesh proof commands produced a complete aggregate packet, but release-ready blockers remain'
+          : 'all mesh production-readiness gates are satisfied',
+    schema_epoch: aggregateSchemaEpoch,
+    luma_profile: 'none',
+    luma_dependency_status: {
+      luma_m0b_schema_epoch: 'landed',
+      luma_gated_write_drills: 'pending',
+      luma_profile_gates: 'n/a',
+    },
+    drill_writer_kind_by_class: mergeMaps(sourceReports.map((report) => report.drill_writer_kind_by_class)),
+    topology: pickTopology(sources),
+    source_reports: sources.map((source) => ({
+      id: source.id,
+      name: source.name,
+      command: source.command,
+      status: source.status,
+      result_status: source.source_status,
+      run_id: source.report?.run_id || null,
+      run_mode: source.report?.run?.mode || null,
+      schema_epoch: source.report?.schema_epoch || null,
+      luma_profile: source.report?.luma_profile || null,
+      repo_dirty: source.report?.repo?.dirty ?? null,
+      report_path: source.report_path,
+      failures: source.failures,
+    })),
+    release_readiness_blockers: blockers,
+    gates: buildGates(sources, blockers),
+    soak: soakReport?.soak,
+    write_class_slos: writeClassSlos,
+    resource_slos: resourceSlos,
+    per_relay_readback: perRelayReadback,
+    state_resolution_drills: stateResolutionRows,
+    conflict_fixtures: [
+      ...conflictRows,
+      {
+        fixture: 'full-conflict-resolution-fixtures',
+        trace_id: runId,
+        status: 'skipped',
+        reason: 'pnpm test:mesh:conflict-drills is not implemented in Slice 11A',
+      },
+    ],
+    read_repair_drills: readRepairRows,
+    luma_gated_write_drills: [
+      ...lumaRows,
+      {
+        write_class: 'LUMA-gated production write classes through LUMA reader path',
+        trace_id: runId,
+        status: 'skipped',
+        reason: 'Slice 11A aggregates existing synthetic mesh-drill evidence only; no LUMA _writerKind, _authorScheme, adapters, envelopes, custody, or schema migration work is exercised.',
+      },
+    ],
+    clock_skew: buildClockSkew(sources),
+    cleanup: buildCleanup(sources),
+    health: {
+      peer_quorum_minimum_observed: Math.min(...sourceReports.map((report) => report.health?.peer_quorum_minimum_observed).filter(Number.isFinite), 2),
+      sustained_message_rate_max_per_sec: maxFinite(sourceReports.map((report) => report.health?.sustained_message_rate_max_per_sec), 0),
+      degradation_reasons_seen: degradationReasons,
+    },
+    release_claims: {
+      allowed: commandPassed
+        ? [
+            'Existing implemented mesh proof commands can be rerun and aggregated into one local evidence packet.',
+            'The aggregate packet identifies source reports, copied artifacts, current commit, dirty state, and unresolved release blockers.',
+          ]
+        : [],
+      forbidden: [
+        'The mesh is release_ready.',
+        'The default shortened local soak satisfies the canonical thirty-minute soak claim.',
+        'Public WSS infrastructure is production-proven.',
+        'The full clock-skew matrix is production-ready.',
+        'LUMA-gated production write classes are mesh-readiness-proven.',
+        'The full app is test-group ready.',
+      ],
+      invalidated_by_luma_epoch_change: false,
+    },
+    downstream_canary: {
+      command: 'pnpm check:production-app-canary',
+      status: 'skipped',
+      reason: 'downstream full-app production canary is not implemented and must not be folded into mesh readiness status',
+    },
+  };
+}
+
+async function main() {
+  const startedAt = Date.now();
+  const runId = makeId('mesh-production-readiness');
+  const artifactDir = path.join(repoRoot, '.tmp/mesh-production-readiness', runId);
+  fs.mkdirSync(artifactDir, { recursive: true });
+
+  const currentCommit = runGit(['rev-parse', 'HEAD']);
+  const requireClean = process.env.VH_MESH_PRODUCTION_READINESS_ALLOW_DIRTY !== 'true';
+  const sources = [];
+  for (const gate of SOURCE_GATES) {
+    sources.push(runSourceGate({ gate, artifactDir, currentCommit, requireClean }));
+  }
+  const blockers = buildReleaseBlockers(sources);
+  const commandPassed = sources.every((source) => source.status === 'pass');
+  const completedAt = Date.now();
+  const report = buildReport({ runId, startedAt, completedAt, sources, blockers, commandPassed });
+  const provisionalReportPath = path.join(artifactDir, 'mesh-production-readiness-report.json');
+  const manifest = buildManifest({ report, sources, blockers, reportPath: provisionalReportPath });
+  const paths = writeAggregatePacket({ report, manifest, artifactDir });
+
+  console.log(JSON.stringify({
+    ok: commandPassed,
+    status: report.status,
+    run_id: runId,
+    report_path: paths.reportPath,
+    latest_report_path: paths.latestReportPath,
+    manifest_path: paths.manifestPath,
+    source_reports: sources.map((source) => ({
+      id: source.id,
+      status: source.status,
+      result_status: source.source_status,
+      report_path: source.report_path,
+      failures: source.failures,
+    })),
+    release_ready_blockers: blockers.map((blocker) => blocker.id),
+  }, null, 2));
+
+  if (!commandPassed) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  console.error(`[vh:mesh-production-readiness] fatal: ${error instanceof Error ? error.stack ?? error.message : String(error)}`);
+  process.exit(1);
+});

--- a/packages/e2e/src/mesh/production-readiness-check.mjs
+++ b/packages/e2e/src/mesh/production-readiness-check.mjs
@@ -9,6 +9,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const repoRoot = path.resolve(__dirname, '../../../..');
 const latestDir = path.join(repoRoot, '.tmp/mesh-production-readiness/latest');
+const SOURCE_REPORT_FRESHNESS_TOLERANCE_MS = 5000;
 
 const SOURCE_GATES = [
   {
@@ -105,6 +106,11 @@ function commandText(command) {
   return command.join(' ');
 }
 
+function parseTimestampMs(value) {
+  if (typeof value !== 'string' || value.length === 0) return NaN;
+  return Date.parse(value);
+}
+
 function hasScript(scriptName) {
   try {
     const rootPackage = readJson(path.join(repoRoot, 'package.json'));
@@ -146,7 +152,16 @@ function reportPathForSource(sourceDir) {
   return path.join(sourceDir, 'mesh-production-readiness-report.json');
 }
 
-function validationFailuresForSource({ gate, report, exitCode, currentCommit, sourceReportPath, requireClean }) {
+export function validationFailuresForSource({
+  gate,
+  report,
+  exitCode,
+  currentCommit,
+  sourceReportPath,
+  requireClean,
+  startedAtMs,
+  completedAtMs,
+}) {
   const failures = [];
   if (exitCode !== 0) {
     failures.push(`command exited ${exitCode}`);
@@ -163,6 +178,23 @@ function validationFailuresForSource({ gate, report, exitCode, currentCommit, so
   }
   if (gate.expectedMode && report.run?.mode !== gate.expectedMode) {
     failures.push(`expected run.mode ${gate.expectedMode}, observed ${report.run?.mode || 'missing'}`);
+  }
+  const expectedCommand = commandText(gate.command);
+  if (report.run?.command !== expectedCommand) {
+    failures.push(`expected run.command ${expectedCommand}, observed ${report.run?.command || 'missing'}`);
+  }
+  const reportCompletedAtMs = parseTimestampMs(report.run?.completed_at || report.generated_at);
+  if (!Number.isFinite(reportCompletedAtMs)) {
+    failures.push('missing or invalid source report completion timestamp');
+  } else if (
+    Number.isFinite(startedAtMs) &&
+    Number.isFinite(completedAtMs) &&
+    (reportCompletedAtMs < startedAtMs - SOURCE_REPORT_FRESHNESS_TOLERANCE_MS ||
+      reportCompletedAtMs > completedAtMs + SOURCE_REPORT_FRESHNESS_TOLERANCE_MS)
+  ) {
+    failures.push(
+      `source report completion timestamp ${report.run?.completed_at || report.generated_at} is outside this gate run window`,
+    );
   }
   if (report.repo?.commit !== currentCommit) {
     failures.push(`report commit ${report.repo?.commit || 'missing'} does not match ${currentCommit}`);
@@ -235,6 +267,8 @@ function runSourceGate({ gate, artifactDir, currentCommit, requireClean }) {
     currentCommit,
     sourceReportPath,
     requireClean,
+    startedAtMs: startedAt,
+    completedAtMs: completedAt,
   });
   if (parseError) failures.push(`failed to parse source report: ${parseError}`);
   return {
@@ -542,6 +576,8 @@ function buildReport({ runId, startedAt, completedAt, sources, blockers, command
       result_status: source.source_status,
       run_id: source.report?.run_id || null,
       run_mode: source.report?.run?.mode || null,
+      run_command: source.report?.run?.command || null,
+      source_completed_at: source.report?.run?.completed_at || source.report?.generated_at || null,
       schema_epoch: source.report?.schema_epoch || null,
       luma_profile: source.report?.luma_profile || null,
       repo_dirty: source.report?.repo?.dirty ?? null,
@@ -648,7 +684,9 @@ async function main() {
   }
 }
 
-main().catch((error) => {
-  console.error(`[vh:mesh-production-readiness] fatal: ${error instanceof Error ? error.stack ?? error.message : String(error)}`);
-  process.exit(1);
-});
+if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
+  main().catch((error) => {
+    console.error(`[vh:mesh-production-readiness] fatal: ${error instanceof Error ? error.stack ?? error.message : String(error)}`);
+    process.exit(1);
+  });
+}

--- a/packages/e2e/src/mesh/production-readiness-check.test.mjs
+++ b/packages/e2e/src/mesh/production-readiness-check.test.mjs
@@ -1,0 +1,95 @@
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import { validationFailuresForSource } from './production-readiness-check.mjs';
+
+const thisFile = fileURLToPath(import.meta.url);
+const currentCommit = 'abc123';
+const gateStartedAtMs = Date.parse('2026-05-07T00:00:00.000Z');
+const gateCompletedAtMs = Date.parse('2026-05-07T00:00:20.000Z');
+
+function sourceReport(overrides = {}) {
+  return {
+    schema_version: 'mesh-production-readiness-v1',
+    generated_at: '2026-05-07T00:00:10.000Z',
+    run_id: 'mesh-source-report-test',
+    repo: {
+      commit: currentCommit,
+      dirty: false,
+    },
+    run: {
+      mode: 'local_production_topology',
+      started_at: '2026-05-07T00:00:01.000Z',
+      completed_at: '2026-05-07T00:00:10.000Z',
+      command: 'pnpm test:mesh:state-resolution-drills',
+    },
+    status: 'review_required',
+    cleanup: {
+      status: 'pass',
+    },
+    write_class_slos: [],
+    resource_slos: [],
+    ...overrides,
+  };
+}
+
+function failuresFor({ gate, report }) {
+  return validationFailuresForSource({
+    gate,
+    report,
+    exitCode: 0,
+    currentCommit,
+    sourceReportPath: thisFile,
+    requireClean: true,
+    startedAtMs: gateStartedAtMs,
+    completedAtMs: gateCompletedAtMs,
+  });
+}
+
+describe('production-readiness source evidence validation', () => {
+  it('accepts a fresh source report for the exact gate command', () => {
+    const failures = failuresFor({
+      gate: {
+        command: ['pnpm', 'test:mesh:state-resolution-drills'],
+        expectedMode: 'local_production_topology',
+      },
+      report: sourceReport(),
+    });
+
+    expect(failures).toEqual([]);
+  });
+
+  it('rejects a same-mode source report from a different gate command', () => {
+    const failures = failuresFor({
+      gate: {
+        command: ['pnpm', 'test:mesh:disconnect-drills'],
+        expectedMode: 'local_production_topology',
+      },
+      report: sourceReport(),
+    });
+
+    expect(failures).toContain(
+      'expected run.command pnpm test:mesh:disconnect-drills, observed pnpm test:mesh:state-resolution-drills',
+    );
+  });
+
+  it('rejects a same-command source report outside the aggregate gate window', () => {
+    const failures = failuresFor({
+      gate: {
+        command: ['pnpm', 'test:mesh:state-resolution-drills'],
+        expectedMode: 'local_production_topology',
+      },
+      report: sourceReport({
+        generated_at: '2026-05-06T23:59:00.000Z',
+        run: {
+          ...sourceReport().run,
+          completed_at: '2026-05-06T23:59:00.000Z',
+        },
+      }),
+    });
+
+    expect(failures).toContain(
+      'source report completion timestamp 2026-05-06T23:59:00.000Z is outside this gate run window',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- adds `pnpm check:mesh:production-readiness` as the aggregate mesh evidence gate
- runs/copies/validates the eight existing mesh proof reports into a stable latest evidence packet
- keeps the aggregate status `review_required` with explicit blockers instead of claiming `release_ready`

## Verification
- `node --check packages/e2e/src/mesh/production-readiness-check.mjs`
- `pnpm docs:check`
- `git diff --check`
- `git diff --check origin/main...HEAD`
- `pnpm --filter @vh/e2e typecheck`
- `node tools/scripts/check-diff-coverage.mjs`
- `VH_MESH_PRODUCTION_READINESS_ALLOW_DIRTY=true pnpm check:mesh:production-readiness`
- `pnpm check:mesh:production-readiness`
- JSON sanity check over `.tmp/mesh-production-readiness/latest/mesh-production-readiness-report.json`

## Evidence
- Latest aggregate report: `.tmp/mesh-production-readiness/latest/mesh-production-readiness-report.json`
- Latest evidence manifest: `.tmp/mesh-production-readiness/latest/mesh-production-readiness-evidence.md`

## Boundaries
- No `release_ready` claim
- No LUMA schema, adapter, envelope, custody, or migration work
- LUMA-gated write coverage remains an explicit blocker