### PR TITLE
Add production app canary gate

### DIFF
--- a/docs/ops/mesh-production-topology-drills.md
+++ b/docs/ops/mesh-production-topology-drills.md
@@ -352,14 +352,24 @@ gate-run timestamp window. The packet includes
 and copied source reports under `source-reports/<gate>/`; after Slice 14A it has
 12 source reports, including `source-reports/evidence_scrub/`.
 
-For Slice 11A through Slice 14A, a successful aggregate command still reports
-`status: review_required` while release blockers remain. Expected blockers
-after Slice 14A include the canonical 30-minute soak, public WSS deployment
-proof, downstream full-app canary, and LUMA-gated write coverage through the
-LUMA reader path. The command exits non-zero for missing, malformed, dirty,
-stale, failed, command-mismatched, unscrubbed, or incomplete source evidence,
-and for any overclaiming packet that would emit `release_ready` before the
-blockers are gone.
+For Slice 11A through Slice 14B, a successful aggregate command still reports
+`status: review_required` while release blockers remain. Expected blockers after
+Slice 14A include the canonical 30-minute soak, public WSS deployment proof,
+downstream full-app canary, and LUMA-gated write coverage through the LUMA
+reader path. After Slice 14B, the aggregate no longer treats the downstream
+full-app canary as unimplemented, but the separate canary command still blocks
+until the mesh report is `release_ready` and real downstream observation exists.
+The aggregate command exits non-zero for missing, malformed, dirty, stale,
+failed, command-mismatched, unscrubbed, or incomplete source evidence, and for
+any overclaiming packet that would emit `release_ready` before the blockers are
+gone.
+
+After Slice 14B, `pnpm check:production-app-canary` is a separate fail-closed
+downstream gate. It defaults to the latest mesh readiness report but accepts
+`--mesh-report <path>` / `VH_PRODUCTION_APP_CANARY_MESH_REPORT`; while the mesh
+packet remains `review_required`, the expected canary outcome is a blocked
+`.tmp/production-app-canary/<run_id>/production-app-canary-report.json` with
+`reason: mesh_not_release_ready` and a non-zero exit.
 
 `VH_RELAY_PEER_AUTH_MODE=private_network_allowlist` is a local/private-network
 harness mode. Because Gun relay and browser clients share the `/gun` WebSocket
@@ -379,7 +389,7 @@ distributing a new trusted key.
 ## Review Boundary
 
 The report status remains `review_required` for Slice
-6B/7B/7C/8/9/9B/10/11A/12A/13A/13B/14A even when the local restarted-relay
+6B/7B/7C/8/9/9B/10/11A/12A/13A/13B/14A/14B even when the local restarted-relay
 drill, deployed-WSS local TLS profile, state-resolution drill, disconnect
 drill, partition/heal drill, read-repair drill, bounded rolling-restart soak,
 peer-config rollback drill, and aggregate evidence packet are well formed. A
@@ -411,7 +421,10 @@ means only that the candidate aggregate packet was deterministically transformed
 into `.tmp/mesh-production-readiness/promoted/<run_id>/` and the promoted output
 was rescanned for raw tokens, private key material, unsafe origins, unsafe
 absolute paths, stale placeholder evidence, overclaims, and disallowed writer
-kinds. None of these outcomes proves
+kinds. The Slice 14B downstream canary command is separate from mesh readiness;
+on current `review_required` mesh evidence, its expected non-zero blocked report
+proves only that the app-level readiness claim is fail-closed. None of these
+outcomes proves
 public WSS
 infrastructure, automatic peer-federation recovery, runtime peer-config key
 rotation without a new trusted-key distribution path, LUMA-gated write state

--- a/docs/specs/spec-mesh-production-readiness.md
+++ b/docs/specs/spec-mesh-production-readiness.md
@@ -1426,21 +1426,31 @@ Acceptance gates:
 
 Downstream full-app canary:
 
-- New command: `pnpm check:production-app-canary`
+- Command: `pnpm check:production-app-canary`
 - Runs only after `pnpm check:mesh:production-readiness` passes.
