### PR TITLE
Add MVP consolidated closeout packet

### DIFF
--- a/docs/foundational/STATUS.md
+++ b/docs/foundational/STATUS.md
@@ -7,8 +7,8 @@
 
 
 **Last Updated:** 2026-05-11
-**Version:** 0.9.0 (LUMA public-beta MVP readiness gate aligned with Mesh evidence boundary)
-**Assessment:** Controlled beta candidate. The integrated VENN/HERMES/AGORA app is distributable in constrained Web PWA beta when the release commit has a passing public-beta evidence packet. The Web PWA now has deterministic MVP release-gate evidence, public-beta policy surfaces, a provisioned public support/contact path with minimum private escalation protocol, curated launch-content fallback, accepted synthesis correction, story-thread moderation, report-intake/admin-action coverage, minimum trusted beta operator authorization for current remediation writes, a public-beta launch closeout audit in `docs/ops/public-beta-launch-readiness-closeout.md`, service-backed five-user local engagement lane coverage, and a LUMA public-beta MVP readiness gate for the beta-local identity/signed-write layer. Live corroborated headlines remain beta-gated by production-readiness evidence; LUMA production-attestation/Silver, public WSS mesh `release_ready`, and full production app readiness remain separate downstream gates; legal/commercial approval remains outside repo automation.
+**Version:** 0.9.1 (MVP consolidated closeout packet aligned with Mesh/app readiness boundaries)
+**Assessment:** Controlled beta candidate. The integrated VENN/HERMES/AGORA app is distributable in constrained Web PWA beta when the release commit has a passing public-beta evidence packet. The Web PWA now has deterministic MVP release-gate evidence, public-beta policy surfaces, a provisioned public support/contact path with minimum private escalation protocol, curated launch-content fallback, accepted synthesis correction, story-thread moderation, report-intake/admin-action coverage, minimum trusted beta operator authorization for current remediation writes, a public-beta launch closeout audit in `docs/ops/public-beta-launch-readiness-closeout.md`, a consolidated MVP closeout packet at `.tmp/mvp-closeout/latest/mvp-closeout-report.json`, service-backed five-user local engagement lane coverage, and a LUMA public-beta MVP readiness gate for the beta-local identity/signed-write layer. Live corroborated headlines remain beta-gated by production-readiness evidence; LUMA production-attestation/Silver, public WSS mesh `release_ready`, production app canary pass, full production app readiness, and test-group readiness remain separate downstream gates; legal/commercial approval remains outside repo automation.
 
 > ⚠️ **This document reflects actual implementation status, not target architecture.**
 > For the full vision, see `System_Architecture.md` and whitepapers in `docs/`.
@@ -82,7 +82,8 @@ Current policy state:
   - closeout doc: `docs/ops/public-beta-launch-readiness-closeout.md`;
   - focused gate: `pnpm check:public-beta-launch-closeout`;
   - MVP report gate: `public_beta_launch_closeout` inside `pnpm check:mvp-release-gates`;
-  - required release packet: `pnpm check:mvp-release-gates`, `pnpm check:launch-content-snapshot`, `pnpm check:public-beta-compliance`, `pnpm docs:check`, lint/dependency checks, and touched package typechecks on the release commit;
+  - consolidated truth packet: `pnpm check:mvp-closeout`, writing `.tmp/mvp-closeout/latest/mvp-closeout-report.json`;
+  - required release packet: `pnpm check:mvp-release-gates`, `pnpm check:mvp-closeout`, `pnpm check:launch-content-snapshot`, `pnpm check:public-beta-compliance`, `pnpm docs:check`, lint/dependency checks, and touched package typechecks on the release commit;
   - remaining work is labeled `ship_blocker` only when the release commit evidence packet is missing/failing, external approval is required but unrecorded, or release copy claims production-grade live headlines without `release_ready`; otherwise known admin/support/native/ops polish is `post_beta_follow_up`.
 - LUMA public-beta MVP readiness is now an explicit deterministic gate:
   - focused gate: `pnpm check:luma:mvp-production-readiness`;
@@ -103,13 +104,12 @@ Current policy state:
   - stable latest scout path: `/Users/bldt/Desktop/VHC/VHC/services/news-aggregator/.tmp/news-source-scout/latest/source-candidate-scout-report.json`
   - daemon starter-surface resolution is the authoritative keep/watch/remove enforcement path;
   - web/server surfaces can autoload the latest health artifact for diagnostics and optional browser-runtime bootstrap flows.
-- `main` currently carries a 29-source keep surface and the latest source-health runtime policy is green:
+- `main` currently carries a complete-window source-health keep surface and the latest source-health runtime policy is green only when the configured release evidence window passes:
   - latest artifact: `/Users/bldt/Desktop/VHC/VHC/services/news-aggregator/.tmp/news-source-admission/latest/source-health-report.json`
   - `readinessStatus: ready`
   - `releaseEvidence.status: pass`
-  - `enabledSourceCount: 29`
-  - `contributingSourceCount: 29`
-  - `corroboratingSourceCount: 29`
+  - `recentWindowRunCount` must meet `thresholds.releaseEvidenceWindowRunCount`
+  - `warn` is an adjudication state, not consolidated release-green evidence
 - UI / UX product work and periodic soak measurement are now explicitly separated:
   - UI lanes build against the current published feed contract;
   - soak lanes validate the production pipeline behind that contract on merged `main`;

--- a/docs/ops/public-beta-launch-readiness-closeout.md
+++ b/docs/ops/public-beta-launch-readiness-closeout.md
@@ -5,9 +5,9 @@
 > Last Reviewed: 2026-04-28
 > Depends On: docs/plans/VENN_NEWS_MVP_ROADMAP_2026-04-20.md, docs/ops/public-beta-compliance-minimums.md, docs/ops/BETA_SESSION_RUNSHEET.md
 
-Version: 0.3
+Version: 0.4
 Document path: `docs/ops/public-beta-launch-readiness-closeout.md`
-Audit baseline: current public-beta closeout baseline plus the LUMA public-beta MVP readiness slice.
+Audit baseline: current public-beta closeout baseline plus the LUMA public-beta MVP readiness slice and consolidated MVP closeout packet.
 Scope: Web PWA public beta launch-readiness evidence, deterministic gate inventory, and remaining-work classification.
 
 ## 1. Closeout Verdict
@@ -15,6 +15,8 @@ Scope: Web PWA public beta launch-readiness evidence, deterministic gate invento
 Engineering closeout status: Web PWA public beta candidate, constrained to the implemented beta scope.
 
 No repository feature gap is currently classified as a Web PWA public-beta ship blocker when the release owner produces a passing evidence packet on the release commit. The implemented beta scope includes the core news loop, accepted synthesis detail, point stance persistence, deterministic story threads, correction/moderation/report remediation paths, operator trust gate, public policy routes, public support issue intake, private escalation protocol, curated fallback launch content, and LUMA public-beta MVP readiness for the beta-local identity/signed-write layer.
