### PR TITLE
Add strict LUMA-gated write coverage gate

### DIFF
--- a/docs/ops/mesh-production-topology-drills.md
+++ b/docs/ops/mesh-production-topology-drills.md
@@ -2,7 +2,7 @@
 
 > Status: Active
 > Owner: VHC Core Engineering
-> Last Reviewed: 2026-05-05
+> Last Reviewed: 2026-05-09
 > Depends On: docs/specs/spec-mesh-production-readiness.md, docs/specs/spec-data-topology-privacy-v0.md, docs/specs/spec-signed-pin-custody-v0.md
 
 This runbook covers the local production-shaped mesh topology proof path.
@@ -116,6 +116,29 @@ rejection for expired, unsigned, bad-signature, wrong-key, and local-peer
 configs, then rollback to the previous topology shape through a freshly issued
 signed rollback config. Rollback evidence must not be based on accepting an old
 cached config file.
+
+Run the LUMA-gated write coverage gate:
+
+```sh
+pnpm test:mesh:luma-gated-write-coverage
+```
+
+With the current mesh-only profile, the expected result is a non-zero exit and
+a blocked report at:
+
+```text
+.tmp/mesh-luma-gated-write-coverage/latest/mesh-luma-gated-write-coverage-report.json
+```
+
+The blocked default is intentional: `luma_profile: none` does not exercise
+LUMA-owned `_writerKind`, `_authorScheme`, envelope, custody, adapter, public-id
+derivation, or reader-path behavior. To validate real LUMA coverage, provide an
+explicit report with `VH_MESH_LUMA_GATED_WRITE_COVERAGE_REPORT` or
+`--source-report <path>`. The report must be current-commit, clean, under
+`schema_epoch: post_luma_m0b`, use a non-`none` LUMA profile, and prove every
+required LUMA-gated write class through the LUMA reader path. A single passing
+LUMA row, a synthetic `vh/__mesh_drills/*` row, or a merged
+`drill_writer_kind_by_class` value of `luma` is not enough.
 
 Run the state-resolution drill:
 
@@ -392,7 +415,12 @@ exists.
 The aggregate command exits non-zero for missing, malformed, dirty, stale,
 failed, command-mismatched, unscrubbed, or incomplete source evidence, and for
 any overclaiming packet that would emit `release_ready` before the blockers are
-gone.
+gone. The default blocked LUMA coverage command is not one of the 12 aggregate
+source reports while the mesh profile remains `luma_profile: none`; the
+aggregate consumes LUMA coverage only from an explicit
+`VH_MESH_LUMA_GATED_WRITE_COVERAGE_REPORT` path and fails closed if that report
+is malformed, stale, dirty, wrong-epoch, partial, synthetic-only, or
+overclaiming.
 
 After Slice 14B, `pnpm check:production-app-canary` is a separate fail-closed
 downstream gate. It defaults to the latest mesh readiness report but accepts
@@ -459,7 +487,10 @@ public WSS command proves public WSS deployment only when it exits zero with
 fail-closed input validation. None of these outcomes proves automatic
 peer-federation recovery, runtime peer-config key rotation without a new
 trusted-key distribution path, LUMA-gated write state resolution, public WSS
-clock-skew or conflict behavior, or post-M0.B LUMA-gated write coverage.
+clock-skew or conflict behavior, or post-M0.B LUMA-gated write coverage. A
+passing Slice 14E LUMA coverage report means only that explicit coverage
+evidence satisfied the all-required-class reader-path contract; it does not
+claim LUMA gate behavior itself, which remains owned by LUMA acceptance gates.
 
 If direct restarted-relay readback is `blocked` or `review_required`, do not tune
 Gun peer behavior indefinitely. The next branch must choose and drill one

--- a/docs/specs/spec-mesh-production-readiness.md
+++ b/docs/specs/spec-mesh-production-readiness.md
@@ -122,6 +122,14 @@ Current head at closeout:
   CSP mismatch, relay health failure, or app boot failure. Only a passing run
   may emit `deployment_scope: public_wss_deployment`; blocked runs emit
   `public_wss_deployment_blocked`.
+- `pnpm test:mesh:luma-gated-write-coverage` is the Slice 14E LUMA coverage
+  gate. By default it writes a blocked report because `luma_profile: none`
+  cannot prove LUMA-owned `_writerKind`, `_authorScheme`, envelope, custody,
+  adapter, public-id derivation, or reader-path behavior. It may pass only from
+  explicit current-commit, clean, `post_luma_m0b` evidence proving every
+  required LUMA-gated write class through the LUMA reader path. One passing
+  LUMA row, synthetic mesh-drill evidence, or any merged
+  `drill_writer_kind_by_class` value is insufficient.
 - `pnpm test:mesh:state-resolution-drills` is the Slice 7C state-resolution
   proof: it writes synthetic non-LUMA §5.10 competing records under
   `vh/__mesh_drills/<run_id>/state_resolution/*`, restarts/heals one relay
@@ -1428,8 +1436,10 @@ Acceptance gates:
   - public WSS deployment proof passes with
     `run.deployment_scope: public_wss_deployment`; local TLS/WSS evidence and
     blocked public attempts do not satisfy this item
-  - any LUMA-gated write class (drill_writer_kind `'luma'`) was exercised
-    against the LUMA reader path, not bypassed via drill writer contract
+  - every required LUMA-gated write class is proven by explicit current-commit
+    evidence through the LUMA reader path under the current schema epoch;
+    partial rows, stale reports, synthetic mesh-drill rows, and writer-kind
+    summaries do not satisfy this item
   - any promoted evidence under `.tmp/mesh-production-readiness/promoted/` or
     `docs/reports/evidence/mesh-production/` passed
     `pnpm check:mesh-evidence-scrub` (§5.7.1)
@@ -2447,6 +2457,22 @@ drilled through the LUMA reader path):
 - "LUMA-gated write classes (forum thread/comment, vote/aggregate, directory
   publish, news report) have transport readiness under the current LUMA
   schema epoch."
