### PR TITLE
MVP public beta go/no-go approval hold

### DIFF
--- a/docs/reports/mvp-public-beta-launch-control-2026-05-13.json
+++ b/docs/reports/mvp-public-beta-launch-control-2026-05-13.json
@@ -2,16 +2,22 @@
   "schema_version": "mvp-public-beta-launch-control-v1",
   "date": "2026-05-13",
   "created_at": "2026-05-13T01:51:53Z",
-  "branch": "coord/mvp-public-beta-launch-control-v1",
-  "release_control_commit": "9eb58154a321ee202095cfdb7d02fce67fb4cab3",
-  "release_control_base": "origin/main after PR #627 merge",
+  "updated_at": "2026-05-13T10:42:57Z",
+  "branch": "coord/mvp-public-beta-go-no-go-v1",
+  "release_control_commit": "bb120a2e376784475202d59552f4b04531ee798b",
+  "release_control_base": "origin/main after PR #628 merge",
   "rc_packet_path": "docs/reports/mvp-public-beta-release-candidate-2026-05-12.md",
   "node": "v20.20.0",
   "pnpm": "9.7.1",
   "repo_dirty_during_engineering_evidence": false,
-  "verification_timing": "The deterministic MVP/LUMA/Mesh evidence matrix was rerun on the clean release-control commit before this docs-only launch-control packet was added. After the packet edit, the docs/diff checks were rerun against the branch diff.",
+  "verification_timing": "The deterministic MVP/LUMA/Mesh evidence matrix was rerun on the clean PR #628-merged release-control commit before this docs-only go/no-go approval update was added. After the packet edit, the docs/diff/launch-control checks are rerun against the branch diff.",
   "final_status": "hold_external_approval_pending",