+
+`pnpm check:mvp-closeout` is the consolidated release-truth reader for this scope. It reads the MVP release-gates packet, source-health packet, LUMA MVP readiness packet, Mesh readiness packet, and production app canary packet, then writes `.tmp/mvp-closeout/latest/mvp-closeout-report.json` with bounded allowed/forbidden claims. It does not override any upstream gate.
 
 The full-product five-user engagement lane supplements the deterministic report packet with a production-shaped local-stack run: five beta-local users open singleton and bundled stories, read accepted synthesis/frame tables, register point-level stances, confirm mesh aggregate readback, and hold threaded story discussions across reloads. This lane is release-like manual QA; it does not replace the named deterministic command/report gates below.
 
@@ -28,6 +30,7 @@ Run these commands on the final public-beta release commit and preserve their ou
 | --- | --- | --- | --- |
 | Launch closeout audit | `pnpm check:public-beta-launch-closeout` | This document plus the static checker in `tools/scripts/check-public-beta-launch-closeout.mjs` | `pass` |
 | MVP release gates | `pnpm check:mvp-release-gates` | `.tmp/mvp-release-gates/latest/mvp-release-gates-report.json` | `overallStatus: pass` |
+| MVP consolidated closeout | `pnpm check:mvp-closeout` | `.tmp/mvp-closeout/latest/mvp-closeout-report.json` | `status: pass`; bounded MVP claims only; Mesh/app/Silver claims remain forbidden unless separately proven |
 | Curated launch-content fallback | `pnpm check:launch-content-snapshot` | `.tmp/launch-content-snapshot/latest/launch-content-snapshot-report.json` | `overallStatus: pass` |
 | Public-beta compliance minimums | `pnpm check:public-beta-compliance` | `tools/scripts/check-public-beta-compliance.mjs` and `docs/ops/public-beta-compliance-minimums.md` | `pass` |
 | LUMA public-beta MVP readiness | `pnpm check:luma:mvp-production-readiness` | `.tmp/luma-mvp-production-readiness/latest/luma-mvp-production-readiness-report.json` | `status: pass` |
@@ -88,7 +91,7 @@ Every known remaining item is classified below. `ship_blocker` means public-beta
 
 | Item | Classification | Closeout decision |
 | --- | --- | --- |
-| `release_commit_gate_packet_missing_or_failing` | ship_blocker | A public-beta release commit must have passing `pnpm check:public-beta-launch-closeout`, `pnpm check:mvp-release-gates`, `pnpm check:launch-content-snapshot`, `pnpm check:public-beta-compliance`, `pnpm docs:check`, lint/dependency checks, and touched package typechecks. |
+| `release_commit_gate_packet_missing_or_failing` | ship_blocker | A public-beta release commit must have passing `pnpm check:public-beta-launch-closeout`, `pnpm check:mvp-release-gates`, `pnpm check:mvp-closeout`, `pnpm check:launch-content-snapshot`, `pnpm check:public-beta-compliance`, `pnpm docs:check`, lint/dependency checks, and touched package typechecks. |
 | `external_release_approval_not_recorded` | ship_blocker | This repo does not create legal/commercial approval. If the organization requires legal/operator approval before public distribution, that signoff must be recorded outside the code gates before public launch claims are made. |
 | `production_live_headline_claim_without_release_ready` | ship_blocker | Do not market live public headlines as production-grade unless `pnpm check:storycluster:production-readiness` resolves to `release_ready`. The Web PWA beta may still use the constrained beta and validated-snapshot scope. |
 | `full_product_engagement_claim_without_live_lane` | ship_blocker | Do not claim the full multi-user product loop was exercised against release-like service wiring unless `pnpm live:stack:up:analysis-stub` and `pnpm test:live:five-user-engagement` pass on the release candidate or the claim is removed. |
@@ -109,7 +112,10 @@ Every known remaining item is classified below. `ship_blocker` means public-beta
 Allowed public-beta claim:
 
 - "Web PWA public beta candidate with deterministic MVP gate coverage, curated fallback launch content, public policy/support surfaces, audited correction/moderation/report remediation paths, and trusted beta operator gates for current remediation writes."
+- "MVP public-beta release gates passed for the implemented MVP scope."
 - "LUMA public-beta is MVP-production-ready as a fail-closed beta-local identity and signed-write layer."
+- "Source health passed the complete release evidence window."
+- "Mesh is tracked separately and is currently `review_required` unless its own report says `release_ready`."
 
 Disallowed without additional evidence:
 

--- a/package.json
+++ b/package.json
@@ -44,6 +44,8 @@
     "report:storycluster:production-readiness": "pnpm --filter @vh/e2e report:live:daemon-feed:production-readiness",
     "check:storycluster:production-readiness": "pnpm check:storycluster:correctness && pnpm check:news-sources:health && VH_STORYCLUSTER_PRODUCTION_READINESS_ENFORCE=true pnpm report:storycluster:production-readiness",
     "check:mvp-release-gates": "node ./packages/e2e/src/mvp-release-gates.mjs",
+    "report:mvp-closeout": "node ./packages/e2e/src/mvp-closeout.mjs",
+    "check:mvp-closeout": "node ./packages/e2e/src/mvp-closeout.mjs --check",
     "check:launch-content-snapshot": "node ./packages/e2e/src/launch-content-snapshot.mjs",
     "check:public-beta-compliance": "node ./tools/scripts/check-public-beta-compliance.mjs",
     "check:public-beta-launch-closeout": "node ./tools/scripts/check-public-beta-launch-closeout.mjs",

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -44,6 +44,8 @@
     "report:offline-cluster-replay": "node ./src/live/daemon-feed-semantic-soak-offline-replay-report.mjs",
     "report:live:daemon-feed:production-readiness": "node ./src/live/storycluster-production-readiness.mjs",
     "check:mvp-release-gates": "node ./src/mvp-release-gates.mjs",
+    "report:mvp-closeout": "node ./src/mvp-closeout.mjs",
+    "check:mvp-closeout": "node ./src/mvp-closeout.mjs --check",
     "check:launch-content-snapshot": "node ./src/launch-content-snapshot.mjs",
     "codegen": "playwright codegen",
     "typecheck": "tsc --noEmit"

