### PR TITLE
Harden public WSS host validation

### DIFF
--- a/packages/e2e/src/mesh/deployed-wss-peer-config-canary.mjs
+++ b/packages/e2e/src/mesh/deployed-wss-peer-config-canary.mjs
@@ -201,6 +201,31 @@ function hostHash(value) {
   return crypto.createHash('sha256').update(value).digest('hex').slice(0, 12);
 }
 
+function parseIpv6Hextets(value) {
+  const parts = value.split('::');
+  if (parts.length > 2) return null;
+  const left = parts[0] ? parts[0].split(':') : [];
+  const right = parts.length === 2 && parts[1] ? parts[1].split(':') : [];
+  if (left.some((part) => part.length === 0) || right.some((part) => part.length === 0)) return null;
+  const missing = parts.length === 2 ? 8 - left.length - right.length : 0;
+  if (missing < 0 || (parts.length === 1 && left.length !== 8)) return null;
+  const hextets = [
+    ...left,
+    ...Array.from({ length: missing }, () => '0'),
+    ...right,
+  ].map((part) => Number.parseInt(part, 16));
+  if (hextets.length !== 8 || hextets.some((part) => !Number.isInteger(part) || part < 0 || part > 0xffff)) {
+    return null;
+  }
+  return hextets;
+}
+
+function isIpv4EmbeddedIpv6(hextets) {
+  const leadingZeros = hextets.slice(0, 5).every((part) => part === 0);
+  if (leadingZeros && hextets[5] === 0xffff) return true;
+  return hextets.slice(0, 6).every((part) => part === 0) && (hextets[6] !== 0 || hextets[7] !== 0);
+}
+
 function redactedPublicUrl(value) {
   try {
     const url = new URL(value);
@@ -245,12 +270,21 @@ function hostnameIsPublic(hostname) {
   }
 
   if (net.isIP(normalized) === 6) {
-    const first = Number.parseInt(normalized.split(':')[0] || '0', 16);
+    const hextets = parseIpv6Hextets(normalized);
+    if (hextets && isIpv4EmbeddedIpv6(hextets)) {
+      return { ok: false, reason: `host ${hostname} uses an IPv4-embedded IPv6 literal; use a public DNS name or direct public IPv4 literal` };
+    }
+    const first = hextets?.[0] ?? Number.parseInt(normalized.split(':')[0] || '0', 16);
+    const second = hextets?.[1] ?? 0;
     const privateRange =
       normalized === '::' ||
       normalized === '::1' ||
-      normalized.startsWith('fe80:') ||
-      (Number.isFinite(first) && (first & 0xfe00) === 0xfc00);
+      (Number.isFinite(first) && (first & 0xffc0) === 0xfe80) ||
+      (Number.isFinite(first) && (first & 0xfe00) === 0xfc00) ||
+      (Number.isFinite(first) && (first & 0xff00) === 0xff00) ||
+      (first === 0x0100 && second === 0) ||
+      (first === 0x2001 && second === 0x0002) ||
+      (first === 0x2001 && second === 0x0db8);
     return privateRange ? { ok: false, reason: `host ${hostname} is not publicly routable` } : { ok: true };
   }
 

--- a/packages/e2e/src/mesh/deployed-wss-peer-config-canary.vitest.mjs
+++ b/packages/e2e/src/mesh/deployed-wss-peer-config-canary.vitest.mjs
@@ -83,7 +83,7 @@ describe('public WSS proof input validation', () => {
   it('rejects localhost, private-network, insecure, and broad CSP proof inputs', () => {
     const parsed = parsePublicProofConfig(validEnv({
       VH_MESH_PUBLIC_PEER_CONFIG_URL: 'https://127.0.0.1:8443/mesh-peer-config.json',
-      VH_MESH_PUBLIC_WSS_PEERS: 'ws://relay-a.mesh.example.com/gun,wss://10.1.2.3/gun,wss://relay.local/gun',
+      VH_MESH_PUBLIC_WSS_PEERS: 'ws://relay-a.mesh.example.com/gun,wss://10.1.2.3/gun,wss://[::ffff:10.1.2.3]/gun,wss://[fd00::1]/gun,wss://[2001:db8::1]/gun,wss://relay.local/gun',
       VH_MESH_PUBLIC_CSP_CONNECT_SRC: "'self' https: wss://*.mesh.example.com ws://relay-a.mesh.example.com",
       VH_MESH_PUBLIC_APP_URL: 'http://app.mesh.example.com/',
     }));
@@ -92,6 +92,9 @@ describe('public WSS proof input validation', () => {
     expect(parsed.failures.join('\n')).toContain('public peer-config URL https://127.0.0.1:8443/mesh-peer-config.json rejected');
     expect(parsed.failures.join('\n')).toContain('public WSS peer ws://relay-a.mesh.example.com/gun must use wss:');
     expect(parsed.failures.join('\n')).toContain('public WSS peer wss://10.1.2.3/gun rejected');
+    expect(parsed.failures.join('\n')).toContain('uses an IPv4-embedded IPv6 literal');
+    expect(parsed.failures.join('\n')).toContain('public WSS peer wss://[fd00::1]/gun rejected');
+    expect(parsed.failures.join('\n')).toContain('public WSS peer wss://[2001:db8::1]/gun rejected');
     expect(parsed.failures.join('\n')).toContain('public WSS peer wss://relay.local/gun rejected');
     expect(parsed.failures.join('\n')).toContain('CSP connect-src token https: is too broad');
     expect(parsed.failures.join('\n')).toContain('CSP connect-src token wss://*.mesh.example.com is too broad');


### PR DESCRIPTION
## Summary
- Reject IPv4-embedded IPv6 literals in the public WSS proof host validator so loopback/private IPv4 cannot be smuggled through bracketed IPv6 input.
- Expand public IPv6 literal rejection for non-public ranges including ULA, link-local, multicast, discard-only, benchmarking, and documentation prefixes.
- Add focused Vitest coverage for mapped IPv6, ULA, and documentation-range endpoint rejection.

## Verification
- node --check packages/e2e/src/mesh/deployed-wss-peer-config-canary.mjs
- pnpm --dir packages/e2e exec vitest run src/mesh/deployed-wss-peer-config-canary.vitest.mjs --config vitest.config.ts --reporter=dot
- pnpm --filter @vh/e2e typecheck
- pnpm docs:check
- git diff --check origin/main...HEAD
- node tools/scripts/check-diff-coverage.mjs
- pnpm test:mesh:deployed-wss-peer-config:public (expected blocked exit 1 with missing public inputs)
- pnpm check:mesh:production-readiness

## Evidence
Latest local aggregate: mesh-production-readiness-20260509T142003Z-e3b0d96e, status review_required, schema_epoch post_luma_m0b, luma_profile none, 12 source reports, evidence_scrub pass. Remaining blockers: canonical-30-minute-soak, public-wss-deployment-proof, luma-gated-write-coverage.

Caveat: local Node is v23.10.0 while repo engine is >=20 <23; GitHub CI should run Node 20.