+
+Slice 14E strict coverage contract:
+
+- The aggregate may clear `luma-gated-write-coverage` only from an explicit
+  `VH_MESH_LUMA_GATED_WRITE_COVERAGE_REPORT` packet or equivalent direct report
+  argument, not by scanning stale `.tmp/latest` output.
+- The report must use `schema_version: mesh-luma-gated-write-coverage-v1`,
+  `status: pass`, `schema_epoch: post_luma_m0b`, a non-`none` `luma_profile`,
+  current `repo.commit`, and `repo.dirty: false`.
+- Required classes are forum thread, forum comment, vote or aggregate,
+  directory publish, and news report/status. Each class must have a passing row
+  with `writer_kind` or `_writerKind` equal to `luma`, a LUMA reader/readback
+  path marker, and a `trace_id`.
+- Any missing class, skipped class, wrong epoch, wrong profile, dirty or stale
+  report, synthetic `vh/__mesh_drills/*` row, `_drillWriterKind:
+  'mesh-drill'`, or overclaiming release-ready statement keeps the blocker.
 
 Still not allowed after mesh readiness alone:
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "test:mesh:peer-config-rollback-drill": "pnpm --filter @vh/e2e test:mesh:peer-config-rollback-drill",
     "test:mesh:clock-skew-drills": "pnpm --filter @vh/e2e test:mesh:clock-skew-drills",
     "test:mesh:conflict-drills": "pnpm --filter @vh/e2e test:mesh:conflict-drills",
+    "test:mesh:luma-gated-write-coverage": "pnpm --filter @vh/e2e test:mesh:luma-gated-write-coverage",
     "check:mesh-evidence-scrub": "pnpm --filter @vh/e2e check:mesh-evidence-scrub",
     "check:mesh:production-readiness": "pnpm --filter @vh/e2e check:mesh:production-readiness",
     "check:production-app-canary": "pnpm --filter @vh/e2e check:production-app-canary",

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -36,6 +36,7 @@
     "test:mesh:peer-config-rollback-drill": "node ./src/mesh/peer-config-rollback-drill.mjs",
     "test:mesh:clock-skew-drills": "node ./src/mesh/clock-skew-drills.mjs",
     "test:mesh:conflict-drills": "node ./src/mesh/conflict-drills.mjs",
+    "test:mesh:luma-gated-write-coverage": "node ./src/mesh/luma-gated-write-coverage.mjs",
     "check:mesh-evidence-scrub": "node ./src/mesh/evidence-scrub-check.mjs",
     "check:mesh:production-readiness": "node ./src/mesh/production-readiness-check.mjs",
     "check:production-app-canary": "node ./src/live/production-app-canary.mjs",

--- a/packages/e2e/src/mesh/evidence-scrub-check.mjs
+++ b/packages/e2e/src/mesh/evidence-scrub-check.mjs
@@ -298,7 +298,10 @@ export function validateAggregatePacket({ sourceDir = defaultSourceDir } = {}) {
       failures.push(`write class ${writeClass} has disallowed writer kind ${writerKind}`);
     }
   }
