### PR TITLE
Enforce complete source-health release windows

### DIFF
--- a/docs/foundational/STATUS.md
+++ b/docs/foundational/STATUS.md
@@ -55,7 +55,7 @@ Current policy state:
 - Release/readiness reviewers should treat that deterministic corpus plus the daemon-first semantic gate as the authoritative correctness gate.
 - Unified production-readiness now requires one explicit combined rule:
   - StoryCluster correctness must pass via `pnpm check:storycluster:correctness`;
-  - source-health release evidence must remain fresh and pass via `pnpm check:news-sources:health`;
+  - source-health release evidence must remain fresh, cover the complete configured recent run window, and pass via `pnpm check:news-sources:health`; `warn` is an adjudication state, not consolidated release-green evidence;
   - headline-soak trend evidence must remain fresh and pass via `pnpm report:storycluster:production-readiness`.
 - The combined production-readiness decision surface is:
   - command: `pnpm check:storycluster:production-readiness`

--- a/docs/ops/NEWS_SOURCE_ADMISSION_RUNBOOK.md
+++ b/docs/ops/NEWS_SOURCE_ADMISSION_RUNBOOK.md
@@ -134,6 +134,10 @@ Operational artifact expectations:
    - `readinessStatus`
    - `releaseEvidence.status`
    - `releaseEvidence.reasons`
+   - `releaseEvidence.recentWindowRunCount`
+   - `releaseEvidence.recentReadyRunCount`
+   - `releaseEvidence.recentReviewRunCount`
+   - `releaseEvidence.recentBlockedRunCount`
    - `recommendedAction`
    - `keepSourceIds`
    - `watchSourceIds`
@@ -164,6 +168,9 @@ Operational artifact expectations:
 7. source-health is one required input to the combined production-readiness rule, not a standalone release claim:
    - StoryCluster correctness must pass;
    - source-health release evidence must pass and remain fresh;
+   - source-health release evidence must include the full configured release window; `insufficient_release_evidence_window`, `blocked_run_within_release_window`, and `non_ready_runs_exceed_threshold` are release blockers, not review-only warnings;
+   - when the only blocker is a missing local release-evidence window, the enforced check may collect the remaining live runs; any warning, blocked run, source watch/remove transition, or non-ready threshold breach still stops the gate;
+   - `pnpm check:news-sources:health` treats any non-`pass` release evidence, including `warn` from `latest_run_not_ready` or `new_watch_sources_detected`, as non-green for consolidated release gates;
    - headline-soak trend release evidence must pass and remain fresh.
 
 ## Operational Interpretation

--- a/docs/specs/spec-news-aggregator-v0.md
+++ b/docs/specs/spec-news-aggregator-v0.md
@@ -32,7 +32,7 @@ Season 0 source contract:
 Season 0 production-readiness contract:
 
 1. StoryCluster correctness must pass through the deterministic corpus/replay gate plus the daemon-first semantic gate;
-2. source-health release evidence must remain fresh and pass over the recent run window;
+2. source-health release evidence must remain fresh and pass over the complete configured recent run window; consolidated release gates treat source-health `warn` evidence as non-green until the latest run returns to `pass`;
 3. headline-soak release evidence must remain fresh and pass over the recent run window;
 4. headline-soak release evidence currently passes the recent run window only when all of these are true:
    - at least 4 recent executions are present;

