### PR TITLE
Persist LUMA mesh coverage evidence in packets

### DIFF
--- a/docs/ops/mesh-production-topology-drills.md
+++ b/docs/ops/mesh-production-topology-drills.md
@@ -153,8 +153,19 @@ records through the existing LUMA-aware adapter paths, and then validates the
 generated source rows through the same strict coverage gate. It emits
 `luma_profile: e2e` only for this local hermetic evidence packet. The default
 no-argument command remains blocked, and recent LUMA system-writer story,
-storyline, index, and analysis checks remain separate guardrails rather than
-coverage classes for this blocker.
+storyline, index, analysis, topic synthesis, and topic digest checks remain
+separate guardrails rather than coverage classes for this blocker.
+
+When a passing report is supplied through
+`VH_MESH_LUMA_GATED_WRITE_COVERAGE_REPORT`, `pnpm
+check:mesh:production-readiness` copies that exact report into the aggregate
+packet under
+`supporting-evidence/luma-gated-write-coverage/mesh-luma-gated-write-coverage-report.json`.
+The aggregate still has 12 mesh source reports; the LUMA coverage report is
+supporting evidence, not a thirteenth mesh source gate. Promotion scrub fails
+closed if a passing LUMA coverage section points only at missing `.tmp` state
+or if the in-packet report is absent, stale, dirty, wrong-epoch, wrong-profile,
+or inconsistent with the aggregate summary.
 
 Run the state-resolution drill:
 
@@ -429,6 +440,11 @@ pnpm check:mesh-evidence-scrub -- --source-dir docs/reports/evidence/mesh-produc
 
 Without that override, the scrub gate intentionally treats the packet as stale
 once the evidence commit or merge commit changes `HEAD`.
+
+Passing LUMA coverage must be durable inside the packet before promotion. A
+packet whose `luma_gated_write_coverage.report_path` points at an external or
+missing `.tmp/mesh-luma-gated-write-coverage/...` report is not independently
+reviewable and must fail `pnpm check:mesh-evidence-scrub`.
 
 For Slice 11A through Slice 14C, a successful aggregate command still reports
 `status: review_required` while release blockers remain. Expected blockers after

--- a/docs/specs/spec-mesh-production-readiness.md
+++ b/docs/specs/spec-mesh-production-readiness.md
@@ -1810,8 +1810,9 @@ promotion; the gate fails closed for missing, stale, dirty, or overclaiming
 aggregate evidence, missing referenced source reports, stale placeholder
 evidence, raw daemon tokens, bearer credentials, private signing material,
 unredacted relay/config origins, unsafe absolute machine paths, implied
-LUMA-gated write coverage, or writer kinds outside synthetic mesh evidence. The
-gate writes the scrubbed packet under
+LUMA-gated write coverage, dangling LUMA coverage `.tmp` references, missing
+durable LUMA coverage reports, or writer kinds outside synthetic mesh evidence.
+The gate writes the scrubbed packet under
 `.tmp/mesh-production-readiness/promoted/<run_id>/` and rescans the transformed
 output before passing. The scrub script is the only sanctioned promotion path;
 manual copy-paste into `docs/reports/evidence/` is forbidden.
@@ -2489,9 +2490,26 @@ Slice 14F hermetic reader-path evidence:
 - The local E2E packet uses `luma_profile: e2e`; it is acceptable evidence for
   clearing only `luma-gated-write-coverage` in a local aggregate run. It is not
   a production LUMA profile, a public WSS proof, or a downstream app canary.
