### PR TITLE
Add MVP public-beta launch-control packet

### DIFF
--- a/docs/ops/public-beta-launch-readiness-closeout.md
+++ b/docs/ops/public-beta-launch-readiness-closeout.md
@@ -18,6 +18,8 @@ No repository feature gap is currently classified as a Web PWA public-beta ship 
 
 `pnpm check:mvp-closeout` is the consolidated release-truth reader for this scope. It reads the MVP release-gates packet, source-health packet, LUMA MVP readiness packet, Mesh readiness packet, and production app canary packet, then writes `.tmp/mvp-closeout/latest/mvp-closeout-report.json` with bounded allowed/forbidden claims. It does not override any upstream gate.
 
+The release-owner decision handoff is recorded in `docs/reports/mvp-public-beta-launch-control-2026-05-13.md`. That packet converts the engineering release-candidate evidence into an explicit go/hold control surface with approvals, bounded launch copy, support/escalation ownership, rollback ownership, and final launch status. The launch-control packet must not fake signoff; if any required approval or owner field is pending, its final status remains `hold_external_approval_pending`.
+
 The full-product five-user engagement lane supplements the deterministic report packet with a production-shaped local-stack run: five beta-local users open singleton and bundled stories, read accepted synthesis/frame tables, register point-level stances, confirm mesh aggregate readback, and hold threaded story discussions across reloads. This lane is release-like manual QA; it does not replace the named deterministic command/report gates below.
 
 This closeout does not claim legal approval, production-grade live headline freshness, production-attestation/Silver, verified-human identity, one-human-one-vote, Sybil resistance, public WSS mesh `release_ready`, full production app readiness, full RBAC/admin membership management, a private support desk, native App Store/TestFlight readiness, automated escalation/SLA handling, or a complete trust-and-safety operations console.
@@ -28,6 +30,7 @@ Run these commands on the final public-beta release commit and preserve their ou
 
 | Evidence | Command | Deterministic report or artifact | Required result |
 | --- | --- | --- | --- |
+| Release-owner launch control | committed launch-control packet | `docs/reports/mvp-public-beta-launch-control-2026-05-13.md` and optional JSON mirror | `go_for_public_beta_launch` only when deterministic evidence passes and required approvals/owners are recorded; otherwise `hold_external_approval_pending` |
 | Launch closeout audit | `pnpm check:public-beta-launch-closeout` | This document plus the static checker in `tools/scripts/check-public-beta-launch-closeout.mjs` | `pass` |
 | MVP release gates | `pnpm check:mvp-release-gates` | `.tmp/mvp-release-gates/latest/mvp-release-gates-report.json` | `overallStatus: pass` |
 | MVP consolidated closeout | `pnpm check:mvp-closeout` | `.tmp/mvp-closeout/latest/mvp-closeout-report.json` | `status: pass`; bounded MVP claims only; Mesh/app/Silver claims remain forbidden unless separately proven |

