### PR TITLE
LUMA M0.B sentiment outbox namespace guard

### DIFF
--- a/docs/plans/LUMA_SERVICE_V0_ROADMAP_2026-05-02.md
+++ b/docs/plans/LUMA_SERVICE_V0_ROADMAP_2026-05-02.md
@@ -212,6 +212,10 @@ Acceptance criteria:
 - Property test: no two domain derivations collide.
 - Property test: `voterId` differs across topic and across epoch.
 - Lint test: a non-aggregate public write with `district_hash` is rejected even when `cohortSize` is declared.
+- Public namespace leak gate: `pnpm check:public-namespace-leaks` fails on raw
+  nullifiers, proof material, district-hash/person-identifier pairs, and local
+  `VoteIntentRecord` fields in post-cutover public `vh/*` records while
+  ignoring encrypted sentiment outbox records.
 - Migration test: every adapter listed above produces records carrying `_protocolVersion`, `_writerKind`, and (where required) `_authorScheme`. Legacy fixtures route through the migration adapter without surfacing to product UI.
 - Materializer test: `voteIntentMaterializer.ts` derives `voterId` for the correct `(topic_id, epoch)` and writes the public aggregate voter node carrying `_writerKind: 'luma'` and a valid `SignedWriteEnvelope`. Local `VoteIntentRecord` does not appear on any public path.
 - Mesh re-run: `pnpm check:mesh:production-readiness` produces a report with `schema_epoch: 'post_luma_m0b'` that meets the per-class conditions enumerated in the "Mesh re-run gate (post-M0.B)" deliverable above. The overall report status MAY be `review_required` if non-schema mesh slices are pending; the M0.B exit gate inspects per-class pass for the migrated write classes, not the overall report status.
@@ -220,7 +224,9 @@ Forbidden during M0.B:
 
 - Changing on-chain attestation keying.
 - Renaming `principalNullifier`.
-- Migrating sentiment/outbox payloads (defer per Open M0.B-3).
+- Migrating plaintext sentiment payload contents or moving sentiment events to
+  public mesh. M0.B only classifies the encrypted outbox envelope and preserves
+  the `~<devicePub>/outbox/sentiment/*` path.
 - Touching `packages/luma-sdk` provider interfaces (those belong to M0.C; coordinate the shared `packages/luma-sdk/src/index.ts` via the sequencing rule in "Parallel M0.B/M0.C write-set split" below).
 - Claiming per-class transport readiness for any write class migrated by M0.B before the post-M0.B mesh re-run produces a report meeting the per-class conditions in the "Mesh re-run gate" deliverable above. (M0.B does not require the overall mesh report to be `release_ready`; it requires the per-class pass for the migrated classes.)
 - Widening LUMA's `_writerKind` enum to include `'mesh-drill'` or any drill writer kind. Drill writer is namespace-scoped and lives outside the LUMA enum (mesh spec §5.9).
@@ -667,7 +673,7 @@ The spec owns the locked decisions. The roadmap tracks decisions still required 
 
 | ID | Topic | Default proposal |
 | --- | --- | --- |
-| M0.B-3 | `~<devicePub>/outbox/sentiment/*` unchanged | yes |
+| M0.B-3 | `~<devicePub>/outbox/sentiment/*` unchanged | yes; classified with `sentiment-outbox-envelope-v1` metadata only |
 | M0.D-2 | Real multi-device link in M0.D vs deferred | deferred |
 | M0.D-3 | XP/reputation continuity across Sign Out | preserved |
 | M0.D-4 | Legacy-vault migration policy | reuse existing `deviceKey` as `deviceCredential` |
@@ -721,3 +727,4 @@ The spec owns the locked decisions. The roadmap tracks decisions still required 
 | 0.11 | 2026-05-07 | Reviewer | M0.B ForumPost publish-back narrow slice. Hermes Docs article publish-back moves to `hermes-post-v1`, `forumAuthorId`, and `SignedWriteEnvelope` audience `vh-forum-post`; fallback article threads use `hermes-thread-v1`. News reports, nominations, aggregate voters, mesh drills, relay, services, and unrelated adapters remain out of scope. Added `pnpm check:luma-forum-post-v1`. |
 | 0.12 | 2026-05-07 | Reviewer | M0.B news report intake narrow slice. New report submissions move to `hermes-news-report-v2`, derived `forumAuthorId` in `reporter_id`, and `SignedWriteEnvelope` audience `vh-news-report`; legacy `hermes-news-report-v1` remains read/operator-action compatible, and operator status/audit updates stay outside the immutable intake envelope. Added `pnpm check:luma-news-report-v1`. |
 | 0.13 | 2026-05-07 | Reviewer | M0.B forum nomination narrow slice. Nomination bridge outputs move to `hermes-nomination-v1`, derived `forumAuthorId` in `nominatorAuthorId`, and `SignedWriteEnvelope` audience `vh-forum-nomination`; legacy `nominatorNullifier` fixtures remain compatibility-read only, and local budget nullifier use stays out of the public nomination record. Added `pnpm check:luma-forum-nomination-v1`. |