-- Recent LUMA system-writer story, storyline, index, and analysis gates remain
-  protected-surface guardrails. They do not count as any of the five required
-  user LUMA-gated write coverage classes.
+- Recent LUMA system-writer story, storyline, index, analysis, topic
+  synthesis, and topic digest gates remain protected-surface guardrails. They
+  do not count as any of the five required user LUMA-gated write coverage
+  classes.
+
+Slice 14H durable in-packet LUMA coverage evidence:
+
+- When `VH_MESH_LUMA_GATED_WRITE_COVERAGE_REPORT` validates, the aggregate
+  command MUST copy that exact report into the readiness packet under
+  `supporting-evidence/luma-gated-write-coverage/mesh-luma-gated-write-coverage-report.json`.
+- The aggregate MUST keep the mesh `source_reports` count unchanged; LUMA
+  coverage is supporting evidence described by `luma_gated_write_coverage`, not
+  a thirteenth mesh source gate.
+- The aggregate MUST record the copied report path, source run id, source
+  commit, dirty state, schema version, schema epoch, LUMA profile, required
+  class statuses, and trace IDs.
+- Promotion scrub MUST fail closed if passing LUMA coverage points outside the
+  packet, points at `.tmp`-only state, omits the copied report, or if the copied
+  report is stale, dirty, wrong-epoch, wrong-profile, missing a required class,
+  or inconsistent with the aggregate summary.
 
 Still not allowed after mesh readiness alone:
 

--- a/packages/e2e/src/mesh/evidence-scrub-check.mjs
+++ b/packages/e2e/src/mesh/evidence-scrub-check.mjs
@@ -4,6 +4,12 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
+import {
+  DEFAULT_LUMA_SCHEMA_EPOCH,
+  LUMA_GATED_WRITE_COVERAGE_REPORT_NAME,
+  LUMA_GATED_WRITE_COVERAGE_SCHEMA_VERSION,
+  validateLumaCoverageReport,
+} from './luma-gated-write-coverage.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -17,6 +23,7 @@ export const EVIDENCE_SCRUB_MODE = 'mesh_evidence_scrub_promotion';
 const AGGREGATE_REPORT = 'mesh-production-readiness-report.json';
 const AGGREGATE_MANIFEST = 'mesh-production-readiness-evidence.md';
 const SOURCE_REPORT_NAME = 'mesh-production-readiness-report.json';
