### PR TITLE
Add MVP public-beta release candidate packet

### DIFF
--- a/docs/reports/mvp-public-beta-release-candidate-2026-05-12.md
+++ b/docs/reports/mvp-public-beta-release-candidate-2026-05-12.md
@@ -1,0 +1,164 @@
+# MVP Public Beta Release Candidate Packet
+
+Date: 2026-05-12
+Created at: 2026-05-12T22:49:14Z
+Branch: `coord/mvp-public-beta-rc-packet-v1`
+Frozen baseline commit: `4c3fd64478e36e86f9bf8a8d9fd787865390b13b`
+Node: `v20.20.0`
+pnpm: `9.7.1`
+Packet status: release-candidate evidence packet, pending human/operator approvals.
+
+Dynamic run ids, generated-at timestamps, and current branch-head commit checks live in the generated reports listed below. This committed note records the stable release-candidate claim boundary and the report paths a reviewer should inspect after rerunning the evidence matrix on the final commit.
+
+## Release Candidate Verdict
+
+The Web PWA is an MVP public-beta release candidate for the implemented scope, with deterministic MVP gates, source health, and LUMA public-beta readiness passing; Mesh production readiness and full-app/test-group readiness remain separate unfinished gates.
+
+This packet does not make Mesh `release_ready`, does not pass production app canary, does not claim downstream production app observation, and does not record legal/commercial approval.
+
+## Evidence Matrix
+
+| Evidence | Command | Result | Report or note |
+| --- | --- | --- | --- |
+| Public beta launch closeout | `pnpm check:public-beta-launch-closeout` | PASS | `docs/ops/public-beta-launch-readiness-closeout.md` |
+| MVP release gates | `pnpm check:mvp-release-gates` | PASS, 14/14 gates | `.tmp/mvp-release-gates/latest/mvp-release-gates-report.json` |
+| MVP consolidated closeout | `pnpm check:mvp-closeout` | PASS | `.tmp/mvp-closeout/latest/mvp-closeout-report.json` |
+| Launch content snapshot | `pnpm check:launch-content-snapshot` | PASS | `.tmp/launch-content-snapshot/latest/launch-content-snapshot-report.json` |
+| Public beta compliance | `pnpm check:public-beta-compliance` | PASS | `tools/scripts/check-public-beta-compliance.mjs` |
+| LUMA public-beta MVP readiness | `pnpm check:luma:mvp-production-readiness` | PASS | `.tmp/luma-mvp-production-readiness/latest/luma-mvp-production-readiness-report.json` |
+| LUMA mesh reader-path coverage | `pnpm test:mesh:luma-gated-write-coverage -- --mode local-e2e` | PASS | `.tmp/mesh-luma-gated-write-coverage/latest/mesh-luma-gated-write-coverage-report.json` |
+| Mesh aggregate boundary | `VH_MESH_SOAK_DURATION_MS=1800000 VH_MESH_LUMA_GATED_WRITE_COVERAGE_REPORT=.tmp/mesh-luma-gated-write-coverage/latest/mesh-luma-gated-write-coverage-report.json pnpm check:mesh:production-readiness` | Command completed; report remains `review_required` | `.tmp/mesh-production-readiness/latest/mesh-production-readiness-report.json` |
+| Production app canary boundary | `pnpm check:production-app-canary -- --mesh-report .tmp/mesh-production-readiness/latest/mesh-production-readiness-report.json` | EXPECTED BLOCKED, nonzero, `mesh_not_release_ready` | `.tmp/production-app-canary/latest/production-app-canary-report.json` |
+| Documentation governance | `pnpm docs:check` | PASS | local command output |
+| E2E package typecheck | `pnpm --filter @vh/e2e typecheck` | PASS | local command output |
+| Public namespace leaks | `pnpm check:public-namespace-leaks` | PASS | local command output |
+| Whitespace diff check | `git diff --check origin/main...HEAD` | PASS | local command output |
+| Diff coverage guard | `node tools/scripts/check-diff-coverage.mjs` | PASS | local command output |
+
+## Source Health
+
+Report path: `services/news-aggregator/.tmp/news-source-admission/latest/source-health-report.json`
+
+- `readinessStatus`: `ready`
+- `releaseEvidence.status`: `pass`
+- `releaseEvidence.recentWindowRunCount`: `5`
+- `releaseEvidence.recentReadyRunCount`: `5`
+- `releaseEvidence.recentReviewRunCount`: `0`
+- `releaseEvidence.recentBlockedRunCount`: `0`
+- Source disposition: `28` keep, `0` watch, `0` remove
+- Release evidence reasons: none
+
+Claim boundary: source health passed the complete 5/5 ready release evidence window. This packet does not relax source-health thresholds and does not remove, suppress, or admit sources by fiat.
+
+## LUMA Public Beta MVP
+
+Report path: `.tmp/luma-mvp-production-readiness/latest/luma-mvp-production-readiness-report.json`
+
+- `status`: `pass`
+- `profile`: `public-beta`
+- `blockers`: none
+
+Claim boundary: LUMA public-beta is MVP-production-ready as a fail-closed beta-local identity and signed-write layer. This packet does not claim LUMA Silver, verified-human identity, one-human-one-vote, Sybil resistance, cryptographic residency, or production attestation.
+
+## Mesh Boundary
+
+Report path: `.tmp/mesh-production-readiness/latest/mesh-production-readiness-report.json`
+
+- `status`: `review_required`
+- `schema_epoch`: `post_luma_m0b`
+- `luma_profile`: `none`
+- LUMA gated write coverage status: `pass`
+- Release-readiness blockers:
+  - `public-wss-deployment-proof`
+  - `required-write-class-sample-floors`
+
+Claim boundary: Mesh is tracked separately and remains `review_required`. Public WSS proof and required write/resource sample floors are not satisfied by this packet. The Mesh command completing does not convert this packet into a Mesh `release_ready` claim.
+
+## Production App Canary Boundary
+
+Report path: `.tmp/production-app-canary/latest/production-app-canary-report.json`
+
+- `status`: `blocked`
+- `reason`: `mesh_not_release_ready`
+- Downstream observation: `not_run`
+- Downstream reason: `prerequisites_blocked`
+
+Claim boundary: the production app canary did not pass. Downstream production app surfaces were not observed end to end because the Mesh prerequisite is still blocked.
+
+## Supplemental Launch Rehearsal
+
+The release copy may say the local product loop was rehearsed only because this packet ran the release-like local stack lane:
+
+| Evidence | Command | Result |
+| --- | --- | --- |
+| Start local analysis-stub stack | `pnpm live:stack:up:analysis-stub` | PASS |
+| Five-user engagement rehearsal | `pnpm test:live:five-user-engagement` | PASS |
+| Stop local stack | `pnpm live:stack:down` | PASS |
+
+The rehearsal exercised five isolated beta-local users across feed rendering, accepted synthesis detail, point stance writes, aggregate readback, and story-thread discussion against the local analysis-stub stack. This is not production app canary evidence, does not prove production downstream observation, and does not replace deterministic gates.
+
+Launch rehearsal findings fixed in this release-candidate branch:
+
+- Local stack startup now exports the deterministic E2E system-writer identity into the news daemon and E2E browser environment, so system-authored fixture/stub stories use the same LUMA writer contract the reader expects.
+- The live mesh synthesis prefilter now resolves the deterministic E2E system-writer pin before classifying records, so valid system-written LUMA records are not rejected as `missing-pin`.
+- The five-user live test now fails closed if a beta-local identity was not actually published before feed/detail/stance activity starts.
+- The aggregate voter reader now hydrates nested LUMA signed-write envelope relation pointers before strict parsing, so relay-persisted aggregate voter rows are not dropped when Gun returns nested envelope fields as references.
+
+These fixes do not change Mesh readiness gates, production app canary implementation, source-health thresholds, source registry policy, relay runtime, or LUMA runtime/schema/custody/envelope/signed-write/provider/identifier/identity-vault surfaces.
+
+## Allowed Claims
+
+- "MVP public-beta release gates passed for the implemented MVP scope."
+- "Source health passed the complete release evidence window."
+- "LUMA public-beta is MVP-production-ready as a fail-closed beta-local identity and signed-write layer."
+- "The Web PWA is a public beta candidate for the documented implemented scope."
+- "Mesh is tracked separately and is currently review_required unless its own report says release_ready."
+- "The local analysis-stub five-user rehearsal passed for the Web PWA feed/detail/stance/thread loop."
+
+## Forbidden Claims
+
+- Mesh `release_ready`.
+- Production app canary pass.
+- Downstream production app surfaces observed end to end.
+- Full production app readiness.
+- Test-group readiness.
+- Legal or commercial approval unless externally recorded.
+- Production-grade live headline freshness unless StoryCluster production readiness separately says `release_ready`.
+- LUMA Silver, verified-human identity, one-human-one-vote, Sybil resistance, or production attestation.
+- Public WSS proof satisfied unless the Mesh report says so.
+- Mesh sample floors satisfied unless the Mesh report says so.
+- Native App Store or TestFlight readiness.
+
+## Launch Copy Boundaries
+
+Allowed launch copy can describe the Web PWA as an MVP public-beta release candidate for the implemented scope with deterministic MVP gates, source health, LUMA public-beta MVP readiness, curated launch-content fallback, public policy/support surfaces, audited correction/moderation/report remediation paths, and trusted beta operator gates.
+
+Launch copy must not imply production-grade live headline freshness, Mesh `release_ready`, production app canary pass, downstream production app observation, full app readiness, test-group readiness, legal/commercial approval, native App Store/TestFlight readiness, or production-grade LUMA/Silver/verified-human claims.
+
+## Release Owner Handoff
+
+| Item | Status |
+| --- | --- |
+| Release owner | Pending |
+| Signoff date | Pending |
+| External/legal approval status | Pending; outside repo automation |
+| Launch copy approval | Pending |
+| Support issue intake path | Public beta GitHub support issue intake, plus private escalation path when needed |
+| Private escalation path | Pending external operator confirmation |
+| Rollback contact/path | Pending release owner assignment |
+
+Known hold conditions:
+
+- Any rerun of `pnpm check:public-beta-launch-closeout`, `pnpm check:mvp-release-gates`, `pnpm check:mvp-closeout`, source health, public-beta compliance, or LUMA MVP readiness fails on the release commit.
+- Launch copy makes any forbidden claim above.
+- Required external/operator/legal approval is missing for the intended distribution path.
+- The release owner needs production app canary pass, Mesh `release_ready`, full-app readiness, test-group readiness, native App Store/TestFlight readiness, or production-grade live headline freshness for the intended launch claim.
+- The local five-user product-loop rehearsal fails and launch copy still claims the feed/detail/stance/thread loop was exercised.
+
+Next operator actions:
+
+- Rerun the deterministic evidence matrix on the final release commit.
+- Preserve generated report paths listed in this packet for reviewer inspection.
+- Obtain release owner and external/legal approval if required by the launch process.
+- Publish only the bounded Web PWA MVP public-beta claims listed above.
+- Keep Mesh production readiness, production app canary downstream observation, full-app readiness, and test-group readiness as separate unfinished gates.