+| 0.14 | 2026-05-08 | Reviewer | M0.B encrypted sentiment outbox classification and public namespace leak gate. Sentiment outbox remains under `~<devicePub>/outbox/sentiment/*`, new writes carry `sentiment-outbox-envelope-v1` with `luma-sensitive-v1` topology metadata, legacy bare encrypted envelopes remain read-compatible only, and `pnpm check:public-namespace-leaks` guards post-cutover public `vh/*` records. |

--- a/docs/specs/spec-civic-sentiment.md
+++ b/docs/specs/spec-civic-sentiment.md
@@ -125,7 +125,10 @@ Lightbulb:
 
 ## 6. Storage and topology
 
-- `SentimentSignal` event-level records: local or encrypted outbox only
+- `SentimentSignal` event-level records: local or encrypted outbox only; new
+  outbox writes use `sentiment-outbox-envelope-v1` with `_protocolVersion:
+  'luma-sensitive-v1'` and `topologyClass:
+  'sensitive-encrypted-outbox'`
 - public mesh: aggregate-only projections
 - per-user Eye/Lightbulb weights are persisted on-device for stable reload behavior
 - topic engagement summary path: `vh/aggregates/topics/<topicId>/engagement/summary`
@@ -147,6 +150,8 @@ District dashboards must remain aggregate-only:
 3. Toggle semantics tests (`+/-` and neutral reset) by `(topic_id, synthesis_id, epoch, point_id)`.
 4. Aggregate projection determinism tests by `(topic_id, synthesis_id, epoch)`.
 5. Privacy tests: ensure district dashboard payloads are aggregate-only.
+6. Public namespace leak tests: ensure local `VoteIntentRecord` fields and
+   raw sentiment proof material never appear under public `vh/*` paths.
 
 ## 9. FPD production-wiring clarifications (2026-02-19)
 

--- a/docs/specs/spec-data-topology-privacy-v0.md
+++ b/docs/specs/spec-data-topology-privacy-v0.md
@@ -2,11 +2,11 @@
 
 > Status: Normative Spec
 > Owner: VHC Spec Owners
-> Last Reviewed: 2026-05-07
+> Last Reviewed: 2026-05-08
 > Depends On: docs/foundational/System_Architecture.md, docs/CANON_MAP.md, docs/specs/spec-luma-service-v0.md, docs/specs/spec-mesh-production-readiness.md, docs/specs/spec-signed-pin-custody-v0.md
 
 
-Version: 0.7
+Version: 0.8
 Status: Canonical (V2-first)
 
 Defines data placement, mesh path conventions, and privacy constraints for Season 0.
@@ -21,7 +21,7 @@ Defines data placement, mesh path conventions, and privacy constraints for Seaso
 | TopicSynthesisCorrection | local cache/index | `vh/topics/<topicId>/synthesis_corrections/*` | - | optional hash anchor | - | Public audit |
 | Topic latest pointer | local cache/index | `vh/topics/<topicId>/latest` | - | - | - | Public |
 | HermesNewsReport | local cache/operator queue | `vh/news/reports/*` and `vh/news/reports/index/status/*` | - | - | - | Public workflow/audit |
-| SentimentSignal event | local state | forbidden | `~<devicePub>/outbox/sentiment/<eventId>` | - | - | Sensitive |
+| SentimentSignal event | local state | forbidden | `~<devicePub>/outbox/sentiment/<eventId>` as `sentiment-outbox-envelope-v1` | - | - | Sensitive |
 | AggregateSentiment (legacy summary) | local cache | compatibility-only; canonical public point aggregates use `PointAggregateSnapshotV1` below | - | optional aggregate anchor | - | Public |
 | TopicEngagementAggregateV1 | local cache | `vh/aggregates/topics/<topicId>/engagement/summary` | - | optional aggregate anchor | - | Public |
 | Linked-social OAuth tokens | vault (encrypted) | forbidden | optional encrypted backup | - | - | Secret |
@@ -112,6 +112,12 @@ records.
 7. AggregateVoterNodeV1 is public only when it uses the scoped LUMA `voterId`, `_authorScheme: 'voter-v1'`, `_writerKind: 'luma'`, and a valid `vh-aggregate-voter` envelope. It MUST NOT contain raw nullifiers, proof material, private signing keys, `district_hash`, or local `VoteIntentRecord` fields.
 8. NominationEventV1 is public only when it uses the derived `forumAuthorId` in `nominatorAuthorId`, `_authorScheme: 'forum-author-v1'`, `_writerKind: 'luma'`, and a valid `vh-forum-nomination` envelope. It MUST NOT contain raw nullifiers, proof material, private signing keys, or `district_hash`.
 9. VoteAdmissionReceipt is internal client state only.
+10. `~<devicePub>/outbox/sentiment/*` is a sensitive encrypted outbox, not a
+    public LUMA record. New writes carry `schemaVersion:
+    'sentiment-outbox-envelope-v1'`, `_protocolVersion:
+    'luma-sensitive-v1'`, `topologyClass: 'sensitive-encrypted-outbox'`,
+    `__encrypted: true`, and `ciphertext`. They MUST NOT carry `_writerKind`,
+    `_authorScheme`, or `SignedWriteEnvelope`.
 
 ## 4. Linked-social storage rules
 
@@ -131,6 +137,8 @@ records.
 If encrypted outbox is used:
 
 - payloads must be encrypted per recipient