+const LUMA_COVERAGE_SUPPORT_PREFIX = 'supporting-evidence/luma-gated-write-coverage/';
 const STALE_PLACEHOLDER_FIXTURES = new Set(['full-conflict-resolution-fixtures']);
 const ALLOWED_WRITER_KINDS = new Set(['mesh-drill']);
 const URL_PATTERN = /\b(?:https?|wss?):\/\/[^\s"'`<>)]+/gi;
@@ -56,6 +63,10 @@ function readJson(filePath) {
 function writeJson(filePath, value) {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
   fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function unique(values) {
+  return [...new Set(values.filter((value) => value !== undefined && value !== null && value !== ''))];
 }
 
 function safeRelativeLabel(filePath) {
@@ -241,6 +252,114 @@ function sourceReportFailures({ aggregate, sourceDir }) {
   return failures;
 }
 
+function normalizePacketRelativePath(value) {
+  return String(value || '')
+    .replaceAll('\\', '/')
+    .replace(/^\.\//, '');
+}
+
+function resolveInPacketPath(sourceDir, relativePath) {
+  const normalized = normalizePacketRelativePath(relativePath);
+  const resolved = path.resolve(sourceDir, normalized);
+  const relative = path.relative(sourceDir, resolved);
+  if (relative.startsWith('..') || path.isAbsolute(relative)) return null;
+  return { normalized, resolved };
+}
+
+function lumaCoverageEvidenceFailures({ aggregate, sourceDir }) {
+  const failures = [];
+  const coverage = aggregate.luma_gated_write_coverage || {};
+
+  if (coverage.status !== 'pass') {
+    return failures;
+  }
+
+  if (!coverage.report_path || typeof coverage.report_path !== 'string') {
+    failures.push('passing LUMA coverage is missing a durable report_path');
+    return failures;
+  }
+  if (path.isAbsolute(coverage.report_path)) {
+    failures.push('passing LUMA coverage report_path must be packet-relative');
+    return failures;
+  }
+
+  const resolved = resolveInPacketPath(sourceDir, coverage.report_path);
+  if (!resolved) {
+    failures.push('passing LUMA coverage report_path escapes the evidence packet');
+    return failures;
+  }
+  if (!resolved.normalized.startsWith(LUMA_COVERAGE_SUPPORT_PREFIX)) {
+    failures.push('passing LUMA coverage report_path must point inside supporting-evidence/luma-gated-write-coverage');
+  }
+  if (path.basename(resolved.normalized) !== LUMA_GATED_WRITE_COVERAGE_REPORT_NAME) {
+    failures.push(`passing LUMA coverage report_path must end with ${LUMA_GATED_WRITE_COVERAGE_REPORT_NAME}`);
+  }
+  if (resolved.normalized.startsWith('.tmp/') || resolved.normalized.startsWith('/.tmp/')) {
+    failures.push('passing LUMA coverage report_path points at non-durable .tmp state');
+  }
+  if (!fs.existsSync(resolved.resolved)) {
+    failures.push(`missing durable LUMA coverage report at ${coverage.report_path}`);
+    return failures;
+  }
+
+  let report = null;
+  try {
+    report = readJson(resolved.resolved);
+  } catch (error) {
+    failures.push(`failed to parse durable LUMA coverage report: ${error instanceof Error ? error.message : String(error)}`);
+    return failures;
+  }
+
+  const expectedSchemaEpoch = coverage.schema_epoch || aggregate.schema_epoch || DEFAULT_LUMA_SCHEMA_EPOCH;
+  const expectedLumaProfile = coverage.luma_profile || null;
+  const validation = validateLumaCoverageReport(report, {
+    currentCommit: aggregate.repo?.commit || null,
+    requireClean: true,
+    expectedSchemaEpoch,
+    expectedLumaProfile,
+  });
+  failures.push(...validation.failures.map((failure) => `durable LUMA coverage report invalid: ${failure}`));
+
+  if (coverage.schema_version !== LUMA_GATED_WRITE_COVERAGE_SCHEMA_VERSION) {
+    failures.push(`LUMA coverage schema_version is ${coverage.schema_version || 'missing'}`);
+  }
+  if (!coverage.source_run_id || coverage.source_run_id !== report.run_id) {
+    failures.push(`LUMA coverage source_run_id ${coverage.source_run_id || 'missing'} does not match durable report ${report.run_id || 'missing'}`);
+  }
+  if (coverage.source_commit !== report.repo?.commit) {
+    failures.push(`LUMA coverage source_commit ${coverage.source_commit || 'missing'} does not match durable report ${report.repo?.commit || 'missing'}`);
+  }
+  if (coverage.source_commit !== aggregate.repo?.commit) {
+    failures.push(`LUMA coverage source_commit ${coverage.source_commit || 'missing'} does not match aggregate commit ${aggregate.repo?.commit || 'missing'}`);
+  }
+  if (coverage.source_dirty !== false || report.repo?.dirty !== false) {
+    failures.push('LUMA coverage source_dirty or durable report repo.dirty is not false');
+  }
+  if (coverage.schema_epoch !== report.schema_epoch) {
+    failures.push(`LUMA coverage schema_epoch ${coverage.schema_epoch || 'missing'} does not match durable report ${report.schema_epoch || 'missing'}`);
+  }
+  if (!coverage.luma_profile || coverage.luma_profile === 'none' || coverage.luma_profile !== report.luma_profile) {
+    failures.push(`LUMA coverage luma_profile ${coverage.luma_profile || 'missing'} does not match durable report ${report.luma_profile || 'missing'}`);
+  }
+
+  const aggregateClasses = new Map((coverage.required_write_classes || []).map((row) => [row.write_class, row]));
+  for (const row of validation.required_write_classes || []) {
+    const aggregateRow = aggregateClasses.get(row.write_class);
+    if (!aggregateRow) {
+      failures.push(`LUMA coverage aggregate summary is missing ${row.write_class}`);
+      continue;
+    }
+    if (aggregateRow.status !== 'pass') {
+      failures.push(`LUMA coverage aggregate summary for ${row.write_class} is ${aggregateRow.status || 'missing'}`);
+    }
+    if (row.status === 'pass' && aggregateRow.trace_id !== row.trace_id) {
+      failures.push(`LUMA coverage aggregate summary trace_id for ${row.write_class} does not match durable report`);
+    }
+  }
+
+  return unique(failures);
+}
+
 export function validateAggregatePacket({ sourceDir = defaultSourceDir, expectedCommit = runGit(['rev-parse', 'HEAD']) } = {}) {
   const failures = [];
   const resolvedSourceDir = path.resolve(repoRoot, sourceDir);
@@ -304,6 +423,7 @@ export function validateAggregatePacket({ sourceDir = defaultSourceDir, expected
     failures.push('aggregate implies LUMA-gated write coverage in a mesh-only evidence packet');
   }
   failures.push(...sourceReportFailures({ aggregate: report, sourceDir: resolvedSourceDir }));
+  failures.push(...lumaCoverageEvidenceFailures({ aggregate: report, sourceDir: resolvedSourceDir }));
 
   return {
     ok: failures.length === 0,
@@ -520,17 +640,20 @@ export function runEvidenceScrub({ sourceDir = defaultSourceDir, expectedCommit 
   const promotedDir = path.join(promotedRoot, validation.report?.run_id || runId);
   let redactions = { paths: 0, urls: 0, secrets: 0, stalePlaceholders: 0 };
   let scanFailures = [];
+  let promotedValidationFailures = [];
 
   if (validation.report) {
     redactions = scrubPacket({ sourceDir: validation.sourceDir, promotedDir });
     scanFailures = scanPromotedPacket({ promotedDir });
+    const promotedValidation = validateAggregatePacket({ sourceDir: promotedDir, expectedCommit });
+    promotedValidationFailures = promotedValidation.failures.map((failure) => `promoted packet validation failed: ${failure}`);
   } else {
     fs.rmSync(promotedDir, { recursive: true, force: true });
     fs.mkdirSync(promotedDir, { recursive: true });
   }
 
   const completedAt = Date.now();
-  const failures = [...validation.failures, ...scanFailures];
+  const failures = [...validation.failures, ...scanFailures, ...promotedValidationFailures];
   const scrubReport = buildScrubReport({
     runId,
     sourceReport: validation.report,

--- a/packages/e2e/src/mesh/production-readiness-check.mjs
+++ b/packages/e2e/src/mesh/production-readiness-check.mjs
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'node:url';
 import {
   DEFAULT_LUMA_SCHEMA_EPOCH,
   LUMA_GATED_WRITE_COVERAGE_COMMAND,
+  LUMA_GATED_WRITE_COVERAGE_REPORT_NAME,
   LUMA_GATED_WRITE_COVERAGE_REPORT_ENV,
   validateLumaCoverageReport,
 } from './luma-gated-write-coverage.mjs';
@@ -19,6 +20,8 @@ const SOURCE_REPORT_FRESHNESS_TOLERANCE_MS = 5000;
 const EVIDENCE_SCRUB_SOURCE_ID = 'evidence_scrub';
 const EVIDENCE_SCRUB_MODE = 'mesh_evidence_scrub_promotion';
 const EVIDENCE_SCRUB_REPORT_NAME = 'evidence-scrub-source-report.json';
+const LUMA_COVERAGE_SUPPORT_DIR = 'supporting-evidence/luma-gated-write-coverage';
+const LUMA_COVERAGE_SUPPORT_REPORT_PATH = `${LUMA_COVERAGE_SUPPORT_DIR}/${LUMA_GATED_WRITE_COVERAGE_REPORT_NAME}`;
 const REQUIRED_CONFLICT_FIXTURES = [
   'same-key-concurrent-deterministic-writes',
   'stale-overwrite-attempt-rejected',
@@ -142,6 +145,10 @@ function copyDir(src, dest) {
       fs.copyFileSync(sourcePath, destPath);
     }
   }
+}
+
+function packetRelativePath(relativePath) {
+  return `./${relativePath.replaceAll(path.sep, '/')}`;
 }
 
 function commandText(command) {
@@ -374,8 +381,29 @@ export function loadLumaCoverageEvidence({
     provided: true,
     status: validation.ok ? 'pass' : 'blocked',
     report_path: resolvedReportPath,
+    original_report_path: resolvedReportPath,
     report,
     validation,
+  };
+}
+
+export function persistLumaCoverageEvidenceForPacket({ artifactDir, lumaCoverageEvidence }) {
+  if (!lumaCoverageEvidence?.provided || !lumaCoverageEvidence.validation?.ok || !lumaCoverageEvidence.report_path) {
+    return lumaCoverageEvidence;
+  }
+
+  const durableReportPath = path.join(artifactDir, LUMA_COVERAGE_SUPPORT_REPORT_PATH);
+  fs.mkdirSync(path.dirname(durableReportPath), { recursive: true });
+  fs.copyFileSync(lumaCoverageEvidence.report_path, durableReportPath);
+
+  return {
+    ...lumaCoverageEvidence,
+    original_report_path: lumaCoverageEvidence.original_report_path || lumaCoverageEvidence.report_path,
+    report_path: packetRelativePath(LUMA_COVERAGE_SUPPORT_REPORT_PATH),
+    supporting_evidence: {
+      report_path: packetRelativePath(LUMA_COVERAGE_SUPPORT_REPORT_PATH),
+      absolute_report_path: durableReportPath,
+    },
   };
 }
 
@@ -739,6 +767,7 @@ function buildManifest({ report, sources, blockers, reportPath }) {
 - Schema epoch: \`${report.schema_epoch}\`
 - LUMA profile: \`${report.luma_profile}\`
 - Report: \`${reportPath}\`
+- LUMA coverage report: \`${report.luma_gated_write_coverage.report_path || 'not provided'}\`
 
 ## Source Reports
 
@@ -779,6 +808,7 @@ function writeAggregatePacket({ report, manifest, artifactDir }) {
   fs.copyFileSync(reportPath, path.join(latestDir, 'mesh-production-readiness-report.json'));
   fs.copyFileSync(manifestPath, path.join(latestDir, 'mesh-production-readiness-evidence.md'));
   copyDir(path.join(artifactDir, 'source-reports'), path.join(latestDir, 'source-reports'));
+  copyDir(path.join(artifactDir, 'supporting-evidence'), path.join(latestDir, 'supporting-evidence'));
   return { reportPath, manifestPath, latestReportPath: path.join(latestDir, 'mesh-production-readiness-report.json') };
 }
 
@@ -872,6 +902,12 @@ function buildReport({ runId, startedAt, completedAt, sources, blockers, command
       command: LUMA_GATED_WRITE_COVERAGE_COMMAND,
       report_env: LUMA_GATED_WRITE_COVERAGE_REPORT_ENV,
       report_path: lumaCoverageEvidence?.report_path || null,
+      source_run_id: lumaCoverageEvidence?.report?.run_id || null,
+      source_commit: lumaCoverageEvidence?.report?.repo?.commit || null,
+      source_dirty: lumaCoverageEvidence?.report?.repo?.dirty ?? null,
+      schema_version: lumaCoverageEvidence?.report?.schema_version || null,
+      schema_epoch: lumaCoverageEvidence?.report?.schema_epoch || null,
+      luma_profile: lumaCoverageEvidence?.report?.luma_profile || null,
       status: lumaCoverageStatus,
       failures: lumaCoverageEvidence?.validation?.failures || [],
       required_write_classes: lumaCoverageEvidence?.validation?.required_write_classes || [],
@@ -931,7 +967,11 @@ async function main() {
 
   const currentCommit = runGit(['rev-parse', 'HEAD']);
   const requireClean = process.env.VH_MESH_PRODUCTION_READINESS_ALLOW_DIRTY !== 'true';
-  const lumaCoverageEvidence = loadLumaCoverageEvidence({ currentCommit, requireClean });
+  const loadedLumaCoverageEvidence = loadLumaCoverageEvidence({ currentCommit, requireClean });
+  const lumaCoverageEvidence = persistLumaCoverageEvidenceForPacket({
+    artifactDir,
+    lumaCoverageEvidence: loadedLumaCoverageEvidence,
+  });
   const sources = [];
   for (const gate of SOURCE_GATES) {
     sources.push(runSourceGate({ gate, artifactDir, currentCommit, requireClean }));

--- a/packages/e2e/src/mesh/production-readiness-check.test.mjs
+++ b/packages/e2e/src/mesh/production-readiness-check.test.mjs
@@ -11,6 +11,7 @@ import {
 } from './evidence-scrub-check.mjs';
 import {
   LUMA_GATED_WRITE_COVERAGE_COMMAND,
+  LUMA_GATED_WRITE_COVERAGE_REPORT_NAME,
   LUMA_GATED_WRITE_COVERAGE_SCHEMA_VERSION,
   REQUIRED_LUMA_WRITE_CLASSES,
   validateLumaCoverageReport,
@@ -20,6 +21,7 @@ import {
   buildReleaseBlockers,
   conflictRowsForAggregate,
   downstreamCanaryMetadata,
+  persistLumaCoverageEvidenceForPacket,
   validationFailuresForSource,
 } from './production-readiness-check.mjs';
 
@@ -254,6 +256,53 @@ function evidenceScrubPacket({
   return sourceDir;
 }
 
+function addDurableLumaCoverageToPacket(sourceDir, { reportOverrides = {}, writeReport = true, reportPath = null } = {}) {
+  const aggregatePath = path.join(sourceDir, 'mesh-production-readiness-report.json');
+  const aggregate = JSON.parse(fs.readFileSync(aggregatePath, 'utf8'));
+  const durableRelativePath = reportPath || `./supporting-evidence/luma-gated-write-coverage/${LUMA_GATED_WRITE_COVERAGE_REPORT_NAME}`;
+  const durablePath = path.resolve(sourceDir, durableRelativePath.replace(/^\.\//, ''));
+  const report = passingLumaCoverageReport({
+    repo: {
+      commit: aggregate.repo.commit,
+      dirty: false,
+    },
+    ...reportOverrides,
+  });
+  const validation = validateLumaCoverageReport(report, {
+    currentCommit: aggregate.repo.commit,
+    expectedLumaProfile: report.luma_profile,
+  });
+
+  if (writeReport) {
+    writeJson(durablePath, report);
+  }
+  aggregate.luma_gated_write_coverage = {
+    command: LUMA_GATED_WRITE_COVERAGE_COMMAND,
+    report_env: 'VH_MESH_LUMA_GATED_WRITE_COVERAGE_REPORT',
+    report_path: durableRelativePath,
+    source_run_id: report.run_id,
+    source_commit: report.repo.commit,
+    source_dirty: report.repo.dirty,
+    schema_version: report.schema_version,
+    schema_epoch: report.schema_epoch,
+    luma_profile: report.luma_profile,
+    status: 'pass',
+    failures: validation.failures,
+    required_write_classes: validation.required_write_classes,
+  };
+  aggregate.luma_dependency_status.luma_gated_write_drills = 'pass';
+  aggregate.luma_gated_write_drills = [
+    ...validation.required_write_classes,
+    {
+      write_class: 'LUMA-gated production write classes through LUMA reader path',
+      trace_id: aggregate.run_id,
+      status: 'pass',
+    },
+  ];
+  writeJson(aggregatePath, aggregate);
+  return { aggregate, report, durablePath, durableRelativePath };
+}
+
 describe('production-readiness source evidence validation', () => {
   it('includes the peer-config rollback drill as command-matched source evidence', () => {
     expect(SOURCE_GATES).toContainEqual(expect.objectContaining({
@@ -385,6 +434,35 @@ describe('production-readiness source evidence validation', () => {
     );
 
     expect(blockers.map((blocker) => blocker.id)).not.toContain('luma-gated-write-coverage');
+  });
+
+  it('copies passing LUMA coverage evidence into durable packet supporting evidence', () => {
+    const artifactDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vh-mesh-luma-support-'));
+    const sourceReportPath = path.join(artifactDir, 'input-luma-coverage.json');
+    const report = passingLumaCoverageReport();
+    writeJson(sourceReportPath, report);
+
+    try {
+      const persisted = persistLumaCoverageEvidenceForPacket({
+        artifactDir,
+        lumaCoverageEvidence: {
+          ...lumaCoverageEvidence(report),
+          report_path: sourceReportPath,
+          original_report_path: sourceReportPath,
+        },
+      });
+
+      const durablePath = path.join(
+        artifactDir,
+        'supporting-evidence/luma-gated-write-coverage',
+        LUMA_GATED_WRITE_COVERAGE_REPORT_NAME,
+      );
+      expect(persisted.report_path).toBe(`./supporting-evidence/luma-gated-write-coverage/${LUMA_GATED_WRITE_COVERAGE_REPORT_NAME}`);
+      expect(persisted.supporting_evidence.report_path).toBe(persisted.report_path);
+      expect(JSON.parse(fs.readFileSync(durablePath, 'utf8'))).toEqual(report);
+    } finally {
+      fs.rmSync(artifactDir, { recursive: true, force: true });
+    }
   });
 
   it('accepts a fresh source report for the exact gate command', () => {
@@ -620,24 +698,96 @@ describe('mesh evidence scrub promotion', () => {
   it('allows passing LUMA rows only when explicit coverage status passed', () => {
     const sourceDir = evidenceScrubPacket();
     try {
-      const aggregatePath = path.join(sourceDir, 'mesh-production-readiness-report.json');
-      const aggregate = JSON.parse(fs.readFileSync(aggregatePath, 'utf8'));
-      aggregate.luma_gated_write_coverage = {
-        status: 'pass',
-        report_path: '/tmp/mesh-luma-gated-write-coverage-report.json',
-      };
-      aggregate.luma_gated_write_drills = [
-        {
-          write_class: 'forum_thread',
-          trace_id: 'luma-coverage-pass',
-          status: 'pass',
-        },
-      ];
-      writeJson(aggregatePath, aggregate);
+      addDurableLumaCoverageToPacket(sourceDir);
 
       const validation = validateAggregatePacket({ sourceDir });
 
+      expect(validation.ok).toBe(true);
       expect(validation.failures).not.toContain('aggregate implies LUMA-gated write coverage in a mesh-only evidence packet');
+    } finally {
+      fs.rmSync(sourceDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects passing LUMA coverage when the durable copied report is missing', () => {
+    const sourceDir = evidenceScrubPacket();
+    try {
+      addDurableLumaCoverageToPacket(sourceDir, { writeReport: false });
+
+      const validation = validateAggregatePacket({ sourceDir });
+
+      expect(validation.ok).toBe(false);
+      expect(validation.failures).toContain(
+        `missing durable LUMA coverage report at ./supporting-evidence/luma-gated-write-coverage/${LUMA_GATED_WRITE_COVERAGE_REPORT_NAME}`,
+      );
+    } finally {
+      fs.rmSync(sourceDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects passing LUMA coverage when it points at dangling .tmp state', () => {
+    const sourceDir = evidenceScrubPacket();
+    try {
+      addDurableLumaCoverageToPacket(sourceDir, {
+        writeReport: false,
+        reportPath: `./.tmp/mesh-luma-gated-write-coverage/latest/${LUMA_GATED_WRITE_COVERAGE_REPORT_NAME}`,
+      });
+
+      const validation = validateAggregatePacket({ sourceDir });
+
+      expect(validation.ok).toBe(false);
+      expect(validation.failures).toContain(
+        'passing LUMA coverage report_path must point inside supporting-evidence/luma-gated-write-coverage',
+      );
+      expect(validation.failures).toContain('passing LUMA coverage report_path points at non-durable .tmp state');
+    } finally {
+      fs.rmSync(sourceDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects stale durable LUMA coverage reports with the wrong commit', () => {
+    const sourceDir = evidenceScrubPacket();
+    try {
+      addDurableLumaCoverageToPacket(sourceDir, {
+        reportOverrides: {
+          repo: {
+            commit: '2222222222222222222222222222222222222222',
+            dirty: false,
+          },
+        },
+      });
+
+      const validation = validateAggregatePacket({ sourceDir });
+
+      expect(validation.ok).toBe(false);
+      expect(validation.failures).toContain(
+        `durable LUMA coverage report invalid: report commit 2222222222222222222222222222222222222222 does not match ${liveCommit()}`,
+      );
+    } finally {
+      fs.rmSync(sourceDir, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves durable LUMA coverage evidence through scrub promotion', () => {
+    const sourceDir = evidenceScrubPacket();
+    try {
+      addDurableLumaCoverageToPacket(sourceDir);
+
+      const result = runEvidenceScrub({
+        sourceDir,
+        command: `pnpm check:mesh-evidence-scrub -- --source-dir ${path.relative(repoRoot, sourceDir)}`,
+      });
+
+      expect(result.ok).toBe(true);
+      const promotedDir = path.resolve(repoRoot, result.promoted_dir.replace(/^\.\//, ''));
+      const promotedReport = JSON.parse(fs.readFileSync(path.join(promotedDir, 'mesh-production-readiness-report.json'), 'utf8'));
+      const promotedLumaPath = path.join(promotedDir, promotedReport.luma_gated_write_coverage.report_path.replace(/^\.\//, ''));
+
+      expect(promotedReport.luma_gated_write_coverage.report_path).toBe(
+        `./supporting-evidence/luma-gated-write-coverage/${LUMA_GATED_WRITE_COVERAGE_REPORT_NAME}`,
+      );
+      expect(fs.existsSync(promotedLumaPath)).toBe(true);
+      expect(validateAggregatePacket({ sourceDir: promotedDir }).ok).toBe(true);
     } finally {
       fs.rmSync(sourceDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- copy passing LUMA-gated write coverage reports into mesh readiness packets under supporting-evidence/luma-gated-write-coverage
- record durable source metadata on luma_gated_write_coverage without adding a 13th mesh source report
- make evidence scrub fail closed on missing, stale, dirty, dangling .tmp, or inconsistent LUMA supporting evidence
- update mesh readiness spec/runbook for the durable in-packet contract

## Verification
- node --check packages/e2e/src/mesh/production-readiness-check.mjs
- node --check packages/e2e/src/mesh/evidence-scrub-check.mjs
- pnpm --filter @vh/e2e exec vitest run src/mesh/production-readiness-check.test.mjs --reporter=dot
- pnpm --filter @vh/e2e typecheck
- pnpm docs:check
- git diff --check origin/main...HEAD
- node tools/scripts/check-diff-coverage.mjs
- pnpm check:public-namespace-leaks
- pnpm check:luma-topic-synthesis-system-v1
- pnpm check:luma-topic-digest-system-v1
- pnpm check:luma-system-writer-surface
- pnpm check:luma-signed-write-surface
- pnpm check:luma-provider-surface
- pnpm check:luma-vault-compartments
- pnpm check:luma-delegation-signer-surface
- pnpm check:luma-forum-author-v1
- pnpm check:luma-forum-post-v1
- pnpm check:luma-forum-nomination-v1
- pnpm check:luma-aggregate-voter-v1
- pnpm check:luma-directory-v1
- pnpm check:luma-news-report-v1
- pnpm check:luma-news-story-system-v1
- pnpm check:luma-news-storyline-system-v1
- pnpm check:luma-news-index-system-v1
- pnpm check:luma-news-analysis-system-v1
- pnpm check:luma-identity-lifecycle
- pnpm check:luma-wallet-binding
- pnpm check:luma-multidevice-stubs
- pnpm test:mesh:luma-gated-write-coverage -- --mode local-e2e
- VH_MESH_LUMA_GATED_WRITE_COVERAGE_REPORT=.tmp/mesh-luma-gated-write-coverage/latest/mesh-luma-gated-write-coverage-report.json pnpm check:mesh:production-readiness
- pnpm check:mesh-evidence-scrub -- --source-dir .tmp/mesh-production-readiness/mesh-production-readiness-20260510T124257Z-f5586280
- pnpm check:production-app-canary -- --mesh-report .tmp/mesh-production-readiness/promoted/mesh-production-readiness-20260510T124257Z-f5586280/mesh-production-readiness-report.json (expected nonzero: mesh_not_release_ready)