-  "status_reason": "Engineering evidence passed, but release-owner approval, external/legal disposition, launch-copy approval, support/private-escalation ownership, and rollback ownership are pending.",
+  "status_reason": "Engineering evidence passed, but release-owner approval, external/legal disposition, launch-copy approval, support/private-escalation ownership, and rollback ownership were not supplied in the release-owner/operator input for this update and no repo-local approval artifact was found.",
+  "approval_input_result": {
+    "required_approval_text_provided": false,
+    "repo_local_approval_artifact_found": false,
+    "decision_effect": "all required human/operator/legal/support/escalation/rollback fields remain pending"
+  },
   "evidence": {
     "public_beta_launch_closeout": {
       "command": "pnpm check:public-beta-launch-closeout",
@@ -74,6 +80,7 @@
       "command": "VH_MESH_SOAK_DURATION_MS=1800000 VH_MESH_LUMA_GATED_WRITE_COVERAGE_REPORT=.tmp/mesh-luma-gated-write-coverage/latest/mesh-luma-gated-write-coverage-report.json pnpm check:mesh:production-readiness",
       "command_exit": 0,
       "status": "review_required",
+      "run_id": "mesh-production-readiness-20260513T094337Z-cdda22f7",
       "schema_epoch": "post_luma_m0b",
       "luma_profile": "none",
       "blockers": [
@@ -104,8 +111,9 @@
       "stack_down_command": "pnpm live:stack:down",
       "stack_up_status": "pass",
       "test_status": "pass",
-      "test_duration": "6.2m",
-      "stack_down_status": "pass"
+      "test_duration": "6.1m",
+      "stack_down_status": "pass",
+      "latest_result": "pass_on_clean_rerun"
     }
   },
   "approvals": {
@@ -115,6 +123,7 @@
       "timestamp": null
     },
     "external_legal_approval": {
+      "requirement_disposition": "pending",
       "approval_status": "pending",
       "approver_reference": "pending",
       "timestamp": null

--- a/docs/reports/mvp-public-beta-launch-control-2026-05-13.md
+++ b/docs/reports/mvp-public-beta-launch-control-2026-05-13.md
@@ -2,23 +2,32 @@
 
 Date: 2026-05-13
 Created at: 2026-05-13T01:51:53Z
-Branch: `coord/mvp-public-beta-launch-control-v1`
-Release-control commit: `9eb58154a321ee202095cfdb7d02fce67fb4cab3`
-Release-control base: `origin/main` after PR #627 merge
+Go/no-go approval update at: 2026-05-13T10:42:57Z
+Branch: `coord/mvp-public-beta-go-no-go-v1`
+Release-control commit: `bb120a2e376784475202d59552f4b04531ee798b`
+Release-control base: `origin/main` after PR #628 merge
 RC packet: `docs/reports/mvp-public-beta-release-candidate-2026-05-12.md`
 Node: `v20.20.0`
 pnpm: `9.7.1`
 Repo dirty state during engineering evidence: clean
 
-Verification timing: the deterministic MVP/LUMA/Mesh evidence matrix was rerun on the clean release-control commit before this docs-only launch-control packet was added. After the packet edit, the docs/diff checks were rerun against the branch diff.
+Verification timing: the deterministic MVP/LUMA/Mesh evidence matrix was rerun on the clean PR #628-merged release-control commit before this docs-only go/no-go approval update was added. After the packet edit, the docs/diff/launch-control checks are rerun against the branch diff.
 
 ## Final Status
 
 `hold_external_approval_pending`
 
-Engineering evidence passed on the release-control commit for the implemented Web PWA MVP public-beta scope. Launch is held because release-owner approval, external/legal disposition, launch-copy approval, support/private-escalation ownership, and rollback ownership have not been supplied in this repo packet. Do not infer signoff from green engineering evidence.
+Engineering evidence passed on the release-control commit for the implemented Web PWA MVP public-beta scope. Launch is held because release-owner approval, external/legal disposition, launch-copy approval, support/private-escalation ownership, and rollback ownership were not supplied in the release-owner/operator input for this update and no repo-local approval artifact was found. Do not infer signoff from green engineering evidence.
 
 Status may move to `go_for_public_beta_launch` only when every required approval/owner field below is approved, assigned, or explicitly marked `not_required` by the release owner.
+
+## Approval Input Result
+
+Required approval text provided in this go/no-go update: none.
+
+Repo-local approval artifact found: none.
+
+Decision effect: all required human/operator/legal/support/escalation/rollback fields remain pending, so the final launch-control status remains `hold_external_approval_pending`.
 
 ## Evidence Summary
 
@@ -36,9 +45,9 @@ Status may move to `go_for_public_beta_launch` only when every required approval
 | Diff coverage guard | `node tools/scripts/check-diff-coverage.mjs` | PASS, no coverage-eligible source files changed | local command output |
 | Public namespace leaks | `pnpm check:public-namespace-leaks` | PASS | local command output |
 | LUMA mesh reader-path coverage | `pnpm test:mesh:luma-gated-write-coverage -- --mode local-e2e` | PASS | `.tmp/mesh-luma-gated-write-coverage/latest/mesh-luma-gated-write-coverage-report.json` |
-| Mesh aggregate boundary | `VH_MESH_SOAK_DURATION_MS=1800000 VH_MESH_LUMA_GATED_WRITE_COVERAGE_REPORT=.tmp/mesh-luma-gated-write-coverage/latest/mesh-luma-gated-write-coverage-report.json pnpm check:mesh:production-readiness` | Command exited 0; report remains `review_required` | `.tmp/mesh-production-readiness/latest/mesh-production-readiness-report.json` |
+| Mesh aggregate boundary | `VH_MESH_SOAK_DURATION_MS=1800000 VH_MESH_LUMA_GATED_WRITE_COVERAGE_REPORT=.tmp/mesh-luma-gated-write-coverage/latest/mesh-luma-gated-write-coverage-report.json pnpm check:mesh:production-readiness` | Command exited 0; report remains `review_required`; run `mesh-production-readiness-20260513T094337Z-cdda22f7` | `.tmp/mesh-production-readiness/latest/mesh-production-readiness-report.json` |
 | Production app canary boundary | `pnpm check:production-app-canary -- --mesh-report .tmp/mesh-production-readiness/latest/mesh-production-readiness-report.json` | EXPECTED BLOCKED, exit 1, `mesh_not_release_ready` | `.tmp/production-app-canary/latest/production-app-canary-report.json` |
-| Local product-loop rehearsal | `pnpm live:stack:up:analysis-stub`; `pnpm test:live:five-user-engagement`; `pnpm live:stack:down` | PASS; stack down PASS; five-user test 6.2m | local command output |
+| Local product-loop rehearsal | `pnpm live:stack:up:analysis-stub`; `pnpm test:live:five-user-engagement`; `pnpm live:stack:down` | PASS on clean rerun; stack down PASS; five-user test 6.1m | local command output |
 
 ## Engineering Evidence Details
 
@@ -49,10 +58,10 @@ Status may move to `go_for_public_beta_launch` only when every required approval
 | Source health | `readinessStatus: ready`; `releaseEvidence.status: pass`; `recentWindowRunCount: 5`; `recentReadyRunCount: 5`; `recentReviewRunCount: 0`; `recentBlockedRunCount: 0`; `keepSourceCount: 28`; `watchSourceCount: 0`; `removeSourceCount: 0`; `reasonCounts: {}` |
 | LUMA public-beta MVP | `status: pass`; `profile: public-beta`; blockers `[]` |
 | Mesh LUMA coverage | `status: pass`; `schema_epoch: post_luma_m0b`; `luma_profile: e2e`; failures `[]` |
-| Mesh readiness | `status: review_required`; `schema_epoch: post_luma_m0b`; `luma_profile: none`; blockers `public-wss-deployment-proof`, `required-write-class-sample-floors` |
+| Mesh readiness | `status: review_required`; `schema_epoch: post_luma_m0b`; `luma_profile: none`; run `mesh-production-readiness-20260513T094337Z-cdda22f7`; blockers `public-wss-deployment-proof`, `required-write-class-sample-floors` |
 | Canonical Mesh soak | 30-minute duration satisfied; `soak_gate: pass`; `terminal_failures: 0`; `duplicate_canonical_writes: 0`; `repair_events: 0`; Mesh still remains `review_required` because sample floors are not satisfied |
 | Production app canary | `status: blocked`; `reason: mesh_not_release_ready`; downstream observation `not_run`; downstream reason `prerequisites_blocked` |
-| Launch rehearsal | PASS against local `analysis-stub` stack; five beta-local users exercised feed/detail/stance/thread activity and aggregate readback |
+| Launch rehearsal | PASS on clean rerun against local `analysis-stub` stack; five beta-local users exercised feed/detail/stance/thread activity and aggregate readback |
 
 ## Release Copy
 
@@ -85,7 +94,7 @@ Forbidden launch copy:
 | Approval or owner | Name, team, or reference | Approval status | Timestamp | Notes |
 | --- | --- | --- | --- | --- |
 | Release owner | Pending | `pending` | Pending | Required before public launch. |
-| External/legal approval | Pending | `pending` | Pending | This packet records no legal, commercial, or external distribution approval. |
+| External/legal approval | Requirement disposition pending; approver pending | `pending` | Pending | This update records no legal, commercial, or external distribution approval, and does not state whether approval is required or not required. |
 | Launch copy approval | Pending | `pending` | Pending | Only the bounded copy above is allowed until approved by the release owner. |
 | Support intake owner | Pending | `pending` | Pending | Public issue intake path exists through the Web PWA `/support` surface and VHC public beta GitHub Issue Form; owner assignment is pending. |
 | Private escalation owner | Pending | `pending` | Pending | Private escalation channel/reference remains outside repo automation and must be supplied before launch. |


### PR DESCRIPTION
## Summary

Updates the MVP public-beta launch-control packet with the final go/no-go approval state for the current handoff.

Final launch-control status remains `hold_external_approval_pending` because no release-owner/operator approval text was supplied or found for:

- release owner approval
- external/legal disposition
- launch-copy approval
- support intake owner
- private escalation owner/channel
- rollback owner/path

This is intentionally docs-only. It does not turn green engineering evidence into human/operator/legal signoff.

## Base And Packet

- Base commit after PR #628 merge: `bb120a2e376784475202d59552f4b04531ee798b`
- Branch/head evidence commit: `de1c1eb4457a77d1a1e664c1b24d162c6f520478`
- Launch-control note: `docs/reports/mvp-public-beta-launch-control-2026-05-13.md`
- Machine-readable packet: `docs/reports/mvp-public-beta-launch-control-2026-05-13.json`

## Approval Table Summary

| Field | Status | Notes |
| --- | --- | --- |
| Release owner | `pending` | No name/team or approval timestamp supplied. |
| External/legal | `pending` | Requirement disposition is also pending; no approval/not-required reference supplied. |
| Launch copy approval | `pending` | Bounded copy remains allowed but not approved by a release owner. |
| Support intake owner | `pending` | Public intake path exists through Web PWA `/support` and the public beta GitHub Issue Form, but owner assignment is pending. |
| Private escalation | `pending` | Owner/channel/reference not supplied. |
| Rollback owner/path | `pending` | Engineering rollback path is documented, but owner signoff is pending. |

## Final Evidence Matrix

All final command-sensitive evidence below was refreshed on branch head `de1c1eb4457a77d1a1e664c1b24d162c6f520478` unless noted.

- `pnpm check:public-beta-launch-closeout` PASS
- `pnpm check:mvp-release-gates` PASS, 14/14 gates, failing gates `[]`
- `pnpm check:mvp-closeout` PASS
- `pnpm check:launch-content-snapshot` PASS
- `pnpm check:public-beta-compliance` PASS
- `pnpm check:luma:mvp-production-readiness` PASS
- `pnpm check:news-sources:health` READY, release evidence PASS, 5/5 ready window, 28 keep / 0 watch / 0 remove
- `pnpm docs:check` PASS
- `git diff --check origin/main...HEAD` PASS
- `node tools/scripts/check-diff-coverage.mjs` PASS, no coverage-eligible source files changed
- `pnpm check:public-namespace-leaks` PASS
- `pnpm test:mesh:luma-gated-write-coverage -- --mode local-e2e` PASS, `post_luma_m0b`, `luma_profile: e2e`
- `VH_MESH_SOAK_DURATION_MS=1800000 VH_MESH_LUMA_GATED_WRITE_COVERAGE_REPORT=.tmp/mesh-luma-gated-write-coverage/latest/mesh-luma-gated-write-coverage-report.json pnpm check:mesh:production-readiness` exit 0, final aggregate `review_required`, run `mesh-production-readiness-20260513T104727Z-dfc38c96`
- `pnpm check:production-app-canary -- --mesh-report .tmp/mesh-production-readiness/latest/mesh-production-readiness-report.json` expected blocked, exit 1, `mesh_not_release_ready`
- `pnpm live:stack:up:analysis-stub` PASS
- `pnpm test:live:five-user-engagement` PASS on final branch-head run, 6.2m
- `pnpm live:stack:down` PASS

## Allowed Launch Copy

- "Web PWA MVP public beta candidate for the implemented scope."
- "MVP release gates passed."
- "Source health passed the complete release evidence window."
- "LUMA public-beta is MVP-production-ready as a fail-closed beta-local identity and signed-write layer."
- "Local analysis-stub five-user feed/detail/stance/thread rehearsal passed."
- "Mesh production readiness remains separate and is currently review_required."

## Forbidden Claims / Explicit Non-Claims

This PR does not claim:

- Mesh `release_ready`
- production app canary pass
- downstream production app surfaces observed end-to-end
- full production app readiness
- test-group readiness
- legal/commercial approval
- production-grade live headline freshness
- LUMA Silver, verified-human, one-human-one-vote, Sybil resistance, or production attestation
- public WSS proof satisfied
- Mesh sample floors satisfied
- native App Store/TestFlight readiness
- private support desk or SLA

## Boundaries

Mesh remains `review_required` with blockers `public-wss-deployment-proof` and `required-write-class-sample-floors`.

Production app canary remains blocked on `mesh_not_release_ready`; downstream observation is `not_run` with `prerequisites_blocked`.

LUMA MVP readiness is `pass` only for the bounded public-beta MVP profile. This PR makes no LUMA runtime/schema/custody/envelope/signed-write/provider/identifier/identity-vault changes.

Protected-surface confirmation: changed files are limited to the launch-control Markdown/JSON reports. No app runtime, relay runtime, Mesh readiness implementation, production app canary implementation, LUMA runtime/schema/custody surfaces, source-health thresholds/registry, or aggregate adapter runtime changed.
