### PR TITLE
Allow historical mesh evidence scrub validation

### DIFF
--- a/docs/ops/mesh-production-topology-drills.md
+++ b/docs/ops/mesh-production-topology-drills.md
@@ -420,6 +420,16 @@ gate-run timestamp window. The packet includes
 and copied source reports under `source-reports/<gate>/`; after Slice 14A it has
 12 source reports, including `source-reports/evidence_scrub/`.
 
+When revalidating a committed packet after its evidence commit has landed, pass
+the aggregate packet's recorded source commit explicitly:
+
+```sh
+pnpm check:mesh-evidence-scrub -- --source-dir docs/reports/evidence/mesh-production/<packet>/<run-id> --expected-commit <aggregate-repo-commit>
+```
+
+Without that override, the scrub gate intentionally treats the packet as stale
+once the evidence commit or merge commit changes `HEAD`.
+
 For Slice 11A through Slice 14C, a successful aggregate command still reports
 `status: review_required` while release blockers remain. Expected blockers after
 Slice 14C are public WSS deployment proof and LUMA-gated write coverage through

--- a/docs/specs/spec-mesh-production-readiness.md
+++ b/docs/specs/spec-mesh-production-readiness.md
@@ -1779,10 +1779,14 @@ release claims that are absent from the generated report.
 Status: Implemented for `.tmp` promotion staging as
 `pnpm check:mesh-evidence-scrub`. The command consumes
 `.tmp/mesh-production-readiness/latest` by default, or an explicit
-`--source-dir` / `VH_MESH_EVIDENCE_SOURCE_DIR` packet. The production-readiness
-aggregate gate MUST call it against the current run directory, not the mutable
-`latest` alias, then record an `evidence_scrub` source report before writing
-the final aggregate.
+`--source-dir` / `VH_MESH_EVIDENCE_SOURCE_DIR` packet. By default the scrub
+gate requires the packet's aggregate commit to match the current `HEAD`. When
+reviewing a committed historical packet after the evidence commit or merge has
+changed `HEAD`, reviewers MUST provide `--expected-commit <sha>` or
+`VH_MESH_EVIDENCE_EXPECTED_COMMIT=<sha>` using the aggregate packet's recorded
+source commit. The production-readiness aggregate gate MUST call it against the
+current run directory, not the mutable `latest` alias, then record an
+`evidence_scrub` source report before writing the final aggregate.
 
 `.tmp` readiness packets are unredacted machine proof. Promoting any field from
 a `.tmp` packet into a tracked artifact under `docs/reports/evidence/` or into

--- a/packages/e2e/src/mesh/evidence-scrub-check.mjs
+++ b/packages/e2e/src/mesh/evidence-scrub-check.mjs
@@ -241,7 +241,7 @@ function sourceReportFailures({ aggregate, sourceDir }) {
   return failures;
 }
 
