### PR TITLE
Add public WSS proof harness gate

### DIFF
--- a/docs/ops/mesh-production-topology-drills.md
+++ b/docs/ops/mesh-production-topology-drills.md
@@ -75,6 +75,35 @@ expected WSS relay and HTTPS peer-config origins, plus `'self'`, without dev
 localhost sources or broad `https:`/`wss:` wildcards, and signed peer-config
 rollover is fetched fresh instead of being pinned by service-worker cache.
 
+Run the explicit public WSS deployment proof only when real public endpoints
+are available:
+
+```sh
+VH_MESH_PUBLIC_PEER_CONFIG_URL=https://<public-config-origin>/mesh-peer-config.json \
+VH_MESH_PUBLIC_PEER_CONFIG_PUBLIC_KEY=<public signer key> \
+VH_MESH_PUBLIC_CONFIG_ID=<expected config id> \
+VH_MESH_PUBLIC_WSS_PEERS='["wss://<relay-a>/gun","wss://<relay-b>/gun","wss://<relay-c>/gun"]' \
+VH_MESH_PUBLIC_CSP_CONNECT_SRC="'self' https://<public-config-origin> wss://<relay-a> wss://<relay-b> wss://<relay-c>" \
+VH_MESH_PUBLIC_MINIMUM_PEER_COUNT=3 \
+VH_MESH_PUBLIC_QUORUM_REQUIRED=2 \
+VH_MESH_PUBLIC_APP_URL=https://<public app origin>/ \
+pnpm test:mesh:deployed-wss-peer-config:public
+```
+
+If `VH_MESH_PUBLIC_RELAY_HEALTH_ENDPOINTS` is omitted, the proof derives
+`https://<relay>/healthz`, `/readyz`, and `/metrics` from each WSS peer. If a
+rollover/cache proof is required, provide
+`VH_MESH_PUBLIC_ROLLOVER_PEER_CONFIG_URL`, `VH_MESH_PUBLIC_ROLLOVER_CONFIG_ID`,
+and `VH_MESH_PUBLIC_ROLLOVER_APP_URL` together.
+
+The public command fails closed on missing inputs, localhost/private/link-local
+or `.local` endpoints, `ws://`/`http://` relay peers, unsigned/stale/future
+signed configs, wrong config id, wrong quorum, peer-list mismatch, broad CSP
+tokens, relay health failures, or browser app boot failure. Only a passing
+public run may emit `deployment_scope: public_wss_deployment`; blocked public
+runs emit `public_wss_deployment_blocked` and do not retire the readiness
+blocker.
+
 Run the operator peer-config rollback drill:
 
 ```sh
@@ -352,13 +381,14 @@ gate-run timestamp window. The packet includes
 and copied source reports under `source-reports/<gate>/`; after Slice 14A it has
 12 source reports, including `source-reports/evidence_scrub/`.
 
-For Slice 11A through Slice 14B, a successful aggregate command still reports
+For Slice 11A through Slice 14C, a successful aggregate command still reports
 `status: review_required` while release blockers remain. Expected blockers after
-Slice 14A include the canonical 30-minute soak, public WSS deployment proof,
-downstream full-app canary, and LUMA-gated write coverage through the LUMA
-reader path. After Slice 14B, the aggregate no longer treats the downstream
-full-app canary as unimplemented, but the separate canary command still blocks
-until the mesh report is `release_ready` and real downstream observation exists.
+Slice 14C are public WSS deployment proof and LUMA-gated write coverage through
+the LUMA reader path. After Slice 14D, public WSS proof is implemented as an
+explicit operator-input gate, but the blocker remains until that public command
+passes against real public endpoints. The separate downstream app canary still
+blocks until the mesh report is `release_ready` and real downstream observation
+exists.
 The aggregate command exits non-zero for missing, malformed, dirty, stale,
 failed, command-mismatched, unscrubbed, or incomplete source evidence, and for
 any overclaiming packet that would emit `release_ready` before the blockers are
@@ -423,13 +453,13 @@ was rescanned for raw tokens, private key material, unsafe origins, unsafe
 absolute paths, stale placeholder evidence, overclaims, and disallowed writer
 kinds. The Slice 14B downstream canary command is separate from mesh readiness;
 on current `review_required` mesh evidence, its expected non-zero blocked report
-proves only that the app-level readiness claim is fail-closed. None of these
-outcomes proves
-public WSS
-infrastructure, automatic peer-federation recovery, runtime peer-config key
-rotation without a new trusted-key distribution path, LUMA-gated write state
-resolution, public WSS clock-skew or conflict behavior, or post-M0.B
-LUMA-gated write coverage.
+proves only that the app-level readiness claim is fail-closed. The Slice 14D
+public WSS command proves public WSS deployment only when it exits zero with
+`deployment_scope: public_wss_deployment`; a blocked public attempt proves only
+fail-closed input validation. None of these outcomes proves automatic
+peer-federation recovery, runtime peer-config key rotation without a new
+trusted-key distribution path, LUMA-gated write state resolution, public WSS
+clock-skew or conflict behavior, or post-M0.B LUMA-gated write coverage.
 
 If direct restarted-relay readback is `blocked` or `review_required`, do not tune
 Gun peer behavior indefinitely. The next branch must choose and drill one

--- a/docs/specs/spec-mesh-production-readiness.md
+++ b/docs/specs/spec-mesh-production-readiness.md
@@ -113,6 +113,15 @@ Current head at closeout:
   hermetic `local_tls_wss_profile` with signed HTTPS peer config, three
   `wss://` relays, local peer allowance disabled, CSP `connect-src` checks, and
   service-worker peer-config rollover checks.
+- `pnpm test:mesh:deployed-wss-peer-config:public` is the Slice 14D public WSS
+  proof mode: it requires operator-provided public peer-config URL, signer
+  public key, config id, expected public `wss://` peers, exact CSP
+  `connect-src`, quorum, relay health endpoints or derivable health paths, and
+  public app URL. It fails closed for missing inputs, localhost/private
+  endpoints, insecure schemes, unsigned/stale/future configs, wrong quorum,
+  CSP mismatch, relay health failure, or app boot failure. Only a passing run
+  may emit `deployment_scope: public_wss_deployment`; blocked runs emit
+  `public_wss_deployment_blocked`.
 - `pnpm test:mesh:state-resolution-drills` is the Slice 7C state-resolution
   proof: it writes synthetic non-LUMA §5.10 competing records under
   `vh/__mesh_drills/<run_id>/state_resolution/*`, restarts/heals one relay
@@ -624,9 +633,12 @@ Acceptance gates:
   peer allowance disabled.
 - Slice 6B command exists:
   `pnpm test:mesh:deployed-wss-peer-config`
+- Slice 14D public proof command exists:
+  `pnpm test:mesh:deployed-wss-peer-config:public`
 - Slice 6B report records whether the proof ran against
-  `deployment_scope: local_tls_wss_profile` or a real public deployment. A local
-  TLS profile pass MUST NOT be described as public WSS infrastructure deployed.
+  `deployment_scope: local_tls_wss_profile`, `public_wss_deployment_blocked`,
+  or a passing real public deployment. A local TLS profile pass or blocked
+  public attempt MUST NOT be described as public WSS infrastructure deployed.
 - Health panel reports quorum with actual peer health, not configured URL count.
 - Peer-config fetch is not served from stale service-worker cache during config
   rollover.