+- sentiment outbox records must use `sentiment-outbox-envelope-v1` metadata
+  for new writes; legacy bare encrypted envelopes are read-compatible only
 - decrypted aggregate outputs must strip person-level identifiers
 - dashboards may expose district-level aggregates only after cohort threshold checks
 
@@ -149,6 +157,12 @@ If encrypted outbox is used:
 7. Static lint: system-writer records (records carrying
    `_writerKind: 'system'`) outside the namespaces enumerated in §8 are
    hard-rejected.
+8. Static lint: `pnpm check:public-namespace-leaks` fails on post-cutover
+   public `vh/*` records carrying raw nullifiers, proof material,
+   `district_hash` outside aggregate cohort allow-lists, district/person
+   identifier pairs, or local `VoteIntentRecord` fields. The same gate
+   ignores encrypted sentiment outbox records because they are sensitive
+   `~<devicePub>/outbox/sentiment/*` records, not public namespace records.
 
 ### 7.1 Mesh drill test namespace rule
 

--- a/docs/specs/spec-luma-service-v0.md
+++ b/docs/specs/spec-luma-service-v0.md
@@ -993,7 +993,15 @@ A recorded full-product engagement run is replayed; every emitted `LumaEvent` is
 
 ### 21.5 Public-namespace leak gate
 
-`pnpm check:public-namespace-leaks` runs against a recorded mesh fixture and fails on raw nullifier presence in records written after the cutover commit timestamp. Legacy records are not counted.
+`pnpm check:public-namespace-leaks` is path-aware. It fails on post-cutover
+public `vh/*` records carrying raw nullifiers, constituency proof material,
+`district_hash` outside the aggregate cohort allow-list, district/person
+identifier pairs, or local `VoteIntentRecord` fields. Legacy records are not
+counted. Encrypted sentiment outbox records under
+`~<devicePub>/outbox/sentiment/*` are ignored by this public-namespace gate
+because they are sensitive encrypted outbox records, not public mesh records.
+When a recorded mesh fixture is supplied, the gate applies the same rules to
+that fixture.
 
 ### 21.6 Linkability-domain registry gate
 

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "check:luma-forum-post-v1": "node ./tools/scripts/check-luma-forum-post-v1.mjs",
     "check:luma-news-report-v1": "node ./tools/scripts/check-luma-news-report-v1.mjs",
     "check:luma-forum-nomination-v1": "node ./tools/scripts/check-luma-forum-nomination-v1.mjs",
+    "check:public-namespace-leaks": "node ./tools/scripts/check-public-namespace-leaks.mjs",
     "report:news-sources:admission": "pnpm --filter @vh/news-aggregator report:source-admission",
     "report:news-sources:health": "NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter @vh/news-aggregator report:source-health",
     "scout:news-sources:candidates": "NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter @vh/news-aggregator report:source-scout",