+- Defaults to
+  `.tmp/mesh-production-readiness/latest/mesh-production-readiness-report.json`;
+  operators and tests may override with `--mesh-report <path>` or
+  `VH_PRODUCTION_APP_CANARY_MESH_REPORT`.
+- Operators may require a LUMA profile with `--expected-luma-profile <profile>`
+  or `VH_PRODUCTION_APP_CANARY_LUMA_PROFILE`.
 - Covers production WSS relay config, app preview/deploy shape, `/api/analyze`,
   news synthesis publication, point stance write/readback, and story-thread
   creation/comment flow.
 - Fails if it cannot consume the latest mesh readiness report or if that report
   is not `release_ready`.
+- Slice 14B implements the fail-closed preflight/report shell only: while mesh
+  readiness is still `review_required`, the command emits a `blocked`
+  production-app canary report with `reason: mesh_not_release_ready` and exits
+  non-zero by design.
 - Emits a separate report; it may depend on mesh readiness but must not be
   folded into the mesh readiness status.
 
 ### Slice 12 - Operational Runbook And Rollback
 
 Status: Slice 12A implemented for local TLS/WSS peer-config rollback rehearsal
-and operator runbook. Public WSS rollback, runtime key distribution, evidence
-scrub promotion, and downstream full-app canary remain unclaimed.
+and operator runbook. Public WSS rollback, runtime key distribution, and a
+passing downstream full-app canary remain unclaimed.
 
 Purpose:
 
@@ -2116,9 +2126,6 @@ Implemented mesh commands:
 - `pnpm test:mesh:conflict-drills`
 - `pnpm check:mesh-evidence-scrub`
 - `pnpm check:mesh:production-readiness`
-
-Required new commands:
-
 - `pnpm check:production-app-canary`
 
 ## 7. Release Claim Boundary
@@ -2342,6 +2349,26 @@ Still not allowed after Slice 14A evidence scrub and promotion gate:
 - "The default shortened local command satisfies the canonical thirty-minute
   soak claim."
 - "The app is ready for a test group."