--- a/services/news-aggregator/src/sourceAdmissionReport.test.ts
+++ b/services/news-aggregator/src/sourceAdmissionReport.test.ts
@@ -1406,17 +1406,19 @@ describe('sourceAdmissionReport', () => {
 
   it('detects direct execution only when argv[1] matches the module path', () => {
     const originalArgv1 = process.argv[1];
-    const modulePath = '/Users/bldt/Desktop/VHC/VHC/services/news-aggregator/src/sourceAdmissionReport.ts';
+    const modulePath = path.join(process.cwd(), 'src/sourceAdmissionReport.ts');
 
-    process.argv[1] = undefined as unknown as string;
-    expect(sourceAdmissionReportInternal.isDirectExecution()).toBe(false);
+    try {
+      process.argv[1] = undefined as unknown as string;
+      expect(sourceAdmissionReportInternal.isDirectExecution()).toBe(false);
 
-    process.argv[1] = '/tmp/not-the-module.js';
-    expect(sourceAdmissionReportInternal.isDirectExecution()).toBe(false);
+      process.argv[1] = '/tmp/not-the-module.js';
+      expect(sourceAdmissionReportInternal.isDirectExecution()).toBe(false);
 
-    process.argv[1] = modulePath;
-    expect(sourceAdmissionReportInternal.isDirectExecution()).toBe(true);
-
-    process.argv[1] = originalArgv1;
+      process.argv[1] = modulePath;
+      expect(sourceAdmissionReportInternal.isDirectExecution()).toBe(true);
+    } finally {
+      process.argv[1] = originalArgv1;
+    }
   });
 });

--- a/services/news-aggregator/src/sourceHealthReport.test.ts
+++ b/services/news-aggregator/src/sourceHealthReport.test.ts
@@ -127,6 +127,55 @@ describe('sourceHealthReport', () => {
     expect(decision.reasons).toEqual([]);
   });
 