-export function validateAggregatePacket({ sourceDir = defaultSourceDir } = {}) {
+export function validateAggregatePacket({ sourceDir = defaultSourceDir, expectedCommit = runGit(['rev-parse', 'HEAD']) } = {}) {
   const failures = [];
   const resolvedSourceDir = path.resolve(repoRoot, sourceDir);
   const reportPath = path.join(resolvedSourceDir, AGGREGATE_REPORT);
@@ -268,7 +268,6 @@ export function validateAggregatePacket({ sourceDir = defaultSourceDir } = {}) {
     return { ok: false, failures, report: null, reportPath, manifestPath, sourceDir: resolvedSourceDir };
   }
 
-  const currentCommit = runGit(['rev-parse', 'HEAD']);
   if (report.schema_version !== 'mesh-production-readiness-v1') {
     failures.push(`unexpected schema_version ${report.schema_version || 'missing'}`);
   }
@@ -278,8 +277,8 @@ export function validateAggregatePacket({ sourceDir = defaultSourceDir } = {}) {
   if (!report.run_id) {
     failures.push('missing run_id');
   }
-  if (report.repo?.commit !== currentCommit) {
-    failures.push(`aggregate commit ${report.repo?.commit || 'missing'} does not match current HEAD ${currentCommit}`);
+  if (report.repo?.commit !== expectedCommit) {
+    failures.push(`aggregate commit ${report.repo?.commit || 'missing'} does not match expected commit ${expectedCommit}`);
   }
   if (report.repo?.dirty) {
     failures.push('aggregate repo.dirty is true');
@@ -388,7 +387,7 @@ export function scanPromotedPacket({ promotedDir }) {
   return findings;
 }
 
-function buildScrubReport({ runId, sourceReport, sourceDir, promotedDir, command, startedAt, completedAt, redactions, failures }) {
+function buildScrubReport({ runId, sourceReport, sourceDir, promotedDir, command, expectedCommit, startedAt, completedAt, redactions, failures }) {
   const status = failures.length === 0 ? 'pass' : 'blocked';
   const promotedReportPath = path.join(promotedDir, AGGREGATE_REPORT);
   const promotedManifestPath = path.join(promotedDir, AGGREGATE_MANIFEST);
@@ -406,6 +405,7 @@ function buildScrubReport({ runId, sourceReport, sourceDir, promotedDir, command
       mode: EVIDENCE_SCRUB_MODE,
       source_run_id: sourceReport?.run_id || null,
       source_dir: safeRelativeLabel(sourceDir),
+      expected_commit: expectedCommit,
       promoted_dir: safeRelativeLabel(promotedDir),
       started_at: new Date(startedAt).toISOString(),
       completed_at: new Date(completedAt).toISOString(),
@@ -491,6 +491,7 @@ function buildScrubReport({ runId, sourceReport, sourceDir, promotedDir, command
 function parseArgs(argv) {
   const options = {
     sourceDir: process.env.VH_MESH_EVIDENCE_SOURCE_DIR || defaultSourceDir,
+    expectedCommit: process.env.VH_MESH_EVIDENCE_EXPECTED_COMMIT || null,
   };
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
@@ -499,6 +500,9 @@ function parseArgs(argv) {
     }
     if (arg === '--source-dir') {
       options.sourceDir = argv[index + 1];
+      index += 1;
+    } else if (arg === '--expected-commit') {
+      options.expectedCommit = argv[index + 1];
       index += 1;
     } else if (arg === '--help' || arg === '-h') {
       options.help = true;
@@ -509,9 +513,9 @@ function parseArgs(argv) {
   return options;
 }
 
-export function runEvidenceScrub({ sourceDir = defaultSourceDir, command = null } = {}) {
+export function runEvidenceScrub({ sourceDir = defaultSourceDir, expectedCommit = runGit(['rev-parse', 'HEAD']), command = null } = {}) {
   const startedAt = Date.now();
-  const validation = validateAggregatePacket({ sourceDir });
+  const validation = validateAggregatePacket({ sourceDir, expectedCommit });
   const runId = makeId('mesh-evidence-scrub');
   const promotedDir = path.join(promotedRoot, validation.report?.run_id || runId);
   let redactions = { paths: 0, urls: 0, secrets: 0, stalePlaceholders: 0 };
@@ -533,6 +537,7 @@ export function runEvidenceScrub({ sourceDir = defaultSourceDir, command = null 
     sourceDir: validation.sourceDir,
     promotedDir,
     command: command || `pnpm check:mesh-evidence-scrub -- --source-dir ${path.relative(repoRoot, validation.sourceDir)}`,
+    expectedCommit,
     startedAt,
     completedAt,
     redactions,
@@ -559,13 +564,17 @@ export function runEvidenceScrub({ sourceDir = defaultSourceDir, command = null 
 async function main() {
   const options = parseArgs(process.argv.slice(2));
   if (options.help) {
-    console.log('Usage: pnpm check:mesh-evidence-scrub [-- --source-dir <packet-dir>]');
+    console.log('Usage: pnpm check:mesh-evidence-scrub [-- --source-dir <packet-dir>] [--expected-commit <sha>]');
     return;
   }
   const resolvedSourceDir = path.resolve(repoRoot, options.sourceDir);
   const result = runEvidenceScrub({
     sourceDir: resolvedSourceDir,
-    command: `pnpm check:mesh-evidence-scrub -- --source-dir ${path.relative(repoRoot, resolvedSourceDir)}`,
+    expectedCommit: options.expectedCommit || runGit(['rev-parse', 'HEAD']),
+    command: [
+      `pnpm check:mesh-evidence-scrub -- --source-dir ${path.relative(repoRoot, resolvedSourceDir)}`,
+      options.expectedCommit ? `--expected-commit ${options.expectedCommit}` : '',
+    ].filter(Boolean).join(' '),
   });
   console.log(JSON.stringify(result, null, 2));
   if (!result.ok) {

--- a/packages/e2e/src/mesh/production-readiness-check.test.mjs
+++ b/packages/e2e/src/mesh/production-readiness-check.test.mjs
@@ -120,10 +120,14 @@ function writeJson(filePath, value) {
   fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
 }
 
-function evidenceScrubPacket({ status = 'review_required', blockers = [{ id: 'canonical-30-minute-soak', command: 'pnpm test:mesh:soak', reason: 'canonical soak remains pending' }], writerKind = 'mesh-drill' } = {}) {
+function evidenceScrubPacket({
+  status = 'review_required',
+  blockers = [{ id: 'canonical-30-minute-soak', command: 'pnpm test:mesh:soak', reason: 'canonical soak remains pending' }],
+  writerKind = 'mesh-drill',
+  commit = liveCommit(),
+} = {}) {
   const sourceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vh-mesh-evidence-scrub-'));
   const sourceReportPath = path.join(sourceDir, 'source-reports/topology/mesh-production-readiness-report.json');
-  const commit = liveCommit();
   const source = sourceReport({
     repo: {
       commit,
@@ -560,6 +564,30 @@ describe('mesh evidence scrub promotion', () => {
       expect(promotedText).not.toContain('mesh-control-token-should-not-survive');
       expect(promotedText).not.toContain('raw-token-value-that-must-not-survive');
       expect(promotedText).toContain('redacted-host-');
+    } finally {
+      fs.rmSync(sourceDir, { recursive: true, force: true });
+    }
+  });
+
+  it('allows explicit expected-commit validation for committed historical packets', () => {
+    const historicalCommit = '1111111111111111111111111111111111111111';
+    const sourceDir = evidenceScrubPacket({ commit: historicalCommit });
+    try {
+      const defaultValidation = validateAggregatePacket({ sourceDir });
+      expect(defaultValidation.ok).toBe(false);
+      expect(defaultValidation.failures).toContain(
+        `aggregate commit ${historicalCommit} does not match expected commit ${liveCommit()}`,
+      );
+
+      const historicalValidation = validateAggregatePacket({ sourceDir, expectedCommit: historicalCommit });
+      expect(historicalValidation.ok).toBe(true);
+
+      const result = runEvidenceScrub({
+        sourceDir,
+        expectedCommit: historicalCommit,
+        command: `pnpm check:mesh-evidence-scrub -- --source-dir ${path.relative(repoRoot, sourceDir)} --expected-commit ${historicalCommit}`,
+      });
+      expect(result.ok).toBe(true);
     } finally {
       fs.rmSync(sourceDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- add --expected-commit / VH_MESH_EVIDENCE_EXPECTED_COMMIT to mesh evidence scrub validation
- keep default current-HEAD validation for fresh .tmp/latest packets
- document post-merge committed-packet revalidation and cover it in focused Vitest

## Verification
- node --check packages/e2e/src/mesh/evidence-scrub-check.mjs
- pnpm --dir packages/e2e exec vitest run src/mesh/production-readiness-check.test.mjs --config vitest.config.ts --reporter=dot
- pnpm check:mesh-evidence-scrub -- --source-dir docs/reports/evidence/mesh-production/current-canonical-soak-luma/mesh-production-readiness-20260510T090611Z-a34c7ec3 --expected-commit 136f7f23e5715f556b5d0a6b84b97932b8516ef5
- pnpm --filter @vh/e2e typecheck
- pnpm docs:check
- git diff --check
- node tools/scripts/check-diff-coverage.mjs
- pnpm check:public-namespace-leaks
- pnpm check:luma-system-writer-surface
- pnpm check:luma-signed-write-surface
- pnpm check:luma-provider-surface
- pnpm check:luma-vault-compartments
- pnpm check:luma-delegation-signer-surface
- pnpm check:mesh:production-readiness
- pnpm check:production-app-canary -- --mesh-report .tmp/mesh-production-readiness/latest/mesh-production-readiness-report.json (expected nonzero, mesh_not_release_ready)