+
+Allowed after Slice 14B downstream production-app canary gate v1:
+
+- "`pnpm check:production-app-canary` reads an explicit `--mesh-report` or the
+  current mesh readiness `latest` report and writes
+  `.tmp/production-app-canary/<run_id>/production-app-canary-report.json` plus a
+  `latest` copy."
+- "The production-app canary fails closed and exits non-zero when the mesh
+  report is missing, malformed, stale, dirty, from the wrong commit, LUMA
+  profile-mismatched, or not `release_ready`."
+- "The mesh production-readiness aggregate records the downstream canary as a
+  separate implemented gate and does not fold canary status into mesh
+  readiness."
+
+Still not allowed after Slice 14B downstream production-app canary gate v1:
+
+- "The production app canary passed."
+- "The full app is test-group ready."
+- "Downstream `/api/analyze`, synthesis publication, point stance, or
+  story-thread flows were observed by the canary."
 
 Allowed after Slices 6B through 14A plus downstream LUMA-gated coverage pass
 (under `schema_epoch: post_luma_m0b` with all LUMA-gated write classes drilled

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "test:mesh:conflict-drills": "pnpm --filter @vh/e2e test:mesh:conflict-drills",
     "check:mesh-evidence-scrub": "pnpm --filter @vh/e2e check:mesh-evidence-scrub",
     "check:mesh:production-readiness": "pnpm --filter @vh/e2e check:mesh:production-readiness",
+    "check:production-app-canary": "pnpm --filter @vh/e2e check:production-app-canary",
     "test:storycluster:smoke": "pnpm --filter @vh/e2e test:live:daemon-feed:build && pnpm --filter @vh/e2e test:live:daemon-feed:semantic-soak",
     "test:storycluster:smoke:readiness": "pnpm --filter @vh/e2e test:live:daemon-feed:build && (pnpm --filter @vh/e2e test:live:daemon-feed:semantic-soak || true) && pnpm --filter @vh/e2e test:live:daemon-feed:semantic-soak:readiness",
     "collect:storycluster:headline-soak": "pnpm report:news-sources:health && pnpm test:storycluster:smoke:readiness",

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -37,6 +37,7 @@
     "test:mesh:conflict-drills": "node ./src/mesh/conflict-drills.mjs",
     "check:mesh-evidence-scrub": "node ./src/mesh/evidence-scrub-check.mjs",
     "check:mesh:production-readiness": "node ./src/mesh/production-readiness-check.mjs",
+    "check:production-app-canary": "node ./src/live/production-app-canary.mjs",
     "report:live:daemon-feed:fixture-candidate-intake": "node ./src/live/daemon-feed-fixture-candidate-intake.mjs",
     "report:offline-cluster-replay": "node ./src/live/daemon-feed-semantic-soak-offline-replay-report.mjs",
     "report:live:daemon-feed:production-readiness": "node ./src/live/storycluster-production-readiness.mjs",

--- a/packages/e2e/src/live/production-app-canary.mjs
+++ b/packages/e2e/src/live/production-app-canary.mjs
@@ -1,0 +1,361 @@
+#!/usr/bin/env node
+
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const defaultRepoRoot = path.resolve(__dirname, '../../../..');
+const DEFAULT_MESH_REPORT_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
+export const PRODUCTION_APP_CANARY_SCHEMA_VERSION = 'production-app-canary-report-v1';
+export const PRODUCTION_APP_CANARY_MODE = 'production_app_canary_v1';
+
+const REQUIRED_DOWNSTREAM_SURFACES = [
+  'production_wss_relay_config',
+  'app_preview_or_deploy_shape',
+  'api_analyze',
+  'news_synthesis_publication',
+  'point_stance_write_readback',
+  'story_thread_create_comment',
+];
+
+const FORBIDDEN_CLAIMS = [
+  'The full app is test-group ready.',
+  'The production app canary passed.',
+  'The downstream app surfaces were observed end-to-end.',
+  'LUMA profile gates passed through the production app canary.',
+  'Mesh review_required evidence is sufficient for a full-app readiness claim.',
+];
+
+function nowIso(date = new Date()) {
+  return date.toISOString();
+}
+
+function nowIsoCompact(date = new Date()) {
+  return nowIso(date).replaceAll('-', '').replaceAll(':', '').replace(/\.\d{3}Z$/, 'Z');
+}
+
+function makeId(prefix, randomBytes = crypto.randomBytes) {
+  return `${prefix}-${nowIsoCompact()}-${randomBytes(4).toString('hex')}`;
+}
+
+function runGit(args, { repoRoot = defaultRepoRoot } = {}) {
+  const result = spawnSync('git', args, {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  });
+  return result.status === 0 ? result.stdout.trim() : '';
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function parsePositiveInteger(value, fallback) {
+  if (value === undefined || value === null || value === '') return fallback;
+  const parsed = Number.parseInt(String(value), 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function argValue(argv, name) {
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === name) {
+      return argv[index + 1] || '';
+    }
+    if (arg.startsWith(`${name}=`)) {
+      return arg.slice(name.length + 1);
+    }
+  }
+  return undefined;
+}
+
+function resolveRepoPath(repoRoot, candidate) {
+  if (!candidate) return candidate;
+  return path.isAbsolute(candidate) ? candidate : path.resolve(repoRoot, candidate);
+}
+
+export function parseProductionAppCanaryOptions({
+  argv = [],
+  env = process.env,
+  repoRoot = defaultRepoRoot,
+} = {}) {
+  const fallbackMeshReportPath = path.join(repoRoot, '.tmp/mesh-production-readiness/latest/mesh-production-readiness-report.json');
+  const meshReportCandidate =
+    argValue(argv, '--mesh-report') ||
+    env.VH_PRODUCTION_APP_CANARY_MESH_REPORT ||
+    fallbackMeshReportPath;
+  const expectedLumaProfile =
+    argValue(argv, '--expected-luma-profile') ||
+    env.VH_PRODUCTION_APP_CANARY_LUMA_PROFILE ||
+    null;
+
+  return {
+    meshReportPath: resolveRepoPath(repoRoot, meshReportCandidate),
+    expectedLumaProfile,
+    maxMeshReportAgeMs: parsePositiveInteger(
+      env.VH_PRODUCTION_APP_CANARY_MAX_MESH_REPORT_AGE_MS,
+      DEFAULT_MESH_REPORT_MAX_AGE_MS,
+    ),
+  };
+}
+
+function meshReportBlockers(meshReport) {
+  return Array.isArray(meshReport?.release_readiness_blockers)
+    ? meshReport.release_readiness_blockers.map((blocker) => ({
+        id: blocker.id || 'unknown',
+        command: blocker.command || null,
+        reason: blocker.reason || null,
+      }))
+    : [];
+}
+
+function checkStatus(condition, blockedReason = null) {
+  return condition
+    ? { status: 'pass' }
+    : { status: 'blocked', reason: blockedReason };
+}
+
+function buildChecks({
+  meshReport,
+  meshReadError,
+  currentCommit,
+  expectedLumaProfile,
+  maxMeshReportAgeMs,
+  nowMs,
+}) {
+  const checks = [];
+  const meshReportLoaded = Boolean(meshReport) && !meshReadError;
+  const generatedAtMs = meshReportLoaded ? Date.parse(meshReport.generated_at || '') : NaN;
+  const observedLumaProfile = meshReport?.luma_profile || null;
+  const expectedProfile = expectedLumaProfile || observedLumaProfile;
+
+  checks.push({
+    id: 'mesh_report_present',
+    ...checkStatus(meshReportLoaded, meshReadError?.reason || 'missing_mesh_report'),
+  });
+
+  checks.push({
+    id: 'mesh_report_fresh',
+    ...checkStatus(
+      meshReportLoaded &&
+        Number.isFinite(generatedAtMs) &&
+        nowMs >= generatedAtMs &&
+        nowMs - generatedAtMs <= maxMeshReportAgeMs,
+      meshReportLoaded && Number.isFinite(generatedAtMs) ? 'stale_mesh_report' : 'malformed_mesh_report',
+    ),
+    max_age_ms: maxMeshReportAgeMs,
+    generated_at: meshReport?.generated_at || null,
+  });
+
+  checks.push({
+    id: 'mesh_report_clean_repo',
+    ...checkStatus(meshReportLoaded && meshReport.repo?.dirty === false, 'mesh_report_dirty'),
+  });
+
+  checks.push({
+    id: 'mesh_report_current_commit',
+    ...checkStatus(meshReportLoaded && meshReport.repo?.commit === currentCommit, 'mesh_report_wrong_commit'),
+    expected_commit: currentCommit || null,
+    observed_commit: meshReport?.repo?.commit || null,
+  });
+
+  checks.push({
+    id: 'luma_profile_match',
+    ...checkStatus(!expectedProfile || observedLumaProfile === expectedProfile, 'luma_profile_mismatch'),
+    expected_luma_profile: expectedProfile || null,
+    observed_luma_profile: observedLumaProfile,
+  });
+
+  checks.push({
+    id: 'mesh_release_ready',
+    ...checkStatus(meshReportLoaded && meshReport.status === 'release_ready', 'mesh_not_release_ready'),
+    observed_status: meshReport?.status || null,
+    blockers: meshReportBlockers(meshReport),
+  });
+
+  const prerequisiteFailures = checks.filter((check) => check.status !== 'pass');
+  checks.push({
+    id: 'downstream_observation',
+    status: 'blocked',
+    reason: prerequisiteFailures.length > 0 ? 'prerequisites_blocked' : 'downstream_observation_not_implemented',
+    required_surfaces: REQUIRED_DOWNSTREAM_SURFACES,
+  });
+
+  return checks;
+}
+
+function primaryReason(checks) {
+  return checks.find((check) => check.status !== 'pass' && check.reason !== 'prerequisites_blocked')?.reason || 'blocked';
+}
+
+export function buildProductionAppCanaryReport({
+  runId,
+  startedAtMs,
+  completedAtMs,
+  command,
+  repo,
+  meshReportPath,
+  meshReport,
+  meshReadError = null,
+  expectedLumaProfile = null,
+  maxMeshReportAgeMs = DEFAULT_MESH_REPORT_MAX_AGE_MS,
+} = {}) {
+  const checks = buildChecks({
+    meshReport,
+    meshReadError,
+    currentCommit: repo?.commit,
+    expectedLumaProfile,
+    maxMeshReportAgeMs,
+    nowMs: completedAtMs,
+  });
+  const reason = primaryReason(checks);
+  const observedLumaProfile = meshReport?.luma_profile || null;
+  const expectedProfile = expectedLumaProfile || observedLumaProfile;
+
+  return {
+    schema_version: PRODUCTION_APP_CANARY_SCHEMA_VERSION,
+    generated_at: new Date(completedAtMs).toISOString(),
+    run_id: runId,
+    repo: {
+      branch: repo?.branch || null,
+      commit: repo?.commit || null,
+      base_ref: 'origin/main',
+      dirty: Boolean(repo?.dirty),
+    },
+    run: {
+      mode: PRODUCTION_APP_CANARY_MODE,
+      started_at: new Date(startedAtMs).toISOString(),
+      completed_at: new Date(completedAtMs).toISOString(),
+      duration_ms: completedAtMs - startedAtMs,
+      command,
+    },
+    status: 'blocked',
+    reason,
+    mesh_report: {
+      path: meshReportPath,
+      loaded: Boolean(meshReport) && !meshReadError,
+      read_error: meshReadError,
+      schema_version: meshReport?.schema_version || null,
+      run_id: meshReport?.run_id || null,
+      generated_at: meshReport?.generated_at || null,
+      status: meshReport?.status || null,
+      source_commit: meshReport?.repo?.commit || null,
+      source_dirty: meshReport?.repo?.dirty ?? null,
+      blockers: meshReportBlockers(meshReport),
+    },
+    luma_profile: {
+      observed: observedLumaProfile,
+      expected: expectedProfile || null,
+      status: expectedProfile && observedLumaProfile !== expectedProfile ? 'blocked' : 'pass',
+    },
+    checks,
+    downstream_observation: {
+      status: 'not_run',
+      reason: reason === 'downstream_observation_not_implemented' ? reason : 'prerequisites_blocked',
+      required_surfaces: REQUIRED_DOWNSTREAM_SURFACES,
+    },
+    release_claims: {
+      allowed: [],
+      forbidden: FORBIDDEN_CLAIMS,
+    },
+  };
+}
+
+function readMeshReport(meshReportPath) {
+  if (!fs.existsSync(meshReportPath)) {
+    return {
+      meshReport: null,
+      meshReadError: {
+        reason: 'missing_mesh_report',
+        detail: `mesh readiness report does not exist at ${meshReportPath}`,
+      },
+    };
+  }
+
+  try {
+    return {
+      meshReport: readJson(meshReportPath),
+      meshReadError: null,
+    };
+  } catch (error) {
+    return {
+      meshReport: null,
+      meshReadError: {
+        reason: 'malformed_mesh_report',
+        detail: error instanceof Error ? error.message : String(error),
+      },
+    };
+  }
+}
+
+function commandText(argv) {
+  return ['pnpm', 'check:production-app-canary', ...argv].join(' ');
+}
+
+export function runProductionAppCanary({
+  argv = [],
+  env = process.env,
+  repoRoot = defaultRepoRoot,
+  outputRoot = path.join(repoRoot, '.tmp/production-app-canary'),
+  now = () => Date.now(),
+  randomBytes = crypto.randomBytes,
+  git = runGit,
+} = {}) {
+  const startedAtMs = now();
+  const runId = makeId('production-app-canary', randomBytes);
+  const options = parseProductionAppCanaryOptions({ argv, env, repoRoot });
+  const { meshReport, meshReadError } = readMeshReport(options.meshReportPath);
+  const repo = {
+    branch: git(['rev-parse', '--abbrev-ref', 'HEAD'], { repoRoot }),
+    commit: git(['rev-parse', 'HEAD'], { repoRoot }),
+    dirty: git(['status', '--short'], { repoRoot }).length > 0,
+  };
+  const completedAtMs = now();
+  const artifactDir = path.join(outputRoot, runId);
+  const reportPath = path.join(artifactDir, 'production-app-canary-report.json');
+  const latestDir = path.join(outputRoot, 'latest');
+  const latestReportPath = path.join(latestDir, 'production-app-canary-report.json');
+  const report = buildProductionAppCanaryReport({
+    runId,
+    startedAtMs,
+    completedAtMs,
+    command: commandText(argv),
+    repo,
+    meshReportPath: options.meshReportPath,
+    meshReport,
+    meshReadError,
+    expectedLumaProfile: options.expectedLumaProfile,
+    maxMeshReportAgeMs: options.maxMeshReportAgeMs,
+  });
+
+  writeJson(reportPath, report);
+  fs.rmSync(latestDir, { recursive: true, force: true });
+  writeJson(latestReportPath, report);
+
+  return {
+    report,
+    reportPath,
+    latestReportPath,
+    exitCode: report.status === 'pass' ? 0 : 1,
+  };
+}
+
+if (process.argv[1] === __filename) {
+  const result = runProductionAppCanary({ argv: process.argv.slice(2) });
+  console.log(`[vh:production-app-canary] report: ${path.relative(defaultRepoRoot, result.reportPath)}`);
+  console.log(`[vh:production-app-canary] latest: ${path.relative(defaultRepoRoot, result.latestReportPath)}`);
+  if (result.exitCode !== 0) {
+    console.error(`[vh:production-app-canary] blocked: ${result.report.reason}`);
+  }
+  process.exit(result.exitCode);
+}

--- a/packages/e2e/src/live/production-app-canary.vitest.mjs
+++ b/packages/e2e/src/live/production-app-canary.vitest.mjs
@@ -1,0 +1,179 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildProductionAppCanaryReport,
+  parseProductionAppCanaryOptions,
+  PRODUCTION_APP_CANARY_SCHEMA_VERSION,
+  runProductionAppCanary,
+} from './production-app-canary.mjs';
+
+const nowMs = Date.parse('2026-05-08T18:00:00.000Z');
+
+function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function meshReport(overrides = {}) {
+  return {
+    schema_version: 'mesh-production-readiness-v1',
+    generated_at: '2026-05-08T17:55:00.000Z',
+    run_id: 'mesh-production-readiness-test',
+    repo: {
+      commit: 'abc123',
+      dirty: false,
+    },
+    status: 'review_required',
+    schema_epoch: 'post_luma_m0b',
+    luma_profile: 'none',
+    release_readiness_blockers: [
+      {
+        id: 'canonical-30-minute-soak',
+        command: 'VH_MESH_SOAK_DURATION_MS=1800000 pnpm test:mesh:soak',
+        reason: 'latest soak evidence is shortened',
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function git(args) {
+  if (args.join(' ') === 'rev-parse --abbrev-ref HEAD') return 'coord/test';
+  if (args.join(' ') === 'rev-parse HEAD') return 'abc123';
+  if (args.join(' ') === 'status --short') return '';
+  return '';
+}
+
+describe('production-app-canary', () => {
+  it('defaults to the repo latest mesh report and supports CLI/env overrides', () => {
+    expect(parseProductionAppCanaryOptions({
+      argv: [],
+      env: {},
+      repoRoot: '/repo',
+    }).meshReportPath).toBe('/repo/.tmp/mesh-production-readiness/latest/mesh-production-readiness-report.json');
+
+    expect(parseProductionAppCanaryOptions({
+      argv: [],
+      env: { VH_PRODUCTION_APP_CANARY_MESH_REPORT: '.tmp/env-report.json' },
+      repoRoot: '/repo',
+    }).meshReportPath).toBe('/repo/.tmp/env-report.json');
+
+    expect(parseProductionAppCanaryOptions({
+      argv: ['--mesh-report', '.tmp/cli-report.json', '--expected-luma-profile=production-attestation'],
+      env: { VH_PRODUCTION_APP_CANARY_MESH_REPORT: '.tmp/env-report.json' },
+      repoRoot: '/repo',
+    })).toMatchObject({
+      meshReportPath: '/repo/.tmp/cli-report.json',
+      expectedLumaProfile: 'production-attestation',
+    });
+  });
+
+  it('blocks current review_required mesh evidence without faking an app canary pass', () => {
+    const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'vh-production-app-canary-'));
+    const meshReportPath = path.join(repoRoot, '.tmp/mesh-production-readiness/latest/mesh-production-readiness-report.json');
+    writeJson(meshReportPath, meshReport());
+
+    const result = runProductionAppCanary({
+      repoRoot,
+      outputRoot: path.join(repoRoot, '.tmp/production-app-canary'),
+      argv: ['--mesh-report', meshReportPath],
+      env: {},
+      now: () => nowMs,
+      randomBytes: () => Buffer.from('00112233', 'hex'),
+      git,
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.report).toMatchObject({
+      schema_version: PRODUCTION_APP_CANARY_SCHEMA_VERSION,
+      status: 'blocked',
+      reason: 'mesh_not_release_ready',
+      mesh_report: {
+        loaded: true,
+        run_id: 'mesh-production-readiness-test',
+        status: 'review_required',
+        source_commit: 'abc123',
+      },
+      luma_profile: {
+        observed: 'none',
+        expected: 'none',
+        status: 'pass',
+      },
+      downstream_observation: {
+        status: 'not_run',
+        reason: 'prerequisites_blocked',
+      },
+    });
+    expect(fs.existsSync(result.reportPath)).toBe(true);
+    expect(fs.existsSync(result.latestReportPath)).toBe(true);
+  });
+
+  it('fails closed on LUMA profile mismatch before downstream observation', () => {
+    const report = buildProductionAppCanaryReport({
+      runId: 'production-app-canary-test',
+      startedAtMs: nowMs,
+      completedAtMs: nowMs,
+      command: 'pnpm check:production-app-canary -- --expected-luma-profile production-attestation',
+      repo: { branch: 'coord/test', commit: 'abc123', dirty: false },
+      meshReportPath: '/repo/.tmp/mesh.json',
+      meshReport: meshReport({ status: 'release_ready', release_readiness_blockers: [] }),
+      expectedLumaProfile: 'production-attestation',
+    });
+
+    expect(report.status).toBe('blocked');
+    expect(report.reason).toBe('luma_profile_mismatch');
+    expect(report.luma_profile).toMatchObject({
+      observed: 'none',
+      expected: 'production-attestation',
+      status: 'blocked',
+    });
+  });
+
+  it('still refuses to pass release_ready mesh evidence until real downstream observation exists', () => {
+    const report = buildProductionAppCanaryReport({
+      runId: 'production-app-canary-test',
+      startedAtMs: nowMs,
+      completedAtMs: nowMs,
+      command: 'pnpm check:production-app-canary',
+      repo: { branch: 'coord/test', commit: 'abc123', dirty: false },
+      meshReportPath: '/repo/.tmp/mesh.json',
+      meshReport: meshReport({ status: 'release_ready', release_readiness_blockers: [] }),
+    });
+
+    expect(report.status).toBe('blocked');
+    expect(report.reason).toBe('downstream_observation_not_implemented');
+    expect(report.release_claims.forbidden).toContain('The production app canary passed.');
+    expect(report.checks.find((check) => check.id === 'downstream_observation')).toMatchObject({
+      status: 'blocked',
+      reason: 'downstream_observation_not_implemented',
+    });
+  });
+
+  it('fails closed on stale, dirty, and wrong-commit mesh reports', () => {
+    const report = buildProductionAppCanaryReport({
+      runId: 'production-app-canary-test',
+      startedAtMs: nowMs,
+      completedAtMs: nowMs,
+      command: 'pnpm check:production-app-canary',
+      repo: { branch: 'coord/test', commit: 'abc123', dirty: false },
+      meshReportPath: '/repo/.tmp/mesh.json',
+      meshReport: meshReport({
+        generated_at: '2026-05-06T17:55:00.000Z',
+        repo: {
+          commit: 'def456',
+          dirty: true,
+        },
+      }),
+    });
+
+    expect(report.reason).toBe('stale_mesh_report');
+    expect(report.checks).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: 'mesh_report_fresh', status: 'blocked', reason: 'stale_mesh_report' }),
+      expect.objectContaining({ id: 'mesh_report_clean_repo', status: 'blocked', reason: 'mesh_report_dirty' }),
+      expect.objectContaining({ id: 'mesh_report_current_commit', status: 'blocked', reason: 'mesh_report_wrong_commit' }),
+    ]));
+  });
+});