@@ -1095,7 +1107,7 @@ interface MeshProductionReadinessReport {
       | 'local_conflict_resolution_fixtures'
       | 'aggregate_production_readiness'
       | 'mesh_evidence_scrub_promotion';
-    deployment_scope?: 'local_tls_wss_profile' | 'public_wss_deployment';
+    deployment_scope?: 'local_tls_wss_profile' | 'public_wss_deployment' | 'public_wss_deployment_blocked';
     started_at: string;
     completed_at: string;
     duration_ms: number;
@@ -1110,13 +1122,13 @@ interface MeshProductionReadinessReport {
     strategy: 'relay_peer_fanout' | 'explicit_replication' | 'authoritative_cluster';
     selected_strategy?: 'explicit_read_repair' | 'scoped_axe' | 'authoritative_cluster';
     selected_strategy_scope?: string;
-    deployment_scope?: 'local_tls_wss_profile' | 'public_wss_deployment';
+    deployment_scope?: 'local_tls_wss_profile' | 'public_wss_deployment' | 'public_wss_deployment_blocked';
     configured_peer_count: number;
     quorum_required: number;
     signed_peer_config: boolean;
     relay_urls_redacted: string[];
     relay_to_relay_peers_configured: boolean;
-    relay_to_relay_auth_mode: 'mtls' | 'peer_bearer_token' | 'private_network_allowlist' | 'signed_peer_handshake';
+    relay_to_relay_auth_mode: 'mtls' | 'peer_bearer_token' | 'private_network_allowlist' | 'signed_peer_handshake' | 'public_tls_wss';
     relay_to_relay_auth_negative_test: 'pass' | 'fail' | 'skipped';
     peer_config_id: string;
     peer_config_issued_at: string;
@@ -1131,7 +1143,7 @@ interface MeshProductionReadinessReport {
       local_mesh_peers_allowed: boolean;
     };
     csp?: {
-      status: 'pass' | 'fail' | 'skipped';
+      status: 'pass' | 'fail' | 'skipped' | 'not_exercised';
       connect_src_expected_origins: string[];
       broad_https_wss_wildcards_allowed: boolean;
     };
@@ -1413,6 +1425,9 @@ Acceptance gates:
   - test namespace cleanup passes
   - peer-config rollback drill passes with fail-closed invalid fixtures and a
     fresh rollback config, not a stale cached config
+  - public WSS deployment proof passes with
+    `run.deployment_scope: public_wss_deployment`; local TLS/WSS evidence and
+    blocked public attempts do not satisfy this item
   - any LUMA-gated write class (drill_writer_kind `'luma'`) was exercised
     against the LUMA reader path, not bypassed via drill writer contract
   - any promoted evidence under `.tmp/mesh-production-readiness/promoted/` or
@@ -1445,6 +1460,35 @@ Downstream full-app canary:
   non-zero by design.
 - Emits a separate report; it may depend on mesh readiness but must not be
   folded into the mesh readiness status.
+
+Public WSS deployment proof:
+
+- Command: `pnpm test:mesh:deployed-wss-peer-config:public`
+- Equivalent aggregate source mode: set
+  `VH_MESH_DEPLOYED_WSS_PUBLIC_PROOF=true` before
+  `pnpm check:mesh:production-readiness` so the deployed-WSS source gate uses
+  public proof behavior while preserving the expected source command.
+- Required inputs: `VH_MESH_PUBLIC_PEER_CONFIG_URL`,
+  `VH_MESH_PUBLIC_PEER_CONFIG_PUBLIC_KEY`, `VH_MESH_PUBLIC_CONFIG_ID`,
+  `VH_MESH_PUBLIC_WSS_PEERS`, `VH_MESH_PUBLIC_CSP_CONNECT_SRC`,
+  `VH_MESH_PUBLIC_MINIMUM_PEER_COUNT`, `VH_MESH_PUBLIC_QUORUM_REQUIRED`, and
+  `VH_MESH_PUBLIC_APP_URL`.
+- Optional input: `VH_MESH_PUBLIC_RELAY_HEALTH_ENDPOINTS`, as a JSON object
+  keyed by peer URL, host, or origin. When omitted, the harness derives
+  `https://<peer>/healthz`, `/readyz`, and `/metrics` from each WSS peer.
+- Optional rollover proof requires all of
+  `VH_MESH_PUBLIC_ROLLOVER_PEER_CONFIG_URL`,
+  `VH_MESH_PUBLIC_ROLLOVER_CONFIG_ID`, and
+  `VH_MESH_PUBLIC_ROLLOVER_APP_URL`.
+- The command exits non-zero and writes a blocked deployed-WSS source report
+  when inputs are missing or point at localhost, loopback, private,
+  link-local, `.local`, insecure, unsigned, stale, future-issued,
+  wrong-config, wrong-peer, wrong-quorum, broad-CSP, unhealthy, or non-booting
+  public surfaces.
+- Only a passing public run may emit
+  `run.deployment_scope: public_wss_deployment`; blocked public evidence uses
+  `public_wss_deployment_blocked` and never removes
+  `public-wss-deployment-proof`.
 
 ### Slice 12 - Operational Runbook And Rollback
 
@@ -2113,6 +2157,7 @@ Implemented mesh commands:
 
 - `pnpm test:mesh:topology-drills`
 - `pnpm test:mesh:deployed-wss-peer-config`
+- `pnpm test:mesh:deployed-wss-peer-config:public`
 - `pnpm test:mesh:state-resolution-drills`
   - `pnpm test:mesh:tombstone-drills` may remain as a compatibility alias, but
     the canonical command covers every §5.10 state-resolution rule, not only
@@ -2370,9 +2415,30 @@ Still not allowed after Slice 14B downstream production-app canary gate v1:
 - "Downstream `/api/analyze`, synthesis publication, point stance, or
   story-thread flows were observed by the canary."
 
-Allowed after Slices 6B through 14A plus downstream LUMA-gated coverage pass
-(under `schema_epoch: post_luma_m0b` with all LUMA-gated write classes drilled
-through the LUMA reader path):
+Allowed after Slice 14D public WSS deployment proof harness v1:
+
+- "`pnpm test:mesh:deployed-wss-peer-config:public` exists and writes a
+  deployed-WSS source report that fails closed when required public inputs are
+  missing, private/local, unsigned, stale, wrong-quorum, CSP-mismatched,
+  unhealthy, or non-booting."
+- "The public proof harness only emits
+  `run.deployment_scope: public_wss_deployment` after real public WSS inputs
+  pass signed peer-config, exact peer-list, quorum, relay health, CSP, and app
+  boot checks."
+- "Without real public endpoints, the expected result is a blocked source report
+  with `deployment_scope: public_wss_deployment_blocked`; mesh readiness keeps
+  `public-wss-deployment-proof`."
+
+Still not allowed after Slice 14D harness v1 without a passing public run:
+
+- "Public WSS infrastructure is production-proven."
+- "Public WSS conflict, partition/heal, clock-skew, rollback, or soak behavior
+  is production-proven."
+- "The mesh is `release_ready` while LUMA-gated write coverage remains pending."
+
+Allowed after a passing public WSS proof plus downstream LUMA-gated coverage
+pass (under `schema_epoch: post_luma_m0b` with all LUMA-gated write classes
+drilled through the LUMA reader path):
 
 - "The mesh has a production WSS three-relay topology with signed peer config,
   authenticated relay fallbacks, named health degradation, peer-failure and

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "test:mesh:browser-canary": "VITE_GUN_PEERS='[\"http://127.0.0.1:7788/gun\",\"http://127.0.0.1:7789/gun\",\"http://127.0.0.1:7790/gun\"]' VITE_GUN_PEER_MINIMUM=3 VITE_GUN_PEER_QUORUM_REQUIRED=2 VITE_VH_ALLOW_LOCAL_MESH_PEERS=true VITE_VH_GUN_LOCAL_STORAGE=false VITE_VH_SHOW_HEALTH=true pnpm --filter @vh/web-pwa build && pnpm --filter @vh/e2e test:mesh:browser-canary",
     "test:mesh:signed-peer-config-canary": "node ./packages/e2e/src/mesh/signed-peer-config-canary.mjs",
     "test:mesh:deployed-wss-peer-config": "pnpm --filter @vh/e2e test:mesh:deployed-wss-peer-config",
+    "test:mesh:deployed-wss-peer-config:public": "pnpm --filter @vh/e2e test:mesh:deployed-wss-peer-config:public",
     "test:mesh:topology-drills": "pnpm --filter @vh/e2e test:mesh:topology-drills",
     "test:mesh:state-resolution-drills": "pnpm --filter @vh/e2e test:mesh:state-resolution-drills",
     "test:mesh:disconnect-drills": "pnpm --filter @vh/e2e test:mesh:disconnect-drills",

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -26,6 +26,7 @@
     "test:mesh:browser-canary": "playwright test --config=playwright.mesh-canary.config.ts src/mesh/browser-mesh-canary.spec.ts",
     "test:mesh:signed-peer-config-canary": "node ./src/mesh/signed-peer-config-canary.mjs",
     "test:mesh:deployed-wss-peer-config": "node ./src/mesh/deployed-wss-peer-config-canary.mjs",
+    "test:mesh:deployed-wss-peer-config:public": "VH_MESH_DEPLOYED_WSS_PUBLIC_PROOF=true node ./src/mesh/deployed-wss-peer-config-canary.mjs",
     "test:mesh:topology-drills": "node ./src/mesh/production-topology-drills.mjs",
     "test:mesh:state-resolution-drills": "node ./src/mesh/state-resolution-drills.mjs",
     "test:mesh:disconnect-drills": "node ./src/mesh/disconnect-drills.mjs",

--- a/packages/e2e/src/mesh/deployed-wss-peer-config-canary.mjs
+++ b/packages/e2e/src/mesh/deployed-wss-peer-config-canary.mjs
@@ -13,6 +13,29 @@ const repoRoot = path.resolve(__dirname, '../../../..');
 const gunRequire = createRequire(path.join(repoRoot, 'packages/gun-client/package.json'));
 const SEA = gunRequire('gun/sea');
 const DEFAULT_TTL_MS = 60 * 60 * 1000;
+const DEFAULT_PUBLIC_CONFIG_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+const DEFAULT_PUBLIC_FETCH_TIMEOUT_MS = 10_000;
+const DEFAULT_PUBLIC_APP_BOOT_TIMEOUT_MS = 30_000;
+const LOCAL_COMMAND = 'pnpm test:mesh:deployed-wss-peer-config';
+const PUBLIC_COMMAND = 'pnpm test:mesh:deployed-wss-peer-config:public';
+const PUBLIC_ENV_FLAG = 'VH_MESH_DEPLOYED_WSS_PUBLIC_PROOF';
+const PUBLIC_ENV_KEYS = {
+  appUrl: ['VH_MESH_PUBLIC_APP_URL'],
+  configId: ['VH_MESH_PUBLIC_CONFIG_ID'],
+  peerConfigUrl: ['VH_MESH_PUBLIC_PEER_CONFIG_URL', 'VH_MESH_PUBLIC_CONFIG_URL'],
+  publicKey: ['VH_MESH_PUBLIC_PEER_CONFIG_PUBLIC_KEY', 'VH_MESH_PUBLIC_SIGNER_PUBLIC_KEY', 'VITE_GUN_PEER_CONFIG_PUBLIC_KEY'],
+  peers: ['VH_MESH_PUBLIC_WSS_PEERS'],
+  cspConnectSrc: ['VH_MESH_PUBLIC_CSP_CONNECT_SRC'],
+  minimumPeerCount: ['VH_MESH_PUBLIC_MINIMUM_PEER_COUNT'],
+  quorumRequired: ['VH_MESH_PUBLIC_QUORUM_REQUIRED'],
+  healthEndpoints: ['VH_MESH_PUBLIC_RELAY_HEALTH_ENDPOINTS'],
+  configMaxAgeMs: ['VH_MESH_PUBLIC_CONFIG_MAX_AGE_MS'],
+  fetchTimeoutMs: ['VH_MESH_PUBLIC_FETCH_TIMEOUT_MS'],
+  appBootTimeoutMs: ['VH_MESH_PUBLIC_APP_BOOT_TIMEOUT_MS'],
+  rolloverPeerConfigUrl: ['VH_MESH_PUBLIC_ROLLOVER_PEER_CONFIG_URL'],
+  rolloverConfigId: ['VH_MESH_PUBLIC_ROLLOVER_CONFIG_ID'],
+  rolloverAppUrl: ['VH_MESH_PUBLIC_ROLLOVER_APP_URL'],
+};
 
 function makeId(prefix) {
   return `${prefix}-${Date.now()}-${crypto.randomBytes(4).toString('hex')}`;
@@ -110,10 +133,680 @@ function originOf(url) {
   return new URL(url).origin;
 }
 
+function safeOriginOf(url) {
+  try {
+    return originOf(url);
+  } catch {
+    return null;
+  }
+}
+
 function copyIfExists(source, destination) {
-  if (fs.existsSync(source)) {
+  if (source && fs.existsSync(source)) {
     fs.copyFileSync(source, destination);
   }
+}
+
+function publicModeEnabled(argv = process.argv.slice(2), env = process.env) {
+  const lifecycle = env.npm_lifecycle_event || '';
+  const flag = String(env[PUBLIC_ENV_FLAG] || '').trim().toLowerCase();
+  return argv.includes('--public') || lifecycle.endsWith(':public') || ['1', 'true', 'yes', 'on'].includes(flag);
+}
+
+function envValue(env, keys) {
+  for (const key of keys) {
+    const value = env[key];
+    if (typeof value === 'string' && value.trim()) {
+      return value.trim();
+    }
+  }
+  return '';
+}
+
+function parseList(raw) {
+  if (!raw || !raw.trim()) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      return parsed.map((entry) => String(entry).trim()).filter(Boolean);
+    }
+  } catch {
+    // fall through to comma/space parsing
+  }
+  return raw.split(/[\s,]+/).map((entry) => entry.trim()).filter(Boolean);
+}
+
+function parsePositiveInteger(raw, fallback = null) {
+  if (!raw || !raw.trim()) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+function normalizeGunPeer(peer) {
+  if (typeof peer !== 'string') return '';
+  const trimmed = peer.trim();
+  if (!trimmed) return '';
+  return trimmed.endsWith('/gun') ? trimmed : `${trimmed.replace(/\/+$/, '')}/gun`;
+}
+
+function uniqueStrings(values) {
+  return Array.from(new Set(values.filter((value) => typeof value === 'string' && value.length > 0)));
+}
+
+function sameOrderedValues(left, right) {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
+function hostHash(value) {
+  return crypto.createHash('sha256').update(value).digest('hex').slice(0, 12);
+}
+
+function redactedPublicUrl(value) {
+  try {
+    const url = new URL(value);
+    const suffix = url.pathname && url.pathname !== '/' ? url.pathname : '';
+    return `${url.protocol}//redacted-${hostHash(url.host)}${suffix}`;
+  } catch {
+    return 'redacted-invalid-url';
+  }
+}
+
+function hostnameIsPublic(hostname) {
+  const normalized = hostname.trim().toLowerCase().replace(/^\[(.*)\]$/, '$1');
+  if (!normalized) return { ok: false, reason: 'missing host' };
+  if (
+    normalized === 'localhost' ||
+    normalized.endsWith('.localhost') ||
+    normalized.endsWith('.local') ||
+    normalized.endsWith('.lan') ||
+    normalized.endsWith('.home') ||
+    normalized.endsWith('.internal')
+  ) {
+    return { ok: false, reason: `host ${hostname} is local/private` };
+  }
+  if (!normalized.includes('.') && net.isIP(normalized) === 0) {
+    return { ok: false, reason: `host ${hostname} is not a public DNS name` };
+  }
+
+  if (net.isIP(normalized) === 4) {
+    const parts = normalized.split('.').map((part) => Number.parseInt(part, 10));
+    const [a, b] = parts;
+    const privateRange =
+      a === 0 ||
+      a === 10 ||
+      a === 127 ||
+      (a === 100 && b >= 64 && b <= 127) ||
+      (a === 169 && b === 254) ||
+      (a === 172 && b >= 16 && b <= 31) ||
+      (a === 192 && b === 168) ||
+      (a === 198 && (b === 18 || b === 19)) ||
+      a >= 224;
+    return privateRange ? { ok: false, reason: `host ${hostname} is not publicly routable` } : { ok: true };
+  }
+
+  if (net.isIP(normalized) === 6) {
+    const first = Number.parseInt(normalized.split(':')[0] || '0', 16);
+    const privateRange =
+      normalized === '::' ||
+      normalized === '::1' ||
+      normalized.startsWith('fe80:') ||
+      (Number.isFinite(first) && (first & 0xfe00) === 0xfc00);
+    return privateRange ? { ok: false, reason: `host ${hostname} is not publicly routable` } : { ok: true };
+  }
+
+  return { ok: true };
+}
+
+function endpointFailures(value, { label, protocols, allowSelf = false }) {
+  if (allowSelf && value === "'self'") return [];
+  const failures = [];
+  let url;
+  try {
+    url = new URL(value);
+  } catch {
+    return [`${label} ${value || 'missing'} is not a valid URL`];
+  }
+  if (!protocols.includes(url.protocol)) {
+    failures.push(`${label} ${value} must use ${protocols.join(' or ')}`);
+  }
+  const host = hostnameIsPublic(url.hostname);
+  if (!host.ok) {
+    failures.push(`${label} ${value} rejected: ${host.reason}`);
+  }
+  return failures;
+}
+
+function cspConnectSrcFailures(tokens, requiredTokens) {
+  const failures = [];
+  for (const token of tokens) {
+    if (token === "'self'") continue;
+    if (token.includes('*') || token === 'https:' || token === 'wss:' || token === 'http:' || token === 'ws:') {
+      failures.push(`CSP connect-src token ${token} is too broad`);
+      continue;
+    }
+    failures.push(...endpointFailures(token, {
+      label: 'CSP connect-src token',
+      protocols: ['https:', 'wss:'],
+      allowSelf: true,
+    }));
+  }
+  const missing = requiredTokens.filter((token) => !tokens.includes(token));
+  const extra = tokens.filter((token) => !requiredTokens.includes(token));
+  if (missing.length > 0) {
+    failures.push(`CSP connect-src missing required tokens: ${missing.join(', ')}`);
+  }
+  if (extra.length > 0) {
+    failures.push(`CSP connect-src has unexpected tokens: ${extra.join(', ')}`);
+  }
+  return uniqueStrings(failures);
+}
+
+function peerOrigins(peers) {
+  return peers.map((peer) => safeOriginOf(peer)).filter(Boolean);
+}
+
+function publicInputContainsPrivateMaterial(value, label) {
+  const normalized = String(value || '');
+  if (/BEGIN [A-Z ]*PRIVATE KEY/.test(normalized) || /\b(privateKey|priv|secretKey)\b/i.test(normalized)) {
+    return [`${label} appears to contain private signing material`];
+  }
+  return [];
+}
+
+function derivedHealthEndpoints(peer) {
+  const base = new URL(peer);
+  base.protocol = 'https:';
+  base.search = '';
+  base.hash = '';
+  const withPath = (pathname) => {
+    const url = new URL(base);
+    url.pathname = pathname;
+    return url.toString();
+  };
+  return {
+    peer,
+    healthz: withPath('/healthz'),
+    readyz: withPath('/readyz'),
+    metrics: withPath('/metrics'),
+    source: 'derived_from_wss_peer',
+  };
+}
+
+function normalizeHealthEndpointRecord(peer, value) {
+  if (typeof value === 'string') {
+    const base = new URL(value);
+    base.search = '';
+    base.hash = '';
+    const withPath = (pathname) => {
+      const url = new URL(base);
+      url.pathname = pathname;
+      return url.toString();
+    };
+    return {
+      peer,
+      healthz: withPath('/healthz'),
+      readyz: withPath('/readyz'),
+      metrics: withPath('/metrics'),
+      source: 'operator_base_url',
+    };
+  }
+  if (value && typeof value === 'object') {
+    return {
+      peer,
+      healthz: value.healthz || value.health || '',
+      readyz: value.readyz || value.ready || '',
+      metrics: value.metrics || '',
+      source: 'operator_endpoint_map',
+    };
+  }
+  return {
+    peer,
+    healthz: '',
+    readyz: '',
+    metrics: '',
+    source: 'operator_endpoint_map',
+  };
+}
+
+function buildHealthEndpointPlan(peers, raw) {
+  const failures = [];
+  const records = [];
+  if (!raw) {
+    records.push(...peers.map(derivedHealthEndpoints));
+  } else {
+    let parsed = null;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      failures.push('VH_MESH_PUBLIC_RELAY_HEALTH_ENDPOINTS must be JSON when provided');
+    }
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      for (const peer of peers) {
+        const peerUrl = new URL(peer);
+        const httpsOriginUrl = new URL(peer);
+        httpsOriginUrl.protocol = 'https:';
+        const value = parsed[peer] || parsed[peerUrl.host] || parsed[peerUrl.origin] || parsed[httpsOriginUrl.origin];
+        if (!value) {
+          failures.push(`missing health endpoint mapping for peer ${redactedPublicUrl(peer)}`);
+        }
+        records.push(normalizeHealthEndpointRecord(peer, value));
+      }
+    } else if (parsed) {
+      failures.push('VH_MESH_PUBLIC_RELAY_HEALTH_ENDPOINTS must be an object keyed by peer URL, host, or origin');
+    }
+  }
+
+  for (const record of records) {
+    for (const key of ['healthz', 'readyz', 'metrics']) {
+      failures.push(...endpointFailures(record[key], {
+        label: `${key} endpoint for ${redactedPublicUrl(record.peer)}`,
+        protocols: ['https:'],
+      }));
+    }
+  }
+  return { records, failures: uniqueStrings(failures) };
+}
+
+export function parsePublicProofConfig(env = process.env) {
+  const failures = [];
+  const peerConfigUrl = envValue(env, PUBLIC_ENV_KEYS.peerConfigUrl);
+  const publicKey = envValue(env, PUBLIC_ENV_KEYS.publicKey);
+  const configId = envValue(env, PUBLIC_ENV_KEYS.configId);
+  const appUrl = envValue(env, PUBLIC_ENV_KEYS.appUrl);
+  const peers = uniqueStrings(parseList(envValue(env, PUBLIC_ENV_KEYS.peers)).map(normalizeGunPeer));
+  const cspConnectSrc = uniqueStrings(parseList(envValue(env, PUBLIC_ENV_KEYS.cspConnectSrc)));
+  const minimumPeerCount = parsePositiveInteger(envValue(env, PUBLIC_ENV_KEYS.minimumPeerCount));
+  const quorumRequired = parsePositiveInteger(envValue(env, PUBLIC_ENV_KEYS.quorumRequired));
+  const configMaxAgeMs = parsePositiveInteger(envValue(env, PUBLIC_ENV_KEYS.configMaxAgeMs), DEFAULT_PUBLIC_CONFIG_MAX_AGE_MS);
+  const fetchTimeoutMs = parsePositiveInteger(envValue(env, PUBLIC_ENV_KEYS.fetchTimeoutMs), DEFAULT_PUBLIC_FETCH_TIMEOUT_MS);
+  const appBootTimeoutMs = parsePositiveInteger(envValue(env, PUBLIC_ENV_KEYS.appBootTimeoutMs), DEFAULT_PUBLIC_APP_BOOT_TIMEOUT_MS);
+  const rolloverPeerConfigUrl = envValue(env, PUBLIC_ENV_KEYS.rolloverPeerConfigUrl);
+  const rolloverConfigId = envValue(env, PUBLIC_ENV_KEYS.rolloverConfigId);
+  const rolloverAppUrl = envValue(env, PUBLIC_ENV_KEYS.rolloverAppUrl);
+
+  if (!peerConfigUrl) failures.push('missing VH_MESH_PUBLIC_PEER_CONFIG_URL');
+  if (!publicKey) failures.push('missing VH_MESH_PUBLIC_PEER_CONFIG_PUBLIC_KEY');
+  if (!configId) failures.push('missing VH_MESH_PUBLIC_CONFIG_ID');
+  if (!appUrl) failures.push('missing VH_MESH_PUBLIC_APP_URL');
+  if (peers.length === 0) failures.push('missing VH_MESH_PUBLIC_WSS_PEERS');
+  if (cspConnectSrc.length === 0) failures.push('missing VH_MESH_PUBLIC_CSP_CONNECT_SRC');
+  if (!minimumPeerCount) failures.push('missing or invalid VH_MESH_PUBLIC_MINIMUM_PEER_COUNT');
+  if (!quorumRequired) failures.push('missing or invalid VH_MESH_PUBLIC_QUORUM_REQUIRED');
+
+  failures.push(...publicInputContainsPrivateMaterial(publicKey, 'public key input'));
+  if (peerConfigUrl) failures.push(...endpointFailures(peerConfigUrl, { label: 'public peer-config URL', protocols: ['https:'] }));
+  if (appUrl) failures.push(...endpointFailures(appUrl, { label: 'public app URL', protocols: ['https:'] }));
+  for (const peer of peers) {
+    failures.push(...endpointFailures(peer, { label: 'public WSS peer', protocols: ['wss:'] }));
+  }
+  if (minimumPeerCount && peers.length > 0 && minimumPeerCount > peers.length) {
+    failures.push(`minimum peer count ${minimumPeerCount} exceeds expected peer count ${peers.length}`);
+  }
+  if (quorumRequired && peers.length > 0 && quorumRequired > peers.length) {
+    failures.push(`quorum ${quorumRequired} exceeds expected peer count ${peers.length}`);
+  }
+
+  const peerConfigOrigin = safeOriginOf(peerConfigUrl);
+  const requiredCspTokens = peerConfigOrigin
+    ? uniqueStrings(["'self'", peerConfigOrigin, ...peerOrigins(peers)])
+    : uniqueStrings(["'self'", ...peerOrigins(peers)]);
+  if (cspConnectSrc.length > 0) {
+    failures.push(...cspConnectSrcFailures(cspConnectSrc, requiredCspTokens));
+  }
+
+  const healthPlan = buildHealthEndpointPlan(peers, envValue(env, PUBLIC_ENV_KEYS.healthEndpoints));
+  failures.push(...healthPlan.failures);
+
+  const rolloverInputs = [rolloverPeerConfigUrl, rolloverConfigId, rolloverAppUrl].filter(Boolean);
+  if (rolloverInputs.length > 0 && rolloverInputs.length !== 3) {
+    failures.push('public rollover proof requires VH_MESH_PUBLIC_ROLLOVER_PEER_CONFIG_URL, VH_MESH_PUBLIC_ROLLOVER_CONFIG_ID, and VH_MESH_PUBLIC_ROLLOVER_APP_URL together');
+  }
+  if (rolloverPeerConfigUrl) {
+    failures.push(...endpointFailures(rolloverPeerConfigUrl, { label: 'public rollover peer-config URL', protocols: ['https:'] }));
+  }
+  if (rolloverAppUrl) {
+    failures.push(...endpointFailures(rolloverAppUrl, { label: 'public rollover app URL', protocols: ['https:'] }));
+  }
+
+  return {
+    ok: failures.length === 0,
+    failures: uniqueStrings(failures),
+    config: {
+      appUrl,
+      peerConfigUrl,
+      publicKey,
+      configId,
+      peers,
+      cspConnectSrc,
+      requiredCspTokens,
+      minimumPeerCount,
+      quorumRequired,
+      configMaxAgeMs,
+      fetchTimeoutMs,
+      appBootTimeoutMs,
+      healthEndpoints: healthPlan.records,
+      rollover: rolloverInputs.length === 3
+        ? { peerConfigUrl: rolloverPeerConfigUrl, configId: rolloverConfigId, appUrl: rolloverAppUrl }
+        : null,
+    },
+  };
+}
+
+function parsePeerConfigEnvelope(input) {
+  if (!input || typeof input !== 'object') {
+    return { payload: null, signature: '', signerPub: '' };
+  }
+  if ('payload' in input) {
+    return {
+      payload: typeof input.payload === 'string' ? JSON.parse(input.payload) : input.payload,
+      signature: typeof input.signature === 'string' ? input.signature : '',
+      signerPub: typeof input.signerPub === 'string' ? input.signerPub : '',
+    };
+  }
+  return {
+    payload: input,
+    signature: typeof input.signature === 'string' ? input.signature : '',
+    signerPub: typeof input.signerPub === 'string' ? input.signerPub : '',
+  };
+}
+
+export async function validatePublicPeerConfigEnvelope({ envelope, expected, nowMs = Date.now() }) {
+  const failures = [];
+  let parsed;
+  try {
+    parsed = parsePeerConfigEnvelope(envelope);
+  } catch (error) {
+    return { ok: false, failures: [`peer config envelope parse failed: ${error instanceof Error ? error.message : String(error)}`], payload: null };
+  }
+  const { payload, signature, signerPub } = parsed;
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    failures.push('peer config payload is missing or invalid');
+  }
+  if (!signature) {
+    failures.push('peer config is unsigned');
+  }
+  if (signerPub && signerPub !== expected.publicKey) {
+    failures.push('peer config signer public key does not match expected public key');
+  }
+  if (signature && payload) {
+    try {
+      const verified = await SEA.verify(signature, expected.publicKey);
+      const canonicalPayload = canonicalize(payload);
+      if (verified !== canonicalPayload && canonicalize(verified) !== canonicalPayload) {
+        failures.push('signed peer config verification failed');
+      }
+    } catch (error) {
+      failures.push(`signed peer config verification failed: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+  if (payload && typeof payload === 'object') {
+    const normalizedPeers = Array.isArray(payload.peers) ? payload.peers.map(normalizeGunPeer).filter(Boolean) : [];
+    if (payload.schemaVersion !== 'mesh-peer-config-v1') {
+      failures.push(`unexpected peer config schemaVersion ${payload.schemaVersion || 'missing'}`);
+    }
+    if (payload.configId !== expected.configId) {
+      failures.push(`expected peer config id ${expected.configId}, observed ${payload.configId || 'missing'}`);
+    }
+    if (!sameOrderedValues(normalizedPeers, expected.peers)) {
+      failures.push('peer config peers do not exactly match expected public peers');
+    }
+    if (payload.minimumPeerCount !== expected.minimumPeerCount) {
+      failures.push(`expected minimumPeerCount ${expected.minimumPeerCount}, observed ${payload.minimumPeerCount || 'missing'}`);
+    }
+    if (payload.quorumRequired !== expected.quorumRequired) {
+      failures.push(`expected quorumRequired ${expected.quorumRequired}, observed ${payload.quorumRequired || 'missing'}`);
+    }
+    if (payload.quorumRequired > normalizedPeers.length) {
+      failures.push('peer config quorumRequired exceeds configured peers');
+    }
+    if (payload.minimumPeerCount > normalizedPeers.length) {
+      failures.push('peer config minimumPeerCount exceeds configured peers');
+    }
+    for (const peer of normalizedPeers) {
+      failures.push(...endpointFailures(peer, { label: 'signed peer config WSS peer', protocols: ['wss:'] }));
+    }
+
+    const issuedAt = typeof payload.issuedAt === 'number' && Number.isFinite(payload.issuedAt) ? payload.issuedAt : null;
+    const expiresAt = typeof payload.expiresAt === 'number' && Number.isFinite(payload.expiresAt) ? payload.expiresAt : null;
+    if (!issuedAt) failures.push('peer config issuedAt is missing or invalid');
+    if (!expiresAt) failures.push('peer config expiresAt is missing or invalid');
+    if (issuedAt && issuedAt > nowMs + 30_000) failures.push('peer config is not yet valid');
+    if (expiresAt && expiresAt <= nowMs) failures.push('peer config is expired');
+    if (issuedAt && expiresAt && expiresAt <= issuedAt) failures.push('peer config expiresAt must be after issuedAt');
+    if (issuedAt && expected.configMaxAgeMs && nowMs - issuedAt > expected.configMaxAgeMs) {
+      failures.push(`peer config issuedAt is older than ${expected.configMaxAgeMs}ms`);
+    }
+  }
+  return {
+    ok: failures.length === 0,
+    failures: uniqueStrings(failures),
+    payload,
+  };
+}
+
+async function fetchJson(url, timeoutMs) {
+  const response = await fetch(url, {
+    cache: 'no-store',
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  const text = await response.text();
+  let json = null;
+  try {
+    json = JSON.parse(text);
+  } catch (error) {
+    throw new Error(`invalid JSON from ${redactedPublicUrl(url)}: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  return { response, json, text };
+}
+
+async function validateFetchedPeerConfig({ url, expected, gateName }) {
+  const startedAt = Date.now();
+  const failures = [];
+  let envelope = null;
+  let payload = null;
+  try {
+    const fetched = await fetchJson(url, expected.fetchTimeoutMs);
+    envelope = fetched.json;
+    if (!fetched.response.ok) {
+      failures.push(`peer config fetch failed with HTTP ${fetched.response.status}`);
+    }
+    const validation = await validatePublicPeerConfigEnvelope({
+      envelope,
+      expected,
+      nowMs: Date.now(),
+    });
+    payload = validation.payload;
+    failures.push(...validation.failures);
+  } catch (error) {
+    failures.push(error instanceof Error ? error.message : String(error));
+  }
+  const completedAt = Date.now();
+  return {
+    gate: {
+      name: gateName,
+      status: failures.length === 0 ? 'pass' : 'fail',
+      command: `fetch ${redactedPublicUrl(url)}`,
+      duration_ms: completedAt - startedAt,
+      exit_code: failures.length === 0 ? 0 : 1,
+      reason: failures.length > 0 ? failures.join('; ') : undefined,
+    },
+    envelope,
+    payload,
+    failures,
+  };
+}
+
+async function runHealthChecks(config) {
+  const startedAt = Date.now();
+  const failures = [];
+  const observations = [];
+  for (const record of config.healthEndpoints) {
+    for (const key of ['healthz', 'readyz', 'metrics']) {
+      try {
+        const response = await fetch(record[key], {
+          cache: 'no-store',
+          signal: AbortSignal.timeout(config.fetchTimeoutMs),
+        });
+        const text = await response.text();
+        observations.push({
+          peer: redactedPublicUrl(record.peer),
+          endpoint: key,
+          url: redactedPublicUrl(record[key]),
+          status: response.status,
+          body_bytes: text.length,
+        });
+        if (!response.ok) {
+          failures.push(`${key} endpoint for ${redactedPublicUrl(record.peer)} returned HTTP ${response.status}`);
+        }
+        if (key === 'metrics' && text.trim().length === 0) {
+          failures.push(`metrics endpoint for ${redactedPublicUrl(record.peer)} returned an empty body`);
+        }
+        if ((key === 'healthz' || key === 'readyz') && text.trim().startsWith('{')) {
+          try {
+            const body = JSON.parse(text);
+            if (body && typeof body === 'object' && body.ok === false) {
+              failures.push(`${key} endpoint for ${redactedPublicUrl(record.peer)} returned ok=false`);
+            }
+          } catch {
+            failures.push(`${key} endpoint for ${redactedPublicUrl(record.peer)} returned malformed JSON`);
+          }
+        }
+      } catch (error) {
+        failures.push(`${key} endpoint for ${redactedPublicUrl(record.peer)} failed: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    }
+  }
+  const completedAt = Date.now();
+  return {
+    gate: {
+      name: 'public-wss-relay-health-ready-metrics',
+      status: failures.length === 0 ? 'pass' : 'fail',
+      command: 'fetch public relay healthz/readyz/metrics endpoints',
+      duration_ms: completedAt - startedAt,
+      exit_code: failures.length === 0 ? 0 : 1,
+      reason: failures.length > 0 ? failures.join('; ') : undefined,
+    },
+    observations,
+    failures,
+  };
+}
+
+function extractConnectSrcTokens(cspText) {
+  if (!cspText) return [];
+  const connectSrc = cspText
+    .split(';')
+    .map((entry) => entry.trim())
+    .find((entry) => entry.startsWith('connect-src '));
+  return connectSrc ? uniqueStrings(connectSrc.split(/\s+/).slice(1)) : [];
+}
+
+async function runAppBoot({ config, appUrl, expectedConfigId, gateName }) {
+  const startedAt = Date.now();
+  const failures = [];
+  const expectedHosts = config.peers.map((peer) => new URL(peer).host);
+  let proof = null;
+  let cspTokens = [];
+  let openedHosts = [];
+  let browser = null;
+  try {
+    const { chromium } = await import('@playwright/test');
+    browser = await chromium.launch({ headless: true });
+    const page = await browser.newPage();
+    await page.addInitScript(() => {
+      const nativeWebSocket = window.WebSocket;
+      const openedUrls = [];
+      class TrackingWebSocket extends nativeWebSocket {
+        constructor(url, protocols) {
+          openedUrls.push(String(url));
+          super(url, protocols);
+        }
+      }
+      Object.defineProperties(TrackingWebSocket, {
+        CONNECTING: { value: nativeWebSocket.CONNECTING },
+        OPEN: { value: nativeWebSocket.OPEN },
+        CLOSING: { value: nativeWebSocket.CLOSING },
+        CLOSED: { value: nativeWebSocket.CLOSED },
+      });
+      window.WebSocket = TrackingWebSocket;
+      window.__VH_PUBLIC_WSS_PROOF__ = {
+        openedUrls: () => [...openedUrls],
+      };
+    });
+    const response = await page.goto(appUrl, {
+      waitUntil: 'domcontentloaded',
+      timeout: config.appBootTimeoutMs,
+    });
+    if (!response || !response.ok()) {
+      failures.push(`public app boot returned HTTP ${response?.status() ?? 'missing response'}`);
+    }
+    const headerCsp = response?.headers()?.['content-security-policy'] || '';
+    const metaCsp = await page.locator('meta[http-equiv="Content-Security-Policy"]').first().getAttribute('content').catch(() => '');
+    cspTokens = extractConnectSrcTokens(headerCsp || metaCsp || '');
+    failures.push(...cspConnectSrcFailures(cspTokens, config.requiredCspTokens));
+
+    const handle = await page.waitForFunction(() => {
+      const proofValue = window.__VH_PEER_TOPOLOGY_PROOF__;
+      return proofValue?.status ? proofValue : false;
+    }, null, { timeout: config.appBootTimeoutMs });
+    proof = await handle.jsonValue();
+    if (proof?.status !== 'resolved') {
+      failures.push(`public app peer topology proof status is ${proof?.status || 'missing'}`);
+    }
+    const topology = proof?.topology || {};
+    if (topology.source !== 'remote-config') failures.push(`public app peer topology source is ${topology.source || 'missing'}`);
+    if (topology.signed !== true) failures.push('public app peer topology is not signed');
+    if (topology.allowLocalPeers !== false) failures.push('public app allows local mesh peers');
+    if (topology.configId !== expectedConfigId) failures.push(`public app configId ${topology.configId || 'missing'} does not match ${expectedConfigId}`);
+    if (!sameOrderedValues(topology.peers || [], config.peers)) failures.push('public app peers do not exactly match expected public peers');
+    if (topology.minimumPeerCount !== config.minimumPeerCount) failures.push(`public app minimumPeerCount ${topology.minimumPeerCount || 'missing'} does not match ${config.minimumPeerCount}`);
+    if (topology.quorumRequired !== config.quorumRequired) failures.push(`public app quorumRequired ${topology.quorumRequired || 'missing'} does not match ${config.quorumRequired}`);
+
+    await page.waitForSelector('[data-testid="feed-shell"]', { timeout: config.appBootTimeoutMs });
+    await page.waitForFunction((hosts) => {
+      const urls = window.__VH_PUBLIC_WSS_PROOF__?.openedUrls?.() || [];
+      const opened = Array.from(new Set(urls.map((url) => {
+        try {
+          return new URL(url).host;
+        } catch {
+          return null;
+        }
+      }).filter(Boolean)));
+      return hosts.every((host) => opened.includes(host));
+    }, expectedHosts, { timeout: config.appBootTimeoutMs });
+    openedHosts = await page.evaluate(() => {
+      const urls = window.__VH_PUBLIC_WSS_PROOF__?.openedUrls?.() || [];
+      return Array.from(new Set(urls.map((url) => {
+        try {
+          return new URL(url).host;
+        } catch {
+          return null;
+        }
+      }).filter(Boolean)));
+    });
+  } catch (error) {
+    failures.push(error instanceof Error ? error.message : String(error));
+  } finally {
+    if (browser) {
+      await browser.close();
+    }
+  }
+  const completedAt = Date.now();
+  return {
+    gate: {
+      name: gateName,
+      status: failures.length === 0 ? 'pass' : 'fail',
+      command: `playwright public app boot ${redactedPublicUrl(appUrl)}`,
+      duration_ms: completedAt - startedAt,
+      exit_code: failures.length === 0 ? 0 : 1,
+      reason: failures.length > 0 ? failures.join('; ') : undefined,
+    },
+    evidence: {
+      config_id: proof?.topology?.configId || null,
+      csp_connect_src_redacted: cspTokens.map((token) => token === "'self'" ? token : redactedPublicUrl(token)),
+      opened_socket_host_hashes: openedHosts.map(hostHash),
+    },
+    failures,
+  };
 }
 
 function writeReport({ artifactDir, report, positiveFixturePath, rolloverFixturePath, manifestPath, browserEvidencePath }) {
@@ -130,6 +823,338 @@ function writeReport({ artifactDir, report, positiveFixturePath, rolloverFixture
   copyIfExists(manifestPath, path.join(latestDir, 'deployed-wss-peer-config-manifest.json'));
   copyIfExists(browserEvidencePath, path.join(latestDir, 'deployed-wss-browser-evidence.json'));
   return { reportPath, latestReportPath };
+}
+
+function invocationCommand(publicMode) {
+  if (!publicMode) return LOCAL_COMMAND;
+  return (process.env.npm_lifecycle_event || '').endsWith(':public') ? PUBLIC_COMMAND : LOCAL_COMMAND;
+}
+
+function publicManifest(config, failures = []) {
+  return {
+    peer_config_url: redactedPublicUrl(config.peerConfigUrl),
+    app_url: redactedPublicUrl(config.appUrl),
+    config_id: config.configId,
+    expected_peer_count: config.peers.length,
+    expected_peer_hashes: config.peers.map((peer) => hostHash(peer)),
+    expected_csp_connect_src_redacted: config.cspConnectSrc.map((token) => token === "'self'" ? token : redactedPublicUrl(token)),
+    minimum_peer_count: config.minimumPeerCount,
+    quorum_required: config.quorumRequired,
+    health_endpoints: config.healthEndpoints.map((record) => ({
+      peer: redactedPublicUrl(record.peer),
+      healthz: redactedPublicUrl(record.healthz),
+      readyz: redactedPublicUrl(record.readyz),
+      metrics: redactedPublicUrl(record.metrics),
+      source: record.source,
+    })),
+    rollover: config.rollover
+      ? {
+          peer_config_url: redactedPublicUrl(config.rollover.peerConfigUrl),
+          app_url: redactedPublicUrl(config.rollover.appUrl),
+          config_id: config.rollover.configId,
+        }
+      : null,
+    failures,
+  };
+}
+
+function publicReport({
+  runId,
+  traceId,
+  startedAt,
+  completedAt,
+  config,
+  gates,
+  failures,
+  browserEvidence,
+  command,
+}) {
+  const allPassed = failures.length === 0 && gates.every((gate) => gate.status === 'pass');
+  const deploymentScope = allPassed ? 'public_wss_deployment' : 'public_wss_deployment_blocked';
+  const issuedAt = browserEvidence?.peer_config_issued_at || null;
+  const expiresAt = browserEvidence?.peer_config_expires_at || null;
+  const minimumPeerCount = config.minimumPeerCount || 0;
+  const quorumRequired = config.quorumRequired || 0;
+  const configId = config.configId || 'missing-public-config-id';
+  return {
+    schema_version: 'mesh-production-readiness-v1',
+    generated_at: new Date(completedAt).toISOString(),
+    run_id: runId,
+    repo: {
+      branch: runGit(['rev-parse', '--abbrev-ref', 'HEAD']),
+      commit: runGit(['rev-parse', 'HEAD']),
+      base_ref: 'origin/main',
+      dirty: runGit(['status', '--short']).length > 0,
+    },
+    run: {
+      mode: 'deployed_wss_topology',
+      deployment_scope: deploymentScope,
+      started_at: new Date(startedAt).toISOString(),
+      completed_at: new Date(completedAt).toISOString(),
+      duration_ms: completedAt - startedAt,
+      command,
+    },
+    status: allPassed ? 'review_required' : 'blocked',
+    status_reason: allPassed
+      ? 'Public WSS deployment proof harness passed for the operator-provided public peer-config, relay health endpoints, CSP scope, and browser app boot; full mesh production readiness remains review_required while other release blockers remain.'
+      : 'Public WSS deployment proof harness failed closed; inspect public_wss_proof.failures and gate reasons.',
+    schema_epoch: 'post_luma_m0b',
+    luma_profile: 'none',
+    luma_dependency_status: {
+      luma_m0b_schema_epoch: 'landed',
+      luma_gated_write_drills: 'pending',
+      luma_profile_gates: 'n/a',
+    },
+    drill_writer_kind_by_class: {
+      'synthetic mesh drill object': 'mesh-drill',
+    },
+    topology: {
+      strategy: 'relay_peer_fanout',
+      deployment_scope: deploymentScope,
+      configured_peer_count: config.peers.length,
+      quorum_required: quorumRequired,
+      signed_peer_config: allPassed,
+      relay_urls_redacted: config.peers.map(redactedPublicUrl),
+      relay_ids: config.peers.map((peer) => `public-wss-${hostHash(peer)}`),
+      relay_to_relay_peers_configured: true,
+      relay_to_relay_auth_mode: 'public_tls_wss',
+      relay_to_relay_auth_negative_test: 'skipped',
+      relay_to_relay_auth_negative_test_reason: 'public mode validates externally exposed relay health/ready/metrics and app WSS boot only; relay runtime auth internals remain out of scope',
+      peer_config_id: configId,
+      peer_config_issued_at: issuedAt,
+      peer_config_expires_at: expiresAt,
+      app_peer_config: {
+        source: 'remote-config',
+        strict: true,
+        signed: allPassed,
+        config_id: configId,
+        minimum_peer_count: minimumPeerCount,
+        quorum_required: quorumRequired,
+        local_mesh_peers_allowed: false,
+      },
+      csp: {
+        status: allPassed ? 'pass' : 'fail',
+        connect_src_expected_origins: config.requiredCspTokens.map((token) => token === "'self'" ? token : redactedPublicUrl(token)),
+        strict_connect_src: true,
+        broad_https_wss_wildcards_allowed: false,
+      },
+      service_worker_peer_config_rollover: {
+        status: config.rollover ? (allPassed ? 'pass' : 'fail') : 'not_exercised',
+        first_config_id: configId,
+        second_config_id: config.rollover?.configId || null,
+        fetch_cache_mode: 'no-store',
+      },
+    },
+    public_wss_proof: {
+      status: allPassed ? 'pass' : 'blocked',
+      deployment_scope: deploymentScope,
+      expected_peer_count: config.peers.length,
+      expected_peer_hashes: config.peers.map((peer) => hostHash(peer)),
+      expected_config_id: configId,
+      app_url: redactedPublicUrl(config.appUrl),
+      peer_config_url: redactedPublicUrl(config.peerConfigUrl),
+      failures,
+      browser_evidence: browserEvidence,
+    },
+    gates,
+    write_class_slos: [],
+    resource_slos: [],
+    per_relay_readback: [],
+    peer_failure_drills: [
+      {
+        name: 'public-wss-peer-kill-write-readback',
+        status: 'skipped',
+        reason: 'public proof v1 validates public endpoint shape, signed peer-config, CSP, relay health, and app boot only; failure injection remains out of scope.',
+      },
+    ],
+    state_resolution_drills: [
+      {
+        object_id: 'state-resolution-matrix-skip-public-wss-proof-v1',
+        object_class: 'state-resolution matrix',
+        state_rule: 'last-write-wins-deterministic-id',
+        expected_winner_write_id: 'skipped',
+        observed_winner_write_id: null,
+        competing_write_ids: [],
+        down_relay_id: null,
+        violation_reason: null,
+        status: 'skipped',
+        reason: 'public WSS proof v1 does not exercise state-resolution, conflict, partition/heal, or LUMA-gated writes.',
+      },
+    ],
+    clock_skew: {
+      skewed_actor: null,
+      skewed_layer: null,
+      skew_ms: 0,
+      named_failure: 'skipped: public WSS proof v1 does not exercise clock-skew/auth-window behavior.',
+      lww_diverged: false,
+      status: 'skipped',
+    },
+    luma_gated_write_drills: [
+      {
+        write_class: 'LUMA-gated public mesh writes',
+        trace_id: traceId,
+        status: 'skipped',
+        reason: 'luma_profile is none; no LUMA _writerKind, _authorScheme, SignedWriteEnvelope, adapter, custody, or schema migration work was exercised.',
+      },
+    ],
+    cleanup: {
+      namespace: 'no vh/__mesh_drills writes in public WSS proof harness',
+      ttl_ms: DEFAULT_TTL_MS,
+      objects_written: 0,
+      objects_cleaned_or_tombstoned: 0,
+      retained_objects: 0,
+      status: 'pass',
+    },
+    health: {
+      peer_quorum_minimum_observed: allPassed ? config.peers.length : 0,
+      sustained_message_rate_max_per_sec: 0,
+      degradation_reasons_seen: allPassed ? [] : ['public-wss-proof-failed-closed'],
+    },
+    release_claims: {
+      allowed: allPassed
+        ? [
+            'The operator-provided public WSS deployment passed the Slice 14D public proof harness for signed peer-config, exact expected peers, quorum, CSP scope, relay health endpoints, and browser app boot.',
+          ]
+        : [],
+      forbidden: [
+        'The mesh is release_ready.',
+        'Public WSS conflict, partition/heal, clock-skew, rollback, or soak behavior is production-proven by this harness.',
+        'LUMA-gated production write classes are mesh-readiness-proven.',
+        'The full app is test-group ready.',
+      ],
+      invalidated_by_luma_epoch_change: true,
+    },
+    downstream_canary: {
+      command: 'pnpm check:production-app-canary',
+      status: 'skipped',
+      reason: 'downstream full-app production canary remains a separate fail-closed gate and is not folded into deployed-WSS proof status',
+    },
+  };
+}
+
+async function runPublicDeployedWssProof() {
+  const startedAt = Date.now();
+  const runId = makeId('mesh-public-wss-proof');
+  const traceId = makeId('trace');
+  const artifactDir = path.join(repoRoot, '.tmp/mesh-production-readiness', runId);
+  fs.mkdirSync(artifactDir, { recursive: true });
+  const manifestPath = path.join(artifactDir, 'deployed-wss-peer-config-manifest.json');
+  const browserEvidencePath = path.join(artifactDir, 'deployed-wss-browser-evidence.json');
+  const command = invocationCommand(true);
+  const parsed = parsePublicProofConfig();
+  const gates = [];
+  const failures = [...parsed.failures];
+  let browserEvidence = null;
+
+  writeJson(manifestPath, publicManifest(parsed.config, failures));
+
+  if (parsed.ok) {
+    const configValidation = await validateFetchedPeerConfig({
+      url: parsed.config.peerConfigUrl,
+      expected: parsed.config,
+      gateName: 'public-wss-signed-peer-config-fetch-verify',
+    });
+    gates.push(configValidation.gate);
+    failures.push(...configValidation.failures);
+    if (configValidation.payload) {
+      browserEvidence = {
+        peer_config_issued_at: new Date(configValidation.payload.issuedAt).toISOString(),
+        peer_config_expires_at: new Date(configValidation.payload.expiresAt).toISOString(),
+      };
+    }
+
+    const health = await runHealthChecks(parsed.config);
+    gates.push(health.gate);
+    failures.push(...health.failures);
+
+    const appBoot = await runAppBoot({
+      config: parsed.config,
+      appUrl: parsed.config.appUrl,
+      expectedConfigId: parsed.config.configId,
+      gateName: 'public-wss-browser-app-boot',
+    });
+    gates.push(appBoot.gate);
+    failures.push(...appBoot.failures);
+    browserEvidence = {
+      ...browserEvidence,
+      first_boot: appBoot.evidence,
+      relay_health: health.observations,
+    };
+
+    if (parsed.config.rollover) {
+      const rolloverExpected = {
+        ...parsed.config,
+        peerConfigUrl: parsed.config.rollover.peerConfigUrl,
+        configId: parsed.config.rollover.configId,
+      };
+      const rolloverConfig = await validateFetchedPeerConfig({
+        url: parsed.config.rollover.peerConfigUrl,
+        expected: rolloverExpected,
+        gateName: 'public-wss-rollover-peer-config-fetch-verify',
+      });
+      gates.push(rolloverConfig.gate);
+      failures.push(...rolloverConfig.failures);
+
+      const rolloverBoot = await runAppBoot({
+        config: parsed.config,
+        appUrl: parsed.config.rollover.appUrl,
+        expectedConfigId: parsed.config.rollover.configId,
+        gateName: 'public-wss-browser-rollover-cache-proof',
+      });
+      gates.push(rolloverBoot.gate);
+      failures.push(...rolloverBoot.failures);
+      browserEvidence = {
+        ...browserEvidence,
+        rollover_boot: rolloverBoot.evidence,
+      };
+    }
+  } else {
+    gates.push({
+      name: 'public-wss-required-inputs',
+      status: 'fail',
+      command: PUBLIC_COMMAND,
+      duration_ms: 0,
+      exit_code: 1,
+      reason: failures.join('; '),
+    });
+  }
+
+  const completedAt = Date.now();
+  const finalFailures = uniqueStrings(failures);
+  writeJson(manifestPath, publicManifest(parsed.config, finalFailures));
+  writeJson(browserEvidencePath, browserEvidence || { status: 'blocked', failures: finalFailures });
+  const report = publicReport({
+    runId,
+    traceId,
+    startedAt,
+    completedAt,
+    config: parsed.config,
+    gates,
+    failures: finalFailures,
+    browserEvidence,
+    command,
+  });
+
+  const reportPaths = writeReport({
+    artifactDir,
+    report,
+    manifestPath,
+    browserEvidencePath,
+  });
+
+  console.log(JSON.stringify({
+    ok: report.public_wss_proof.status === 'pass',
+    status: report.status,
+    run_id: runId,
+    deployment_scope: report.run.deployment_scope,
+    report_path: reportPaths.reportPath,
+    latest_report_path: reportPaths.latestReportPath,
+    failures: finalFailures,
+  }, null, 2));
+
+  if (report.public_wss_proof.status !== 'pass') {
+    process.exitCode = 1;
+  }
 }
 
 function generateTlsCertificate({ artifactDir, certPath, keyPath }) {
@@ -172,7 +1197,7 @@ function generateTlsCertificate({ artifactDir, certPath, keyPath }) {
   }
 }
 
-async function main() {
+async function runLocalDeployedWssCanary() {
   const startedAtMs = Date.now();
   const startedAt = new Date(startedAtMs).toISOString();
   const runId = makeId('mesh-deployed-wss');
@@ -324,7 +1349,7 @@ async function main() {
       started_at: startedAt,
       completed_at: new Date(completedAtMs).toISOString(),
       duration_ms: completedAtMs - startedAtMs,
-      command: 'pnpm test:mesh:deployed-wss-peer-config',
+      command: LOCAL_COMMAND,
     },
     status: 'review_required',
     status_reason: allPassed
@@ -499,7 +1524,17 @@ async function main() {
   }
 }
 
-main().catch((error) => {
-  console.error(`[vh:mesh-deployed-wss-peer-config-canary] fatal: ${error instanceof Error ? error.stack ?? error.message : String(error)}`);
-  process.exitCode = 1;
-});
+async function main() {
+  if (publicModeEnabled()) {
+    await runPublicDeployedWssProof();
+    return;
+  }
+  await runLocalDeployedWssCanary();
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
+  main().catch((error) => {
+    console.error(`[vh:mesh-deployed-wss-peer-config-canary] fatal: ${error instanceof Error ? error.stack ?? error.message : String(error)}`);
+    process.exitCode = 1;
+  });
+}

--- a/packages/e2e/src/mesh/deployed-wss-peer-config-canary.vitest.mjs
+++ b/packages/e2e/src/mesh/deployed-wss-peer-config-canary.vitest.mjs
@@ -1,0 +1,204 @@
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import {
+  parsePublicProofConfig,
+  validatePublicPeerConfigEnvelope,
+} from './deployed-wss-peer-config-canary.mjs';
+
+const thisFile = fileURLToPath(import.meta.url);
+const repoRoot = path.resolve(path.dirname(thisFile), '../../../..');
+const gunRequire = createRequire(path.join(repoRoot, 'packages/gun-client/package.json'));
+const SEA = gunRequire('gun/sea');
+
+function canonicalize(value) {
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => canonicalize(entry)).join(',')}]`;
+  }
+  if (value && typeof value === 'object') {
+    return `{${Object.keys(value)
+      .filter((key) => value[key] !== undefined && key !== 'signature' && key !== 'signerPub')
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonicalize(value[key])}`)
+      .join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+async function signedEnvelope(payload, pair) {
+  return {
+    payload,
+    signature: await SEA.sign(canonicalize(payload), pair),
+    signerPub: pair.pub,
+  };
+}
+
+function validEnv(overrides = {}) {
+  return {
+    VH_MESH_PUBLIC_PEER_CONFIG_URL: 'https://config.mesh.example.com/mesh-peer-config.json',
+    VH_MESH_PUBLIC_PEER_CONFIG_PUBLIC_KEY: 'public-peer-config-key',
+    VH_MESH_PUBLIC_CONFIG_ID: 'mesh-public-config-v1',
+    VH_MESH_PUBLIC_WSS_PEERS: JSON.stringify([
+      'wss://relay-a.mesh.example.com/gun',
+      'wss://relay-b.mesh.example.com/gun',
+      'wss://relay-c.mesh.example.com/gun',
+    ]),
+    VH_MESH_PUBLIC_CSP_CONNECT_SRC: "'self' https://config.mesh.example.com wss://relay-a.mesh.example.com wss://relay-b.mesh.example.com wss://relay-c.mesh.example.com",
+    VH_MESH_PUBLIC_MINIMUM_PEER_COUNT: '3',
+    VH_MESH_PUBLIC_QUORUM_REQUIRED: '2',
+    VH_MESH_PUBLIC_APP_URL: 'https://app.mesh.example.com/',
+    ...overrides,
+  };
+}
+
+describe('public WSS proof input validation', () => {
+  it('fails closed when required operator inputs are missing', () => {
+    const parsed = parsePublicProofConfig({});
+
+    expect(parsed.ok).toBe(false);
+    expect(parsed.failures).toEqual(expect.arrayContaining([
+      'missing VH_MESH_PUBLIC_PEER_CONFIG_URL',
+      'missing VH_MESH_PUBLIC_PEER_CONFIG_PUBLIC_KEY',
+      'missing VH_MESH_PUBLIC_WSS_PEERS',
+      'missing VH_MESH_PUBLIC_CSP_CONNECT_SRC',
+      'missing VH_MESH_PUBLIC_APP_URL',
+    ]));
+  });
+
+  it('accepts only exact public HTTPS/WSS inputs and derives health endpoints', () => {
+    const parsed = parsePublicProofConfig(validEnv());
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.config.healthEndpoints).toHaveLength(3);
+    expect(parsed.config.healthEndpoints[0]).toMatchObject({
+      healthz: 'https://relay-a.mesh.example.com/healthz',
+      readyz: 'https://relay-a.mesh.example.com/readyz',
+      metrics: 'https://relay-a.mesh.example.com/metrics',
+      source: 'derived_from_wss_peer',
+    });
+  });
+
+  it('rejects localhost, private-network, insecure, and broad CSP proof inputs', () => {
+    const parsed = parsePublicProofConfig(validEnv({
+      VH_MESH_PUBLIC_PEER_CONFIG_URL: 'https://127.0.0.1:8443/mesh-peer-config.json',
+      VH_MESH_PUBLIC_WSS_PEERS: 'ws://relay-a.mesh.example.com/gun,wss://10.1.2.3/gun,wss://relay.local/gun',
+      VH_MESH_PUBLIC_CSP_CONNECT_SRC: "'self' https: wss://*.mesh.example.com ws://relay-a.mesh.example.com",
+      VH_MESH_PUBLIC_APP_URL: 'http://app.mesh.example.com/',
+    }));
+
+    expect(parsed.ok).toBe(false);
+    expect(parsed.failures.join('\n')).toContain('public peer-config URL https://127.0.0.1:8443/mesh-peer-config.json rejected');
+    expect(parsed.failures.join('\n')).toContain('public WSS peer ws://relay-a.mesh.example.com/gun must use wss:');
+    expect(parsed.failures.join('\n')).toContain('public WSS peer wss://10.1.2.3/gun rejected');
+    expect(parsed.failures.join('\n')).toContain('public WSS peer wss://relay.local/gun rejected');
+    expect(parsed.failures.join('\n')).toContain('CSP connect-src token https: is too broad');
+    expect(parsed.failures.join('\n')).toContain('CSP connect-src token wss://*.mesh.example.com is too broad');
+    expect(parsed.failures.join('\n')).toContain('public app URL http://app.mesh.example.com/ must use https:');
+  });
+
+  it('rejects accidental private signing material in public-key inputs', () => {
+    const parsed = parsePublicProofConfig(validEnv({
+      VH_MESH_PUBLIC_PEER_CONFIG_PUBLIC_KEY: '-----BEGIN PRIVATE KEY-----\nnot-a-public-key\n-----END PRIVATE KEY-----',
+    }));
+
+    expect(parsed.ok).toBe(false);
+    expect(parsed.failures).toContain('public key input appears to contain private signing material');
+  });
+
+  it('requires all rollover inputs together for service-worker stale-cache proof', () => {
+    const parsed = parsePublicProofConfig(validEnv({
+      VH_MESH_PUBLIC_ROLLOVER_CONFIG_ID: 'mesh-public-config-v2',
+    }));
+
+    expect(parsed.ok).toBe(false);
+    expect(parsed.failures).toContain(
+      'public rollover proof requires VH_MESH_PUBLIC_ROLLOVER_PEER_CONFIG_URL, VH_MESH_PUBLIC_ROLLOVER_CONFIG_ID, and VH_MESH_PUBLIC_ROLLOVER_APP_URL together',
+    );
+  });
+});
+
+describe('public WSS signed peer-config validation', () => {
+  it('accepts a fresh signed config only when it exactly matches expected public peers and quorum', async () => {
+    const pair = await SEA.pair();
+    const issuedAt = Date.parse('2026-05-09T12:00:00.000Z');
+    const parsed = parsePublicProofConfig(validEnv({
+      VH_MESH_PUBLIC_PEER_CONFIG_PUBLIC_KEY: pair.pub,
+    }));
+    const payload = {
+      schemaVersion: 'mesh-peer-config-v1',
+      configId: parsed.config.configId,
+      issuedAt,
+      expiresAt: issuedAt + 60_000,
+      peers: parsed.config.peers,
+      minimumPeerCount: 3,
+      quorumRequired: 2,
+    };
+
+    const result = await validatePublicPeerConfigEnvelope({
+      envelope: await signedEnvelope(payload, pair),
+      expected: parsed.config,
+      nowMs: issuedAt + 10_000,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.failures).toEqual([]);
+  });
+
+  it('rejects unsigned, stale, future-issued, wrong-quorum, and wrong-peer configs', async () => {
+    const pair = await SEA.pair();
+    const issuedAt = Date.parse('2026-05-09T12:00:00.000Z');
+    const parsed = parsePublicProofConfig(validEnv({
+      VH_MESH_PUBLIC_PEER_CONFIG_PUBLIC_KEY: pair.pub,
+      VH_MESH_PUBLIC_CONFIG_MAX_AGE_MS: '1000',
+    }));
+    const basePayload = {
+      schemaVersion: 'mesh-peer-config-v1',
+      configId: parsed.config.configId,
+      issuedAt,
+      expiresAt: issuedAt + 60_000,
+      peers: parsed.config.peers,
+      minimumPeerCount: 3,
+      quorumRequired: 2,
+    };
+
+    const unsigned = await validatePublicPeerConfigEnvelope({
+      envelope: { payload: basePayload },
+      expected: parsed.config,
+      nowMs: issuedAt + 10,
+    });
+    expect(unsigned.failures).toContain('peer config is unsigned');
+
+    const stale = await validatePublicPeerConfigEnvelope({
+      envelope: await signedEnvelope(basePayload, pair),
+      expected: parsed.config,
+      nowMs: issuedAt + 2_000,
+    });
+    expect(stale.failures).toContain('peer config issuedAt is older than 1000ms');
+
+    const future = await validatePublicPeerConfigEnvelope({
+      envelope: await signedEnvelope({ ...basePayload, issuedAt: issuedAt + 60_000, expiresAt: issuedAt + 120_000 }, pair),
+      expected: parsed.config,
+      nowMs: issuedAt,
+    });
+    expect(future.failures).toContain('peer config is not yet valid');
+
+    const wrongQuorum = await validatePublicPeerConfigEnvelope({
+      envelope: await signedEnvelope({ ...basePayload, quorumRequired: 4 }, pair),
+      expected: parsed.config,
+      nowMs: issuedAt + 10,
+    });
+    expect(wrongQuorum.failures).toEqual(expect.arrayContaining([
+      'expected quorumRequired 2, observed 4',
+      'peer config quorumRequired exceeds configured peers',
+    ]));
+
+    const wrongPeer = await validatePublicPeerConfigEnvelope({
+      envelope: await signedEnvelope({ ...basePayload, peers: ['wss://other.mesh.example.com/gun'] }, pair),
+      expected: parsed.config,
+      nowMs: issuedAt + 10,
+    });
+    expect(wrongPeer.failures).toContain('peer config peers do not exactly match expected public peers');
+  });
+});

--- a/packages/e2e/src/mesh/production-readiness-check.mjs
+++ b/packages/e2e/src/mesh/production-readiness-check.mjs
@@ -456,7 +456,7 @@ function runEvidenceScrubGate({ artifactDir, currentCommit, requireClean }) {
   };
 }
 
-function buildReleaseBlockers(sources) {
+export function buildReleaseBlockers(sources) {
   const blockers = [];
   const sourceById = new Map(sources.map((source) => [source.id, source]));
   const soak = sourceById.get('soak')?.report;
@@ -473,8 +473,8 @@ function buildReleaseBlockers(sources) {
   if (deployed?.run?.deployment_scope !== 'public_wss_deployment') {
     blockers.push({
       id: 'public-wss-deployment-proof',
-      command: 'pnpm test:mesh:deployed-wss-peer-config',
-      reason: 'current WSS evidence is the hermetic local TLS profile, not public WSS infrastructure',
+      command: 'pnpm test:mesh:deployed-wss-peer-config:public',
+      reason: 'current WSS evidence is the hermetic local TLS profile or a blocked public proof, not passing public WSS infrastructure evidence',
     });
   }
   if (!hasScript('test:mesh:clock-skew-drills')) {

--- a/packages/e2e/src/mesh/production-readiness-check.test.mjs
+++ b/packages/e2e/src/mesh/production-readiness-check.test.mjs
@@ -11,6 +11,7 @@ import {
 } from './evidence-scrub-check.mjs';
 import {
   SOURCE_GATES,
+  buildReleaseBlockers,
   conflictRowsForAggregate,
   downstreamCanaryMetadata,
   validationFailuresForSource,
@@ -225,6 +226,40 @@ describe('production-readiness source evidence validation', () => {
       command: ['pnpm', 'test:mesh:conflict-drills'],
       expectedMode: 'local_conflict_resolution_fixtures',
     }));
+  });
+
+  it('points the public WSS blocker at the explicit public proof command', () => {
+    const blockers = buildReleaseBlockers([
+      {
+        id: 'deployed_wss',
+        report: {
+          run: { deployment_scope: 'local_tls_wss_profile' },
+          write_class_slos: [],
+          resource_slos: [],
+        },
+      },
+    ]);
+
+    expect(blockers).toContainEqual(expect.objectContaining({
+      id: 'public-wss-deployment-proof',
+      command: 'pnpm test:mesh:deployed-wss-peer-config:public',
+    }));
+  });
+
+  it('removes only the public WSS blocker when deployed evidence is public scoped', () => {
+    const blockers = buildReleaseBlockers([
+      {
+        id: 'deployed_wss',
+        report: {
+          run: { deployment_scope: 'public_wss_deployment' },
+          write_class_slos: [],
+          resource_slos: [],
+        },
+      },
+    ]);
+
+    expect(blockers.map((blocker) => blocker.id)).not.toContain('public-wss-deployment-proof');
+    expect(blockers.map((blocker) => blocker.id)).toContain('luma-gated-write-coverage');
   });
 
   it('accepts a fresh source report for the exact gate command', () => {


### PR DESCRIPTION
## Summary
- add explicit public WSS proof mode for the deployed WSS peer-config canary
- fail closed on missing public inputs, localhost/private endpoints, unsigned or stale configs, quorum/CSP mismatches, relay health failures, app boot failure, and incomplete rollover proof inputs
- keep the existing local TLS deployed-shape canary unchanged and require deployment_scope: public_wss_deployment before retiring the public WSS blocker
- update mesh readiness docs/specs and focused coverage for public-mode validation

## Verification
- node --check packages/e2e/src/mesh/deployed-wss-peer-config-canary.mjs
- pnpm --filter @vh/e2e exec vitest run src/mesh/deployed-wss-peer-config-canary.vitest.mjs src/mesh/production-readiness-check.test.mjs --config ./vitest.config.ts --reporter=dot
- pnpm --filter @vh/e2e typecheck
- pnpm docs:check
- git diff --check origin/main...HEAD
- node tools/scripts/check-diff-coverage.mjs
- pnpm test:mesh:deployed-wss-peer-config:public exits nonzero without public operator inputs and emits a blocked public_wss_deployment_blocked report
- pnpm check:mesh:production-readiness exits 0 with review_required, post_luma_m0b, luma_profile none, 12 source reports, evidence_scrub pass

## Notes
- No real public endpoints were supplied in this slice, so public-wss-deployment-proof remains a release-readiness blocker.
- The local aggregate also lists canonical-30-minute-soak because this verification used the default shortened soak, not the 30-minute evidence lane.
- Protected-surface grep was clean for app runtime, relay runtime, LUMA adapters/schemas/custody/envelopes/write paths, identifiers, signed-write primitives, and identity-vault surfaces.
- Local Node is v23.10.0 while the repo declares >=20 <23; this is the existing local engine caveat.