--- a/packages/gun-client/src/sentimentEventAdapters.test.ts
+++ b/packages/gun-client/src/sentimentEventAdapters.test.ts
@@ -4,6 +4,9 @@ import { HydrationBarrier } from './sync/barrier';
 import type { TopologyGuard } from './topology';
 import type { VennClient } from './types';
 import {
+  SENTIMENT_OUTBOX_ENVELOPE_SCHEMA_VERSION,
+  SENTIMENT_OUTBOX_PROTOCOL_VERSION,
+  SENTIMENT_OUTBOX_TOPOLOGY_CLASS,
   getSentimentOutboxChain,
   readUserEvents,
   sentimentEventAdapterInternal,
@@ -130,6 +133,16 @@ const EVENT: SentimentEvent = {
   emitted_at: 1_700_000_000_000,
 };
 
+function encryptedSentimentEnvelope(ciphertext: string) {
+  return {
+    schemaVersion: SENTIMENT_OUTBOX_ENVELOPE_SCHEMA_VERSION,
+    _protocolVersion: SENTIMENT_OUTBOX_PROTOCOL_VERSION,
+    topologyClass: SENTIMENT_OUTBOX_TOPOLOGY_CLASS,
+    __encrypted: true as const,
+    ciphertext,
+  };
+}
+
 describe('sentimentEventAdapters', () => {
   beforeEach(() => {
     encryptMock.mockReset();
@@ -142,11 +155,11 @@ describe('sentimentEventAdapters', () => {
     const client = createClient(userNode, guard);
 
     const outbox = getSentimentOutboxChain(client);
-    await outbox.get('event-1').put({ __encrypted: true, ciphertext: 'cipher' });
+    await outbox.get('event-1').put(encryptedSentimentEnvelope('cipher'));
 
     expect(guard.validateWrite).toHaveBeenCalledWith(
       '~device-pub-1/outbox/sentiment/event-1/',
-      { __encrypted: true, ciphertext: 'cipher' },
+      encryptedSentimentEnvelope('cipher'),
     );
   });
 
@@ -170,8 +183,14 @@ describe('sentimentEventAdapters', () => {
     expect(encryptMock).toHaveBeenCalledWith(JSON.stringify(EVENT), { epub: 'epub-1', epriv: 'epriv-1' });
     expect(userNode.writes[0]).toEqual({
       path: `outbox/sentiment/${expectedEventId}`,
-      value: { __encrypted: true, ciphertext: 'encrypted-payload' },
+      value: encryptedSentimentEnvelope('encrypted-payload'),
     });
+    expect(JSON.stringify(userNode.writes[0].value)).not.toContain(EVENT.constituency_proof.nullifier);
+    expect(JSON.stringify(userNode.writes[0].value)).not.toContain(EVENT.constituency_proof.district_hash);
+    expect(JSON.stringify(userNode.writes[0].value)).not.toContain(EVENT.constituency_proof.merkle_root);
+    expect(userNode.writes[0].value).not.toHaveProperty('_writerKind');
+    expect(userNode.writes[0].value).not.toHaveProperty('_authorScheme');
+    expect(userNode.writes[0].value).not.toHaveProperty('signedWriteEnvelope');
 
     encryptMock.mockResolvedValueOnce({ ct: 'cipher-object' });
     await writeSentimentEvent(client, { ...EVENT, point_id: 'point-2' });
@@ -209,12 +228,16 @@ describe('sentimentEventAdapters', () => {
 
     userNode.setRead('outbox/sentiment', {
       _: { '#': 'gun-meta' },
-      e1: { __encrypted: true, ciphertext: 'enc-1' },
+      e1: encryptedSentimentEnvelope('enc-1'),
       e2: { __encrypted: true, ciphertext: 'enc-2' },
-      ignoredOtherEpoch: { __encrypted: true, ciphertext: 'enc-3' },
+      ignoredOtherEpoch: encryptedSentimentEnvelope('enc-3'),
       malformedEnvelope: { ciphertext: 'enc-4' },
-      undecipherableEnvelope: { __encrypted: true, ciphertext: 'enc-5' },
-      invalidDecryptedPayload: { __encrypted: true, ciphertext: 'enc-6' },
+      undecipherableEnvelope: encryptedSentimentEnvelope('enc-5'),
+      invalidDecryptedPayload: encryptedSentimentEnvelope('enc-6'),
+      publicWritePretender: {
+        ...encryptedSentimentEnvelope('enc-7'),
+        _writerKind: 'luma',
+      },
       nonObjectEnvelope: 7,
     });
 
@@ -227,6 +250,7 @@ describe('sentimentEventAdapters', () => {
       if (ciphertext === 'enc-6') {
         return JSON.stringify({ topic_id: 'topic-1' });
       }
+      if (ciphertext === 'enc-7') return JSON.stringify({ ...EVENT, point_id: 'point-7' });
       return null;
     });
 
@@ -267,7 +291,7 @@ describe('sentimentEventAdapters', () => {
       point_id: EVENT.point_id,
     });
     userNode.setPutHang(`outbox/sentiment/${eventId}`);
-    userNode.setRead(`outbox/sentiment/${eventId}`, { __encrypted: true, ciphertext: 'encrypted-payload' });
+    userNode.setRead(`outbox/sentiment/${eventId}`, encryptedSentimentEnvelope('encrypted-payload'));
     encryptMock.mockResolvedValueOnce('encrypted-payload');
     decryptMock.mockResolvedValueOnce(JSON.stringify(EVENT));
 

--- a/packages/gun-client/src/sentimentEventAdapters.ts
+++ b/packages/gun-client/src/sentimentEventAdapters.ts
@@ -9,7 +9,14 @@ import { writeWithDurability } from './durableWrite';
 import { readGunTimeoutMs } from './runtimeConfig';
 import type { VennClient } from './types';
 
+export const SENTIMENT_OUTBOX_ENVELOPE_SCHEMA_VERSION = 'sentiment-outbox-envelope-v1' as const;
+export const SENTIMENT_OUTBOX_PROTOCOL_VERSION = 'luma-sensitive-v1' as const;
+export const SENTIMENT_OUTBOX_TOPOLOGY_CLASS = 'sensitive-encrypted-outbox' as const;
+
 export interface EncryptedSentimentEnvelope {
+  readonly schemaVersion: typeof SENTIMENT_OUTBOX_ENVELOPE_SCHEMA_VERSION;
+  readonly _protocolVersion: typeof SENTIMENT_OUTBOX_PROTOCOL_VERSION;
+  readonly topologyClass: typeof SENTIMENT_OUTBOX_TOPOLOGY_CLASS;
   readonly __encrypted: true;
   readonly ciphertext: string;
 }
@@ -69,13 +76,24 @@ async function encryptSentimentEvent(
   }
 
   return {
+    schemaVersion: SENTIMENT_OUTBOX_ENVELOPE_SCHEMA_VERSION,
+    _protocolVersion: SENTIMENT_OUTBOX_PROTOCOL_VERSION,
+    topologyClass: SENTIMENT_OUTBOX_TOPOLOGY_CLASS,
     __encrypted: true,
     ciphertext: typeof encrypted === 'string' ? encrypted : JSON.stringify(encrypted),
   };
 }
 
+function carriesPublicWriteFields(envelope: Record<string, unknown>): boolean {
+  return '_writerKind' in envelope || '_authorScheme' in envelope || 'signedWriteEnvelope' in envelope;
+}
+
 async function decryptSentimentEvent(client: VennClient, envelope: unknown): Promise<SentimentEvent | null> {
   if (!isRecord(envelope) || envelope.__encrypted !== true || typeof envelope.ciphertext !== 'string') {
+    return null;
+  }
+
+  if (carriesPublicWriteFields(envelope)) {
     return null;
   }
 

--- a/packages/gun-client/src/topology.test.ts
+++ b/packages/gun-client/src/topology.test.ts
@@ -1,6 +1,16 @@
 import { describe, expect, it } from 'vitest';
 import { TopologyGuard } from './topology';
 
+function encryptedSentimentEnvelope(ciphertext = 'abc123') {
+  return {
+    schemaVersion: 'sentiment-outbox-envelope-v1',
+    _protocolVersion: 'luma-sensitive-v1',
+    topologyClass: 'sensitive-encrypted-outbox',
+    __encrypted: true,
+    ciphertext,
+  };
+}
+
 describe('TopologyGuard', () => {
   it('blocks PII in public path', () => {
     const guard = new TopologyGuard();
@@ -237,12 +247,21 @@ describe('TopologyGuard', () => {
   it('requires encryption for sentiment outbox path', () => {
     const guard = new TopologyGuard();
     expect(() => guard.validateWrite('~alice/outbox/sentiment/evt-1', { plaintext: true })).toThrow();
+    expect(() => guard.validateWrite('~alice/outbox/sentiment/evt-1', { __encrypted: true })).toThrow(
+      /sentiment outbox requires ciphertext/,
+    );
+    expect(() =>
+      guard.validateWrite('~alice/outbox/sentiment/evt-1', { __encrypted: true, ciphertext: 'abc123' })
+    ).toThrow(/sentiment outbox requires v1 sensitive envelope metadata/);
+    expect(() =>
+      guard.validateWrite('~alice/outbox/sentiment/evt-1', encryptedSentimentEnvelope())
+    ).not.toThrow();
     expect(() =>
       guard.validateWrite('~alice/outbox/sentiment/evt-1', {
-        __encrypted: true,
-        ciphertext: 'abc123'
+        ...encryptedSentimentEnvelope(),
+        _writerKind: 'luma',
       })
-    ).not.toThrow();
+    ).toThrow(/sentiment outbox must not carry public LUMA write fields/);
   });
 
   it('rejects unencrypted writes to hermes docKeys path', () => {

--- a/packages/gun-client/src/topology.ts
+++ b/packages/gun-client/src/topology.ts
@@ -71,6 +71,10 @@ function containsPII(value: unknown): boolean {
   );
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object';
+}
+
 function matchesRule(path: string, rule: TopologyRule): boolean {
   if (!rule.pathPrefix.includes('*')) {
     return path.startsWith(rule.pathPrefix);
@@ -81,6 +85,28 @@ function matchesRule(path: string, rule: TopologyRule): boolean {
     .replace(/\*/g, '[^/]+');
   const regex = new RegExp(`^${escaped}`);
   return regex.test(path);
+}
+
+function isSentimentOutboxPath(path: string): boolean {
+  return matchesRule(path, { pathPrefix: '~*/outbox/sentiment/*', classification: 'sensitive' });
+}
+
+function validateSentimentOutboxEnvelope(path: string, data: unknown): void {
+  if (!isRecord(data) || typeof data.ciphertext !== 'string' || data.ciphertext.length === 0) {
+    throw new Error(`Topology violation: sentiment outbox requires ciphertext at ${path}`);
+  }
+
+  if (
+    data.schemaVersion !== 'sentiment-outbox-envelope-v1'
+    || data._protocolVersion !== 'luma-sensitive-v1'
+    || data.topologyClass !== 'sensitive-encrypted-outbox'
+  ) {
+    throw new Error(`Topology violation: sentiment outbox requires v1 sensitive envelope metadata at ${path}`);
+  }
+
+  if ('_writerKind' in data || '_authorScheme' in data || 'signedWriteEnvelope' in data) {
+    throw new Error(`Topology violation: sentiment outbox must not carry public LUMA write fields at ${path}`);
+  }
 }
 
 export class TopologyGuard {
@@ -104,6 +130,9 @@ export class TopologyGuard {
       // Expect payload to be encrypted/encapsulated
       if (!data || typeof data !== 'object' || !(data as Record<string, unknown>).__encrypted) {
         throw new Error(`Topology violation: sensitive write without encryption flag at ${path}`);
+      }
+      if (isSentimentOutboxPath(path)) {
+        validateSentimentOutboxEnvelope(path, data);
       }
     }
     // local requires no sync; guard not enforced here because writes are in-app only

--- a/tools/scripts/check-public-namespace-leaks.mjs
+++ b/tools/scripts/check-public-namespace-leaks.mjs
@@ -46,7 +46,10 @@ function isSensitiveOutboxPath(recordPath) {
 }
 
 function isAggregateCohortPath(recordPath) {
-  return recordPath.startsWith('vh/aggregates/') && !recordPath.includes('/voters/');
+  return (
+    /^vh\/aggregates\/.+\/districts\/[^/]+\/[^/]+\/?$/.test(recordPath)
+    || recordPath.startsWith('vh/bridge/stats/')
+  );
 }
 
 function isLegacyRecord(record) {
@@ -249,6 +252,12 @@ const redFixtures = [
     path: 'vh/aggregates/topics/topic-1/districts/district-1/summary',
     record: { district_hash: 'district-1', cohortSize: 99, participants: 99 },
     match: /district_hash requires cohortSize >= 100/,
+  },
+  {
+    name: 'point aggregate district hash outside district cohort allow-list',
+    path: 'vh/aggregates/topics/topic-1/syntheses/synth-1/epochs/1/points/point-1',
+    record: { district_hash: 'district-1', cohortSize: 100, participants: 100 },
+    match: /non-aggregate public record carries district_hash/,
   },
   {
     name: 'district hash paired with voter id',

--- a/tools/scripts/check-public-namespace-leaks.mjs
+++ b/tools/scripts/check-public-namespace-leaks.mjs
@@ -1,0 +1,363 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const failures = [];
+const MIN_DISTRICT_COHORT_SIZE = 100;
+
+const legacySchemaVersions = new Set([
+  'hermes-directory-v0',
+  'hermes-thread-v0',
+  'hermes-comment-v1',
+  'hermes-post-v0',
+  'hermes-news-report-v1',
+  'hermes-nomination-v0',
+]);
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(rootDir, relativePath), 'utf8');
+}
+
+function requireToken(source, token, label) {
+  if (!source.includes(token)) {
+    failures.push(`${label} is missing ${token}`);
+  }
+}
+
+function forbidToken(source, token, label) {
+  if (source.includes(token)) {
+    failures.push(`${label} contains forbidden token ${token}`);
+  }
+}
+
+function isRecord(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isPublicNamespace(recordPath) {
+  return recordPath.startsWith('vh/') && !recordPath.startsWith('vh/__mesh_drills/');
+}
+
+function isSensitiveOutboxPath(recordPath) {
+  return /^~[^/]+\/outbox\/sentiment\/[^/]+\/?$/.test(recordPath);
+}
+
+function isAggregateCohortPath(recordPath) {
+  return recordPath.startsWith('vh/aggregates/') && !recordPath.includes('/voters/');
+}
+
+function isLegacyRecord(record) {
+  if (!isRecord(record)) {
+    return false;
+  }
+  return (
+    record.legacy === true
+    || record._cutover === 'pre-luma-m0b'
+    || legacySchemaVersions.has(record.schemaVersion)
+    || legacySchemaVersions.has(record.schema_version)
+  );
+}
+
+function normalizedKey(key) {
+  return key.replace(/[-_]/g, '').toLowerCase();
+}
+
+function isPersonIdentifierKey(key) {
+  const normalized = normalizedKey(key);
+  return [
+    'author',
+    'publicauthor',
+    'reporterid',
+    'nominatorauthorid',
+    'nominatornullifier',
+    'principalnullifier',
+    'nullifier',
+    'voterid',
+  ].includes(normalized);
+}
+
+function isForbiddenSensitiveKey(key) {
+  const normalized = normalizedKey(key);
+  return [
+    'nullifier',
+    'principalnullifier',
+    'nominatornullifier',
+    'reporternullifier',
+    'constituencyproof',
+    'merkleroot',
+    'proofref',
+    'intentid',
+    'privatekey',
+    'privatekeyhex',
+    'epriv',
+    'priv',
+  ].includes(normalized);
+}
+
+function collectEntries(value, prefix = []) {
+  if (!isRecord(value) && !Array.isArray(value)) {
+    return [];
+  }
+
+  const entries = [];
+  for (const [key, child] of Object.entries(value)) {
+    const nextPrefix = [...prefix, key];
+    entries.push([nextPrefix, key, child]);
+    entries.push(...collectEntries(child, nextPrefix));
+  }
+  return entries;
+}
+
+function containsKey(value, wantedKey) {
+  return collectEntries(value).some(([, key]) => normalizedKey(key) === normalizedKey(wantedKey));
+}
+
+function validatePublicRecord(recordPath, record) {
+  const errors = [];
+  if (!isPublicNamespace(recordPath) || isLegacyRecord(record)) {
+    return errors;
+  }
+
+  const entries = collectEntries(record);
+  for (const [keyPath, key] of entries) {
+    if (isForbiddenSensitiveKey(key)) {
+      errors.push(`${recordPath}: forbidden sensitive key ${keyPath.join('.')}`);
+    }
+  }
+
+  if (containsKey(record, 'district_hash')) {
+    if (!isAggregateCohortPath(recordPath)) {
+      errors.push(`${recordPath}: non-aggregate public record carries district_hash`);
+    }
+
+    const cohortSize = isRecord(record) ? Number(record.cohortSize) : Number.NaN;
+    if (!Number.isInteger(cohortSize) || cohortSize < MIN_DISTRICT_COHORT_SIZE) {
+      errors.push(`${recordPath}: district_hash requires cohortSize >= ${MIN_DISTRICT_COHORT_SIZE}`);
+    }
+
+    if (entries.some(([, key]) => isPersonIdentifierKey(key))) {
+      errors.push(`${recordPath}: district_hash is paired with a person-level identifier`);
+    }
+  }
+
+  if (
+    isRecord(record)
+    && ('intent_id' in record || 'proof_ref' in record || ('seq' in record && 'emitted_at' in record))
+  ) {
+    errors.push(`${recordPath}: VoteIntentRecord fields are forbidden on public mesh`);
+  }
+
+  return errors;
+}
+
+function validateRecordedFixture(fixture) {
+  const errors = [];
+  const entries = Array.isArray(fixture) ? fixture : fixture.records;
+  if (!Array.isArray(entries)) {
+    return ['fixture must be an array or an object with a records array'];
+  }
+
+  for (const entry of entries) {
+    if (!isRecord(entry) || typeof entry.path !== 'string' || !('record' in entry)) {
+      errors.push('fixture entry must contain { path, record }');
+      continue;
+    }
+    errors.push(...validatePublicRecord(entry.path, entry.record));
+  }
+
+  return errors;
+}
+
+const validFixtures = [
+  {
+    path: 'vh/forum/threads/thread-1',
+    record: {
+      schemaVersion: 'hermes-thread-v1',
+      _protocolVersion: 'luma-public-v1',
+      _writerKind: 'luma',
+      _authorScheme: 'forum-author-v1',
+      author: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+      signedWriteEnvelope: {
+        publicAuthor: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+        idempotencyKey: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        audience: 'vh-forum-thread',
+      },
+    },
+  },
+  {
+    path: 'vh/aggregates/topics/t/syntheses/s/epochs/1/voters/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef/p',
+    record: {
+      schema_version: 'aggregate-voter-node-v1',
+      _protocolVersion: 'luma-public-v1',
+      _writerKind: 'luma',
+      _authorScheme: 'voter-v1',
+      voter_id: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+      signedWriteEnvelope: {
+        publicAuthor: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+        idempotencyKey: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        audience: 'vh-aggregate-voter',
+      },
+    },
+  },
+  {
+    path: '~device-pub/outbox/sentiment/event-1',
+    record: {
+      schemaVersion: 'sentiment-outbox-envelope-v1',
+      _protocolVersion: 'luma-sensitive-v1',
+      topologyClass: 'sensitive-encrypted-outbox',
+      __encrypted: true,
+      ciphertext: '{"district_hash":"encrypted-not-public","nullifier":"encrypted-not-public"}',
+    },
+  },
+  {
+    path: 'vh/forum/threads/legacy-thread',
+    record: {
+      schemaVersion: 'hermes-thread-v0',
+      author: 'legacy-raw-nullifier',
+      _cutover: 'pre-luma-m0b',
+    },
+  },
+];
+
+const redFixtures = [
+  {
+    name: 'raw nullifier key',
+    path: 'vh/forum/threads/thread-1',
+    record: { schemaVersion: 'hermes-thread-v1', nullifier: 'raw-nullifier' },
+    match: /forbidden sensitive key nullifier/,
+  },
+  {
+    name: 'constituency proof',
+    path: 'vh/news/reports/report-1',
+    record: {
+      schemaVersion: 'hermes-news-report-v2',
+      constituency_proof: { district_hash: 'district-1', nullifier: 'raw-nullifier', merkle_root: 'root' },
+    },
+    match: /forbidden sensitive key constituency_proof/,
+  },
+  {
+    name: 'non-aggregate district hash with cohort',
+    path: 'vh/forum/threads/thread-1',
+    record: { district_hash: 'district-1', cohortSize: 100 },
+    match: /non-aggregate public record carries district_hash/,
+  },
+  {
+    name: 'aggregate district hash under threshold',
+    path: 'vh/aggregates/topics/topic-1/districts/district-1/summary',
+    record: { district_hash: 'district-1', cohortSize: 99, participants: 99 },
+    match: /district_hash requires cohortSize >= 100/,
+  },
+  {
+    name: 'district hash paired with voter id',
+    path: 'vh/aggregates/topics/topic-1/districts/district-1/summary',
+    record: { district_hash: 'district-1', cohortSize: 100, voter_id: 'derived-but-person-level' },
+    match: /paired with a person-level identifier/,
+  },
+  {
+    name: 'VoteIntentRecord fields',
+    path: 'vh/aggregates/topics/topic-1/syntheses/synth-1/epochs/1/voters/voter-1/point-1',
+    record: {
+      intent_id: 'intent-1',
+      voter_id: 'voter-1',
+      proof_ref: 'local-proof',
+      seq: 1,
+      emitted_at: 1,
+    },
+    match: /VoteIntentRecord fields/,
+  },
+];
+
+for (const fixture of validFixtures) {
+  const errors = validatePublicRecord(fixture.path, fixture.record);
+  if (errors.length > 0) {
+    failures.push(`valid fixture ${fixture.path} failed: ${errors.join('; ')}`);
+  }
+}
+
+for (const fixture of redFixtures) {
+  const errors = validatePublicRecord(fixture.path, fixture.record);
+  if (!errors.some((error) => fixture.match.test(error))) {
+    failures.push(`red fixture ${fixture.name} did not fail with ${fixture.match}; got ${errors.join('; ') || 'no errors'}`);
+  }
+}
+
+for (const fixturePath of [
+  ...process.argv.slice(2),
+  ...(process.env.PUBLIC_NAMESPACE_LEAK_FIXTURE ? process.env.PUBLIC_NAMESPACE_LEAK_FIXTURE.split(path.delimiter) : []),
+].filter(Boolean)) {
+  const absolutePath = path.resolve(process.cwd(), fixturePath);
+  const parsed = JSON.parse(fs.readFileSync(absolutePath, 'utf8'));
+  const errors = validateRecordedFixture(parsed);
+  if (errors.length > 0) {
+    failures.push(`${fixturePath}: ${errors.join('; ')}`);
+  }
+}
+
+const packageSource = read('package.json');
+const sentimentAdapterSource = read('packages/gun-client/src/sentimentEventAdapters.ts');
+const sentimentAdapterTestSource = read('packages/gun-client/src/sentimentEventAdapters.test.ts');
+const topologySource = read('packages/gun-client/src/topology.ts');
+const topologyTestSource = read('packages/gun-client/src/topology.test.ts');
+const lumaSpecSource = read('docs/specs/spec-luma-service-v0.md');
+const privacySpecSource = read('docs/specs/spec-data-topology-privacy-v0.md');
+const roadmapSource = read('docs/plans/LUMA_SERVICE_V0_ROADMAP_2026-05-02.md');
+
+requireToken(packageSource, 'check:public-namespace-leaks', 'root package scripts');
+for (const token of [
+  "SENTIMENT_OUTBOX_ENVELOPE_SCHEMA_VERSION = 'sentiment-outbox-envelope-v1'",
+  "SENTIMENT_OUTBOX_PROTOCOL_VERSION = 'luma-sensitive-v1'",
+  "SENTIMENT_OUTBOX_TOPOLOGY_CLASS = 'sensitive-encrypted-outbox'",
+  'carriesPublicWriteFields',
+]) {
+  requireToken(sentimentAdapterSource, token, 'sentiment outbox adapter');
+}
+forbidToken(sentimentAdapterSource, '_writerKind:', 'sentiment outbox adapter');
+forbidToken(sentimentAdapterSource, '_authorScheme:', 'sentiment outbox adapter');
+forbidToken(sentimentAdapterSource, 'signedWriteEnvelope:', 'sentiment outbox adapter');
+
+for (const token of [
+  'sentiment outbox requires v1 sensitive envelope metadata',
+  'sentiment outbox must not carry public LUMA write fields',
+]) {
+  requireToken(topologySource, token, 'topology guard');
+  requireToken(topologyTestSource, token, 'topology guard tests');
+}
+for (const token of [
+  'not.toContain(EVENT.constituency_proof.nullifier)',
+  'not.toContain(EVENT.constituency_proof.district_hash)',
+  'publicWritePretender',
+]) {
+  requireToken(sentimentAdapterTestSource, token, 'sentiment outbox tests');
+}
+for (const token of [
+  'check:public-namespace-leaks',
+  'raw nullifier',
+  'VoteIntentRecord',
+]) {
+  requireToken(lumaSpecSource, token, 'LUMA service spec');
+}
+for (const token of [
+  'sentiment-outbox-envelope-v1',
+  'luma-sensitive-v1',
+  'check:public-namespace-leaks',
+]) {
+  requireToken(privacySpecSource, token, 'data topology privacy spec');
+  requireToken(roadmapSource, token, 'LUMA roadmap');
+}
+
+if (!validFixtures.some((fixture) => isSensitiveOutboxPath(fixture.path))) {
+  failures.push('guard self-test is missing sensitive outbox fixture');
+}
+
+if (failures.length > 0) {
+  console.error('[check:public-namespace-leaks] failed');
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log('[check:public-namespace-leaks] public namespace leak guard ok');


### PR DESCRIPTION
## Summary
- classify new encrypted sentiment outbox writes as `sentiment-outbox-envelope-v1` with `luma-sensitive-v1` topology metadata
- keep `~<devicePub>/outbox/sentiment/*` sensitive and read-compatible with legacy bare encrypted envelopes
- fail closed when sentiment outbox writes omit ciphertext/metadata or carry public LUMA write fields
- add `pnpm check:public-namespace-leaks` for post-cutover public `vh/*` leak red tests
- update LUMA, topology, civic sentiment, and roadmap docs

## Scope guard
- no vote intent materializer/projection changes
- no forum, directory, news, nomination, aggregate, system-writer adapter, mesh drill, relay, service, vault, provider, wallet, lifecycle, multidevice, signed-write, or identifier primitive changes

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm exec vitest run packages/gun-client/src/sentimentEventAdapters.test.ts packages/gun-client/src/topology.test.ts --reporter=verbose`
- `pnpm --filter @vh/types build`
- `pnpm --filter @vh/luma-sdk build`
- `pnpm --filter @vh/data-model typecheck`
- `pnpm --filter @vh/data-model build`
- `pnpm --filter @vh/gun-client test`
- `pnpm --filter @vh/gun-client typecheck`
- `pnpm --filter @vh/gun-client build`
- all existing LUMA guards plus `pnpm check:public-namespace-leaks`
- `pnpm docs:check`
- `git diff --check origin/main...HEAD`
- protected-surface grep over changed files
- `node tools/scripts/check-diff-coverage.mjs`

Local caveat: PNPM still emits the existing Node engine warning for local Node `v23.10.0` vs repo `>=20 <23`.