--- a/packages/e2e/src/mvp-closeout.mjs
+++ b/packages/e2e/src/mvp-closeout.mjs
@@ -1,0 +1,470 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export const MVP_CLOSEOUT_SCHEMA_VERSION = 'mvp-closeout-report-v1';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '../../..');
+const latestDir = path.join(repoRoot, '.tmp/mvp-closeout/latest');
+const latestReportPath = path.join(latestDir, 'mvp-closeout-report.json');
+
+const REQUIRED_REPORTS = Object.freeze({
+  mvpReleaseGates: {
+    id: 'mvp_release_gates',
+    command: 'pnpm check:mvp-release-gates',
+    path: '.tmp/mvp-release-gates/latest/mvp-release-gates-report.json',
+  },
+  sourceHealth: {
+    id: 'source_health',
+    command: 'pnpm check:news-sources:health',
+    path: 'services/news-aggregator/.tmp/news-source-admission/latest/source-health-report.json',
+  },
+  lumaMvp: {
+    id: 'luma_mvp',
+    command: 'pnpm check:luma:mvp-production-readiness',
+    path: '.tmp/luma-mvp-production-readiness/latest/luma-mvp-production-readiness-report.json',
+  },
+});
+
+const OPTIONAL_BOUNDARY_REPORTS = Object.freeze({
+  mesh: {
+    id: 'mesh',
+    command: 'pnpm check:mesh:production-readiness',
+    path: '.tmp/mesh-production-readiness/latest/mesh-production-readiness-report.json',
+  },
+  productionAppCanary: {
+    id: 'production_app_canary',
+    command: 'pnpm check:production-app-canary -- --mesh-report .tmp/mesh-production-readiness/latest/mesh-production-readiness-report.json',
+    path: '.tmp/production-app-canary/latest/production-app-canary-report.json',
+  },
+});
+
+export const BASE_ALLOWED_CLAIMS = Object.freeze([
+  'MVP public-beta release gates passed for the implemented MVP scope.',
+  'LUMA public-beta is MVP-production-ready as a fail-closed beta-local identity and signed-write layer.',
+  'Source health passed the complete release evidence window.',
+  'Mesh is tracked separately and is currently review_required unless its own report says release_ready.',
+]);
+
+export const BASE_FORBIDDEN_CLAIMS = Object.freeze([
+  'Mesh is release_ready unless the Mesh packet itself reports release_ready with no release-readiness blockers.',
+  'Production app canary passed unless the production app canary report status is pass.',
+  'Downstream app surfaces were observed end-to-end.',
+  'The full app is production ready.',
+  'The app is test-group ready.',
+  'LUMA Silver/verified-human/one-human-one-vote/Sybil resistance is ready.',
+  'Public WSS proof or Mesh sample floors are satisfied unless the Mesh packet says so.',
+]);
+
+const MVP_READY_NEXT_ACTIONS = Object.freeze([
+  'Treat the MVP public-beta release packet as green only for the implemented MVP scope.',
+  'Keep Mesh production readiness tracked through public WSS proof, canonical soak, and required sample-floor evidence.',
+  'Keep production app canary downstream observation blocked until Mesh prerequisites pass.',
+  'Do not claim full-app production readiness, test-group readiness, LUMA Silver, verified-human identity, one-human-one-vote, or Sybil resistance from this packet.',
+]);
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function repoPath(relativePath) {
+  return path.join(repoRoot, relativePath);
+}
+
+function relativePath(filePath) {
+  if (!filePath) return null;
+  return path.relative(repoRoot, filePath).split(path.sep).join('/');
+}
+
+function runGit(args) {
+  const result = spawnSync('git', args, {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  });
+  return result.status === 0 ? result.stdout.trim() : '';
+}
+
+function readJsonIfExists(filePath) {
+  if (!fs.existsSync(filePath)) return null;
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function asArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function countSourcesByDecision(sourceHealth, decision) {
+  if (Array.isArray(sourceHealth?.sources)) {
+    return sourceHealth.sources.filter((source) => source?.decision === decision).length;
+  }
+  const key = `${decision}SourceCount`;
+  return Number.isFinite(sourceHealth?.observability?.[key]) ? sourceHealth.observability[key] : 0;
+}
+
+function blockerIds(meshReport) {
+  return asArray(meshReport?.release_readiness_blockers).map((blocker) => String(blocker?.id || ''));
+}
+
+function hasSampleFloorBlocker(meshReport) {
+  const ids = blockerIds(meshReport);
+  if (ids.includes('required-write-class-sample-floors')) return true;
+  const blockers = asArray(meshReport?.release_readiness_blockers);
+  return blockers.some((blocker) => /insufficient_samples|sample[-_\s]?floors?/i.test(`${blocker?.id || ''} ${blocker?.reason || ''}`));
+}
+
+function hasPublicWssBlocker(meshReport) {
+  return blockerIds(meshReport).includes('public-wss-deployment-proof');
+}
+
+function gateStatus(mvpReport, id) {
+  return asArray(mvpReport?.gates).find((gate) => gate?.id === id)?.status || null;
+}
+
+function reportPathFor(evidence, key) {
+  return evidence?.paths?.[key]?.path || evidence?.paths?.[key] || null;
+}
+
+function normalizeReleaseEvidence(sourceHealth) {
+  const releaseEvidence = sourceHealth?.releaseEvidence || {};
+  return {
+    status: releaseEvidence.status || null,
+    recentWindowRunCount: releaseEvidence.recentWindowRunCount ?? 0,
+    recentReadyRunCount: releaseEvidence.recentReadyRunCount ?? 0,
+    recentReviewRunCount: releaseEvidence.recentReviewRunCount ?? 0,
+    recentBlockedRunCount: releaseEvidence.recentBlockedRunCount ?? 0,
+    requiredWindowRunCount: sourceHealth?.thresholds?.releaseEvidenceWindowRunCount ?? 5,
+    reasons: asArray(releaseEvidence.reasons),
+  };
+}
+
+function summarizeMvpReleaseGates(mvpReport, reportPath) {
+  const gates = asArray(mvpReport?.gates);
+  const failingGates = gates
+    .filter((gate) => gate?.status !== 'pass')
+    .map((gate) => ({
+      id: gate.id || null,
+      status: gate.status || null,
+      summary: gate.summary || null,
+    }));
+  return {
+    status: mvpReport?.overallStatus || null,
+    report_path: reportPath,
+    gate_count: gates.length,
+    pass_count: gates.filter((gate) => gate?.status === 'pass').length,
+    failing_gates: failingGates,
+    public_beta_launch_closeout_status: gateStatus(mvpReport, 'public_beta_launch_closeout'),
+    source_health_gate_status: gateStatus(mvpReport, 'source_health'),
+  };
+}
+
+function summarizeSourceHealth(sourceHealth, reportPath) {
+  const releaseEvidence = normalizeReleaseEvidence(sourceHealth);
+  return {
+    status: sourceHealth?.readinessStatus || null,
+    report_path: reportPath,
+    releaseEvidence: {
+      status: releaseEvidence.status,
+      recentWindowRunCount: releaseEvidence.recentWindowRunCount,
+      recentReadyRunCount: releaseEvidence.recentReadyRunCount,
+      recentReviewRunCount: releaseEvidence.recentReviewRunCount,
+      recentBlockedRunCount: releaseEvidence.recentBlockedRunCount,
+      requiredWindowRunCount: releaseEvidence.requiredWindowRunCount,
+      reasons: releaseEvidence.reasons,
+    },
+    keep_count: countSourcesByDecision(sourceHealth, 'keep'),
+    watch_count: countSourcesByDecision(sourceHealth, 'watch'),
+    remove_count: countSourcesByDecision(sourceHealth, 'remove'),
+    reasonCounts: sourceHealth?.observability?.reasonCounts || {},
+  };
+}
+
+function summarizeLumaMvp(lumaReport, reportPath) {
+  return {
+    status: lumaReport?.status || null,
+    report_path: reportPath,
+    profile: lumaReport?.profile || null,
+    blockers: asArray(lumaReport?.blockers),
+    allowed_claims: asArray(lumaReport?.release_claims?.allowed),
+    forbidden_claims: asArray(lumaReport?.release_claims?.forbidden),
+  };
+}
+
+function summarizeMesh(meshReport, reportPath) {
+  return {
+    status: meshReport?.status || null,
+    report_path: reportPath,
+    release_readiness_blockers: asArray(meshReport?.release_readiness_blockers),
+    schema_epoch: meshReport?.schema_epoch || null,
+    luma_gated_write_coverage: {
+      status: meshReport?.luma_gated_write_coverage?.status || null,
+      source_commit: meshReport?.luma_gated_write_coverage?.source_commit || null,
+      source_dirty: meshReport?.luma_gated_write_coverage?.source_dirty ?? null,
+      luma_profile: meshReport?.luma_gated_write_coverage?.luma_profile || null,
+    },
+    sample_floor_blocker_present: hasSampleFloorBlocker(meshReport),
+    public_wss_blocker_present: hasPublicWssBlocker(meshReport),
+  };
+}
+
+function summarizeProductionAppCanary(canaryReport, reportPath, meshStatus) {
+  const expectedBlockedReason = meshStatus && meshStatus !== 'release_ready' ? 'mesh_not_release_ready' : null;
+  return {
+    status: canaryReport?.status || null,
+    report_path: reportPath,
+    reason: canaryReport?.reason || null,
+    expected_blocked_reason: expectedBlockedReason,
+  };
+}
+
+function lowerClaims(claims) {
+  return asArray(claims).map((claim) => String(claim).toLowerCase());
+}
+
+function claimSetImpliesMeshReleaseReady(claims) {
+  return lowerClaims(claims).some((claim) => /\bmesh\b/.test(claim) && /\brelease_ready\b|\brelease ready\b/.test(claim) && !/\bunless\b|\bnot\b|\breview_required\b|\bseparate\b/.test(claim));
+}
+
+function claimSetImpliesProductionCanaryPass(claims) {
+  return lowerClaims(claims).some((claim) => /\bproduction app canary\b/.test(claim) && /\bpassed\b|\bpass\b/.test(claim) && !/\bunless\b|\bnot\b|\bblocked\b|\bseparate\b/.test(claim));
+}
+
+function claimSetImpliesPublicWssSatisfied(claims) {
+  return lowerClaims(claims).some((claim) => /\bpublic wss\b/.test(claim) && /\bsatisfied\b|\bpassed\b|\bproven\b/.test(claim) && !/\bunless\b|\bnot\b|\bseparate\b|\bblocker\b/.test(claim));
+}
+
+function claimSetImpliesSampleFloorsSatisfied(claims) {
+  return lowerClaims(claims).some((claim) => /\bsample[-\s]?floor|\bsample floors\b/.test(claim) && /\bsatisfied\b|\bpassed\b|\bproven\b/.test(claim) && !/\bunless\b|\bnot\b|\bseparate\b|\bblocker\b/.test(claim));
+}
+
+export function validateReleaseClaims({
+  allowedClaims = BASE_ALLOWED_CLAIMS,
+  meshStatus,
+  meshSampleFloorBlockerPresent,
+  meshPublicWssBlockerPresent,
+  productionAppCanaryStatus,
+} = {}) {
+  const failures = [];
+  if (meshStatus !== 'release_ready' && claimSetImpliesMeshReleaseReady(allowedClaims)) {
+    failures.push('allowed claims imply Mesh release_ready while Mesh is not release_ready');
+  }
+  if (productionAppCanaryStatus !== 'pass' && claimSetImpliesProductionCanaryPass(allowedClaims)) {
+    failures.push('allowed claims imply production app canary passed while canary is not pass');
+  }
+  if (meshPublicWssBlockerPresent && claimSetImpliesPublicWssSatisfied(allowedClaims)) {
+    failures.push('allowed claims imply public WSS proof is satisfied while Mesh still has the public WSS blocker');
+  }
+  if (meshSampleFloorBlockerPresent && claimSetImpliesSampleFloorsSatisfied(allowedClaims)) {
+    failures.push('allowed claims imply Mesh sample floors are satisfied while Mesh still has sample-floor blockers');
+  }
+  return failures;
+}
+
+function evidenceCommit(evidence) {
+  return evidence?.repo?.commit || null;
+}
+
+function addCommitFailure(failures, label, evidence, repo) {
+  const observed = evidenceCommit(evidence);
+  if (observed && observed !== repo.commit) {
+    failures.push(`${label} report commit ${observed} does not match current commit ${repo.commit}`);
+  }
+}
+
+function missingReportFailure(label, definition) {
+  return `missing ${label} report at ${definition.path}; run ${definition.command}`;
+}
+
+function buildReleaseClaims(meshSummary) {
+  return {
+    allowed: BASE_ALLOWED_CLAIMS,
+    forbidden: BASE_FORBIDDEN_CLAIMS,
+    mesh_current_status: meshSummary?.status || null,
+  };
+}
+
+export function buildCloseoutReportFromEvidence({
+  repo,
+  evidence,
+  reportPaths,
+  generatedAt = nowIso(),
+  allowedClaims = BASE_ALLOWED_CLAIMS,
+  forbiddenClaims = BASE_FORBIDDEN_CLAIMS,
+} = {}) {
+  const failures = [];
+  const missingReports = [];
+  for (const [key, definition] of Object.entries(REQUIRED_REPORTS)) {
+    if (!evidence?.[key]) {
+      missingReports.push({ id: definition.id, path: definition.path, command: definition.command });
+      failures.push(missingReportFailure(definition.id, definition));
+    }
+  }
+  for (const [key, definition] of Object.entries(OPTIONAL_BOUNDARY_REPORTS)) {
+    if (!evidence?.[key]) {
+      missingReports.push({ id: definition.id, path: definition.path, command: definition.command });
+      failures.push(missingReportFailure(definition.id, definition));
+    }
+  }
+
+  const mvpReleaseGates = summarizeMvpReleaseGates(evidence?.mvpReleaseGates, reportPaths?.mvpReleaseGates || REQUIRED_REPORTS.mvpReleaseGates.path);
+  const sourceHealth = summarizeSourceHealth(evidence?.sourceHealth, reportPaths?.sourceHealth || REQUIRED_REPORTS.sourceHealth.path);
+  const lumaMvp = summarizeLumaMvp(evidence?.lumaMvp, reportPaths?.lumaMvp || REQUIRED_REPORTS.lumaMvp.path);
+  const mesh = summarizeMesh(evidence?.mesh, reportPaths?.mesh || OPTIONAL_BOUNDARY_REPORTS.mesh.path);
+  const productionAppCanary = summarizeProductionAppCanary(
+    evidence?.productionAppCanary,
+    reportPaths?.productionAppCanary || OPTIONAL_BOUNDARY_REPORTS.productionAppCanary.path,
+    mesh.status,
+  );
+  const releaseClaims = {
+    ...buildReleaseClaims(mesh),
+    allowed: allowedClaims,
+    forbidden: forbiddenClaims,
+  };
+
+  if (repo?.dirty !== false) {
+    failures.push('repo is dirty');
+  }
+  if (mvpReleaseGates.status !== 'pass') {
+    failures.push(`mvp release gates status is ${mvpReleaseGates.status || 'missing'}`);
+  }
+  if (mvpReleaseGates.source_health_gate_status !== 'pass') {
+    failures.push(`mvp release gates source_health status is ${mvpReleaseGates.source_health_gate_status || 'missing'}`);
+  }
+  if (mvpReleaseGates.public_beta_launch_closeout_status !== 'pass') {
+    failures.push(`mvp release gates public_beta_launch_closeout status is ${mvpReleaseGates.public_beta_launch_closeout_status || 'missing'}`);
+  }
+  if (sourceHealth.releaseEvidence.status !== 'pass') {
+    failures.push(`source health releaseEvidence.status is ${sourceHealth.releaseEvidence.status || 'missing'}`);
+  }
+  if (sourceHealth.releaseEvidence.recentWindowRunCount < sourceHealth.releaseEvidence.requiredWindowRunCount) {
+    failures.push(
+      `source health release window ${sourceHealth.releaseEvidence.recentWindowRunCount} is below required ${sourceHealth.releaseEvidence.requiredWindowRunCount}`,
+    );
+  }
+  if (lumaMvp.status !== 'pass') {
+    failures.push(`LUMA MVP readiness status is ${lumaMvp.status || 'missing'}`);
+  }
+  if (mesh.status === 'release_ready' && mesh.release_readiness_blockers.length > 0) {
+    failures.push('Mesh report claims release_ready while release_readiness_blockers are present');
+  }
+  if (mesh.status === 'release_ready' && (mesh.sample_floor_blocker_present || mesh.public_wss_blocker_present)) {
+    failures.push('Mesh report claims release_ready while public WSS or sample-floor blockers are present');
+  }
+  if (productionAppCanary.expected_blocked_reason) {
+    if (productionAppCanary.status !== 'blocked' || productionAppCanary.reason !== productionAppCanary.expected_blocked_reason) {
+      failures.push(
+        `production app canary expected ${productionAppCanary.expected_blocked_reason} block, observed status=${productionAppCanary.status || 'missing'} reason=${productionAppCanary.reason || 'missing'}`,
+      );
+    }
+  }
+
+  addCommitFailure(failures, 'mvp release gates', evidence?.mvpReleaseGates, repo);
+  addCommitFailure(failures, 'LUMA MVP', evidence?.lumaMvp, repo);
+  addCommitFailure(failures, 'Mesh', evidence?.mesh, repo);
+  addCommitFailure(failures, 'production app canary', evidence?.productionAppCanary, repo);
+
+  failures.push(
+    ...validateReleaseClaims({
+      allowedClaims,
+      meshStatus: mesh.status,
+      meshSampleFloorBlockerPresent: mesh.sample_floor_blocker_present,
+      meshPublicWssBlockerPresent: mesh.public_wss_blocker_present,
+      productionAppCanaryStatus: productionAppCanary.status,
+    }),
+  );
+
+  const status = failures.length === 0 ? 'pass' : 'blocked';
+  const nextActions =
+    status === 'pass'
+      ? MVP_READY_NEXT_ACTIONS
+      : [
+          ...missingReports.map((report) => `Generate ${report.id} evidence with: ${report.command}`),
+          ...failures.filter((failure) => !failure.startsWith('missing ')).map((failure) => `Resolve closeout blocker: ${failure}`),
+        ];
+
+  return {
+    schema_version: MVP_CLOSEOUT_SCHEMA_VERSION,
+    generated_at: generatedAt,
+    repo,
+    status,
+    failures,
+    missing_reports: missingReports,
+    mvp_release_gates: mvpReleaseGates,
+    source_health: sourceHealth,
+    luma_mvp: lumaMvp,
+    mesh,
+    production_app_canary: productionAppCanary,
+    release_claims: releaseClaims,
+    next_actions: nextActions,
+  };
+}
+
+function readEvidenceFromDisk() {
+  const paths = {
+    mvpReleaseGates: REQUIRED_REPORTS.mvpReleaseGates.path,
+    sourceHealth: REQUIRED_REPORTS.sourceHealth.path,
+    lumaMvp: REQUIRED_REPORTS.lumaMvp.path,
+    mesh: OPTIONAL_BOUNDARY_REPORTS.mesh.path,
+    productionAppCanary: OPTIONAL_BOUNDARY_REPORTS.productionAppCanary.path,
+  };
+  return {
+    paths,
+    evidence: {
+      mvpReleaseGates: readJsonIfExists(repoPath(paths.mvpReleaseGates)),
+      sourceHealth: readJsonIfExists(repoPath(paths.sourceHealth)),
+      lumaMvp: readJsonIfExists(repoPath(paths.lumaMvp)),
+      mesh: readJsonIfExists(repoPath(paths.mesh)),
+      productionAppCanary: readJsonIfExists(repoPath(paths.productionAppCanary)),
+    },
+  };
+}
+
+export function currentRepoState() {
+  return {
+    branch: runGit(['rev-parse', '--abbrev-ref', 'HEAD']) || null,
+    commit: runGit(['rev-parse', 'HEAD']) || null,
+    dirty: runGit(['status', '--porcelain']).length > 0,
+  };
+}
+
+export async function runMvpCloseout({ check = false } = {}) {
+  const { paths, evidence } = readEvidenceFromDisk();
+  const report = buildCloseoutReportFromEvidence({
+    repo: currentRepoState(),
+    evidence,
+    reportPaths: paths,
+  });
+  writeJson(latestReportPath, report);
+  console.info(`[mvp-closeout] wrote ${relativePath(latestReportPath)}`);
+  console.info(`[mvp-closeout] status=${report.status}`);
+  if (check && report.status !== 'pass') {
+    for (const failure of report.failures) {
+      console.error(`[mvp-closeout] blocker: ${failure}`);
+    }
+    process.exitCode = 1;
+  }
+  return report;
+}
+
+function parseArgs(argv) {
+  return {
+    check: argv.includes('--check'),
+  };
+}
+
+if (process.argv[1] === __filename) {
+  const options = parseArgs(process.argv.slice(2));
+  runMvpCloseout(options).catch((error) => {
+    console.error('[mvp-closeout] fatal:', error instanceof Error ? error.stack ?? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/packages/e2e/src/mvp-closeout.vitest.mjs
+++ b/packages/e2e/src/mvp-closeout.vitest.mjs
@@ -1,0 +1,287 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  BASE_ALLOWED_CLAIMS,
+  BASE_FORBIDDEN_CLAIMS,
+  MVP_CLOSEOUT_SCHEMA_VERSION,
+  buildCloseoutReportFromEvidence,
+  validateReleaseClaims,
+} from './mvp-closeout.mjs';
+
+const COMMIT = 'abc123';
+
+function repo(overrides = {}) {
+  return {
+    branch: 'coord/mvp-consolidated-closeout-v1',
+    commit: COMMIT,
+    dirty: false,
+    ...overrides,
+  };
+}
+
+function mvpReleaseGates(overrides = {}) {
+  return {
+    schemaVersion: 'mvp-release-gates-report-v1',
+    overallStatus: 'pass',
+    repo: { commit: COMMIT },
+    gates: [
+      { id: 'source_health', status: 'pass' },
+      { id: 'public_beta_launch_closeout', status: 'pass' },
+      { id: 'luma_mvp_production_readiness', status: 'pass' },
+    ],
+    ...overrides,
+  };
+}
+
+function sourceHealth(overrides = {}) {
+  return {
+    schemaVersion: 'news-source-health-report-v1',
+    readinessStatus: 'ready',
+    releaseEvidence: {
+      status: 'pass',
+      reasons: [],
+      recentWindowRunCount: 5,
+      recentReadyRunCount: 5,
+      recentReviewRunCount: 0,
+      recentBlockedRunCount: 0,
+    },
+    thresholds: {
+      releaseEvidenceWindowRunCount: 5,
+    },
+    observability: {
+      keepSourceCount: 28,
+      watchSourceCount: 0,
+      removeSourceCount: 0,
+      reasonCounts: {},
+    },
+    sources: Array.from({ length: 28 }, (_, index) => ({ id: `source-${index}`, decision: 'keep' })),
+    ...overrides,
+  };
+}
+
+function lumaMvp(overrides = {}) {
+  return {
+    schema_version: 'luma-mvp-production-readiness-v1',
+    status: 'pass',
+    profile: 'public-beta',
+    repo: { commit: COMMIT },
+    blockers: [],
+    release_claims: {
+      allowed: [
+        'LUMA public-beta is MVP-production-ready as a fail-closed beta-local identity and signed-write layer.',
+      ],
+      forbidden: [
+        'Silver attestation readiness',
+        'verified-human identity',
+        'one-human-one-vote',
+        'Sybil resistance',
+      ],
+    },
+    ...overrides,
+  };
+}
+
+function meshReviewRequired(overrides = {}) {
+  return {
+    schema_version: 'mesh-production-readiness-v1',
+    status: 'review_required',
+    repo: { commit: COMMIT, dirty: false },
+    schema_epoch: 'post_luma_m0b',
+    release_readiness_blockers: [
+      { id: 'public-wss-deployment-proof', reason: 'public WSS infrastructure evidence is not passing' },
+      { id: 'required-write-class-sample-floors', reason: 'required rows are insufficient_samples' },
+    ],
+    luma_gated_write_coverage: {
+      status: 'pass',
+      source_commit: COMMIT,
+      source_dirty: false,
+      luma_profile: 'e2e',
+    },
+    ...overrides,
+  };
+}
+
+function productionAppCanary(overrides = {}) {
+  return {
+    schema_version: 'production-app-canary-report-v1',
+    status: 'blocked',
+    reason: 'mesh_not_release_ready',
+    repo: { commit: COMMIT, dirty: false },
+    ...overrides,
+  };
+}
+
+function evidence(overrides = {}) {
+  return {
+    mvpReleaseGates: mvpReleaseGates(),
+    sourceHealth: sourceHealth(),
+    lumaMvp: lumaMvp(),
+    mesh: meshReviewRequired(),
+    productionAppCanary: productionAppCanary(),
+    ...overrides,
+  };
+}
+
+function build(overrides = {}) {
+  return buildCloseoutReportFromEvidence({
+    repo: repo(),
+    evidence: evidence(overrides.evidence || {}),
+    allowedClaims: overrides.allowedClaims || BASE_ALLOWED_CLAIMS,
+    forbiddenClaims: BASE_FORBIDDEN_CLAIMS,
+    generatedAt: '2026-05-12T00:00:00.000Z',
+  });
+}
+
+describe('mvp-closeout report builder', () => {
+  it('publishes the expected schema', () => {
+    expect(MVP_CLOSEOUT_SCHEMA_VERSION).toBe('mvp-closeout-report-v1');
+  });
+
+  it('passes when MVP gates, source health, LUMA, Mesh boundary, and canary boundary are consistent', () => {
+    const report = build();
+
+    expect(report.status).toBe('pass');
+    expect(report.mvp_release_gates.status).toBe('pass');
+    expect(report.source_health.releaseEvidence.status).toBe('pass');
+    expect(report.source_health.releaseEvidence.recentWindowRunCount).toBe(5);
+    expect(report.luma_mvp.status).toBe('pass');
+    expect(report.mesh.status).toBe('review_required');
+    expect(report.mesh.sample_floor_blocker_present).toBe(true);
+    expect(report.mesh.public_wss_blocker_present).toBe(true);
+    expect(report.production_app_canary.status).toBe('blocked');
+    expect(report.production_app_canary.reason).toBe('mesh_not_release_ready');
+    expect(report.release_claims.allowed).toContain('MVP public-beta release gates passed for the implemented MVP scope.');
+    expect(report.release_claims.forbidden).toContain('The full app is production ready.');
+  });
+
+  it('fails when source health is warn', () => {
+    const report = build({
+      evidence: {
+        sourceHealth: sourceHealth({
+          readinessStatus: 'review',
+          releaseEvidence: {
+            status: 'warn',
+            reasons: ['latest_run_not_ready'],
+            recentWindowRunCount: 5,
+            recentReadyRunCount: 4,
+            recentReviewRunCount: 1,
+            recentBlockedRunCount: 0,
+          },
+        }),
+      },
+    });
+
+    expect(report.status).toBe('blocked');
+    expect(report.failures).toContain('source health releaseEvidence.status is warn');
+  });
+
+  it('fails when the source-health release window is incomplete', () => {
+    const report = build({
+      evidence: {
+        sourceHealth: sourceHealth({
+          releaseEvidence: {
+            status: 'pass',
+            reasons: [],
+            recentWindowRunCount: 4,
+            recentReadyRunCount: 4,
+            recentReviewRunCount: 0,
+            recentBlockedRunCount: 0,
+          },
+        }),
+      },
+    });
+
+    expect(report.status).toBe('blocked');
+    expect(report.failures).toContain('source health release window 4 is below required 5');
+  });
+
+  it('fails when LUMA MVP readiness is blocked', () => {
+    const report = build({
+      evidence: {
+        lumaMvp: lumaMvp({
+          status: 'blocked',
+          blockers: [{ id: 'mesh_luma_coverage', reason: 'missing report' }],
+        }),
+      },
+    });
+
+    expect(report.status).toBe('blocked');
+    expect(report.failures).toContain('LUMA MVP readiness status is blocked');
+  });
+
+  it('fails when MVP release gates fail', () => {
+    const report = build({
+      evidence: {
+        mvpReleaseGates: mvpReleaseGates({
+          overallStatus: 'fail',
+          gates: [
+            { id: 'source_health', status: 'fail' },
+            { id: 'public_beta_launch_closeout', status: 'pass' },
+          ],
+        }),
+      },
+    });
+
+    expect(report.status).toBe('blocked');
+    expect(report.failures).toContain('mvp release gates status is fail');
+    expect(report.failures).toContain('mvp release gates source_health status is fail');
+  });
+
+  it('fails when the repo is dirty', () => {
+    const report = buildCloseoutReportFromEvidence({
+      repo: repo({ dirty: true }),
+      evidence: evidence(),
+      allowedClaims: BASE_ALLOWED_CLAIMS,
+      forbiddenClaims: BASE_FORBIDDEN_CLAIMS,
+      generatedAt: '2026-05-12T00:00:00.000Z',
+    });
+
+    expect(report.status).toBe('blocked');
+    expect(report.failures).toContain('repo is dirty');
+  });
+
+  it('fails if allowed claims imply Mesh release_ready while Mesh is review_required', () => {
+    const report = build({
+      allowedClaims: [
+        'MVP public-beta release gates passed for the implemented MVP scope.',
+        'Mesh is release_ready.',
+      ],
+    });
+
+    expect(report.status).toBe('blocked');
+    expect(report.failures).toContain('allowed claims imply Mesh release_ready while Mesh is not release_ready');
+  });
+
+  it('fails if allowed claims imply production app canary pass while canary is blocked', () => {
+    const report = build({
+      allowedClaims: [
+        'MVP public-beta release gates passed for the implemented MVP scope.',
+        'Production app canary passed.',
+      ],
+    });
+
+    expect(report.status).toBe('blocked');
+    expect(report.failures).toContain('allowed claims imply production app canary passed while canary is not pass');
+  });
+
+  it('allows bounded MVP public-beta claims while preserving forbidden Mesh/app/Silver claims', () => {
+    const failures = validateReleaseClaims({
+      allowedClaims: BASE_ALLOWED_CLAIMS,
+      meshStatus: 'review_required',
+      meshSampleFloorBlockerPresent: true,
+      meshPublicWssBlockerPresent: true,
+      productionAppCanaryStatus: 'blocked',
+    });
+    const report = build();
+
+    expect(failures).toEqual([]);
+    expect(report.release_claims.allowed).toContain('Source health passed the complete release evidence window.');
+    expect(report.release_claims.forbidden).toEqual(
+      expect.arrayContaining([
+        'Mesh is release_ready unless the Mesh packet itself reports release_ready with no release-readiness blockers.',
+        'Production app canary passed unless the production app canary report status is pass.',
+        'LUMA Silver/verified-human/one-human-one-vote/Sybil resistance is ready.',
+      ]),
+    );
+  });
+});

--- a/services/news-aggregator/src/sourceAdmissionReport.test.ts
+++ b/services/news-aggregator/src/sourceAdmissionReport.test.ts
@@ -405,6 +405,45 @@ describe('sourceAdmissionReport', () => {
     });
   });
 
+  it('aborts hanging admission response bodies with a bounded timeout', async () => {
+    const source = STARTER_FEED_SOURCES[0];
+    const fetchFn = vi.fn(async (_input: string | URL, init?: RequestInit) => {
+      const response = makeResponse(200, '');
+      vi.spyOn(response, 'text').mockImplementation(() =>
+        new Promise<string>((_resolve, reject) => {
+          init?.signal?.addEventListener(
+            'abort',
+            () => {
+              reject(Object.assign(new Error('body timed out'), { name: 'AbortError' }));
+            },
+            { once: true },
+          );
+        }),
+      );
+      return response;
+    }) as typeof fetch;
+
+    const reportPromise = auditFeedSourceAdmission(source, {
+      fetchFn,
+      fetchTimeoutMs: 5,
+      feedReadAttemptCount: 1,
+      feedReadRetryDelayMs: 0,
+      feedFetchFallback: () => null,
+      sampleSize: 1,
+      minimumSuccessCount: 1,
+      minimumSuccessRate: 1,
+    });
+
+    await expect(reportPromise).resolves.toMatchObject({
+      status: 'inconclusive',
+      reasons: ['feed_links_unavailable', 'feed_fetch_timeout'],
+      feedRead: {
+        ok: false,
+        errorCode: 'feed_fetch_timeout',
+      },
+    });
+  });
+
   it('admits a source when readable samples clear the threshold', async () => {
     const source = STARTER_FEED_SOURCES[0];
     const fetchFn = vi.fn(async (input: string | URL) => {

--- a/services/news-aggregator/src/sourceAdmissionReport.ts
+++ b/services/news-aggregator/src/sourceAdmissionReport.ts
@@ -418,14 +418,53 @@ function wrapFetchWithTimeout(
     const signal = init?.signal
       ? AbortSignal.any([init.signal, timeoutController.signal])
       : timeoutController.signal;
+    let timerCleared = false;
+    const clearTimer = () => {
+      if (timerCleared) {
+        return;
+      }
+      timerCleared = true;
+      clearTimeout(timer);
+    };
 
     try {
-      return await fetchFn(input, {
+      const response = await fetchFn(input, {
         ...init,
         signal,
       });
+      const bodyMethods = new Set<PropertyKey>([
+        'arrayBuffer',
+        'blob',
+        'bytes',
+        'formData',
+        'json',
+        'text',
+      ]);
+      return new Proxy(response, {
+        get(target, property) {
+          const value = Reflect.get(target, property, target);
+          if (typeof value !== 'function') {
+            return value;
+          }
+          if (!bodyMethods.has(property)) {
+            return value.bind(target);
+          }
+          return async (...args: unknown[]) => {
+            try {
+              return await value.apply(target, args);
+            } finally {
+              clearTimer();
+            }
+          };
+        },
+      });
+    } catch (error) {
+      clearTimer();
+      throw error;
     } finally {
-      clearTimeout(timer);
+      if (timeoutController.signal.aborted) {
+        clearTimer();
+      }
     }
   };
 }

--- a/tools/scripts/check-public-beta-launch-closeout.mjs
+++ b/tools/scripts/check-public-beta-launch-closeout.mjs
@@ -17,6 +17,7 @@ const files = {
 
 const requiredScripts = {
   'check:mvp-release-gates': 'node ./packages/e2e/src/mvp-release-gates.mjs',
+  'check:mvp-closeout': 'node ./packages/e2e/src/mvp-closeout.mjs --check',
   'check:launch-content-snapshot': 'node ./packages/e2e/src/launch-content-snapshot.mjs',
   'check:public-beta-compliance': 'node ./tools/scripts/check-public-beta-compliance.mjs',
   'check:public-beta-launch-closeout': 'node ./tools/scripts/check-public-beta-launch-closeout.mjs',
@@ -56,10 +57,12 @@ const requiredLaunchSnapshotCoverage = [
 const requiredEvidenceNeedles = [
   'pnpm check:public-beta-launch-closeout',
   'pnpm check:mvp-release-gates',
+  'pnpm check:mvp-closeout',
   'pnpm check:launch-content-snapshot',
   'pnpm check:public-beta-compliance',
   'pnpm docs:check',
   '.tmp/mvp-release-gates/latest/mvp-release-gates-report.json',
+  '.tmp/mvp-closeout/latest/mvp-closeout-report.json',
   '.tmp/launch-content-snapshot/latest/launch-content-snapshot-report.json',
   'docs/ops/public-beta-launch-readiness-closeout.md',
   'ship_blocker',


### PR DESCRIPTION
## Summary

Adds `pnpm report:mvp-closeout` and `pnpm check:mvp-closeout`, writing `.tmp/mvp-closeout/latest/mvp-closeout-report.json` with schema `mvp-closeout-report-v1`.

The closeout packet is a read-only release-truth aggregator. It reads the latest MVP release-gates, source-health, LUMA MVP, Mesh readiness, and production app canary reports; verifies same-commit/clean-repo consistency where the upstream reports expose commit metadata; and emits bounded allowed/forbidden claims without overriding any upstream gate.

This also fixes a source-health determinism issue observed during evidence generation: a live feed could return headers and then hang during body read, leaving `pnpm check:news-sources:health` stuck after collecting only `2/5` ready release-window runs. The admission fetch timeout now covers response body consumption as well as the initial fetch. No source-health thresholds or registry entries were relaxed.

## Base / Head

- Base commit: `5e09e12f31c9fa9f0bbe43e4d88ee37fee9aa59a`
- Head commit: `b1b61209d9a02d6fff93829194fbef97863c750f`
- Branch: `coord/mvp-consolidated-closeout-v1`

## Generated Closeout

- Report path: `.tmp/mvp-closeout/latest/mvp-closeout-report.json`
- Closeout status: `pass`
- Repo in report: branch `coord/mvp-consolidated-closeout-v1`, commit `b1b61209d9a02d6fff93829194fbef97863c750f`, `dirty: false`

## Evidence Summary

- MVP release gates: `overallStatus: pass`, `14/14` gates passed, failing gates `[]`
- Source health: `readinessStatus: ready`, `releaseEvidence.status: pass`, `recentWindowRunCount: 5`, `recentReadyRunCount: 5`, keep/watch/remove `28/0/0`, `reasonCounts: {}`
- LUMA MVP: `status: pass`, profile `public-beta`, blockers `[]`
- Mesh: `status: review_required`, `schema_epoch: post_luma_m0b`, LUMA gated write coverage `pass`
- Mesh blockers preserved:
  - `canonical-30-minute-soak`
  - `public-wss-deployment-proof`
  - `required-write-class-sample-floors`
- Production app canary boundary: expected nonzero, `status: blocked`, `reason: mesh_not_release_ready`

## Allowed Claims

- MVP public-beta release gates passed for the implemented MVP scope.
- LUMA public-beta is MVP-production-ready as a fail-closed beta-local identity and signed-write layer.
- Source health passed the complete release evidence window.
- Mesh is tracked separately and is currently `review_required` unless its own report says `release_ready`.

## Forbidden Claims

- No Mesh `release_ready` unless the Mesh packet itself reports `release_ready` with no release-readiness blockers.
- No production app canary pass unless the canary report status is `pass`.
- No downstream app surface observation pass.
- No full-app production readiness.
- No test-group readiness.
- No LUMA Silver / verified-human / one-human-one-vote / Sybil-resistance readiness.
- No public WSS proof or Mesh sample-floor satisfaction unless the Mesh packet says so.

## Verification Matrix

- `node --check packages/e2e/src/mvp-closeout.mjs` - pass
- `pnpm --filter @vh/e2e exec vitest run src/mvp-closeout.vitest.mjs --config ./vitest.config.ts --reporter=dot` - pass, 10 tests
- `pnpm --filter @vh/e2e typecheck` - pass
- `pnpm --filter @vh/news-aggregator exec vitest run src/sourceAdmissionReport.test.ts --config ./vitest.config.ts --reporter=dot` - pass, 37 tests
- `pnpm --filter @vh/news-aggregator typecheck` - pass
- `pnpm --filter @vh/news-aggregator test` - pass, 34 files / 417 tests
- `pnpm check:news-sources:health` - pass, source-health release evidence `5/5` ready
- `pnpm test:mesh:luma-gated-write-coverage -- --mode local-e2e` - pass
- `pnpm check:mesh:production-readiness` - pass as an evidence command with Mesh `review_required`; blockers preserved
- `pnpm check:mesh-evidence-scrub -- --source-dir .tmp/mesh-production-readiness/latest --expected-commit b1b61209d9a02d6fff93829194fbef97863c750f` - pass
- `pnpm check:luma:mvp-production-readiness` - pass
- `pnpm check:mvp-release-gates` - pass, `14/14`
- `pnpm report:mvp-closeout` - pass, wrote `.tmp/mvp-closeout/latest/mvp-closeout-report.json`
- `pnpm check:mvp-closeout` - pass
- `pnpm check:public-beta-launch-closeout` - pass
- `pnpm docs:check` - pass
- `git diff --check origin/main...HEAD` - pass
- `node tools/scripts/check-diff-coverage.mjs` - pass
- `pnpm check:public-namespace-leaks` - pass
- `pnpm check:production-app-canary -- --mesh-report .tmp/mesh-production-readiness/latest/mesh-production-readiness-report.json` - expected exit `1`, blocked on `mesh_not_release_ready`

## Protected Surfaces

Changed files are limited to closeout command/tests, source-health admission timeout determinism, package scripts, and release-truth docs/checker. No app runtime, relay runtime, Mesh readiness implementation, production app canary implementation, LUMA runtime/schema/custody/envelope/signed-write/provider/identifier/identity-vault, or source-health threshold/registry changes.

## Explicit Non-Claims

- This PR does not claim Mesh `release_ready`.
- This PR does not claim production app canary pass.
- This PR does not claim downstream app surfaces were observed end-to-end.
- This PR does not claim full-app or test-group readiness.
- This PR does not claim LUMA Silver, verified-human identity, one-human-one-vote, or Sybil resistance.
