### PR TITLE
Repair current LUMA evidence packet

### DIFF
--- a/docs/reports/evidence/mesh-production/current-canonical-soak-luma/mesh-production-readiness-20260510T090611Z-a34c7ec3/mesh-production-readiness-evidence.md
+++ b/docs/reports/evidence/mesh-production/current-canonical-soak-luma/mesh-production-readiness-20260510T090611Z-a34c7ec3/mesh-production-readiness-evidence.md
@@ -7,6 +7,7 @@
 - Schema epoch: `post_luma_m0b`
 - LUMA profile: `none`
 - Report: `./.tmp/mesh-production-readiness/mesh-production-readiness-20260510T090611Z-a34c7ec3/mesh-production-readiness-report.json`
+- LUMA coverage report: `./supporting-evidence/luma-gated-write-coverage/mesh-luma-gated-write-coverage-report.json`
 
 ## Source Reports
 

--- a/docs/reports/evidence/mesh-production/current-canonical-soak-luma/mesh-production-readiness-20260510T090611Z-a34c7ec3/mesh-production-readiness-report.json
+++ b/docs/reports/evidence/mesh-production/current-canonical-soak-luma/mesh-production-readiness-20260510T090611Z-a34c7ec3/mesh-production-readiness-report.json
@@ -10480,7 +10480,7 @@
   "luma_gated_write_coverage": {
     "command": "pnpm test:mesh:luma-gated-write-coverage",
     "report_env": "VH_MESH_LUMA_GATED_WRITE_COVERAGE_REPORT",
-    "report_path": "./.tmp/mesh-luma-gated-write-coverage/mesh-luma-gated-write-coverage-20260510T090537Z-04838dbd/mesh-luma-gated-write-coverage-report.json",
+    "report_path": "./supporting-evidence/luma-gated-write-coverage/mesh-luma-gated-write-coverage-report.json",
     "status": "pass",
     "failures": [],
     "required_write_classes": [
@@ -10534,7 +10534,13 @@
         "schema_epoch": "post_luma_m0b",
         "luma_profile": "e2e"
       }
-    ]
+    ],
+    "source_run_id": "mesh-luma-gated-write-coverage-20260510T090537Z-04838dbd",
+    "source_commit": "136f7f23e5715f556b5d0a6b84b97932b8516ef5",
+    "source_dirty": false,
+    "schema_version": "mesh-luma-gated-write-coverage-v1",
+    "schema_epoch": "post_luma_m0b",
+    "luma_profile": "e2e"
   },
   "luma_gated_write_drills": [
     {

--- a/docs/reports/evidence/mesh-production/current-canonical-soak-luma/mesh-production-readiness-20260510T090611Z-a34c7ec3/supporting-evidence/luma-gated-write-coverage/mesh-luma-gated-write-coverage-report.json
+++ b/docs/reports/evidence/mesh-production/current-canonical-soak-luma/mesh-production-readiness-20260510T090611Z-a34c7ec3/supporting-evidence/luma-gated-write-coverage/mesh-luma-gated-write-coverage-report.json
@@ -1,0 +1,139 @@
+{
+  "schema_version": "mesh-luma-gated-write-coverage-v1",
+  "generated_at": "2026-05-10T09:05:43.056Z",
+  "run_id": "mesh-luma-gated-write-coverage-20260510T090537Z-04838dbd",
+  "repo": {
+    "branch": "coord/mesh-current-canonical-soak-luma-evidence",
+    "commit": "136f7f23e5715f556b5d0a6b84b97932b8516ef5",
+    "base_ref": "origin/main",
+    "dirty": false
+  },
+  "run": {
+    "mode": "luma_gated_write_coverage",
+    "started_at": "2026-05-10T09:05:37.160Z",
+    "completed_at": "2026-05-10T09:05:43.056Z",
+    "duration_ms": 5896,
+    "command": "pnpm test:mesh:luma-gated-write-coverage -- --mode local-e2e"
+  },
+  "status": "pass",
+  "schema_epoch": "post_luma_m0b",
+  "luma_profile": "e2e",
+  "coverage_source_report_path": null,
+  "luma_gated_write_coverage": {
+    "status": "pass",
+    "command": "pnpm test:mesh:luma-gated-write-coverage -- --mode local-e2e",
+    "expected_schema_epoch": "post_luma_m0b",
+    "expected_luma_profile": "e2e",
+    "source_report_path": null,
+    "failures": [],
+    "required_write_classes": [
+      {
+        "write_class": "forum_thread",
+        "label": "forum thread",
+        "status": "pass",
+        "trace_id": "mesh-luma-gated-write-coverage-20260510T090537Z-04838dbd:forum-thread",
+        "writer_kind": "luma",
+        "reader_path": "luma_reader_path",
+        "schema_epoch": "post_luma_m0b",
+        "luma_profile": "e2e"
+      },
+      {
+        "write_class": "forum_comment",
+        "label": "forum comment",
+        "status": "pass",
+        "trace_id": "mesh-luma-gated-write-coverage-20260510T090537Z-04838dbd:forum-comment",
+        "writer_kind": "luma",
+        "reader_path": "luma_reader_path",
+        "schema_epoch": "post_luma_m0b",
+        "luma_profile": "e2e"
+      },
+      {
+        "write_class": "vote_or_aggregate",
+        "label": "vote or aggregate",
+        "status": "pass",
+        "trace_id": "mesh-luma-gated-write-coverage-20260510T090537Z-04838dbd:vote-or-aggregate",
+        "writer_kind": "luma",
+        "reader_path": "luma_reader_path",
+        "schema_epoch": "post_luma_m0b",
+        "luma_profile": "e2e"
+      },
+      {
+        "write_class": "directory_publish",
+        "label": "directory publish",
+        "status": "pass",
+        "trace_id": "mesh-luma-gated-write-coverage-20260510T090537Z-04838dbd:directory-publish",
+        "writer_kind": "luma",
+        "reader_path": "luma_reader_path",
+        "schema_epoch": "post_luma_m0b",
+        "luma_profile": "e2e"
+      },
+      {
+        "write_class": "news_report_status",
+        "label": "news report/status",
+        "status": "pass",
+        "trace_id": "mesh-luma-gated-write-coverage-20260510T090537Z-04838dbd:news-report-status",
+        "writer_kind": "luma",
+        "reader_path": "luma_reader_path",
+        "schema_epoch": "post_luma_m0b",
+        "luma_profile": "e2e"
+      }
+    ]
+  },
+  "luma_gated_write_drills": [
+    {
+      "write_class": "forum_thread",
+      "trace_id": "mesh-luma-gated-write-coverage-20260510T090537Z-04838dbd:forum-thread",
+      "status": "pass",
+      "writer_kind": "luma",
+      "reader_path": "luma_reader_path",
+      "schema_epoch": "post_luma_m0b",
+      "luma_profile": "e2e"
+    },
+    {
+      "write_class": "forum_comment",
+      "trace_id": "mesh-luma-gated-write-coverage-20260510T090537Z-04838dbd:forum-comment",
+      "status": "pass",
+      "writer_kind": "luma",
+      "reader_path": "luma_reader_path",
+      "schema_epoch": "post_luma_m0b",
+      "luma_profile": "e2e"
+    },
+    {
+      "write_class": "vote_or_aggregate",
+      "trace_id": "mesh-luma-gated-write-coverage-20260510T090537Z-04838dbd:vote-or-aggregate",
+      "status": "pass",
+      "writer_kind": "luma",
+      "reader_path": "luma_reader_path",
+      "schema_epoch": "post_luma_m0b",
+      "luma_profile": "e2e"
+    },
+    {
+      "write_class": "directory_publish",
+      "trace_id": "mesh-luma-gated-write-coverage-20260510T090537Z-04838dbd:directory-publish",
+      "status": "pass",
+      "writer_kind": "luma",
+      "reader_path": "luma_reader_path",
+      "schema_epoch": "post_luma_m0b",
+      "luma_profile": "e2e"
+    },
+    {
+      "write_class": "news_report_status",
+      "trace_id": "mesh-luma-gated-write-coverage-20260510T090537Z-04838dbd:news-report-status",
+      "status": "pass",
+      "writer_kind": "luma",
+      "reader_path": "luma_reader_path",
+      "schema_epoch": "post_luma_m0b",
+      "luma_profile": "e2e"
+    }
+  ],
+  "release_claims": {
+    "allowed": [
+      "All required LUMA-gated write classes have current LUMA reader-path coverage evidence."
+    ],
+    "forbidden": [
+      "LUMA gate behavior is verified by mesh."
+    ],
+    "invalidated_by_luma_epoch_change": false
+  },
+  "failures": []
+}


### PR DESCRIPTION
## Summary
- copy the exact Slice 14G LUMA coverage source report into the current canonical soak+LUMA evidence packet under supporting-evidence/luma-gated-write-coverage
- update the aggregate LUMA coverage metadata to point at the durable in-packet report and record source commit/profile/schema metadata
- keep source report count at 12 and preserve the only release blocker as public-wss-deployment-proof

## Verification
- pnpm check:mesh-evidence-scrub -- --source-dir docs/reports/evidence/mesh-production/current-canonical-soak-luma/mesh-production-readiness-20260510T090611Z-a34c7ec3 --expected-commit 136f7f23e5715f556b5d0a6b84b97932b8516ef5
- pnpm docs:check
- git diff --check origin/main...HEAD
- node tools/scripts/check-diff-coverage.mjs
- pnpm check:public-namespace-leaks
- protected-surface grep: no matches