### PR TITLE
Add hermetic LUMA reader-path coverage mode

### DIFF
--- a/docs/ops/mesh-production-topology-drills.md
+++ b/docs/ops/mesh-production-topology-drills.md
@@ -140,6 +140,22 @@ required LUMA-gated write class through the LUMA reader path. A single passing
 LUMA row, a synthetic `vh/__mesh_drills/*` row, or a merged
 `drill_writer_kind_by_class` value of `luma` is not enough.
 
+For deterministic local evidence, run the explicit hermetic LUMA reader-path
+mode:
+
+```sh
+pnpm test:mesh:luma-gated-write-coverage -- --mode local-e2e
+```
+
+This mode builds the required local packages, writes and reads back forum
+thread, forum comment, aggregate voter, directory publish, and news report
+records through the existing LUMA-aware adapter paths, and then validates the
+generated source rows through the same strict coverage gate. It emits
+`luma_profile: e2e` only for this local hermetic evidence packet. The default
+no-argument command remains blocked, and recent LUMA system-writer story,
+storyline, index, and analysis checks remain separate guardrails rather than
+coverage classes for this blocker.
+
 Run the state-resolution drill:
 
 ```sh

--- a/docs/specs/spec-mesh-production-readiness.md
+++ b/docs/specs/spec-mesh-production-readiness.md
@@ -2474,6 +2474,21 @@ Slice 14E strict coverage contract:
   report, synthetic `vh/__mesh_drills/*` row, `_drillWriterKind:
   'mesh-drill'`, or overclaiming release-ready statement keeps the blocker.
 
+Slice 14F hermetic reader-path evidence:
+
+- `pnpm test:mesh:luma-gated-write-coverage -- --mode local-e2e` is the
+  deterministic local evidence producer for the strict gate. The no-argument
+  command remains blocked under `luma_profile: none`.
+- Local E2E mode must generate its source rows from writes and readbacks through
+  existing LUMA-aware adapter paths, then immediately validate that generated
+  source report with the same strict coverage validator.
+- The local E2E packet uses `luma_profile: e2e`; it is acceptable evidence for
+  clearing only `luma-gated-write-coverage` in a local aggregate run. It is not
+  a production LUMA profile, a public WSS proof, or a downstream app canary.
+- Recent LUMA system-writer story, storyline, index, and analysis gates remain
+  protected-surface guardrails. They do not count as any of the five required
+  user LUMA-gated write coverage classes.
+
 Still not allowed after mesh readiness alone:
 
 - "The full app is test-group ready."

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -49,7 +49,9 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@vh/gun-client": "workspace:*"
+    "@vh/data-model": "workspace:*",
+    "@vh/gun-client": "workspace:*",
+    "@vh/luma-sdk": "workspace:*"
   },
   "devDependencies": {
     "@playwright/test": "^1.42.1",

--- a/packages/e2e/src/mesh/luma-gated-write-coverage.mjs
+++ b/packages/e2e/src/mesh/luma-gated-write-coverage.mjs
@@ -3,7 +3,7 @@ import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 import { spawnSync } from 'node:child_process';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -17,6 +17,8 @@ export const LUMA_GATED_WRITE_COVERAGE_COMMAND = 'pnpm test:mesh:luma-gated-writ
 export const LUMA_GATED_WRITE_COVERAGE_REPORT_NAME = 'mesh-luma-gated-write-coverage-report.json';
 export const LUMA_GATED_WRITE_COVERAGE_REPORT_ENV = 'VH_MESH_LUMA_GATED_WRITE_COVERAGE_REPORT';
 export const DEFAULT_LUMA_SCHEMA_EPOCH = 'post_luma_m0b';
+export const LOCAL_E2E_LUMA_PROFILE = 'e2e';
+export const LOCAL_E2E_MODE = 'local-e2e';
 export const REQUIRED_LUMA_WRITE_CLASSES = [
   {
     id: 'forum_thread',
@@ -130,6 +132,30 @@ function normalizeKey(value) {
 
 function unique(values) {
   return [...new Set(values.filter((value) => value !== undefined && value !== null && value !== ''))];
+}
+
+function commandText(args = process.argv.slice(2)) {
+  return [LUMA_GATED_WRITE_COVERAGE_COMMAND, ...args].join(' ').trim();
+}
+
+function toBase64Url(bytes) {
+  return Buffer.from(bytes).toString('base64url');
+}
+
+function bytesToBufferSource(bytes) {
+  const copy = new Uint8Array(bytes.byteLength);
+  copy.set(bytes);
+  return copy.buffer;
+}
+
+function cloneJson(value) {
+  return value === undefined ? undefined : JSON.parse(JSON.stringify(value));
+}
+
+function readOnce(chain) {
+  return new Promise((resolve) => {
+    chain.once((data) => resolve(data ?? null));
+  });
 }
 
 function rowsFromReport(report) {
@@ -324,6 +350,634 @@ function blockedValidation(reason) {
   };
 }
 
+const localE2eBuildPackages = [
+  '@vh/types',
+  '@vh/crypto',
+  '@vh/luma-sdk',
+  '@vh/data-model',
+  '@vh/gun-client',
+];
+let esmResolverRegistered = false;
+
+function runLocalPackageBuilds() {
+  for (const packageName of localE2eBuildPackages) {
+    const result = spawnSync('pnpm', ['--filter', packageName, 'build'], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    });
+    if (result.status !== 0) {
+      const output = [result.stdout, result.stderr].filter(Boolean).join('\n').trim();
+      throw new Error(`failed to build ${packageName}${output ? `\n${output}` : ''}`);
+    }
+  }
+}
+
+async function registerEsmResolver() {
+  if (esmResolverRegistered) {
+    return;
+  }
+  const { register } = await import('node:module');
+  register(pathToFileURL(path.join(repoRoot, 'tools/node/esm-resolve-loader.mjs')).href, pathToFileURL(__filename));
+  esmResolverRegistered = true;
+}
+
+async function loadLocalE2eModules({ skipBuild = false } = {}) {
+  if (!skipBuild) {
+    runLocalPackageBuilds();
+  }
+  await registerEsmResolver();
+  const importRuntimeModule = (specifier) => import(/* @vite-ignore */ specifier);
+  const [forumAdapters, aggregateAdapters, directoryAdapters, newsReportAdapters, dataModel, lumaSdk] = await Promise.all([
+    importRuntimeModule(pathToFileURL(path.join(repoRoot, 'packages/gun-client/dist/forumAdapters.js')).href),
+    importRuntimeModule(pathToFileURL(path.join(repoRoot, 'packages/gun-client/dist/aggregateAdapters.js')).href),
+    importRuntimeModule(pathToFileURL(path.join(repoRoot, 'packages/gun-client/dist/directoryAdapters.js')).href),
+    importRuntimeModule(pathToFileURL(path.join(repoRoot, 'packages/gun-client/dist/newsReportAdapters.js')).href),
+    importRuntimeModule('@vh/data-model'),
+    importRuntimeModule('@vh/luma-sdk'),
+  ]);
+  const gunClient = {
+    ...forumAdapters,
+    ...aggregateAdapters,
+    ...directoryAdapters,
+    ...newsReportAdapters,
+  };
+  return { gunClient, dataModel, lumaSdk };
+}
+
+function createHermeticMeshClient() {
+  const store = new Map();
+  const writes = [];
+  const guardedWrites = [];
+
+  const keyFor = (segments) => segments.join('/');
+  const readPath = (segments) => cloneJson(store.get(keyFor(segments)));
+  const writePath = (segments, value) => {
+    const cloned = cloneJson(value);
+    const key = keyFor(segments);
+    store.set(key, cloned);
+    if (segments.length > 0) {
+      const parent = segments.slice(0, -1);
+      const childKey = segments.at(-1);
+      const parentKey = keyFor(parent);
+      const parentValue = store.get(parentKey);
+      const parentRecord =
+        parentValue && typeof parentValue === 'object' && !Array.isArray(parentValue)
+          ? cloneJson(parentValue)
+          : {};
+      parentRecord[childKey] = cloned;
+      store.set(parentKey, parentRecord);
+    }
+  };
+
+  const makeNode = (segments) => ({
+    get(key) {
+      return makeNode([...segments, String(key)]);
+    },
+    once(callback) {
+      callback?.(readPath(segments), segments.at(-1));
+    },
+    put(value, callback) {
+      writes.push({ path: keyFor(segments), value: cloneJson(value) });
+      writePath(segments, value);
+      callback?.({});
+    },
+    map() {
+      const node = makeNode(segments);
+      node.once = (callback) => {
+        const value = readPath(segments);
+        if (!value || typeof value !== 'object' || Array.isArray(value)) {
+          return;
+        }
+        for (const [key, child] of Object.entries(value)) {
+          callback?.(cloneJson(child), key);
+        }
+      };
+      return node;
+    },
+    off() {},
+  });
+
+  const root = makeNode([]);
+  const vhRoot = root.get('vh');
+  const hydrationBarrier = {
+    ready: true,
+    async prepare() {},
+    markReady() {},
+  };
+  const topologyGuard = {
+    validateWrite(pathName, value) {
+      guardedWrites.push({ path: pathName, value: cloneJson(value) });
+    },
+  };
+
+  return {
+    client: {
+      gun: {
+        get: (key) => root.get(String(key)),
+        user: () => ({}),
+      },
+      mesh: vhRoot,
+      hydrationBarrier,
+      topologyGuard,
+      config: { peers: [] },
+      storage: {},
+      user: {},
+      chat: {},
+      outbox: {},
+      sessionReady: true,
+      markSessionReady() {},
+      async linkDevice() {},
+      async shutdown() {},
+    },
+    store,
+    writes,
+    guardedWrites,
+  };
+}
+
+async function createEd25519KeyPair() {
+  const subtle = globalThis.crypto?.subtle;
+  if (!subtle) {
+    throw new Error('WebCrypto subtle API is unavailable');
+  }
+  const keyPair = await subtle.generateKey('Ed25519', true, ['sign', 'verify']);
+  if (!('privateKey' in keyPair) || !('publicKey' in keyPair)) {
+    throw new Error('Ed25519 key generation failed');
+  }
+  const sign = async ({ canonicalBytes }) =>
+    toBase64Url(
+      new Uint8Array(
+        await subtle.sign('Ed25519', keyPair.privateKey, bytesToBufferSource(canonicalBytes)),
+      ),
+    );
+  const verify = ({ canonicalBytes, signature }) =>
+    subtle.verify(
+      'Ed25519',
+      keyPair.publicKey,
+      bytesToBufferSource(new Uint8Array(Buffer.from(signature, 'base64url'))),
+      bytesToBufferSource(canonicalBytes),
+    );
+  const publicKeySpki = await subtle.exportKey('spki', keyPair.publicKey);
+  return {
+    sign,
+    verify,
+    publicKeySpkiBase64Url: toBase64Url(new Uint8Array(publicKeySpki)),
+  };
+}
+
+function coverageRow({
+  runId,
+  writeClass,
+  traceSuffix,
+  writePath,
+  adapterWrite,
+  adapterReadback,
+  repoCommit,
+}) {
+  return {
+    write_class: writeClass,
+    status: 'pass',
+    trace_id: `${runId}:${traceSuffix}`,
+    writer_kind: 'luma',
+    _writerKind: 'luma',
+    reader_path: 'luma_reader_path',
+    readback_path: 'luma readback',
+    schema_epoch: DEFAULT_LUMA_SCHEMA_EPOCH,
+    luma_profile: LOCAL_E2E_LUMA_PROFILE,
+    repo_commit: repoCommit,
+    namespace: writePath,
+    adapter_write: adapterWrite,
+    adapter_readback: adapterReadback,
+  };
+}
+
+export function buildLocalE2eCoverageSourceReport({
+  runId,
+  startedAt,
+  completedAt,
+  currentCommit,
+  branch,
+  dirty,
+  command = `${LUMA_GATED_WRITE_COVERAGE_COMMAND} -- --mode ${LOCAL_E2E_MODE}`,
+  rows,
+  failures = [],
+  guardedWritePaths = [],
+} = {}) {
+  const report = {
+    schema_version: LUMA_GATED_WRITE_COVERAGE_SCHEMA_VERSION,
+    generated_at: new Date(completedAt).toISOString(),
+    run_id: `${runId}-local-e2e-source`,
+    repo: {
+      branch,
+      commit: currentCommit,
+      base_ref: 'origin/main',
+      dirty,
+    },
+    run: {
+      mode: LOCAL_E2E_MODE,
+      started_at: new Date(startedAt).toISOString(),
+      completed_at: new Date(completedAt).toISOString(),
+      duration_ms: completedAt - startedAt,
+      command,
+    },
+    status: failures.length === 0 ? 'pass' : 'blocked',
+    schema_epoch: DEFAULT_LUMA_SCHEMA_EPOCH,
+    luma_profile: LOCAL_E2E_LUMA_PROFILE,
+    coverage_rows: rows,
+    local_e2e: {
+      hermetic: true,
+      profile: LOCAL_E2E_LUMA_PROFILE,
+      guarded_write_paths: guardedWritePaths,
+      required_write_classes: REQUIRED_LUMA_WRITE_CLASSES.map((definition) => definition.id),
+      note: 'Rows are produced from hermetic writes and adapter readbacks in existing LUMA-aware client paths.',
+    },
+    failures,
+  };
+  const validation = validateLumaCoverageReport(report, {
+    currentCommit,
+    requireClean: true,
+    expectedSchemaEpoch: DEFAULT_LUMA_SCHEMA_EPOCH,
+    expectedLumaProfile: LOCAL_E2E_LUMA_PROFILE,
+  });
+  return {
+    ...report,
+    status: validation.ok ? report.status : 'blocked',
+    validation,
+    failures: unique([...failures, ...validation.failures]),
+  };
+}
+
+async function createSignedForumThread({ dataModel, lumaSdk, runId }) {
+  const keys = await createEd25519KeyPair();
+  const issuedAt = 1_777_777_777_000;
+  const author = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+  const payload = {
+    schemaVersion: 'hermes-thread-v1',
+    _protocolVersion: dataModel.FORUM_PUBLIC_PROTOCOL_VERSION,
+    _writerKind: dataModel.FORUM_WRITER_KIND,
+    _authorScheme: dataModel.FORUM_AUTHOR_SCHEME,
+    id: `thread-${runId}`,
+    title: 'Hermetic LUMA coverage thread',
+    content: 'Deterministic local reader-path coverage.',
+    author,
+    timestamp: issuedAt,
+    tags: ['luma-coverage'],
+    topicId: 'luma-coverage-topic',
+  };
+  const signedWriteEnvelope = await lumaSdk.createSignedWriteEnvelope({
+    profile: LOCAL_E2E_LUMA_PROFILE,
+    audience: dataModel.FORUM_THREAD_AUDIENCE,
+    origin: 'https://vh.example',
+    scheme: dataModel.FORUM_AUTHOR_SCHEME,
+    publicAuthor: lumaSdk.createLumaPublicAuthorId(author, dataModel.FORUM_AUTHOR_SCHEME),
+    sessionRef: {
+      tokenHash: 'a'.repeat(64),
+      envelopeDigest: 'b'.repeat(64),
+    },
+    payload,
+    sequence: issuedAt,
+    nonce: '00112233445566778899aabbccddeeff',
+    issuedAt,
+    sign: keys.sign,
+  });
+  return {
+    record: {
+      ...payload,
+      upvotes: 0,
+      downvotes: 0,
+      score: 0,
+      signedWriteEnvelope,
+    },
+    verify: keys.verify,
+  };
+}
+
+async function createSignedForumComment({ dataModel, lumaSdk, runId, threadId }) {
+  const keys = await createEd25519KeyPair();
+  const issuedAt = 1_777_777_777_001;
+  const author = 'abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd';
+  const payload = {
+    schemaVersion: 'hermes-comment-v2',
+    _protocolVersion: dataModel.FORUM_PUBLIC_PROTOCOL_VERSION,
+    _writerKind: dataModel.FORUM_WRITER_KIND,
+    _authorScheme: dataModel.FORUM_AUTHOR_SCHEME,
+    id: `comment-${runId}`,
+    threadId,
+    parentId: null,
+    content: 'Hermetic LUMA coverage comment',
+    author,
+    timestamp: issuedAt,
+    stance: 'concur',
+  };
+  const signedWriteEnvelope = await lumaSdk.createSignedWriteEnvelope({
+    profile: LOCAL_E2E_LUMA_PROFILE,
+    audience: dataModel.FORUM_COMMENT_AUDIENCE,
+    origin: 'https://vh.example',
+    scheme: dataModel.FORUM_AUTHOR_SCHEME,
+    publicAuthor: lumaSdk.createLumaPublicAuthorId(author, dataModel.FORUM_AUTHOR_SCHEME),
+    sessionRef: {
+      tokenHash: 'c'.repeat(64),
+      envelopeDigest: 'd'.repeat(64),
+    },
+    payload,
+    sequence: issuedAt,
+    nonce: '11223344556677889900aabbccddeeff',
+    issuedAt,
+    sign: keys.sign,
+  });
+  return {
+    record: {
+      ...payload,
+      upvotes: 0,
+      downvotes: 0,
+      signedWriteEnvelope,
+    },
+    verify: keys.verify,
+  };
+}
+
+async function createSignedAggregateVoterNode({ dataModel, lumaSdk, runId }) {
+  const keys = await createEd25519KeyPair();
+  const issuedAt = 1_777_777_777_002;
+  const voterId = '1111111111111111111111111111111111111111111111111111111111111111';
+  const payload = {
+    schema_version: dataModel.AGGREGATE_VOTER_NODE_VERSION,
+    _protocolVersion: dataModel.AGGREGATE_PUBLIC_PROTOCOL_VERSION,
+    _writerKind: dataModel.AGGREGATE_VOTER_WRITER_KIND,
+    _authorScheme: dataModel.AGGREGATE_VOTER_AUTHOR_SCHEME,
+    topic_id: 'luma-coverage-topic',
+    synthesis_id: 'luma-coverage-synthesis',
+    epoch: 1,
+    voter_id: voterId,
+    point_id: `point-${runId}`,
+    agreement: 1,
+    weight: 1,
+    updated_at: '2026-05-09T00:00:00.000Z',
+  };
+  const signedWriteEnvelope = await lumaSdk.createSignedWriteEnvelope({
+    profile: LOCAL_E2E_LUMA_PROFILE,
+    audience: dataModel.AGGREGATE_VOTER_AUDIENCE,
+    origin: 'https://vh.example',
+    scheme: dataModel.AGGREGATE_VOTER_AUTHOR_SCHEME,
+    publicAuthor: lumaSdk.createLumaPublicAuthorId(voterId, dataModel.AGGREGATE_VOTER_AUTHOR_SCHEME),
+    sessionRef: {
+      tokenHash: 'e'.repeat(64),
+      envelopeDigest: 'f'.repeat(64),
+    },
+    payload,
+    sequence: issuedAt,
+    nonce: '22334455667788990011aabbccddeeff',
+    issuedAt,
+    sign: keys.sign,
+  });
+  return {
+    record: {
+      ...payload,
+      signedWriteEnvelope,
+    },
+    verify: keys.verify,
+  };
+}
+
+async function createSignedDirectoryEntry({ dataModel, lumaSdk, runId }) {
+  const keys = await createEd25519KeyPair();
+  const issuedAt = 1_777_777_777_003;
+  const identityDirectoryKey = '2222222222222222222222222222222222222222222222222222222222222222';
+  const payload = {
+    schemaVersion: 'hermes-directory-v1',
+    _protocolVersion: dataModel.DIRECTORY_ENTRY_PROTOCOL_VERSION,
+    _writerKind: dataModel.DIRECTORY_ENTRY_WRITER_KIND,
+    _authorScheme: dataModel.DIRECTORY_ENTRY_AUTHOR_SCHEME,
+    identityDirectoryKey,
+    devicePub: `device-${runId}`,
+    epub: `epub-${runId}`,
+    displayName: 'LUMA Coverage',
+    delegationSigningPublicKey: {
+      signatureSuite: 'jcs-ed25519-sha256-v1',
+      publicKey: {
+        encoding: 'base64url',
+        material: keys.publicKeySpkiBase64Url,
+      },
+      createdAt: issuedAt,
+    },
+    registeredAt: issuedAt,
+    lastSeenAt: issuedAt + 1,
+  };
+  const signedWriteEnvelope = await lumaSdk.createSignedWriteEnvelope({
+    profile: LOCAL_E2E_LUMA_PROFILE,
+    audience: dataModel.DIRECTORY_ENTRY_AUDIENCE,
+    origin: 'https://vh.example',
+    scheme: dataModel.DIRECTORY_ENTRY_AUTHOR_SCHEME,
+    publicAuthor: lumaSdk.createLumaPublicAuthorId(identityDirectoryKey, dataModel.DIRECTORY_ENTRY_AUTHOR_SCHEME),
+    sessionRef: {
+      tokenHash: '1'.repeat(64),
+      envelopeDigest: '2'.repeat(64),
+    },
+    payload,
+    sequence: issuedAt,
+    nonce: '33445566778899001122aabbccddeeff',
+    issuedAt,
+    sign: keys.sign,
+  });
+  return {
+    ...payload,
+    signedWriteEnvelope,
+  };
+}
+
+async function createSignedNewsReport({ dataModel, lumaSdk, runId }) {
+  const keys = await createEd25519KeyPair();
+  const issuedAt = 1_777_777_777_004;
+  const reporterId = '3333333333333333333333333333333333333333333333333333333333333333';
+  const signedPayload = dataModel.newsReportSignedPayload({
+    schemaVersion: 'hermes-news-report-v2',
+    _protocolVersion: dataModel.NEWS_REPORT_PUBLIC_PROTOCOL_VERSION,
+    _writerKind: dataModel.NEWS_REPORT_WRITER_KIND,
+    _authorScheme: dataModel.NEWS_REPORT_AUTHOR_SCHEME,
+    report_id: `report-${runId}`,
+    target: {
+      type: 'synthesis',
+      topic_id: 'luma-coverage-topic',
+      synthesis_id: 'luma-coverage-synthesis',
+      epoch: 1,
+      story_id: 'luma-coverage-story',
+    },
+    reason_code: 'inaccurate_summary',
+    reason: 'Hermetic LUMA reader-path coverage.',
+    reporter_id: reporterId,
+    created_at: issuedAt,
+  });
+  const signedWriteEnvelope = await lumaSdk.createSignedWriteEnvelope({
+    profile: LOCAL_E2E_LUMA_PROFILE,
+    audience: dataModel.NEWS_REPORT_AUDIENCE,
+    origin: 'https://vh.example',
+    scheme: dataModel.NEWS_REPORT_AUTHOR_SCHEME,
+    publicAuthor: lumaSdk.createLumaPublicAuthorId(reporterId, dataModel.NEWS_REPORT_AUTHOR_SCHEME),
+    sessionRef: {
+      tokenHash: '3'.repeat(64),
+      envelopeDigest: '4'.repeat(64),
+    },
+    payload: signedPayload,
+    sequence: issuedAt,
+    nonce: '44556677889900112233aabbccddeeff',
+    issuedAt,
+    sign: keys.sign,
+  });
+  return {
+    ...signedPayload,
+    status: 'pending',
+    audit: {
+      action: 'news_report',
+    },
+    signedWriteEnvelope,
+  };
+}
+
+function assertReadback(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+async function runLocalE2eCoverageEvidence({
+  runId,
+  startedAt,
+  currentCommit,
+  branch,
+  dirty,
+  command,
+  skipBuild = false,
+} = {}) {
+  const { gunClient, dataModel, lumaSdk } = await loadLocalE2eModules({ skipBuild });
+  const { client, guardedWrites } = createHermeticMeshClient();
+  const rows = [];
+
+  const thread = await createSignedForumThread({ dataModel, lumaSdk, runId });
+  await gunClient.getForumThreadChain(client, thread.record.id).put(thread.record);
+  const threadReadback = await readOnce(gunClient.getForumThreadChain(client, thread.record.id));
+  const validatedThread = await gunClient.validateForumThreadRecord(threadReadback, thread.record.id, thread.verify);
+  assertReadback(validatedThread?.id === thread.record.id, 'forum thread LUMA readback failed');
+  rows.push(coverageRow({
+    runId,
+    writeClass: 'forum_thread',
+    traceSuffix: 'forum-thread',
+    writePath: `vh/forum/threads/${thread.record.id}/`,
+    adapterWrite: 'getForumThreadChain.put',
+    adapterReadback: 'validateForumThreadRecord(getForumThreadChain.once)',
+    repoCommit: currentCommit,
+  }));
+
+  const comment = await createSignedForumComment({ dataModel, lumaSdk, runId, threadId: thread.record.id });
+  await gunClient.getForumCommentsChain(client, thread.record.id).get(comment.record.id).put(comment.record);
+  const commentReadback = await readOnce(
+    gunClient.getForumCommentsChain(client, thread.record.id).get(comment.record.id),
+  );
+  const validatedComment = await gunClient.validateForumCommentRecord(
+    commentReadback,
+    thread.record.id,
+    comment.record.id,
+    comment.verify,
+  );
+  assertReadback(validatedComment?.id === comment.record.id, 'forum comment LUMA readback failed');
+  rows.push(coverageRow({
+    runId,
+    writeClass: 'forum_comment',
+    traceSuffix: 'forum-comment',
+    writePath: `vh/forum/threads/${thread.record.id}/comments/${comment.record.id}/`,
+    adapterWrite: 'getForumCommentsChain.get(commentId).put',
+    adapterReadback: 'validateForumCommentRecord(getForumCommentsChain.get(commentId).once)',
+    repoCommit: currentCommit,
+  }));
+
+  const aggregate = await createSignedAggregateVoterNode({ dataModel, lumaSdk, runId });
+  await gunClient.writeVoterNode(
+    client,
+    aggregate.record.topic_id,
+    aggregate.record.synthesis_id,
+    aggregate.record.epoch,
+    aggregate.record.voter_id,
+    aggregate.record,
+  );
+  const aggregateReadback = await gunClient.readAggregateVoterNode(
+    client,
+    aggregate.record.topic_id,
+    aggregate.record.synthesis_id,
+    aggregate.record.epoch,
+    aggregate.record.voter_id,
+    aggregate.record.point_id,
+    { readTimeoutMs: 100 },
+  );
+  const validatedAggregate = await gunClient.validateAggregateVoterNodeRecord(
+    aggregateReadback,
+    {
+      topicId: aggregate.record.topic_id,
+      synthesisId: aggregate.record.synthesis_id,
+      epoch: aggregate.record.epoch,
+      voterId: aggregate.record.voter_id,
+      pointId: aggregate.record.point_id,
+    },
+    aggregate.verify,
+  );
+  assertReadback(validatedAggregate?.voter_id === aggregate.record.voter_id, 'aggregate voter LUMA readback failed');
+  rows.push(coverageRow({
+    runId,
+    writeClass: 'vote_or_aggregate',
+    traceSuffix: 'vote-or-aggregate',
+    writePath: `vh/aggregates/topics/${aggregate.record.topic_id}/syntheses/${aggregate.record.synthesis_id}/epochs/${aggregate.record.epoch}/voters/${aggregate.record.voter_id}/${aggregate.record.point_id}/`,
+    adapterWrite: 'writeVoterNode',
+    adapterReadback: 'readAggregateVoterNode + validateAggregateVoterNodeRecord',
+    repoCommit: currentCommit,
+  }));
+
+  const directoryEntry = await createSignedDirectoryEntry({ dataModel, lumaSdk, runId });
+  await gunClient.publishToDirectory(client, directoryEntry);
+  const directoryReadback = await gunClient.lookupByIdentityDirectoryKey(client, directoryEntry.identityDirectoryKey);
+  assertReadback(
+    directoryReadback?.identityDirectoryKey === directoryEntry.identityDirectoryKey,
+    'directory publish LUMA readback failed',
+  );
+  rows.push(coverageRow({
+    runId,
+    writeClass: 'directory_publish',
+    traceSuffix: 'directory-publish',
+    writePath: `vh/directory/${directoryEntry.identityDirectoryKey}/`,
+    adapterWrite: 'publishToDirectory',
+    adapterReadback: 'lookupByIdentityDirectoryKey',
+    repoCommit: currentCommit,
+  }));
+
+  const newsReport = await createSignedNewsReport({ dataModel, lumaSdk, runId });
+  await gunClient.writeNewsReport(client, newsReport);
+  const newsReportReadback = await gunClient.readNewsReport(client, newsReport.report_id);
+  const pendingReports = await gunClient.readNewsReportsByStatus(client, 'pending');
+  assertReadback(newsReportReadback?.report_id === newsReport.report_id, 'news report LUMA readback failed');
+  assertReadback(
+    pendingReports.some((report) => report.report_id === newsReport.report_id),
+    'news report status-index LUMA readback failed',
+  );
+  rows.push(coverageRow({
+    runId,
+    writeClass: 'news_report_status',
+    traceSuffix: 'news-report-status',
+    writePath: `vh/news/reports/${newsReport.report_id}/`,
+    adapterWrite: 'writeNewsReport',
+    adapterReadback: 'readNewsReport + readNewsReportsByStatus',
+    repoCommit: currentCommit,
+  }));
+
+  return buildLocalE2eCoverageSourceReport({
+    runId,
+    startedAt,
+    completedAt: Date.now(),
+    currentCommit,
+    branch,
+    dirty,
+    command,
+    rows,
+    guardedWritePaths: unique(guardedWrites.map((entry) => entry.path)),
+  });
+}
+
 export function buildLumaCoverageReport({
   runId,
   startedAt,
@@ -408,15 +1062,23 @@ export function buildLumaCoverageReport({
 
 function parseArgs(argv) {
   const args = {
+    mode: process.env.VH_MESH_LUMA_GATED_WRITE_COVERAGE_MODE || null,
     sourceReport: process.env[LUMA_GATED_WRITE_COVERAGE_REPORT_ENV] || null,
     expectedSchemaEpoch: process.env.VH_MESH_LUMA_GATED_WRITE_COVERAGE_SCHEMA_EPOCH || DEFAULT_LUMA_SCHEMA_EPOCH,
     expectedLumaProfile: process.env.VH_MESH_LUMA_GATED_WRITE_COVERAGE_LUMA_PROFILE || null,
+    skipBuild: process.env.VH_MESH_LUMA_GATED_WRITE_COVERAGE_SKIP_BUILD === 'true',
   };
   const tokens = argv.filter((token) => token !== '--');
   for (let index = 0; index < tokens.length; index += 1) {
     const token = tokens[index];
     if (token === '--source-report' || token === '--evidence-report') {
       args.sourceReport = tokens[++index] || null;
+    } else if (token === '--mode') {
+      args.mode = tokens[++index] || null;
+    } else if (token === '--local-e2e') {
+      args.mode = LOCAL_E2E_MODE;
+    } else if (token === '--skip-build') {
+      args.skipBuild = true;
     } else if (token === '--expected-schema-epoch') {
       args.expectedSchemaEpoch = tokens[++index] || args.expectedSchemaEpoch;
     } else if (token === '--expected-luma-profile') {
@@ -442,8 +1104,27 @@ async function main() {
   const resolvedSourcePath = resolveMaybeRelative(args.sourceReport);
   let sourceReport = null;
   let sourceReadFailure = null;
+  const command = commandText(process.argv.slice(2));
 
-  if (resolvedSourcePath) {
+  if (args.mode && args.mode !== LOCAL_E2E_MODE) {
+    sourceReadFailure = `unsupported LUMA coverage mode ${args.mode}`;
+  } else if (args.mode === LOCAL_E2E_MODE && resolvedSourcePath) {
+    sourceReadFailure = 'local-e2e mode does not accept --source-report';
+  } else if (args.mode === LOCAL_E2E_MODE) {
+    try {
+      sourceReport = await runLocalE2eCoverageEvidence({
+        runId,
+        startedAt,
+        currentCommit,
+        branch,
+        dirty,
+        command,
+        skipBuild: args.skipBuild,
+      });
+    } catch (error) {
+      sourceReadFailure = `local E2E LUMA coverage failed: ${error instanceof Error ? error.message : String(error)}`;
+    }
+  } else if (resolvedSourcePath) {
     try {
       sourceReport = readJson(resolvedSourcePath);
     } catch (error) {
@@ -459,11 +1140,12 @@ async function main() {
     currentCommit,
     branch,
     dirty,
+    command,
     sourceReport,
     sourceReportPath: resolvedSourcePath,
     sourceReadFailure,
     expectedSchemaEpoch: args.expectedSchemaEpoch,
-    expectedLumaProfile: args.expectedLumaProfile,
+    expectedLumaProfile: args.expectedLumaProfile || (args.mode === LOCAL_E2E_MODE ? LOCAL_E2E_LUMA_PROFILE : null),
   });
 
   const runDir = path.join(artifactRoot, runId);

--- a/packages/e2e/src/mesh/luma-gated-write-coverage.vitest.mjs
+++ b/packages/e2e/src/mesh/luma-gated-write-coverage.vitest.mjs
@@ -4,7 +4,10 @@ import {
   DEFAULT_LUMA_SCHEMA_EPOCH,
   LUMA_GATED_WRITE_COVERAGE_COMMAND,
   LUMA_GATED_WRITE_COVERAGE_SCHEMA_VERSION,
+  LOCAL_E2E_LUMA_PROFILE,
+  LOCAL_E2E_MODE,
   REQUIRED_LUMA_WRITE_CLASSES,
+  buildLocalE2eCoverageSourceReport,
   buildLumaCoverageReport,
   validateLumaCoverageReport,
 } from './luma-gated-write-coverage.mjs';
@@ -123,5 +126,74 @@ describe('LUMA-gated write coverage validator', () => {
     expect(report.luma_profile).toBe('none');
     expect(report.failures).toContain('luma_profile is none and no LUMA reader-path coverage report was provided');
     expect(report.luma_gated_write_drills.every((row) => row.status === 'skipped')).toBe(true);
+  });
+
+  it('builds a passing local-e2e source report from all required reader-path rows', () => {
+    const report = buildLocalE2eCoverageSourceReport({
+      runId: 'mesh-luma-gated-write-coverage-test',
+      startedAt,
+      completedAt,
+      currentCommit,
+      branch: 'coord/test',
+      dirty: false,
+      rows: passingRows({
+        repo_commit: currentCommit,
+        reader_path: 'luma_reader_path',
+      }),
+      guardedWritePaths: ['vh/forum/threads/thread-1/'],
+    });
+
+    expect(report.status).toBe('pass');
+    expect(report.run.mode).toBe(LOCAL_E2E_MODE);
+    expect(report.luma_profile).toBe(LOCAL_E2E_LUMA_PROFILE);
+    expect(report.validation.ok).toBe(true);
+    expect(report.local_e2e.guarded_write_paths).toEqual(['vh/forum/threads/thread-1/']);
+  });
+
+  it('wraps a local-e2e source report as a passing gate report', () => {
+    const sourceReport = buildLocalE2eCoverageSourceReport({
+      runId: 'mesh-luma-gated-write-coverage-test',
+      startedAt,
+      completedAt,
+      currentCommit,
+      branch: 'coord/test',
+      dirty: false,
+      rows: passingRows({
+        repo_commit: currentCommit,
+      }),
+    });
+
+    const report = buildLumaCoverageReport({
+      runId: 'mesh-luma-gated-write-coverage-test',
+      startedAt,
+      completedAt,
+      currentCommit,
+      branch: 'coord/test',
+      dirty: false,
+      sourceReport,
+      expectedLumaProfile: LOCAL_E2E_LUMA_PROFILE,
+    });
+
+    expect(report.status).toBe('pass');
+    expect(report.luma_profile).toBe(LOCAL_E2E_LUMA_PROFILE);
+    expect(report.luma_gated_write_coverage.required_write_classes.every((row) => row.status === 'pass')).toBe(true);
+    expect(report.luma_gated_write_drills.every((row) => row.writer_kind === 'luma')).toBe(true);
+  });
+
+  it('blocks local-e2e source reports generated from dirty repos', () => {
+    const report = buildLocalE2eCoverageSourceReport({
+      runId: 'mesh-luma-gated-write-coverage-test',
+      startedAt,
+      completedAt,
+      currentCommit,
+      branch: 'coord/test',
+      dirty: true,
+      rows: passingRows({
+        repo_commit: currentCommit,
+      }),
+    });
+
+    expect(report.status).toBe('blocked');
+    expect(report.failures).toContain('report repo.dirty is not false');
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -281,9 +281,15 @@ importers:
 
   packages/e2e:
     dependencies:
+      '@vh/data-model':
+        specifier: workspace:*
+        version: link:../data-model
       '@vh/gun-client':
         specifier: workspace:*
         version: link:../gun-client
+      '@vh/luma-sdk':
+        specifier: workspace:*
+        version: link:../luma-sdk
     devDependencies:
       '@playwright/test':
         specifier: ^1.42.1


### PR DESCRIPTION
## Summary
- add explicit `--mode local-e2e` LUMA reader-path coverage producer for `pnpm test:mesh:luma-gated-write-coverage`
- generate all five strict coverage classes through existing LUMA-aware adapter/readback paths, then validate the produced source report through the strict gate
- keep default no-arg coverage behavior fail-closed on `luma_profile: none`
- document Slice 14F’s bounded contract and recent system-writer guardrail distinction

## Verification
- `node --check packages/e2e/src/mesh/luma-gated-write-coverage.mjs`
- `pnpm --filter @vh/e2e exec vitest run src/mesh/luma-gated-write-coverage.vitest.mjs --config ./vitest.config.ts --reporter=dot`
- `pnpm --filter @vh/e2e exec vitest run src/mesh/luma-gated-write-coverage.vitest.mjs src/mesh/production-readiness-check.test.mjs --config ./vitest.config.ts --reporter=dot`
- `pnpm --filter @vh/e2e typecheck`
- `pnpm docs:check`
- `git diff --check origin/main...HEAD`
- `node tools/scripts/check-diff-coverage.mjs`
- `pnpm check:public-namespace-leaks`
- relevant `pnpm check:luma-*` guards for provider/signed-write/vault/delegation/identity/multidevice/wallet/directory/forum/aggregate/news/system-writer surfaces
- default `pnpm test:mesh:luma-gated-write-coverage` exits 1 with blocked `luma_profile: none`
- explicit `pnpm test:mesh:luma-gated-write-coverage -- --mode local-e2e` exits 0 with `status: pass`, `schema_epoch: post_luma_m0b`, `luma_profile: e2e`
- `VH_MESH_LUMA_GATED_WRITE_COVERAGE_REPORT=.tmp/mesh-luma-gated-write-coverage/latest/mesh-luma-gated-write-coverage-report.json pnpm check:mesh:production-readiness` exits 0 and leaves aggregate `review_required` with 12 source reports and blockers only `canonical-30-minute-soak`, `public-wss-deployment-proof`
- `pnpm check:production-app-canary -- --mesh-report .tmp/mesh-production-readiness/latest/mesh-production-readiness-report.json` exits 1 as expected with `mesh_not_release_ready`

## Scope guardrails
- no LUMA adapter/schema/custody/envelope/signed-write/provider/identifier/identity-vault changes
- no app runtime behavior changes
- no relay runtime changes
- no public WSS proof work
- no fake passing rows or `vh/__mesh_drills/*` coverage evidence