--- a/docs/reports/mvp-public-beta-launch-control-2026-05-13.json
+++ b/docs/reports/mvp-public-beta-launch-control-2026-05-13.json
@@ -1,0 +1,197 @@
+{
+  "schema_version": "mvp-public-beta-launch-control-v1",
+  "date": "2026-05-13",
+  "created_at": "2026-05-13T01:51:53Z",
+  "branch": "coord/mvp-public-beta-launch-control-v1",
+  "release_control_commit": "9eb58154a321ee202095cfdb7d02fce67fb4cab3",
+  "release_control_base": "origin/main after PR #627 merge",
+  "rc_packet_path": "docs/reports/mvp-public-beta-release-candidate-2026-05-12.md",
+  "node": "v20.20.0",
+  "pnpm": "9.7.1",
+  "repo_dirty_during_engineering_evidence": false,
+  "verification_timing": "The deterministic MVP/LUMA/Mesh evidence matrix was rerun on the clean release-control commit before this docs-only launch-control packet was added. After the packet edit, the docs/diff checks were rerun against the branch diff.",
+  "final_status": "hold_external_approval_pending",
+  "status_reason": "Engineering evidence passed, but release-owner approval, external/legal disposition, launch-copy approval, support/private-escalation ownership, and rollback ownership are pending.",
+  "evidence": {
+    "public_beta_launch_closeout": {
+      "command": "pnpm check:public-beta-launch-closeout",
+      "status": "pass",
+      "path": "docs/ops/public-beta-launch-readiness-closeout.md"
+    },
+    "mvp_release_gates": {
+      "command": "pnpm check:mvp-release-gates",
+      "status": "pass",
+      "gate_count": 14,
+      "pass_count": 14,
+      "failing_gates": [],
+      "path": ".tmp/mvp-release-gates/latest/mvp-release-gates-report.json"
+    },
+    "mvp_closeout": {
+      "command": "pnpm check:mvp-closeout",
+      "status": "pass",
+      "blockers": [],
+      "path": ".tmp/mvp-closeout/latest/mvp-closeout-report.json"
+    },
+    "launch_content_snapshot": {
+      "command": "pnpm check:launch-content-snapshot",
+      "status": "pass",
+      "path": ".tmp/launch-content-snapshot/latest/launch-content-snapshot-report.json"
+    },
+    "public_beta_compliance": {
+      "command": "pnpm check:public-beta-compliance",
+      "status": "pass"
+    },
+    "luma_mvp_readiness": {
+      "command": "pnpm check:luma:mvp-production-readiness",
+      "status": "pass",
+      "profile": "public-beta",
+      "blockers": [],
+      "path": ".tmp/luma-mvp-production-readiness/latest/luma-mvp-production-readiness-report.json"
+    },
+    "source_health": {
+      "command": "pnpm check:news-sources:health",
+      "readiness_status": "ready",
+      "release_evidence_status": "pass",
+      "recent_window_run_count": 5,
+      "recent_ready_run_count": 5,
+      "recent_review_run_count": 0,
+      "recent_blocked_run_count": 0,
+      "keep_source_count": 28,
+      "watch_source_count": 0,
+      "remove_source_count": 0,
+      "reason_counts": {},
+      "path": "services/news-aggregator/.tmp/news-source-admission/latest/source-health-report.json"
+    },
+    "mesh_luma_gated_write_coverage": {
+      "command": "pnpm test:mesh:luma-gated-write-coverage -- --mode local-e2e",
+      "status": "pass",
+      "schema_epoch": "post_luma_m0b",
+      "luma_profile": "e2e",
+      "failures": [],
+      "path": ".tmp/mesh-luma-gated-write-coverage/latest/mesh-luma-gated-write-coverage-report.json"
+    },
+    "mesh_production_readiness": {
+      "command": "VH_MESH_SOAK_DURATION_MS=1800000 VH_MESH_LUMA_GATED_WRITE_COVERAGE_REPORT=.tmp/mesh-luma-gated-write-coverage/latest/mesh-luma-gated-write-coverage-report.json pnpm check:mesh:production-readiness",
+      "command_exit": 0,
+      "status": "review_required",
+      "schema_epoch": "post_luma_m0b",
+      "luma_profile": "none",
+      "blockers": [
+        "public-wss-deployment-proof",
+        "required-write-class-sample-floors"
+      ],
+      "canonical_soak": {
+        "full_duration_satisfied": true,
+        "soak_gate": "pass",
+        "terminal_failures": 0,
+        "duplicate_canonical_writes": 0,
+        "repair_events": 0
+      },
+      "path": ".tmp/mesh-production-readiness/latest/mesh-production-readiness-report.json"
+    },
+    "production_app_canary": {
+      "command": "pnpm check:production-app-canary -- --mesh-report .tmp/mesh-production-readiness/latest/mesh-production-readiness-report.json",
+      "expected_exit": 1,
+      "status": "blocked",
+      "reason": "mesh_not_release_ready",
+      "downstream_observation_status": "not_run",
+      "downstream_observation_reason": "prerequisites_blocked",
+      "path": ".tmp/production-app-canary/latest/production-app-canary-report.json"
+    },
+    "launch_rehearsal": {
+      "stack_up_command": "pnpm live:stack:up:analysis-stub",
+      "test_command": "pnpm test:live:five-user-engagement",
+      "stack_down_command": "pnpm live:stack:down",
+      "stack_up_status": "pass",
+      "test_status": "pass",
+      "test_duration": "6.2m",
+      "stack_down_status": "pass"
+    }
+  },
+  "approvals": {
+    "release_owner": {
+      "name": "pending",
+      "approval_status": "pending",
+      "timestamp": null
+    },
+    "external_legal_approval": {
+      "approval_status": "pending",
+      "approver_reference": "pending",
+      "timestamp": null
+    },
+    "launch_copy_approval": {
+      "approval_status": "pending",
+      "approved_copy_path_or_text": "pending",
+      "timestamp": null
+    },
+    "support_intake_owner": {
+      "name_or_team": "pending",
+      "approval_status": "pending",
+      "public_issue_intake_path": "Web PWA /support surface linked to the VHC public beta GitHub Issue Form"
+    },
+    "private_escalation_owner": {
+      "name_or_team": "pending",
+      "approval_status": "pending",
+      "escalation_channel_reference": "pending"
+    },
+    "rollback_owner": {
+      "name_or_team": "pending",
+      "approval_status": "pending",
+      "rollback_trigger_and_path": "Hold or withdraw public launch copy, keep the Web PWA at the last approved public-beta candidate state, and revert or supersede this launch-control packet if it records an incorrect approval or claim boundary."
+    }
+  },
+  "allowed_launch_copy": [
+    "Web PWA MVP public beta candidate for the implemented scope.",
+    "MVP release gates passed.",
+    "Source health passed the complete release evidence window.",
+    "LUMA public-beta is MVP-production-ready as a fail-closed beta-local identity and signed-write layer.",
+    "Local analysis-stub five-user feed/detail/stance/thread rehearsal passed.",
+    "Mesh production readiness remains separate and is currently review_required."
+  ],
+  "forbidden_launch_copy": [
+    "Mesh release_ready.",
+    "Production app canary pass.",
+    "Downstream production app surfaces observed end to end.",
+    "Full production app readiness.",
+    "Test-group readiness.",
+    "Legal or commercial approval unless explicitly recorded.",
+    "Production-grade live headline freshness unless StoryCluster production readiness separately says release_ready.",
+    "LUMA Silver, verified-human identity, one-human-one-vote, Sybil resistance, or production attestation.",
+    "Public WSS proof satisfied unless the Mesh report says so.",
+    "Mesh sample floors satisfied unless the Mesh report says so.",
+    "Native App Store or TestFlight readiness.",
+    "Private support desk or SLA unless externally provisioned."
+  ],
+  "protected_surfaces": {
+    "branch_runtime_changes": "none",
+    "inherited_rc_runtime_fix": "PR #627 includes one tested aggregate readback fix in packages/gun-client/src/aggregateAdapters.ts for nested LUMA signed-write envelope relation pointers.",
+    "unchanged_in_this_branch": [
+      "app runtime",
+      "relay runtime",
+      "Mesh readiness implementation",
+      "production app canary implementation",
+      "LUMA runtime/schema/custody/envelope/signed-write/provider/identifier/identity-vault",
+      "source-health thresholds",
+      "source registry",
+      "aggregate adapter runtime"
+    ]
+  },
+  "go_no_go_logic": {
+    "go_for_public_beta_launch": [
+      "deterministic evidence matrix passes",
+      "mvp closeout status is pass",
+      "source health is ready with release evidence pass",
+      "LUMA MVP readiness is pass",
+      "public-beta launch closeout is pass",
+      "launch copy has no forbidden claims",
+      "required human/operator/legal approvals are approved or explicitly not_required",
+      "support intake, private escalation, and rollback owners are assigned"
+    ],
+    "hold_external_approval_pending": [
+      "engineering evidence passes but any required approval, owner, or launch-copy field is pending"
+    ],
+    "blocked_engineering_evidence": [
+      "any deterministic release gate fails"
+    ]
+  }
+}