-  if ((report.luma_gated_write_drills || []).some((row) => row.status === 'pass')) {
+  if (
+    report.luma_gated_write_coverage?.status !== 'pass' &&
+    (report.luma_gated_write_drills || []).some((row) => row.status === 'pass')
+  ) {
     failures.push('aggregate implies LUMA-gated write coverage in a mesh-only evidence packet');
   }
   failures.push(...sourceReportFailures({ aggregate: report, sourceDir: resolvedSourceDir }));

--- a/packages/e2e/src/mesh/luma-gated-write-coverage.mjs
+++ b/packages/e2e/src/mesh/luma-gated-write-coverage.mjs
@@ -1,0 +1,495 @@
+#!/usr/bin/env node
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '../../../..');
+const artifactRoot = path.join(repoRoot, '.tmp/mesh-luma-gated-write-coverage');
+const latestDir = path.join(artifactRoot, 'latest');
+
+export const LUMA_GATED_WRITE_COVERAGE_SCHEMA_VERSION = 'mesh-luma-gated-write-coverage-v1';
+export const LUMA_GATED_WRITE_COVERAGE_MODE = 'luma_gated_write_coverage';
+export const LUMA_GATED_WRITE_COVERAGE_COMMAND = 'pnpm test:mesh:luma-gated-write-coverage';
+export const LUMA_GATED_WRITE_COVERAGE_REPORT_NAME = 'mesh-luma-gated-write-coverage-report.json';
+export const LUMA_GATED_WRITE_COVERAGE_REPORT_ENV = 'VH_MESH_LUMA_GATED_WRITE_COVERAGE_REPORT';
+export const DEFAULT_LUMA_SCHEMA_EPOCH = 'post_luma_m0b';
+export const REQUIRED_LUMA_WRITE_CLASSES = [
+  {
+    id: 'forum_thread',
+    label: 'forum thread',
+    aliases: ['forum thread', 'forum-thread', 'forum_thread', 'forum'],
+  },
+  {
+    id: 'forum_comment',
+    label: 'forum comment',
+    aliases: ['forum comment', 'forum-comment', 'forum_comment', 'comment'],
+  },
+  {
+    id: 'vote_or_aggregate',
+    label: 'vote or aggregate',
+    aliases: [
+      'vote',
+      'votes',
+      'vote or aggregate',
+      'vote/aggregate',
+      'vote_or_aggregate',
+      'aggregate',
+      'aggregate voter node',
+      'point aggregate voter node',
+      'aggregate snapshot',
+      'point aggregate snapshot',
+    ],
+  },
+  {
+    id: 'directory_publish',
+    label: 'directory publish',
+    aliases: ['directory publish', 'directory-publish', 'directory_publish', 'directory entry', 'directory'],
+  },
+  {
+    id: 'news_report_status',
+    label: 'news report/status',
+    aliases: [
+      'news report',
+      'news-report',
+      'news_report',
+      'news status',
+      'news-status',
+      'news_report_status',
+      'news report/status',
+      'report status',
+    ],
+  },
+];
+
+const acceptedReaderPathValues = new Set([
+  'luma',
+  'luma reader',
+  'luma reader path',
+  'luma readback',
+  'luma reader path evidence',
+  'luma reader validated',
+]);
+
+const classAliasByKey = new Map(
+  REQUIRED_LUMA_WRITE_CLASSES.flatMap((definition) =>
+    [definition.id, definition.label, ...definition.aliases].map((alias) => [normalizeKey(alias), definition.id]),
+  ),
+);
+
+function nowIsoCompact(date = new Date()) {
+  return date.toISOString().replaceAll('-', '').replaceAll(':', '').replace(/\.\d{3}Z$/, 'Z');
+}
+
+function makeId(prefix) {
+  return `${prefix}-${nowIsoCompact()}-${crypto.randomBytes(4).toString('hex')}`;
+}
+
+function runGit(args) {
+  const result = spawnSync('git', args, {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  });
+  return result.status === 0 ? result.stdout.trim() : '';
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function copyDir(src, dest) {
+  fs.rmSync(dest, { recursive: true, force: true });
+  fs.mkdirSync(dest, { recursive: true });
+  for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
+    const sourcePath = path.join(src, entry.name);
+    const destPath = path.join(dest, entry.name);
+    if (entry.isDirectory()) {
+      copyDir(sourcePath, destPath);
+    } else if (entry.isFile()) {
+      fs.copyFileSync(sourcePath, destPath);
+    }
+  }
+}
+
+function normalizeKey(value) {
+  return String(value || '')
+    .trim()
+    .toLowerCase()
+    .replace(/[_-]+/g, ' ')
+    .replace(/\s*\/\s*/g, '/')
+    .replace(/\s+/g, ' ');
+}
+
+function unique(values) {
+  return [...new Set(values.filter((value) => value !== undefined && value !== null && value !== ''))];
+}
+
+function rowsFromReport(report) {
+  const rowCollections = [
+    report?.luma_gated_write_drills,
+    report?.coverage_rows,
+    report?.coverage?.classes,
+    report?.luma_gated_write_coverage?.required_write_classes,
+  ];
+  return rowCollections.flatMap((rows) => (Array.isArray(rows) ? rows : []));
+}
+
+function classIdForRow(row) {
+  const value = row?.coverage_class || row?.write_class_id || row?.write_class || row?.class || row?.label;
+  return classAliasByKey.get(normalizeKey(value)) || null;
+}
+
+function writerKindForRow(row) {
+  return row?.writer_kind || row?.writerKind || row?._writerKind || row?.public_protocol_fields?._writerKind || null;
+}
+
+function readerPathForRow(row) {
+  return (
+    row?.reader_path ||
+    row?.readerPath ||
+    row?.readback_path ||
+    row?.verification_path ||
+    row?.evidence_path ||
+    row?.path ||
+    null
+  );
+}
+
+function hasAcceptedReaderPath(row) {
+  if (row?.luma_reader_path === true || row?.reader_path_verified === true) return true;
+  return acceptedReaderPathValues.has(normalizeKey(readerPathForRow(row)));
+}
+
+function hasSyntheticMarker(row) {
+  const namespace = row?.namespace || row?.write_namespace || row?.source_namespace || '';
+  return (
+    row?.synthetic === true ||
+    row?.synthetic_mesh_drill === true ||
+    row?.drill_writer_kind === 'mesh-drill' ||
+    row?._drillWriterKind === 'mesh-drill' ||
+    String(namespace).startsWith('vh/__mesh_drills/')
+  );
+}
+
+function rowEvidenceFailures(row, { expectedSchemaEpoch, expectedLumaProfile, currentCommit }) {
+  const failures = [];
+  if (row?.status !== 'pass') {
+    failures.push(`status is ${row?.status || 'missing'}`);
+  }
+  if (writerKindForRow(row) !== 'luma') {
+    failures.push(`writer kind is ${writerKindForRow(row) || 'missing'}`);
+  }
+  if (!hasAcceptedReaderPath(row)) {
+    failures.push(`reader path is ${readerPathForRow(row) || 'missing'}`);
+  }
+  if (hasSyntheticMarker(row)) {
+    failures.push('row is marked as synthetic mesh-drill evidence');
+  }
+  if (!row?.trace_id) {
+    failures.push('missing trace_id');
+  }
+  if (row?.schema_epoch && row.schema_epoch !== expectedSchemaEpoch) {
+    failures.push(`schema_epoch is ${row.schema_epoch}`);
+  }
+  if (expectedLumaProfile && row?.luma_profile && row.luma_profile !== expectedLumaProfile) {
+    failures.push(`luma_profile is ${row.luma_profile}`);
+  }
+  if (currentCommit && row?.repo_commit && row.repo_commit !== currentCommit) {
+    failures.push(`repo_commit is ${row.repo_commit}`);
+  }
+  return failures;
+}
+
+function classResult({ definition, rows, expectedSchemaEpoch, expectedLumaProfile, currentCommit }) {
+  const matchingRows = rows.filter((row) => classIdForRow(row) === definition.id);
+  const evaluatedRows = matchingRows.map((row) => ({
+    row,
+    failures: rowEvidenceFailures(row, { expectedSchemaEpoch, expectedLumaProfile, currentCommit }),
+  }));
+  const accepted = evaluatedRows.find((entry) => entry.failures.length === 0);
+
+  if (accepted) {
+    return {
+      write_class: definition.id,
+      label: definition.label,
+      status: 'pass',
+      trace_id: accepted.row.trace_id,
+      writer_kind: writerKindForRow(accepted.row),
+      reader_path: readerPathForRow(accepted.row) || 'luma_reader_path',
+      schema_epoch: accepted.row.schema_epoch || expectedSchemaEpoch,
+      luma_profile: accepted.row.luma_profile || expectedLumaProfile || null,
+    };
+  }
+
+  const reason = matchingRows.length === 0
+    ? `missing ${definition.label} LUMA reader-path evidence`
+    : `${definition.label} evidence did not satisfy strict LUMA reader-path contract: ${unique(evaluatedRows.flatMap((entry) => entry.failures)).join('; ')}`;
+
+  return {
+    write_class: definition.id,
+    label: definition.label,
+    status: 'blocked',
+    reason,
+  };
+}
+
+export function validateLumaCoverageReport(report, {
+  currentCommit = null,
+  requireClean = true,
+  expectedSchemaEpoch = DEFAULT_LUMA_SCHEMA_EPOCH,
+  expectedLumaProfile = null,
+} = {}) {
+  const failures = [];
+  const rows = rowsFromReport(report);
+
+  if (!report || typeof report !== 'object') {
+    return {
+      ok: false,
+      status: 'blocked',
+      failures: ['missing or malformed LUMA coverage report'],
+      required_write_classes: REQUIRED_LUMA_WRITE_CLASSES.map((definition) => ({
+        write_class: definition.id,
+        label: definition.label,
+        status: 'blocked',
+        reason: 'missing or malformed LUMA coverage report',
+      })),
+    };
+  }
+
+  if (report.schema_version !== LUMA_GATED_WRITE_COVERAGE_SCHEMA_VERSION) {
+    failures.push(`unexpected schema_version ${report.schema_version || 'missing'}`);
+  }
+  if (report.status !== 'pass') {
+    failures.push(`report status is ${report.status || 'missing'}`);
+  }
+  if (report.schema_epoch !== expectedSchemaEpoch) {
+    failures.push(`schema_epoch is ${report.schema_epoch || 'missing'}`);
+  }
+  if (!report.luma_profile || report.luma_profile === 'none') {
+    failures.push(`luma_profile is ${report.luma_profile || 'missing'}`);
+  }
+  if (expectedLumaProfile && report.luma_profile !== expectedLumaProfile) {
+    failures.push(`luma_profile is ${report.luma_profile || 'missing'}, expected ${expectedLumaProfile}`);
+  }
+  if (currentCommit && report.repo?.commit !== currentCommit) {
+    failures.push(`report commit ${report.repo?.commit || 'missing'} does not match ${currentCommit}`);
+  }
+  if (requireClean && report.repo?.dirty !== false) {
+    failures.push('report repo.dirty is not false');
+  }
+
+  const requiredResults = REQUIRED_LUMA_WRITE_CLASSES.map((definition) =>
+    classResult({
+      definition,
+      rows,
+      expectedSchemaEpoch,
+      expectedLumaProfile: expectedLumaProfile || report.luma_profile,
+      currentCommit,
+    }),
+  );
+
+  for (const result of requiredResults) {
+    if (result.status !== 'pass') {
+      failures.push(result.reason);
+    }
+  }
+
+  return {
+    ok: failures.length === 0,
+    status: failures.length === 0 ? 'pass' : 'blocked',
+    failures: unique(failures),
+    required_write_classes: requiredResults,
+  };
+}
+
+function blockedValidation(reason) {
+  return {
+    ok: false,
+    status: 'blocked',
+    failures: [reason],
+    required_write_classes: REQUIRED_LUMA_WRITE_CLASSES.map((definition) => ({
+      write_class: definition.id,
+      label: definition.label,
+      status: 'blocked',
+      reason,
+    })),
+  };
+}
+
+export function buildLumaCoverageReport({
+  runId,
+  startedAt,
+  completedAt,
+  command = LUMA_GATED_WRITE_COVERAGE_COMMAND,
+  currentCommit,
+  branch,
+  dirty,
+  sourceReport = null,
+  sourceReportPath = null,
+  sourceReadFailure = null,
+  expectedSchemaEpoch = DEFAULT_LUMA_SCHEMA_EPOCH,
+  expectedLumaProfile = null,
+} = {}) {
+  const validation = sourceReadFailure
+    ? blockedValidation(sourceReadFailure)
+    : sourceReport
+      ? validateLumaCoverageReport(sourceReport, {
+          currentCommit,
+          requireClean: true,
+          expectedSchemaEpoch,
+          expectedLumaProfile,
+        })
+      : blockedValidation('luma_profile is none and no LUMA reader-path coverage report was provided');
+
+  const lumaProfile = sourceReport?.luma_profile || expectedLumaProfile || 'none';
+  const status = validation.ok ? 'pass' : 'blocked';
+
+  return {
+    schema_version: LUMA_GATED_WRITE_COVERAGE_SCHEMA_VERSION,
+    generated_at: new Date(completedAt).toISOString(),
+    run_id: runId,
+    repo: {
+      branch,
+      commit: currentCommit,
+      base_ref: 'origin/main',
+      dirty,
+    },
+    run: {
+      mode: LUMA_GATED_WRITE_COVERAGE_MODE,
+      started_at: new Date(startedAt).toISOString(),
+      completed_at: new Date(completedAt).toISOString(),
+      duration_ms: completedAt - startedAt,
+      command,
+    },
+    status,
+    schema_epoch: expectedSchemaEpoch,
+    luma_profile: lumaProfile,
+    coverage_source_report_path: sourceReportPath,
+    luma_gated_write_coverage: {
+      status,
+      command,
+      expected_schema_epoch: expectedSchemaEpoch,
+      expected_luma_profile: expectedLumaProfile,
+      source_report_path: sourceReportPath,
+      failures: validation.failures,
+      required_write_classes: validation.required_write_classes,
+    },
+    luma_gated_write_drills: validation.required_write_classes.map((result) => ({
+      write_class: result.write_class,
+      trace_id: result.trace_id || runId,
+      status: result.status === 'pass' ? 'pass' : 'skipped',
+      reason: result.reason,
+      writer_kind: result.writer_kind || null,
+      reader_path: result.reader_path || null,
+      schema_epoch: result.schema_epoch || expectedSchemaEpoch,
+      luma_profile: result.luma_profile || lumaProfile,
+    })),
+    release_claims: {
+      allowed: validation.ok
+        ? ['All required LUMA-gated write classes have current LUMA reader-path coverage evidence.']
+        : [],
+      forbidden: [
+        'LUMA gate behavior is verified by mesh.',
+        ...(validation.ok ? [] : ['LUMA-gated production write classes are mesh-readiness-proven.']),
+      ],
+      invalidated_by_luma_epoch_change: false,
+    },
+    failures: validation.failures,
+  };
+}
+
+function parseArgs(argv) {
+  const args = {
+    sourceReport: process.env[LUMA_GATED_WRITE_COVERAGE_REPORT_ENV] || null,
+    expectedSchemaEpoch: process.env.VH_MESH_LUMA_GATED_WRITE_COVERAGE_SCHEMA_EPOCH || DEFAULT_LUMA_SCHEMA_EPOCH,
+    expectedLumaProfile: process.env.VH_MESH_LUMA_GATED_WRITE_COVERAGE_LUMA_PROFILE || null,
+  };
+  const tokens = argv.filter((token) => token !== '--');
+  for (let index = 0; index < tokens.length; index += 1) {
+    const token = tokens[index];
+    if (token === '--source-report' || token === '--evidence-report') {
+      args.sourceReport = tokens[++index] || null;
+    } else if (token === '--expected-schema-epoch') {
+      args.expectedSchemaEpoch = tokens[++index] || args.expectedSchemaEpoch;
+    } else if (token === '--expected-luma-profile') {
+      args.expectedLumaProfile = tokens[++index] || null;
+    } else {
+      throw new Error(`unknown argument ${token}`);
+    }
+  }
+  return args;
+}
+
+function resolveMaybeRelative(filePath) {
+  return filePath ? path.resolve(repoRoot, filePath) : null;
+}
+
+async function main() {
+  const startedAt = Date.now();
+  const runId = makeId('mesh-luma-gated-write-coverage');
+  const args = parseArgs(process.argv.slice(2));
+  const currentCommit = runGit(['rev-parse', 'HEAD']);
+  const branch = runGit(['rev-parse', '--abbrev-ref', 'HEAD']);
+  const dirty = runGit(['status', '--short']).length > 0;
+  const resolvedSourcePath = resolveMaybeRelative(args.sourceReport);
+  let sourceReport = null;
+  let sourceReadFailure = null;
+
+  if (resolvedSourcePath) {
+    try {
+      sourceReport = readJson(resolvedSourcePath);
+    } catch (error) {
+      sourceReadFailure = `failed to read LUMA coverage source report: ${error instanceof Error ? error.message : String(error)}`;
+    }
+  }
+
+  const completedAt = Date.now();
+  const report = buildLumaCoverageReport({
+    runId,
+    startedAt,
+    completedAt,
+    currentCommit,
+    branch,
+    dirty,
+    sourceReport,
+    sourceReportPath: resolvedSourcePath,
+    sourceReadFailure,
+    expectedSchemaEpoch: args.expectedSchemaEpoch,
+    expectedLumaProfile: args.expectedLumaProfile,
+  });
+
+  const runDir = path.join(artifactRoot, runId);
+  const reportPath = path.join(runDir, LUMA_GATED_WRITE_COVERAGE_REPORT_NAME);
+  writeJson(reportPath, report);
+  copyDir(runDir, latestDir);
+
+  console.log(JSON.stringify({
+    ok: report.status === 'pass',
+    status: report.status,
+    run_id: runId,
+    report_path: reportPath,
+    latest_report_path: path.join(latestDir, LUMA_GATED_WRITE_COVERAGE_REPORT_NAME),
+    schema_epoch: report.schema_epoch,
+    luma_profile: report.luma_profile,
+    failures: report.failures,
+  }, null, 2));
+
+  if (report.status !== 'pass') {
+    process.exitCode = 1;
+  }
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/packages/e2e/src/mesh/luma-gated-write-coverage.vitest.mjs
+++ b/packages/e2e/src/mesh/luma-gated-write-coverage.vitest.mjs
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_LUMA_SCHEMA_EPOCH,
+  LUMA_GATED_WRITE_COVERAGE_COMMAND,
+  LUMA_GATED_WRITE_COVERAGE_SCHEMA_VERSION,
+  REQUIRED_LUMA_WRITE_CLASSES,
+  buildLumaCoverageReport,
+  validateLumaCoverageReport,
+} from './luma-gated-write-coverage.mjs';
+
+const currentCommit = 'abc123';
+const startedAt = Date.parse('2026-05-09T00:00:00.000Z');
+const completedAt = Date.parse('2026-05-09T00:00:01.000Z');
+
+function passingRows(overrides = {}) {
+  return REQUIRED_LUMA_WRITE_CLASSES.map((definition, index) => ({
+    write_class: definition.id,
+    status: 'pass',
+    trace_id: `trace-${index}`,
+    writer_kind: 'luma',
+    reader_path: 'luma_reader_path',
+    schema_epoch: DEFAULT_LUMA_SCHEMA_EPOCH,
+    luma_profile: 'e2e',
+    ...overrides,
+  }));
+}
+
+function coverageReport(overrides = {}) {
+  return {
+    schema_version: LUMA_GATED_WRITE_COVERAGE_SCHEMA_VERSION,
+    generated_at: '2026-05-09T00:00:01.000Z',
+    run_id: 'mesh-luma-gated-write-coverage-test',
+    repo: {
+      branch: 'coord/test',
+      commit: currentCommit,
+      base_ref: 'origin/main',
+      dirty: false,
+    },
+    run: {
+      mode: 'luma_gated_write_coverage',
+      started_at: '2026-05-09T00:00:00.000Z',
+      completed_at: '2026-05-09T00:00:01.000Z',
+      command: LUMA_GATED_WRITE_COVERAGE_COMMAND,
+    },
+    status: 'pass',
+    schema_epoch: DEFAULT_LUMA_SCHEMA_EPOCH,
+    luma_profile: 'e2e',
+    luma_gated_write_drills: passingRows(),
+    ...overrides,
+  };
+}
+
+describe('LUMA-gated write coverage validator', () => {
+  it('passes only when every required class has LUMA reader-path evidence', () => {
+    const validation = validateLumaCoverageReport(coverageReport(), { currentCommit });
+
+    expect(validation.ok).toBe(true);
+    expect(validation.required_write_classes).toHaveLength(REQUIRED_LUMA_WRITE_CLASSES.length);
+    expect(validation.required_write_classes.every((row) => row.status === 'pass')).toBe(true);
+  });
+
+  it('does not accept one passing LUMA row as full coverage', () => {
+    const validation = validateLumaCoverageReport(
+      coverageReport({
+        luma_gated_write_drills: [passingRows()[0]],
+      }),
+      { currentCommit },
+    );
+
+    expect(validation.ok).toBe(false);
+    expect(validation.failures).toContain('missing forum comment LUMA reader-path evidence');
+    expect(validation.failures).toContain('missing directory publish LUMA reader-path evidence');
+  });
+
+  it('rejects synthetic mesh-drill evidence even when writer_kind says luma', () => {
+    const validation = validateLumaCoverageReport(
+      coverageReport({
+        luma_gated_write_drills: passingRows({
+          namespace: 'vh/__mesh_drills/test/luma',
+        }),
+      }),
+      { currentCommit },
+    );
+
+    expect(validation.ok).toBe(false);
+    expect(validation.failures.join('\n')).toContain('synthetic mesh-drill evidence');
+  });
+
+  it('rejects dirty, stale, wrong-epoch, and luma_profile none reports', () => {
+    const validation = validateLumaCoverageReport(
+      coverageReport({
+        schema_epoch: 'pre_luma_m0b',
+        luma_profile: 'none',
+        repo: {
+          branch: 'coord/test',
+          commit: 'old-commit',
+          base_ref: 'origin/main',
+          dirty: true,
+        },
+      }),
+      { currentCommit },
+    );
+
+    expect(validation.ok).toBe(false);
+    expect(validation.failures).toContain('schema_epoch is pre_luma_m0b');
+    expect(validation.failures).toContain('luma_profile is none');
+    expect(validation.failures).toContain(`report commit old-commit does not match ${currentCommit}`);
+    expect(validation.failures).toContain('report repo.dirty is not false');
+  });
+
+  it('builds a default blocked report without source evidence', () => {
+    const report = buildLumaCoverageReport({
+      runId: 'mesh-luma-gated-write-coverage-test',
+      startedAt,
+      completedAt,
+      currentCommit,
+      branch: 'coord/test',
+      dirty: false,
+    });
+
+    expect(report.status).toBe('blocked');
+    expect(report.luma_profile).toBe('none');
+    expect(report.failures).toContain('luma_profile is none and no LUMA reader-path coverage report was provided');
+    expect(report.luma_gated_write_drills.every((row) => row.status === 'skipped')).toBe(true);
+  });
+});