--- a/packages/e2e/src/mesh/production-readiness-check.mjs
+++ b/packages/e2e/src/mesh/production-readiness-check.mjs
@@ -173,6 +173,16 @@ function sumFinite(values) {
   return values.filter((value) => Number.isFinite(value)).reduce((sum, value) => sum + value, 0);
 }
 
+export function downstreamCanaryMetadata({ scriptImplemented = hasScript('check:production-app-canary') } = {}) {
+  return {
+    command: 'pnpm check:production-app-canary',
+    status: 'skipped',
+    reason: scriptImplemented
+      ? 'downstream full-app production canary is implemented as a separate fail-closed gate and is not folded into mesh readiness status'
+      : 'downstream full-app production canary is not implemented and must not be folded into mesh readiness status',
+  };
+}
+
 function normalizeReportRows(sources, field) {
   return sources.flatMap((source) => {
     const rows = Array.isArray(source.report?.[field]) ? source.report[field] : [];
@@ -829,11 +839,7 @@ function buildReport({ runId, startedAt, completedAt, sources, blockers, command
       ],
       invalidated_by_luma_epoch_change: false,
     },
-    downstream_canary: {
-      command: 'pnpm check:production-app-canary',
-      status: 'skipped',
-      reason: 'downstream full-app production canary is not implemented and must not be folded into mesh readiness status',
-    },
+    downstream_canary: downstreamCanaryMetadata(),
   };
 }
 

--- a/packages/e2e/src/mesh/production-readiness-check.test.mjs
+++ b/packages/e2e/src/mesh/production-readiness-check.test.mjs
@@ -12,6 +12,7 @@ import {
 import {
   SOURCE_GATES,
   conflictRowsForAggregate,
+  downstreamCanaryMetadata,
   validationFailuresForSource,
 } from './production-readiness-check.mjs';
 
@@ -361,6 +362,22 @@ describe('production-readiness source evidence validation', () => {
         source_run_id: 'conflict-report',
       }),
     ]);