--- a/docs/reports/mvp-public-beta-launch-control-2026-05-13.md
+++ b/docs/reports/mvp-public-beta-launch-control-2026-05-13.md
@@ -1,0 +1,158 @@
+# MVP Public Beta Launch Control Packet
+
+Date: 2026-05-13
+Created at: 2026-05-13T01:51:53Z
+Branch: `coord/mvp-public-beta-launch-control-v1`
+Release-control commit: `9eb58154a321ee202095cfdb7d02fce67fb4cab3`
+Release-control base: `origin/main` after PR #627 merge
+RC packet: `docs/reports/mvp-public-beta-release-candidate-2026-05-12.md`
+Node: `v20.20.0`
+pnpm: `9.7.1`
+Repo dirty state during engineering evidence: clean
+
+Verification timing: the deterministic MVP/LUMA/Mesh evidence matrix was rerun on the clean release-control commit before this docs-only launch-control packet was added. After the packet edit, the docs/diff checks were rerun against the branch diff.
+
+## Final Status
+
+`hold_external_approval_pending`
+
+Engineering evidence passed on the release-control commit for the implemented Web PWA MVP public-beta scope. Launch is held because release-owner approval, external/legal disposition, launch-copy approval, support/private-escalation ownership, and rollback ownership have not been supplied in this repo packet. Do not infer signoff from green engineering evidence.
+
+Status may move to `go_for_public_beta_launch` only when every required approval/owner field below is approved, assigned, or explicitly marked `not_required` by the release owner.
+
+## Evidence Summary
+
+| Evidence | Command | Result | Report or note |
+| --- | --- | --- | --- |
+| Public beta launch closeout | `pnpm check:public-beta-launch-closeout` | PASS | `docs/ops/public-beta-launch-readiness-closeout.md` |
+| MVP release gates | `pnpm check:mvp-release-gates` | PASS, 14/14 gates | `.tmp/mvp-release-gates/latest/mvp-release-gates-report.json` |
+| MVP consolidated closeout | `pnpm check:mvp-closeout` | PASS | `.tmp/mvp-closeout/latest/mvp-closeout-report.json` |
+| Launch content snapshot | `pnpm check:launch-content-snapshot` | PASS | `.tmp/launch-content-snapshot/latest/launch-content-snapshot-report.json` |
+| Public beta compliance | `pnpm check:public-beta-compliance` | PASS | `tools/scripts/check-public-beta-compliance.mjs` |
+| LUMA public-beta MVP readiness | `pnpm check:luma:mvp-production-readiness` | PASS | `.tmp/luma-mvp-production-readiness/latest/luma-mvp-production-readiness-report.json` |
+| Source health | `pnpm check:news-sources:health` | READY; release evidence PASS; 5/5 ready window; 28 keep, 0 watch, 0 remove | `services/news-aggregator/.tmp/news-source-admission/latest/source-health-report.json` |
+| Documentation governance | `pnpm docs:check` | PASS | local command output |
+| Whitespace diff check | `git diff --check origin/main...HEAD` | PASS before and after packet edit | local command output |
+| Diff coverage guard | `node tools/scripts/check-diff-coverage.mjs` | PASS, no coverage-eligible source files changed | local command output |
+| Public namespace leaks | `pnpm check:public-namespace-leaks` | PASS | local command output |
+| LUMA mesh reader-path coverage | `pnpm test:mesh:luma-gated-write-coverage -- --mode local-e2e` | PASS | `.tmp/mesh-luma-gated-write-coverage/latest/mesh-luma-gated-write-coverage-report.json` |
+| Mesh aggregate boundary | `VH_MESH_SOAK_DURATION_MS=1800000 VH_MESH_LUMA_GATED_WRITE_COVERAGE_REPORT=.tmp/mesh-luma-gated-write-coverage/latest/mesh-luma-gated-write-coverage-report.json pnpm check:mesh:production-readiness` | Command exited 0; report remains `review_required` | `.tmp/mesh-production-readiness/latest/mesh-production-readiness-report.json` |
+| Production app canary boundary | `pnpm check:production-app-canary -- --mesh-report .tmp/mesh-production-readiness/latest/mesh-production-readiness-report.json` | EXPECTED BLOCKED, exit 1, `mesh_not_release_ready` | `.tmp/production-app-canary/latest/production-app-canary-report.json` |
+| Local product-loop rehearsal | `pnpm live:stack:up:analysis-stub`; `pnpm test:live:five-user-engagement`; `pnpm live:stack:down` | PASS; stack down PASS; five-user test 6.2m | local command output |
+
+## Engineering Evidence Details
+
+| Area | Status |
+| --- | --- |
+| MVP release gates | `overallStatus: pass`; 14 gates, 14 pass, failing gates `[]` |
+| MVP closeout | `status: pass`; blockers `[]` |
+| Source health | `readinessStatus: ready`; `releaseEvidence.status: pass`; `recentWindowRunCount: 5`; `recentReadyRunCount: 5`; `recentReviewRunCount: 0`; `recentBlockedRunCount: 0`; `keepSourceCount: 28`; `watchSourceCount: 0`; `removeSourceCount: 0`; `reasonCounts: {}` |
+| LUMA public-beta MVP | `status: pass`; `profile: public-beta`; blockers `[]` |
+| Mesh LUMA coverage | `status: pass`; `schema_epoch: post_luma_m0b`; `luma_profile: e2e`; failures `[]` |
+| Mesh readiness | `status: review_required`; `schema_epoch: post_luma_m0b`; `luma_profile: none`; blockers `public-wss-deployment-proof`, `required-write-class-sample-floors` |
+| Canonical Mesh soak | 30-minute duration satisfied; `soak_gate: pass`; `terminal_failures: 0`; `duplicate_canonical_writes: 0`; `repair_events: 0`; Mesh still remains `review_required` because sample floors are not satisfied |
+| Production app canary | `status: blocked`; `reason: mesh_not_release_ready`; downstream observation `not_run`; downstream reason `prerequisites_blocked` |
+| Launch rehearsal | PASS against local `analysis-stub` stack; five beta-local users exercised feed/detail/stance/thread activity and aggregate readback |
+
+## Release Copy
+
+Allowed launch copy:
+
+- "Web PWA MVP public beta candidate for the implemented scope."
+- "MVP release gates passed."
+- "Source health passed the complete release evidence window."
+- "LUMA public-beta is MVP-production-ready as a fail-closed beta-local identity and signed-write layer."
+- "Local analysis-stub five-user feed/detail/stance/thread rehearsal passed."
+- "Mesh production readiness remains separate and is currently review_required."
+
+Forbidden launch copy:
+
+- Mesh `release_ready`.
+- Production app canary pass.
+- Downstream production app surfaces observed end to end.
+- Full production app readiness.
+- Test-group readiness.
+- Legal or commercial approval unless explicitly recorded.
+- Production-grade live headline freshness unless StoryCluster production readiness separately says `release_ready`.
+- LUMA Silver, verified-human identity, one-human-one-vote, Sybil resistance, or production attestation.
+- Public WSS proof satisfied unless the Mesh report says so.
+- Mesh sample floors satisfied unless the Mesh report says so.
+- Native App Store or TestFlight readiness.
+- Private support desk or SLA unless externally provisioned.
+
+## Approval Table
+
+| Approval or owner | Name, team, or reference | Approval status | Timestamp | Notes |
+| --- | --- | --- | --- | --- |
+| Release owner | Pending | `pending` | Pending | Required before public launch. |
+| External/legal approval | Pending | `pending` | Pending | This packet records no legal, commercial, or external distribution approval. |
+| Launch copy approval | Pending | `pending` | Pending | Only the bounded copy above is allowed until approved by the release owner. |
+| Support intake owner | Pending | `pending` | Pending | Public issue intake path exists through the Web PWA `/support` surface and VHC public beta GitHub Issue Form; owner assignment is pending. |
+| Private escalation owner | Pending | `pending` | Pending | Private escalation channel/reference remains outside repo automation and must be supplied before launch. |
+| Rollback owner | Pending | `pending` | Pending | Owner assignment is pending. Engineering rollback path is documented below but is not an owner signoff. |
+
+## Support And Escalation
+
+Public intake path: Web PWA `/support` surface linked to the VHC public beta GitHub Issue Form.
+
+Private escalation path: pending release-owner/operator confirmation. Do not claim a private support desk, SLA, legal intake, or staffed escalation channel until the release owner records the external reference.
+
+Minimum expected escalation classes before launch:
+
+- deletion, correction, copyright, attribution, abuse, safety, account, and access issues that cannot safely remain in a public GitHub issue;
+- engineering incidents that invalidate any deterministic gate in this packet;
+- launch-copy or public-claim issues that imply a forbidden claim.
+
+## Rollback Path
+
+Rollback owner: pending.
+
+Rollback triggers:
+
+- any deterministic evidence rerun fails before launch;
+- launch copy includes a forbidden claim;
+- required approval is rejected or remains pending for the intended distribution path;
+- support/escalation or rollback ownership remains unassigned;
+- a public-beta incident requires halting distribution or correcting public claims.
+
+Engineering rollback path:
+
+- hold or withdraw public launch copy;
+- keep the Web PWA at the last approved public-beta candidate state;
+- revert or supersede this launch-control packet if it records an incorrect approval or claim boundary;
+- keep Mesh production readiness, production app canary, full-app readiness, test-group readiness, native readiness, and legal/commercial approval as separate gates.
+
+## Runtime And Scope Boundaries
+
+This launch-control branch adds no runtime changes.
+
+The merged RC history includes one narrow tested runtime readback fix in `packages/gun-client/src/aggregateAdapters.ts` for nested LUMA signed-write envelope relation pointers. That fix belongs to PR #627 and is part of the release-control base.
+
+This packet makes no changes to:
+
+- app runtime;
+- relay runtime;
+- Mesh readiness implementation;
+- production app canary implementation;
+- LUMA runtime, schema, custody, envelope, signed-write, provider, identifier, or identity-vault surfaces;
+- source-health thresholds or source registry;
+- aggregate adapter runtime.
+
+## Go/No-Go Rule
+
+`go_for_public_beta_launch` requires all of the following:
+
+- deterministic evidence matrix passes;
+- MVP closeout status is `pass`;
+- source health is `ready` with release evidence `pass`;
+- LUMA MVP readiness is `pass`;
+- public-beta launch closeout is `pass`;
+- launch copy has no forbidden claims;
+- required human/operator/legal approvals are approved or explicitly `not_required`;
+- support intake, private escalation, and rollback owners are assigned.
+
+`hold_external_approval_pending` applies when engineering evidence passes but any required approval, owner, or launch-copy field remains pending.
+
+`blocked_engineering_evidence` applies if any deterministic release gate fails.
+
+Current decision: `hold_external_approval_pending`.


