### PR TITLE
LUMA M0.B news story system-writer v1

### DIFF
--- a/apps/web-pwa/src/env.d.ts
+++ b/apps/web-pwa/src/env.d.ts
@@ -31,6 +31,7 @@ interface ImportMetaEnv {
   readonly VITE_NEWS_SOURCE_RELIABILITY_MIN_SUCCESS_COUNT?: string;
   readonly VITE_NEWS_SOURCE_RELIABILITY_CACHE_TTL_MS?: string;
   readonly VITE_NEWS_BRIDGE_ENABLED?: 'true' | 'false';
+  readonly VITE_E2E_SYSTEM_WRITER_PIN_JSON?: string;
   readonly VITE_SYNTHESIS_BRIDGE_ENABLED?: 'true' | 'false';
   readonly VITE_HERMES_DOCS_ENABLED?: 'true' | 'false';
   readonly VITE_DOCS_COLLAB_ENABLED?: 'true' | 'false';

--- a/apps/web-pwa/src/store/hermesForum.test.ts
+++ b/apps/web-pwa/src/store/hermesForum.test.ts
@@ -200,10 +200,22 @@ beforeEach(() => {
   getForumTagIndexChainMock.mockClear();
 });
 
+const realSetTimeout = globalThis.setTimeout.bind(globalThis);
+
+function waitRealTime(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    realSetTimeout(resolve, ms);
+  });
+}
+
 async function waitForMockCall(mock: { mock: { calls: unknown[] } }, count = 1): Promise<void> {
-  for (let i = 0; i < 50 && mock.mock.calls.length < count; i += 1) {
+  for (let i = 0; i < 250 && mock.mock.calls.length < count; i += 1) {
     await vi.advanceTimersByTimeAsync(1);
     await Promise.resolve();
+    if (mock.mock.calls.length >= count) {
+      break;
+    }
+    await waitRealTime(1);
   }
   expect(mock.mock.calls.length).toBeGreaterThanOrEqual(count);
 }

--- a/apps/web-pwa/src/store/index.ts
+++ b/apps/web-pwa/src/store/index.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import {
   createClient,
   publishToDirectory,
+  type SystemWriterPin,
   type VennClient,
 } from '@vh/gun-client';
 import {
@@ -30,6 +31,7 @@ import { loadIdentityRecord } from '../utils/vaultTyped';
 import { createMockClient } from './mockClient';
 import { setClientResolver } from './clientResolver';
 import { resolveGunPeerTopology, type GunPeerTopology } from './peerConfig';
+import systemWriterPin from '../luma/system-writer-pin.json';
 export { resolveGunPeers, resolveGunPeerTopology, resolveGunPeerTopologySync } from './peerConfig';
 
 const PROFILE_KEY = 'vh_profile';
@@ -51,6 +53,46 @@ interface AppState {
 
 let initInFlight: Promise<void> | null = null;
 let directoryPublishQueue: Promise<unknown> = Promise.resolve();
+
+function isSystemWriterPin(value: unknown): value is SystemWriterPin {
+  if (!value || typeof value !== 'object') return false;
+  const candidate = value as Partial<SystemWriterPin>;
+  return candidate.pinVersion === 1
+    && candidate.schemaEpoch === 'luma-public-v1'
+    && candidate.maxProtocolVersion === 'luma-public-v1'
+    && candidate.signatureSuite === 'jcs-ed25519-sha256-v1'
+    && Array.isArray(candidate.writers)
+    && candidate.writers.length > 0
+    && candidate.writers.every((writer) => (
+      writer
+      && typeof writer.id === 'string'
+      && writer.id.trim() === writer.id
+      && writer.id.length > 0
+      && (writer.status === 'active' || writer.status === 'retired')
+      && writer.publicKey?.encoding === 'spki-base64url'
+      && typeof writer.publicKey.material === 'string'
+      && writer.publicKey.material.trim() === writer.publicKey.material
+      && writer.publicKey.material.length > 0
+    ));
+}
+
+function resolveClientSystemWriterPin(): SystemWriterPin {
+  const bakedPin = systemWriterPin as SystemWriterPin;
+  const e2ePinJson = import.meta.env.DEV
+    ? import.meta.env.VITE_E2E_SYSTEM_WRITER_PIN_JSON?.trim()
+    : undefined;
+  if (!e2ePinJson) return bakedPin;
+  try {
+    const parsed = JSON.parse(e2ePinJson) as unknown;
+    if (isSystemWriterPin(parsed)) {
+      return parsed;
+    }
+  } catch {
+    // Fall through to the baked public pin.
+  }
+  console.warn('[vh:web-pwa] ignoring invalid E2E system writer pin override');
+  return bakedPin;
+}
 
 type PeerTopologyProof =
   | {
@@ -489,7 +531,8 @@ export const useAppStore = create<AppState>((set, get) => ({
         const client = createClient({
           peers: peerTopology.peers,
           gunLocalStorage: resolveGunLocalStorage(),
-          requireSession: true
+          requireSession: true,
+          systemWriterPin: resolveClientSystemWriterPin()
         });
         exposePeerTopologyProof({
           status: 'resolved',

--- a/docs/plans/LUMA_SERVICE_V0_ROADMAP_2026-05-02.md
+++ b/docs/plans/LUMA_SERVICE_V0_ROADMAP_2026-05-02.md
@@ -189,7 +189,8 @@ Deliverables:
   - Topology lint: fail-closed `district_hash` rule (only on aggregate-class paths with cohort proof).
   - Topology lint: protocol/schema reject matrix from mesh spec §5.11 enforced at the adapter layer.
   - Topology lint: drill record outside `vh/__mesh_drills/*` is hard-rejected.
-  - New release gates: `pnpm check:public-namespace-leaks`, `pnpm check:linkability-domain-registry`, `pnpm check:luma-directory-v1`, `pnpm check:luma-forum-author-v1`, `pnpm check:luma-aggregate-voter-v1`, `pnpm check:luma-forum-post-v1`, `pnpm check:luma-news-report-v1`, `pnpm check:luma-forum-nomination-v1`.
+  - New release gates: `pnpm check:public-namespace-leaks`, `pnpm check:linkability-domain-registry`, `pnpm check:luma-directory-v1`, `pnpm check:luma-forum-author-v1`, `pnpm check:luma-aggregate-voter-v1`, `pnpm check:luma-forum-post-v1`, `pnpm check:luma-news-report-v1`, `pnpm check:luma-forum-nomination-v1`, `pnpm check:luma-news-story-system-v1`.
+  - News bundle/story system-writer migration starts with `vh/news/stories/<storyId>` only: story nodes carry `_writerKind: 'system'` and validate with the shared system-writer validator, while latest/hot indexes, storylines, analysis, synthesis, discovery, and topic engagement migrate in later slices.
   - Re-run `pnpm test:live:five-user-engagement` against the new taxonomy.
 - Mesh re-run gate (post-M0.B): schema-epoch revalidation only.
   - After all adapter and materializer migration deliverables land, re-run `pnpm check:mesh:production-readiness` against the new schema epoch with `schema_epoch: 'post_luma_m0b'`. The drill harness exercises migrated write classes through their real post-M0.B reader path, not the mesh drill writer contract.

--- a/docs/specs/spec-data-topology-privacy-v0.md
+++ b/docs/specs/spec-data-topology-privacy-v0.md
@@ -241,6 +241,15 @@ allowed namespaces, allowed record classes, and signature shape.
 | Civic representative directory snapshot | `spec-civic-action-kit-v0.md` | `vh/civic/reps/<jurisdictionVersion>` |
 | Topic engagement summary | `spec-civic-sentiment-v0.md` / topic engagement adapters | `vh/aggregates/topics/<topicId>/engagement/summary` |
 
+Implementation status:
+- `vh/news/stories/<storyId>` is the first concrete M0.B system-writer adapter
+  migration. New story-node writes use the shared validator contract above and
+  carry the system-writer metadata on the stored public node.
+- `vh/news/index/latest/*`, `vh/news/index/hot/*`, storylines, analysis
+  artifacts, synthesis records, discovery indexes, and topic engagement
+  records are intentionally outside that first adapter slice and must migrate
+  through separate branches.
+
 Forbidden uses:
 
 - User-author writes (forum thread, forum comment, forum post, forum nomination,

--- a/docs/specs/spec-luma-service-v0.md
+++ b/docs/specs/spec-luma-service-v0.md
@@ -688,6 +688,12 @@ record-derived id):
 | Comment moderation record (`CommentModeration.operator_id`) | operator id is a system-writer-signed pseudonym; carries `_writerKind: 'system'`, no `_authorScheme` |
 | News report operator action (`audit.operator_id`) | same as above |
 
+M0.B implementation note: `vh/news/stories/<storyId>` is the first concrete
+system-writer adapter migration. It signs the stored story-node wrapper with
+the build-pinned system-writer key and leaves latest/hot indexes, storylines,
+analysis, synthesis, discovery, and topic engagement for later system-writer
+slices.
+
 `AggregateVoterNodeV1` uses schema version `aggregate-voter-node-v1`,
 `_protocolVersion: 'luma-public-v1'`, `_writerKind: 'luma'`,
 `_authorScheme: 'voter-v1'`, and `SignedWriteEnvelope.audience =

--- a/docs/specs/spec-news-aggregator-v0.md
+++ b/docs/specs/spec-news-aggregator-v0.md
@@ -149,6 +149,24 @@ Canonical publication contract:
 `created_at` contract:
 - `created_at` is the initial publish timestamp for a `story_id`; when the earliest source publish time is available it should seed this value, otherwise the initial cluster publish time may seed it; it MUST remain immutable after initial publish.
 
+Public story-node storage contract:
+- Product code continues to consume the `StoryBundle` DTO above.
+- New writes to `vh/news/stories/<storyId>` MUST store the bundle inside the
+  node's `__story_bundle_json` field and MUST carry `_protocolVersion:
+  'luma-public-v1'`, `_writerKind: 'system'`, `_systemWriterId`,
+  `_systemIssuedAt`, and `_systemSignature`.
+- `_systemSignature` uses `jcs-ed25519-sha256-v1` over
+  JCS-canonical(node minus `_systemSignature`) and MUST validate through the
+  shared system-writer validator in `packages/gun-client/src/systemWriter.ts`.
+- The signed story node MUST NOT carry `_authorScheme` or
+  `SignedWriteEnvelope`; story bundles are system-published, not user-authored.
+- Legacy bare `story-bundle-v0` nodes remain read-compatible. A node carrying
+  `_writerKind: 'system'` but failing system-writer validation is rejected and
+  MUST NOT route through the legacy reader.
+- Latest/hot indexes under `vh/news/index/latest/*` and
+  `vh/news/index/hot/*` are not part of this M0.B story-node migration and do
+  not gain system-writer metadata in this slice.
+
 PR0 identity wiring freeze:
 - `StoryBundle.story_id` is the canonical NEWS_STORY identity key.
 - Discovery NEWS_STORY projections should forward this value as `FeedItem.story_id` when available.

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "check:luma-forum-nomination-v1": "node ./tools/scripts/check-luma-forum-nomination-v1.mjs",
     "check:public-namespace-leaks": "node ./tools/scripts/check-public-namespace-leaks.mjs",
     "check:luma-system-writer-surface": "node ./tools/scripts/check-luma-system-writer-surface.mjs",
+    "check:luma-news-story-system-v1": "node ./tools/scripts/check-luma-news-story-system-v1.mjs",
     "report:news-sources:admission": "pnpm --filter @vh/news-aggregator report:source-admission",
     "report:news-sources:health": "NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter @vh/news-aggregator report:source-health",
     "scout:news-sources:candidates": "NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter @vh/news-aggregator report:source-scout",

--- a/packages/e2e/playwright.daemon-first-feed.config.ts
+++ b/packages/e2e/playwright.daemon-first-feed.config.ts
@@ -1,6 +1,7 @@
 import * as path from 'node:path';
 import { defineConfig, devices, type TestConfig } from '@playwright/test';
 import { buildPortClearShellCommand } from './src/live/daemonFirstFeedProcesses';
+import { E2E_SYSTEM_WRITER_PIN_JSON } from './src/live/lumaSystemWriterTestFixture';
 
 process.env.VH_DAEMON_FEED_RUN_ID ??= `${Date.now()}-${process.pid}`;
 
@@ -420,6 +421,7 @@ const localWebServers: TestConfig['webServer'] = [
       VITE_NEWS_RUNTIME_ROLE: 'consumer',
       VH_DAEMON_FEED_USE_FIXTURE_FEED: useFixtureFeed ? 'true' : 'false',
       VH_DAEMON_FEED_FIXTURE_BASE_URL: fixtureFeedBaseUrl,
+      VITE_E2E_SYSTEM_WRITER_PIN_JSON: E2E_SYSTEM_WRITER_PIN_JSON,
       VITE_GUN_PEERS: `["${gunPeerUrl}"]`,
       VITE_NEWS_FEED_SOURCES: resolveDevFeedSourcesJson(),
       ...resolveAnalysisRelayEnv(),

--- a/packages/e2e/src/live/daemonFirstFeedHarness.ts
+++ b/packages/e2e/src/live/daemonFirstFeedHarness.ts
@@ -19,6 +19,11 @@ import {
 } from './browserNewsStore';
 import { nudgeFeed } from './feedReadiness';
 import { resolveDaemonFeedSourcesJson } from './daemonFeedSources';
+import {
+  E2E_SYSTEM_WRITER_ID,
+  E2E_SYSTEM_WRITER_PIN_JSON,
+  E2E_SYSTEM_WRITER_PRIVATE_KEY_PKCS8_BASE64URL,
+} from './lumaSystemWriterTestFixture';
 
 export const SHOULD_RUN = process.env.VH_RUN_DAEMON_FIRST_FEED === 'true';
 export const GUN_PORT = Number(process.env.VH_DAEMON_FEED_GUN_PORT ?? '8777');
@@ -260,6 +265,9 @@ function commonEnv(): NodeJS.ProcessEnv {
     VH_STORYCLUSTER_REMOTE_AUTH_HEADER: storyclusterRemote.authHeader,
     VH_STORYCLUSTER_REMOTE_AUTH_SCHEME: storyclusterRemote.authScheme,
     VH_NEWS_DAEMON_HOLDER_ID: 'vh-e2e-news-daemon',
+    VH_NEWS_SYSTEM_WRITER_ID: E2E_SYSTEM_WRITER_ID,
+    VH_NEWS_SYSTEM_WRITER_PIN_JSON: E2E_SYSTEM_WRITER_PIN_JSON,
+    VH_NEWS_SYSTEM_WRITER_PRIVATE_KEY_PKCS8_BASE64URL: E2E_SYSTEM_WRITER_PRIVATE_KEY_PKCS8_BASE64URL,
   };
 }
 

--- a/packages/e2e/src/live/lumaSystemWriterTestFixture.ts
+++ b/packages/e2e/src/live/lumaSystemWriterTestFixture.ts
@@ -1,0 +1,26 @@
+export const E2E_SYSTEM_WRITER_ID = 'vh-e2e-news-daemon-system-writer-v1';
+
+export const E2E_SYSTEM_WRITER_PUBLIC_KEY_SPKI_BASE64URL =
+  'MCowBQYDK2VwAyEA4ZHLho6yDOsGogTtrVUWiTRIGYlxKexsprzKjbuy9js';
+
+export const E2E_SYSTEM_WRITER_PRIVATE_KEY_PKCS8_BASE64URL =
+  'MC4CAQAwBQYDK2VwBCIEIOHbQB3dtUl7cAXBpr6o_V7Tb1YuS6hcp7CLnRS-CscA';
+
+export const E2E_SYSTEM_WRITER_PIN = {
+  pinVersion: 1,
+  schemaEpoch: 'luma-public-v1',
+  maxProtocolVersion: 'luma-public-v1',
+  signatureSuite: 'jcs-ed25519-sha256-v1',
+  writers: [
+    {
+      id: E2E_SYSTEM_WRITER_ID,
+      status: 'active',
+      publicKey: {
+        encoding: 'spki-base64url',
+        material: E2E_SYSTEM_WRITER_PUBLIC_KEY_SPKI_BASE64URL,
+      },
+    },
+  ],
+};
+
+export const E2E_SYSTEM_WRITER_PIN_JSON = JSON.stringify(E2E_SYSTEM_WRITER_PIN);

--- a/packages/e2e/src/live/playwright.daemon-first-feed.config.vitest.mjs
+++ b/packages/e2e/src/live/playwright.daemon-first-feed.config.vitest.mjs
@@ -97,6 +97,20 @@ describe('playwright.daemon-first-feed.config', () => {
     expect(sourceIds).toEqual(['guardian-us', 'nbc-politics', 'pbs-politics']);
   });
 
+  it('passes the E2E system-writer public pin override to the web app only', async () => {
+    const config = await loadConfig('run-system-writer-pin-check');
+    const entries = config.webServer;
+    const appServer = entries[entries.length - 1];
+    const pin = JSON.parse(appServer.env.VITE_E2E_SYSTEM_WRITER_PIN_JSON);
+
+    expect(pin).toMatchObject({
+      pinVersion: 1,
+      schemaEpoch: 'luma-public-v1',
+      signatureSuite: 'jcs-ed25519-sha256-v1',
+    });
+    expect(pin.writers[0].id).toBe('vh-e2e-news-daemon-system-writer-v1');
+  });
+
   it('propagates analysis relay model and timeout overrides when the live relay is enabled', async () => {
     const config = await loadConfig('run-analysis-relay-check', {
       OPENAI_API_KEY: 'test-openai-key',

--- a/packages/gun-client/src/newsAdapters.test.ts
+++ b/packages/gun-client/src/newsAdapters.test.ts
@@ -10,8 +10,14 @@ import {
   TARGET_LATEST_INDEX_PAYLOAD_FIXTURE,
 } from './__fixtures__/latestIndexMigrationFixtures';
 import type { TopologyGuard } from './topology';
-import type { VennClient } from './types';
+import type { VennClient, VennClientConfig } from './types';
 import { HydrationBarrier } from './sync/barrier';
+import {
+  SYSTEM_WRITER_KIND,
+  SYSTEM_WRITER_PROTOCOL_VERSION,
+  type SystemWriterPin,
+  type SystemWriterSignHook,
+} from './systemWriter';
 import {
   DEFAULT_NEWS_HOTNESS_CONFIG,
   computeStoryHotness,
@@ -33,6 +39,7 @@ import {
   removeNewsHotIndexEntry,
   removeNewsLatestIndexEntry,
   removeNewsStory,
+  type SystemWriterStoryBundleRecord,
   writeNewsBundle,
   writeNewsHotIndexEntry,
   writeNewsIngestionLease,
@@ -148,12 +155,29 @@ function createFakeMesh(): FakeMesh {
   };
 }
 
-function createClient(mesh: FakeMesh, guard: TopologyGuard): VennClient {
+const ED25519 = 'Ed25519';
+const STORY_BUNDLE_JSON_KEY = '__story_bundle_json';
+const TEST_SYSTEM_WRITER_ID = 'vh-system-writer-dev-v1';
+const TEST_SYSTEM_ISSUED_AT = 1_700_000_030_000;
+const TEST_SYSTEM_SIGNATURE = 'test-system-signature';
+const defaultSystemWriterSign: SystemWriterSignHook = () => TEST_SYSTEM_SIGNATURE;
+
+function createClient(
+  mesh: FakeMesh,
+  guard: TopologyGuard,
+  config: Partial<VennClientConfig> = {},
+): VennClient {
   const barrier = new HydrationBarrier();
   barrier.markReady();
 
   return {
-    config: { peers: [] },
+    config: {
+      peers: [],
+      systemWriterId: TEST_SYSTEM_WRITER_ID,
+      systemWriterNow: () => TEST_SYSTEM_ISSUED_AT,
+      systemWriterSign: defaultSystemWriterSign,
+      ...config,
+    },
     hydrationBarrier: barrier,
     storage: {} as VennClient['storage'],
     topologyGuard: guard,
@@ -167,6 +191,65 @@ function createClient(mesh: FakeMesh, guard: TopologyGuard): VennClient {
     linkDevice: vi.fn(),
     shutdown: vi.fn()
   };
+}
+
+function bytesToBase64Url(bytes: Uint8Array): string {
+  return Buffer.from(bytes).toString('base64url');
+}
+
+function bytesToBufferSource(bytes: Uint8Array): BufferSource {
+  const copy = new Uint8Array(bytes.byteLength);
+  copy.set(bytes);
+  return copy.buffer;
+}
+
+async function createRealSystemWriterHooks(): Promise<{
+  pin: SystemWriterPin;
+  sign: SystemWriterSignHook;
+}> {
+  const keyPair = await crypto.subtle.generateKey(ED25519, true, ['sign', 'verify']);
+  const publicKeySpki = new Uint8Array(await crypto.subtle.exportKey('spki', keyPair.publicKey));
+  const pin: SystemWriterPin = {
+    pinVersion: 1,
+    schemaEpoch: SYSTEM_WRITER_PROTOCOL_VERSION,
+    maxProtocolVersion: SYSTEM_WRITER_PROTOCOL_VERSION,
+    signatureSuite: 'jcs-ed25519-sha256-v1',
+    writers: [
+      {
+        id: TEST_SYSTEM_WRITER_ID,
+        status: 'active',
+        publicKey: {
+          encoding: 'spki-base64url',
+          material: bytesToBase64Url(publicKeySpki),
+        },
+      },
+    ],
+  };
+  return {
+    pin,
+    sign: async ({ canonicalBytes }) => bytesToBase64Url(new Uint8Array(
+      await crypto.subtle.sign(ED25519, keyPair.privateKey, bytesToBufferSource(canonicalBytes))
+    )),
+  };
+}
+
+function expectSystemStoryRecord(
+  value: unknown,
+  options: { readonly writerId?: string } = {},
+): SystemWriterStoryBundleRecord {
+  expect(value).toMatchObject({
+    _protocolVersion: SYSTEM_WRITER_PROTOCOL_VERSION,
+    _writerKind: SYSTEM_WRITER_KIND,
+    _systemWriterId: options.writerId ?? TEST_SYSTEM_WRITER_ID,
+    _systemIssuedAt: TEST_SYSTEM_ISSUED_AT,
+    _systemSignature: expect.any(String),
+    story_id: STORY.story_id,
+    created_at: expect.any(Number),
+    schemaVersion: STORY.schemaVersion,
+  });
+  expect(value).not.toHaveProperty('_authorScheme');
+  expect(value).not.toHaveProperty('signedWriteEnvelope');
+  return value as SystemWriterStoryBundleRecord;
 }
 
 const STORY: StoryBundle = {
@@ -255,11 +338,8 @@ describe('newsAdapters', () => {
     expect(result).toEqual(STORY);
     expect(mesh.writes).toHaveLength(1);
     expect(mesh.writes[0].path).toBe('news/stories/story-123');
-    expect(mesh.writes[0].value).toMatchObject({
-      story_id: STORY.story_id,
-      created_at: STORY.created_at,
-      schemaVersion: STORY.schemaVersion
-    });
+    const record = expectSystemStoryRecord(mesh.writes[0].value);
+    expect(record._systemSignature).toBe(TEST_SYSTEM_SIGNATURE);
     expect(typeof (mesh.writes[0].value as Record<string, unknown>).__story_bundle_json).toBe('string');
     expect(
       JSON.parse((mesh.writes[0].value as Record<string, unknown>).__story_bundle_json as string)
@@ -325,6 +405,7 @@ describe('newsAdapters', () => {
     });
 
     expect(result.created_at).toBe(frozenCreatedAt);
+    expectSystemStoryRecord(mesh.writes[0].value);
     expect(
       JSON.parse((mesh.writes[0].value as Record<string, unknown>).__story_bundle_json as string),
     ).toMatchObject({
@@ -356,6 +437,37 @@ describe('newsAdapters', () => {
 
     expect(result.created_at).toBe(1_700_000_010_000);
     expect(mesh.writes).toHaveLength(1);
+    expectSystemStoryRecord(mesh.writes[0].value);
+    expect(
+      JSON.parse((mesh.writes[0].value as Record<string, unknown>).__story_bundle_json as string),
+    ).toMatchObject({
+      story_id: 'story-123',
+      created_at: 1_700_000_010_000,
+    });
+  });
+
+  it('writeNewsStory enforces first-write-wins created_at from valid system records', async () => {
+    const mesh = createFakeMesh();
+    const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+    const hooks = await createRealSystemWriterHooks();
+    const client = createClient(mesh, guard, {
+      systemWriterPin: hooks.pin,
+      systemWriterSign: hooks.sign,
+    });
+    await writeNewsStory(client, {
+      ...STORY,
+      created_at: 1_700_000_010_000,
+    });
+    const existingRecord = mesh.writes[0].value;
+    mesh.writes.length = 0;
+    mesh.setRead('news/stories/story-123', existingRecord);
+
+    const result = await writeNewsStory(client, {
+      ...STORY,
+      created_at: 1_700_000_999_000,
+    });
+
+    expect(result.created_at).toBe(1_700_000_010_000);
     expect(
       JSON.parse((mesh.writes[0].value as Record<string, unknown>).__story_bundle_json as string),
     ).toMatchObject({
@@ -398,6 +510,108 @@ describe('newsAdapters', () => {
         refresh_token: 'secret'
       })
     ).rejects.toThrow('forbidden identity/token fields');
+  });
+
+  it('writeNewsStory fails closed without a system writer signer and does not write a bare story', async () => {
+    const mesh = createFakeMesh();
+    const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+    const client = createClient(mesh, guard, { systemWriterSign: undefined });
+
+    await expect(writeNewsStory(client, STORY)).rejects.toThrow('system writer signer is required');
+    expect(mesh.writes).toHaveLength(0);
+  });
+
+  it.each([
+    ['NaN', Number.NaN],
+    ['negative', -1],
+  ])('writeNewsStory rejects invalid system issued-at values: %s', async (_label, issuedAt) => {
+    const mesh = createFakeMesh();
+    const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+    const client = createClient(mesh, guard, { systemWriterNow: () => issuedAt });
+
+    await expect(writeNewsStory(client, STORY)).rejects.toThrow('system writer issued-at');
+    expect(mesh.writes).toHaveLength(0);
+  });
+
+  it.each([
+    ['non-string', 123],
+    ['blank', ''],
+    ['padded', ' signature'],
+  ])('writeNewsStory rejects invalid system writer signatures: %s', async (_label, signature) => {
+    const mesh = createFakeMesh();
+    const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+    const client = createClient(mesh, guard, {
+      systemWriterSign: vi.fn(async () => signature) as unknown as SystemWriterSignHook,
+    });
+
+    await expect(writeNewsStory(client, STORY)).rejects.toThrow('system writer signer returned an invalid signature');
+    expect(mesh.writes).toHaveLength(0);
+  });
+
+  it('writeNewsStory resolves writer id from the active pin when explicit id is blank', async () => {
+    const mesh = createFakeMesh();
+    const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+    const sign = vi.fn(async () => TEST_SYSTEM_SIGNATURE);
+    const client = createClient(mesh, guard, {
+      systemWriterId: ' ',
+      systemWriterPin: {
+        pinVersion: 1,
+        schemaEpoch: SYSTEM_WRITER_PROTOCOL_VERSION,
+        maxProtocolVersion: SYSTEM_WRITER_PROTOCOL_VERSION,
+        signatureSuite: 'jcs-ed25519-sha256-v1',
+        writers: [
+          {
+            id: 'pinned-news-writer-v1',
+            status: 'active',
+            publicKey: {
+              encoding: 'spki-base64url',
+              material: 'public-material',
+            },
+          },
+        ],
+      },
+      systemWriterSign: sign,
+    });
+
+    await writeNewsStory(client, STORY);
+    const record = expectSystemStoryRecord(mesh.writes[0].value, { writerId: 'pinned-news-writer-v1' });
+    expect(record._systemWriterId).toBe('pinned-news-writer-v1');
+    expect(sign).toHaveBeenCalledWith(expect.objectContaining({
+      writerId: 'pinned-news-writer-v1',
+    }));
+  });
+
+  it('writeNewsStory falls back to the default system writer id when no active pin writer exists', async () => {
+    const mesh = createFakeMesh();
+    const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+    const sign = vi.fn(async () => TEST_SYSTEM_SIGNATURE);
+    const client = createClient(mesh, guard, {
+      systemWriterId: undefined,
+      systemWriterPin: {
+        pinVersion: 1,
+        schemaEpoch: SYSTEM_WRITER_PROTOCOL_VERSION,
+        maxProtocolVersion: SYSTEM_WRITER_PROTOCOL_VERSION,
+        signatureSuite: 'jcs-ed25519-sha256-v1',
+        writers: [
+          {
+            id: 'retired-news-writer-v1',
+            status: 'retired',
+            publicKey: {
+              encoding: 'spki-base64url',
+              material: 'public-material',
+            },
+          },
+        ],
+      },
+      systemWriterSign: sign,
+    });
+
+    await writeNewsStory(client, STORY);
+    const record = expectSystemStoryRecord(mesh.writes[0].value);
+    expect(record._systemWriterId).toBe(TEST_SYSTEM_WRITER_ID);
+    expect(sign).toHaveBeenCalledWith(expect.objectContaining({
+      writerId: TEST_SYSTEM_WRITER_ID,
+    }));
   });
 
   it('writeNewsStory surfaces put ack errors', async () => {
@@ -531,7 +745,7 @@ describe('newsAdapters', () => {
 
   it('readNewsStory parses encoded bundle payloads', async () => {
     const mesh = createFakeMesh();
-    mesh.setRead('news/stories/story-encoded', {
+    mesh.setRead('news/stories/story-123', {
       __story_bundle_json: JSON.stringify(STORY),
       story_id: STORY.story_id,
       created_at: STORY.created_at
@@ -539,8 +753,156 @@ describe('newsAdapters', () => {
     const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
     const client = createClient(mesh, guard);
 
-    const story = await readNewsStory(client, 'story-encoded');
+    const story = await readNewsStory(client, 'story-123');
     expect(story).toEqual(STORY);
+  });
+
+  it('readNewsStory validates signed system story records through the shared system-writer validator', async () => {
+    const mesh = createFakeMesh();
+    const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+    const hooks = await createRealSystemWriterHooks();
+    const client = createClient(mesh, guard, {
+      systemWriterPin: hooks.pin,
+      systemWriterSign: hooks.sign,
+    });
+
+    await writeNewsStory(client, STORY);
+    const record = expectSystemStoryRecord(mesh.writes[0].value);
+    expect(record._systemSignature).not.toBe(TEST_SYSTEM_SIGNATURE);
+    mesh.setRead('news/stories/story-123', record);
+
+    await expect(readNewsStory(client, 'story-123')).resolves.toEqual(STORY);
+  });
+
+  it('readNewsStory rejects tampered system story metadata and payloads', async () => {
+    const mesh = createFakeMesh();
+    const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+    const hooks = await createRealSystemWriterHooks();
+    const client = createClient(mesh, guard, {
+      systemWriterPin: hooks.pin,
+      systemWriterSign: hooks.sign,
+    });
+    await writeNewsStory(client, STORY);
+    const record = expectSystemStoryRecord(mesh.writes[0].value);
+
+    const cases: Array<[string, SystemWriterStoryBundleRecord]> = [
+      [
+        'payload',
+        {
+          ...record,
+          [STORY_BUNDLE_JSON_KEY]: JSON.stringify({ ...STORY, headline: 'tampered' }),
+        },
+      ],
+      ['protocol version', { ...record, _protocolVersion: 'luma-public-v2' }],
+      ['writer kind', { ...record, _writerKind: 'legacy' as never }],
+      ['writer id', { ...record, _systemWriterId: 'unknown-writer' }],
+      ['issued-at', { ...record, _systemIssuedAt: record._systemIssuedAt + 1 }],
+      ['signature', { ...record, _systemSignature: 'bad-signature' }],
+      [
+        'user author fields',
+        {
+          ...record,
+          _authorScheme: 'forum-author-v1',
+        } as unknown as SystemWriterStoryBundleRecord,
+      ],
+      [
+        'client envelope',
+        {
+          ...record,
+          signedWriteEnvelope: { signature: 'not-for-system' },
+        } as unknown as SystemWriterStoryBundleRecord,
+      ],
+    ];
+
+    for (const [_label, tampered] of cases) {
+      mesh.setRead('news/stories/story-123', tampered);
+      await expect(readNewsStory(client, 'story-123')).resolves.toBeNull();
+    }
+  });
+
+  it('readNewsStory rejects system records whose signed story id does not match the path', async () => {
+    const mesh = createFakeMesh();
+    const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+    const hooks = await createRealSystemWriterHooks();
+    const client = createClient(mesh, guard, {
+      systemWriterPin: hooks.pin,
+      systemWriterSign: hooks.sign,
+    });
+    await writeNewsStory(client, STORY);
+    const record = expectSystemStoryRecord(mesh.writes[0].value);
+    mesh.setRead('news/stories/different-story', record);
+
+    await expect(readNewsStory(client, 'different-story')).resolves.toBeNull();
+  });
+
+  it('readNewsStory fails closed for system records when the pin is unavailable', async () => {
+    const mesh = createFakeMesh();
+    const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+    const hooks = await createRealSystemWriterHooks();
+    const signingClient = createClient(mesh, guard, {
+      systemWriterPin: hooks.pin,
+      systemWriterSign: hooks.sign,
+    });
+    await writeNewsStory(signingClient, STORY);
+    const record = expectSystemStoryRecord(mesh.writes[0].value);
+    mesh.setRead('news/stories/story-123', record);
+    const readerWithoutPin = createClient(mesh, guard, { systemWriterPin: null });
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    try {
+      await expect(readNewsStory(readerWithoutPin, 'story-123')).resolves.toBeNull();
+      expect(warning).toHaveBeenCalledWith(
+        '[vh:news] system-writer-validation-failed',
+        expect.objectContaining({
+          event: 'system-writer-validation-failed',
+          reason: 'missing-pin',
+          path: 'vh/news/stories/story-123',
+        })
+      );
+    } finally {
+      warning.mockRestore();
+    }
+  });
+
+  it('readNewsStory dispatches system-writer validation events when browser event APIs are available', async () => {
+    const mesh = createFakeMesh();
+    const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+    const hooks = await createRealSystemWriterHooks();
+    const signingClient = createClient(mesh, guard, {
+      systemWriterPin: hooks.pin,
+      systemWriterSign: hooks.sign,
+    });
+    await writeNewsStory(signingClient, STORY);
+    const record = expectSystemStoryRecord(mesh.writes[0].value);
+    mesh.setRead('news/stories/story-123', record);
+    const readerWithoutPin = createClient(mesh, guard, { systemWriterPin: null });
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const dispatchEvent = vi.fn();
+    class TestCustomEvent {
+      readonly type: string;
+      readonly detail: unknown;
+
+      constructor(type: string, init?: { detail?: unknown }) {
+        this.type = type;
+        this.detail = init?.detail;
+      }
+    }
+    vi.stubGlobal('CustomEvent', TestCustomEvent);
+    vi.stubGlobal('dispatchEvent', dispatchEvent);
+
+    try {
+      await expect(readNewsStory(readerWithoutPin, 'story-123')).resolves.toBeNull();
+      expect(dispatchEvent).toHaveBeenCalledWith(expect.objectContaining({
+        type: 'system-writer-validation-failed',
+        detail: expect.objectContaining({
+          reason: 'missing-pin',
+          path: 'vh/news/stories/story-123',
+        }),
+      }));
+    } finally {
+      warning.mockRestore();
+      vi.unstubAllGlobals();
+    }
   });
 
   it('readNewsStory returns null for malformed encoded bundle payloads', async () => {
@@ -641,11 +1003,11 @@ describe('newsAdapters', () => {
 
     try {
       const mesh = createFakeMesh();
-      mesh.setRead('news/stories/settled-story', STORY);
+      mesh.setRead('news/stories/story-123', STORY);
       const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
       const client = createClient(mesh, guard);
 
-      await expect(readNewsStory(client, 'settled-story')).resolves.toEqual(STORY);
+      await expect(readNewsStory(client, 'story-123')).resolves.toEqual(STORY);
 
       // With clearTimeout disabled, timeout callback still runs and must short-circuit.
       await vi.advanceTimersByTimeAsync(2_500);
@@ -968,19 +1330,17 @@ describe('newsAdapters', () => {
       expect(result.story_id).toBe('story-123');
       expect(mesh.writes).toHaveLength(3);
       expect(mesh.writes[0].path).toBe('news/stories/story-123');
-      expect(mesh.writes[0].value).toMatchObject({
-        story_id: STORY.story_id,
-        created_at: STORY.created_at,
-        schemaVersion: STORY.schemaVersion
-      });
+      expectSystemStoryRecord(mesh.writes[0].value);
       expect(
         JSON.parse((mesh.writes[0].value as Record<string, unknown>).__story_bundle_json as string)
       ).toEqual(STORY);
       expect(mesh.writes[1]).toEqual({ path: 'news/index/latest/story-123', value: STORY.cluster_window_end });
+      expect(typeof mesh.writes[1].value).toBe('number');
       expect(mesh.writes[2]).toEqual({
         path: 'news/index/hot/story-123',
         value: computeStoryHotness(STORY, Date.now()),
       });
+      expect(typeof mesh.writes[2].value).toBe('number');
     } finally {
       vi.useRealTimers();
     }

--- a/packages/gun-client/src/newsAdapters.ts
+++ b/packages/gun-client/src/newsAdapters.ts
@@ -7,6 +7,16 @@ import {
 import { createGuardedChain, type ChainWithGet } from './chain';
 import { writeWithDurability, type DurableWriteResult } from './durableWrite';
 import { readGunTimeoutMs } from './runtimeConfig';
+import {
+  SYSTEM_WRITER_KIND,
+  SYSTEM_WRITER_PROTOCOL_VERSION,
+  SYSTEM_WRITER_VALIDATION_EVENT,
+  canonicalizeSystemWriterRecordBytes,
+  validateSystemWriterRecord,
+  type SystemWriterRecordFields,
+  type SystemWriterValidationFailure,
+  type UnsignedSystemWriterRecordFields,
+} from './systemWriter';
 import type { VennClient } from './types';
 
 export type NewsLatestIndex = Record<string, number>;
@@ -65,11 +75,22 @@ const FORBIDDEN_NEWS_KEYS = new Set<string>([
 ]);
 
 const STORY_BUNDLE_JSON_KEY = '__story_bundle_json';
+const DEFAULT_SYSTEM_WRITER_ID = 'vh-system-writer-dev-v1';
 const READ_ONCE_TIMEOUT_MS = readGunTimeoutMs(
   ['VITE_VH_GUN_READ_TIMEOUT_MS', 'VH_GUN_READ_TIMEOUT_MS'],
   2_500,
 );
 const ROOT_INDEX_SETTLE_MS = 150;
+
+export interface SystemWriterStoryBundleRecord extends Record<string, unknown>, SystemWriterRecordFields {
+  readonly [STORY_BUNDLE_JSON_KEY]: string;
+  readonly story_id: string;
+  readonly created_at: number;
+  readonly schemaVersion: StoryBundle['schemaVersion'];
+}
+
+type UnsignedSystemWriterStoryBundleRecord =
+  Omit<SystemWriterStoryBundleRecord, '_systemSignature'> & UnsignedSystemWriterRecordFields;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object';
@@ -458,6 +479,59 @@ function encodeStoryBundleForGun(story: StoryBundle): Record<string, unknown> {
   };
 }
 
+function resolveSystemWriterId(client: VennClient): string {
+  const configured = client.config.systemWriterId?.trim();
+  if (configured) {
+    return configured;
+  }
+
+  const activePinnedWriter = client.config.systemWriterPin?.writers.find((writer) => writer.status === 'active');
+  return activePinnedWriter?.id ?? DEFAULT_SYSTEM_WRITER_ID;
+}
+
+function resolveSystemWriterIssuedAt(client: VennClient): number {
+  const issuedAt = client.config.systemWriterNow?.() ?? Date.now();
+  if (!Number.isSafeInteger(issuedAt) || issuedAt < 0) {
+    throw new Error('system writer issued-at must be a non-negative safe integer');
+  }
+  return issuedAt;
+}
+
+async function buildSystemWriterStoryRecord(
+  client: VennClient,
+  story: StoryBundle,
+): Promise<SystemWriterStoryBundleRecord> {
+  const sign = client.config.systemWriterSign;
+  if (!sign) {
+    throw new Error('system writer signer is required for news story writes');
+  }
+
+  const writerId = resolveSystemWriterId(client);
+  const path = storyPath(story.story_id);
+  const unsignedRecord: UnsignedSystemWriterStoryBundleRecord = {
+    ...encodeStoryBundleForGun(story),
+    _protocolVersion: SYSTEM_WRITER_PROTOCOL_VERSION,
+    _writerKind: SYSTEM_WRITER_KIND,
+    _systemWriterId: writerId,
+    _systemIssuedAt: resolveSystemWriterIssuedAt(client),
+  } as UnsignedSystemWriterStoryBundleRecord;
+  const canonicalBytes = canonicalizeSystemWriterRecordBytes(unsignedRecord);
+  const signature = await sign({
+    canonicalBytes,
+    writerId,
+    path,
+    record: unsignedRecord,
+  });
+  if (typeof signature !== 'string' || signature.trim() !== signature || signature.length === 0) {
+    throw new Error('system writer signer returned an invalid signature');
+  }
+
+  return {
+    ...unsignedRecord,
+    _systemSignature: signature,
+  } as SystemWriterStoryBundleRecord;
+}
+
 function decodeStoryBundlePayload(payload: unknown): unknown {
   if (!isRecord(payload)) {
     return payload;
@@ -475,8 +549,8 @@ function decodeStoryBundlePayload(payload: unknown): unknown {
   }
 }
 
-function parseStoryBundle(data: unknown): StoryBundle | null {
-  const payload = decodeStoryBundlePayload(stripGunMetadata(data));
+function parseLegacyStoryBundle(data: unknown): StoryBundle | null {
+  const payload = decodeStoryBundlePayload(data);
   if (hasForbiddenNewsPayloadFields(payload)) {
     return null;
   }
@@ -485,6 +559,63 @@ function parseStoryBundle(data: unknown): StoryBundle | null {
     return null;
   }
   return parsed.data;
+}
+
+function isSystemWriterMarkedRecord(value: unknown): value is Record<string, unknown> {
+  return isRecord(value) && value._writerKind === SYSTEM_WRITER_KIND;
+}
+
+function carriesLumaProtocolFields(value: unknown): boolean {
+  return isRecord(value) && (
+    '_protocolVersion' in value
+    || '_writerKind' in value
+    || '_systemWriterId' in value
+    || '_systemSignature' in value
+    || '_systemIssuedAt' in value
+    || '_authorScheme' in value
+    || 'signedWriteEnvelope' in value
+  );
+}
+
+function emitSystemWriterValidationFailure(
+  failure: SystemWriterValidationFailure,
+): void {
+  console.warn(`[vh:news] ${SYSTEM_WRITER_VALIDATION_EVENT}`, failure);
+  if (typeof globalThis.dispatchEvent === 'function' && typeof CustomEvent !== 'undefined') {
+    globalThis.dispatchEvent(
+      new CustomEvent(SYSTEM_WRITER_VALIDATION_EVENT, { detail: failure })
+    );
+  }
+}
+
+async function parseStoryBundleFromStoredRecord(
+  client: VennClient,
+  storyId: string,
+  data: unknown,
+): Promise<StoryBundle | null> {
+  const payload = stripGunMetadata(data);
+  if (isSystemWriterMarkedRecord(payload)) {
+    const validation = await validateSystemWriterRecord({
+      path: storyPath(storyId),
+      record: payload,
+      pin: client.config.systemWriterPin,
+      verify: client.config.systemWriterVerify,
+    });
+    if (!validation.valid) {
+      emitSystemWriterValidationFailure(validation);
+      return null;
+    }
+
+    const parsed = parseLegacyStoryBundle(payload);
+    return parsed?.story_id === storyId ? parsed : null;
+  }
+
+  if (carriesLumaProtocolFields(payload)) {
+    return null;
+  }
+
+  const parsed = parseLegacyStoryBundle(payload);
+  return parsed?.story_id === storyId ? parsed : null;
 }
 
 function sanitizeStoryBundle(data: unknown): StoryBundle {
@@ -694,7 +825,7 @@ export async function readNewsStory(client: VennClient, storyId: string): Promis
   if (raw === null) {
     return null;
   }
-  const parsed = parseStoryBundle(raw);
+  const parsed = await parseStoryBundleFromStoredRecord(client, storyId, raw);
   if (!parsed) {
     return null;
   }
@@ -716,7 +847,7 @@ export async function writeNewsStory(client: VennClient, story: unknown): Promis
   const sanitized = sanitizeStoryBundle(story);
   await assertCanonicalNewsTopicId(sanitized);
   const normalized = await enforceCreatedAtFirstWriteWins(client, sanitized);
-  const encoded = encodeStoryBundleForGun(normalized);
+  const encoded = await buildSystemWriterStoryRecord(client, normalized);
   await putWithAck(
     getNewsStoryChain(client, normalized.story_id) as unknown as ChainWithGet<Record<string, unknown>>,
     encoded,

--- a/packages/gun-client/src/synthesisAdapters.test.ts
+++ b/packages/gun-client/src/synthesisAdapters.test.ts
@@ -129,7 +129,10 @@ function createClient(mesh: FakeMesh, guard: TopologyGuard, peers: string[] = []
   barrier.markReady();
 
   return {
-    config: { peers },
+    config: {
+      peers,
+      systemWriterSign: vi.fn(async () => 'test-system-story-signature')
+    },
     hydrationBarrier: barrier,
     storage: {} as VennClient['storage'],
     topologyGuard: guard,

--- a/packages/gun-client/src/systemWriter.ts
+++ b/packages/gun-client/src/systemWriter.ts
@@ -55,6 +55,17 @@ export interface SystemWriterRecordFields {
   readonly _systemIssuedAt: number;
 }
 
+export type UnsignedSystemWriterRecordFields = Omit<SystemWriterRecordFields, '_systemSignature'>;
+
+export interface SystemWriterSignInput {
+  readonly canonicalBytes: Uint8Array;
+  readonly writerId: string;
+  readonly path: string;
+  readonly record: Record<string, unknown> & UnsignedSystemWriterRecordFields;
+}
+
+export type SystemWriterSignHook = (input: SystemWriterSignInput) => string | Promise<string>;
+
 export interface SystemWriterVerifyInput {
   readonly canonicalBytes: Uint8Array;
   readonly signature: string;

--- a/packages/gun-client/src/types.ts
+++ b/packages/gun-client/src/types.ts
@@ -2,6 +2,7 @@ import type { IGunInstance } from 'gun';
 import type { ChainWithGet } from './chain';
 import type { StorageAdapter } from './storage/types';
 import type { HydrationBarrier } from './sync/barrier';
+import type { SystemWriterPin, SystemWriterSignHook, SystemWriterVerifyHook } from './systemWriter';
 import type { TopologyGuard } from './topology';
 
 export interface VennClientConfig {
@@ -12,6 +13,11 @@ export interface VennClientConfig {
   gunLocalStorage?: boolean;
   gunRadisk?: boolean;
   gunFile?: string | false;
+  systemWriterPin?: SystemWriterPin | null;
+  systemWriterVerify?: SystemWriterVerifyHook;
+  systemWriterSign?: SystemWriterSignHook;
+  systemWriterId?: string;
+  systemWriterNow?: () => number;
 }
 
 export interface Namespace<T = unknown> {

--- a/services/news-aggregator/src/daemon.ts
+++ b/services/news-aggregator/src/daemon.ts
@@ -31,6 +31,7 @@ import {
   parseStoryClusterRemoteConfig,
   parseTopicMapping,
   readEnvVar,
+  resolveSystemWriterClientConfigFromEnv,
   resolveLeaseHolderId,
   verifyStoryClusterHealth,
   type AsyncEnrichmentQueueOptions,
@@ -396,11 +397,13 @@ export async function startNewsAggregatorDaemonFromEnv(): Promise<NewsAggregator
     mkdirSync(path.dirname(gunFile), { recursive: true });
   }
   const writeLanes = createDaemonWriteLaneRegistry({ logger: console });
+  const systemWriterConfig = await resolveSystemWriterClientConfigFromEnv();
   const client = createNodeMeshClient({
     peers: gunPeers.length > 0 ? gunPeers : undefined,
     requireSession: false,
     gunRadisk,
     gunFile,
+    ...systemWriterConfig,
   });
   const bundleSynthesisEnrichment = createBundleSynthesisEnrichmentFromEnv(client, console, {
     runWrite: writeLanes.run,

--- a/services/news-aggregator/src/daemonUtils.test.ts
+++ b/services/news-aggregator/src/daemonUtils.test.ts
@@ -15,6 +15,7 @@ import {
   parseTopicMapping,
   resolveFeedSourceConfig,
   resolveLeaseHolderId,
+  resolveSystemWriterClientConfigFromEnv,
   verifyStoryClusterHealth,
   DEFAULT_LEASE_TTL_MS,
   DEFAULT_TOPIC_MAPPING,
@@ -453,6 +454,121 @@ describe('daemonUtils', () => {
       '{"peer":"https://x.example/gun"}',
     ]);
     expect(parseGunPeers('[invalid-json')).toEqual([]);
+  });
+
+  it('omits system-writer client config when no system-writer env is present', async () => {
+    await expect(resolveSystemWriterClientConfigFromEnv()).resolves.toEqual({});
+  });
+
+  it('resolves system-writer public pin metadata from env', async () => {
+    vi.stubEnv('VH_SYSTEM_WRITER_ID', 'writer-env-v1');
+    vi.stubEnv('VH_SYSTEM_WRITER_PUBLIC_KEY_SPKI_BASE64URL', 'public-material');
+
+    await expect(resolveSystemWriterClientConfigFromEnv()).resolves.toMatchObject({
+      systemWriterId: 'writer-env-v1',
+      systemWriterPin: {
+        pinVersion: 1,
+        schemaEpoch: 'luma-public-v1',
+        maxProtocolVersion: 'luma-public-v1',
+        signatureSuite: 'jcs-ed25519-sha256-v1',
+        writers: [
+          {
+            id: 'writer-env-v1',
+            status: 'active',
+            publicKey: {
+              encoding: 'spki-base64url',
+              material: 'public-material',
+            },
+          },
+        ],
+      },
+    });
+  });
+
+  it('prefers news-specific system-writer env over generic fallbacks', async () => {
+    vi.stubEnv('VH_SYSTEM_WRITER_ID', 'generic-writer-v1');
+    vi.stubEnv('VH_SYSTEM_WRITER_PUBLIC_KEY_SPKI_BASE64URL', 'generic-public-material');
+    vi.stubEnv('VH_NEWS_SYSTEM_WRITER_ID', 'news-writer-v1');
+    vi.stubEnv('VH_NEWS_SYSTEM_WRITER_PUBLIC_KEY_SPKI_BASE64URL', 'news-public-material');
+
+    await expect(resolveSystemWriterClientConfigFromEnv()).resolves.toMatchObject({
+      systemWriterId: 'news-writer-v1',
+      systemWriterPin: {
+        writers: [
+          {
+            id: 'news-writer-v1',
+            publicKey: {
+              material: 'news-public-material',
+            },
+          },
+        ],
+      },
+    });
+  });
+
+  it('resolves system-writer pin JSON and signer hook from daemon-only env', async () => {
+    const importedKey = { key: 'private-key' };
+    const importKey = vi.fn(async () => importedKey);
+    const sign = vi.fn(async () => new Uint8Array([1, 2, 3]).buffer);
+    vi.stubGlobal('crypto', {
+      subtle: {
+        importKey,
+        sign,
+      },
+    });
+    vi.stubEnv('VH_NEWS_SYSTEM_WRITER_ID', 'writer-json-v1');
+    vi.stubEnv(
+      'VH_NEWS_SYSTEM_WRITER_PIN_JSON',
+      JSON.stringify({
+        pinVersion: 1,
+        schemaEpoch: 'luma-public-v1',
+        maxProtocolVersion: 'luma-public-v1',
+        signatureSuite: 'jcs-ed25519-sha256-v1',
+        writers: [
+          {
+            id: 'writer-json-v1',
+            status: 'active',
+            publicKey: {
+              encoding: 'spki-base64url',
+              material: 'public-material',
+            },
+          },
+        ],
+      }),
+    );
+    vi.stubEnv(
+      'VH_NEWS_SYSTEM_WRITER_PRIVATE_KEY_PKCS8_BASE64URL',
+      Buffer.from('private-material').toString('base64url'),
+    );
+
+    const config = await resolveSystemWriterClientConfigFromEnv();
+    expect(config.systemWriterId).toBe('writer-json-v1');
+    expect(config.systemWriterPin?.writers[0]?.id).toBe('writer-json-v1');
+    await expect(config.systemWriterSign?.({
+      canonicalBytes: new Uint8Array([9]),
+      writerId: 'writer-json-v1',
+      path: 'vh/news/stories/story-1/',
+      record: {
+        _protocolVersion: 'luma-public-v1',
+        _writerKind: 'system',
+        _systemWriterId: 'writer-json-v1',
+        _systemIssuedAt: 1,
+      },
+    })).resolves.toBe('AQID');
+    expect(importKey).toHaveBeenCalledWith(
+      'pkcs8',
+      expect.any(ArrayBuffer),
+      'Ed25519',
+      false,
+      ['sign'],
+    );
+    expect(sign).toHaveBeenCalledWith('Ed25519', importedKey, expect.any(ArrayBuffer));
+  });
+
+  it('rejects invalid system-writer pin JSON', async () => {
+    vi.stubEnv('VH_SYSTEM_WRITER_PIN_JSON', JSON.stringify({ pinVersion: 0 }));
+
+    await expect(resolveSystemWriterClientConfigFromEnv()).rejects.toThrow('system writer pin JSON');
   });
 
   it('resolves starter feed sources through the source-health policy surface', () => {

--- a/services/news-aggregator/src/daemonUtils.ts
+++ b/services/news-aggregator/src/daemonUtils.ts
@@ -5,7 +5,7 @@ import {
   type FeedSource,
   type TopicMapping,
 } from '@vh/ai-engine';
-import type { NewsIngestionLease } from '@vh/gun-client';
+import type { NewsIngestionLease, SystemWriterPin, SystemWriterSignHook, VennClientConfig } from '@vh/gun-client';
 import { resolveStarterFeedSources, type ResolvedStarterFeedSources } from './sourceRegistry';
 export {
   createAsyncEnrichmentQueue,
@@ -35,6 +35,130 @@ export interface StoryClusterRemoteConfig {
 export function readEnvVar(name: string): string | undefined {
   const value = process.env?.[name];
   return typeof value === 'string' ? value : undefined;
+}
+
+const DEFAULT_SYSTEM_WRITER_ID = 'vh-system-writer-dev-v1';
+const SYSTEM_WRITER_PRIVATE_KEY_ENV_VARS = [
+  'VH_NEWS_SYSTEM_WRITER_PRIVATE_KEY_PKCS8_BASE64URL',
+  'VH_SYSTEM_WRITER_PRIVATE_KEY_PKCS8_BASE64URL',
+] as const;
+const SYSTEM_WRITER_PIN_JSON_ENV_VARS = [
+  'VH_NEWS_SYSTEM_WRITER_PIN_JSON',
+  'VH_SYSTEM_WRITER_PIN_JSON',
+] as const;
+const SYSTEM_WRITER_PUBLIC_KEY_ENV_VARS = [
+  'VH_NEWS_SYSTEM_WRITER_PUBLIC_KEY_SPKI_BASE64URL',
+  'VH_SYSTEM_WRITER_PUBLIC_KEY_SPKI_BASE64URL',
+] as const;
+
+function base64UrlToBytes(value: string): Uint8Array {
+  return new Uint8Array(Buffer.from(value, 'base64url'));
+}
+
+function bytesToBase64Url(bytes: Uint8Array): string {
+  return Buffer.from(bytes).toString('base64url');
+}
+
+function bytesToBufferSource(bytes: Uint8Array): BufferSource {
+  const copy = new Uint8Array(bytes.byteLength);
+  copy.set(bytes);
+  return copy.buffer;
+}
+
+function readFirstEnvVar(names: readonly string[]): string | undefined {
+  for (const name of names) {
+    const value = readEnvVar(name)?.trim();
+    if (value) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function parseSystemWriterPinJson(value: string): SystemWriterPin {
+  const parsed = JSON.parse(value) as SystemWriterPin;
+  if (
+    parsed.pinVersion !== 1
+    || parsed.schemaEpoch !== 'luma-public-v1'
+    || parsed.maxProtocolVersion !== 'luma-public-v1'
+    || parsed.signatureSuite !== 'jcs-ed25519-sha256-v1'
+    || !Array.isArray(parsed.writers)
+    || parsed.writers.length === 0
+  ) {
+    throw new Error('system writer pin JSON is not a valid luma-public-v1 pin');
+  }
+  return parsed;
+}
+
+function resolveSystemWriterPin(writerId: string): SystemWriterPin | undefined {
+  const pinJson = readFirstEnvVar(SYSTEM_WRITER_PIN_JSON_ENV_VARS);
+  if (pinJson) {
+    return parseSystemWriterPinJson(pinJson);
+  }
+
+  const publicKeyMaterial = readFirstEnvVar(SYSTEM_WRITER_PUBLIC_KEY_ENV_VARS);
+  if (!publicKeyMaterial) {
+    return undefined;
+  }
+
+  return {
+    pinVersion: 1,
+    schemaEpoch: 'luma-public-v1',
+    maxProtocolVersion: 'luma-public-v1',
+    signatureSuite: 'jcs-ed25519-sha256-v1',
+    writers: [
+      {
+        id: writerId,
+        status: 'active',
+        publicKey: {
+          encoding: 'spki-base64url',
+          material: publicKeyMaterial,
+        },
+      },
+    ],
+  };
+}
+
+async function createSystemWriterSignHook(privateKeyPkcs8Base64Url: string): Promise<SystemWriterSignHook> {
+  const subtle = globalThis.crypto?.subtle;
+  if (!subtle) {
+    throw new Error('WebCrypto is required for system writer signing');
+  }
+  const privateKey = await subtle.importKey(
+    'pkcs8',
+    bytesToBufferSource(base64UrlToBytes(privateKeyPkcs8Base64Url)),
+    'Ed25519',
+    false,
+    ['sign']
+  );
+
+  return async ({ canonicalBytes }) => bytesToBase64Url(new Uint8Array(
+    await subtle.sign('Ed25519', privateKey, bytesToBufferSource(canonicalBytes))
+  ));
+}
+
+export async function resolveSystemWriterClientConfigFromEnv(): Promise<Pick<
+  VennClientConfig,
+  'systemWriterId' | 'systemWriterPin' | 'systemWriterSign'
+>> {
+  const configuredWriterId = firstNonEmpty(
+    readEnvVar('VH_NEWS_SYSTEM_WRITER_ID'),
+    readEnvVar('VH_SYSTEM_WRITER_ID'),
+  );
+  const writerId = configuredWriterId ?? DEFAULT_SYSTEM_WRITER_ID;
+  const privateKeyPkcs8 = readFirstEnvVar(SYSTEM_WRITER_PRIVATE_KEY_ENV_VARS);
+  const pin = resolveSystemWriterPin(writerId);
+  const sign = privateKeyPkcs8 ? await createSystemWriterSignHook(privateKeyPkcs8) : undefined;
+
+  if (!configuredWriterId && !pin && !sign) {
+    return {};
+  }
+
+  return {
+    systemWriterId: writerId,
+    ...(pin ? { systemWriterPin: pin } : {}),
+    ...(sign ? { systemWriterSign: sign } : {}),
+  };
 }
 function firstNonEmpty(...values: Array<string | undefined>): string | undefined {
   for (const value of values) {

--- a/tools/scripts/check-luma-news-story-system-v1.mjs
+++ b/tools/scripts/check-luma-news-story-system-v1.mjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const failures = [];
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(rootDir, relativePath), 'utf8');
+}
+
+function requireToken(source, token, label) {
+  if (!source.includes(token)) {
+    failures.push(`${label} is missing ${token}`);
+  }
+}
+
+function forbidToken(source, token, label) {
+  if (source.includes(token)) {
+    failures.push(`${label} contains forbidden token ${token}`);
+  }
+}
+
+function sliceFunction(source, functionName) {
+  const start = source.indexOf(`function ${functionName}`);
+  if (start === -1) {
+    failures.push(`missing function ${functionName}`);
+    return '';
+  }
+  const nextExport = source.indexOf('\nexport ', start + 1);
+  const nextFunction = source.indexOf('\nfunction ', start + 1);
+  const candidates = [nextExport, nextFunction].filter((index) => index !== -1);
+  const end = candidates.length > 0 ? Math.min(...candidates) : source.length;
+  return source.slice(start, end);
+}
+
+function sliceExportedFunction(source, functionName) {
+  const start = source.indexOf(`export async function ${functionName}`);
+  if (start === -1) {
+    failures.push(`missing exported function ${functionName}`);
+    return '';
+  }
+  const nextExport = source.indexOf('\nexport ', start + 1);
+  const end = nextExport === -1 ? source.length : nextExport;
+  return source.slice(start, end);
+}
+
+const packageSource = read('package.json');
+const newsAdapterSource = read('packages/gun-client/src/newsAdapters.ts');
+const newsAdapterTestSource = read('packages/gun-client/src/newsAdapters.test.ts');
+const typesSource = read('packages/gun-client/src/types.ts');
+const appStoreSource = read('apps/web-pwa/src/store/index.ts');
+const daemonSource = read('services/news-aggregator/src/daemon.ts');
+const daemonUtilsSource = read('services/news-aggregator/src/daemonUtils.ts');
+const e2eDaemonHarnessSource = read('packages/e2e/src/live/daemonFirstFeedHarness.ts');
+const e2ePlaywrightConfigSource = read('packages/e2e/playwright.daemon-first-feed.config.ts');
+const privacySpecSource = read('docs/specs/spec-data-topology-privacy-v0.md');
+const newsSpecSource = read('docs/specs/spec-news-aggregator-v0.md');
+const roadmapSource = read('docs/plans/LUMA_SERVICE_V0_ROADMAP_2026-05-02.md');
+
+requireToken(packageSource, 'check:luma-news-story-system-v1', 'root package scripts');
+requireToken(typesSource, 'systemWriterPin?: SystemWriterPin | null', 'gun-client config');
+requireToken(typesSource, 'systemWriterSign?: SystemWriterSignHook', 'gun-client config');
+requireToken(typesSource, 'systemWriterVerify?: SystemWriterVerifyHook', 'gun-client config');
+requireToken(appStoreSource, 'systemWriterPin: resolveClientSystemWriterPin()', 'web-pwa client wiring');
+requireToken(appStoreSource, 'import.meta.env.DEV', 'web-pwa E2E pin override guard');
+requireToken(appStoreSource, 'VITE_E2E_SYSTEM_WRITER_PIN_JSON', 'web-pwa E2E pin override guard');
+requireToken(daemonSource, 'resolveSystemWriterClientConfigFromEnv', 'news daemon client wiring');
+requireToken(daemonUtilsSource, 'VH_SYSTEM_WRITER_PRIVATE_KEY_PKCS8_BASE64URL', 'news daemon signer env resolver');
+requireToken(e2eDaemonHarnessSource, 'VH_NEWS_SYSTEM_WRITER_PRIVATE_KEY_PKCS8_BASE64URL', 'daemon-first E2E signer fixture');
+requireToken(e2ePlaywrightConfigSource, 'VITE_E2E_SYSTEM_WRITER_PIN_JSON', 'daemon-first E2E reader pin fixture');
+
+for (const token of [
+  'SystemWriterStoryBundleRecord',
+  'SYSTEM_WRITER_PROTOCOL_VERSION',
+  'SYSTEM_WRITER_KIND',
+  'SYSTEM_WRITER_VALIDATION_EVENT',
+  'canonicalizeSystemWriterRecordBytes',
+  'validateSystemWriterRecord',
+  'buildSystemWriterStoryRecord',
+  'system writer signer is required for news story writes',
+  'parseStoryBundleFromStoredRecord',
+]) {
+  requireToken(newsAdapterSource, token, 'news story system writer adapter');
+}
+
+const storyWriter = sliceExportedFunction(newsAdapterSource, 'writeNewsStory');
+requireToken(storyWriter, 'buildSystemWriterStoryRecord', 'writeNewsStory');
+forbidToken(storyWriter, 'encodeStoryBundleForGun(normalized)', 'writeNewsStory legacy write path');
+
+const readStory = sliceExportedFunction(newsAdapterSource, 'readNewsStory');
+requireToken(readStory, 'parseStoryBundleFromStoredRecord', 'readNewsStory');
+
+const latestWriter = sliceExportedFunction(newsAdapterSource, 'writeNewsLatestIndexEntry');
+for (const token of ['SYSTEM_WRITER_KIND', '_writerKind', '_systemSignature', 'buildSystemWriterStoryRecord']) {
+  forbidToken(latestWriter, token, 'latest index writer');
+}
+
+const hotWriter = sliceExportedFunction(newsAdapterSource, 'writeNewsHotIndexEntry');
+for (const token of ['SYSTEM_WRITER_KIND', '_writerKind', '_systemSignature', 'buildSystemWriterStoryRecord']) {
+  forbidToken(hotWriter, token, 'hot index writer');
+}
+
+const signerBuilder = sliceFunction(daemonUtilsSource, 'createSystemWriterSignHook');
+for (const token of ['apps/web-pwa/src', 'signedWriteEnvelope', 'createSignedWriteEnvelope', 'canPerform(']) {
+  forbidToken(signerBuilder, token, 'daemon system writer signer');
+}
+
+for (const token of [
+  'readNewsStory validates signed system story records through the shared system-writer validator',
+  'readNewsStory rejects tampered system story metadata and payloads',
+  'readNewsStory rejects system records whose signed story id does not match the path',
+  'readNewsStory fails closed for system records when the pin is unavailable',
+  'writeNewsStory fails closed without a system writer signer and does not write a bare story',
+  'writeNewsStory enforces first-write-wins created_at from valid system records',
+  'writeNewsBundle writes story, latest index, and deterministic hot index',
+]) {
+  requireToken(newsAdapterTestSource, token, 'news story system writer tests');
+}
+
+for (const token of [
+  'News bundle / story',
+  'vh/news/stories/<storyId>',
+  'system-writer-validation-failed',
+]) {
+  requireToken(privacySpecSource, token, 'data topology privacy spec');
+}
+for (const token of [
+  "_writerKind: 'system'",
+  '_systemSignature',
+  'vh/news/stories/<storyId>',
+]) {
+  requireToken(newsSpecSource, token, 'news aggregator spec');
+}
+for (const token of [
+  'check:luma-news-story-system-v1',
+  'news bundle/story',
+]) {
+  requireToken(roadmapSource, token, 'LUMA roadmap');
+}
+
+for (const relativePath of [
+  'packages/gun-client/src/newsAdapters.ts',
+  'apps/web-pwa/src/store/index.ts',
+  'apps/web-pwa/src/luma/system-writer-pin.json',
+]) {
+  const source = read(relativePath);
+  for (const token of [
+    'BEGIN PRIVATE KEY',
+    'PRIVATE KEY-----',
+    'SYSTEM_WRITER_PRIVATE',
+    'subtle.sign(',
+    'crypto.sign(',
+    'createPrivateKey(',
+  ]) {
+    forbidToken(source, token, relativePath);
+  }
+}
+
+if (failures.length > 0) {
+  console.error('[check:luma-news-story-system-v1] failed');
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log('[check:luma-news-story-system-v1] news story system-writer surface ok');


### PR DESCRIPTION
## Summary
- Add system-writer signing and validation for new `StoryBundle` records at `vh/news/stories/<storyId>`.
- Keep legacy bare story bundle reads compatible while fail-closing invalid `_writerKind: system` records through `validateSystemWriterRecord`.
- Wire the browser client with the baked public system-writer pin, plus a DEV-only E2E public-pin override used by the daemon-first harness.
- Add daemon-only env resolution for injected Ed25519 signing, and seed the daemon-first E2E harness with a test-only signer/public-pin pair so CI can publish and read system-signed stories.
- Add `check:luma-news-story-system-v1` and update LUMA/news/topology docs for the narrow story-node migration.

## Scope guards
- No migration of latest/hot indexes, storylines, analysis, synthesis, discovery, or topic-engagement records.
- No changes to forum, directory, aggregate, news report, nomination, sentiment outbox, `voteIntentMaterializer`, mesh drills, relay, vault/provider/wallet/lifecycle/multidevice, signed-write envelope behavior, or identifier derivation.
- System story records do not carry `_authorScheme` or client `signedWriteEnvelope`.
- Private system-writer key material and browser signing helpers are not bundled into app/gun-client source; the only private key fixture is scoped to the E2E daemon harness.

## Verification
- `pnpm --filter @vh/gun-client test`
- `pnpm --filter @vh/gun-client typecheck`
- `pnpm --filter @vh/gun-client build`
- `pnpm --filter @vh/gun-client test -- src/newsAdapters.test.ts`
- `pnpm --filter @vh/news-aggregator test -- src/daemonUtils.test.ts`
- `pnpm --filter @vh/news-aggregator typecheck`
- `pnpm --filter @vh/data-model test`
- `pnpm --filter @vh/data-model typecheck`
- `pnpm --filter @vh/data-model build`
- `pnpm --filter @vh/luma-sdk test`
- `pnpm --filter @vh/luma-sdk typecheck`
- `pnpm --filter @vh/luma-sdk build`
- `pnpm --filter @vh/types test`
- `pnpm --filter @vh/types typecheck`
- `pnpm --filter @vh/types build`
- `pnpm --filter @vh/crypto build`
- `pnpm --filter @vh/web-pwa typecheck`
- `pnpm --filter @vh/web-pwa build`
- `pnpm --filter @vh/e2e typecheck`
- `pnpm --filter @vh/e2e exec vitest run src/live/playwright.daemon-first-feed.config.vitest.mjs src/live/daemonFirstFeedHarness.vitest.mjs --reporter=verbose`
- `pnpm test:storycluster:correctness`
- full LUMA guard sweep including `pnpm check:luma-news-story-system-v1` and `pnpm check:public-namespace-leaks`
- `pnpm docs:check`
- `git diff --check origin/main...HEAD`
- protected-surface grep
- `node tools/scripts/check-diff-coverage.mjs`

Local caveat: pnpm reports the existing Node engine warning for local Node `v23.10.0` versus repo engine `>=20 <23`. A full `@vh/news-aggregator` package test attempt also hit the existing direct-execution expectation failures in `sourceAdmissionReport.test.ts` and `sourceHealthReport.test.ts`; the touched `daemonUtils` suite passes.