### PR TITLE
LUMA M0.B ForumPost v1 publish-back migration

### DIFF
--- a/apps/web-pwa/src/components/docs/ArticleEditor.test.tsx
+++ b/apps/web-pwa/src/components/docs/ArticleEditor.test.tsx
@@ -31,11 +31,12 @@ const mockSaveDraft = vi.fn((docId: string, updates: any) => {
   if (existing) storeDocuments.set(docId, { ...existing, ...updates, lastModifiedAt: Date.now() });
 });
 
-const mockPublishArticle = vi.fn((docId: string) => {
+const mockPublishArticle = vi.fn(async (docId: string) => {
   const existing = storeDocuments.get(docId);
   if (existing) storeDocuments.set(docId, {
     ...existing, publishedAt: Date.now(), publishedArticleId: `pub-${docId}`,
   });
+  return Boolean(existing);
 });
 
 const mockGetDraft = vi.fn((docId: string) => storeDocuments.get(docId));
@@ -233,21 +234,21 @@ describe('ArticleEditor', () => {
       expect(screen.getByTestId('save-draft-btn')).toBeDisabled();
     });
 
-    it('sets publishedAt on publish', () => {
+    it('sets publishedAt on publish', async () => {
       render(<ArticleEditor initialContent="content" />);
       fireEvent.change(screen.getByTestId('article-title-input'), { target: { value: 'My Article' } });
       fireEvent.click(screen.getByTestId('publish-btn'));
       expect(mockCreateDraft).toHaveBeenCalled();
-      expect(mockPublishArticle).toHaveBeenCalled();
-      expect(screen.getByTestId('published-banner')).toBeInTheDocument();
+      await waitFor(() => expect(mockPublishArticle).toHaveBeenCalled());
+      await waitFor(() => expect(screen.getByTestId('published-banner')).toBeInTheDocument());
     });
 
-    it('calls onComplete with docId after publish', () => {
+    it('calls onComplete with docId after publish', async () => {
       const onComplete = vi.fn();
       render(<ArticleEditor initialContent="content" onComplete={onComplete} />);
       fireEvent.change(screen.getByTestId('article-title-input'), { target: { value: 'Title' } });
       fireEvent.click(screen.getByTestId('publish-btn'));
-      expect(onComplete).toHaveBeenCalledWith('test-doc-0');
+      await waitFor(() => expect(onComplete).toHaveBeenCalledWith('test-doc-0'));
     });
 
     it('passes source context to createDraft', () => {

--- a/apps/web-pwa/src/components/docs/ArticleEditor.test.tsx
+++ b/apps/web-pwa/src/components/docs/ArticleEditor.test.tsx
@@ -251,6 +251,19 @@ describe('ArticleEditor', () => {
       await waitFor(() => expect(onComplete).toHaveBeenCalledWith('test-doc-0'));
     });
 
+    it('does not complete when publishArticle fails closed', async () => {
+      mockPublishArticle.mockResolvedValueOnce(false);
+      const onComplete = vi.fn();
+      render(<ArticleEditor initialContent="content" onComplete={onComplete} />);
+      fireEvent.change(screen.getByTestId('article-title-input'), { target: { value: 'Title' } });
+      fireEvent.click(screen.getByTestId('publish-btn'));
+
+      await waitFor(() => expect(mockPublishArticle).toHaveBeenCalledWith('test-doc-0'));
+      expect(onComplete).not.toHaveBeenCalled();
+      expect(screen.queryByTestId('published-banner')).not.toBeInTheDocument();
+      expect(screen.getByTestId('editor-heading')).toHaveTextContent('Edit Article');
+    });
+
     it('passes source context to createDraft', () => {
       const ctx = { sourceTopicId: 'topic-1', sourceThreadId: 'thread-1', sourceSynthesisId: 'synth-1' };
       render(<ArticleEditor initialContent="content" sourceContext={ctx} />);

--- a/apps/web-pwa/src/components/docs/ArticleEditor.tsx
+++ b/apps/web-pwa/src/components/docs/ArticleEditor.tsx
@@ -116,7 +116,7 @@ export const ArticleEditor: React.FC<ArticleEditorProps> = ({
     } finally { setSaving(false); }
   }, [canSave, saving, docId, content, sourceContext, createDraft, saveDraft, title, docType]);
 
-  const handlePublish = useCallback(() => {
+  const handlePublish = useCallback(async () => {
     if (!canSave || publishing || published) return;
     setPublishing(true);
     try {
@@ -130,9 +130,11 @@ export const ArticleEditor: React.FC<ArticleEditorProps> = ({
       } else {
         saveDraft(cid, { title, encryptedContent: content, type: docType });
       }
-      publishArticle(cid);
-      setPublished(true);
-      onComplete?.(cid);
+      const didPublish = await publishArticle(cid);
+      if (didPublish) {
+        setPublished(true);
+        onComplete?.(cid);
+      }
     } finally { setPublishing(false); }
   }, [canSave, publishing, published, docId, content, sourceContext, createDraft, saveDraft, title, docType, publishArticle, onComplete]);
 

--- a/apps/web-pwa/src/components/hermes/forum/CommentComposerWithArticle.test.tsx
+++ b/apps/web-pwa/src/components/hermes/forum/CommentComposerWithArticle.test.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import '@testing-library/jest-dom/vitest';
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { CommentComposerWithArticle } from './CommentComposerWithArticle';
 import { REPLY_WARNING_THRESHOLD, REPLY_CHAR_LIMIT } from './CommentComposer';
 
@@ -62,7 +62,7 @@ const mockSaveDraft = vi.fn((docId: string, updates: any) => {
   }
 });
 
-const mockPublishArticle = vi.fn((docId: string) => {
+const mockPublishArticle = vi.fn(async (docId: string) => {
   const existing = storeDocuments.get(docId);
   if (existing) {
     storeDocuments.set(docId, {
@@ -70,7 +70,9 @@ const mockPublishArticle = vi.fn((docId: string) => {
       publishedAt: Date.now(),
       publishedArticleId: `pub-${docId}`,
     });
+    return true;
   }
+  return false;
 });
 
 vi.mock('../../../store/hermesDocs', () => ({
@@ -196,7 +198,7 @@ describe('CommentComposerWithArticle', () => {
     expect(contentInput.value).toBe(text);
   });
 
-  it('editor complete callback closes editor', () => {
+  it('editor complete callback closes editor', async () => {
     render(<CommentComposerWithArticle threadId="thread-1" />);
     typeIntoComposer('x'.repeat(REPLY_WARNING_THRESHOLD));
     fireEvent.click(screen.getByTestId('convert-to-article-btn'));
@@ -207,9 +209,11 @@ describe('CommentComposerWithArticle', () => {
     fireEvent.click(screen.getByTestId('publish-btn'));
 
     // After publish, editor closes and composer returns
-    expect(
-      screen.getByTestId('comment-composer-container'),
-    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('comment-composer-container'),
+      ).toBeInTheDocument();
+    });
   });
 
   it('uses custom sourceContext when provided', () => {

--- a/apps/web-pwa/src/store/forum/lumaRecords.ts
+++ b/apps/web-pwa/src/store/forum/lumaRecords.ts
@@ -1,10 +1,13 @@
 import {
   FORUM_AUTHOR_SCHEME,
   FORUM_COMMENT_AUDIENCE,
+  FORUM_POST_AUDIENCE,
   FORUM_PUBLIC_PROTOCOL_VERSION,
   FORUM_THREAD_AUDIENCE,
   FORUM_WRITER_KIND,
   type ForumCommentSignedPayload,
+  type ForumPost,
+  type ForumPostSignedPayload,
   type ForumThreadSignedPayload
 } from '@vh/data-model';
 import {
@@ -58,6 +61,19 @@ interface CommentRecordInput {
   readonly timestamp: number;
   readonly stance: 'concur' | 'counter' | 'discuss';
   readonly targetId?: string;
+  readonly via?: 'human' | 'familiar';
+}
+
+interface PostRecordInput {
+  readonly identity: LumaForumIdentity;
+  readonly id: string;
+  readonly threadId: string;
+  readonly parentId: string | null;
+  readonly topicId: string;
+  readonly type: 'reply' | 'article';
+  readonly content: string;
+  readonly timestamp: number;
+  readonly articleRefId?: string;
   readonly via?: 'human' | 'familiar';
 }
 
@@ -196,6 +212,53 @@ export async function createLumaForumCommentRecord(input: CommentRecordInput): P
     signedWriteEnvelope: {
       ...signedWriteEnvelope,
       audience: FORUM_COMMENT_AUDIENCE,
+      scheme: FORUM_AUTHOR_SCHEME,
+      publicAuthor: forumAuthorId,
+      payload
+    }
+  };
+}
+
+export async function createLumaForumPostRecord(input: PostRecordInput): Promise<ForumPost> {
+  const forumAuthorId = await deriveForumAuthorId(input.identity.session.nullifier);
+  const timestamp = input.timestamp;
+  const payload: ForumPostSignedPayload = stripUndefined({
+    schemaVersion: 'hermes-post-v1',
+    _protocolVersion: FORUM_PUBLIC_PROTOCOL_VERSION,
+    _writerKind: FORUM_WRITER_KIND,
+    _authorScheme: FORUM_AUTHOR_SCHEME,
+    id: input.id,
+    threadId: input.threadId,
+    parentId: input.parentId,
+    topicId: input.topicId,
+    author: forumAuthorId,
+    via: input.via,
+    type: input.type,
+    content: input.content,
+    timestamp,
+    articleRefId: input.articleRefId
+  });
+  const signedWriteEnvelope = await createSignedWriteEnvelope({
+    profile: lumaForumDeploymentProfile(),
+    audience: FORUM_POST_AUDIENCE,
+    origin: currentOrigin(),
+    scheme: FORUM_AUTHOR_SCHEME,
+    publicAuthor: createLumaPublicAuthorId(forumAuthorId, FORUM_AUTHOR_SCHEME),
+    sessionRef: await deriveForumSignedWriteSessionRef(input.identity),
+    payload,
+    sequence: timestamp,
+    nonce: randomNonceHex(),
+    issuedAt: timestamp,
+    sign: ({ canonicalBytes }) => signWithStoredDelegationSigningKey(canonicalBytes)
+  });
+
+  return {
+    ...payload,
+    upvotes: 0,
+    downvotes: 0,
+    signedWriteEnvelope: {
+      ...signedWriteEnvelope,
+      audience: FORUM_POST_AUDIENCE,
       scheme: FORUM_AUTHOR_SCHEME,
       publicAuthor: forumAuthorId,
       payload

--- a/apps/web-pwa/src/store/hermesDocs.test.ts
+++ b/apps/web-pwa/src/store/hermesDocs.test.ts
@@ -13,13 +13,30 @@ import { useDiscoveryStore } from './discovery';
 import { useAppStore } from './index';
 import type { StoreApi, UseBoundStore } from 'zustand';
 
+vi.mock('@vh/identity-vault', () => ({
+  signWithStoredDelegationSigningKey: vi.fn(async () => 'test-delegation-signature')
+}));
+
 // ── Helpers ───────────────────────────────────────────────────────────
 
 let counter = 0;
+const TEST_PRINCIPAL_NULLIFIER = 'test-principal-nullifier';
+const fakeIdentity = {
+  handle: 'test-handle',
+  session: {
+    token: 'test-session-token',
+    nullifier: TEST_PRINCIPAL_NULLIFIER,
+    trustScore: 1,
+    scaledTrustScore: 9000,
+    createdAt: 1_700_000_000_000,
+    expiresAt: 1_700_086_400_000,
+  },
+};
 const fakeDeps: Partial<DocsDeps> = {
   now: () => 1_700_000_000_000 + counter++,
   randomId: () => `id-${counter++}`,
   owner: () => 'test-owner',
+  identity: () => fakeIdentity as any,
   publishBack: () => {},
 };
 
@@ -155,10 +172,10 @@ describe('hermesDocs store – saveDraft', () => {
     expect(store.getState().documents.size).toBe(0);
   });
 
-  it('does not allow saving a published document', () => {
+  it('does not allow saving a published document', async () => {
     const store = makeStore();
     const doc = store.getState().createDraft('pub');
-    store.getState().publishArticle(doc!.id);
+    await store.getState().publishArticle(doc!.id);
     const beforeSave = store.getState().getDraft(doc!.id)!.title;
     store.getState().saveDraft(doc!.id, { title: 'changed' });
     expect(store.getState().getDraft(doc!.id)!.title).toBe(beforeSave);
@@ -166,16 +183,16 @@ describe('hermesDocs store – saveDraft', () => {
 });
 
 describe('hermesDocs store – publishArticle', () => {
-  it('sets publishedAt and publishedArticleId', () => {
+  it('sets publishedAt and publishedArticleId', async () => {
     const store = makeStore();
     const doc = store.getState().createDraft('to publish');
-    store.getState().publishArticle(doc!.id);
+    await store.getState().publishArticle(doc!.id);
     const published = store.getState().getDraft(doc!.id);
     expect(published!.publishedAt).toBeGreaterThan(0);
     expect(published!.publishedArticleId).toBeTruthy();
   });
 
-  it('wires full DocPublishLink contract and publish-back payloads', () => {
+  it('wires full DocPublishLink contract and publish-back payloads', async () => {
     const publishBack = vi.fn();
     const store = createDocsStore({
       ...fakeDeps,
@@ -189,7 +206,7 @@ describe('hermesDocs store – publishArticle', () => {
     });
     store.getState().saveDraft(doc!.id, { title: 'Linked Article' });
 
-    store.getState().publishArticle(doc!.id);
+    await store.getState().publishArticle(doc!.id);
 
     expect(publishBack).toHaveBeenCalledTimes(1);
     const artifacts = publishBack.mock.calls[0][0];
@@ -204,12 +221,23 @@ describe('hermesDocs store – publishArticle', () => {
     });
     expect(artifacts.forumThread).toBeUndefined();
     expect(artifacts.forumPost).toMatchObject({
-      schemaVersion: 'hermes-post-v0',
+      schemaVersion: 'hermes-post-v1',
+      _protocolVersion: 'luma-public-v1',
+      _writerKind: 'luma',
+      _authorScheme: 'forum-author-v1',
       threadId: 'thread-1',
       topicId: 'topic-1',
       type: 'article',
       articleRefId: link.articleId,
+      author: expect.stringMatching(/^[0-9a-f]{64}$/),
+      signedWriteEnvelope: expect.objectContaining({
+        audience: 'vh-forum-post',
+        scheme: 'forum-author-v1',
+        publicAuthor: expect.stringMatching(/^[0-9a-f]{64}$/),
+      }),
     });
+    expect(artifacts.forumPost.author).not.toBe(TEST_PRINCIPAL_NULLIFIER);
+    expect(artifacts.forumPost.author).not.toBe(doc!.owner);
     expect(artifacts.discoveryItem).toMatchObject({
       topic_id: link.articleId,
       kind: 'ARTICLE',
@@ -226,21 +254,49 @@ describe('hermesDocs store – publishArticle', () => {
     expect(published.publishedAt).toBe(link.publishedAt);
   });
 
-  it('creates a deterministic forum thread payload when sourceThreadId is absent', () => {
+  it('creates a deterministic forum thread payload when sourceThreadId is absent', async () => {
     const publishBack = vi.fn();
     const store = createDocsStore({
       ...fakeDeps,
       publishBack,
     }, true);
-    const doc = store.getState().createDraft('deterministic');
+    const doc = store.getState().createDraft('deterministic', {
+      sourceTopicId: 'topic-without-thread',
+      sourceSynthesisId: 'synth-without-thread',
+      sourceEpoch: 9,
+    });
 
-    store.getState().publishArticle(doc!.id);
+    await store.getState().publishArticle(doc!.id);
 
     const artifacts = publishBack.mock.calls[0][0];
     const expectedThreadId = `article-thread-${doc!.id}`;
     expect(artifacts.link.threadId).toBe(expectedThreadId);
     expect(artifacts.forumThread?.id).toBe(expectedThreadId);
+    expect(artifacts.forumThread?.schemaVersion).toBe('hermes-thread-v1');
+    expect(artifacts.forumThread?.sourceEpoch).toBe(9);
+    expect(artifacts.forumThread?.signedWriteEnvelope.audience).toBe('vh-forum-thread');
     expect(artifacts.forumPost.threadId).toBe(expectedThreadId);
+  });
+
+  it('fails closed through the default identity accessor when no active identity exists', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const publishBack = vi.fn();
+      const store = createDocsStore({
+        now: () => 1_700_000_000_000,
+        randomId: () => 'default-identity-doc',
+        owner: () => 'default-identity-owner',
+        publishBack,
+      }, true);
+      const doc = store.getState().createDraft('unsigned default identity publish');
+
+      await expect(store.getState().publishArticle(doc!.id)).resolves.toBe(false);
+
+      expect(publishBack).not.toHaveBeenCalled();
+      expect(store.getState().getDraft(doc!.id)!.publishedAt).toBeUndefined();
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   it('writes forum publish payloads and discovery ARTICLE item on default runtime path', async () => {
@@ -253,11 +309,12 @@ describe('hermesDocs store – publishArticle', () => {
       now: () => 1_700_000_000_000,
       randomId: () => `runtime-${++idCounter}`,
       owner: () => 'runtime-owner',
+      identity: () => fakeIdentity as any,
     }, true);
 
     const doc = store.getState().createDraft('runtime payload');
     store.getState().saveDraft(doc!.id, { title: 'Runtime Linked Article' });
-    store.getState().publishArticle(doc!.id);
+    await store.getState().publishArticle(doc!.id);
 
     await new Promise((resolve) => setTimeout(resolve, 0));
 
@@ -268,15 +325,20 @@ describe('hermesDocs store – publishArticle', () => {
     expect(writes.get(`vh/forum/threads/${expectedThreadId}`)).toEqual(
       expect.objectContaining({
         id: expectedThreadId,
-        schemaVersion: 'hermes-thread-v0',
+        schemaVersion: 'hermes-thread-v1',
+        _writerKind: 'luma',
+        signedWriteEnvelope: expect.objectContaining({ audience: 'vh-forum-thread' }),
       }),
     );
     expect(writes.get(expectedPostPath)).toEqual(
       expect.objectContaining({
-        schemaVersion: 'hermes-post-v0',
+        schemaVersion: 'hermes-post-v1',
+        _writerKind: 'luma',
         threadId: expectedThreadId,
         type: 'article',
         articleRefId: published.publishedArticleId,
+        author: expect.stringMatching(/^[0-9a-f]{64}$/),
+        signedWriteEnvelope: expect.objectContaining({ audience: 'vh-forum-post' }),
       }),
     );
     expect(useDiscoveryStore.getState().items).toContainEqual(
@@ -288,30 +350,46 @@ describe('hermesDocs store – publishArticle', () => {
     );
   });
 
-  it('does not double-publish', () => {
+  it('does not double-publish', async () => {
     const store = makeStore();
     const doc = store.getState().createDraft('once');
-    store.getState().publishArticle(doc!.id);
+    await store.getState().publishArticle(doc!.id);
     const firstPublished = store.getState().getDraft(doc!.id)!;
-    store.getState().publishArticle(doc!.id);
+    await store.getState().publishArticle(doc!.id);
     const secondPublished = store.getState().getDraft(doc!.id)!;
     expect(firstPublished.publishedAt).toBe(secondPublished.publishedAt);
     expect(firstPublished.publishedArticleId).toBe(secondPublished.publishedArticleId);
   });
 
-  it('no-ops for non-existent docId', () => {
+  it('no-ops for non-existent docId', async () => {
     const store = makeStore();
-    store.getState().publishArticle('ghost');
+    await store.getState().publishArticle('ghost');
     expect(store.getState().documents.size).toBe(0);
+  });
+
+  it('fails closed without an active identity and does not mark the document published', async () => {
+    const publishBack = vi.fn();
+    const store = createDocsStore({
+      ...fakeDeps,
+      identity: () => null,
+      publishBack,
+    }, true);
+    const doc = store.getState().createDraft('unsigned publish');
+
+    await expect(store.getState().publishArticle(doc!.id)).resolves.toBe(false);
+
+    expect(publishBack).not.toHaveBeenCalled();
+    expect(store.getState().getDraft(doc!.id)!.publishedAt).toBeUndefined();
+    expect(store.getState().getDraft(doc!.id)!.publishedArticleId).toBeUndefined();
   });
 });
 
 describe('hermesDocs store – listPublished', () => {
-  it('returns only published documents', () => {
+  it('returns only published documents', async () => {
     const store = makeStore();
     const doc1 = store.getState().createDraft('draft1');
     const doc2 = store.getState().createDraft('draft2');
-    store.getState().publishArticle(doc1!.id);
+    await store.getState().publishArticle(doc1!.id);
     const published = store.getState().listPublished();
     expect(published).toHaveLength(1);
     expect(published[0].id).toBe(doc1!.id);
@@ -324,13 +402,13 @@ describe('hermesDocs store – listPublished', () => {
     expect(store.getState().listPublished()).toHaveLength(0);
   });
 
-  it('returns all published documents', () => {
+  it('returns all published documents', async () => {
     const store = makeStore();
     const doc1 = store.getState().createDraft('a');
     const doc2 = store.getState().createDraft('b');
     const doc3 = store.getState().createDraft('c');
-    store.getState().publishArticle(doc1!.id);
-    store.getState().publishArticle(doc3!.id);
+    await store.getState().publishArticle(doc1!.id);
+    await store.getState().publishArticle(doc3!.id);
     const published = store.getState().listPublished();
     expect(published).toHaveLength(2);
     expect(published.map((d) => d.id)).toContain(doc1!.id);
@@ -349,11 +427,11 @@ describe('hermesDocs store – getDraft / listDrafts', () => {
     expect(store.getState().getDraft('nope')).toBeUndefined();
   });
 
-  it('listDrafts excludes published documents', () => {
+  it('listDrafts excludes published documents', async () => {
     const store = makeStore();
     const doc1 = store.getState().createDraft('draft1');
     const doc2 = store.getState().createDraft('draft2');
-    store.getState().publishArticle(doc1!.id);
+    await store.getState().publishArticle(doc1!.id);
     const drafts = store.getState().listDrafts();
     expect(drafts).toHaveLength(1);
     expect(drafts[0].id).toBe(doc2!.id);
@@ -406,9 +484,9 @@ describe('hermesDocs store – flag off', () => {
     expect(disabled.getState().documents.size).toBe(0);
   });
 
-  it('publishArticle is no-op when disabled', () => {
+  it('publishArticle is no-op when disabled', async () => {
     const store = makeStore(false);
-    store.getState().publishArticle('anything');
+    await store.getState().publishArticle('anything');
     expect(store.getState().documents.size).toBe(0);
   });
 
@@ -454,8 +532,8 @@ describe('createMockHermesDocsStore', () => {
     expect(store.getState().enabled).toBe(true);
   });
 
-  it('supports full CRUD cycle', () => {
-    const store = createMockHermesDocsStore();
+  it('supports full CRUD cycle', async () => {
+    const store = createMockHermesDocsStore({ identity: () => fakeIdentity as any });
     const doc = store.getState().createDraft('mock content');
     expect(doc).not.toBeNull();
     expect(doc!.owner).toBe('mock-owner');
@@ -463,21 +541,21 @@ describe('createMockHermesDocsStore', () => {
     store.getState().saveDraft(doc!.id, { title: 'Mock Title' });
     expect(store.getState().getDraft(doc!.id)!.title).toBe('Mock Title');
 
-    store.getState().publishArticle(doc!.id);
+    await store.getState().publishArticle(doc!.id);
     expect(store.getState().getDraft(doc!.id)!.publishedAt).toBeGreaterThan(0);
   });
 
-  it('publishArticle catches publishBack errors gracefully', () => {
+  it('publishArticle catches publishBack errors gracefully', async () => {
     const publishBack = vi.fn(() => {
       throw new Error('runtime write failed');
     });
-    const store = createMockHermesDocsStore({ publishBack });
+    const store = createMockHermesDocsStore({ identity: () => fakeIdentity as any, publishBack });
     store.getState().createDraft('text');
     const docs = Array.from(store.getState().documents.values());
     const docId = docs[0].id;
 
-    // Should not throw — error is caught internally
-    expect(() => store.getState().publishArticle(docId)).not.toThrow();
+    // Should not reject — error is caught internally
+    await expect(store.getState().publishArticle(docId)).resolves.toBe(true);
     expect(publishBack).toHaveBeenCalledTimes(1);
     // doc is now published despite publishBack error (state updated before publishBack call)
     const published = store.getState().documents.get(docId);
@@ -494,5 +572,21 @@ describe('createMockHermesDocsStore', () => {
     });
     const doc = store.getState().createDraft('text');
     expect(doc!.owner).toBe('custom-owner');
+  });
+
+  it('uses the default mock-store identity accessor and fails closed without identity', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const publishBack = vi.fn();
+      const store = createMockHermesDocsStore({ publishBack });
+      const doc = store.getState().createDraft('mock unsigned');
+
+      await expect(store.getState().publishArticle(doc!.id)).resolves.toBe(false);
+
+      expect(publishBack).not.toHaveBeenCalled();
+      expect(store.getState().getDraft(doc!.id)!.publishedAt).toBeUndefined();
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 });

--- a/apps/web-pwa/src/store/hermesDocs.ts
+++ b/apps/web-pwa/src/store/hermesDocs.ts
@@ -12,9 +12,7 @@ import { create } from 'zustand';
 import {
   DocPublishLinkSchema,
   FeedItemSchema,
-  ForumPostSchema,
   HermesDocumentSchema,
-  HermesThreadSchema,
   type DocPublishLink,
   type FeedItem,
   type ForumPost,
@@ -22,8 +20,15 @@ import {
   type HermesThread,
 } from '@vh/data-model';
 import { getForumThreadChain } from '@vh/gun-client';
+import type { IdentityRecord } from '@vh/types';
 import { useDiscoveryStore } from './discovery';
+import { getFullIdentity } from './identityProvider';
 import { useAppStore } from './index';
+import {
+  assertLumaForumIdentity,
+  createLumaForumPostRecord,
+  createLumaForumThreadRecord
+} from './forum/lumaRecords';
 import { serializeThreadForGun, stripUndefined } from './forum/helpers';
 
 // ── Feature flag ──────────────────────────────────────────────────────
@@ -55,7 +60,7 @@ export interface DocsState {
   enabled: boolean;
   createDraft: (fromReplyText: string, sourceContext?: SourceContext) => HermesDocument | null;
   saveDraft: (docId: string, updates: Partial<Pick<HermesDocument, 'title' | 'encryptedContent' | 'type'>>) => void;
-  publishArticle: (docId: string) => void;
+  publishArticle: (docId: string) => Promise<boolean>;
   getDraft: (docId: string) => HermesDocument | undefined;
   listDrafts: () => HermesDocument[];
   listPublished: () => HermesDocument[];
@@ -65,6 +70,7 @@ export interface DocsDeps {
   now: () => number;
   randomId: () => string;
   owner: () => string;
+  identity: () => IdentityRecord | null;
   publishBack: (artifacts: PublishBackArtifacts) => void;
 }
 
@@ -83,10 +89,12 @@ function toForumContent(content: string): string {
   return content.slice(0, FORUM_CONTENT_LIMIT);
 }
 
-export function createPublishBackArtifacts(
+export async function createPublishBackArtifacts(
   doc: HermesDocument,
   deps: Pick<DocsDeps, 'now' | 'randomId'>,
-): PublishBackArtifacts {
+  identityRecord: IdentityRecord | null,
+): Promise<PublishBackArtifacts> {
+  const identity = assertLumaForumIdentity(identityRecord);
   const threadId = doc.sourceThreadId ?? `${FORUM_THREAD_PREFIX}${doc.id}`;
   const topicId = doc.sourceTopicId ?? threadId;
   const publishedAt = deps.now();
@@ -104,18 +112,15 @@ export function createPublishBackArtifacts(
 
   const forumContent = toForumContent(doc.encryptedContent);
 
-  const forumPost = ForumPostSchema.parse({
+  const forumPost = await createLumaForumPostRecord({
     id: `post-${link.articleId}`,
-    schemaVersion: 'hermes-post-v0',
     threadId: /* v8 ignore next -- threadId always set via fallback */ link.threadId ?? threadId,
     parentId: null,
     topicId: link.topicId,
-    author: doc.owner,
+    identity,
     type: 'article',
     content: forumContent,
     timestamp: link.publishedAt,
-    upvotes: 0,
-    downvotes: 0,
     articleRefId: link.articleId,
   });
 
@@ -133,20 +138,17 @@ export function createPublishBackArtifacts(
 
   const forumThread = doc.sourceThreadId
     ? undefined
-    : HermesThreadSchema.parse({
+    : await createLumaForumThreadRecord({
+      identity,
       id: threadId,
-      schemaVersion: 'hermes-thread-v0',
       title: doc.title,
       content: forumContent,
-      author: doc.owner,
       timestamp: link.publishedAt,
       tags: ['article'],
       topicId: link.topicId,
       /* v8 ignore next -- both branches tested via with/without synthesisId tests */
       ...(link.synthesisId ? { sourceSynthesisId: link.synthesisId } : {}),
-      upvotes: 0,
-      downvotes: 0,
-      score: 0,
+      ...(link.epoch != null ? { sourceEpoch: link.epoch } : {}),
     });
 
   return {
@@ -204,6 +206,7 @@ export function createDocsStore(overrides?: Partial<DocsDeps>, forceEnabled?: bo
     now: overrides?.now ?? (() => Date.now()),
     randomId: overrides?.randomId ?? defaultRandomId,
     owner: overrides?.owner ?? (() => 'anonymous'),
+    identity: overrides?.identity ?? (() => getFullIdentity<IdentityRecord>()),
     publishBack: overrides?.publishBack ?? publishBackToRuntime,
   };
 
@@ -263,14 +266,20 @@ export function createDocsStore(overrides?: Partial<DocsDeps>, forceEnabled?: bo
       });
     },
 
-    publishArticle(docId: string) {
-      if (!get().enabled) return;
+    async publishArticle(docId: string): Promise<boolean> {
+      if (!get().enabled) return false;
 
       const existing = get().documents.get(docId);
-      if (!existing) return;
-      if (existing.publishedAt != null) return; // already published
+      if (!existing) return false;
+      if (existing.publishedAt != null) return false; // already published
 
-      const artifacts = createPublishBackArtifacts(existing, deps);
+      let artifacts: PublishBackArtifacts;
+      try {
+        artifacts = await createPublishBackArtifacts(existing, deps, deps.identity());
+      } catch (error) {
+        console.warn('[vh:docs] publish back LUMA signing failed', error);
+        return false;
+      }
 
       const published: HermesDocument = {
         ...existing,
@@ -295,6 +304,7 @@ export function createDocsStore(overrides?: Partial<DocsDeps>, forceEnabled?: bo
       } catch (error) {
         console.warn('[vh:docs] publish back failed', error);
       }
+      return true;
     },
 
     getDraft(docId: string): HermesDocument | undefined {
@@ -323,6 +333,7 @@ export function createMockHermesDocsStore(overrides?: Partial<DocsDeps>) {
       now: overrides?.now ?? (() => Date.now()),
       randomId: overrides?.randomId ?? (() => `mock-doc-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`),
       owner: overrides?.owner ?? (() => 'mock-owner'),
+      identity: overrides?.identity ?? (() => getFullIdentity<IdentityRecord>()),
       publishBack: overrides?.publishBack ?? publishBackToRuntime,
     },
     true, // force enabled

--- a/docs/plans/LUMA_SERVICE_V0_ROADMAP_2026-05-02.md
+++ b/docs/plans/LUMA_SERVICE_V0_ROADMAP_2026-05-02.md
@@ -178,6 +178,7 @@ Deliverables:
 - Adapter and materializer migration (the surfaces the mesh hardening
   series already touched, now on the LUMA epoch):
   - `packages/gun-client/src/forumAdapters.ts`: thread/comment writes use `forumAuthorId`, carry `_writerKind: 'luma'`, embed `SignedWriteEnvelope` with audience `vh-forum-thread` / `vh-forum-comment`.
+  - `apps/web-pwa/src/store/hermesDocs.ts`: Docs article publish-back writes `hermes-post-v1` with `forumAuthorId` and `SignedWriteEnvelope.audience = 'vh-forum-post'`; fallback article threads use the existing LUMA `hermes-thread-v1` helper path.
   - `packages/gun-client/src/directoryAdapters.ts`: directory publish uses `identityDirectoryKey` and the LUMA envelope. Coordinate with mesh hardening durability rules in `spec-mesh-production-readiness.md` §5.1 (no regression on durable-write contract).
   - `packages/gun-client/src/aggregateAdapters.ts`: aggregate voter node uses scoped `voterId` per `(topic_id, epoch)`. No raw nullifier in any field. Aggregate snapshot retains supersession-by-version semantics from mesh spec §5.10.
   - `packages/gun-client/src/sentimentEventAdapters.ts`: encrypted outbox writer-kind is unchanged (`~<devicePub>/outbox/sentiment/*` per Open M0.B-3); add `_protocolVersion` and explicit topology classification.
@@ -187,7 +188,7 @@ Deliverables:
   - Topology lint: fail-closed `district_hash` rule (only on aggregate-class paths with cohort proof).
   - Topology lint: protocol/schema reject matrix from mesh spec §5.11 enforced at the adapter layer.
   - Topology lint: drill record outside `vh/__mesh_drills/*` is hard-rejected.
-  - New release gates: `pnpm check:public-namespace-leaks`, `pnpm check:linkability-domain-registry`, `pnpm check:luma-directory-v1`, `pnpm check:luma-forum-author-v1`, `pnpm check:luma-aggregate-voter-v1`.
+  - New release gates: `pnpm check:public-namespace-leaks`, `pnpm check:linkability-domain-registry`, `pnpm check:luma-directory-v1`, `pnpm check:luma-forum-author-v1`, `pnpm check:luma-aggregate-voter-v1`, `pnpm check:luma-forum-post-v1`.
   - Re-run `pnpm test:live:five-user-engagement` against the new taxonomy.
 - Mesh re-run gate (post-M0.B): schema-epoch revalidation only.
   - After all adapter and materializer migration deliverables land, re-run `pnpm check:mesh:production-readiness` against the new schema epoch with `schema_epoch: 'post_luma_m0b'`. The drill harness exercises migrated write classes through their real post-M0.B reader path, not the mesh drill writer contract.
@@ -716,3 +717,4 @@ The spec owns the locked decisions. The roadmap tracks decisions still required 
 | 0.8 | 2026-05-04 | Reviewer | M0.E/M0.F foundation prep. Added `docs/ops/luma-verifier-current-state.md` as the current-state DEV verifier input for M2.A and mechanically moved the DEV-only verifier to `services/luma-verifier-dev`; release note: DEV-only verifier moved; behavior unchanged. No public adapters, public schemas, provider interfaces, or mesh drill harness paths were migrated. |
 | 0.9 | 2026-05-07 | Reviewer | M0.B forum-author narrow slice. Thread/comment writes move to `forumAuthorId`, `hermes-thread-v1` / `hermes-comment-v2`, and `SignedWriteEnvelope` audiences `vh-forum-thread` / `vh-forum-comment`; forum post, nomination, aggregate/voter, sentiment outbox, mesh drills, relay, and service migrations remain out of scope. Added `pnpm check:luma-forum-author-v1`. |
 | 0.10 | 2026-05-07 | Reviewer | M0.B aggregate voter narrow slice. Aggregate voter node writes move to scoped LUMA `voterId`, `aggregate-voter-node-v1`, and `SignedWriteEnvelope` audience `vh-aggregate-voter`; point aggregate snapshots, sentiment outbox encryption, mesh drills, relay, services, and unrelated adapters remain out of scope. Added `pnpm check:luma-aggregate-voter-v1`. |
+| 0.11 | 2026-05-07 | Reviewer | M0.B ForumPost publish-back narrow slice. Hermes Docs article publish-back moves to `hermes-post-v1`, `forumAuthorId`, and `SignedWriteEnvelope` audience `vh-forum-post`; fallback article threads use `hermes-thread-v1`. News reports, nominations, aggregate voters, mesh drills, relay, services, and unrelated adapters remain out of scope. Added `pnpm check:luma-forum-post-v1`. |

--- a/docs/specs/spec-data-topology-privacy-v0.md
+++ b/docs/specs/spec-data-topology-privacy-v0.md
@@ -210,12 +210,12 @@ allowed namespaces, allowed record classes, and signature shape.
 
 Forbidden uses:
 
-- User-author writes (forum thread, forum comment, vote, directory
+- User-author writes (forum thread, forum comment, forum post, vote, directory
   publish, news report intake, civic forwarding receipts) — those go
   through `_writerKind: 'luma'` and `SignedWriteEnvelope`.
 - Drill records — those use `_drillWriterKind: 'mesh-drill'` under
   `vh/__mesh_drills/*`.
-- Any path under `vh/__mesh_drills/*`, `vh/forum/*` thread/comment
+- Any path under `vh/__mesh_drills/*`, `vh/forum/*` thread/comment/post
   payloads, `vh/aggregates/*` per-voter records, or `vh/directory/*`
   identity entries.
 

--- a/docs/specs/spec-hermes-forum-v0.md
+++ b/docs/specs/spec-hermes-forum-v0.md
@@ -320,7 +320,7 @@ appeals, and a broader case-management console.
 ```ts
 type PostType = 'reply' | 'article';
 
-interface ForumPost {
+interface ForumPostV0 {
   id: string;
   schemaVersion: 'hermes-post-v0';
   threadId: string;
@@ -337,6 +337,29 @@ interface ForumPost {
   // required when type='article'
   articleRefId?: string;
 }
+
+interface ForumPostSignedPayload {
+  id: string;
+  schemaVersion: 'hermes-post-v1';
+  _protocolVersion: 'luma-public-v1';
+  _writerKind: 'luma';
+  _authorScheme: 'forum-author-v1';
+  threadId: string;
+  parentId: string | null;
+  topicId: string;
+  author: string; // 64-char forumAuthorId, not raw principal nullifier
+  via?: 'human' | 'familiar';
+  type: PostType;
+  content: string;
+  timestamp: number;
+  articleRefId?: string;
+}
+
+interface ForumPostV1 extends ForumPostSignedPayload {
+  upvotes: number;
+  downvotes: number;
+  signedWriteEnvelope: SignedWriteEnvelope<ForumPostSignedPayload>;
+}
 ```
 
 Constraints:
@@ -344,6 +367,12 @@ Constraints:
 - `reply` max 240 chars (hard block)
 - `article` is longform and Docs-backed
 - If reply input exceeds 240, client must block send and surface `Convert to Article`
+- New post writes MUST use `hermes-post-v1`, `forumAuthorId`, and
+  `SignedWriteEnvelope.audience = 'vh-forum-post'`. `hermes-post-v0` is
+  legacy read-compatible only.
+- Hermes Docs publish-back MUST fail closed when the active LUMA identity is
+  unavailable; it MUST NOT publish public posts with `doc.owner` or a raw
+  principal nullifier as `ForumPost.author`.
 
 ### 2.5 Size limits and proposal elevation rules
 
@@ -717,3 +746,4 @@ UX:
 11. Comment moderation schema rejects malformed/path-mismatched payloads, preserves audit metadata, and hides moderated story-reply content without changing deterministic `news-story:*` thread identity.
 12. News report schema and Gun adapters reject malformed/path-mismatched payloads, preserve operator audit metadata, and route pending reports to audited synthesis correction or comment moderation actions.
 13. LUMA forum-author migration: new thread/comment writes carry 64-char `forumAuthorId`, `_protocolVersion: 'luma-public-v1'`, `_writerKind: 'luma'`, `_authorScheme: 'forum-author-v1'`, and a valid `SignedWriteEnvelope`; legacy v0/v1 hydration stays compatible.
+14. LUMA ForumPost publish-back migration: new Docs article publish-back records carry `hermes-post-v1`, 64-char `forumAuthorId`, `_protocolVersion: 'luma-public-v1'`, `_writerKind: 'luma'`, `_authorScheme: 'forum-author-v1'`, and `SignedWriteEnvelope.audience = 'vh-forum-post'`; fallback article threads use `hermes-thread-v1`.

--- a/docs/specs/spec-luma-service-v0.md
+++ b/docs/specs/spec-luma-service-v0.md
@@ -683,6 +683,15 @@ including the row in aggregate fan-in. Legacy bare voter nodes MAY be
 compatibility-read by migration adapters, but new public writes MUST use the
 LUMA v1 envelope shape.
 
+`ForumPostV1` uses schema version `hermes-post-v1` and signs a
+`ForumPostSignedPayload` through the standard envelope. It carries
+`_protocolVersion: 'luma-public-v1'`, `_writerKind: 'luma'`,
+`_authorScheme: 'forum-author-v1'`, and `SignedWriteEnvelope.audience =
+'vh-forum-post'`. Readers MUST validate that `ForumPost.author`,
+`signedWriteEnvelope.publicAuthor`, and the signed payload `author` match the
+same `forumAuthorId`. Hermes Docs publish-back MUST use this shape for new
+article posts and MUST use `hermes-thread-v1` for fallback article threads.
+
 Adding a new `_authorScheme` value is a Protocol RFC under §1.4 and requires
 a corresponding linkability-domain registry entry under §9.3. Removing a
 value is also an RFC; legacy records under the old scheme remain readable

--- a/docs/sprints/05-sprint-the-bridge.md
+++ b/docs/sprints/05-sprint-the-bridge.md
@@ -285,11 +285,14 @@ type ForumPostType = 'reply' | 'article';
 
 interface ForumPost {
   id: string;
-  schemaVersion: 'hermes-post-v0';
+  schemaVersion: 'hermes-post-v1';
+  _protocolVersion: 'luma-public-v1';
+  _writerKind: 'luma';
+  _authorScheme: 'forum-author-v1';
   threadId: string;
   parentId: string | null;
   topicId: string;
-  author: string;
+  author: string; // derived forumAuthorId, never raw nullifier/doc.owner
   via?: 'human' | 'familiar';
   type: ForumPostType;
   content: string; // reply <= 240
@@ -297,6 +300,7 @@ interface ForumPost {
   timestamp: number;
   upvotes: number;
   downvotes: number;
+  signedWriteEnvelope: SignedWriteEnvelope<ForumPostSignedPayload>;
 }
 ```
 
@@ -305,6 +309,7 @@ Tasks:
 - [ ] Enforce cap at UI + schema boundary
 - [ ] Add conversion route and docs handoff payload
 - [ ] Preserve thread/topic context on publish
+- [ ] Publish-back uses `vh-forum-post` signed writes and v1 fallback threads
 - [ ] Add tests for overflow and conversion path
 
 ### 3.3 Storage paths

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "check:luma-directory-v1": "node ./tools/scripts/check-luma-directory-v1.mjs",
     "check:luma-forum-author-v1": "node ./tools/scripts/check-luma-forum-author-v1.mjs",
     "check:luma-aggregate-voter-v1": "node ./tools/scripts/check-luma-aggregate-voter-v1.mjs",
+    "check:luma-forum-post-v1": "node ./tools/scripts/check-luma-forum-post-v1.mjs",
     "report:news-sources:admission": "pnpm --filter @vh/news-aggregator report:source-admission",
     "report:news-sources:health": "NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter @vh/news-aggregator report:source-health",
     "scout:news-sources:candidates": "NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter @vh/news-aggregator report:source-scout",

--- a/packages/data-model/src/schemas/hermes/forum.test.ts
+++ b/packages/data-model/src/schemas/hermes/forum.test.ts
@@ -5,11 +5,14 @@ import {
   deriveUrlTopicId,
   FORUM_AUTHOR_SCHEME,
   FORUM_COMMENT_AUDIENCE,
+  FORUM_POST_AUDIENCE,
   FORUM_PUBLIC_PROTOCOL_VERSION,
   FORUM_THREAD_AUDIENCE,
   FORUM_WRITER_KIND,
   ForumPostSchema,
+  ForumPostSchemaV1,
   forumCommentSignedPayload,
+  forumPostSignedPayload,
   forumThreadSignedPayload,
   HermesCommentModerationSchema,
   HermesCommentSchema,
@@ -128,6 +131,30 @@ function signedCommentEnvelope(payload = forumCommentSignedPayload(baseCommentV2
   } as const;
 }
 
+function signedPostEnvelope(payload = forumPostSignedPayload(basePostV1())) {
+  return {
+    envelopeVersion: 1,
+    signatureSuite: 'jcs-ed25519-sha256-v1',
+    protocolVersion: 'luma-write-v1',
+    profile: 'public-beta',
+    audience: FORUM_POST_AUDIENCE,
+    origin: 'https://vh.example',
+    scheme: FORUM_AUTHOR_SCHEME,
+    publicAuthor: payload.author,
+    sessionRef: {
+      tokenHash: HEX_64,
+      envelopeDigest: 'b'.repeat(64)
+    },
+    payload,
+    payloadDigest: 'c'.repeat(64),
+    sequence: now,
+    nonce: HEX_32,
+    idempotencyKey: 'd'.repeat(64),
+    issuedAt: now,
+    signature: 'signature'
+  } as const;
+}
+
 function baseThreadV1() {
   const payload = {
     schemaVersion: 'hermes-thread-v1' as const,
@@ -170,6 +197,30 @@ function baseCommentV2() {
     upvotes: 0,
     downvotes: 0,
     signedWriteEnvelope: signedCommentEnvelope(payload)
+  };
+}
+
+function basePostV1() {
+  const payload = {
+    schemaVersion: 'hermes-post-v1' as const,
+    _protocolVersion: FORUM_PUBLIC_PROTOCOL_VERSION,
+    _writerKind: FORUM_WRITER_KIND,
+    _authorScheme: FORUM_AUTHOR_SCHEME,
+    id: 'post-luma-1',
+    threadId: 'thread-luma-1',
+    parentId: null,
+    topicId: 'topic-luma-1',
+    author: FORUM_AUTHOR_ID,
+    type: 'article' as const,
+    content: 'Signed article publish-back content',
+    timestamp: now,
+    articleRefId: 'article-luma-1'
+  };
+  return {
+    ...payload,
+    upvotes: 0,
+    downvotes: 0,
+    signedWriteEnvelope: signedPostEnvelope(payload)
   };
 }
 
@@ -831,6 +882,85 @@ describe('ForumPostSchema', () => {
     expect(parsed.articleRefId).toBe('doc-article-1');
   });
 
+  it('accepts LUMA v1 article posts with forum-author metadata and signed envelope', () => {
+    const post = basePostV1();
+    const parsed = ForumPostSchemaV1.parse(post);
+
+    expect(parsed).toMatchObject({
+      schemaVersion: 'hermes-post-v1',
+      _protocolVersion: 'luma-public-v1',
+      _writerKind: 'luma',
+      _authorScheme: 'forum-author-v1',
+      author: expect.stringMatching(/^[0-9a-f]{64}$/),
+      signedWriteEnvelope: expect.objectContaining({
+        audience: 'vh-forum-post',
+        scheme: 'forum-author-v1',
+        publicAuthor: post.author,
+        payload: forumPostSignedPayload(post)
+      })
+    });
+  });
+
+  it('omits undefined optional fields from LUMA post signed payloads', () => {
+    const payload = forumPostSignedPayload({
+      ...basePostV1(),
+      via: undefined
+    });
+
+    expect(Object.prototype.hasOwnProperty.call(payload, 'via')).toBe(false);
+  });
+
+  it('rejects LUMA v1 posts with raw-author, publicAuthor, audience, or signed payload mismatches', () => {
+    const post = basePostV1();
+
+    expect(ForumPostSchema.safeParse({ ...post, author: 'raw-nullifier' }).success).toBe(false);
+    expect(ForumPostSchema.safeParse({
+      ...post,
+      signedWriteEnvelope: {
+        ...post.signedWriteEnvelope,
+        publicAuthor: OTHER_FORUM_AUTHOR_ID
+      }
+    }).success).toBe(false);
+    expect(ForumPostSchema.safeParse({
+      ...post,
+      signedWriteEnvelope: {
+        ...post.signedWriteEnvelope,
+        audience: 'vh-forum-thread'
+      }
+    }).success).toBe(false);
+    expect(ForumPostSchema.safeParse({
+      ...post,
+      content: 'Tampered post content after signing'
+    }).success).toBe(false);
+  });
+
+  it('accepts LUMA post signed payloads regardless of envelope payload key order', () => {
+    const post = basePostV1();
+    const reorderedPayload = {
+      articleRefId: post.signedWriteEnvelope.payload.articleRefId,
+      timestamp: post.signedWriteEnvelope.payload.timestamp,
+      content: post.signedWriteEnvelope.payload.content,
+      type: post.signedWriteEnvelope.payload.type,
+      author: post.signedWriteEnvelope.payload.author,
+      topicId: post.signedWriteEnvelope.payload.topicId,
+      parentId: post.signedWriteEnvelope.payload.parentId,
+      threadId: post.signedWriteEnvelope.payload.threadId,
+      id: post.signedWriteEnvelope.payload.id,
+      _authorScheme: post.signedWriteEnvelope.payload._authorScheme,
+      _writerKind: post.signedWriteEnvelope.payload._writerKind,
+      _protocolVersion: post.signedWriteEnvelope.payload._protocolVersion,
+      schemaVersion: post.signedWriteEnvelope.payload.schemaVersion
+    };
+
+    expect(ForumPostSchema.safeParse({
+      ...post,
+      signedWriteEnvelope: {
+        ...post.signedWriteEnvelope,
+        payload: reorderedPayload
+      }
+    }).success).toBe(true);
+  });
+
   it('accepts reply with via field', () => {
     const parsed = ForumPostSchema.parse({ ...baseReplyPost, via: 'human' });
     expect(parsed.via).toBe('human');
@@ -927,7 +1057,7 @@ describe('ForumPostSchema', () => {
 
   it('rejects invalid schemaVersion', () => {
     expect(
-      ForumPostSchema.safeParse({ ...baseReplyPost, schemaVersion: 'hermes-post-v1' }).success
+      ForumPostSchema.safeParse({ ...baseReplyPost, schemaVersion: 'hermes-post-v9' }).success
     ).toBe(false);
   });
 

--- a/packages/data-model/src/schemas/hermes/forum.ts
+++ b/packages/data-model/src/schemas/hermes/forum.ts
@@ -9,6 +9,7 @@ export const FORUM_AUTHOR_SCHEME = 'forum-author-v1';
 export const FORUM_WRITER_KIND = 'luma';
 export const FORUM_THREAD_AUDIENCE = 'vh-forum-thread';
 export const FORUM_COMMENT_AUDIENCE = 'vh-forum-comment';
+export const FORUM_POST_AUDIENCE = 'vh-forum-post';
 
 const LowerHex64Schema = z.string().regex(/^[0-9a-f]{64}$/);
 const LowerHex32Schema = z.string().regex(/^[0-9a-f]{32}$/);
@@ -300,46 +301,118 @@ const POST_TYPE = z.enum(['reply', 'article']);
 
 const REPLY_CONTENT_LIMIT = 240;
 
-export const ForumPostSchema = z
-  .object({
-    id: z.string().min(1),
-    schemaVersion: z.literal('hermes-post-v0'),
-    threadId: z.string().min(1),
-    parentId: z.string().min(1).nullable(),
-    topicId: z.string().min(1),
-    author: z.string().min(1),
-    via: z.enum(['human', 'familiar']).optional(),
-    type: POST_TYPE,
-    content: z.string().min(1).max(CONTENT_LIMIT),
-    timestamp: z.number().int().nonnegative(),
-    upvotes: z.number().int().nonnegative(),
-    downvotes: z.number().int().nonnegative(),
-    articleRefId: z.string().min(1).optional()
-  })
-  .superRefine((value, ctx) => {
-    if (value.type === 'reply' && value.content.length > REPLY_CONTENT_LIMIT) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ['content'],
-        message: `Reply content must not exceed ${REPLY_CONTENT_LIMIT} characters`
-      });
-    }
-    if (value.type === 'article' && !value.articleRefId) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ['articleRefId'],
-        message: 'articleRefId is required for article posts'
-      });
-    }
-    if (value.type === 'reply' && value.articleRefId) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ['articleRefId'],
-        message: 'articleRefId must be omitted for reply posts'
-      });
-    }
-  });
+const ForumPostBaseFields = {
+  id: z.string().min(1),
+  threadId: z.string().min(1),
+  parentId: z.string().min(1).nullable(),
+  topicId: z.string().min(1),
+  via: z.enum(['human', 'familiar']).optional(),
+  type: POST_TYPE,
+  content: z.string().min(1).max(CONTENT_LIMIT),
+  timestamp: z.number().int().nonnegative(),
+  articleRefId: z.string().min(1).optional()
+} as const satisfies Record<string, z.ZodTypeAny>;
 
+function refineForumPostContent(
+  value: {
+    readonly type: z.infer<typeof POST_TYPE>;
+    readonly content: string;
+    readonly articleRefId?: string;
+  },
+  ctx: z.RefinementCtx
+): void {
+  if (value.type === 'reply' && value.content.length > REPLY_CONTENT_LIMIT) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['content'],
+      message: `Reply content must not exceed ${REPLY_CONTENT_LIMIT} characters`
+    });
+  }
+  if (value.type === 'article' && !value.articleRefId) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['articleRefId'],
+      message: 'articleRefId is required for article posts'
+    });
+  }
+  if (value.type === 'reply' && value.articleRefId) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['articleRefId'],
+      message: 'articleRefId must be omitted for reply posts'
+    });
+  }
+}
+
+export const ForumPostSchemaV0 = z.object({
+  schemaVersion: z.literal('hermes-post-v0'),
+  ...ForumPostBaseFields,
+  author: z.string().min(1),
+  upvotes: z.number().int().nonnegative(),
+  downvotes: z.number().int().nonnegative()
+}).superRefine(refineForumPostContent);
+
+const ForumPostSignedPayloadObjectSchema = z.object({
+  schemaVersion: z.literal('hermes-post-v1'),
+  _protocolVersion: z.literal(FORUM_PUBLIC_PROTOCOL_VERSION),
+  _writerKind: z.literal(FORUM_WRITER_KIND),
+  _authorScheme: z.literal(FORUM_AUTHOR_SCHEME),
+  ...ForumPostBaseFields,
+  author: LowerHex64Schema
+}).strict();
+
+export const ForumPostSignedPayloadSchema = ForumPostSignedPayloadObjectSchema.superRefine(refineForumPostContent);
+
+export const ForumPostSignedWriteEnvelopeSchema = z.object({
+  envelopeVersion: z.literal(1),
+  signatureSuite: z.literal('jcs-ed25519-sha256-v1'),
+  protocolVersion: z.literal('luma-write-v1'),
+  profile: z.enum(['dev', 'e2e', 'public-beta', 'production-attestation']),
+  audience: z.literal(FORUM_POST_AUDIENCE),
+  origin: z.string().min(1),
+  scheme: z.literal(FORUM_AUTHOR_SCHEME),
+  publicAuthor: LowerHex64Schema,
+  sessionRef: ForumSignedWriteSessionRefSchema,
+  payload: ForumPostSignedPayloadSchema,
+  payloadDigest: LowerHex64Schema,
+  sequence: z.number().int().nonnegative(),
+  nonce: LowerHex32Schema,
+  idempotencyKey: LowerHex64Schema,
+  issuedAt: z.number().int().nonnegative(),
+  signature: z.string().min(1)
+}).strict();
+
+export const ForumPostSchemaV1 = ForumPostSignedPayloadObjectSchema.extend({
+  upvotes: z.number().int().nonnegative(),
+  downvotes: z.number().int().nonnegative(),
+  signedWriteEnvelope: ForumPostSignedWriteEnvelopeSchema
+}).strict().superRefine((value, ctx) => {
+  refineForumPostContent(value, ctx);
+
+  if (value.signedWriteEnvelope.publicAuthor !== value.author) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['signedWriteEnvelope', 'publicAuthor'],
+      message: 'signedWriteEnvelope.publicAuthor must match post author'
+    });
+  }
+
+  const payload = tryForumPostSignedPayload(value);
+  if (payload && !sameCanonicalJson(value.signedWriteEnvelope.payload, payload)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['signedWriteEnvelope', 'payload'],
+      message: 'signedWriteEnvelope.payload must match immutable post payload'
+    });
+  }
+});
+
+export const ForumPostSchema = z.union([ForumPostSchemaV0, ForumPostSchemaV1]);
+
+export type ForumPostV0 = z.infer<typeof ForumPostSchemaV0>;
+export type ForumPostSignedPayload = z.infer<typeof ForumPostSignedPayloadSchema>;
+export type ForumPostSignedWriteEnvelope = z.infer<typeof ForumPostSignedWriteEnvelopeSchema>;
+export type ForumPostV1 = z.infer<typeof ForumPostSchemaV1>;
 export type ForumPost = z.infer<typeof ForumPostSchema>;
 export const REPLY_CONTENT_MAX = REPLY_CONTENT_LIMIT;
 
@@ -405,6 +478,25 @@ export function forumCommentSignedPayload(comment: ForumCommentSignedPayload): F
   }));
 }
 
+export function forumPostSignedPayload(post: ForumPostSignedPayload): ForumPostSignedPayload {
+  return ForumPostSignedPayloadSchema.parse(stripUndefinedFields({
+    schemaVersion: post.schemaVersion,
+    _protocolVersion: post._protocolVersion,
+    _writerKind: post._writerKind,
+    _authorScheme: post._authorScheme,
+    id: post.id,
+    threadId: post.threadId,
+    parentId: post.parentId,
+    topicId: post.topicId,
+    author: post.author,
+    via: post.via,
+    type: post.type,
+    content: post.content,
+    timestamp: post.timestamp,
+    articleRefId: post.articleRefId
+  }));
+}
+
 export function migrateCommentToV1(comment: HermesCommentV0 | HermesCommentV1 | HermesCommentV2): HermesComment {
   if (comment.schemaVersion === 'hermes-comment-v1') {
     const { type: _omit, ...rest } = comment;
@@ -432,7 +524,20 @@ export function computeThreadScore(thread: HermesThread, now: number): number {
 }
 
 function sameCanonicalJson(a: unknown, b: unknown): boolean {
-  return JSON.stringify(a) === JSON.stringify(b);
+  return stableJson(a) === stableJson(b);
+}
+
+function stableJson(value: unknown): string {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableJson(item)).join(',')}]`;
+  }
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, field]) => field !== undefined)
+    .sort(([left], [right]) => left.localeCompare(right));
+  return `{${entries.map(([key, field]) => `${JSON.stringify(key)}:${stableJson(field)}`).join(',')}}`;
 }
 
 function stripUndefinedFields<T extends Record<string, unknown>>(value: T): T {
@@ -450,6 +555,14 @@ function tryForumThreadSignedPayload(thread: ForumThreadSignedPayload): ForumThr
 function tryForumCommentSignedPayload(comment: ForumCommentSignedPayload): ForumCommentSignedPayload | null {
   try {
     return forumCommentSignedPayload(comment);
+  } catch {
+    return null;
+  }
+}
+
+function tryForumPostSignedPayload(post: ForumPostSignedPayload): ForumPostSignedPayload | null {
+  try {
+    return forumPostSignedPayload(post);
   } catch {
     return null;
   }

--- a/packages/luma-sdk/src/providers/index.ts
+++ b/packages/luma-sdk/src/providers/index.ts
@@ -18,6 +18,7 @@ export type AudienceTag =
   | 'vh-directory-entry'
   | 'vh-forum-thread'
   | 'vh-forum-comment'
+  | 'vh-forum-post'
   | 'vh-aggregate-voter'
   | 'vh-stance-vote'
   | 'vh-stance-clear'

--- a/packages/luma-sdk/src/signedWrites.test.ts
+++ b/packages/luma-sdk/src/signedWrites.test.ts
@@ -154,6 +154,15 @@ describe('LUMA SignedWriteEnvelope SDK surface', () => {
     })).resolves.toMatch(/^[0-9a-f]{64}$/);
   });
 
+  it('registers the forum post audience for M0.B publish-back migration', async () => {
+    expect(LUMA_SIGNED_WRITE_AUDIENCES).toContain('vh-forum-post');
+    await expect(deriveSignedWriteIdempotencyKey({
+      payloadDigest: EXPECTED_PAYLOAD_DIGEST,
+      audience: 'vh-forum-post',
+      sequence: 1
+    })).resolves.toMatch(/^[0-9a-f]{64}$/);
+  });
+
   it('creates and verifies the frozen M0.B JCS/Ed25519 vector', async () => {
     const envelope = await createVectorEnvelope();
     const verification = await verifySignedWriteEnvelope({

--- a/packages/luma-sdk/src/signedWrites.ts
+++ b/packages/luma-sdk/src/signedWrites.ts
@@ -18,6 +18,7 @@ export const LUMA_SIGNED_WRITE_AUDIENCES = Object.freeze([
   'vh-directory-entry',
   'vh-forum-thread',
   'vh-forum-comment',
+  'vh-forum-post',
   'vh-aggregate-voter',
   'vh-stance-vote',
   'vh-stance-clear',

--- a/tools/scripts/check-luma-forum-post-v1.mjs
+++ b/tools/scripts/check-luma-forum-post-v1.mjs
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const failures = [];
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(rootDir, relativePath), 'utf8');
+}
+
+function requireToken(source, token, label) {
+  if (!source.includes(token)) {
+    failures.push(`${label} is missing ${token}`);
+  }
+}
+
+function forbidToken(source, token, label) {
+  if (source.includes(token)) {
+    failures.push(`${label} contains forbidden token ${token}`);
+  }
+}
+
+function sliceBetween(source, startToken, endToken, label) {
+  const start = source.indexOf(startToken);
+  const end = endToken ? source.indexOf(endToken, start + startToken.length) : source.length;
+  if (start < 0 || end <= start) {
+    failures.push(`${label} block was not found`);
+    return '';
+  }
+  return source.slice(start, end);
+}
+
+const forumSchemaSource = read('packages/data-model/src/schemas/hermes/forum.ts');
+const forumSchemaTestSource = read('packages/data-model/src/schemas/hermes/forum.test.ts');
+const signedWritesSource = read('packages/luma-sdk/src/signedWrites.ts');
+const providersSource = read('packages/luma-sdk/src/providers/index.ts');
+const lumaRecordsSource = read('apps/web-pwa/src/store/forum/lumaRecords.ts');
+const docsStoreSource = read('apps/web-pwa/src/store/hermesDocs.ts');
+const docsStoreTestSource = read('apps/web-pwa/src/store/hermesDocs.test.ts');
+const articleEditorSource = read('apps/web-pwa/src/components/docs/ArticleEditor.tsx');
+const forumSpecSource = read('docs/specs/spec-hermes-forum-v0.md');
+const lumaSpecSource = read('docs/specs/spec-luma-service-v0.md');
+const privacySpecSource = read('docs/specs/spec-data-topology-privacy-v0.md');
+const roadmapSource = read('docs/plans/LUMA_SERVICE_V0_ROADMAP_2026-05-02.md');
+const bridgeSprintSource = read('docs/sprints/05-sprint-the-bridge.md');
+
+for (const token of [
+  "FORUM_POST_AUDIENCE = 'vh-forum-post'",
+  "schemaVersion: z.literal('hermes-post-v1')",
+  'ForumPostSignedPayloadSchema',
+  'ForumPostSignedWriteEnvelopeSchema',
+  'ForumPostSchemaV1',
+  'signedWriteEnvelope.publicAuthor must match post author',
+  'signedWriteEnvelope.payload must match immutable post payload',
+  'forumPostSignedPayload'
+]) {
+  requireToken(forumSchemaSource, token, 'forum post data-model schema');
+}
+
+for (const token of [
+  "'vh-forum-post'",
+  'LUMA_SIGNED_WRITE_AUDIENCES'
+]) {
+  requireToken(signedWritesSource, token, 'LUMA signed-write audience surface');
+}
+requireToken(providersSource, "'vh-forum-post'", 'LUMA provider AudienceTag');
+
+for (const token of [
+  'createLumaForumPostRecord',
+  'deriveForumAuthorId(input.identity.session.nullifier)',
+  'createSignedWriteEnvelope({',
+  'createLumaPublicAuthorId(forumAuthorId, FORUM_AUTHOR_SCHEME)',
+  'signWithStoredDelegationSigningKey',
+  'audience: FORUM_POST_AUDIENCE',
+  "schemaVersion: 'hermes-post-v1'",
+  'author: forumAuthorId'
+]) {
+  requireToken(lumaRecordsSource, token, 'app LUMA forum record helper');
+}
+forbidToken(lumaRecordsSource, 'author: input.identity.session.nullifier', 'app LUMA forum record helper');
+forbidToken(lumaRecordsSource, 'publicAuthor: input.identity.session.nullifier', 'app LUMA forum record helper');
+
+const publishBackBlock = sliceBetween(
+  docsStoreSource,
+  'export async function createPublishBackArtifacts(',
+  '/* v8 ignore next 5',
+  'Hermes Docs publish-back artifact builder'
+);
+for (const token of [
+  'assertLumaForumIdentity(identityRecord)',
+  'createLumaForumPostRecord({',
+  'createLumaForumThreadRecord({',
+  'identity,',
+  "audience: 'vh-forum-post'",
+  "schemaVersion: 'hermes-post-v1'",
+  "schemaVersion: 'hermes-thread-v1'"
+]) {
+  requireToken(docsStoreSource + docsStoreTestSource, token, 'Hermes Docs publish-back path/tests');
+}
+for (const token of [
+  "schemaVersion: 'hermes-post-v0'",
+  "schemaVersion: 'hermes-thread-v0'",
+  'author: doc.owner',
+  'author: existing.owner',
+  'author: deps.owner()'
+]) {
+  forbidToken(publishBackBlock, token, 'Hermes Docs publish-back artifact builder');
+}
+requireToken(docsStoreSource, 'publishArticle: (docId: string) => Promise<boolean>', 'Hermes Docs async publish API');
+requireToken(docsStoreSource, 'return false', 'Hermes Docs fail-closed publish path');
+requireToken(articleEditorSource, 'const didPublish = await publishArticle(cid)', 'ArticleEditor async publish path');
+
+for (const token of [
+  'accepts LUMA v1 article posts with forum-author metadata and signed envelope',
+  'rejects LUMA v1 posts with raw-author, publicAuthor, audience, or signed payload mismatches',
+  'accepts LUMA post signed payloads regardless of envelope payload key order'
+]) {
+  requireToken(forumSchemaTestSource, token, 'forum post schema tests');
+}
+for (const token of [
+  'fails closed without an active identity and does not mark the document published',
+  "schemaVersion: 'hermes-post-v1'",
+  "schemaVersion: 'hermes-thread-v1'",
+  "audience: 'vh-forum-post'",
+  "audience: 'vh-forum-thread'"
+]) {
+  requireToken(docsStoreTestSource, token, 'Hermes Docs publish-back tests');
+}
+
+for (const token of [
+  'hermes-post-v1',
+  'ForumPostSignedPayload',
+  'forumAuthorId',
+  'vh-forum-post'
+]) {
+  requireToken(forumSpecSource, token, 'Hermes forum spec');
+  requireToken(lumaSpecSource, token, 'LUMA service spec');
+}
+for (const token of [
+  'forum post',
+  "_writerKind: 'luma'",
+  'SignedWriteEnvelope'
+]) {
+  requireToken(privacySpecSource, token, 'data topology privacy spec');
+}
+for (const token of [
+  'check:luma-forum-post-v1',
+  'vh-forum-post',
+  'hermes-post-v1',
+  'Hermes Docs article publish-back'
+]) {
+  requireToken(roadmapSource, token, 'LUMA roadmap');
+}
+for (const token of [
+  "schemaVersion: 'hermes-post-v1'",
+  "_authorScheme: 'forum-author-v1'",
+  'derived forumAuthorId',
+  'vh-forum-post'
+]) {
+  requireToken(bridgeSprintSource, token, 'Bridge sprint ForumPost publish-back plan');
+}
+
+if (failures.length > 0) {
+  console.error('[check:luma-forum-post-v1] failed');
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log('[check:luma-forum-post-v1] forum post v1 surface ok');


### PR DESCRIPTION
## Summary
- Adds `hermes-post-v1` ForumPost schema support with LUMA protocol metadata, `forum-author-v1`, and `vh-forum-post` signed-write envelope validation.
- Moves Hermes Docs publish-back to derive `forumAuthorId`, sign v1 forum posts, and use the existing LUMA `hermes-thread-v1` fallback thread path.
- Makes article publish completion wait for a successful LUMA publish artifact build; missing identity fails closed without marking the document published.
- Adds `check:luma-forum-post-v1` and updates LUMA/forum/privacy/roadmap/sprint docs for the publish-back contract.

## Scope boundaries
- No changes to directory, aggregate voter, news report, nomination, sentiment outbox, mesh drill, relay, service, vault, wallet, provider, lifecycle, or public identifier derivation behavior.
- Legacy `hermes-post-v0` remains schema/read compatible only; new Hermes Docs publish-back writes v1.

## Verification
- `pnpm --filter @vh/data-model test`
- `pnpm --filter @vh/luma-sdk test`
- `pnpm exec vitest run apps/web-pwa/src/store/hermesDocs.test.ts apps/web-pwa/src/components/docs/ArticleEditor.test.tsx apps/web-pwa/src/components/hermes/forum/CommentComposerWithArticle.test.tsx --reporter=verbose`
- `pnpm --filter @vh/data-model typecheck`
- `pnpm --filter @vh/luma-sdk typecheck`
- `pnpm --filter @vh/web-pwa typecheck`
- `pnpm --filter @vh/data-model build`
- `pnpm --filter @vh/luma-sdk build`
- `pnpm --filter @vh/web-pwa build`
- all existing LUMA guards, including new `pnpm check:luma-forum-post-v1`
- `pnpm docs:check`
- `git diff --check origin/main...HEAD`
- `node tools/scripts/check-diff-coverage.mjs` (100% line/branch coverage on changed runtime files)
- protected-surface grep for adapter/schema/materializer/mesh/relay/service exclusions

Known local caveat: PNPM emits the existing Node engine warning for local Node `v23.10.0` vs repo engine `>=20 <23`.