### PR DESCRIPTION
## Summary
- Adds the MVP public-beta launch-control packet at `docs/reports/mvp-public-beta-launch-control-2026-05-13.md` plus a machine-readable JSON mirror.
- Updates `docs/ops/public-beta-launch-readiness-closeout.md` to point release owners at the launch-control decision artifact.
- Final launch-control status is `hold_external_approval_pending`: engineering evidence is green for the implemented Web PWA MVP public-beta scope, but required human/operator/legal/copy/support/escalation/rollback fields are pending.

## Base / Head
- Base commit: `9eb58154a321ee202095cfdb7d02fce67fb4cab3` (`origin/main` after PR #627 merge)
- Head commit: `421e4811` (`coord/mvp-public-beta-launch-control-v1`)
- Launch-control note: `docs/reports/mvp-public-beta-launch-control-2026-05-13.md`
- Launch-control JSON: `docs/reports/mvp-public-beta-launch-control-2026-05-13.json`

## Final Status
- `hold_external_approval_pending`
- Reason: deterministic engineering evidence passed, but release-owner approval, external/legal disposition, launch-copy approval, support/private-escalation ownership, and rollback ownership are not supplied in this repo packet.
- This PR does not fake signoff and does not convert the candidate to `go_for_public_beta_launch`.

## Evidence Command Matrix
Full deterministic evidence was rerun on the clean release-control commit before adding this docs-only packet, because the LUMA/Mesh/MVP evidence readers are commit-clean and evidence-commit bound.

- `pnpm check:public-beta-launch-closeout` PASS
- `pnpm check:mvp-release-gates` PASS, 14/14 gates
- `pnpm check:mvp-closeout` PASS
- `pnpm check:launch-content-snapshot` PASS
- `pnpm check:public-beta-compliance` PASS
- `pnpm check:luma:mvp-production-readiness` PASS
- `pnpm check:news-sources:health` PASS: `ready`, release evidence `pass`, 5/5 ready window, 28 keep / 0 watch / 0 remove
- `pnpm docs:check` PASS
- `git diff --check origin/main...HEAD` PASS
- `node tools/scripts/check-diff-coverage.mjs` PASS, no coverage-eligible source files changed
- `pnpm check:public-namespace-leaks` PASS
- `pnpm test:mesh:luma-gated-write-coverage -- --mode local-e2e` PASS
- `VH_MESH_SOAK_DURATION_MS=1800000 VH_MESH_LUMA_GATED_WRITE_COVERAGE_REPORT=.tmp/mesh-luma-gated-write-coverage/latest/mesh-luma-gated-write-coverage-report.json pnpm check:mesh:production-readiness` exited 0 and produced honest `review_required`
- `pnpm check:production-app-canary -- --mesh-report .tmp/mesh-production-readiness/latest/mesh-production-readiness-report.json` expected exit 1; report `blocked`, reason `mesh_not_release_ready`
- `pnpm live:stack:up:analysis-stub` PASS
- `pnpm test:live:five-user-engagement` PASS, 6.2m
- `pnpm live:stack:down` PASS

Post-packet docs-diff rerun on the committed docs branch:
- `pnpm docs:check` PASS
- `git diff --check origin/main...HEAD` PASS
- `node tools/scripts/check-diff-coverage.mjs` PASS
- `pnpm check:public-beta-launch-closeout` PASS
- `pnpm check:public-namespace-leaks` PASS

## Approval Table Summary
- Release owner: pending
- External/legal approval: pending
- Launch copy approval: pending
- Support intake owner: pending; public intake path exists through `/support` and the VHC public beta GitHub Issue Form
- Private escalation owner/channel: pending
- Rollback owner: pending

Because these required approval/owner fields are pending, final status remains `hold_external_approval_pending`.

## Support / Escalation / Rollback
- Public support intake path: Web PWA `/support` surface linked to the VHC public beta GitHub Issue Form.
- Private escalation path: pending release-owner/operator confirmation; no private support desk or SLA is claimed.
- Rollback owner: pending.
- Engineering rollback path documented in the packet: hold or withdraw public launch copy, keep the Web PWA at the last approved public-beta candidate state, and revert or supersede the launch-control packet if it records an incorrect approval or claim boundary.

## Allowed Launch Copy
- "Web PWA MVP public beta candidate for the implemented scope."
- "MVP release gates passed."
- "Source health passed the complete release evidence window."
- "LUMA public-beta is MVP-production-ready as a fail-closed beta-local identity and signed-write layer."
- "Local analysis-stub five-user feed/detail/stance/thread rehearsal passed."
- "Mesh production readiness remains separate and is currently review_required."

## Forbidden Claims / Explicit Non-Claims
- No Mesh `release_ready` claim.
- No production app canary pass claim.
- No downstream production app surfaces observed end-to-end claim.
- No full production app readiness claim.
- No test-group readiness claim.
- No legal or commercial approval claim unless explicitly recorded.
- No production-grade live headline freshness claim unless StoryCluster production readiness separately says `release_ready`.
- No LUMA Silver, verified-human, one-human-one-vote, Sybil resistance, or production attestation claim.
- No public WSS proof satisfied claim unless the Mesh report says so.
- No Mesh sample floors satisfied claim unless the Mesh report says so.
- No native App Store/TestFlight readiness claim.
- No private support desk or SLA claim unless externally provisioned.

## Mesh / App / LUMA Boundaries
- Mesh remains `review_required` with blockers `public-wss-deployment-proof` and `required-write-class-sample-floors`.
- Production app canary remains blocked on `mesh_not_release_ready`; downstream observation is `not_run`.
- LUMA public-beta MVP readiness passes only as a fail-closed beta-local identity and signed-write layer.
- This branch adds no runtime changes.
- The merged PR #627 base includes one tested aggregate readback fix in `packages/gun-client/src/aggregateAdapters.ts` for nested LUMA signed-write envelope relation pointers. This branch does not add Mesh-readiness, relay, canary, LUMA runtime/schema/custody/envelope/signed-write/provider/identifier/identity-vault, source-health threshold/registry, or aggregate adapter runtime changes.