+  it('fails the release-enforced check on warning status by default', () => {
+    expect(
+      sourceHealthReportInternal.shouldFailEnforcedReleaseEvidence('warn', true, undefined),
+    ).toBe(true);
+    expect(
+      sourceHealthReportInternal.shouldFailEnforcedReleaseEvidence('fail', true, undefined),
+    ).toBe(true);
+    expect(
+      sourceHealthReportInternal.shouldFailEnforcedReleaseEvidence('pass', true, undefined),
+    ).toBe(false);
+    expect(
+      sourceHealthReportInternal.shouldFailEnforcedReleaseEvidence('warn', false, undefined),
+    ).toBe(false);
+    expect(
+      sourceHealthReportInternal.shouldFailEnforcedReleaseEvidence('warn', true, '0'),
+    ).toBe(false);
+  });
+
+  it('auto-collects only a clean missing release-evidence window', () => {
+    const cleanMissingWindow = {
+      status: 'fail',
+      recommendedAction: 'hold_release_for_trend_recovery',
+      reasons: ['insufficient_release_evidence_window'],
+      recentWindowRunCount: 1,
+      recentReadyRunCount: 1,
+      recentReviewRunCount: 0,
+      recentBlockedRunCount: 0,
+      latestNewWatchSourceIds: [],
+      latestNewRemoveSourceIds: [],
+    } as const;
+
+    expect(
+      sourceHealthReportInternal.shouldCollectAdditionalReleaseEvidence(cleanMissingWindow),
+    ).toBe(true);
+    expect(
+      sourceHealthReportInternal.shouldCollectAdditionalReleaseEvidence({
+        ...cleanMissingWindow,
+        reasons: ['insufficient_release_evidence_window', 'latest_run_not_ready'],
+      }),
+    ).toBe(false);
+    expect(
+      sourceHealthReportInternal.shouldCollectAdditionalReleaseEvidence({
+        ...cleanMissingWindow,
+        status: 'warn',
+        reasons: ['latest_run_not_ready'],
+      }),
+    ).toBe(false);
+  });
+
   it('marks admitted sources with lifecycle instability for watch review', () => {
     const source = makeAdmissionSource({
       sourceId: 'guardian-us',
@@ -312,7 +361,13 @@ describe('sourceHealthReport', () => {
     expect(report.releaseEvidence).toEqual({
       status: 'fail',
       recommendedAction: 'hold_release_for_trend_recovery',
-      reasons: ['blocked_run_within_release_window'],
+      reasons: [
+        'insufficient_release_evidence_window',
+        'blocked_run_within_release_window',
+        'latest_run_not_ready',
+        'new_watch_sources_detected',
+        'new_remove_sources_detected',
+      ],
       recentWindowRunCount: 1,
       recentReadyRunCount: 0,
       recentReviewRunCount: 0,
@@ -376,14 +431,46 @@ describe('sourceHealthReport', () => {
     expect(report.recommendedAction).toBe('review_watchlist');
     expect(report.watchSourceIds).toEqual(['guardian-us']);
     expect(report.releaseEvidence).toEqual({
-      status: 'warn',
-      recommendedAction: 'review_recent_deterioration',
-      reasons: ['latest_run_not_ready', 'new_watch_sources_detected'],
+      status: 'fail',
+      recommendedAction: 'hold_release_for_trend_recovery',
+      reasons: [
+        'insufficient_release_evidence_window',
+        'latest_run_not_ready',
+        'new_watch_sources_detected',
+      ],
       recentWindowRunCount: 1,
       recentReadyRunCount: 0,
       recentReviewRunCount: 1,
       recentBlockedRunCount: 0,
       latestNewWatchSourceIds: ['guardian-us'],
+      latestNewRemoveSourceIds: [],
+    });
+  });
+
+  it('holds release evidence until the configured recovery window is complete', () => {
+    const report = buildSourceHealthReport(
+      makeAdmissionReport([
+        makeAdmissionSource({ sourceId: 'fox-latest' }),
+      ]),
+      {
+        artifactDir: '/repo/.tmp/news-source-admission/run-ready-single',
+        thresholds: {
+          minContributingSourceCount: 0,
+        },
+        now: () => 1_700_000_000_000,
+      },
+    );
+
+    expect(report.readinessStatus).toBe('ready');
+    expect(report.releaseEvidence).toEqual({
+      status: 'fail',
+      recommendedAction: 'hold_release_for_trend_recovery',
+      reasons: ['insufficient_release_evidence_window'],
+      recentWindowRunCount: 1,
+      recentReadyRunCount: 1,
+      recentReviewRunCount: 0,
+      recentBlockedRunCount: 0,
+      latestNewWatchSourceIds: [],
       latestNewRemoveSourceIds: [],
     });
   });
@@ -625,13 +712,33 @@ describe('sourceHealthReport', () => {
         },
       ],
     });
+    writeHistoricalSourceHealthReport(artifactRoot, 'run-3', {
+      generatedAt: '2026-03-17T00:00:00.000Z',
+      sources: [
+        {
+          sourceId: 'fox-latest',
+          baseDecision: 'keep',
+          decision: 'keep',
+        },
+      ],
+    });
+    writeHistoricalSourceHealthReport(artifactRoot, 'run-4', {
+      generatedAt: '2026-03-18T00:00:00.000Z',
+      sources: [
+        {
+          sourceId: 'fox-latest',
+          baseDecision: 'keep',
+          decision: 'keep',
+        },
+      ],
+    });
 
     const report = buildSourceHealthReport(
       makeAdmissionReport([
         makeAdmissionSource({ sourceId: 'fox-latest' }),
       ]),
       {
-        artifactDir: path.join(artifactRoot, 'run-3'),
+        artifactDir: path.join(artifactRoot, 'run-5'),
         thresholds: {
           minContributingSourceCount: 0,
         },
@@ -648,13 +755,13 @@ describe('sourceHealthReport', () => {
 
     expect(trendIndex.schemaVersion).toBe(SOURCE_HEALTH_TREND_INDEX_SCHEMA_VERSION);
     expect(trendIndex.lookbackRunCount).toBe(8);
-    expect(trendIndex.runCount).toBe(3);
+    expect(trendIndex.runCount).toBe(5);
     expect(trendIndex.releaseEvidence).toEqual({
       status: 'pass',
       recommendedAction: 'release_ready',
       reasons: [],
-      recentWindowRunCount: 3,
-      recentReadyRunCount: 2,
+      recentWindowRunCount: 5,
+      recentReadyRunCount: 4,
       recentReviewRunCount: 1,
       recentBlockedRunCount: 0,
       latestNewWatchSourceIds: [],
@@ -664,13 +771,63 @@ describe('sourceHealthReport', () => {
       'ready',
       'review',
       'ready',
+      'ready',
+      'ready',
     ]);
-    expect(trendIndex.runs[2]).toMatchObject({
+    expect(trendIndex.runs[4]).toMatchObject({
       globalFeedStageFailure: false,
       latestPublicationAction: 'publish_latest',
       keepSourceIds: ['fox-latest'],
       watchSourceIds: [],
       removeSourceIds: [],
+    });
+
+    rmSync(artifactRoot, { recursive: true, force: true });
+  });
+
+  it('fails release evidence when non-ready runs exceed the recovery threshold', () => {
+    const artifactRoot = mkdtempSync(path.join(os.tmpdir(), 'vh-source-health-nonready-threshold-'));
+    for (const [runId, generatedAt, decision] of [
+      ['run-1', '2026-03-15T00:00:00.000Z', 'keep'],
+      ['run-2', '2026-03-16T00:00:00.000Z', 'watch'],
+      ['run-3', '2026-03-17T00:00:00.000Z', 'watch'],
+      ['run-4', '2026-03-18T00:00:00.000Z', 'keep'],
+    ] as const) {
+      writeHistoricalSourceHealthReport(artifactRoot, runId, {
+        generatedAt,
+        sources: [
+          {
+            sourceId: 'fox-latest',
+            baseDecision: decision,
+            decision,
+          },
+        ],
+      });
+    }
+
+    const report = buildSourceHealthReport(
+      makeAdmissionReport([
+        makeAdmissionSource({ sourceId: 'fox-latest' }),
+      ]),
+      {
+        artifactDir: path.join(artifactRoot, 'run-5'),
+        thresholds: {
+          minContributingSourceCount: 0,
+        },
+        now: () => Date.parse('2026-03-19T00:00:00.000Z'),
+      },
+    );
+
+    expect(report.releaseEvidence).toEqual({
+      status: 'fail',
+      recommendedAction: 'hold_release_for_trend_recovery',
+      reasons: ['non_ready_runs_exceed_threshold'],
+      recentWindowRunCount: 5,
+      recentReadyRunCount: 3,
+      recentReviewRunCount: 2,
+      recentBlockedRunCount: 0,
+      latestNewWatchSourceIds: [],
+      latestNewRemoveSourceIds: [],
     });
 
     rmSync(artifactRoot, { recursive: true, force: true });
@@ -1013,13 +1170,29 @@ describe('sourceHealthReport', () => {
         },
       }),
     ]);
+    for (const [runId, generatedAt] of [
+      ['run-3', '2026-03-20T07:00:00.000Z'],
+      ['run-4', '2026-03-20T08:00:00.000Z'],
+      ['run-5', '2026-03-20T09:00:00.000Z'],
+    ] as const) {
+      writeHistoricalSourceHealthReport(artifactRoot, runId, {
+        generatedAt,
+        readinessStatus: 'ready',
+        sources: [
+          {
+            sourceId: 'fox-latest',
+            decision: 'keep',
+          },
+        ],
+      });
+    }
 
     const report = buildSourceHealthReport(
       makeAdmissionReport([
         makeAdmissionSource({ sourceId: 'fox-latest' }),
       ]),
       {
-        artifactDir: path.join(artifactRoot, 'run-3'),
+        artifactDir: path.join(artifactRoot, 'run-6'),
         thresholds: {
           minContributingSourceCount: 0,
         },
@@ -1027,7 +1200,7 @@ describe('sourceHealthReport', () => {
       },
     );
 
-    expect(report.historySummary.priorReportCount).toBe(1);
+    expect(report.historySummary.priorReportCount).toBe(4);
     expect(report.releaseEvidence.status).toBe('pass');
 
     rmSync(artifactRoot, { recursive: true, force: true });
@@ -1068,9 +1241,9 @@ describe('sourceHealthReport', () => {
     expect(report.historySummary.priorReportCount).toBe(0);
     expect(report.sources[0]?.history.priorReportCount).toBe(0);
     expect(report.releaseEvidence).toEqual({
-      status: 'pass',
-      recommendedAction: 'release_ready',
-      reasons: [],
+      status: 'fail',
+      recommendedAction: 'hold_release_for_trend_recovery',
+      reasons: ['insufficient_release_evidence_window'],
       recentWindowRunCount: 1,
       recentReadyRunCount: 1,
       recentReviewRunCount: 0,
@@ -1113,9 +1286,9 @@ describe('sourceHealthReport', () => {
     expect(report.historySummary.priorReportCount).toBe(0);
     expect(report.sources[0]?.history.priorReportCount).toBe(0);
     expect(report.releaseEvidence).toEqual({
-      status: 'pass',
-      recommendedAction: 'release_ready',
-      reasons: [],
+      status: 'fail',
+      recommendedAction: 'hold_release_for_trend_recovery',
+      reasons: ['insufficient_release_evidence_window'],
       recentWindowRunCount: 1,
       recentReadyRunCount: 1,
       recentReviewRunCount: 0,
@@ -1178,9 +1351,9 @@ describe('sourceHealthReport', () => {
 
     expect(failedArtifact.sourceHealthReport.runAssessment.globalFeedStageFailure).toBe(true);
     expect(failedArtifact.sourceHealthTrendIndex.releaseEvidence).toEqual({
-      status: 'pass',
-      recommendedAction: 'release_ready',
-      reasons: [],
+      status: 'fail',
+      recommendedAction: 'hold_release_for_trend_recovery',
+      reasons: ['insufficient_release_evidence_window'],
       recentWindowRunCount: 1,
       recentReadyRunCount: 1,
       recentReviewRunCount: 0,
@@ -1261,19 +1434,20 @@ describe('sourceHealthReport', () => {
 
   it('detects direct execution only when argv[1] matches the module path', () => {
     const originalArgv1 = process.argv[1];
-    const modulePath =
-      '/Users/bldt/Desktop/VHC/VHC/services/news-aggregator/src/sourceHealthReport.ts';
+    const modulePath = path.join(process.cwd(), 'src/sourceHealthReport.ts');
 
-    process.argv[1] = undefined as unknown as string;
-    expect(sourceHealthReportInternal.isDirectExecution()).toBe(false);
+    try {
+      process.argv[1] = undefined as unknown as string;
+      expect(sourceHealthReportInternal.isDirectExecution()).toBe(false);
 
-    process.argv[1] = '/tmp/not-the-module.js';
-    expect(sourceHealthReportInternal.isDirectExecution()).toBe(false);
+      process.argv[1] = '/tmp/not-the-module.js';
+      expect(sourceHealthReportInternal.isDirectExecution()).toBe(false);
 
-    process.argv[1] = modulePath;
-    expect(sourceHealthReportInternal.isDirectExecution()).toBe(true);
-
-    process.argv[1] = originalArgv1;
+      process.argv[1] = modulePath;
+      expect(sourceHealthReportInternal.isDirectExecution()).toBe(true);
+    } finally {
+      process.argv[1] = originalArgv1;
+    }
   });
 
   it('builds a runtime policy summary directly from source decisions', () => {

--- a/services/news-aggregator/src/sourceHealthReport.ts
+++ b/services/news-aggregator/src/sourceHealthReport.ts
@@ -878,6 +878,11 @@ function buildSourceHealthReleaseEvidence(
   let status: SourceHealthReleaseEvidenceStatus = 'pass';
   let recommendedAction: SourceHealthReleaseEvidence['recommendedAction'] = 'release_ready';
 
+  if (recentRuns.length < thresholds.releaseEvidenceWindowRunCount) {
+    status = 'fail';
+    recommendedAction = 'hold_release_for_trend_recovery';
+    reasons.push('insufficient_release_evidence_window');
+  }
   if (recentBlockedRunCount > 0) {
     status = 'fail';
     recommendedAction = 'hold_release_for_trend_recovery';
@@ -889,19 +894,25 @@ function buildSourceHealthReleaseEvidence(
     reasons.push('non_ready_runs_exceed_threshold');
   }
 
-  if (status !== 'fail' && latestRun?.readinessStatus !== 'ready') {
-    status = 'warn';
-    recommendedAction = 'review_recent_deterioration';
+  if (latestRun?.readinessStatus !== 'ready') {
+    if (status !== 'fail') {
+      status = 'warn';
+      recommendedAction = 'review_recent_deterioration';
+    }
     reasons.push('latest_run_not_ready');
   }
-  if (status !== 'fail' && latestNewWatchSourceIds.length > 0) {
-    status = 'warn';
-    recommendedAction = 'review_recent_deterioration';
+  if (latestNewWatchSourceIds.length > 0) {
+    if (status !== 'fail') {
+      status = 'warn';
+      recommendedAction = 'review_recent_deterioration';
+    }
     reasons.push('new_watch_sources_detected');
   }
-  if (status !== 'fail' && latestNewRemoveSourceIds.length > 0) {
-    status = 'warn';
-    recommendedAction = 'review_recent_deterioration';
+  if (latestNewRemoveSourceIds.length > 0) {
+    if (status !== 'fail') {
+      status = 'warn';
+      recommendedAction = 'review_recent_deterioration';
+    }
     reasons.push('new_remove_sources_detected');
   }
 
@@ -1368,9 +1379,63 @@ function isDirectExecution(): boolean {
   return fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
 }
 
-/* c8 ignore start */
-async function main(): Promise<void> {
-  const artifact = await writeSourceHealthArtifact();
+function shouldFailEnforcedReleaseEvidence(
+  releaseStatus: SourceHealthReleaseEvidenceStatus,
+  enforceReleaseEvidence: boolean,
+  failOnWarnRaw: string | undefined,
+): boolean {
+  const failOnWarn = parseBoolean(failOnWarnRaw, enforceReleaseEvidence);
+  return (
+    enforceReleaseEvidence
+    && (
+      releaseStatus === 'fail'
+      || (failOnWarn && releaseStatus === 'warn')
+    )
+  );
+}
+
+function shouldCollectAdditionalReleaseEvidence(
+  releaseEvidence: SourceHealthReleaseEvidence,
+): boolean {
+  return (
+    releaseEvidence.status === 'fail'
+    && releaseEvidence.reasons.length === 1
+    && releaseEvidence.reasons[0] === 'insufficient_release_evidence_window'
+  );
+}
+
+async function collectCompleteReleaseEvidenceWindow(
+  initialArtifact: Awaited<ReturnType<typeof writeSourceHealthArtifact>>,
+): Promise<Awaited<ReturnType<typeof writeSourceHealthArtifact>>> {
+  let artifact = initialArtifact;
+  let remainingRuns = Math.max(
+    0,
+    artifact.sourceHealthReport.thresholds.releaseEvidenceWindowRunCount
+      - artifact.sourceHealthReport.releaseEvidence.recentWindowRunCount,
+  );
+
+  while (
+    remainingRuns > 0
+    && shouldCollectAdditionalReleaseEvidence(artifact.sourceHealthReport.releaseEvidence)
+  ) {
+    console.info('[vh:news-source-health] collecting additional release evidence run', {
+      remainingRuns,
+      latestArtifactDir: artifact.latestArtifactDir,
+    });
+    artifact = await writeSourceHealthArtifact();
+    remainingRuns = Math.max(
+      0,
+      artifact.sourceHealthReport.thresholds.releaseEvidenceWindowRunCount
+        - artifact.sourceHealthReport.releaseEvidence.recentWindowRunCount,
+    );
+  }
+
+  return artifact;
+}
+
+function logSourceHealthArtifact(
+  artifact: Awaited<ReturnType<typeof writeSourceHealthArtifact>>,
+): void {
   console.info('[vh:news-source-health] report written', {
     artifactDir: artifact.artifactDir,
     admissionReportPath: artifact.admissionReportPath,
@@ -1393,15 +1458,24 @@ async function main(): Promise<void> {
     watchSourceIds: artifact.sourceHealthReport.watchSourceIds,
     removeSourceIds: artifact.sourceHealthReport.removeSourceIds,
   });
+}
 
+/* c8 ignore start */
+async function main(): Promise<void> {
   const enforceReleaseEvidence = parseBoolean(
     process.env.VH_NEWS_SOURCE_HEALTH_ENFORCE_RELEASE_EVIDENCE,
     false,
   );
-  const failOnWarn = parseBoolean(
-    process.env.VH_NEWS_SOURCE_HEALTH_FAIL_ON_WARN,
-    false,
-  );
+  let artifact = await writeSourceHealthArtifact();
+  if (
+    enforceReleaseEvidence
+    && shouldCollectAdditionalReleaseEvidence(artifact.sourceHealthReport.releaseEvidence)
+  ) {
+    artifact = await collectCompleteReleaseEvidenceWindow(artifact);
+  }
+
+  logSourceHealthArtifact(artifact);
+
   const releaseStatus = artifact.sourceHealthReport.releaseEvidence.status;
   if (releaseStatus === 'warn') {
     const message = `[vh:news-source-health] release evidence warn: ${artifact.sourceHealthReport.releaseEvidence.reasons.join(', ') || 'recent deterioration detected'}`;
@@ -1413,10 +1487,10 @@ async function main(): Promise<void> {
   }
 
   if (
-    enforceReleaseEvidence
-    && (
-      releaseStatus === 'fail'
-      || (failOnWarn && releaseStatus === 'warn')
+    shouldFailEnforcedReleaseEvidence(
+      releaseStatus,
+      enforceReleaseEvidence,
+      process.env.VH_NEWS_SOURCE_HEALTH_FAIL_ON_WARN,
     )
   ) {
     throw new Error(
@@ -1452,5 +1526,7 @@ export const sourceHealthReportInternal = {
   isGlobalFeedStageFailureAdmissionReport,
   parseBoolean,
   parseHistoricalSourceHealthRecord,
+  shouldCollectAdditionalReleaseEvidence,
+  shouldFailEnforcedReleaseEvidence,
   readHistoricalSourceHealthReports,
 };


### PR DESCRIPTION
## Summary

This is the MVP source-health recovery/adjudication v1 slice. It does not alter Mesh, LUMA, app runtime, relay runtime, or production app canary implementation surfaces.

Changes:
- Source-health release evidence now fails closed with `insufficient_release_evidence_window` until the full configured recent-run window is present.
- `pnpm check:news-sources:health` now treats any non-`pass` release evidence as non-green by default, including `warn` from `latest_run_not_ready` or new watch/remove source transitions.
- CI/enforced mode may auto-collect additional live source-health runs only when the sole blocker is a clean missing release-evidence window; warn/blocked/latest-source-transition states still stop the gate.
- Source-health tests now cover complete-window enforcement, non-ready threshold failure, warning-status enforcement, auto-collection guardrails, and portable direct-execution paths.
- Source-health ops/spec/status docs now state that `warn` is an adjudication state, not consolidated release-green evidence.

## Base

Base commit: `dde9be0aa8d1b287174789da2d2b2fc3da83e9cb` (`origin/main` after PR #624 merge).

Head commit: `8740c4e51cf29632dfdd07e6c684b6bc50b1c13e`.

## Source-health before / diagnosis

The #624 caveat described the opaque blocker as:
- `readinessStatus: blocked`
- `releaseEvidence.status: fail`
- `recommendedAction: hold_release_for_trend_recovery`
- reasons including `blocked_run_within_release_window` and `non_ready_runs_exceed_threshold`
- 3 recent runs, 3 blocked, 0 ready
- watch/remove pressure on `nypost-politics` / `fox-latest`
- reason counts including `fetch-failed`, `feed_links_unavailable`, and `feed_fetch_timeout`

In the fresh post-#624 worktree, the live sources recovered, but baseline exposed a policy bug: a brand-new one-run trend could report `releaseEvidence.status=pass` despite `releaseEvidenceWindowRunCount=5`. That made the pass path too permissive.

CI then confirmed the fix was correctly fail-closed on a fresh runner when `fox-latest` entered watch, but the gate also needed a legitimate recovery path for clean new environments. The enforced check now collects the full release evidence window only when missing-window evidence is the sole blocker.

## Remediation / adjudication

No source was silently dropped, removed, or quarantined.

Current source action summary:
- keep: 28 sources
- watch: 0 sources
- remove: 0 sources
- contributing: 28 sources
- corroborating: 28 sources
- zero-contribution enabled sources: 0
- reasonCounts: `{}`

A transient `nevadaindependent-main` review run was observed during local verification (`feed_links_unavailable` / `feed_fetch_timeout`), and the stricter check would now fail a latest-run `warn`. The first CI Source Health run also failed correctly when `fox-latest` entered watch with `below_keep_readable_rate_threshold`. The rerun recovered to `ready` and passed under the existing release-window policy.

Latest local source-health packet from `pnpm check:mvp-release-gates`:
- path: `services/news-aggregator/.tmp/news-source-admission/1778602543650/source-health-report.json`
- `readinessStatus: ready`
- `releaseEvidence.status: pass`
- `recentWindowRunCount: 5`
- `recentReadyRunCount: 5`
- `recentReviewRunCount: 0`
- `recentBlockedRunCount: 0`
- `latestNewWatchSourceIds: []`
- `latestNewRemoveSourceIds: []`

Latest CI Source Health rerun:
- job: `https://github.com/CarbonCasteInc/VHC/actions/runs/25746386947/job/75616068029`
- status: pass
- path in runner: `services/news-aggregator/.tmp/news-source-admission/1778603696600/source-health-report.json`
- `readinessStatus: ready`
- `releaseEvidence.status: pass`
- `recentWindowRunCount: 5`
- `recentReadyRunCount: 5`
- `recentReviewRunCount: 0`
- `recentBlockedRunCount: 0`
- keep/watch/remove: 28/0/0
- reasonCounts: `{}`

## Gate results

Node: `v20.20.0`; pnpm: `9.7.1`.

Passing locally:
- `pnpm check:news-sources:health`
- `pnpm check:luma:mvp-production-readiness`
- `pnpm check:mvp-release-gates` -> `overallStatus: pass`, 14/14 gates pass
- `pnpm --filter @vh/news-aggregator exec vitest run src/sourceHealthReport.test.ts --config ./vitest.config.ts --reporter=dot`
- `pnpm --filter @vh/news-aggregator test` -> 34 files / 416 tests
- `pnpm --filter @vh/news-aggregator typecheck`
- `pnpm --filter @vh/e2e typecheck`
- `pnpm docs:check`
- `git diff --check origin/main...HEAD`
- `node tools/scripts/check-diff-coverage.mjs`
- `node --check services/news-aggregator/dist/sourceHealthReport.js`
- `node --check services/news-aggregator/dist/sourceAdmissionReport.js`
- `pnpm check:public-namespace-leaks`

CI: all required jobs pass on run `25746386947`, including Source Health after rerun.

## Mesh / LUMA / app-readiness boundaries

LUMA MVP readiness passes on this branch after regenerating final-commit local Mesh/LUMA evidence.

Mesh is not claimed release-ready.
- Current regenerated local Mesh packet: `.tmp/mesh-production-readiness/mesh-production-readiness-20260512T160135Z-56cc6664/mesh-production-readiness-report.json`
- status: `review_required`
- commit: `8740c4e51cf29632dfdd07e6c684b6bc50b1c13e`
- blockers preserved: `canonical-30-minute-soak`, `public-wss-deployment-proof`, `required-write-class-sample-floors`
- current insufficient sample floor: `resource_slos:soak/mesh-soak-20260512T160939Z-560756f5/relay_open_sockets_file_descriptors`

Evidence scrub:
- `pnpm check:mesh-evidence-scrub -- --source-dir .tmp/mesh-production-readiness/mesh-production-readiness-20260512T160135Z-56cc6664 --expected-commit 8740c4e51cf29632dfdd07e6c684b6bc50b1c13e` -> pass

Production app canary:
- `pnpm check:production-app-canary -- --mesh-report .tmp/mesh-production-readiness/latest/mesh-production-readiness-report.json` -> expected nonzero block on `mesh_not_release_ready`.
- `mesh_report_present`, freshness, clean repo, current commit, and LUMA profile checks passed; downstream observation was not reached.

## Explicit non-claims

- No Mesh `release_ready` claim.
- No production app canary pass claim.
- No downstream production-app observation claim.
- No full-app readiness claim.
- No test-group readiness claim.