--- a/packages/e2e/src/live/five-user-news-engagement.live.spec.ts
+++ b/packages/e2e/src/live/five-user-news-engagement.live.spec.ts
@@ -207,7 +207,7 @@ async function ensureIdentity(page: Page, label: string): Promise<void> {
     () => Boolean((window as Window & { __vh_identity_published?: unknown }).__vh_identity_published),
     undefined,
     { timeout: 30_000 },
-  ).catch(() => undefined);
+  );
   await gotoFeed(page);
 }
 

--- a/packages/e2e/src/live/mesh-synthesis-prefilter.mjs
+++ b/packages/e2e/src/live/mesh-synthesis-prefilter.mjs
@@ -1,6 +1,12 @@
 #!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 const DEFAULT_PEERS = ['http://127.0.0.1:7777/gun'];
 const DEFAULT_READ_TIMEOUT_MS = 6_000;
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 function readPositiveIntEnv(name, fallback) {
   const value = Number.parseInt(process.env[name] ?? '', 10);
@@ -53,6 +59,44 @@ function hasVoteableAcceptedSynthesis(synthesis) {
   );
 }
 
+function readConst(source, name) {
+  const match = source.match(new RegExp(`export const ${name} =\\n?\\s*'([^']+)';`));
+  if (!match) {
+    throw new Error(`missing ${name}`);
+  }
+  return match[1];
+}
+
+function resolveE2eSystemWriterPin() {
+  const explicitPin =
+    process.env.VITE_E2E_SYSTEM_WRITER_PIN_JSON?.trim()
+    || process.env.VH_NEWS_SYSTEM_WRITER_PIN_JSON?.trim();
+  if (explicitPin) {
+    return JSON.parse(explicitPin);
+  }
+
+  const fixturePath = path.join(__dirname, 'lumaSystemWriterTestFixture.ts');
+  const source = fs.readFileSync(fixturePath, 'utf8');
+  const writerId = readConst(source, 'E2E_SYSTEM_WRITER_ID');
+  const publicKey = readConst(source, 'E2E_SYSTEM_WRITER_PUBLIC_KEY_SPKI_BASE64URL');
+  return {
+    pinVersion: 1,
+    schemaEpoch: 'luma-public-v1',
+    maxProtocolVersion: 'luma-public-v1',
+    signatureSuite: 'jcs-ed25519-sha256-v1',
+    writers: [
+      {
+        id: writerId,
+        status: 'active',
+        publicKey: {
+          encoding: 'spki-base64url',
+          material: publicKey,
+        },
+      },
+    ],
+  };
+}
+
 async function main() {
   const options = parseArgs(process.argv.slice(2));
   const timeoutMs = readPositiveIntEnv(
@@ -66,7 +110,12 @@ async function main() {
   // and emit only the final JSON payload from this short-lived helper process.
   console.log = () => {};
   const { createClient, readTopicLatestSynthesis } = await import('@vh/gun-client');
-  const client = createClient({ requireSession: false, peers, gunRadisk: false });
+  const client = createClient({
+    requireSession: false,
+    peers,
+    gunRadisk: false,
+    systemWriterPin: resolveE2eSystemWriterPin(),
+  });
   client.markSessionReady();
   await new Promise((resolve) => setTimeout(resolve, 500));
 

--- a/packages/gun-client/src/aggregateAdapters.test.ts
+++ b/packages/gun-client/src/aggregateAdapters.test.ts
@@ -1318,6 +1318,85 @@ describe('aggregateAdapters', () => {
     ]);
   });
 
+  it('readAggregateVoterRows hydrates nested LUMA signed-write envelopes from relation pointers', async () => {
+    const mesh = createFakeMesh();
+    const node = await createLumaAggregateVoterNode({ point_id: 'point-1' });
+    const { signedWriteEnvelope, ...publicPayload } = node;
+    const voterPath =
+      `aggregates/topics/topic-1/syntheses/synth-1/epochs/4/voters/${LUMA_VOTER_ID}/point-1`;
+
+    mesh.setRead('aggregates/topics/topic-1/syntheses/synth-1/epochs/4/voters', {
+      [LUMA_VOTER_ID]: { '#': `vh/${voterPath.replace('/point-1', '')}` },
+    });
+    mesh.setRead(voterPath, {
+      ...publicPayload,
+      signedWriteEnvelope: { '#': `vh/${voterPath}/signedWriteEnvelope` },
+    });
+    mesh.setRead(`${voterPath}/signedWriteEnvelope`, {
+      ...signedWriteEnvelope,
+      payload: { '#': `vh/${voterPath}/signedWriteEnvelope/payload` },
+      sessionRef: { '#': `vh/${voterPath}/signedWriteEnvelope/sessionRef` },
+    });
+    mesh.setRead(`${voterPath}/signedWriteEnvelope/payload`, signedWriteEnvelope.payload);
+    mesh.setRead(`${voterPath}/signedWriteEnvelope/sessionRef`, signedWriteEnvelope.sessionRef);
+
+    const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+    const client = createClient(mesh, guard);
+
+    await expect(readAggregateVoterRows(client, 'topic-1', 'synth-1', 4, 'point-1')).resolves.toEqual([
+      {
+        voter_id: LUMA_VOTER_ID,
+        node,
+        updated_at_ms: Date.parse('2026-02-18T22:20:00.000Z'),
+      },
+    ]);
+  });
+
+  it('readAggregateVoterNode hydrates a linked LUMA envelope with embedded child records', async () => {
+    const mesh = createFakeMesh();
+    const node = await createLumaAggregateVoterNode({ point_id: 'point-1' });
+    const { signedWriteEnvelope, ...publicPayload } = node;
+    const voterPath =
+      `aggregates/topics/topic-1/syntheses/synth-1/epochs/4/voters/${LUMA_VOTER_ID}/point-1`;
+
+    mesh.setRead(voterPath, {
+      ...publicPayload,
+      signedWriteEnvelope: { '#': `vh/${voterPath}/signedWriteEnvelope` },
+    });
+    mesh.setRead(`${voterPath}/signedWriteEnvelope`, signedWriteEnvelope);
+
+    const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+    const client = createClient(mesh, guard);
+
+    await expect(
+      readAggregateVoterNode(client, 'topic-1', 'synth-1', 4, LUMA_VOTER_ID, 'point-1', {
+        readTimeoutMs: 25,
+      }),
+    ).resolves.toEqual(node);
+  });
+
+  it('readAggregateVoterNode returns null when a linked LUMA envelope cannot be resolved', async () => {
+    const mesh = createFakeMesh();
+    const node = await createLumaAggregateVoterNode({ point_id: 'point-1' });
+    const { signedWriteEnvelope: _signedWriteEnvelope, ...publicPayload } = node;
+    const voterPath =
+      `aggregates/topics/topic-1/syntheses/synth-1/epochs/4/voters/${LUMA_VOTER_ID}/point-1`;
+
+    mesh.setRead(voterPath, {
+      ...publicPayload,
+      signedWriteEnvelope: { '#': `vh/${voterPath}/signedWriteEnvelope` },
+    });
+
+    const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+    const client = createClient(mesh, guard);
+
+    await expect(
+      readAggregateVoterNode(client, 'topic-1', 'synth-1', 4, LUMA_VOTER_ID, 'point-1', {
+        readTimeoutMs: 25,
+      }),
+    ).resolves.toBeNull();
+  });
+
   it('readAggregateVoterRows recovers leaf rows from map voter IDs when root once returns null', async () => {
     const mesh = createFakeMesh();
     mesh.setRead('aggregates/topics/topic-1/syntheses/synth-1/epochs/4/voters', undefined);

--- a/packages/gun-client/src/aggregateAdapters.ts
+++ b/packages/gun-client/src/aggregateAdapters.ts
@@ -100,6 +100,79 @@ function parseAggregateVoterNodeForPath(
   return aggregateVoterNodeMatchesPath(parsed.data, context, voterId) ? parsed.data : null;
 }
 
+function isGunRelation(value: unknown): boolean {
+  return isRecord(value) && typeof value['#'] === 'string';
+}
+
+async function readResolvedRecord<T>(
+  chain: ChainWithGet<T>,
+  timeoutMs?: number,
+): Promise<Record<string, unknown> | null> {
+  const raw = await readOnce(chain, timeoutMs);
+  const stripped = stripGunMetadata(raw);
+  return isRecord(stripped) ? stripped : null;
+}
+
+async function readAggregateVoterNodeForPath(
+  chain: ChainWithGet<unknown>,
+  context: AggregateVoterPathContext,
+  voterId: string,
+  options?: { readonly readTimeoutMs?: number },
+): Promise<AggregateVoterNode | null> {
+  const raw = await readOnce(chain, options?.readTimeoutMs);
+  const parsed = parseAggregateVoterNodeForPath(raw, context, voterId);
+  if (parsed) {
+    return parsed;
+  }
+
+  const record = stripGunMetadata(raw);
+  if (!isRecord(record)) {
+    return null;
+  }
+
+  const envelopeCandidate = stripGunMetadata(record.signedWriteEnvelope);
+  const needsEnvelopeHydration =
+    !isRecord(envelopeCandidate)
+    || isGunRelation(envelopeCandidate)
+    || !isRecord(stripGunMetadata(envelopeCandidate.payload))
+    || isGunRelation(stripGunMetadata(envelopeCandidate.payload))
+    || !isRecord(stripGunMetadata(envelopeCandidate.sessionRef))
+    || isGunRelation(stripGunMetadata(envelopeCandidate.sessionRef));
+
+  if (!needsEnvelopeHydration) {
+    return null;
+  }
+
+  const envelopeChain = chain.get('signedWriteEnvelope') as unknown as ChainWithGet<unknown>;
+  const envelopeRecord = await readResolvedRecord(envelopeChain, options?.readTimeoutMs);
+  if (!envelopeRecord) {
+    return null;
+  }
+
+  const envelopePayload = await readResolvedRecord(
+    envelopeChain.get('payload') as unknown as ChainWithGet<unknown>,
+    options?.readTimeoutMs,
+  );
+  const envelopeSessionRef = await readResolvedRecord(
+    envelopeChain.get('sessionRef') as unknown as ChainWithGet<unknown>,
+    options?.readTimeoutMs,
+  );
+  const hydratedEnvelope = {
+    ...envelopeRecord,
+    ...(envelopePayload ? { payload: envelopePayload } : {}),
+    ...(envelopeSessionRef ? { sessionRef: envelopeSessionRef } : {}),
+  };
+
+  return parseAggregateVoterNodeForPath(
+    {
+      ...record,
+      signedWriteEnvelope: hydratedEnvelope,
+    },
+    context,
+    voterId,
+  );
+}
+
 function assertAggregateVoterNodeMatchesPath(
   node: AggregateVoterNode,
   context: AggregateVoterPathContext,
@@ -706,8 +779,11 @@ async function readVoterPointRow(
   context: AggregateVoterPathContext,
 ): Promise<AggregateVoterPointRow | null> {
   const normalizedVoterId = voterId.trim();
-  const raw = await readOnce(votersChain.get(normalizedVoterId).get(context.pointId));
-  const parsed = parseAggregateVoterNodeForPath(raw, context, normalizedVoterId);
+  const parsed = await readAggregateVoterNodeForPath(
+    votersChain.get(normalizedVoterId).get(context.pointId) as unknown as ChainWithGet<unknown>,
+    context,
+    normalizedVoterId,
+  );
   if (!parsed) {
     return null;
   }
@@ -1083,8 +1159,7 @@ export async function readAggregateVoterNode(
     .get(normalizedVoterId)
     .get(normalizedPointId) as unknown as ChainWithGet<unknown>;
 
-  const raw = await readOnce(chain, options?.readTimeoutMs);
-  return parseAggregateVoterNodeForPath(raw, context, normalizedVoterId);
+  return readAggregateVoterNodeForPath(chain, context, normalizedVoterId, options);
 }
 
 async function confirmAggregateVoterNodeReadback(

--- a/tools/scripts/live-local-stack.sh
+++ b/tools/scripts/live-local-stack.sh
@@ -45,6 +45,57 @@ ANALYSIS_STUB_PID_FILE="${ANALYSIS_STUB_PID_FILE:-/tmp/vh-local-analysis-stub.pi
 RELAY_DATA_PATH="${RELAY_DATA_PATH:-$ROOT/.tmp/live-local-stack/relay-data}"
 STORYCLUSTER_STATE_DIR="${STORYCLUSTER_STATE_DIR:-$ROOT/.tmp/live-local-stack/storycluster-state}"
 
+load_e2e_system_writer_fixture() {
+  local fixture_output writer_id pin_json private_key
+  fixture_output="$(
+    node - "$ROOT/packages/e2e/src/live/lumaSystemWriterTestFixture.ts" <<'NODE'
+const fs = require('node:fs');
+const source = fs.readFileSync(process.argv[2], 'utf8');
+function readConst(name) {
+  const match = source.match(new RegExp(`export const ${name} =\\n?\\s*'([^']+)';`));
+  if (!match) {
+    throw new Error(`missing ${name}`);
+  }
+  return match[1];
+}
+const writerId = readConst('E2E_SYSTEM_WRITER_ID');
+const publicKey = readConst('E2E_SYSTEM_WRITER_PUBLIC_KEY_SPKI_BASE64URL');
+const privateKey = readConst('E2E_SYSTEM_WRITER_PRIVATE_KEY_PKCS8_BASE64URL');
+const pin = {
+  pinVersion: 1,
+  schemaEpoch: 'luma-public-v1',
+  maxProtocolVersion: 'luma-public-v1',
+  signatureSuite: 'jcs-ed25519-sha256-v1',
+  writers: [
+    {
+      id: writerId,
+      status: 'active',
+      publicKey: {
+        encoding: 'spki-base64url',
+        material: publicKey,
+      },
+    },
+  ],
+};
+console.log(writerId);
+console.log(JSON.stringify(pin));
+console.log(privateKey);
+NODE
+  )"
+  writer_id="$(printf '%s\n' "$fixture_output" | sed -n '1p')"
+  pin_json="$(printf '%s\n' "$fixture_output" | sed -n '2p')"
+  private_key="$(printf '%s\n' "$fixture_output" | sed -n '3p')"
+
+  [[ -n "$writer_id" ]] || die "Unable to load e2e system writer id"
+  [[ -n "$pin_json" ]] || die "Unable to load e2e system writer pin"
+  [[ -n "$private_key" ]] || die "Unable to load e2e system writer private key"
+
+  export VH_NEWS_SYSTEM_WRITER_ID="${VH_NEWS_SYSTEM_WRITER_ID:-$writer_id}"
+  export VH_NEWS_SYSTEM_WRITER_PIN_JSON="${VH_NEWS_SYSTEM_WRITER_PIN_JSON:-$pin_json}"
+  export VH_NEWS_SYSTEM_WRITER_PRIVATE_KEY_PKCS8_BASE64URL="${VH_NEWS_SYSTEM_WRITER_PRIVATE_KEY_PKCS8_BASE64URL:-$private_key}"
+  export VITE_E2E_SYSTEM_WRITER_PIN_JSON="${VITE_E2E_SYSTEM_WRITER_PIN_JSON:-$VH_NEWS_SYSTEM_WRITER_PIN_JSON}"
+}
+
 artifact_root_has_snapshot() {
   local artifact_root="$1"
   [[ -d "$artifact_root" ]] || return 1
@@ -120,6 +171,7 @@ load_profile_env() {
   set -a && source "$ENV_FILE" && set +a
 
   export VITE_E2E_MODE=false
+  export VITE_LUMA_DEV_FALLBACK="${VITE_LUMA_DEV_FALLBACK:-true}"
   export VITE_VH_ANALYSIS_PIPELINE=true
   export VITE_NEWS_RUNTIME_ENABLED=false
   export VITE_NEWS_RUNTIME_ROLE=consumer
@@ -164,6 +216,10 @@ load_profile_env() {
   export VH_STORYCLUSTER_TEXT_MODEL="${VH_STORYCLUSTER_TEXT_MODEL:-gpt-4o-mini}"
   export VH_STORYCLUSTER_OPENAI_TIMEOUT_MS="${VH_STORYCLUSTER_OPENAI_TIMEOUT_MS:-120000}"
   export VH_NEWS_DAEMON_HOLDER_ID="${VH_NEWS_DAEMON_HOLDER_ID:-vh-local-news-daemon}"
+
+  if [[ "$STACK_MODE" != 'validated-snapshot' ]]; then
+    load_e2e_system_writer_fixture
+  fi
 
   if [[ "$STACK_MODE" == 'fixture' ]]; then
     export VH_DAEMON_FEED_USE_FIXTURE_FEED=true
@@ -324,6 +380,9 @@ start_daemon() {
     VH_ANALYSIS_EVAL_ARTIFACTS_ENABLED="${VH_ANALYSIS_EVAL_ARTIFACTS_ENABLED:-}" \
     VH_ANALYSIS_EVAL_ARTIFACT_DIR="${VH_ANALYSIS_EVAL_ARTIFACT_DIR:-}" \
     VH_ARTICLE_TEXT_EXTRA_ALLOWLIST_DOMAINS="${VH_ARTICLE_TEXT_EXTRA_ALLOWLIST_DOMAINS:-}" \
+    VH_NEWS_SYSTEM_WRITER_ID="${VH_NEWS_SYSTEM_WRITER_ID:-}" \
+    VH_NEWS_SYSTEM_WRITER_PIN_JSON="${VH_NEWS_SYSTEM_WRITER_PIN_JSON:-}" \
+    VH_NEWS_SYSTEM_WRITER_PRIVATE_KEY_PKCS8_BASE64URL="${VH_NEWS_SYSTEM_WRITER_PRIVATE_KEY_PKCS8_BASE64URL:-}" \
     node "$ROOT/tools/scripts/spawn-detached.mjs" \
     "$DAEMON_PID_FILE" \
     "$ROOT" \


### PR DESCRIPTION
## Summary
- Adds the committed MVP public-beta release-candidate packet at `docs/reports/mvp-public-beta-release-candidate-2026-05-12.md`.
- Keeps the RC claim bounded to the implemented Web PWA MVP public-beta scope.
- Records that MVP release gates, source health, LUMA MVP readiness, launch content, public-beta compliance, and public-beta launch closeout are green.
- Preserves the separate unfinished boundaries: Mesh remains `review_required`; production app canary remains blocked on `mesh_not_release_ready`; full-app/test-group/native/legal readiness is not claimed.
- Fixes the launch-rehearsal local stack path so analysis-stub five-user engagement can exercise the LUMA system-writer and aggregate-voter readback path deterministically.

## Base / Head
- Base commit: `4c3fd64478e36e86f9bf8a8d9fd787865390b13b`
- Head commit: `cedc2407797d33c4d653de3ae9aac96215f21ad3`
- Branch: `coord/mvp-public-beta-rc-packet-v1`

## Release-Candidate Packet
- Packet: `docs/reports/mvp-public-beta-release-candidate-2026-05-12.md`
- Latest closeout artifact: `.tmp/mvp-closeout/latest/mvp-closeout-report.json`
- Latest MVP release gates artifact: `.tmp/mvp-release-gates/latest/mvp-release-gates-report.json`
- Latest source-health artifact: `services/news-aggregator/.tmp/news-source-admission/latest/source-health-report.json`
- Latest LUMA MVP artifact: `.tmp/luma-mvp-production-readiness/latest/luma-mvp-production-readiness-report.json`
- Latest Mesh LUMA coverage artifact: `.tmp/mesh-luma-gated-write-coverage/latest/mesh-luma-gated-write-coverage-report.json`
- Latest Mesh readiness artifact: `.tmp/mesh-production-readiness/latest/mesh-production-readiness-report.json`
- Latest production canary artifact: `.tmp/production-app-canary/latest/production-app-canary-report.json`

## Evidence Status
- MVP closeout: `pass`
- MVP release gates: `pass`, 14/14, failing gates `[]`
- Source health: `ready`; release evidence `pass`; 5/5 ready release window; 28 keep, 0 watch, 0 remove, reason counts `{}`
- LUMA MVP readiness: `pass`; profile `public-beta`; blockers `[]`
- Mesh readiness: `review_required`; blockers preserved:
  - `public-wss-deployment-proof`
  - `required-write-class-sample-floors`
- Mesh LUMA gated write coverage: `pass`; source commit `cedc2407797d33c4d653de3ae9aac96215f21ad3`; source dirty `false`; profile `e2e`
- Production app canary boundary: expected nonzero exit 1; report `blocked`; reason `mesh_not_release_ready`; downstream observation `not_run`
- Supplemental launch rehearsal: `pnpm live:stack:up:analysis-stub`, `pnpm test:live:five-user-engagement`, and `pnpm live:stack:down` passed during the RC evidence run after the launch-rehearsal fixes.

## Allowed Claims
- MVP public-beta release gates passed for the implemented MVP scope.
- Source health passed the complete release evidence window.
- LUMA public-beta is MVP-production-ready as a fail-closed beta-local identity and signed-write layer.
- The Web PWA is a public beta candidate for the documented implemented scope.
- Mesh is tracked separately and is currently `review_required` unless its own report says `release_ready`.

## Forbidden Claims / Explicit Non-Claims
- No Mesh `release_ready` claim.
- No production app canary pass claim.
- No downstream production app observation pass claim.
- No full production app readiness claim.
- No test-group readiness claim.
- No legal, commercial, launch-copy, or operator approval claim unless externally recorded.
- No production-grade live headline freshness claim unless StoryCluster production readiness separately says `release_ready`.
- No LUMA Silver, verified-human, one-human-one-vote, Sybil resistance, or production attestation claim.
- No public WSS proof or Mesh sample-floor satisfaction claim.
- No native App Store/TestFlight readiness claim.

## External Approvals
- Release owner signoff: pending / outside repo automation.
- External/legal approval: pending / outside repo automation.
- Launch copy approval: pending / outside repo automation.
- Support intake and escalation ownership: pending / outside repo automation.

## Verification
- `node --check packages/e2e/src/live/mesh-synthesis-prefilter.mjs` PASS
- `bash -n tools/scripts/live-local-stack.sh` PASS
- `pnpm --filter @vh/gun-client exec vitest run src/aggregateAdapters.test.ts --config ./vitest.config.ts --reporter=dot` PASS
- `pnpm --filter @vh/gun-client typecheck` PASS
- `pnpm --filter @vh/gun-client build` PASS
- `pnpm --filter @vh/e2e typecheck` PASS
- `pnpm check:news-sources:health` PASS
- `pnpm check:luma:mvp-production-readiness` PASS
- `pnpm check:mvp-release-gates` PASS
- `pnpm check:mvp-closeout` PASS
- `pnpm check:launch-content-snapshot` PASS
- `pnpm check:public-beta-compliance` PASS
- `pnpm check:public-beta-launch-closeout` PASS
- `pnpm test:mesh:luma-gated-write-coverage -- --mode local-e2e` PASS
- `VH_MESH_SOAK_DURATION_MS=1800000 VH_MESH_LUMA_GATED_WRITE_COVERAGE_REPORT=.tmp/mesh-luma-gated-write-coverage/latest/mesh-luma-gated-write-coverage-report.json pnpm check:mesh:production-readiness` exited 0 and produced honest `review_required` Mesh report
- `pnpm check:production-app-canary -- --mesh-report .tmp/mesh-production-readiness/latest/mesh-production-readiness-report.json` expected nonzero exit 1, `mesh_not_release_ready`
- `pnpm live:stack:up:analysis-stub` PASS
- `pnpm test:live:five-user-engagement` PASS
- `pnpm live:stack:down` PASS
- `pnpm docs:check` PASS
- `git diff --check origin/main...HEAD` PASS
- `node tools/scripts/check-diff-coverage.mjs` PASS, 100% line and branch coverage for `packages/gun-client/src/aggregateAdapters.ts`
- `pnpm check:public-namespace-leaks` PASS

## Protected Surfaces
No changes to app runtime, relay runtime, Mesh readiness implementation, production app canary implementation, LUMA runtime/schema/custody/envelope/signed-write/provider/identifier/identity-vault, source-health thresholds, or source registry.