+  });
+});
+
+describe('downstreamCanaryMetadata', () => {
+  it('distinguishes implemented separate canary from absent canary', () => {
+    expect(downstreamCanaryMetadata({ scriptImplemented: false })).toMatchObject({
+      command: 'pnpm check:production-app-canary',
+      status: 'skipped',
+      reason: expect.stringContaining('not implemented'),
+    });
+
+    expect(downstreamCanaryMetadata({ scriptImplemented: true })).toMatchObject({
+      command: 'pnpm check:production-app-canary',
+      status: 'skipped',
+      reason: expect.stringContaining('implemented as a separate fail-closed gate'),
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- add a fail-closed `pnpm check:production-app-canary` gate wired through `@vh/e2e`
- record blocked canary reports with explicit mesh report source, repo state, LUMA profile, blockers, downstream surface list, and forbidden claims
- update mesh production-readiness aggregate metadata/docs so the canary is separate and not folded into mesh readiness

## Verification
- `node --check packages/e2e/src/live/production-app-canary.mjs`
- `node --check packages/e2e/src/mesh/production-readiness-check.mjs`
- `pnpm --dir packages/e2e exec vitest run src/live/production-app-canary.vitest.mjs src/mesh/production-readiness-check.test.mjs --config vitest.config.ts --reporter=dot`
- `pnpm --filter @vh/e2e typecheck`
- `pnpm docs:check`
- `git diff --check origin/main...HEAD`
- `node tools/scripts/check-diff-coverage.mjs`
- `pnpm check:mesh:production-readiness` -> `mesh-production-readiness-20260508T202804Z-0a36d65a`, `review_required`, 12 source reports
- `pnpm check:production-app-canary -- --mesh-report .tmp/mesh-production-readiness/latest/mesh-production-readiness-report.json` -> expected exit 1, `production-app-canary-20260508T203947Z-d7dc94f5`, `blocked`, `mesh_not_release_ready`
- `pnpm check:mesh:production-readiness` -> `mesh-production-readiness-20260508T204009Z-81945a6f`, `review_required`, 12 source reports, canary not folded into mesh readiness

Local caveat: local Node is `v23.10.0`; repo engine is `>=20 <23`. CI should run on the repo-supported Node lane.