--- a/packages/e2e/src/mesh/production-readiness-check.mjs
+++ b/packages/e2e/src/mesh/production-readiness-check.mjs
@@ -4,6 +4,12 @@ import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import {
+  DEFAULT_LUMA_SCHEMA_EPOCH,
+  LUMA_GATED_WRITE_COVERAGE_COMMAND,
+  LUMA_GATED_WRITE_COVERAGE_REPORT_ENV,
+  validateLumaCoverageReport,
+} from './luma-gated-write-coverage.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -319,6 +325,60 @@ export function validationFailuresForSource({
   return unique(failures);
 }
 
+function resolveMaybeRelative(filePath) {
+  return filePath ? path.resolve(repoRoot, filePath) : null;
+}
+
+export function loadLumaCoverageEvidence({
+  currentCommit,
+  requireClean = true,
+  reportPath = process.env[LUMA_GATED_WRITE_COVERAGE_REPORT_ENV] || null,
+  expectedSchemaEpoch = process.env.VH_MESH_LUMA_GATED_WRITE_COVERAGE_SCHEMA_EPOCH || DEFAULT_LUMA_SCHEMA_EPOCH,
+  expectedLumaProfile = process.env.VH_MESH_LUMA_GATED_WRITE_COVERAGE_LUMA_PROFILE || null,
+} = {}) {
+  if (!reportPath) {
+    return {
+      provided: false,
+      status: 'pending',
+      report_path: null,
+      validation: {
+        ok: false,
+        status: 'blocked',
+        failures: ['no explicit LUMA-gated write coverage report was provided'],
+        required_write_classes: [],
+      },
+    };
+  }
+
+  const resolvedReportPath = resolveMaybeRelative(reportPath);
+  let report = null;
+  let validation = null;
+  try {
+    report = readJson(resolvedReportPath);
+    validation = validateLumaCoverageReport(report, {
+      currentCommit,
+      requireClean,
+      expectedSchemaEpoch,
+      expectedLumaProfile,
+    });
+  } catch (error) {
+    validation = {
+      ok: false,
+      status: 'blocked',
+      failures: [`failed to read LUMA-gated write coverage report: ${error instanceof Error ? error.message : String(error)}`],
+      required_write_classes: [],
+    };
+  }
+
+  return {
+    provided: true,
+    status: validation.ok ? 'pass' : 'blocked',
+    report_path: resolvedReportPath,
+    report,
+    validation,
+  };
+}
+
 function runSourceGate({ gate, artifactDir, currentCommit, requireClean }) {
   const startedAt = Date.now();
   const result = spawnSync(gate.command[0], gate.command.slice(1), {
@@ -456,7 +516,7 @@ function runEvidenceScrubGate({ artifactDir, currentCommit, requireClean }) {
   };
 }
 
-export function buildReleaseBlockers(sources) {
+export function buildReleaseBlockers(sources, { lumaCoverageEvidence = null } = {}) {
   const blockers = [];
   const sourceById = new Map(sources.map((source) => [source.id, source]));
   const soak = sourceById.get('soak')?.report;
@@ -519,15 +579,14 @@ export function buildReleaseBlockers(sources) {
     });
   }
 
-  const lumaRows = sources.flatMap((source) => source.report?.luma_gated_write_drills || []);
-  const lumaPassed = lumaRows.some((row) => row.status === 'pass');
-  const drillWriterKinds = mergeMaps(sources.map((source) => source.report?.drill_writer_kind_by_class));
-  const hasLumaWriter = Object.values(drillWriterKinds).includes('luma');
-  if (!lumaPassed || !hasLumaWriter) {
+  const lumaCoveragePassed = Boolean(lumaCoverageEvidence?.provided && lumaCoverageEvidence.validation?.ok);
+  if (!lumaCoveragePassed) {
     blockers.push({
       id: 'luma-gated-write-coverage',
-      command: 'future LUMA-gated mesh write drill through the LUMA reader path',
-      reason: 'current mesh packet uses synthetic mesh-drill records and does not prove LUMA-gated production write classes',
+      command: LUMA_GATED_WRITE_COVERAGE_COMMAND,
+      reason: lumaCoverageEvidence?.provided
+        ? 'explicit LUMA-gated write coverage report is missing required classes, stale, dirty, wrong-epoch, synthetic-only, or otherwise invalid'
+        : 'no explicit LUMA-gated write coverage report proves every required class through the LUMA reader path',
     });
   }
 
@@ -723,7 +782,7 @@ function writeAggregatePacket({ report, manifest, artifactDir }) {
   return { reportPath, manifestPath, latestReportPath: path.join(latestDir, 'mesh-production-readiness-report.json') };
 }
 
-function buildReport({ runId, startedAt, completedAt, sources, blockers, commandPassed }) {
+function buildReport({ runId, startedAt, completedAt, sources, blockers, commandPassed, lumaCoverageEvidence = null }) {
   const currentCommit = runGit(['rev-parse', 'HEAD']);
   const dirty = runGit(['status', '--short']).length > 0;
   const sourceReports = sources.map((source) => source.report).filter(Boolean);
@@ -736,6 +795,16 @@ function buildReport({ runId, startedAt, completedAt, sources, blockers, command
   const stateResolutionRows = normalizeReportRows(sources, 'state_resolution_drills');
   const readRepairRows = normalizeReportRows(sources, 'read_repair_drills');
   const lumaRows = normalizeReportRows(sources, 'luma_gated_write_drills');
+  const lumaCoverageProvided = Boolean(lumaCoverageEvidence?.provided);
+  const lumaCoveragePassed = Boolean(lumaCoverageProvided && lumaCoverageEvidence.validation?.ok);
+  const lumaCoverageStatus = lumaCoveragePassed ? 'pass' : lumaCoverageProvided ? 'blocked' : 'pending';
+  const lumaCoverageRows = (lumaCoverageEvidence?.validation?.required_write_classes || []).map((row) => ({
+    ...row,
+    status: row.status === 'pass' ? 'pass' : 'skipped',
+    trace_id: row.trace_id || runId,
+    source_gate: 'luma_gated_write_coverage',
+    source_run_id: lumaCoverageEvidence?.report?.run_id || null,
+  }));
   const degradationReasons = unique(sourceReports.flatMap((report) => report.health?.degradation_reasons_seen || []));
   const soakReport = sources.find((source) => source.id === 'soak')?.report;
   const clockSkewPassed = sources.find((source) => source.id === 'clock_skew')?.report?.clock_skew?.status === 'pass';
@@ -769,7 +838,7 @@ function buildReport({ runId, startedAt, completedAt, sources, blockers, command
     luma_profile: 'none',
     luma_dependency_status: {
       luma_m0b_schema_epoch: 'landed',
-      luma_gated_write_drills: 'pending',
+      luma_gated_write_drills: lumaCoverageStatus,
       luma_profile_gates: 'n/a',
     },
     drill_writer_kind_by_class: mergeMaps(sourceReports.map((report) => report.drill_writer_kind_by_class)),
@@ -799,13 +868,24 @@ function buildReport({ runId, startedAt, completedAt, sources, blockers, command
     state_resolution_drills: stateResolutionRows,
     conflict_fixtures: conflictRowsForAggregate({ sources, conflictPassed, runId }),
     read_repair_drills: readRepairRows,
+    luma_gated_write_coverage: {
+      command: LUMA_GATED_WRITE_COVERAGE_COMMAND,
+      report_env: LUMA_GATED_WRITE_COVERAGE_REPORT_ENV,
+      report_path: lumaCoverageEvidence?.report_path || null,
+      status: lumaCoverageStatus,
+      failures: lumaCoverageEvidence?.validation?.failures || [],
+      required_write_classes: lumaCoverageEvidence?.validation?.required_write_classes || [],
+    },
     luma_gated_write_drills: [
       ...lumaRows,
+      ...lumaCoverageRows,
       {
         write_class: 'LUMA-gated production write classes through LUMA reader path',
         trace_id: runId,
-        status: 'skipped',
-        reason: 'The aggregate gate uses existing synthetic mesh-drill evidence only; no LUMA _writerKind, _authorScheme, adapters, envelopes, custody, or schema migration work is exercised.',
+        status: lumaCoveragePassed ? 'pass' : 'skipped',
+        reason: lumaCoveragePassed
+          ? 'Explicit LUMA-gated write coverage report satisfied every required class through the LUMA reader path.'
+          : 'The aggregate gate uses existing synthetic mesh-drill evidence only; no LUMA _writerKind, _authorScheme, adapters, envelopes, custody, or schema migration work is exercised.',
       },
     ],
     clock_skew: buildClockSkew(sources),
@@ -851,12 +931,14 @@ async function main() {
 
   const currentCommit = runGit(['rev-parse', 'HEAD']);
   const requireClean = process.env.VH_MESH_PRODUCTION_READINESS_ALLOW_DIRTY !== 'true';
+  const lumaCoverageEvidence = loadLumaCoverageEvidence({ currentCommit, requireClean });
   const sources = [];
   for (const gate of SOURCE_GATES) {
     sources.push(runSourceGate({ gate, artifactDir, currentCommit, requireClean }));
   }
-  const initialBlockers = buildReleaseBlockers(sources);
-  const initialCommandPassed = sources.every((source) => source.status === 'pass');
+  const initialBlockers = buildReleaseBlockers(sources, { lumaCoverageEvidence });
+  const lumaCoverageCommandPassed = !lumaCoverageEvidence.provided || lumaCoverageEvidence.validation.ok;
+  const initialCommandPassed = sources.every((source) => source.status === 'pass') && lumaCoverageCommandPassed;
   const candidateCompletedAt = Date.now();
   const candidateReport = buildReport({
     runId,
@@ -865,6 +947,7 @@ async function main() {
     sources,
     blockers: initialBlockers,
     commandPassed: initialCommandPassed,
+    lumaCoverageEvidence,
   });
   const provisionalReportPath = path.join(artifactDir, 'mesh-production-readiness-report.json');
   const candidateManifest = buildManifest({
@@ -879,10 +962,10 @@ async function main() {
     sources.push(runEvidenceScrubGate({ artifactDir, currentCommit, requireClean }));
   }
 
-  const blockers = buildReleaseBlockers(sources);
-  const commandPassed = sources.every((source) => source.status === 'pass');
+  const blockers = buildReleaseBlockers(sources, { lumaCoverageEvidence });
+  const commandPassed = sources.every((source) => source.status === 'pass') && lumaCoverageCommandPassed;
   const completedAt = Date.now();
-  const report = buildReport({ runId, startedAt, completedAt, sources, blockers, commandPassed });
+  const report = buildReport({ runId, startedAt, completedAt, sources, blockers, commandPassed, lumaCoverageEvidence });
   const manifest = buildManifest({ report, sources, blockers, reportPath: provisionalReportPath });
   const paths = writeAggregatePacket({ report, manifest, artifactDir });
 

--- a/packages/e2e/src/mesh/production-readiness-check.test.mjs
+++ b/packages/e2e/src/mesh/production-readiness-check.test.mjs
@@ -10,6 +10,12 @@ import {
   validateAggregatePacket,
 } from './evidence-scrub-check.mjs';
 import {
+  LUMA_GATED_WRITE_COVERAGE_COMMAND,
+  LUMA_GATED_WRITE_COVERAGE_SCHEMA_VERSION,
+  REQUIRED_LUMA_WRITE_CLASSES,
+  validateLumaCoverageReport,
+} from './luma-gated-write-coverage.mjs';
+import {
   SOURCE_GATES,
   buildReleaseBlockers,
   conflictRowsForAggregate,
@@ -45,6 +51,47 @@ function sourceReport(overrides = {}) {
     write_class_slos: [],
     resource_slos: [],
     ...overrides,
+  };
+}
+
+function passingLumaCoverageReport(overrides = {}) {
+  return {
+    schema_version: LUMA_GATED_WRITE_COVERAGE_SCHEMA_VERSION,
+    generated_at: '2026-05-07T00:00:10.000Z',
+    run_id: 'mesh-luma-gated-write-coverage-test',
+    repo: {
+      commit: currentCommit,
+      dirty: false,
+    },
+    run: {
+      mode: 'luma_gated_write_coverage',
+      started_at: '2026-05-07T00:00:01.000Z',
+      completed_at: '2026-05-07T00:00:10.000Z',
+      command: LUMA_GATED_WRITE_COVERAGE_COMMAND,
+    },
+    status: 'pass',
+    schema_epoch: 'post_luma_m0b',
+    luma_profile: 'e2e',
+    luma_gated_write_drills: REQUIRED_LUMA_WRITE_CLASSES.map((definition, index) => ({
+      write_class: definition.id,
+      trace_id: `luma-trace-${index}`,
+      status: 'pass',
+      writer_kind: 'luma',
+      reader_path: 'luma_reader_path',
+      schema_epoch: 'post_luma_m0b',
+      luma_profile: 'e2e',
+    })),
+    ...overrides,
+  };
+}
+
+function lumaCoverageEvidence(report = passingLumaCoverageReport()) {
+  return {
+    provided: true,
+    status: 'pass',
+    report_path: '/tmp/mesh-luma-gated-write-coverage-report.json',
+    report,
+    validation: validateLumaCoverageReport(report, { currentCommit }),
   };
 }
 
@@ -262,6 +309,80 @@ describe('production-readiness source evidence validation', () => {
     expect(blockers.map((blocker) => blocker.id)).toContain('luma-gated-write-coverage');
   });
 
+  it('does not run the default-blocked LUMA coverage command as a source gate', () => {
+    expect(SOURCE_GATES.map((gate) => gate.id)).not.toContain('luma_gated_write_coverage');
+  });
+
+  it('keeps the LUMA blocker for legacy partial row plus luma writer kind evidence', () => {
+    const blockers = buildReleaseBlockers([
+      {
+        id: 'legacy_luma_shape',
+        report: {
+          luma_gated_write_drills: [
+            {
+              write_class: 'forum thread',
+              status: 'pass',
+              trace_id: 'legacy-row',
+            },
+          ],
+          drill_writer_kind_by_class: {
+            'forum thread': 'luma',
+          },
+        },
+      },
+    ]);
+
+    expect(blockers).toContainEqual(expect.objectContaining({
+      id: 'luma-gated-write-coverage',
+      command: LUMA_GATED_WRITE_COVERAGE_COMMAND,
+    }));
+  });
+
+  it('clears the LUMA blocker only with explicit all-class reader-path evidence', () => {
+    const blockers = buildReleaseBlockers(
+      [
+        {
+          id: 'soak',
+          report: {
+            soak: {
+              full_duration_satisfied: true,
+            },
+          },
+        },
+        {
+          id: 'deployed_wss',
+          report: {
+            run: { deployment_scope: 'public_wss_deployment' },
+          },
+        },
+        {
+          id: 'conflict',
+          report: {
+            conflict: { status: 'pass' },
+            conflict_fixtures: [
+              'same-key-concurrent-deterministic-writes',
+              'stale-overwrite-attempt-rejected',
+              'future-protocol-version-rejected',
+              'unknown-schema-version-quarantined',
+              'missing-drill-author-scheme-quarantined',
+              'unsupported-drill-author-scheme-quarantined',
+            ].map((fixture) => ({ fixture, status: 'pass' })),
+          },
+        },
+        {
+          id: 'evidence_scrub',
+          status: 'pass',
+          report: {
+            evidence_scrub: { status: 'pass' },
+          },
+        },
+      ],
+      { lumaCoverageEvidence: lumaCoverageEvidence() },
+    );
+
+    expect(blockers.map((blocker) => blocker.id)).not.toContain('luma-gated-write-coverage');
+  });
+
   it('accepts a fresh source report for the exact gate command', () => {
     const failures = failuresFor({
       gate: {
@@ -463,6 +584,32 @@ describe('mesh evidence scrub promotion', () => {
 
       expect(validation.ok).toBe(false);
       expect(validation.failures).toContain('write class forum-post has disallowed writer kind luma');
+    } finally {
+      fs.rmSync(sourceDir, { recursive: true, force: true });
+    }
+  });
+
+  it('allows passing LUMA rows only when explicit coverage status passed', () => {
+    const sourceDir = evidenceScrubPacket();
+    try {
+      const aggregatePath = path.join(sourceDir, 'mesh-production-readiness-report.json');
+      const aggregate = JSON.parse(fs.readFileSync(aggregatePath, 'utf8'));
+      aggregate.luma_gated_write_coverage = {
+        status: 'pass',
+        report_path: '/tmp/mesh-luma-gated-write-coverage-report.json',
+      };
+      aggregate.luma_gated_write_drills = [
+        {
+          write_class: 'forum_thread',
+          trace_id: 'luma-coverage-pass',
+          status: 'pass',
+        },
+      ];
+      writeJson(aggregatePath, aggregate);
+
+      const validation = validateAggregatePacket({ sourceDir });
+
+      expect(validation.failures).not.toContain('aggregate implies LUMA-gated write coverage in a mesh-only evidence packet');
     } finally {
       fs.rmSync(sourceDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- add `pnpm test:mesh:luma-gated-write-coverage` as a standalone fail-closed report-backed gate
- validate required LUMA-gated classes with an all-class LUMA reader-path contract instead of one passing row plus writer-kind metadata
- keep the default `luma_profile: none` mesh aggregate at 12 source reports and `review_required`
- allow production readiness to consume explicit LUMA coverage only from `VH_MESH_LUMA_GATED_WRITE_COVERAGE_REPORT`, failing closed on bad evidence
- update evidence scrub so passing LUMA rows require explicit passed coverage status, while mesh-only packets still reject implied LUMA coverage
- update mesh readiness docs/runbook for the Slice 14E contract

## Verification
- node --check packages/e2e/src/mesh/luma-gated-write-coverage.mjs
- node --check packages/e2e/src/mesh/production-readiness-check.mjs
- node --check packages/e2e/src/mesh/evidence-scrub-check.mjs
- pnpm --filter @vh/e2e exec vitest run src/mesh/luma-gated-write-coverage.vitest.mjs src/mesh/production-readiness-check.test.mjs --config ./vitest.config.ts --reporter=dot
- pnpm --filter @vh/e2e typecheck
- pnpm docs:check
- git diff --check origin/main...HEAD
- node tools/scripts/check-diff-coverage.mjs
- pnpm test:mesh:luma-gated-write-coverage exits 1 as expected and writes blocked report with repo_dirty false
- pnpm check:mesh:production-readiness exits 0 with review_required, post_luma_m0b, luma_profile none, 12 source reports, evidence_scrub pass

## Evidence
- LUMA gate blocked report: `mesh-luma-gated-write-coverage-20260509T180617Z-1c06b4e9`, status blocked, luma_profile none, repo_dirty false
- Mesh aggregate: `mesh-production-readiness-20260509T180628Z-e861cff1`, review_required, source_count 12, luma coverage pending
- Remaining local blockers: canonical-30-minute-soak, public-wss-deployment-proof, luma-gated-write-coverage
- Protected-surface grep: clean for app runtime, relay runtime, LUMA adapters/schemas/custody/envelopes/write paths, identifiers, signed-write primitives, public-id derivation, and identity-vault surfaces

## Notes
- This branch intentionally does not add LUMA adapters, schemas, custody, envelopes, signed-write primitives, identity vault, app runtime behavior, relay runtime behavior, public WSS deployment proof, or fake successful LUMA writes.
- Local Node is v23.10.0 while the repo declares >=20 <23; CI uses Node 20.