### PR TITLE
Mesh Slice 12A operator rollback drill

### DIFF
--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -51,6 +51,46 @@ This document defines compile-time flags used by the web PWA for FPD rollout.
   - **Status:** always-on in production wiring.
   - **Control model:** no runtime/compile-time feature flag; card-back voting uses BiasTable v2 unconditionally.
 
+## Mesh peer-config flags
+
+- **`VITE_VH_STRICT_PEER_CONFIG`**
+  - **Default:** production builds default to strict; non-production may opt in.
+  - **Description:** Requires explicit Gun peers or a verified signed peer-config
+    source. In strict mode, invalid peer config fails closed before accepting
+    peer sockets.
+  - **Production requirement:** `true`
+
+- **`VITE_GUN_PEER_CONFIG_URL`**
+  - **Default:** empty
+  - **Description:** HTTPS URL for the signed mesh peer-config payload.
+  - **Production requirement:** set to the deployed peer-config origin.
+
+- **`VITE_GUN_PEER_CONFIG_PUBLIC_KEY`**
+  - **Default:** empty
+  - **Description:** Trusted public key used to verify signed peer-config
+    payloads.
+  - **Production requirement:** set. Rotation requires a new app build or a
+    future trusted runtime key-distribution path.
+
+- **`VITE_GUN_PEER_MINIMUM` / `VITE_GUN_PEER_QUORUM_REQUIRED`**
+  - **Default:** strict mode expects three peers and quorum two.
+  - **Description:** Browser topology floors. Signed strict configs must include
+    `minimumPeerCount` and `quorumRequired`, and `quorumRequired` cannot exceed
+    the signed peer count.
+
+- **`VITE_VH_ALLOW_LOCAL_MESH_PEERS`**
+  - **Default:** `false`
+  - **Description:** Allows local `http://`, `ws://`, loopback peer URLs only for
+    local harnesses.
+  - **Production requirement:** `false`
+
+- **`VITE_VH_CSP_CONNECT_SRC` / `VITE_VH_CSP_STRICT_CONNECT_SRC`**
+  - **Default:** environment-specific
+  - **Description:** Adds the peer-config and WSS relay origins to CSP
+    `connect-src`; strict mode rejects broad wildcard/path/malformed extra
+    sources in the mesh canary.
+  - **Production requirement:** exact expected HTTPS/WSS origins only.
+
 ## Deployment guardrails
 
 1. Production builds must enforce `VITE_CONSTITUENCY_PROOF_REAL=true`.
@@ -61,3 +101,6 @@ This document defines compile-time flags used by the web PWA for FPD rollout.
    resistance.
 2. E2E-mode (`VITE_E2E_MODE=true`) is test-only and cannot ship.
 3. Any flag change requires a new build artifact because flags are compile-time constants.
+4. Mesh peer-config key, URL, local-peer allowance, quorum, or CSP changes require
+   a new Web PWA build and a rerun of `pnpm test:mesh:peer-config-rollback-drill`
+   plus `pnpm check:mesh:production-readiness`.

--- a/docs/ops/mesh-production-operator-runbook.md
+++ b/docs/ops/mesh-production-operator-runbook.md
@@ -1,0 +1,189 @@
+# Mesh Production Operator Runbook
+
+> Status: Active for local TLS/WSS operator rehearsal
+> Owner: VHC Core Engineering
+> Last Reviewed: 2026-05-07
+> Depends On: `docs/specs/spec-mesh-production-readiness.md`, `docs/ops/mesh-production-topology-drills.md`, `docs/feature-flags.md`
+
+This runbook makes the mesh topology lifecycle executable by an operator. It is
+not a public WSS deployment guide yet. The current rehearsed path uses the
+hermetic local TLS/WSS profile and synthetic peer-config fixtures only.
+
+## Operator Gates
+
+Run the rollback drill before changing signed peer config in any production-like
+environment:
+
+```sh
+pnpm test:mesh:peer-config-rollback-drill
+```
+
+Then refresh the aggregate packet:
+
+```sh
+pnpm check:mesh:production-readiness
+```
+
+The aggregate packet must remain `status: review_required` until the remaining
+release blockers are actually implemented. A passing rollback drill only proves
+that the local TLS/WSS Web PWA can accept signed config A, accept signed config
+B, fail closed on invalid configs, and accept a freshly issued signed rollback
+config for the previous topology shape.
+
+## Required Build-Time Inputs
+
+The Web PWA peer-config trust inputs are compile-time `VITE_*` values:
+
+- `VITE_VH_STRICT_PEER_CONFIG=true`
+- `VITE_GUN_PEER_CONFIG_URL=<https peer-config url>`
+- `VITE_GUN_PEER_CONFIG_PUBLIC_KEY=<trusted signing public key>`
+- `VITE_GUN_PEER_MINIMUM=3`
+- `VITE_GUN_PEER_QUORUM_REQUIRED=2`
+- `VITE_VH_ALLOW_LOCAL_MESH_PEERS=false`
+- `VITE_VH_CSP_CONNECT_SRC="<expected wss origins> <peer-config origin>"`
+- `VITE_VH_CSP_STRICT_CONNECT_SRC=true`
+
+Because these are baked into the bundle, changing the trusted signing key or CSP
+connect-src requires a new app build and rollout. Do not describe runtime key
+rotation as proven unless a later slice implements trusted runtime key
+distribution.
+
+## Health Probes
+
+For each relay origin, verify:
+
+```sh
+curl -fsS https://<relay-origin>/healthz
+curl -fsS https://<relay-origin>/readyz
+curl -fsS https://<relay-origin>/metrics | rg 'vh_relay_active_connections|vh_relay_ws_bytes'
+```
+
+Expected result:
+
+- `/healthz` returns `{ "ok": true, "service": "vh-relay" }`.
+- `/readyz` returns a successful readiness response.
+- `/metrics` exposes connection and byte counters.
+
+If quorum health fails, do not roll forward peer config. Use the latest
+readiness report `health.degradation_reasons_seen[]` and the relay logs before
+attempting rollback.
+
+## Signed Peer-Config Lifecycle
+
+Each signed config must include:
+
+- `schemaVersion: "mesh-peer-config-v1"`
+- `configId`
+- `issuedAt`
+- `expiresAt`
+- `peers`
+- `minimumPeerCount`
+- `quorumRequired`
+
+Strict mode fails closed for unsigned, expired, bad-signature, wrong-key,
+insufficient-peer, impossible-quorum, and insecure/local-peer configs when local
+peer allowance is disabled.
+
+## Roll Forward
+
+1. Generate signed config B with a new `configId`, current `issuedAt`, future
+   `expiresAt`, expected three WSS peers, `minimumPeerCount: 3`, and
+   `quorumRequired: 2`.
+2. Confirm `connect-src` includes exactly `'self'`, the WSS relay origins, and
+   the HTTPS peer-config origin.
+3. Publish config B at the peer-config URL with `Cache-Control: no-store`.
+4. Build and deploy the Web PWA with the intended trusted public key and CSP.
+5. Verify the app proof hook or operator evidence shows:
+   - `source: remote-config`
+   - `strict: true`
+   - `signed: true`
+   - expected `configId`
+   - `local_mesh_peers_allowed: false`
+   - three WSS peers and quorum two
+
+## Roll Back
+
+Rollback is not accepting an old cached file. Rollback means issuing a fresh
+signed rollback config with a new `configId`, current `issuedAt`, future
+`expiresAt`, and the previous topology shape.
+
+1. Generate signed rollback config R using the currently trusted signing key.
+2. Publish R at the peer-config URL with `Cache-Control: no-store`.
+3. Reload or otherwise force old tabs to refetch peer config.
+4. Verify the app proof shows R's `configId` and previous peer topology shape.
+5. Refresh `pnpm check:mesh:production-readiness` and confirm the rollback source
+   report is present, command-matched, fresh, clean, and `review_required`.
+
+Current old-tab claim boundary: the drilled behavior is reload/refetch. The app
+does not yet claim live in-place topology replacement for already-open tabs.
+
+## Signing-Key Rotation And Revocation
+
+The current browser trust root is `VITE_GUN_PEER_CONFIG_PUBLIC_KEY`, so rotation
+requires a new app build or another trusted key-distribution path in a later
+slice.
+
+Safe rotation procedure:
+
+1. Generate the new signing key pair outside the repo.
+2. Build a new app artifact with the new public key.
+3. Publish a config signed by the new private key.
+4. Verify old-key configs fail closed in the rollback drill equivalent.
+5. Remove the compromised old public key from all deploy artifacts.
+
+Do not serve a config signed by an unknown or removed key. The rollback drill
+proves wrong-key configs fail closed; it does not prove runtime multi-key trust.
+
+## Relay Credential Rotation
+
+Relay daemon tokens and relay-to-relay credentials are operationally separate
+from peer-config signing keys.
+
+1. Rotate `VH_RELAY_DAEMON_TOKEN` on one relay at a time.
+2. Verify `/readyz` and `/metrics`.
+3. Rotate relay-to-relay credentials or allowlist settings.
+4. Verify quorum remains healthy before moving to the next relay.
+
+The local harness still uses `VH_RELAY_PEER_AUTH_MODE=private_network_allowlist`;
+public WSS must use a production trust path before public deployment claims.
+
+## Service Worker And CSP
+
+Peer config must be fetched with `cache: "no-store"` and served with
+`Cache-Control: no-store`. During rollout or rollback:
+
+- update CSP before expecting the app to connect to new origins;
+- reject broad `https:` or `wss:` wildcards;
+- reject dev localhost connect-src entries in strict deployed canaries;
+- reload old tabs after config changes;
+- check the service-worker rollover/rollback evidence in the latest report.
+
+## Trace Lookup
+
+Use these IDs across artifacts:
+
+- `run_id`: names the report directory under `.tmp/mesh-production-readiness/`
+- `trace_id`: joins browser evidence to the report
+- `configId`: identifies accepted/rejected peer-config payloads
+- `write_id`: used by data drills; peer-config rollback does not write drill data
+
+For aggregate evidence, inspect:
+
+```text
+.tmp/mesh-production-readiness/latest/mesh-production-readiness-report.json
+.tmp/mesh-production-readiness/latest/mesh-production-readiness-evidence.md
+.tmp/mesh-production-readiness/latest/source-reports/peer_config_rollback/
+```
+
+## Cleanup And Compaction
+
+Peer-config rollback writes no `vh/__mesh_drills/*` records. Data drills still
+write synthetic records and must clean or tombstone their namespaces. For health
+probe compaction, use:
+
+```sh
+pnpm mesh:compact-health-probes
+```
+
+Never promote `.tmp` evidence into durable docs until a future evidence scrub
+gate exists and passes.

