### PR TITLE
Promote mesh evidence scrub gate

### DIFF
--- a/docs/ops/mesh-production-topology-drills.md
+++ b/docs/ops/mesh-production-topology-drills.md
@@ -342,21 +342,24 @@ pnpm check:mesh:production-readiness
 
 The aggregate command reruns the implemented mesh proof commands, copies each
 source `.tmp/mesh-production-readiness/latest/*` packet before the next command
-overwrites it, and writes a new aggregate packet to the stable latest path. The
-validator requires each copied source report to match the expected gate command,
-run mode, commit, clean-state policy, and current gate-run timestamp window. The
-packet includes `mesh-production-readiness-report.json`,
-`mesh-production-readiness-evidence.md`, and copied source reports under
-`source-reports/<gate>/`.
+overwrites it, builds a candidate aggregate in the current run directory, then
+runs `pnpm check:mesh-evidence-scrub -- --source-dir <run-dir>` against that
+explicit packet. The final aggregate is written only after the scrub source
+report is recorded. The validator requires each copied source report to match
+the expected gate command, run mode, commit, clean-state policy, and current
+gate-run timestamp window. The packet includes
+`mesh-production-readiness-report.json`, `mesh-production-readiness-evidence.md`,
+and copied source reports under `source-reports/<gate>/`; after Slice 14A it has
+12 source reports, including `source-reports/evidence_scrub/`.
 
-For Slice 11A through Slice 13B, a successful aggregate command still reports
+For Slice 11A through Slice 14A, a successful aggregate command still reports
 `status: review_required` while release blockers remain. Expected blockers
-after Slice 13B include the canonical 30-minute soak, public WSS deployment
-proof, evidence scrub promotion, downstream full-app canary, and LUMA-gated
-write coverage through the LUMA reader path. The command exits non-zero for
-missing, malformed, dirty, stale, failed, command-mismatched, or incomplete
-source evidence, and for any overclaiming packet that would emit
-`release_ready` before the blockers are gone.
+after Slice 14A include the canonical 30-minute soak, public WSS deployment
+proof, downstream full-app canary, and LUMA-gated write coverage through the
+LUMA reader path. The command exits non-zero for missing, malformed, dirty,
+stale, failed, command-mismatched, unscrubbed, or incomplete source evidence,
+and for any overclaiming packet that would emit `release_ready` before the
+blockers are gone.
 
 `VH_RELAY_PEER_AUTH_MODE=private_network_allowlist` is a local/private-network
 harness mode. Because Gun relay and browser clients share the `/gun` WebSocket
@@ -375,12 +378,12 @@ distributing a new trusted key.
 
 ## Review Boundary
 
-The report status remains `review_required` for Slice 6B/7B/7C/8/9/9B/10/11A/12A/13A/13B even when the
-local restarted-relay drill, deployed-WSS local TLS profile, state-resolution
-drill, disconnect drill, partition/heal drill, read-repair drill, and bounded
-rolling-restart soak pass, peer-config rollback drill passes, and the aggregate
-evidence packet is well formed. A passing
-restarted-relay section means only that the restarted local relay directly read
+The report status remains `review_required` for Slice
+6B/7B/7C/8/9/9B/10/11A/12A/13A/13B/14A even when the local restarted-relay
+drill, deployed-WSS local TLS profile, state-resolution drill, disconnect
+drill, partition/heal drill, read-repair drill, bounded rolling-restart soak,
+peer-config rollback drill, and aggregate evidence packet are well formed. A
+passing restarted-relay section means only that the restarted local relay directly read
 the missed synthetic drill write inside this bounded harness. A passing
 deployed-WSS section means only that the local TLS/WSS profile, signed WSS
 peer-config boot, CSP allowlist, and service-worker rollover proof passed.
@@ -403,12 +406,17 @@ the local non-LUMA mesh clock/auth window matrix passed. A passing conflict
 section means only that local synthetic conflict/protocol fixtures passed and
 did not become LUMA schema migration evidence. A passing aggregate section
 means only that the implemented source reports were collected, validated,
-copied, and summarized in one operator packet. None of these outcomes proves
+copied, and summarized in one operator packet. A passing evidence-scrub section
+means only that the candidate aggregate packet was deterministically transformed
+into `.tmp/mesh-production-readiness/promoted/<run_id>/` and the promoted output
+was rescanned for raw tokens, private key material, unsafe origins, unsafe
+absolute paths, stale placeholder evidence, overclaims, and disallowed writer
+kinds. None of these outcomes proves
 public WSS
 infrastructure, automatic peer-federation recovery, runtime peer-config key
 rotation without a new trusted-key distribution path, LUMA-gated write state
-resolution, public WSS clock-skew or conflict behavior, evidence scrub
-promotion, or post-M0.B LUMA-gated write coverage.
+resolution, public WSS clock-skew or conflict behavior, or post-M0.B
+LUMA-gated write coverage.
 
 If direct restarted-relay readback is `blocked` or `review_required`, do not tune
 Gun peer behavior indefinitely. The next branch must choose and drill one

--- a/docs/specs/spec-mesh-production-readiness.md
+++ b/docs/specs/spec-mesh-production-readiness.md
@@ -1041,9 +1041,10 @@ without replacing it with a more specific one.
 
 ### Slice 11 - Release Gate And Evidence Packet
 
-Status: Implemented as an aggregate evidence-packet scaffold. The command
-produces a complete `review_required` packet when implemented proof commands
-pass but release-ready blockers remain.
+Status: Implemented as an aggregate evidence-packet scaffold with a
+post-aggregate evidence scrub promotion gate. The command produces a complete
+`review_required` packet when implemented proof commands and the scrub source
+report pass but release-ready blockers remain.
 
 Purpose:
 
@@ -1092,14 +1093,15 @@ interface MeshProductionReadinessReport {
       | 'local_tls_wss_peer_config_rollback'
       | 'local_clock_skew_matrix'
       | 'local_conflict_resolution_fixtures'
-      | 'aggregate_production_readiness';
+      | 'aggregate_production_readiness'
+      | 'mesh_evidence_scrub_promotion';
     deployment_scope?: 'local_tls_wss_profile' | 'public_wss_deployment';
     started_at: string;
     completed_at: string;
     duration_ms: number;
     command: string;
   };
-  status: 'release_ready' | 'review_required' | 'blocked';
+  status: 'release_ready' | 'review_required' | 'blocked' | 'pass';
   schema_epoch: 'pre_luma_m0b' | 'post_luma_m0b' | string;
   luma_profile: 'public-beta' | 'production-attestation' | 'none';
   luma_dependency_status: Record<string, 'landed' | 'in-progress' | 'pending' | 'n/a'>;