--- a/docs/ops/mesh-production-topology-drills.md
+++ b/docs/ops/mesh-production-topology-drills.md
@@ -75,6 +75,19 @@ expected WSS relay and HTTPS peer-config origins, plus `'self'`, without dev
 localhost sources or broad `https:`/`wss:` wildcards, and signed peer-config
 rollover is fetched fresh instead of being pinned by service-worker cache.
 
+Run the operator peer-config rollback drill:
+
+```sh
+pnpm test:mesh:peer-config-rollback-drill
+```
+
+That command uses the same hermetic local TLS/WSS profile with local peer
+allowance disabled. It verifies signed config A, signed config B, fail-closed
+rejection for expired, unsigned, bad-signature, wrong-key, and local-peer
+configs, then rollback to the previous topology shape through a freshly issued
+signed rollback config. Rollback evidence must not be based on accepting an old
+cached config file.
+
 Run the state-resolution drill:
 
 ```sh
@@ -299,7 +312,7 @@ packet includes `mesh-production-readiness-report.json`,
 `mesh-production-readiness-evidence.md`, and copied source reports under
 `source-reports/<gate>/`.
 
-For Slice 11A, a successful aggregate command still reports
+For Slice 11A and Slice 12A, a successful aggregate command still reports
 `status: review_required` while release blockers remain. Expected blockers
 include the canonical 30-minute soak, public WSS deployment proof, full
 clock-skew matrix, conflict-resolution fixtures, evidence scrub promotion,
@@ -314,12 +327,22 @@ path in this server, public production WSS rollout still needs a trust path
 that either separates relay-peer sockets from browser client sockets or uses a
 client-compatible signed peer handshake.
 
+## Operator Runbook
+
+The operator-facing rollback/deploy path is documented in
+`docs/ops/mesh-production-operator-runbook.md`. The current rehearsed rollback
+claim is local TLS/WSS only: reload/refetch accepts a fresh rollback config and
+invalid configs fail closed. It is not a public WSS rollback proof and it does
+not prove runtime signing-key rotation without rebuilding or otherwise
+distributing a new trusted key.
+
 ## Review Boundary
 
-The report status remains `review_required` for Slice 6B/7B/7C/8/9/9B/10/11A even when the
+The report status remains `review_required` for Slice 6B/7B/7C/8/9/9B/10/11A/12A even when the
 local restarted-relay drill, deployed-WSS local TLS profile, state-resolution
 drill, disconnect drill, partition/heal drill, read-repair drill, and bounded
-rolling-restart soak pass and the aggregate evidence packet is well formed. A passing
+rolling-restart soak pass, peer-config rollback drill passes, and the aggregate
+evidence packet is well formed. A passing
 restarted-relay section means only that the restarted local relay directly read
 the missed synthetic drill write inside this bounded harness. A passing
 deployed-WSS section means only that the local TLS/WSS profile, signed WSS
@@ -341,7 +364,8 @@ recorded budgets; if `soak.full_duration_satisfied` is false it is not the
 canonical 30-minute soak claim. A passing aggregate section means only that the
 implemented source reports were collected, validated, copied, and summarized in
 one operator packet. None of these outcomes proves public WSS
-infrastructure, automatic peer-federation recovery, LUMA-gated write state
+infrastructure, automatic peer-federation recovery, runtime peer-config key
+rotation without a new trusted-key distribution path, LUMA-gated write state
 resolution, the full clock-skew matrix, evidence scrub promotion, or post-M0.B
 LUMA-gated write coverage.
 

--- a/docs/specs/spec-mesh-production-readiness.md
+++ b/docs/specs/spec-mesh-production-readiness.md
@@ -1089,6 +1089,7 @@ interface MeshProductionReadinessReport {
       | 'local_partition_heal_topology'
       | 'local_read_repair_strategy'
       | 'local_rolling_restart_soak'
+      | 'local_tls_wss_peer_config_rollback'
       | 'aggregate_production_readiness';
     deployment_scope?: 'local_tls_wss_profile' | 'public_wss_deployment';
     started_at: string;
@@ -1134,7 +1135,37 @@ interface MeshProductionReadinessReport {
       status: 'pass' | 'fail' | 'skipped';
       first_config_id: string;
       second_config_id: string;
+      rollback_config_id?: string;
       fetch_cache_mode: 'no-store' | string;
+    };
+    peer_config_rollback?: {
+      status: 'pass' | 'fail' | 'skipped';
+      deployment_scope: 'local_tls_wss_profile' | 'public_wss_deployment';
+      initial_config_id: string;
+      forward_config_id: string;
+      rollback_config_id: string;
+      rollback_reuses_stale_config_file: boolean;
+      rollback_signed_after_forward_config: boolean;
+      previous_topology_shape_restored: boolean;
+      fail_closed_cases: Array<{
+        fixture: string;
+        expected_error: string;
+        observed_error: string | null;
+        opened_socket_hosts: string[];
+        status: 'pass' | 'fail';
+      }>;
+      old_tab_behavior: {
+        status: 'pass' | 'fail' | 'skipped';
+        behavior?: string;
+        reason?: string;
+        fail_closed_signal?: string;
+      };
+      key_rotation_evidence: {
+        status: 'pass' | 'fail' | 'skipped';
+        accepted_key_fingerprint?: string;
+        rejected_key_fingerprint?: string;
+        reason: string;
+      };
     };
     restarted_relay_catchup?: {
       relay_id: string;
@@ -1376,6 +1407,8 @@ Acceptance gates:
   - all write classes with sufficient samples meet p95 budgets
   - relay resource budgets pass
   - test namespace cleanup passes
+  - peer-config rollback drill passes with fail-closed invalid fixtures and a
+    fresh rollback config, not a stale cached config
   - any LUMA-gated write class (drill_writer_kind `'luma'`) was exercised
     against the LUMA reader path, not bypassed via drill writer contract
   - any promoted evidence under `docs/reports/evidence/mesh-production/`
@@ -1400,7 +1433,9 @@ Downstream full-app canary:
 
 ### Slice 12 - Operational Runbook And Rollback
 
-Status: Queued.
+Status: Slice 12A implemented for local TLS/WSS peer-config rollback rehearsal
+and operator runbook. Public WSS rollback, runtime key distribution, evidence
+scrub promotion, and downstream full-app canary remain unclaimed.
 
 Purpose:
 
@@ -1426,7 +1461,7 @@ Scope:
 
 Primary files likely touched:
 
-- a new mesh production topology runbook under `docs/ops/`
+- `docs/ops/mesh-production-operator-runbook.md`
 - `docs/plans/CANARY_ROLLBACK_PLAN.md` or successor rollback doc
 - `docs/feature-flags.md`
 - `docs/foundational/STATUS.md`
@@ -1467,6 +1502,21 @@ Acceptance gates:
   canaries pass.
 - Service-worker and CSP rollout checks pass before a WSS peer-config rollout is
   marked operator-ready.
+
+Slice 12A implemented command:
+
+- `pnpm test:mesh:peer-config-rollback-drill`
+
+Slice 12A command scope:
+
+- uses the local TLS/WSS deployed-shape harness, not public WSS infrastructure
+- verifies signed config A, signed config B, invalid fail-closed fixtures, and a
+  freshly issued signed rollback config for the previous topology shape
+- records fail-closed signal as failed topology proof plus zero accepted peer
+  socket hosts
+- records key-rotation evidence only as wrong-key/revoked-key rejection; runtime
+  trusted-key replacement without a new build is not claimed
+- writes no `vh/__mesh_drills/*` records and exercises no LUMA write classes
 
 ## 5. Cross-Cutting Rules
 
@@ -2026,6 +2076,7 @@ Implemented mesh commands:
 - `pnpm test:mesh:partition-drills`
 - `pnpm test:mesh:read-repair-drills`
 - `pnpm test:mesh:soak`
+- `pnpm test:mesh:peer-config-rollback-drill`
 - `pnpm check:mesh:production-readiness`
 
 Required new commands:
@@ -2169,6 +2220,27 @@ Still not allowed after Slice 11A aggregate evidence-packet proof:
 - "The default shortened local command satisfies the canonical thirty-minute
   soak claim."
 - "Public WSS infrastructure is production-proven."
+- "The full clock-skew matrix is production-ready."
+- "LUMA-gated production write classes are mesh-readiness-proven."
+- "The app is ready for a test group."
+
+Allowed after Slice 12A operator rollback proof:
+
+- "The local TLS/WSS profile has an operator-rehearsed signed peer-config
+  rollback drill: config A, config B, invalid fail-closed fixtures, and a fresh
+  rollback-to-previous-topology-shape config."
+- "The operator runbook names deploy, rollback, CSP, service-worker,
+  signing-key, relay-token, health-probe, trace-lookup, and evidence
+  interpretation steps for the bounded local profile."
+
+Still not allowed after Slice 12A operator rollback proof:
+
+- "The mesh is `release_ready`."
+- "Public WSS rollback is production-proven."
+- "Runtime peer-config signing-key rotation works without rebuilding the app or
+  otherwise distributing a new trusted key."
+- "The default shortened local command satisfies the canonical thirty-minute
+  soak claim."
 - "The full clock-skew matrix is production-ready."
 - "LUMA-gated production write classes are mesh-readiness-proven."
 - "The app is ready for a test group."

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "test:mesh:partition-drills": "pnpm --filter @vh/e2e test:mesh:partition-drills",
     "test:mesh:read-repair-drills": "pnpm --filter @vh/e2e test:mesh:read-repair-drills",
     "test:mesh:soak": "pnpm --filter @vh/e2e test:mesh:soak",
+    "test:mesh:peer-config-rollback-drill": "pnpm --filter @vh/e2e test:mesh:peer-config-rollback-drill",
     "check:mesh:production-readiness": "pnpm --filter @vh/e2e check:mesh:production-readiness",
     "test:storycluster:smoke": "pnpm --filter @vh/e2e test:live:daemon-feed:build && pnpm --filter @vh/e2e test:live:daemon-feed:semantic-soak",
     "test:storycluster:smoke:readiness": "pnpm --filter @vh/e2e test:live:daemon-feed:build && (pnpm --filter @vh/e2e test:live:daemon-feed:semantic-soak || true) && pnpm --filter @vh/e2e test:live:daemon-feed:semantic-soak:readiness",

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -32,6 +32,7 @@
     "test:mesh:partition-drills": "node ./src/mesh/partition-drills.mjs",
     "test:mesh:read-repair-drills": "node ./src/mesh/read-repair-drills.mjs",
     "test:mesh:soak": "node ./src/mesh/soak-drills.mjs",
+    "test:mesh:peer-config-rollback-drill": "node ./src/mesh/peer-config-rollback-drill.mjs",
     "check:mesh:production-readiness": "node ./src/mesh/production-readiness-check.mjs",
     "report:live:daemon-feed:fixture-candidate-intake": "node ./src/live/daemon-feed-fixture-candidate-intake.mjs",
     "report:offline-cluster-replay": "node ./src/live/daemon-feed-semantic-soak-offline-replay-report.mjs",

--- a/packages/e2e/src/mesh/deployed-wss-peer-config-server.mjs
+++ b/packages/e2e/src/mesh/deployed-wss-peer-config-server.mjs
@@ -9,6 +9,14 @@ const rolloverFixturePath = process.env.VH_MESH_DEPLOYED_WSS_ROLLOVER_CONFIG_PAT
 const certPath = process.env.VH_MESH_TLS_CERT_PATH;
 const keyPath = process.env.VH_MESH_TLS_KEY_PATH;
 const controlToken = process.env.VH_MESH_DEPLOYED_WSS_CONTROL_TOKEN ?? '';
+const optionalFixtureEnv = {
+  rollback: process.env.VH_MESH_PEER_CONFIG_ROLLBACK_CONFIG_PATH,
+  expired: process.env.VH_MESH_PEER_CONFIG_EXPIRED_CONFIG_PATH,
+  unsigned: process.env.VH_MESH_PEER_CONFIG_UNSIGNED_CONFIG_PATH,
+  bad_signature: process.env.VH_MESH_PEER_CONFIG_BAD_SIGNATURE_CONFIG_PATH,
+  wrong_key: process.env.VH_MESH_PEER_CONFIG_WRONG_KEY_CONFIG_PATH,
+  local_peers: process.env.VH_MESH_PEER_CONFIG_LOCAL_PEERS_CONFIG_PATH,
+};
 
 if (!Number.isFinite(port) || port <= 0) {
   throw new Error('VH_MESH_DEPLOYED_WSS_CONFIG_PORT must be a positive integer');
@@ -20,8 +28,34 @@ if (!certPath || !keyPath) {
   throw new Error('VH_MESH_TLS_CERT_PATH and VH_MESH_TLS_KEY_PATH are required');
 }
 
-let activeFixturePath = positiveFixturePath;
+const fixtures = new Map([
+  ['positive', positiveFixturePath],
+  ['rollover', rolloverFixturePath],
+  ...Object.entries(optionalFixtureEnv).filter((entry) => Boolean(entry[1])),
+]);
+let activeFixtureLabel = 'positive';
 let configHits = 0;
+const configHitsByLabel = {};
+
+function activeFixturePath() {
+  return fixtures.get(activeFixtureLabel) ?? positiveFixturePath;
+}
+
+function readRequestBody(req) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    req.on('data', (chunk) => chunks.push(chunk));
+    req.on('error', reject);
+    req.on('end', () => {
+      try {
+        const raw = Buffer.concat(chunks).toString('utf8');
+        resolve(raw ? JSON.parse(raw) : {});
+      } catch (error) {
+        reject(error);
+      }
+    });
+  });
+}
 
 function applyCors(res) {
   res.setHeader('Access-Control-Allow-Origin', '*');
@@ -40,7 +74,7 @@ const server = https.createServer(
     cert: fs.readFileSync(certPath),
     key: fs.readFileSync(keyPath),
   },
-  (req, res) => {
+  async (req, res) => {
     applyCors(res);
     if (req.method === 'OPTIONS') {
       res.writeHead(204);
@@ -55,8 +89,10 @@ const server = https.createServer(
     if (req.method === 'GET' && url.pathname === '/__state') {
       sendJson(res, 200, {
         ok: true,
-        active: activeFixturePath === rolloverFixturePath ? 'rollover' : 'positive',
+        active: activeFixtureLabel,
+        available: Array.from(fixtures.keys()),
         config_hits: configHits,
+        config_hits_by_label: configHitsByLabel,
       });
       return;
     }
@@ -65,14 +101,36 @@ const server = https.createServer(
         sendJson(res, 403, { ok: false, error: 'forbidden' });
         return;
       }
-      activeFixturePath = rolloverFixturePath;
+      activeFixtureLabel = 'rollover';
       sendJson(res, 200, { ok: true, active: 'rollover' });
+      return;
+    }
+    if (req.method === 'POST' && url.pathname === '/__control/select') {
+      if (controlToken && req.headers['x-vh-mesh-control-token'] !== controlToken) {
+        sendJson(res, 403, { ok: false, error: 'forbidden' });
+        return;
+      }
+      let body;
+      try {
+        body = await readRequestBody(req);
+      } catch (error) {
+        sendJson(res, 400, { ok: false, error: error instanceof Error ? error.message : String(error) });
+        return;
+      }
+      const active = typeof body.active === 'string' ? body.active : '';
+      if (!fixtures.has(active)) {
+        sendJson(res, 400, { ok: false, error: `unknown fixture ${active || 'missing'}`, available: Array.from(fixtures.keys()) });
+        return;
+      }
+      activeFixtureLabel = active;
+      sendJson(res, 200, { ok: true, active: activeFixtureLabel });
       return;
     }
     if (req.method === 'GET' && url.pathname === '/mesh-peer-config.json') {
       try {
         configHits += 1;
-        const body = fs.readFileSync(activeFixturePath, 'utf8');
+        configHitsByLabel[activeFixtureLabel] = (configHitsByLabel[activeFixtureLabel] ?? 0) + 1;
+        const body = fs.readFileSync(activeFixturePath(), 'utf8');
         res.writeHead(200, { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' });
         res.end(body);
       } catch (error) {

--- a/packages/e2e/src/mesh/peer-config-rollback-drill.mjs
+++ b/packages/e2e/src/mesh/peer-config-rollback-drill.mjs
@@ -1,0 +1,579 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import net from 'node:net';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '../../../..');
+const gunRequire = createRequire(path.join(repoRoot, 'packages/gun-client/package.json'));
+const SEA = gunRequire('gun/sea');
+const DEFAULT_TTL_MS = 60 * 60 * 1000;
+
+function makeId(prefix) {
+  return `${prefix}-${Date.now()}-${crypto.randomBytes(4).toString('hex')}`;
+}
+
+function canonicalize(value) {
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => canonicalize(entry)).join(',')}]`;
+  }
+  if (value && typeof value === 'object') {
+    return `{${Object.keys(value)
+      .filter((key) => value[key] !== undefined && key !== 'signature' && key !== 'signerPub')
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonicalize(value[key])}`)
+      .join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function findFreePort() {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        server.close(() => reject(new Error('failed to allocate free port')));
+        return;
+      }
+      server.close((error) => {
+        if (error) reject(error);
+        else resolve(address.port);
+      });
+    });
+  });
+}
+
+async function allocatePorts(count) {
+  const ports = new Set();
+  while (ports.size < count) {
+    ports.add(await findFreePort());
+  }
+  return Array.from(ports);
+}
+
+function runGit(args) {
+  const result = spawnSync('git', args, {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  });
+  return result.status === 0 ? result.stdout.trim() : '';
+}
+
+function runStep(steps, name, command, args, env) {
+  const startedAt = Date.now();
+  const result = spawnSync(command, args, {
+    cwd: repoRoot,
+    env,
+    stdio: 'inherit',
+  });
+  const completedAt = Date.now();
+  const exitCode = typeof result.status === 'number' ? result.status : 1;
+  steps.push({
+    name,
+    command: [command, ...args].join(' '),
+    duration_ms: completedAt - startedAt,
+    exit_code: exitCode,
+    status: exitCode === 0 ? 'pass' : 'fail',
+    reason: exitCode === 0 ? undefined : result.error?.message ?? `exit ${exitCode}`,
+  });
+  return exitCode === 0;
+}
+
+async function signPayload(payload, pair) {
+  const signature = await SEA.sign(canonicalize(payload), pair);
+  return {
+    payload,
+    signature,
+    signerPub: pair.pub,
+  };
+}
+
+function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function copyIfExists(source, destination) {
+  if (fs.existsSync(source)) {
+    fs.copyFileSync(source, destination);
+  }
+}
+
+function redactedRelayUrl(peerUrl) {
+  const url = new URL(peerUrl);
+  const hostHash = crypto.createHash('sha256').update(url.host).digest('hex').slice(0, 10);
+  return `${url.protocol}//redacted-${hostHash}${url.pathname}`;
+}
+
+function originOf(url) {
+  return new URL(url).origin;
+}
+
+function generateTlsCertificate({ artifactDir, certPath, keyPath }) {
+  const configPath = path.join(artifactDir, 'openssl-local-wss.cnf');
+  fs.writeFileSync(configPath, [
+    '[req]',
+    'distinguished_name = dn',
+    'x509_extensions = v3_req',
+    'prompt = no',
+    '[dn]',
+    'CN = 127.0.0.1',
+    '[v3_req]',
+    'subjectAltName = @alt_names',
+    '[alt_names]',
+    'IP.1 = 127.0.0.1',
+    'DNS.1 = localhost',
+    '',
+  ].join('\n'));
+  const result = spawnSync('openssl', [
+    'req',
+    '-x509',
+    '-nodes',
+    '-newkey',
+    'rsa:2048',
+    '-keyout',
+    keyPath,
+    '-out',
+    certPath,
+    '-days',
+    '1',
+    '-config',
+    configPath,
+  ], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  if (result.status !== 0) {
+    throw new Error(`openssl certificate generation failed: ${result.stderr || result.stdout}`);
+  }
+}
+
+function writeReport({ artifactDir, report, fixturePaths, manifestPath, browserEvidencePath }) {
+  const latestDir = path.join(repoRoot, '.tmp/mesh-production-readiness/latest');
+  fs.rmSync(latestDir, { recursive: true, force: true });
+  fs.mkdirSync(latestDir, { recursive: true });
+
+  const reportPath = path.join(artifactDir, 'mesh-production-readiness-report.json');
+  const latestReportPath = path.join(latestDir, 'mesh-production-readiness-report.json');
+  writeJson(reportPath, report);
+  writeJson(latestReportPath, report);
+  for (const [label, filePath] of Object.entries(fixturePaths)) {
+    copyIfExists(filePath, path.join(latestDir, `peer-config-rollback-${label}.json`));
+  }
+  copyIfExists(manifestPath, path.join(latestDir, 'peer-config-rollback-manifest.json'));
+  copyIfExists(browserEvidencePath, path.join(latestDir, 'peer-config-rollback-browser-evidence.json'));
+  return { reportPath, latestReportPath };
+}
+
+async function main() {
+  const startedAtMs = Date.now();
+  const startedAt = new Date(startedAtMs).toISOString();
+  const runId = makeId('mesh-peer-config-rollback');
+  const traceId = makeId('trace');
+  const artifactDir = path.join(repoRoot, '.tmp/mesh-production-readiness', runId);
+  const fixtureDir = path.join(artifactDir, 'fixtures');
+  fs.mkdirSync(fixtureDir, { recursive: true });
+
+  const ports = await allocatePorts(8);
+  const relayHttpPorts = ports.slice(0, 3);
+  const relayWssPorts = ports.slice(3, 6);
+  const appPort = ports[6];
+  const configPort = ports[7];
+  const peerUrls = relayWssPorts.map((port) => `wss://127.0.0.1:${port}/gun`);
+  const forwardPeerUrls = [...peerUrls].reverse();
+  const httpPeerUrls = relayHttpPorts.map((port) => `http://127.0.0.1:${port}/gun`);
+  const configUrl = `https://127.0.0.1:${configPort}/mesh-peer-config.json`;
+  const controlToken = makeId('control');
+  const controlSelectUrl = `https://127.0.0.1:${configPort}/__control/select`;
+  const stateUrl = `https://127.0.0.1:${configPort}/__state`;
+  const issuedAt = Date.now();
+  const expiresAt = issuedAt + DEFAULT_TTL_MS;
+  const configId = `rollback-config-a-${runId}`;
+  const forwardConfigId = `rollback-config-b-${runId}`;
+  const rollbackConfigId = `rollback-config-a-fresh-${runId}`;
+  const pair = await SEA.pair();
+  const wrongPair = await SEA.pair();
+  const certPath = path.join(artifactDir, 'local-wss-cert.pem');
+  const keyPath = path.join(artifactDir, 'local-wss-key.pem');
+  generateTlsCertificate({ artifactDir, certPath, keyPath });
+
+  const basePayload = {
+    schemaVersion: 'mesh-peer-config-v1',
+    configId,
+    issuedAt,
+    expiresAt,
+    peers: peerUrls,
+    minimumPeerCount: 3,
+    quorumRequired: 2,
+  };
+  const forwardPayload = {
+    ...basePayload,
+    configId: forwardConfigId,
+    issuedAt: issuedAt + 1,
+    expiresAt: expiresAt + 1,
+    peers: forwardPeerUrls,
+  };
+  const rollbackPayload = {
+    ...basePayload,
+    configId: rollbackConfigId,
+    issuedAt: issuedAt + 2,
+    expiresAt: expiresAt + 2,
+    peers: peerUrls,
+  };
+  const expiredPayload = {
+    ...basePayload,
+    configId: `${configId}-expired`,
+    issuedAt: issuedAt - (2 * DEFAULT_TTL_MS),
+    expiresAt: issuedAt - DEFAULT_TTL_MS,
+  };
+  const localPeersPayload = {
+    ...basePayload,
+    configId: `${configId}-local-peers`,
+    peers: httpPeerUrls,
+  };
+  const wrongKeyPayload = {
+    ...basePayload,
+    configId: `${configId}-wrong-key`,
+  };
+
+  const fixturePaths = {
+    positive: path.join(fixtureDir, 'peer-config-a.json'),
+    rollover: path.join(fixtureDir, 'peer-config-b.json'),
+    rollback: path.join(fixtureDir, 'peer-config-rollback-to-a-shape.json'),
+    expired: path.join(fixtureDir, 'peer-config-expired.json'),
+    unsigned: path.join(fixtureDir, 'peer-config-unsigned.json'),
+    bad_signature: path.join(fixtureDir, 'peer-config-bad-signature.json'),
+    wrong_key: path.join(fixtureDir, 'peer-config-wrong-key.json'),
+    local_peers: path.join(fixtureDir, 'peer-config-local-peers.json'),
+  };
+  const manifestPath = path.join(artifactDir, 'peer-config-rollback-manifest.json');
+  const browserEvidencePath = path.join(artifactDir, 'peer-config-rollback-browser-evidence.json');
+
+  const positiveFixture = await signPayload(basePayload, pair);
+  writeJson(fixturePaths.positive, positiveFixture);
+  writeJson(fixturePaths.rollover, await signPayload(forwardPayload, pair));
+  writeJson(fixturePaths.rollback, await signPayload(rollbackPayload, pair));
+  writeJson(fixturePaths.expired, await signPayload(expiredPayload, pair));
+  writeJson(fixturePaths.unsigned, { payload: basePayload });
+  writeJson(fixturePaths.bad_signature, {
+    ...positiveFixture,
+    payload: {
+      ...basePayload,
+      configId: `${configId}-bad-signature`,
+    },
+    signature: `bad-${positiveFixture.signature}`,
+  });
+  writeJson(fixturePaths.wrong_key, await signPayload(wrongKeyPayload, wrongPair));
+  writeJson(fixturePaths.local_peers, await signPayload(localPeersPayload, pair));
+
+  const expectedCspConnectSrc = Array.from(new Set([
+    ...peerUrls.map(originOf),
+    originOf(configUrl),
+  ]));
+  const manifest = {
+    runId,
+    traceId,
+    configId,
+    forwardConfigId,
+    rollbackConfigId,
+    configUrl,
+    controlSelectUrl,
+    stateUrl,
+    controlToken,
+    peerUrls,
+    forwardPeerUrls,
+    rollbackPeerUrls: peerUrls,
+    relayIds: ['rollback-wss-relay-a', 'rollback-wss-relay-b', 'rollback-wss-relay-c'],
+    publicKey: pair.pub,
+    wrongKeyPublicKey: wrongPair.pub,
+    issuedAt,
+    expiresAt,
+    deploymentScope: 'local_tls_wss_profile',
+    expectedCspConnectSrc,
+    fixtures: fixturePaths,
+    invalidFixtures: [
+      { label: 'expired', expectedError: 'peer config is expired' },
+      { label: 'unsigned', expectedError: 'requires a signed peer config' },
+      { label: 'bad_signature', expectedError: 'signed peer config verification failed' },
+      { label: 'wrong_key', expectedError: 'signed peer config verification failed' },
+      { label: 'local_peers', expectedError: 'rejects insecure peer' },
+    ],
+  };
+  writeJson(manifestPath, manifest);
+
+  const sharedEnv = {
+    ...process.env,
+    VH_MESH_DEPLOYED_WSS_RELAY_HTTP_PORTS: relayHttpPorts.join(','),
+    VH_MESH_DEPLOYED_WSS_RELAY_WSS_PORTS: relayWssPorts.join(','),
+    VH_MESH_DEPLOYED_WSS_APP_PORT: String(appPort),
+    VH_MESH_DEPLOYED_WSS_CONFIG_PORT: String(configPort),
+    VH_MESH_DEPLOYED_WSS_MANIFEST_PATH: manifestPath,
+    VH_MESH_PEER_CONFIG_ROLLBACK_MANIFEST_PATH: manifestPath,
+    VH_MESH_PEER_CONFIG_ROLLBACK_BROWSER_EVIDENCE_PATH: browserEvidencePath,
+    VH_MESH_DEPLOYED_WSS_PEER_CONFIG_PATH: fixturePaths.positive,
+    VH_MESH_DEPLOYED_WSS_ROLLOVER_CONFIG_PATH: fixturePaths.rollover,
+    VH_MESH_PEER_CONFIG_ROLLBACK_CONFIG_PATH: fixturePaths.rollback,
+    VH_MESH_PEER_CONFIG_EXPIRED_CONFIG_PATH: fixturePaths.expired,
+    VH_MESH_PEER_CONFIG_UNSIGNED_CONFIG_PATH: fixturePaths.unsigned,
+    VH_MESH_PEER_CONFIG_BAD_SIGNATURE_CONFIG_PATH: fixturePaths.bad_signature,
+    VH_MESH_PEER_CONFIG_WRONG_KEY_CONFIG_PATH: fixturePaths.wrong_key,
+    VH_MESH_PEER_CONFIG_LOCAL_PEERS_CONFIG_PATH: fixturePaths.local_peers,
+    VH_MESH_DEPLOYED_WSS_CONTROL_TOKEN: controlToken,
+    VH_MESH_TLS_CERT_PATH: certPath,
+    VH_MESH_TLS_KEY_PATH: keyPath,
+    VITE_GUN_PEER_CONFIG_URL: configUrl,
+    VITE_GUN_PEER_CONFIG_PUBLIC_KEY: pair.pub,
+    VITE_GUN_PEER_MINIMUM: '3',
+    VITE_GUN_PEER_QUORUM_REQUIRED: '2',
+    VITE_VH_STRICT_PEER_CONFIG: 'true',
+    VITE_VH_ALLOW_LOCAL_MESH_PEERS: 'false',
+    VITE_VH_EXPOSE_PEER_TOPOLOGY: 'true',
+    VITE_VH_GUN_LOCAL_STORAGE: 'false',
+    VITE_VH_SHOW_HEALTH: 'true',
+    VITE_VH_CSP_CONNECT_SRC: expectedCspConnectSrc.join(' '),
+    VITE_VH_CSP_STRICT_CONNECT_SRC: 'true',
+  };
+
+  const steps = [];
+  const composePassed = runStep(steps, 'rollback-drill-compose-config', 'docker', [
+    'compose',
+    '-f',
+    'infra/docker/docker-compose.mesh-wss.yml',
+    'config',
+  ], sharedEnv);
+  const buildPassed = composePassed && runStep(steps, 'build-peer-config-rollback-drill', 'pnpm', ['--filter', '@vh/web-pwa', 'build'], sharedEnv);
+  if (buildPassed) {
+    runStep(steps, 'playwright-peer-config-rollback-drill', 'pnpm', [
+      '--filter',
+      '@vh/e2e',
+      'exec',
+      'playwright',
+      'test',
+      '--config=playwright.mesh-deployed-wss.config.ts',
+      'src/mesh/peer-config-rollback-drill.spec.ts',
+    ], sharedEnv);
+  }
+
+  const completedAtMs = Date.now();
+  const browserEvidence = fs.existsSync(browserEvidencePath) ? JSON.parse(fs.readFileSync(browserEvidencePath, 'utf8')) : null;
+  const allPassed = steps.every((step) => step.status === 'pass') && browserEvidence?.status === 'pass';
+  const report = {
+    schema_version: 'mesh-production-readiness-v1',
+    generated_at: new Date(completedAtMs).toISOString(),
+    run_id: runId,
+    repo: {
+      branch: runGit(['rev-parse', '--abbrev-ref', 'HEAD']),
+      commit: runGit(['rev-parse', 'HEAD']),
+      base_ref: 'origin/main',
+      dirty: runGit(['status', '--short']).length > 0,
+    },
+    run: {
+      mode: 'local_tls_wss_peer_config_rollback',
+      deployment_scope: 'local_tls_wss_profile',
+      started_at: startedAt,
+      completed_at: new Date(completedAtMs).toISOString(),
+      duration_ms: completedAtMs - startedAtMs,
+      command: 'pnpm test:mesh:peer-config-rollback-drill',
+    },
+    status: 'review_required',
+    status_reason: allPassed
+      ? 'Slice 12A local TLS/WSS signed peer-config rollback drill passed; full mesh production readiness remains review_required because public WSS, canonical soak, full clock-skew, conflict fixtures, evidence scrub, downstream app canary, and LUMA-gated write coverage remain pending.'
+      : 'Slice 12A local TLS/WSS signed peer-config rollback drill failed; inspect gates and Playwright traces.',
+    schema_epoch: 'post_luma_m0b',
+    luma_profile: 'none',
+    luma_dependency_status: {
+      luma_m0b_schema_epoch: 'landed',
+      luma_gated_write_drills: 'pending',
+      luma_profile_gates: 'n/a',
+    },
+    drill_writer_kind_by_class: {
+      'signed peer-config rollback fixture': 'mesh-drill',
+    },
+    topology: {
+      strategy: 'relay_peer_fanout',
+      selected_strategy_scope: 'peer-config lifecycle proof only; no mesh data repair writes are exercised in Slice 12A',
+      deployment_scope: 'local_tls_wss_profile',
+      configured_peer_count: 3,
+      quorum_required: 2,
+      signed_peer_config: allPassed,
+      relay_urls_redacted: peerUrls.map(redactedRelayUrl),
+      relay_ids: manifest.relayIds,
+      relay_to_relay_peers_configured: true,
+      relay_to_relay_auth_mode: 'private_network_allowlist',
+      relay_to_relay_auth_negative_test: 'skipped',
+      relay_to_relay_auth_negative_test_reason: 'covered by pnpm test:mesh:topology-drills; Slice 12A drills peer-config lifecycle and rollback',
+      peer_config_id: configId,
+      peer_config_issued_at: new Date(issuedAt).toISOString(),
+      peer_config_expires_at: new Date(expiresAt).toISOString(),
+      app_peer_config: {
+        source: 'remote-config',
+        strict: true,
+        signed: allPassed,
+        config_id: rollbackConfigId,
+        minimum_peer_count: 3,
+        quorum_required: 2,
+        local_mesh_peers_allowed: false,
+      },
+      csp: {
+        status: allPassed ? 'pass' : 'fail',
+        connect_src_expected_origins: expectedCspConnectSrc,
+        strict_connect_src: true,
+        broad_https_wss_wildcards_allowed: false,
+      },
+      service_worker_peer_config_rollover: {
+        status: browserEvidence?.service_worker?.status ?? (allPassed ? 'pass' : 'fail'),
+        first_config_id: configId,
+        second_config_id: forwardConfigId,
+        rollback_config_id: rollbackConfigId,
+        fetch_cache_mode: 'no-store',
+        config_hits_by_label: browserEvidence?.service_worker?.config_hits_by_label ?? {},
+      },
+      peer_config_rollback: {
+        status: allPassed ? 'pass' : 'fail',
+        deployment_scope: 'local_tls_wss_profile',
+        initial_config_id: configId,
+        forward_config_id: forwardConfigId,
+        rollback_config_id: rollbackConfigId,
+        rollback_reuses_stale_config_file: false,
+        rollback_signed_after_forward_config: true,
+        previous_topology_shape_restored: browserEvidence?.rollback?.previous_topology_shape_restored === true,
+        fail_closed_cases: browserEvidence?.fail_closed_cases ?? [],
+        old_tab_behavior: browserEvidence?.old_tab_behavior ?? {
+          status: 'skipped',
+          reason: 'browser evidence did not run',
+        },
+        key_rotation_evidence: {
+          status: browserEvidence?.key_rotation?.status ?? 'skipped',
+          accepted_key_fingerprint: crypto.createHash('sha256').update(pair.pub).digest('hex').slice(0, 16),
+          rejected_key_fingerprint: crypto.createHash('sha256').update(wrongPair.pub).digest('hex').slice(0, 16),
+          reason: 'the drill proves configs signed by a removed/wrong key fail closed; production key rotation still requires a new app build or trusted public-key distribution path',
+        },
+      },
+    },
+    gates: steps.map((step) => ({
+      name: step.name,
+      status: step.status,
+      command: step.command,
+      duration_ms: step.duration_ms,
+      exit_code: step.exit_code,
+      reason: step.reason,
+    })),
+    write_class_slos: [],
+    resource_slos: [],
+    per_relay_readback: [],
+    peer_failure_drills: [
+      {
+        name: 'peer-config-rollback-stale-config-fail-closed',
+        status: allPassed ? 'pass' : 'fail',
+        reason: allPassed
+          ? 'local TLS/WSS app boot accepted A, accepted B, rejected invalid configs, and accepted a fresh rollback-to-A-shape signed config'
+          : 'rollback drill browser evidence failed or did not run',
+      },
+    ],
+    state_resolution_drills: [
+      {
+        object_id: 'state-resolution-matrix-skip-slice-12a',
+        object_class: 'state-resolution matrix',
+        state_rule: 'out-of-scope',
+        expected_winner_write_id: 'skipped',
+        observed_winner_write_id: null,
+        competing_write_ids: [],
+        down_relay_id: null,
+        violation_reason: null,
+        status: 'skipped',
+        reason: 'Slice 12A drills operator peer-config lifecycle and does not write synthetic state-resolution records.',
+      },
+    ],
+    clock_skew: {
+      skewed_actor: null,
+      skewed_layer: 'signed-peer-config-validity-window',
+      skew_ms: 0,
+      named_failure: 'peer-config-expired',
+      lww_diverged: false,
+      status: allPassed ? 'pass' : 'fail',
+      reason: 'expired signed peer config was rejected as a config validity-window failure, not as generic mesh transport failure',
+    },
+    luma_gated_write_drills: [
+      {
+        write_class: 'LUMA-gated public mesh writes',
+        trace_id: traceId,
+        status: 'skipped',
+        reason: 'Slice 12A uses signed peer-config fixtures only; no LUMA _writerKind, _authorScheme, SignedWriteEnvelope, adapter, custody, or schema migration work was exercised.',
+      },
+    ],
+    cleanup: {
+      namespace: 'no vh/__mesh_drills writes in peer-config rollback drill',
+      ttl_ms: DEFAULT_TTL_MS,
+      objects_written: 0,
+      objects_cleaned_or_tombstoned: 0,
+      retained_objects: 0,
+      status: 'pass',
+    },
+    health: {
+      peer_quorum_minimum_observed: allPassed ? 3 : 0,
+      sustained_message_rate_max_per_sec: 0,
+      degradation_reasons_seen: allPassed ? ['peer-config-expired', 'peer-config-signature-invalid', 'peer-config-local-peer-forbidden'] : ['peer-config-rollback-drill-failed'],
+    },
+    release_claims: {
+      allowed: allPassed
+        ? [
+            'The local TLS/WSS profile can roll from signed peer-config A to B and back to a freshly issued rollback-to-A-shape config with local peer allowance disabled.',
+            'Expired, unsigned, bad-signature, wrong-key, and local-peer signed configs fail closed without initializing accepted peer sockets.',
+            'The operator runbook has a locally rehearsed peer-config rollback drill that can feed the aggregate mesh readiness packet.',
+          ]
+        : [],
+      forbidden: [
+        'The mesh is release_ready.',
+        'Public WSS infrastructure rollback is production-proven.',
+        'Runtime public-key rotation works without rebuilding or otherwise distributing a new trusted key.',
+        'The full clock-skew matrix is production-ready.',
+        'LUMA-gated production write classes are mesh-readiness-proven.',
+      ],
+      invalidated_by_luma_epoch_change: false,
+    },
+    downstream_canary: {
+      command: 'pnpm check:mesh:production-readiness',
+      status: 'skipped',
+      reason: 'aggregate production-readiness gate is a separate command and remains review_required while release blockers remain',
+    },
+  };
+
+  const reportPaths = writeReport({
+    artifactDir,
+    report,
+    fixturePaths,
+    manifestPath,
+    browserEvidencePath,
+  });
+
+  console.log(JSON.stringify({
+    ok: allPassed,
+    status: report.status,
+    run_id: runId,
+    config_id: configId,
+    forward_config_id: forwardConfigId,
+    rollback_config_id: rollbackConfigId,
+    deployment_scope: report.run.deployment_scope,
+    report_path: reportPaths.reportPath,
+    latest_report_path: reportPaths.latestReportPath,
+    signed_peer_config: report.topology.signed_peer_config,
+    health_reasons: report.health.degradation_reasons_seen,
+  }, null, 2));
+
+  if (!allPassed) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  console.error(`[vh:mesh-peer-config-rollback-drill] fatal: ${error instanceof Error ? error.stack ?? error.message : String(error)}`);
+  process.exitCode = 1;
+});

--- a/packages/e2e/src/mesh/peer-config-rollback-drill.spec.ts
+++ b/packages/e2e/src/mesh/peer-config-rollback-drill.spec.ts
@@ -1,0 +1,341 @@
+import { test, expect, type Page } from '@playwright/test';
+import * as fs from 'node:fs';
+
+interface InvalidFixtureCase {
+  label: string;
+  expectedError: string;
+}
+
+interface PeerConfigRollbackManifest {
+  runId: string;
+  traceId: string;
+  configId: string;
+  forwardConfigId: string;
+  rollbackConfigId: string;
+  peerUrls: string[];
+  forwardPeerUrls: string[];
+  rollbackPeerUrls: string[];
+  configUrl: string;
+  controlSelectUrl: string;
+  stateUrl: string;
+  controlToken: string;
+  publicKey: string;
+  wrongKeyPublicKey: string;
+  expectedCspConnectSrc: string[];
+  fixtures: Record<string, string>;
+  invalidFixtures: InvalidFixtureCase[];
+}
+
+type PeerTopologyProof =
+  | {
+      status: 'resolved';
+      resolver: 'resolveGunPeerTopology';
+      topology: {
+        source: string;
+        strict: boolean;
+        signed: boolean;
+        configId?: string;
+        peers: string[];
+        minimumPeerCount: number;
+        quorumRequired: number;
+        allowLocalPeers: boolean;
+      };
+      clientPeers: string[];
+    }
+  | {
+      status: 'failed';
+      resolver: 'resolveGunPeerTopology';
+      error: string;
+      clientPeers: [];
+    };
+
+type CanaryWindow = Window & {
+  __VH_PEER_TOPOLOGY_PROOF__?: PeerTopologyProof;
+  __VH_GUN_PEERS__?: unknown;
+  __VH_PEER_CONFIG_ROLLBACK_CANARY__?: {
+    openedUrls: () => string[];
+  };
+};
+
+const manifestPath = process.env.VH_MESH_PEER_CONFIG_ROLLBACK_MANIFEST_PATH;
+if (!manifestPath) {
+  throw new Error('VH_MESH_PEER_CONFIG_ROLLBACK_MANIFEST_PATH is required');
+}
+
+const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as PeerConfigRollbackManifest;
+const browserEvidencePath = process.env.VH_MESH_PEER_CONFIG_ROLLBACK_BROWSER_EVIDENCE_PATH;
+
+function expectedSocketHosts(): string[] {
+  return manifest.peerUrls.map((peerUrl) => new URL(peerUrl).host);
+}
+
+function httpsHealthUrl(peerUrl: string, pathname: string): string {
+  const url = new URL(peerUrl);
+  url.protocol = 'https:';
+  url.pathname = pathname;
+  url.search = '';
+  url.hash = '';
+  return url.toString();
+}
+
+async function openedPeerSocketHosts(page: Page): Promise<string[]> {
+  const urls = await page.evaluate(() => {
+    return (window as CanaryWindow).__VH_PEER_CONFIG_ROLLBACK_CANARY__?.openedUrls() ?? [];
+  });
+  const hosts = urls
+    .map((url) => {
+      try {
+        return new URL(url).host;
+      } catch {
+        return null;
+      }
+    })
+    .filter((host): host is string => Boolean(host));
+  return Array.from(new Set(hosts));
+}
+
+async function waitForProof(page: Page, status: PeerTopologyProof['status']): Promise<PeerTopologyProof> {
+  const handle = await page.waitForFunction(
+    (expected) => {
+      const proof = (window as CanaryWindow).__VH_PEER_TOPOLOGY_PROOF__;
+      return proof?.status === expected ? proof : false;
+    },
+    status,
+    { timeout: 20_000 },
+  );
+  return await handle.jsonValue() as PeerTopologyProof;
+}
+
+async function selectFixture(page: Page, active: string): Promise<void> {
+  const response = await page.request.post(manifest.controlSelectUrl, {
+    headers: { 'x-vh-mesh-control-token': manifest.controlToken },
+    data: { active },
+  });
+  expect(response.ok()).toBe(true);
+  await expect(response.json()).resolves.toMatchObject({ ok: true, active });
+}
+
+async function navigateFresh(page: Page, seenAnyProof: boolean): Promise<void> {
+  if (seenAnyProof) {
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    return;
+  }
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+}
+
+async function expectResolvedTopology(params: {
+  page: Page;
+  configId: string;
+  peers: string[];
+  seenAnyProof: boolean;
+}): Promise<{ proof: PeerTopologyProof; openedHosts: string[] }> {
+  const { page, configId, peers, seenAnyProof } = params;
+  await navigateFresh(page, seenAnyProof);
+  const proof = await waitForProof(page, 'resolved');
+  expect(proof).toMatchObject({
+    status: 'resolved',
+    resolver: 'resolveGunPeerTopology',
+    topology: {
+      source: 'remote-config',
+      strict: true,
+      signed: true,
+      configId,
+      peers,
+      minimumPeerCount: 3,
+      quorumRequired: 2,
+      allowLocalPeers: false,
+    },
+    clientPeers: peers,
+  });
+  await expect(page.locator('[data-testid="feed-shell"]')).toBeVisible({ timeout: 20_000 });
+  await expect
+    .poll(() => openedPeerSocketHosts(page), { timeout: 15_000 })
+    .toEqual(expect.arrayContaining(expectedSocketHosts()));
+  await expect(page.evaluate(() => (window as CanaryWindow).__VH_GUN_PEERS__)).resolves.toBeUndefined();
+  return {
+    proof,
+    openedHosts: await openedPeerSocketHosts(page),
+  };
+}
+
+async function expectFailClosed(params: {
+  page: Page;
+  expectedError: string;
+  seenAnyProof: boolean;
+}): Promise<{ proof: PeerTopologyProof; openedHosts: string[]; feedShellVisible: boolean }> {
+  const { page, expectedError, seenAnyProof } = params;
+  await navigateFresh(page, seenAnyProof);
+  const proof = await waitForProof(page, 'failed');
+  if (proof.status !== 'failed') {
+    throw new Error(`expected fail-closed peer topology proof, got ${proof.status}`);
+  }
+  expect(proof.resolver).toBe('resolveGunPeerTopology');
+  expect(proof.clientPeers).toEqual([]);
+  expect(proof.error).toContain(expectedError);
+  await expect(page.evaluate(() => (window as CanaryWindow).__VH_GUN_PEERS__)).resolves.toBeUndefined();
+  const openedHosts = await openedPeerSocketHosts(page);
+  expect(openedHosts.filter((host) => expectedSocketHosts().includes(host))).toEqual([]);
+  const feedShellVisible = await page.locator('[data-testid="feed-shell"]').isVisible().catch(() => false);
+  return { proof, openedHosts, feedShellVisible };
+}
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    const nativeWebSocket = window.WebSocket;
+    const openedUrls: string[] = [];
+
+    class TrackingWebSocket extends nativeWebSocket {
+      constructor(url: string | URL, protocols?: string | string[]) {
+        openedUrls.push(String(url));
+        super(url, protocols);
+      }
+    }
+
+    Object.defineProperties(TrackingWebSocket, {
+      CONNECTING: { value: nativeWebSocket.CONNECTING },
+      OPEN: { value: nativeWebSocket.OPEN },
+      CLOSING: { value: nativeWebSocket.CLOSING },
+      CLOSED: { value: nativeWebSocket.CLOSED },
+    });
+
+    window.WebSocket = TrackingWebSocket as typeof WebSocket;
+    (window as CanaryWindow).__VH_PEER_CONFIG_ROLLBACK_CANARY__ = {
+      openedUrls: () => [...openedUrls],
+    };
+  });
+});
+
+test('rolls forward, fails closed on invalid configs, and accepts fresh rollback config', async ({ page }) => {
+  for (const peerUrl of manifest.peerUrls) {
+    const health = await page.request.get(httpsHealthUrl(peerUrl, '/healthz'));
+    expect(health.ok()).toBe(true);
+    await expect(health.json()).resolves.toMatchObject({ ok: true, service: 'vh-relay' });
+
+    const ready = await page.request.get(httpsHealthUrl(peerUrl, '/readyz'));
+    expect(ready.ok()).toBe(true);
+
+    const metrics = await page.request.get(httpsHealthUrl(peerUrl, '/metrics'));
+    expect(metrics.ok()).toBe(true);
+    await expect(metrics.text()).resolves.toContain('vh_relay_active_connections');
+  }
+
+  const timeline: unknown[] = [];
+  const failClosedCases: unknown[] = [];
+  let seenAnyProof = false;
+
+  await selectFixture(page, 'positive');
+  const initial = await expectResolvedTopology({
+    page,
+    configId: manifest.configId,
+    peers: manifest.peerUrls,
+    seenAnyProof,
+  });
+  seenAnyProof = true;
+  timeline.push({
+    phase: 'initial',
+    config_id: manifest.configId,
+    proof: initial.proof,
+    opened_socket_hosts: initial.openedHosts,
+  });
+
+  await selectFixture(page, 'rollover');
+  const forward = await expectResolvedTopology({
+    page,
+    configId: manifest.forwardConfigId,
+    peers: manifest.forwardPeerUrls,
+    seenAnyProof,
+  });
+  timeline.push({
+    phase: 'roll-forward',
+    config_id: manifest.forwardConfigId,
+    proof: forward.proof,
+    opened_socket_hosts: forward.openedHosts,
+  });
+
+  for (const fixture of manifest.invalidFixtures) {
+    await selectFixture(page, fixture.label);
+    const result = await expectFailClosed({
+      page,
+      expectedError: fixture.expectedError,
+      seenAnyProof,
+    });
+    failClosedCases.push({
+      fixture: fixture.label,
+      expected_error: fixture.expectedError,
+      observed_error: result.proof.status === 'failed' ? result.proof.error : null,
+      feed_shell_visible: result.feedShellVisible,
+      opened_socket_hosts: result.openedHosts,
+      status: 'pass',
+    });
+  }
+
+  await selectFixture(page, 'rollback');
+  const rollback = await expectResolvedTopology({
+    page,
+    configId: manifest.rollbackConfigId,
+    peers: manifest.rollbackPeerUrls,
+    seenAnyProof,
+  });
+  timeline.push({
+    phase: 'rollback',
+    config_id: manifest.rollbackConfigId,
+    proof: rollback.proof,
+    opened_socket_hosts: rollback.openedHosts,
+  });
+
+  const state = await page.request.get(manifest.stateUrl);
+  expect(state.ok()).toBe(true);
+  const stateBody = await state.json() as {
+    ok: boolean;
+    active: string;
+    config_hits?: number;
+    config_hits_by_label?: Record<string, number>;
+  };
+  expect(stateBody).toMatchObject({ ok: true, active: 'rollback' });
+  expect(stateBody.config_hits ?? 0).toBeGreaterThanOrEqual(8);
+  expect(stateBody.config_hits_by_label?.positive ?? 0).toBeGreaterThanOrEqual(1);
+  expect(stateBody.config_hits_by_label?.rollover ?? 0).toBeGreaterThanOrEqual(1);
+  expect(stateBody.config_hits_by_label?.rollback ?? 0).toBeGreaterThanOrEqual(1);
+
+  const previousTopologyShapeRestored = JSON.stringify(manifest.peerUrls) === JSON.stringify(manifest.rollbackPeerUrls)
+    && manifest.rollbackConfigId !== manifest.configId;
+
+  if (browserEvidencePath) {
+    fs.writeFileSync(
+      browserEvidencePath,
+      `${JSON.stringify({
+        gate: 'local-tls-wss-peer-config-rollback-drill',
+        status: 'pass',
+        run_id: manifest.runId,
+        trace_id: manifest.traceId,
+        initial_config_id: manifest.configId,
+        forward_config_id: manifest.forwardConfigId,
+        rollback_config_id: manifest.rollbackConfigId,
+        timeline,
+        fail_closed_cases: failClosedCases,
+        rollback: {
+          previous_topology_shape_restored: previousTopologyShapeRestored,
+          rollback_reuses_stale_config_file: false,
+          rollback_config_id_differs_from_original: manifest.rollbackConfigId !== manifest.configId,
+        },
+        service_worker: {
+          status: 'pass',
+          fetch_cache_mode: 'no-store',
+          config_hits: stateBody.config_hits ?? 0,
+          config_hits_by_label: stateBody.config_hits_by_label ?? {},
+        },
+        key_rotation: {
+          status: 'pass',
+          accepted_public_key: manifest.publicKey,
+          rejected_public_key: manifest.wrongKeyPublicKey,
+          rejected_fixture: 'wrong_key',
+        },
+        old_tab_behavior: {
+          status: 'pass',
+          behavior: 'operator rollback proof uses reload/refetch; current app does not claim live in-place topology replacement for already-open tabs',
+          fail_closed_signal: 'failed peer topology proof plus zero accepted peer socket hosts after reload; feed shell may remain visible and is not the fail-closed signal',
+        },
+      }, null, 2)}\n`,
+    );
+  }
+});

--- a/packages/e2e/src/mesh/production-readiness-check.mjs
+++ b/packages/e2e/src/mesh/production-readiness-check.mjs
@@ -11,7 +11,7 @@ const repoRoot = path.resolve(__dirname, '../../../..');
 const latestDir = path.join(repoRoot, '.tmp/mesh-production-readiness/latest');
 const SOURCE_REPORT_FRESHNESS_TOLERANCE_MS = 5000;
 
-const SOURCE_GATES = [
+export const SOURCE_GATES = [
   {
     id: 'topology',
     name: 'local production topology',
@@ -59,6 +59,12 @@ const SOURCE_GATES = [
     name: 'bounded rolling restart soak',
     command: ['pnpm', 'test:mesh:soak'],
     expectedMode: 'local_rolling_restart_soak',
+  },
+  {
+    id: 'peer_config_rollback',
+    name: 'peer-config rollback drill',
+    command: ['pnpm', 'test:mesh:peer-config-rollback-drill'],
+    expectedMode: 'local_tls_wss_peer_config_rollback',
   },
 ];
 
@@ -356,6 +362,7 @@ function buildReleaseBlockers(sources) {
 function pickTopology(sources) {
   const reports = sources.map((source) => source.report).filter(Boolean);
   const deployed = sources.find((source) => source.id === 'deployed_wss')?.report;
+  const rollback = sources.find((source) => source.id === 'peer_config_rollback')?.report;
   const topology = sources.find((source) => source.id === 'topology')?.report;
   const readRepair = sources.find((source) => source.id === 'read_repair')?.report;
   const soak = sources.find((source) => source.id === 'soak')?.report;
@@ -368,7 +375,7 @@ function pickTopology(sources) {
       readRepair?.topology?.selected_strategy_scope ||
       soak?.topology?.selected_strategy_scope ||
       'aggregate of existing synthetic mesh drill proof paths only',
-    deployment_scope: deployed?.run?.deployment_scope || deployed?.topology?.deployment_scope || 'local_tls_wss_profile',
+    deployment_scope: deployed?.run?.deployment_scope || rollback?.run?.deployment_scope || deployed?.topology?.deployment_scope || 'local_tls_wss_profile',
     configured_peer_count: maxFinite(topologies.map((entry) => entry.configured_peer_count), 3),
     quorum_required: maxFinite(topologies.map((entry) => entry.quorum_required), 2),
     signed_peer_config: topologies.some((entry) => entry.signed_peer_config === true),
@@ -383,20 +390,30 @@ function pickTopology(sources) {
       topology?.topology?.relay_to_relay_auth_negative_test ||
       readRepair?.topology?.relay_to_relay_auth_negative_test ||
       'skipped',
-    peer_config_id: deployed?.topology?.peer_config_id || signed?.topology?.peer_config_id || soak?.topology?.peer_config_id || 'aggregate',
+    peer_config_id:
+      rollback?.topology?.peer_config_rollback?.rollback_config_id ||
+      deployed?.topology?.peer_config_id ||
+      signed?.topology?.peer_config_id ||
+      soak?.topology?.peer_config_id ||
+      'aggregate',
     peer_config_issued_at:
+      rollback?.topology?.peer_config_issued_at ||
       deployed?.topology?.peer_config_issued_at ||
       signed?.topology?.peer_config_issued_at ||
       soak?.topology?.peer_config_issued_at ||
       new Date().toISOString(),
     peer_config_expires_at:
+      rollback?.topology?.peer_config_expires_at ||
       deployed?.topology?.peer_config_expires_at ||
       signed?.topology?.peer_config_expires_at ||
       soak?.topology?.peer_config_expires_at ||
       new Date().toISOString(),
-    app_peer_config: deployed?.topology?.app_peer_config || signed?.topology?.app_peer_config,
-    csp: deployed?.topology?.csp,
-    service_worker_peer_config_rollover: deployed?.topology?.service_worker_peer_config_rollover,
+    app_peer_config: rollback?.topology?.app_peer_config || deployed?.topology?.app_peer_config || signed?.topology?.app_peer_config,
+    csp: rollback?.topology?.csp || deployed?.topology?.csp,
+    service_worker_peer_config_rollover:
+      rollback?.topology?.service_worker_peer_config_rollover ||
+      deployed?.topology?.service_worker_peer_config_rollover,
+    peer_config_rollback: rollback?.topology?.peer_config_rollback,
     restarted_relay_catchup: topology?.topology?.restarted_relay_catchup,
     read_repair: readRepair?.topology?.read_repair || soak?.topology?.read_repair,
   };
@@ -597,7 +614,7 @@ function buildReport({ runId, startedAt, completedAt, sources, blockers, command
         fixture: 'full-conflict-resolution-fixtures',
         trace_id: runId,
         status: 'skipped',
-        reason: 'pnpm test:mesh:conflict-drills is not implemented in Slice 11A',
+        reason: 'pnpm test:mesh:conflict-drills is not implemented',
       },
     ],
     read_repair_drills: readRepairRows,
@@ -607,7 +624,7 @@ function buildReport({ runId, startedAt, completedAt, sources, blockers, command
         write_class: 'LUMA-gated production write classes through LUMA reader path',
         trace_id: runId,
         status: 'skipped',
-        reason: 'Slice 11A aggregates existing synthetic mesh-drill evidence only; no LUMA _writerKind, _authorScheme, adapters, envelopes, custody, or schema migration work is exercised.',
+        reason: 'The aggregate gate uses existing synthetic mesh-drill evidence only; no LUMA _writerKind, _authorScheme, adapters, envelopes, custody, or schema migration work is exercised.',
       },
     ],
     clock_skew: buildClockSkew(sources),

--- a/packages/e2e/src/mesh/production-readiness-check.test.mjs
+++ b/packages/e2e/src/mesh/production-readiness-check.test.mjs
@@ -1,7 +1,7 @@
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
-import { validationFailuresForSource } from './production-readiness-check.mjs';
+import { SOURCE_GATES, validationFailuresForSource } from './production-readiness-check.mjs';
 
 const thisFile = fileURLToPath(import.meta.url);
 const currentCommit = 'abc123';
@@ -47,6 +47,14 @@ function failuresFor({ gate, report }) {
 }
 
 describe('production-readiness source evidence validation', () => {
+  it('includes the peer-config rollback drill as command-matched source evidence', () => {
+    expect(SOURCE_GATES).toContainEqual(expect.objectContaining({
+      id: 'peer_config_rollback',
+      command: ['pnpm', 'test:mesh:peer-config-rollback-drill'],
+      expectedMode: 'local_tls_wss_peer_config_rollback',
+    }));
+  });
+
   it('accepts a fresh source report for the exact gate command', () => {
     const failures = failuresFor({
       gate: {


### PR DESCRIPTION
## Summary
- add `pnpm test:mesh:peer-config-rollback-drill` for signed peer-config roll-forward, invalid-config fail-closed, and fresh rollback rehearsal in the local TLS/WSS mesh profile
- add the mesh production operator runbook covering deploy, rollback, key/token rotation, CSP/SW rollout, trace lookup, cleanup, and evidence interpretation
- wire the rollback drill into `pnpm check:mesh:production-readiness` as a ninth source gate with exact command/mode freshness validation

## Boundaries
- local TLS/WSS profile only; no public WSS deployment proof claimed
- aggregate status remains `review_required` and does not claim `release_ready`
- no LUMA schema, adapter, envelope, custody, `_writerKind`, `_authorScheme`, or migration work
- fail-closed signal is app topology proof failure plus zero accepted peer sockets; the feed shell may remain visible and is not used as the signal

## Verification
- `pnpm docs:check`
- `git diff --check origin/main...HEAD`
- `pnpm --filter @vh/e2e typecheck`
- `node tools/scripts/check-diff-coverage.mjs`
- `pnpm test:mesh:peer-config-rollback-drill`
- `pnpm check:mesh:production-readiness`
- JSON sanity check for clean `review_required`, `post_luma_m0b`, `luma_profile: none`, nine clean source reports, seven blockers, and no `release_ready` claim