@@ -1204,7 +1206,7 @@ interface MeshProductionReadinessReport {
     name: string;
     command: string;
     status: 'pass' | 'fail';
-    result_status: 'release_ready' | 'review_required' | 'blocked' | 'missing';
+    result_status: 'release_ready' | 'review_required' | 'blocked' | 'missing' | 'pass';
     run_id: string | null;
     run_mode: string | null;
     run_command: string | null;
@@ -1413,8 +1415,9 @@ Acceptance gates:
     fresh rollback config, not a stale cached config
   - any LUMA-gated write class (drill_writer_kind `'luma'`) was exercised
     against the LUMA reader path, not bypassed via drill writer contract
-  - any promoted evidence under `docs/reports/evidence/mesh-production/`
-    passed `pnpm check:mesh-evidence-scrub` (§5.7.1)
+  - any promoted evidence under `.tmp/mesh-production-readiness/promoted/` or
+    `docs/reports/evidence/mesh-production/` passed
+    `pnpm check:mesh-evidence-scrub` (§5.7.1)
 - The gate fails if a release commit claims production mesh without a passing
   report.
 - `pnpm check:mesh:production-readiness` is necessary but not sufficient for
@@ -1709,9 +1712,18 @@ release claims that are absent from the generated report.
 
 #### 5.7.1 Evidence-promotion scrub gate
 
+Status: Implemented for `.tmp` promotion staging as
+`pnpm check:mesh-evidence-scrub`. The command consumes
+`.tmp/mesh-production-readiness/latest` by default, or an explicit
+`--source-dir` / `VH_MESH_EVIDENCE_SOURCE_DIR` packet. The production-readiness
+aggregate gate MUST call it against the current run directory, not the mutable
+`latest` alias, then record an `evidence_scrub` source report before writing
+the final aggregate.
+
 `.tmp` readiness packets are unredacted machine proof. Promoting any field from
-a `.tmp` packet into a tracked artifact under `docs/reports/evidence/` requires
-running a scrub step. The scrub step MUST remove or redact:
+a `.tmp` packet into a tracked artifact under `docs/reports/evidence/` or into
+the local promotion staging directory requires running a scrub step. The scrub
+step MUST remove or redact:
 
 - raw mesh paths (replace with `redactedPathHash` per
   `spec-luma-service-v0.md` §16.1)
@@ -1725,10 +1737,16 @@ running a scrub step. The scrub step MUST remove or redact:
 - evidence vector material, biometric features, raw camera/IMU buffers
 - private contact information, support correspondence, personal abuse evidence
 
-A new release gate `pnpm check:mesh-evidence-scrub` MUST run against any
-candidate promotion; the gate fails if any forbidden field is present. The
-scrub script is the only sanctioned promotion path; manual copy-paste into
-`docs/reports/evidence/` is forbidden.
+A release gate `pnpm check:mesh-evidence-scrub` MUST run against any candidate
+promotion; the gate fails closed for missing, stale, dirty, or overclaiming
+aggregate evidence, missing referenced source reports, stale placeholder
+evidence, raw daemon tokens, bearer credentials, private signing material,
+unredacted relay/config origins, unsafe absolute machine paths, implied
+LUMA-gated write coverage, or writer kinds outside synthetic mesh evidence. The
+gate writes the scrubbed packet under
+`.tmp/mesh-production-readiness/promoted/<run_id>/` and rescans the transformed
+output before passing. The scrub script is the only sanctioned promotion path;
+manual copy-paste into `docs/reports/evidence/` is forbidden.
 
 Opaque correlation identifiers (`run_id`, `write_id`, `trace_id`,
 `drill_run_id`) are explicitly permitted in promoted evidence.
@@ -2096,13 +2114,12 @@ Implemented mesh commands:
 - `pnpm test:mesh:peer-config-rollback-drill`
 - `pnpm test:mesh:clock-skew-drills`
 - `pnpm test:mesh:conflict-drills`
+- `pnpm check:mesh-evidence-scrub`
 - `pnpm check:mesh:production-readiness`
 
 Required new commands:
 
 - `pnpm check:production-app-canary`
-- `pnpm check:mesh-evidence-scrub` (gates promotion of `.tmp` packets to
-  `docs/reports/evidence/`; see §5.7.1)
 
 ## 7. Release Claim Boundary
 
@@ -2302,9 +2319,33 @@ Still not allowed after Slice 13B conflict/protocol fixture proof:
   soak claim."
 - "The app is ready for a test group."
 
-Allowed after Slices 6B through 13B pass (under `schema_epoch:
-post_luma_m0b` with all LUMA-gated write classes drilled through the LUMA
-reader path):
+Allowed after Slice 14A evidence scrub and promotion gate:
+
+- "`pnpm check:mesh-evidence-scrub` deterministically promotes a mesh readiness
+  packet from `.tmp/mesh-production-readiness/latest` or an explicit
+  `--source-dir` into `.tmp/mesh-production-readiness/promoted/<run_id>/`."
+- "The aggregate readiness packet can remove the `evidence-scrub-promotion`
+  blocker only when the `evidence_scrub` source report is fresh, clean,
+  command-matched, and has `evidence_scrub.status: pass`."
+- "The promoted packet has been rescanned for raw tokens, bearer credentials,
+  private signing material, unredacted relay/config origins, unsafe absolute
+  machine paths, stale placeholder evidence, release overclaims, implied
+  LUMA-gated write coverage, and disallowed writer kinds."
+
+Still not allowed after Slice 14A evidence scrub and promotion gate:
+
+- "The mesh is `release_ready`."
+- "Public WSS infrastructure or public WSS conflict behavior is
+  production-proven."
+- "LUMA public schema migrations or LUMA-gated write classes are
+  mesh-readiness-proven."
+- "The default shortened local command satisfies the canonical thirty-minute
+  soak claim."
+- "The app is ready for a test group."
+
+Allowed after Slices 6B through 14A plus downstream LUMA-gated coverage pass
+(under `schema_epoch: post_luma_m0b` with all LUMA-gated write classes drilled
+through the LUMA reader path):
 
 - "The mesh has a production WSS three-relay topology with signed peer config,
   authenticated relay fallbacks, named health degradation, peer-failure and

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "test:mesh:peer-config-rollback-drill": "pnpm --filter @vh/e2e test:mesh:peer-config-rollback-drill",
     "test:mesh:clock-skew-drills": "pnpm --filter @vh/e2e test:mesh:clock-skew-drills",
     "test:mesh:conflict-drills": "pnpm --filter @vh/e2e test:mesh:conflict-drills",
+    "check:mesh-evidence-scrub": "pnpm --filter @vh/e2e check:mesh-evidence-scrub",
     "check:mesh:production-readiness": "pnpm --filter @vh/e2e check:mesh:production-readiness",
     "test:storycluster:smoke": "pnpm --filter @vh/e2e test:live:daemon-feed:build && pnpm --filter @vh/e2e test:live:daemon-feed:semantic-soak",
     "test:storycluster:smoke:readiness": "pnpm --filter @vh/e2e test:live:daemon-feed:build && (pnpm --filter @vh/e2e test:live:daemon-feed:semantic-soak || true) && pnpm --filter @vh/e2e test:live:daemon-feed:semantic-soak:readiness",

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -35,6 +35,7 @@
     "test:mesh:peer-config-rollback-drill": "node ./src/mesh/peer-config-rollback-drill.mjs",
     "test:mesh:clock-skew-drills": "node ./src/mesh/clock-skew-drills.mjs",
     "test:mesh:conflict-drills": "node ./src/mesh/conflict-drills.mjs",
+    "check:mesh-evidence-scrub": "node ./src/mesh/evidence-scrub-check.mjs",
     "check:mesh:production-readiness": "node ./src/mesh/production-readiness-check.mjs",
     "report:live:daemon-feed:fixture-candidate-intake": "node ./src/live/daemon-feed-fixture-candidate-intake.mjs",
     "report:offline-cluster-replay": "node ./src/live/daemon-feed-semantic-soak-offline-replay-report.mjs",

--- a/packages/e2e/src/mesh/evidence-scrub-check.mjs
+++ b/packages/e2e/src/mesh/evidence-scrub-check.mjs
@@ -20,6 +20,7 @@ const SOURCE_REPORT_NAME = 'mesh-production-readiness-report.json';
 const STALE_PLACEHOLDER_FIXTURES = new Set(['full-conflict-resolution-fixtures']);
 const ALLOWED_WRITER_KINDS = new Set(['mesh-drill']);
 const URL_PATTERN = /\b(?:https?|wss?):\/\/[^\s"'`<>)]+/gi;
+const LOCAL_ENDPOINT_PATTERN = /\b(?:localhost|127(?:\.\d{1,3}){3}|0\.0\.0\.0|\[::1\])(?::\d{2,5})?\b/gi;
 const MACHINE_PATH_PATTERN = /(^|[\s"'`=:(])\/(?:Users|home|private|var\/folders|tmp)\//g;
 const PRIVATE_KEY_BLOCK_PATTERN = /-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z0-9 ]*PRIVATE KEY-----/g;
 const BEARER_PATTERN = /\bBearer\s+(?!\[redacted)[A-Za-z0-9._~+/=-]{12,}/gi;
@@ -111,6 +112,11 @@ function scrubString(value, key, redactions) {
     return redactedUrl(match);
   });
 
+  next = next.replace(LOCAL_ENDPOINT_PATTERN, (match) => {
+    redactions.urls += 1;
+    return `redactedLocalEndpointHash:${sha(match, 12)}`;
+  });
+
   if (looksLikeAbsoluteMachinePath(next)) {
     redactions.paths += 1;
     return safeRelativeLabel(next);
@@ -122,12 +128,27 @@ function scrubString(value, key, redactions) {
     return `${prefix}${safeRelativeLabel(rawPath)}`;
   });
 
+  for (const fixture of STALE_PLACEHOLDER_FIXTURES) {
+    if (next.includes(fixture)) {
+      redactions.stalePlaceholders += 1;
+      next = next.replaceAll(fixture, `[removed-stale-placeholder:${sha(fixture, 12)}]`);
+    }
+  }
+
   return next;
 }
 
 function scrubJson(value, key, redactions) {
   if (Array.isArray(value)) {
-    return value.map((entry) => scrubJson(entry, key, redactions));
+    return value
+      .map((entry) => scrubJson(entry, key, redactions))
+      .filter((entry) => {
+        if (entry && typeof entry === 'object' && STALE_PLACEHOLDER_FIXTURES.has(entry.fixture)) {
+          redactions.stalePlaceholders += 1;
+          return false;
+        }
+        return true;
+      });
   }
   if (value && typeof value === 'object') {
     const out = {};
@@ -293,7 +314,7 @@ export function validateAggregatePacket({ sourceDir = defaultSourceDir } = {}) {
 }
 
 function scrubPacket({ sourceDir, promotedDir }) {
-  const redactions = { paths: 0, urls: 0, secrets: 0 };
+  const redactions = { paths: 0, urls: 0, secrets: 0, stalePlaceholders: 0 };
   fs.rmSync(promotedDir, { recursive: true, force: true });
   fs.mkdirSync(promotedDir, { recursive: true });
 
@@ -338,6 +359,15 @@ export function scanPromotedPacket({ promotedDir }) {
     MACHINE_PATH_PATTERN.lastIndex = 0;
     if (MACHINE_PATH_PATTERN.test(text)) {
       findings.push(`${relativePath}: unsafe absolute machine path remains`);
+    }
+    LOCAL_ENDPOINT_PATTERN.lastIndex = 0;
+    for (const match of text.matchAll(LOCAL_ENDPOINT_PATTERN)) {
+      findings.push(`${relativePath}: unsafe local endpoint remains at ${match[0]}`);
+    }
+    for (const fixture of STALE_PLACEHOLDER_FIXTURES) {
+      if (text.includes(fixture)) {
+        findings.push(`${relativePath}: stale placeholder evidence remains at ${fixture}`);
+      }
     }
     URL_PATTERN.lastIndex = 0;
     for (const match of text.matchAll(URL_PATTERN)) {
@@ -481,7 +511,7 @@ export function runEvidenceScrub({ sourceDir = defaultSourceDir, command = null 
   const validation = validateAggregatePacket({ sourceDir });
   const runId = makeId('mesh-evidence-scrub');
   const promotedDir = path.join(promotedRoot, validation.report?.run_id || runId);
-  let redactions = { paths: 0, urls: 0, secrets: 0 };
+  let redactions = { paths: 0, urls: 0, secrets: 0, stalePlaceholders: 0 };
   let scanFailures = [];
 
   if (validation.report) {

--- a/packages/e2e/src/mesh/evidence-scrub-check.mjs
+++ b/packages/e2e/src/mesh/evidence-scrub-check.mjs
@@ -1,0 +1,548 @@
+#!/usr/bin/env node
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '../../../..');
+const defaultSourceDir = path.join(repoRoot, '.tmp/mesh-production-readiness/latest');
+const promotedRoot = path.join(repoRoot, '.tmp/mesh-production-readiness/promoted');
+
+export const EVIDENCE_SCRUB_SOURCE_ID = 'evidence_scrub';
+export const EVIDENCE_SCRUB_MODE = 'mesh_evidence_scrub_promotion';
+
+const AGGREGATE_REPORT = 'mesh-production-readiness-report.json';
+const AGGREGATE_MANIFEST = 'mesh-production-readiness-evidence.md';
+const SOURCE_REPORT_NAME = 'mesh-production-readiness-report.json';
+const STALE_PLACEHOLDER_FIXTURES = new Set(['full-conflict-resolution-fixtures']);
+const ALLOWED_WRITER_KINDS = new Set(['mesh-drill']);
+const URL_PATTERN = /\b(?:https?|wss?):\/\/[^\s"'`<>)]+/gi;
+const MACHINE_PATH_PATTERN = /(^|[\s"'`=:(])\/(?:Users|home|private|var\/folders|tmp)\//g;
+const PRIVATE_KEY_BLOCK_PATTERN = /-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z0-9 ]*PRIVATE KEY-----/g;
+const BEARER_PATTERN = /\bBearer\s+(?!\[redacted)[A-Za-z0-9._~+/=-]{12,}/gi;
+const TOKEN_VALUE_PATTERN =
+  /"([^"]*(?:token|secret|privateKey|private_key|private-key|signingKey|signing_key|signing-key|controlToken|authorization|credential)[^"]*)"\s*:\s*"(?!\[redacted)([^"]{8,})"/gi;
+
+function sha(value, length = 16) {
+  return crypto.createHash('sha256').update(String(value)).digest('hex').slice(0, length);
+}
+
+function nowIso(date = new Date()) {
+  return date.toISOString();
+}
+
+function makeId(prefix) {
+  return `${prefix}-${nowIso().replaceAll('-', '').replaceAll(':', '').replace(/\.\d{3}Z$/, 'Z')}-${crypto
+    .randomBytes(4)
+    .toString('hex')}`;
+}
+
+function runGit(args) {
+  const result = spawnSync('git', args, {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  });
+  return result.status === 0 ? result.stdout.trim() : '';
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function safeRelativeLabel(filePath) {
+  const absolutePath = path.resolve(filePath);
+  const relativePath = path.relative(repoRoot, absolutePath);
+  if (!relativePath.startsWith('..') && !path.isAbsolute(relativePath)) {
+    return `./${relativePath.replaceAll(path.sep, '/')}`;
+  }
+  return `redactedPathHash:${sha(absolutePath)}`;
+}
+
+function redactedUrl(value) {
+  try {
+    const url = new URL(value);
+    const hostHash = sha(url.host, 12);
+    return `${url.protocol}//redacted-host-${hostHash}${url.pathname === '/' ? '' : url.pathname}`;
+  } catch {
+    return `redactedUrlHash:${sha(value)}`;
+  }
+}
+
+function looksLikeUrl(value) {
+  return /^(?:https?|wss?):\/\//i.test(value);
+}
+
+function looksLikeAbsoluteMachinePath(value) {
+  return typeof value === 'string' && path.isAbsolute(value) && /^(?:\/Users|\/home|\/private|\/var\/folders|\/tmp)\//.test(value);
+}
+
+function sensitiveKey(key) {
+  return /(?:token|secret|private[_-]?key|privateKey|signing[_-]?key|signingKey|controlToken|authorization|bearer|daemonCredential|credential)/i.test(
+    key,
+  );
+}
+
+function scrubString(value, key, redactions) {
+  if (sensitiveKey(key)) {
+    redactions.secrets += 1;
+    return `[redacted:${sha(`${key}:${value}`, 12)}]`;
+  }
+
+  let next = value.replace(PRIVATE_KEY_BLOCK_PATTERN, (match) => {
+    redactions.secrets += 1;
+    return `[redacted-private-key:${sha(match, 12)}]`;
+  });
+
+  next = next.replace(BEARER_PATTERN, (match) => {
+    redactions.secrets += 1;
+    return `Bearer [redacted:${sha(match, 12)}]`;
+  });
+
+  next = next.replace(URL_PATTERN, (match) => {
+    redactions.urls += 1;
+    return redactedUrl(match);
+  });
+
+  if (looksLikeAbsoluteMachinePath(next)) {
+    redactions.paths += 1;
+    return safeRelativeLabel(next);
+  }
+
+  next = next.replace(/(^|[\s"'`=:(])\/(?:Users|home|private|var\/folders|tmp)\/[^\s"'`)]+/g, (match, prefix) => {
+    const rawPath = match.slice(prefix.length);
+    redactions.paths += 1;
+    return `${prefix}${safeRelativeLabel(rawPath)}`;
+  });
+
+  return next;
+}
+
+function scrubJson(value, key, redactions) {
+  if (Array.isArray(value)) {
+    return value.map((entry) => scrubJson(entry, key, redactions));
+  }
+  if (value && typeof value === 'object') {
+    const out = {};
+    for (const [entryKey, entryValue] of Object.entries(value)) {
+      out[entryKey] = scrubJson(entryValue, entryKey, redactions);
+    }
+    return out;
+  }
+  if (typeof value === 'string') {
+    if (looksLikeUrl(value)) {
+      redactions.urls += 1;
+      return redactedUrl(value);
+    }
+    return scrubString(value, key, redactions);
+  }
+  return value;
+}
+
+function scrubText(value, redactions) {
+  return scrubString(value, 'text', redactions).replace(TOKEN_VALUE_PATTERN, (_match, key, token) => {
+    redactions.secrets += 1;
+    return `"${key}": "[redacted:${sha(`${key}:${token}`, 12)}]"`;
+  });
+}
+
+function listFiles(dir) {
+  const files = [];
+  if (!fs.existsSync(dir)) return files;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const entryPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...listFiles(entryPath));
+    } else if (entry.isFile()) {
+      files.push(entryPath);
+    }
+  }
+  return files;
+}
+
+function safeResolveSourceReport(sourceDir, row) {
+  const candidates = [];
+  if (typeof row.report_path === 'string' && row.report_path.length > 0) {
+    candidates.push(path.isAbsolute(row.report_path) ? row.report_path : path.resolve(repoRoot, row.report_path));
+    candidates.push(path.resolve(sourceDir, row.report_path));
+  }
+  if (row.id) {
+    candidates.push(path.join(sourceDir, 'source-reports', row.id, SOURCE_REPORT_NAME));
+  }
+  return candidates.find((candidate) => fs.existsSync(candidate)) || null;
+}
+
+function sourceReportFailures({ aggregate, sourceDir }) {
+  const failures = [];
+  const sourceRows = Array.isArray(aggregate.source_reports) ? aggregate.source_reports : [];
+  if (sourceRows.length === 0) {
+    failures.push('aggregate report has no source_reports rows');
+    return failures;
+  }
+
+  for (const row of sourceRows) {
+    const sourcePath = safeResolveSourceReport(sourceDir, row);
+    if (!sourcePath) {
+      failures.push(`missing referenced source report for ${row.id || 'unknown'}`);
+      continue;
+    }
+    let sourceReport = null;
+    try {
+      sourceReport = readJson(sourcePath);
+    } catch (error) {
+      failures.push(`failed to parse source report for ${row.id || sourcePath}: ${error instanceof Error ? error.message : String(error)}`);
+      continue;
+    }
+    if (sourceReport.schema_version !== 'mesh-production-readiness-v1') {
+      failures.push(`source report ${row.id || sourcePath} has unexpected schema_version ${sourceReport.schema_version || 'missing'}`);
+    }
+    if (row.run_id && sourceReport.run_id !== row.run_id) {
+      failures.push(`source report ${row.id} run_id ${sourceReport.run_id || 'missing'} does not match aggregate row ${row.run_id}`);
+    }
+    if (row.run_command && sourceReport.run?.command !== row.run_command) {
+      failures.push(`source report ${row.id} command ${sourceReport.run?.command || 'missing'} does not match aggregate row ${row.run_command}`);
+    }
+    if (sourceReport.repo?.commit !== aggregate.repo?.commit) {
+      failures.push(`source report ${row.id || sourcePath} commit ${sourceReport.repo?.commit || 'missing'} does not match aggregate commit`);
+    }
+    if (sourceReport.repo?.dirty) {
+      failures.push(`source report ${row.id || sourcePath} repo.dirty is true`);
+    }
+  }
+
+  return failures;
+}
+
+export function validateAggregatePacket({ sourceDir = defaultSourceDir } = {}) {
+  const failures = [];
+  const resolvedSourceDir = path.resolve(repoRoot, sourceDir);
+  const reportPath = path.join(resolvedSourceDir, AGGREGATE_REPORT);
+  const manifestPath = path.join(resolvedSourceDir, AGGREGATE_MANIFEST);
+  let report = null;
+
+  if (!fs.existsSync(resolvedSourceDir)) {
+    failures.push(`source directory does not exist: ${safeRelativeLabel(resolvedSourceDir)}`);
+  }
+  if (!fs.existsSync(reportPath)) {
+    failures.push(`missing ${AGGREGATE_REPORT}`);
+  }
+  if (!fs.existsSync(manifestPath)) {
+    failures.push(`missing ${AGGREGATE_MANIFEST}`);
+  }
+  if (failures.length > 0) {
+    return { ok: false, failures, report: null, reportPath, manifestPath, sourceDir: resolvedSourceDir };
+  }
+
+  try {
+    report = readJson(reportPath);
+  } catch (error) {
+    failures.push(`failed to parse ${AGGREGATE_REPORT}: ${error instanceof Error ? error.message : String(error)}`);
+    return { ok: false, failures, report: null, reportPath, manifestPath, sourceDir: resolvedSourceDir };
+  }
+
+  const currentCommit = runGit(['rev-parse', 'HEAD']);
+  if (report.schema_version !== 'mesh-production-readiness-v1') {
+    failures.push(`unexpected schema_version ${report.schema_version || 'missing'}`);
+  }
+  if (report.run?.mode !== 'aggregate_production_readiness') {
+    failures.push(`expected aggregate_production_readiness run mode, observed ${report.run?.mode || 'missing'}`);
+  }
+  if (!report.run_id) {
+    failures.push('missing run_id');
+  }
+  if (report.repo?.commit !== currentCommit) {
+    failures.push(`aggregate commit ${report.repo?.commit || 'missing'} does not match current HEAD ${currentCommit}`);
+  }
+  if (report.repo?.dirty) {
+    failures.push('aggregate repo.dirty is true');
+  }
+  if (report.status === 'release_ready' && (report.release_readiness_blockers || []).length > 0) {
+    failures.push('aggregate claims release_ready while release_readiness_blockers remain');
+  }
+  if ((report.release_claims?.allowed || []).some((claim) => /\brelease_ready\b|production-proven|LUMA-gated production write/i.test(claim))) {
+    failures.push('allowed release_claims include a release-ready, production-proven, or LUMA-gated write claim');
+  }
+  if ((report.conflict_fixtures || []).some((row) => STALE_PLACEHOLDER_FIXTURES.has(row.fixture))) {
+    failures.push('aggregate contains stale placeholder conflict fixture evidence');
+  }
+  for (const [writeClass, writerKind] of Object.entries(report.drill_writer_kind_by_class || {})) {
+    if (!ALLOWED_WRITER_KINDS.has(writerKind)) {
+      failures.push(`write class ${writeClass} has disallowed writer kind ${writerKind}`);
+    }
+  }
+  if ((report.luma_gated_write_drills || []).some((row) => row.status === 'pass')) {
+    failures.push('aggregate implies LUMA-gated write coverage in a mesh-only evidence packet');
+  }
+  failures.push(...sourceReportFailures({ aggregate: report, sourceDir: resolvedSourceDir }));
+
+  return {
+    ok: failures.length === 0,
+    failures,
+    report,
+    reportPath,
+    manifestPath,
+    sourceDir: resolvedSourceDir,
+  };
+}
+
+function scrubPacket({ sourceDir, promotedDir }) {
+  const redactions = { paths: 0, urls: 0, secrets: 0 };
+  fs.rmSync(promotedDir, { recursive: true, force: true });
+  fs.mkdirSync(promotedDir, { recursive: true });
+
+  for (const sourcePath of listFiles(sourceDir)) {
+    const relativePath = path.relative(sourceDir, sourcePath);
+    const destPath = path.join(promotedDir, relativePath);
+    fs.mkdirSync(path.dirname(destPath), { recursive: true });
+    const raw = fs.readFileSync(sourcePath, 'utf8');
+    if (/\.json$/i.test(sourcePath)) {
+      try {
+        const scrubbed = scrubJson(JSON.parse(raw), path.basename(sourcePath), redactions);
+        fs.writeFileSync(destPath, `${JSON.stringify(scrubbed, null, 2)}\n`);
+      } catch {
+        fs.writeFileSync(destPath, scrubText(raw, redactions));
+      }
+    } else {
+      fs.writeFileSync(destPath, scrubText(raw, redactions));
+    }
+  }
+
+  return redactions;
+}
+
+export function scanPromotedPacket({ promotedDir }) {
+  const findings = [];
+  for (const filePath of listFiles(promotedDir)) {
+    const relativePath = path.relative(promotedDir, filePath).replaceAll(path.sep, '/');
+    const text = fs.readFileSync(filePath, 'utf8');
+    if (PRIVATE_KEY_BLOCK_PATTERN.test(text)) {
+      findings.push(`${relativePath}: private key block remains`);
+    }
+    PRIVATE_KEY_BLOCK_PATTERN.lastIndex = 0;
+    if (BEARER_PATTERN.test(text)) {
+      findings.push(`${relativePath}: raw bearer token remains`);
+    }
+    BEARER_PATTERN.lastIndex = 0;
+    let tokenMatch;
+    TOKEN_VALUE_PATTERN.lastIndex = 0;
+    while ((tokenMatch = TOKEN_VALUE_PATTERN.exec(text))) {
+      findings.push(`${relativePath}: raw sensitive value remains at ${tokenMatch[1]}`);
+    }
+    MACHINE_PATH_PATTERN.lastIndex = 0;
+    if (MACHINE_PATH_PATTERN.test(text)) {
+      findings.push(`${relativePath}: unsafe absolute machine path remains`);
+    }
+    URL_PATTERN.lastIndex = 0;
+    for (const match of text.matchAll(URL_PATTERN)) {
+      const urlText = match[0];
+      try {
+        const url = new URL(urlText);
+        if (!url.hostname.startsWith('redacted-host-')) {
+          findings.push(`${relativePath}: unredacted origin remains at ${url.protocol}//${url.host}`);
+        }
+      } catch {
+        findings.push(`${relativePath}: unparseable URL remains`);
+      }
+    }
+  }
+  return findings;
+}
+
+function buildScrubReport({ runId, sourceReport, sourceDir, promotedDir, command, startedAt, completedAt, redactions, failures }) {
+  const status = failures.length === 0 ? 'pass' : 'blocked';
+  const promotedReportPath = path.join(promotedDir, AGGREGATE_REPORT);
+  const promotedManifestPath = path.join(promotedDir, AGGREGATE_MANIFEST);
+  return {
+    schema_version: 'mesh-production-readiness-v1',
+    generated_at: new Date(completedAt).toISOString(),
+    run_id: runId,
+    repo: {
+      branch: runGit(['rev-parse', '--abbrev-ref', 'HEAD']),
+      commit: runGit(['rev-parse', 'HEAD']),
+      base_ref: 'origin/main',
+      dirty: runGit(['status', '--short']).length > 0,
+    },
+    run: {
+      mode: EVIDENCE_SCRUB_MODE,
+      source_run_id: sourceReport?.run_id || null,
+      source_dir: safeRelativeLabel(sourceDir),
+      promoted_dir: safeRelativeLabel(promotedDir),
+      started_at: new Date(startedAt).toISOString(),
+      completed_at: new Date(completedAt).toISOString(),
+      duration_ms: completedAt - startedAt,
+      command,
+    },
+    status,
+    schema_epoch: sourceReport?.schema_epoch || null,
+    luma_profile: sourceReport?.luma_profile || 'none',
+    luma_dependency_status: sourceReport?.luma_dependency_status || {},
+    drill_writer_kind_by_class: {},
+    source_reports: [],
+    release_readiness_blockers: [],
+    gates: [
+      {
+        name: 'evidence-scrub-promotion',
+        status: failures.length === 0 ? 'pass' : 'fail',
+        result_status: failures.length === 0 ? 'pass' : 'blocked',
+        command,
+        duration_ms: completedAt - startedAt,
+        exit_code: failures.length === 0 ? 0 : 1,
+        artifact_path: safeRelativeLabel(promotedReportPath),
+        reason: failures.length > 0 ? failures.join('; ') : undefined,
+      },
+    ],
+    write_class_slos: [],
+    resource_slos: [],
+    per_relay_readback: [],
+    state_resolution_drills: [],
+    conflict_fixtures: [],
+    luma_gated_write_drills: [
+      {
+        write_class: 'LUMA-gated production write classes through LUMA reader path',
+        trace_id: runId,
+        status: 'skipped',
+        reason: 'Evidence scrub promotion only verifies redaction and promotion safety for synthetic mesh evidence.',
+      },
+    ],
+    clock_skew: {
+      skewed_actor: null,
+      skewed_layer: null,
+      skew_ms: 0,
+      named_failure: null,
+      lww_diverged: false,
+      status: 'skipped',
+    },
+    cleanup: {
+      namespace: safeRelativeLabel(promotedDir),
+      objects_written: listFiles(promotedDir).length,
+      objects_cleaned_or_tombstoned: 0,
+      retained_objects: 0,
+      status: failures.length === 0 ? 'pass' : 'fail',
+    },
+    health: {
+      peer_quorum_minimum_observed: 0,
+      sustained_message_rate_max_per_sec: 0,
+      degradation_reasons_seen: [],
+    },
+    release_claims: {
+      allowed: failures.length === 0 ? ['The promoted mesh evidence packet passed deterministic scrub and leak rescan.'] : [],
+      forbidden: [
+        'The scrubbed packet proves public WSS deployment.',
+        'The scrubbed packet proves LUMA-gated production write coverage.',
+        'The scrubbed packet authorizes a release_ready claim while blockers remain.',
+      ],
+      invalidated_by_luma_epoch_change: false,
+    },
+    evidence_scrub: {
+      status: failures.length === 0 ? 'pass' : 'fail',
+      source_run_id: sourceReport?.run_id || null,
+      source_dir: safeRelativeLabel(sourceDir),
+      promoted_dir: safeRelativeLabel(promotedDir),
+      promoted_report_path: safeRelativeLabel(promotedReportPath),
+      promoted_manifest_path: safeRelativeLabel(promotedManifestPath),
+      files_scanned: listFiles(promotedDir).length,
+      files_written: listFiles(promotedDir).length,
+      redactions,
+      failures,
+    },
+  };
+}
+
+function parseArgs(argv) {
+  const options = {
+    sourceDir: process.env.VH_MESH_EVIDENCE_SOURCE_DIR || defaultSourceDir,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--') {
+      continue;
+    }
+    if (arg === '--source-dir') {
+      options.sourceDir = argv[index + 1];
+      index += 1;
+    } else if (arg === '--help' || arg === '-h') {
+      options.help = true;
+    } else {
+      throw new Error(`unknown argument: ${arg}`);
+    }
+  }
+  return options;
+}
+
+export function runEvidenceScrub({ sourceDir = defaultSourceDir, command = null } = {}) {
+  const startedAt = Date.now();
+  const validation = validateAggregatePacket({ sourceDir });
+  const runId = makeId('mesh-evidence-scrub');
+  const promotedDir = path.join(promotedRoot, validation.report?.run_id || runId);
+  let redactions = { paths: 0, urls: 0, secrets: 0 };
+  let scanFailures = [];
+
+  if (validation.report) {
+    redactions = scrubPacket({ sourceDir: validation.sourceDir, promotedDir });
+    scanFailures = scanPromotedPacket({ promotedDir });
+  } else {
+    fs.rmSync(promotedDir, { recursive: true, force: true });
+    fs.mkdirSync(promotedDir, { recursive: true });
+  }
+
+  const completedAt = Date.now();
+  const failures = [...validation.failures, ...scanFailures];
+  const scrubReport = buildScrubReport({
+    runId,
+    sourceReport: validation.report,
+    sourceDir: validation.sourceDir,
+    promotedDir,
+    command: command || `pnpm check:mesh-evidence-scrub -- --source-dir ${path.relative(repoRoot, validation.sourceDir)}`,
+    startedAt,
+    completedAt,
+    redactions,
+    failures,
+  });
+  const sourceReportPath = path.join(promotedDir, 'evidence-scrub-source-report.json');
+  writeJson(sourceReportPath, scrubReport);
+
+  return {
+    ok: failures.length === 0,
+    status: scrubReport.status,
+    run_id: runId,
+    source_run_id: validation.report?.run_id || null,
+    source_dir: safeRelativeLabel(validation.sourceDir),
+    promoted_dir: safeRelativeLabel(promotedDir),
+    promoted_report_path: safeRelativeLabel(path.join(promotedDir, AGGREGATE_REPORT)),
+    promoted_manifest_path: safeRelativeLabel(path.join(promotedDir, AGGREGATE_MANIFEST)),
+    source_report_path: sourceReportPath,
+    failures,
+    redactions,
+  };
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    console.log('Usage: pnpm check:mesh-evidence-scrub [-- --source-dir <packet-dir>]');
+    return;
+  }
+  const resolvedSourceDir = path.resolve(repoRoot, options.sourceDir);
+  const result = runEvidenceScrub({
+    sourceDir: resolvedSourceDir,
+    command: `pnpm check:mesh-evidence-scrub -- --source-dir ${path.relative(repoRoot, resolvedSourceDir)}`,
+  });
+  console.log(JSON.stringify(result, null, 2));
+  if (!result.ok) {
+    process.exitCode = 1;
+  }
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
+  main().catch((error) => {
+    console.error(`[vh:mesh-evidence-scrub] fatal: ${error instanceof Error ? error.stack ?? error.message : String(error)}`);
+    process.exit(1);
+  });
+}

--- a/packages/e2e/src/mesh/production-readiness-check.mjs
+++ b/packages/e2e/src/mesh/production-readiness-check.mjs
@@ -10,6 +10,9 @@ const __dirname = path.dirname(__filename);
 const repoRoot = path.resolve(__dirname, '../../../..');
 const latestDir = path.join(repoRoot, '.tmp/mesh-production-readiness/latest');
 const SOURCE_REPORT_FRESHNESS_TOLERANCE_MS = 5000;
+const EVIDENCE_SCRUB_SOURCE_ID = 'evidence_scrub';
+const EVIDENCE_SCRUB_MODE = 'mesh_evidence_scrub_promotion';
+const EVIDENCE_SCRUB_REPORT_NAME = 'evidence-scrub-source-report.json';
 const REQUIRED_CONFLICT_FIXTURES = [
   'same-key-concurrent-deterministic-writes',
   'stale-overwrite-attempt-rejected',
@@ -88,6 +91,12 @@ export const SOURCE_GATES = [
     expectedMode: 'local_conflict_resolution_fixtures',
   },
 ];
+
+const EVIDENCE_SCRUB_GATE = {
+  id: EVIDENCE_SCRUB_SOURCE_ID,
+  name: 'evidence scrub promotion',
+  expectedMode: EVIDENCE_SCRUB_MODE,
+};
 
 function nowIsoCompact(date = new Date()) {
   return date.toISOString().replaceAll('-', '').replaceAll(':', '').replace(/\.\d{3}Z$/, 'Z');
@@ -350,6 +359,93 @@ function runSourceGate({ gate, artifactDir, currentCommit, requireClean }) {
   };
 }
 
+function parseLastJsonObject(text) {
+  if (typeof text !== 'string' || text.trim().length === 0) return null;
+  const start = text.lastIndexOf('\n{');
+  const first = text.indexOf('{');
+  if (start < 0 && first < 0) return null;
+  const jsonText = start >= 0 ? text.slice(start + 1) : text.slice(first);
+  if (!jsonText || jsonText.trim().length === 0) return null;
+  return JSON.parse(jsonText);
+}
+
+function runEvidenceScrubGate({ artifactDir, currentCommit, requireClean }) {
+  const sourceDirArg = path.relative(repoRoot, artifactDir);
+  const command = ['pnpm', 'check:mesh-evidence-scrub', '--', '--source-dir', sourceDirArg];
+  const startedAt = Date.now();
+  const result = spawnSync(command[0], command.slice(1), {
+    cwd: repoRoot,
+    env: process.env,
+    encoding: 'utf8',
+    stdio: ['inherit', 'pipe', 'pipe'],
+  });
+  const completedAt = Date.now();
+  if (result.stdout) process.stdout.write(result.stdout);
+  if (result.stderr) process.stderr.write(result.stderr);
+
+  const exitCode = typeof result.status === 'number' ? result.status : 1;
+  const sourceDir = path.join(artifactDir, 'source-reports', EVIDENCE_SCRUB_SOURCE_ID);
+  fs.rmSync(sourceDir, { recursive: true, force: true });
+  fs.mkdirSync(sourceDir, { recursive: true });
+
+  let report = null;
+  let output = null;
+  let parseError = null;
+  try {
+    output = parseLastJsonObject(result.stdout || '');
+  } catch (error) {
+    parseError = error instanceof Error ? error.message : String(error);
+  }
+  const producedReportPath = output?.source_report_path;
+  const copiedReportPath = reportPathForSource(sourceDir);
+  if (producedReportPath && fs.existsSync(producedReportPath)) {
+    fs.copyFileSync(producedReportPath, copiedReportPath);
+    fs.copyFileSync(producedReportPath, path.join(sourceDir, EVIDENCE_SCRUB_REPORT_NAME));
+  }
+  if (fs.existsSync(copiedReportPath)) {
+    try {
+      report = readJson(copiedReportPath);
+    } catch (error) {
+      parseError = error instanceof Error ? error.message : String(error);
+    }
+  }
+
+  const failures = validationFailuresForSource({
+    gate: {
+      ...EVIDENCE_SCRUB_GATE,
+      command,
+    },
+    report,
+    exitCode,
+    currentCommit,
+    sourceReportPath: copiedReportPath,
+    requireClean,
+    startedAtMs: startedAt,
+    completedAtMs: completedAt,
+  });
+  if (report?.evidence_scrub?.status !== 'pass') {
+    failures.push(`evidence_scrub.status is ${report?.evidence_scrub?.status || 'missing'}`);
+  }
+  if (parseError) failures.push(`failed to parse evidence scrub output/report: ${parseError}`);
+
+  return {
+    id: EVIDENCE_SCRUB_SOURCE_ID,
+    name: EVIDENCE_SCRUB_GATE.name,
+    command: commandText(command),
+    expected_mode: EVIDENCE_SCRUB_MODE,
+    started_at: new Date(startedAt).toISOString(),
+    completed_at: new Date(completedAt).toISOString(),
+    duration_ms: completedAt - startedAt,
+    exit_code: exitCode,
+    report,
+    source_dir: sourceDir,
+    report_path: copiedReportPath,
+    source_status: report?.status || 'missing',
+    status: failures.length === 0 ? 'pass' : 'fail',
+    failures: unique(failures),
+  };
+}
+
 function buildReleaseBlockers(sources) {
   const blockers = [];
   const sourceById = new Map(sources.map((source) => [source.id, source]));
@@ -391,11 +487,18 @@ function buildReleaseBlockers(sources) {
       reason: 'conflict-resolution fixture source report is missing, stale, failed, or incomplete',
     });
   }
+  const evidenceScrub = sourceById.get(EVIDENCE_SCRUB_SOURCE_ID);
   if (!hasScript('check:mesh-evidence-scrub')) {
     blockers.push({
       id: 'evidence-scrub-promotion',
       command: 'pnpm check:mesh-evidence-scrub',
       reason: 'evidence scrub gate for promoted docs/reports/evidence packets is not implemented',
+    });
+  } else if (evidenceScrub?.status !== 'pass' || evidenceScrub.report?.evidence_scrub?.status !== 'pass') {
+    blockers.push({
+      id: 'evidence-scrub-promotion',
+      command: 'pnpm check:mesh-evidence-scrub',
+      reason: 'candidate aggregate packet has not passed deterministic evidence scrub and promoted-packet rescan',
     });
   }
   if (!hasScript('check:production-app-canary')) {
@@ -590,12 +693,17 @@ ${report.release_claims.forbidden.map((claim) => `- ${claim}`).join('\n')}
 `;
 }
 
-function writeAggregatePacket({ report, manifest, artifactDir }) {
+function writePacketFiles({ report, manifest, artifactDir }) {
   fs.mkdirSync(artifactDir, { recursive: true });
   const reportPath = path.join(artifactDir, 'mesh-production-readiness-report.json');
   const manifestPath = path.join(artifactDir, 'mesh-production-readiness-evidence.md');
   writeJson(reportPath, report);
   fs.writeFileSync(manifestPath, manifest);
+  return { reportPath, manifestPath };
+}
+
+function writeAggregatePacket({ report, manifest, artifactDir }) {
+  const { reportPath, manifestPath } = writePacketFiles({ report, manifest, artifactDir });
 
   fs.rmSync(latestDir, { recursive: true, force: true });
   fs.mkdirSync(latestDir, { recursive: true });
@@ -741,11 +849,34 @@ async function main() {
   for (const gate of SOURCE_GATES) {
     sources.push(runSourceGate({ gate, artifactDir, currentCommit, requireClean }));
   }
+  const initialBlockers = buildReleaseBlockers(sources);
+  const initialCommandPassed = sources.every((source) => source.status === 'pass');
+  const candidateCompletedAt = Date.now();
+  const candidateReport = buildReport({
+    runId,
+    startedAt,
+    completedAt: candidateCompletedAt,
+    sources,
+    blockers: initialBlockers,
+    commandPassed: initialCommandPassed,
+  });
+  const provisionalReportPath = path.join(artifactDir, 'mesh-production-readiness-report.json');
+  const candidateManifest = buildManifest({
+    report: candidateReport,
+    sources,
+    blockers: initialBlockers,
+    reportPath: provisionalReportPath,
+  });
+  writePacketFiles({ report: candidateReport, manifest: candidateManifest, artifactDir });
+
+  if (initialCommandPassed) {
+    sources.push(runEvidenceScrubGate({ artifactDir, currentCommit, requireClean }));
+  }
+
   const blockers = buildReleaseBlockers(sources);
   const commandPassed = sources.every((source) => source.status === 'pass');
   const completedAt = Date.now();
   const report = buildReport({ runId, startedAt, completedAt, sources, blockers, commandPassed });
-  const provisionalReportPath = path.join(artifactDir, 'mesh-production-readiness-report.json');
   const manifest = buildManifest({ report, sources, blockers, reportPath: provisionalReportPath });
   const paths = writeAggregatePacket({ report, manifest, artifactDir });
 

--- a/packages/e2e/src/mesh/production-readiness-check.test.mjs
+++ b/packages/e2e/src/mesh/production-readiness-check.test.mjs
@@ -86,12 +86,20 @@ function evidenceScrubPacket({ status = 'review_required', blockers = [{ id: 'ca
       command: 'pnpm test:mesh:topology-drills',
     },
     run_id: 'source-topology-run',
+    conflict_fixtures: [
+      {
+        fixture: 'full-conflict-resolution-fixtures',
+        status: 'skipped',
+        reason: 'stale placeholder must not survive promoted evidence',
+      },
+    ],
   });
   writeJson(sourceReportPath, source);
   writeJson(path.join(sourceDir, 'source-reports/topology/raw-control.json'), {
     controlToken: 'mesh-control-token-should-not-survive',
     peerUrl: 'wss://127.0.0.1:7790/gun',
     artifactPath: '/Users/bldt/Desktop/VHC/VHC/.tmp/raw-packet.json',
+    opened_socket_hosts: ['127.0.0.1:7790'],
   });
 
   const aggregate = {
@@ -375,6 +383,7 @@ describe('mesh evidence scrub promotion', () => {
 
       expect(promotedText).not.toContain('/Users/bldt/');
       expect(promotedText).not.toContain('127.0.0.1');
+      expect(promotedText).not.toContain('full-conflict-resolution-fixtures');
       expect(promotedText).not.toContain('mesh-control-token-should-not-survive');
       expect(promotedText).not.toContain('raw-token-value-that-must-not-survive');
       expect(promotedText).toContain('redacted-host-');

--- a/packages/e2e/src/mesh/production-readiness-check.test.mjs
+++ b/packages/e2e/src/mesh/production-readiness-check.test.mjs
@@ -1,6 +1,14 @@
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
+import {
+  runEvidenceScrub,
+  validateAggregatePacket,
+} from './evidence-scrub-check.mjs';
 import {
   SOURCE_GATES,
   conflictRowsForAggregate,
@@ -8,6 +16,7 @@ import {
 } from './production-readiness-check.mjs';
 
 const thisFile = fileURLToPath(import.meta.url);
+const repoRoot = path.resolve(path.dirname(thisFile), '../../../..');
 const currentCommit = 'abc123';
 const gateStartedAtMs = Date.parse('2026-05-07T00:00:00.000Z');
 const gateCompletedAtMs = Date.parse('2026-05-07T00:00:20.000Z');
@@ -48,6 +57,140 @@ function failuresFor({ gate, report }) {
     startedAtMs: gateStartedAtMs,
     completedAtMs: gateCompletedAtMs,
   });
+}
+
+function liveCommit() {
+  return spawnSync('git', ['rev-parse', 'HEAD'], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  }).stdout.trim();
+}
+
+function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function evidenceScrubPacket({ status = 'review_required', blockers = [{ id: 'canonical-30-minute-soak', command: 'pnpm test:mesh:soak', reason: 'canonical soak remains pending' }], writerKind = 'mesh-drill' } = {}) {
+  const sourceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vh-mesh-evidence-scrub-'));
+  const sourceReportPath = path.join(sourceDir, 'source-reports/topology/mesh-production-readiness-report.json');
+  const commit = liveCommit();
+  const source = sourceReport({
+    repo: {
+      commit,
+      dirty: false,
+    },
+    run: {
+      ...sourceReport().run,
+      mode: 'local_production_topology',
+      command: 'pnpm test:mesh:topology-drills',
+    },
+    run_id: 'source-topology-run',
+  });
+  writeJson(sourceReportPath, source);
+  writeJson(path.join(sourceDir, 'source-reports/topology/raw-control.json'), {
+    controlToken: 'mesh-control-token-should-not-survive',
+    peerUrl: 'wss://127.0.0.1:7790/gun',
+    artifactPath: '/Users/bldt/Desktop/VHC/VHC/.tmp/raw-packet.json',
+  });
+
+  const aggregate = {
+    schema_version: 'mesh-production-readiness-v1',
+    generated_at: '2026-05-07T00:00:30.000Z',
+    run_id: 'aggregate-evidence-scrub-test',
+    repo: {
+      branch: 'coord/test',
+      commit,
+      base_ref: 'origin/main',
+      dirty: false,
+    },
+    run: {
+      mode: 'aggregate_production_readiness',
+      started_at: '2026-05-07T00:00:00.000Z',
+      completed_at: '2026-05-07T00:00:30.000Z',
+      duration_ms: 30000,
+      command: 'pnpm check:mesh:production-readiness',
+    },
+    status,
+    schema_epoch: 'post_luma_m0b',
+    luma_profile: 'none',
+    luma_dependency_status: {
+      luma_m0b_schema_epoch: 'landed',
+      luma_gated_write_drills: 'pending',
+    },
+    drill_writer_kind_by_class: {
+      'forum-post': writerKind,
+    },
+    topology: {
+      relay_urls_redacted: ['wss://127.0.0.1:7790/gun'],
+    },
+    source_reports: [
+      {
+        id: 'topology',
+        name: 'topology',
+        command: 'pnpm test:mesh:topology-drills',
+        status: 'pass',
+        result_status: 'review_required',
+        run_id: 'source-topology-run',
+        run_mode: 'local_production_topology',
+        run_command: 'pnpm test:mesh:topology-drills',
+        source_completed_at: '2026-05-07T00:00:10.000Z',
+        schema_epoch: 'post_luma_m0b',
+        luma_profile: 'none',
+        repo_dirty: false,
+        report_path: sourceReportPath,
+        failures: [],
+      },
+    ],
+    release_readiness_blockers: blockers,
+    gates: [],
+    write_class_slos: [],
+    resource_slos: [],
+    per_relay_readback: [],
+    state_resolution_drills: [],
+    conflict_fixtures: [],
+    luma_gated_write_drills: [
+      {
+        write_class: 'LUMA-gated production write classes through LUMA reader path',
+        trace_id: 'aggregate-evidence-scrub-test',
+        status: 'skipped',
+      },
+    ],
+    clock_skew: {
+      skewed_actor: null,
+      skewed_layer: null,
+      skew_ms: 0,
+      named_failure: null,
+      lww_diverged: false,
+      status: 'skipped',
+    },
+    cleanup: {
+      status: 'pass',
+    },
+    health: {
+      peer_quorum_minimum_observed: 2,
+      sustained_message_rate_max_per_sec: 0,
+      degradation_reasons_seen: [],
+    },
+    release_claims: {
+      allowed: ['Existing implemented mesh proof commands can be aggregated into one local evidence packet.'],
+      forbidden: ['The mesh is release_ready.'],
+      invalidated_by_luma_epoch_change: false,
+    },
+  };
+  writeJson(path.join(sourceDir, 'mesh-production-readiness-report.json'), aggregate);
+  fs.writeFileSync(
+    path.join(sourceDir, 'mesh-production-readiness-evidence.md'),
+    [
+      '# Evidence',
+      'Report: `/Users/bldt/Desktop/VHC/VHC/.tmp/raw-report.json`',
+      'Relay: `wss://127.0.0.1:7790/gun`',
+      'Authorization: Bearer raw-token-value-that-must-not-survive',
+      '',
+    ].join('\n'),
+  );
+
+  return sourceDir;
 }
 
 describe('production-readiness source evidence validation', () => {
@@ -210,5 +353,57 @@ describe('production-readiness source evidence validation', () => {
         source_run_id: 'conflict-report',
       }),
     ]);
+  });
+});
+
+describe('mesh evidence scrub promotion', () => {
+  it('promotes a scrubbed packet with redacted paths, origins, and tokens', () => {
+    const sourceDir = evidenceScrubPacket();
+    try {
+      const result = runEvidenceScrub({
+        sourceDir,
+        command: `pnpm check:mesh-evidence-scrub -- --source-dir ${path.relative(repoRoot, sourceDir)}`,
+      });
+
+      expect(result.ok).toBe(true);
+      const promotedDir = path.resolve(repoRoot, result.promoted_dir.replace(/^\.\//, ''));
+      const promotedText = fs
+        .readdirSync(promotedDir, { recursive: true })
+        .filter((entry) => fs.statSync(path.join(promotedDir, entry)).isFile())
+        .map((entry) => fs.readFileSync(path.join(promotedDir, entry), 'utf8'))
+        .join('\n');
+
+      expect(promotedText).not.toContain('/Users/bldt/');
+      expect(promotedText).not.toContain('127.0.0.1');
+      expect(promotedText).not.toContain('mesh-control-token-should-not-survive');
+      expect(promotedText).not.toContain('raw-token-value-that-must-not-survive');
+      expect(promotedText).toContain('redacted-host-');
+    } finally {
+      fs.rmSync(sourceDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects release_ready aggregate claims while blockers remain', () => {
+    const sourceDir = evidenceScrubPacket({ status: 'release_ready' });
+    try {
+      const validation = validateAggregatePacket({ sourceDir });
+
+      expect(validation.ok).toBe(false);
+      expect(validation.failures).toContain('aggregate claims release_ready while release_readiness_blockers remain');
+    } finally {
+      fs.rmSync(sourceDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects writer kinds outside synthetic mesh drill evidence', () => {
+    const sourceDir = evidenceScrubPacket({ writerKind: 'luma' });
+    try {
+      const validation = validateAggregatePacket({ sourceDir });
+
+      expect(validation.ok).toBe(false);
+      expect(validation.failures).toContain('write class forum-post has disallowed writer kind luma');
+    } finally {
+      fs.rmSync(sourceDir, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Adds the mesh evidence scrub promotion gate and wires it into `pnpm check:mesh:production-readiness`.
- Promotes scrubbed source evidence into the production-readiness packet as an explicit `evidence_scrub` source report.
- Hardens the scrubber during review to catch bare local endpoints and stale placeholder fixture names in promoted packets.
- Updates mesh production-readiness docs/specs to describe the current promotion contract and remaining proof boundaries.

## Review fix
The independent review pass found that the initial scrubber did not remove bare `127.0.0.1:<port>` values or stale placeholder fixture strings from some promoted source reports. This PR now redacts those endpoints, removes stale fixture rows, and fails the promoted-packet rescan if either class remains.

## Verification
- `node --check packages/e2e/src/mesh/evidence-scrub-check.mjs`
- `pnpm --filter @vh/e2e exec vitest run src/mesh/production-readiness-check.test.mjs --reporter=dot`
- `pnpm --filter @vh/e2e typecheck`
- `pnpm docs:check`
- `node tools/scripts/check-diff-coverage.mjs`
- `git diff --check origin/main...HEAD`
- `pnpm check:mesh-evidence-scrub -- --source-dir .tmp/mesh-production-readiness/latest`
- `pnpm check:mesh:production-readiness`

Latest clean aggregate: `mesh-production-readiness-20260508T173101Z-c70d868c`.
Latest scrub source report: `mesh-evidence-scrub-20260508T174215Z-d0a38d4e`.
