### PR TITLE
Follow up public-news release gates

### DIFF
--- a/apps/web-pwa/src/luma/system-writer-pin.json
+++ b/apps/web-pwa/src/luma/system-writer-pin.json
@@ -22,10 +22,18 @@
     },
     {
       "id": "vh-public-beta-news-system-writer-v3",
-      "status": "active",
+      "status": "retired",
       "publicKey": {
         "encoding": "spki-base64url",
         "material": "MCowBQYDK2VwAyEAv8YZ8WoDOfearavnNDQt98ndEzk5pqyeEz1KX6lDE1s"
+      }
+    },
+    {
+      "id": "vh-public-beta-news-system-writer-v4",
+      "status": "active",
+      "publicKey": {
+        "encoding": "spki-base64url",
+        "material": "MCowBQYDK2VwAyEAzcTUyVZKnSbCb8DhAyXWJYWH9drlLrmdGj0HZkjwjQU"
       }
     }
   ]

--- a/apps/web-pwa/src/store/store.test.ts
+++ b/apps/web-pwa/src/store/store.test.ts
@@ -170,7 +170,10 @@ describe('useAppStore', () => {
   });
 
   it('uses the public-beta news system writer as the baked distribution pin', () => {
-    expect(resolveClientSystemWriterPin().writers).toEqual(expect.arrayContaining([
+    const writers = resolveClientSystemWriterPin().writers;
+
+    expect(writers.filter((writer) => writer.status === 'active')).toHaveLength(1);
+    expect(writers).toEqual(expect.arrayContaining([
       expect.objectContaining({
         id: 'vh-public-beta-news-system-writer-v1',
         status: 'retired',
@@ -181,10 +184,18 @@ describe('useAppStore', () => {
       }),
       expect.objectContaining({
         id: 'vh-public-beta-news-system-writer-v3',
-        status: 'active',
+        status: 'retired',
         publicKey: {
           encoding: 'spki-base64url',
           material: 'MCowBQYDK2VwAyEAv8YZ8WoDOfearavnNDQt98ndEzk5pqyeEz1KX6lDE1s',
+        },
+      }),
+      expect.objectContaining({
+        id: 'vh-public-beta-news-system-writer-v4',
+        status: 'active',
+        publicKey: {
+          encoding: 'spki-base64url',
+          material: 'MCowBQYDK2VwAyEAzcTUyVZKnSbCb8DhAyXWJYWH9drlLrmdGj0HZkjwjQU',
         },
       }),
     ]));

--- a/infra/relay/server.js
+++ b/infra/relay/server.js
@@ -1822,6 +1822,75 @@ function derivePublicFeedStoryState(story, synthesis, lifecycle) {
   };
 }
 
+const INCOMPLETE_PUBLIC_SYNTHESIS_LIFECYCLE_STATUSES = new Set([
+  'pending',
+  'in_progress',
+  'retryable_failure',
+]);
+
+function latestIndexStaleIncompleteLifecycleFilter() {
+  return {
+    enabled: boolEnv(
+      'VH_RELAY_NEWS_INDEX_HIDE_STALE_INCOMPLETE_LIFECYCLE',
+      process.env.NODE_ENV === 'production',
+    ),
+    staleWindowMs: numberEnv(
+      'VH_RELAY_NEWS_INDEX_INCOMPLETE_LIFECYCLE_STALE_MS',
+      numberEnv('VH_PUBLIC_FEED_SYNTHESIS_PENDING_STALE_MS', 7 * 24 * 60 * 60 * 1000),
+    ),
+    now: Date.now(),
+  };
+}
+
+function staleIncompleteLifecycleExclusion(entry, filter) {
+  if (!filter?.enabled) return null;
+  const story = entry?.story;
+  const storyState = entry?.storyState;
+  const storyId = String(entry?.entry?.[0] ?? story?.story_id ?? '').trim();
+  if (!storyId || !story || !storyState || typeof storyState !== 'object') return null;
+  const lifecycleStatus = String(storyState.lifecycle_status ?? '').trim();
+  if (!INCOMPLETE_PUBLIC_SYNTHESIS_LIFECYCLE_STATUSES.has(lifecycleStatus)) return null;
+  const lifecycleUpdatedAt = Number(storyState.lifecycle_updated_at);
+  const latestActivityAt = latestIndexRecordTimestamp(entry.entry?.[1])
+    ?? resolveLatestActivityFromStory(story)
+    ?? null;
+  const base = {
+    story_id: storyId,
+    latest_activity_at: latestActivityAt,
+    lifecycle_status: lifecycleStatus,
+    lifecycle_updated_at: Number.isFinite(lifecycleUpdatedAt) ? lifecycleUpdatedAt : null,
+    stale_window_ms: filter.staleWindowMs,
+  };
+  if (!Number.isFinite(lifecycleUpdatedAt) || lifecycleUpdatedAt <= 0) {
+    return {
+      ...base,
+      reason: 'synthesis_lifecycle_incomplete_missing_updated_at',
+    };
+  }
+  const ageMs = Math.max(0, Math.floor(filter.now - lifecycleUpdatedAt));
+  if (ageMs > filter.staleWindowMs) {
+    return {
+      ...base,
+      reason: 'synthesis_lifecycle_incomplete_stale',
+      lifecycle_age_ms: ageMs,
+    };
+  }
+  return null;
+}
+
+function hideStaleIncompleteLifecycleEntry(entry, filter) {
+  const exclusion = staleIncompleteLifecycleExclusion(entry, filter);
+  return exclusion ? { excluded: exclusion } : entry;
+}
+
+function exclusionReasonCounts(records) {
+  return records.reduce((acc, record) => {
+    const reason = String(record?.reason ?? 'unknown');
+    acc[reason] = (acc[reason] || 0) + 1;
+    return acc;
+  }, {});
+}
+
 function createFeedCompositionAccumulator(now = Date.now()) {
   return {
     total_visible: 0,
@@ -2167,6 +2236,8 @@ async function readNewsLatestIndexRecords(gun, options = {}) {
   const repairedRecords = [];
   const compositionNow = Date.now();
   const composition = createFeedCompositionAccumulator(compositionNow);
+  const staleIncompleteFilter = latestIndexStaleIncompleteLifecycleFilter();
+  staleIncompleteFilter.now = compositionNow;
   const entries = await mapWithConcurrency(keys, concurrency, async (storyId) => {
     const direct = readableRoot && typeof readableRoot === 'object' && storyId in readableRoot
       ? stripGunMetadata(readableRoot[storyId])
@@ -2213,7 +2284,10 @@ async function readNewsLatestIndexRecords(gun, options = {}) {
     if (record !== null && record !== undefined && latestIndexRecordHasTimestamp(record)) {
       const metadataStatus = latestIndexProductMetadataStatus(record, storyResult.story);
       if (metadataStatus === 'complete') {
-        return { entry: [storyId, record], story: storyResult.story, storyState };
+        return hideStaleIncompleteLifecycleEntry(
+          { entry: [storyId, record], story: storyResult.story, storyState },
+          staleIncompleteFilter,
+        );
       }
       const synthesized = synthesizeLatestIndexRecordFromStory(
         storyId,
@@ -2221,9 +2295,10 @@ async function readNewsLatestIndexRecords(gun, options = {}) {
         fallbackLatestActivityAt,
       );
       return {
-        entry: [storyId, synthesized],
-        story: storyResult.story,
-        storyState,
+        ...hideStaleIncompleteLifecycleEntry(
+          { entry: [storyId, synthesized], story: storyResult.story, storyState },
+          staleIncompleteFilter,
+        ),
         repaired: {
           story_id: storyId,
           reason: `latest_index_product_metadata_${metadataStatus}_from_story_body`,
@@ -2238,9 +2313,10 @@ async function readNewsLatestIndexRecords(gun, options = {}) {
       fallbackLatestActivityAt,
     );
     return {
-      entry: [storyId, synthesized],
-      story: storyResult.story,
-      storyState,
+      ...hideStaleIncompleteLifecycleEntry(
+        { entry: [storyId, synthesized], story: storyResult.story, storyState },
+        staleIncompleteFilter,
+      ),
       repaired: {
         story_id: storyId,
         reason: record === null || record === undefined
@@ -2284,9 +2360,14 @@ async function readNewsLatestIndexRecords(gun, options = {}) {
   const chronologicalPageEntries = visibleEntries.slice(0, maxRecords);
   const selectedEntries = [...chronologicalPageEntries];
   const compositionBackfillRecords = [];
+  const compositionBackfillMinLimit = positiveInteger(
+    options.compositionBackfillMinLimit,
+    numberEnv('VH_RELAY_NEWS_INDEX_COMPOSITION_BACKFILL_MIN_LIMIT', 12),
+  );
   const shouldBackfillCorroboratedStory =
     consistencyFilter
     && !hasBeforeCursor
+    && maxRecords >= compositionBackfillMinLimit
     && selectedEntries.length > 0
     && selectedEntries.every((entry) => storySourceCount(entry.story) <= 1);
   if (shouldBackfillCorroboratedStory) {
@@ -2334,11 +2415,17 @@ async function readNewsLatestIndexRecords(gun, options = {}) {
       mode: consistencyFilter ? 'relay_visible_filter' : 'disabled',
       scan_limit: keys.length,
       excluded_count: excludedRecords.length,
+      excluded_reason_counts: exclusionReasonCounts(excludedRecords),
       repaired_count: repairedRecords.length,
       story_body_timeout_ms: consistencyFilter ? storyTimeoutMs : null,
       latest_index_source_key_count: latestSourceKeys.length,
       story_fallback_enabled: Boolean(consistencyFilter && storyFallbackEnabled),
       story_fallback_key_count: storyFallbackKeys.length,
+      stale_incomplete_lifecycle_filter: {
+        enabled: Boolean(staleIncompleteFilter.enabled),
+        stale_window_ms: staleIncompleteFilter.staleWindowMs,
+      },
+      composition_backfill_min_limit: compositionBackfillMinLimit,
     },
     composition: addFeedCompositionWindowFields(finalizeFeedComposition(composition), {
       organicEntries: chronologicalPageEntries,
@@ -2370,6 +2457,7 @@ function latestIndexRestCacheKey(options = {}) {
     includeExcluded: Boolean(options.includeExcluded),
     consistencyFilter: options.consistencyFilter === false ? false : true,
     scanLimit: options.scanLimit ?? null,
+    compositionBackfillMinLimit: options.compositionBackfillMinLimit ?? null,
     before: latestIndexParsedBefore(options),
   });
 }
@@ -2862,7 +2950,7 @@ async function buildNewsLatestIndexResultFromSnapshot(gun, snapshot, options = {
   );
   const beforeCursor = latestIndexParsedBefore(options);
   const hasBeforeCursor = beforeCursor !== null;
-  const visibleEntries = (Array.isArray(snapshot.entries) ? snapshot.entries : [])
+  const orderedSnapshotEntries = (Array.isArray(snapshot.entries) ? snapshot.entries : [])
     .filter((entry) => {
       const timestamp = latestIndexRecordTimestamp(entry.entry?.[1]);
       return !hasBeforeCursor || (Number.isFinite(timestamp) && timestamp < beforeCursor);
@@ -2872,11 +2960,24 @@ async function buildNewsLatestIndexResultFromSnapshot(gun, snapshot, options = {
       const rightTimestamp = latestIndexRecordTimestamp(right.entry?.[1]) ?? 0;
       return rightTimestamp - leftTimestamp || String(left.entry?.[0] ?? '').localeCompare(String(right.entry?.[0] ?? ''));
     });
+  const staleIncompleteFilter = latestIndexStaleIncompleteLifecycleFilter();
+  const excludedRecords = [];
+  const visibleEntries = [];
+  for (const entry of orderedSnapshotEntries) {
+    const exclusion = staleIncompleteLifecycleExclusion(entry, staleIncompleteFilter);
+    if (exclusion) excludedRecords.push(exclusion);
+    else visibleEntries.push(entry);
+  }
   const chronologicalPageEntries = visibleEntries.slice(0, maxRecords);
   let selectedEntries = [...chronologicalPageEntries];
   const compositionBackfillRecords = [];
+  const compositionBackfillMinLimit = positiveInteger(
+    options.compositionBackfillMinLimit,
+    numberEnv('VH_RELAY_NEWS_INDEX_COMPOSITION_BACKFILL_MIN_LIMIT', 12),
+  );
   const shouldBackfillCorroboratedStory =
     !hasBeforeCursor
+    && maxRecords >= compositionBackfillMinLimit
     && selectedEntries.length > 0
     && selectedEntries.every((entry) => storySourceCount(entry.story) <= 1);
   if (shouldBackfillCorroboratedStory) {
@@ -2930,6 +3031,13 @@ async function buildNewsLatestIndexResultFromSnapshot(gun, snapshot, options = {
       empty_read_cache: cacheInfo,
       snapshot_story_body_readback: bodyReadbackResult.info,
       snapshot_story_state_refresh: refreshResult.info,
+      excluded_count: excludedRecords.length,
+      excluded_reason_counts: exclusionReasonCounts(excludedRecords),
+      stale_incomplete_lifecycle_filter: {
+        enabled: Boolean(staleIncompleteFilter.enabled),
+        stale_window_ms: staleIncompleteFilter.staleWindowMs,
+      },
+      composition_backfill_min_limit: compositionBackfillMinLimit,
     },
     composition: addFeedCompositionWindowFields(finalizeFeedComposition(composition), {
       organicEntries: chronologicalPageEntries,
@@ -2938,7 +3046,7 @@ async function buildNewsLatestIndexResultFromSnapshot(gun, snapshot, options = {
       now: compositionNow,
     }),
     storyStates,
-    excludedRecords: [],
+    excludedRecords,
     repairedRecords: snapshot.repairedRecords ?? [],
     compositionBackfillRecords,
     records,
@@ -2951,16 +3059,26 @@ async function readNewsLatestIndexRecordsWithEmptyRetry(gun, options = {}) {
   const retryAttempts = Math.max(1, numberEnv('VH_RELAY_NEWS_INDEX_REST_EMPTY_RETRY_ATTEMPTS', 1));
   const retryDelayMs = Math.max(0, numberEnv('VH_RELAY_NEWS_INDEX_REST_EMPTY_RETRY_DELAY_MS', 250));
   const cacheTtlMs = Math.max(0, numberEnv('VH_RELAY_NEWS_INDEX_REST_EMPTY_CACHE_TTL_MS', 5 * 60_000));
+  const snapshotMaxAgeMs = Math.max(
+    0,
+    numberEnv('VH_RELAY_NEWS_INDEX_SNAPSHOT_MAX_AGE_MS', 24 * 60 * 60 * 1000),
+  );
   const cacheKey = latestIndexRestCacheKey(options);
   const snapshotCacheKey = latestIndexSnapshotCacheKey(options);
-  if (boolEnv('VH_RELAY_NEWS_INDEX_REST_PREFER_SNAPSHOT', false)) {
+  if (boolEnv('VH_RELAY_NEWS_INDEX_REST_PREFER_SNAPSHOT', process.env.NODE_ENV === 'production')) {
     const snapshot = newsLatestIndexSnapshotCache.get(snapshotCacheKey)
-      ?? readPersistedNewsLatestIndexSnapshot(snapshotCacheKey, cacheTtlMs);
-    if (snapshot && Array.isArray(snapshot.entries) && snapshot.entries.length > 0) {
+      ?? readPersistedNewsLatestIndexSnapshot(snapshotCacheKey, snapshotMaxAgeMs);
+    if (
+      snapshot
+      && Array.isArray(snapshot.entries)
+      && snapshot.entries.length > 0
+      && (snapshotMaxAgeMs <= 0 || Date.now() - snapshot.cached_at <= snapshotMaxAgeMs)
+    ) {
       return buildNewsLatestIndexResultFromSnapshot(gun, snapshot, options, {
         served_from: 'preferred_latest_index_snapshot',
         cached_at: snapshot.cached_at,
         age_ms: Date.now() - snapshot.cached_at,
+        snapshot_max_age_ms: snapshotMaxAgeMs,
       });
     }
   }
@@ -3004,12 +3122,13 @@ async function readNewsLatestIndexRecordsWithEmptyRetry(gun, options = {}) {
           };
         }
         const snapshot = newsLatestIndexSnapshotCache.get(snapshotCacheKey)
-          ?? readPersistedNewsLatestIndexSnapshot(snapshotCacheKey, cacheTtlMs);
-        if (snapshot && Date.now() - snapshot.cached_at <= cacheTtlMs) {
+          ?? readPersistedNewsLatestIndexSnapshot(snapshotCacheKey, snapshotMaxAgeMs);
+        if (snapshot && (snapshotMaxAgeMs <= 0 || Date.now() - snapshot.cached_at <= snapshotMaxAgeMs)) {
           return buildNewsLatestIndexResultFromSnapshot(gun, snapshot, options, {
             served_from: 'last_non_empty_latest_index_snapshot',
             cached_at: snapshot.cached_at,
             age_ms: Date.now() - snapshot.cached_at,
+            snapshot_max_age_ms: snapshotMaxAgeMs,
           });
         }
       }
@@ -3087,6 +3206,7 @@ async function readNewsHotIndexRecords(gun, options = {}) {
   const mergedEntries = [...visibleEntries];
   const seenStoryIds = new Set(mergedEntries.map((entry) => String(entry[0])));
   let latestFallbackInfo = null;
+  let latestFallbackVisibleStoryIds = null;
   if (maxRecords > 0) {
     const latestFallback = await readNewsLatestIndexRecordsWithEmptyRetry(gun, {
       limit: maxRecords,
@@ -3100,6 +3220,7 @@ async function readNewsHotIndexRecords(gun, options = {}) {
       return null;
     });
     if (latestFallback) {
+      latestFallbackVisibleStoryIds = new Set(Object.keys(latestFallback.records ?? {}));
       let added = 0;
       for (const [storyId, story] of Object.entries(latestFallback.stories ?? {})) {
         const hotRecord = synthesizeHotIndexRecordFromStory(storyId, story);
@@ -3125,7 +3246,21 @@ async function readNewsHotIndexRecords(gun, options = {}) {
       };
     }
   }
-  const sortedEntries = mergedEntries
+  const visibleLatestOnly = boolEnv(
+    'VH_RELAY_NEWS_HOT_INDEX_REST_VISIBLE_LATEST_ONLY',
+    process.env.NODE_ENV === 'production',
+  );
+  const responseEntries = visibleLatestOnly && latestFallbackVisibleStoryIds && latestFallbackVisibleStoryIds.size > 0
+    ? mergedEntries.filter((entry) => latestFallbackVisibleStoryIds.has(String(entry[0])))
+    : mergedEntries;
+  if (latestFallbackInfo && visibleLatestOnly && latestFallbackVisibleStoryIds) {
+    latestFallbackInfo = {
+      ...latestFallbackInfo,
+      visible_latest_only: true,
+      visible_latest_story_count: latestFallbackVisibleStoryIds.size,
+    };
+  }
+  const sortedEntries = responseEntries
     .sort((left, right) =>
       (hotIndexRecordHotness(right[1]) ?? 0) - (hotIndexRecordHotness(left[1]) ?? 0)
       || String(left[0]).localeCompare(String(right[0])),
@@ -4364,7 +4499,11 @@ const server = http.createServer((req, res) => {
       : undefined;
     const scanLimit = parsedUrl.searchParams.get('scan_limit');
     const before = parsedUrl.searchParams.get('before');
-    void readNewsLatestIndexRecordsWithEmptyRetry(gun, { limit, includeRoot, includeExcluded, consistencyFilter, scanLimit, before })
+    const compositionBackfillMinLimit = parsedUrl.searchParams.get('composition_backfill_min_limit');
+    void readNewsLatestIndexRecordsWithEmptyRetry(
+      gun,
+      { limit, includeRoot, includeExcluded, consistencyFilter, scanLimit, before, compositionBackfillMinLimit },
+    )
       .then((result) => {
         const payload = {
           ok: true,

--- a/packages/e2e/src/live/public-feed-browser-smoke.mjs
+++ b/packages/e2e/src/live/public-feed-browser-smoke.mjs
@@ -1983,6 +1983,30 @@ async function readPublicNewsStoreSnapshot(page) {
   }).catch(() => null);
 }
 
+function publicNewsStoreHasPreloadedMeshWindow(snapshot, meshIndexCount) {
+  const expectedCount = Math.max(0, Math.floor(Number(meshIndexCount) || 0));
+  if (expectedCount <= 0 || !snapshot || typeof snapshot !== 'object') return false;
+  const latestIndexCount = Number(snapshot.latestIndexCount);
+  const storyCount = Number(snapshot.storyCount);
+  return Number.isFinite(latestIndexCount)
+    && Number.isFinite(storyCount)
+    && latestIndexCount >= expectedCount
+    && storyCount >= expectedCount;
+}
+
+function shouldRejectScrollGrowthWithoutMeshRefresh({
+  meshIndexCount,
+  initialVisibleCount,
+  newVisibleStoryCount,
+  loadMoreRefreshCallCount,
+  beforeScrollNewsStore,
+}) {
+  return meshIndexCount > initialVisibleCount
+    && newVisibleStoryCount > 0
+    && loadMoreRefreshCallCount === 0
+    && !publicNewsStoreHasPreloadedMeshWindow(beforeScrollNewsStore, meshIndexCount);
+}
+
 async function waitForPublicNewsStoreIdle(page, timeoutMs, progress, label) {
   const startedAt = Date.now();
   const result = await page.waitForFunction(() => {
@@ -3238,6 +3262,7 @@ async function runPublicFeedBrowserSmoke({
     const afterScrollNewStoryIds = afterScrollCards
       .map((card) => card.storyId)
       .filter((storyId) => storyId && !initialStoryIds.has(storyId));
+    const preloadedMeshWindow = publicNewsStoreHasPreloadedMeshWindow(beforeScrollNewsStore, meshIndexCount);
     progress('scroll-screenshot', {
       count: afterScrollCards.length,
       newStoryIds: afterScrollNewStoryIds.slice(0, 12),
@@ -3245,11 +3270,18 @@ async function runPublicFeedBrowserSmoke({
       initialCount: initialCards.length,
       beforeScrollNewsStore,
       afterScrollNewsStore,
+      preloadedMeshWindow,
       refreshRecorder,
       loadMoreRefreshCalls: loadMoreRefreshCalls.slice(0, 12),
     });
     if (afterScrollCards.length < minHeadlines) throw new Error(`scroll-feed-lost-headlines:${afterScrollCards.length}/${minHeadlines}`);
-    if (meshIndexCount > initialCards.length && afterScrollNewStoryIds.length > 0 && loadMoreRefreshCalls.length === 0) {
+    if (shouldRejectScrollGrowthWithoutMeshRefresh({
+      meshIndexCount,
+      initialVisibleCount: initialCards.length,
+      newVisibleStoryCount: afterScrollNewStoryIds.length,
+      loadMoreRefreshCallCount: loadMoreRefreshCalls.length,
+      beforeScrollNewsStore,
+    })) {
       throw new Error(`public-feed-load-more-not-from-mesh:${afterScrollCards.length}/${initialCards.length}/${meshIndexCount}:preloaded-window`);
     }
     if (meshIndexCount > initialCards.length && afterScrollNewStoryIds.length === 0) {
@@ -3444,6 +3476,8 @@ async function runPublicFeedBrowserSmoke({
       checks: {
         daemonGunLatestIndexReadback: gunReadback,
         publicRelaySynthesisReadback,
+        publicRelayAnalysisFrameCoverage,
+        publicRelayPaginationReadback,
         publicRelayRestDiagnostics: publicRelayRestDiagnostics.summary(),
         deployedSystemWriterPin: systemWriterPinResolution.evidence,
         identityCreation: identity,
@@ -3558,6 +3592,8 @@ export const publicFeedBrowserSmokeInternal = {
   installRefreshLatestRecorder,
   readRefreshLatestRecorder,
   readPublicNewsStoreSnapshot,
+  publicNewsStoreHasPreloadedMeshWindow,
+  shouldRejectScrollGrowthWithoutMeshRefresh,
   findVisibleStoryRow,
   summarizeBrowserLogDiagnostics,
   waitForInitialOpenHeadlines,

--- a/packages/e2e/src/live/public-feed-browser-smoke.mjs
+++ b/packages/e2e/src/live/public-feed-browser-smoke.mjs
@@ -32,6 +32,14 @@ const DEFAULT_PUBLIC_RELAY_SYNTHESIS_INDEX_LIMIT = 80;
 const DEFAULT_PUBLIC_FEED_MVP_FRESHNESS_WINDOW_MS = 24 * 60 * 60 * 1000;
 const LOCAL_HOSTNAMES = new Set(['localhost', '127.0.0.1', '::1', '0.0.0.0']);
 const REST_DIAGNOSTIC_EXCERPT_MAX = 320;
+const REQUIRED_PUBLIC_RELAY_HTTP_ROUTES = Object.freeze([
+  '/vh/news/latest-index',
+  '/vh/news/hot-index',
+  '/vh/news/story',
+  '/vh/news/synthesis-lifecycle',
+  '/vh/topics/synthesis',
+  '/vh/aggregates/point',
+]);
 const SECRET_TEXT_PATTERNS = [
   /sk-[A-Za-z0-9_*=\\-]{8,}/g,
   /\bBearer\s+[A-Za-z0-9._~+/=-]+/gi,
@@ -895,6 +903,101 @@ async function fetchJsonWithTimeout(url, timeoutMs, label = 'public-relay-json',
   } finally {
     clearTimeout(timeout);
   }
+}
+
+function publicRelayHealthRequiresRouteSurface(origin, payload) {
+  const service = String(payload?.service ?? '').trim();
+  if (service === 'vh-relay') return true;
+  if (service === 'vh-public-beta-origin') return false;
+  try {
+    return new URL(origin).hostname.toLowerCase().startsWith('gun-');
+  } catch {
+    return false;
+  }
+}
+
+function normalizePublicHttpRoutes(value) {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((route) => String(route ?? '').trim())
+    .filter(Boolean);
+}
+
+async function readPublicRelayHealthReadbacks({
+  origins = [],
+  timeoutMs = 10_000,
+  restDiagnostics = null,
+} = {}) {
+  const normalizedOrigins = [...new Set(origins.map(normalizeUrl).filter(Boolean))];
+  const readbacks = [];
+  for (const origin of normalizedOrigins) {
+    const url = new URL('/healthz', origin);
+    try {
+      const payload = await fetchJsonWithTimeout(
+        url.href,
+        Math.max(1, Math.min(timeoutMs, 10_000)),
+        'public-relay-healthz',
+        restDiagnostics,
+      );
+      const publicHttpRoutes = normalizePublicHttpRoutes(payload?.public_http_routes);
+      const required = publicRelayHealthRequiresRouteSurface(origin, payload);
+      const failures = [];
+      if (required && payload?.route_surface !== 'vh-relay-http-v1') {
+        failures.push(`route_surface_missing_or_unexpected:${String(payload?.route_surface ?? 'missing')}`);
+      }
+      if (required) {
+        const missingRoutes = REQUIRED_PUBLIC_RELAY_HTTP_ROUTES.filter((route) => !publicHttpRoutes.includes(route));
+        if (missingRoutes.length > 0) {
+          failures.push(`public_http_routes_missing:${missingRoutes.join(',')}`);
+        }
+      }
+      const relayPeerCount = Number(payload?.relay_peer_count);
+      readbacks.push({
+        origin,
+        status: failures.length === 0 ? 'pass' : 'fail',
+        relayRouteSurfaceRequired: required,
+        service: payload?.service ?? null,
+        relayId: payload?.relay_id ?? null,
+        routeSurface: payload?.route_surface ?? null,
+        publicHttpRoutes,
+        relayPeerCount: Number.isFinite(relayPeerCount) ? relayPeerCount : null,
+        failures,
+      });
+    } catch (error) {
+      readbacks.push({
+        origin,
+        status: 'fail',
+        relayRouteSurfaceRequired: publicRelayHealthRequiresRouteSurface(origin, null),
+        service: null,
+        relayId: null,
+        routeSurface: null,
+        publicHttpRoutes: [],
+        relayPeerCount: null,
+        failures: [
+          `healthz_fetch_failed:${redactDiagnosticExcerpt(
+            error instanceof Error ? error.message : String(error),
+          )}`,
+        ],
+      });
+    }
+  }
+  const failedOrigins = readbacks.filter((readback) => readback.status !== 'pass');
+  return {
+    status: normalizedOrigins.length === 0
+      ? 'not_configured'
+      : failedOrigins.length === 0
+        ? 'pass'
+        : 'fail',
+    origins: normalizedOrigins,
+    originCount: normalizedOrigins.length,
+    requiredRouteSurface: 'vh-relay-http-v1',
+    requiredPublicHttpRoutes: [...REQUIRED_PUBLIC_RELAY_HTTP_ROUTES],
+    failedOrigins: failedOrigins.map((readback) => ({
+      origin: readback.origin,
+      failures: readback.failures,
+    })),
+    readbacks,
+  };
 }
 
 function parsePublicPointAggregatePayload(payload, pointId) {
@@ -3471,6 +3574,7 @@ export const publicFeedBrowserSmokeInternal = {
   loadRepoSystemWriterPin,
   latestIndexRecordsFromPayload,
   readPublicRelayLatestIndexPage,
+  readPublicRelayHealthReadbacks,
   readPublicRelayPaginationReadback,
   assertPublicRelayPaginationReadback,
   readPublicRelaySynthesisCandidates,

--- a/packages/e2e/src/live/public-feed-browser-smoke.vitest.mjs
+++ b/packages/e2e/src/live/public-feed-browser-smoke.vitest.mjs
@@ -289,6 +289,86 @@ describe('public feed browser smoke helpers', () => {
     }
   });
 
+  it('records public relay health route-surface diagnostics without requiring app-origin metadata', async () => {
+    const fetchMock = vi.fn(async (url) => {
+      const href = String(url);
+      if (href === 'https://gun-a.example/healthz') {
+        return new Response(JSON.stringify({
+          service: 'vh-relay',
+          relay_id: 'vh-public-beta-relay-a',
+          route_surface: 'vh-relay-http-v1',
+          public_http_routes: [
+            '/vh/news/latest-index',
+            '/vh/news/hot-index',
+            '/vh/news/story',
+            '/vh/news/synthesis-lifecycle',
+            '/vh/topics/synthesis',
+            '/vh/aggregates/point',
+          ],
+          relay_peer_count: 2,
+        }), { status: 200 });
+      }
+      if (href === 'https://gun-c.example/healthz') {
+        return new Response(JSON.stringify({
+          service: 'vh-relay',
+          relay_id: 'vh-public-beta-relay-c',
+          relay_peer_count: 2,
+        }), { status: 200 });
+      }
+      if (href === 'https://venn.example/healthz') {
+        return new Response(JSON.stringify({
+          service: 'vh-public-beta-origin',
+        }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ ok: false, href }), { status: 500 });
+    });
+    const restDiagnostics = internal.createRestDiagnosticsRecorder();
+    vi.stubGlobal('fetch', fetchMock);
+    try {
+      const readback = await internal.readPublicRelayHealthReadbacks({
+        origins: [
+          'https://gun-a.example',
+          'https://gun-c.example',
+          'https://venn.example',
+        ],
+        timeoutMs: 1_000,
+        restDiagnostics,
+      });
+
+      expect(readback).toMatchObject({
+        status: 'fail',
+        originCount: 3,
+        requiredRouteSurface: 'vh-relay-http-v1',
+        failedOrigins: [{
+          origin: 'https://gun-c.example/',
+          failures: expect.arrayContaining([
+            'route_surface_missing_or_unexpected:missing',
+            expect.stringContaining('public_http_routes_missing:/vh/news/latest-index'),
+          ]),
+        }],
+      });
+      expect(readback.readbacks.find((entry) => entry.origin === 'https://gun-a.example/')).toMatchObject({
+        status: 'pass',
+        relayRouteSurfaceRequired: true,
+        routeSurface: 'vh-relay-http-v1',
+        publicHttpRoutes: expect.arrayContaining(['/vh/news/story']),
+        relayPeerCount: 2,
+      });
+      expect(readback.readbacks.find((entry) => entry.origin === 'https://venn.example/')).toMatchObject({
+        status: 'pass',
+        relayRouteSurfaceRequired: false,
+        service: 'vh-public-beta-origin',
+      });
+      expect(restDiagnostics.summary()).toMatchObject({
+        httpStatusCounts: { 200: 3 },
+        cloudflare1033Count: 0,
+        vhRelay502Count: 0,
+      });
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   it('treats a changed existing public voter row as a new agree readback', () => {
     const beforeRows = [
       { voter_id: 'voter-a', node: { agreement: -1 } },

--- a/packages/e2e/src/live/public-feed-browser-smoke.vitest.mjs
+++ b/packages/e2e/src/live/public-feed-browser-smoke.vitest.mjs
@@ -173,6 +173,48 @@ describe('public feed browser smoke helpers', () => {
     expect(refreshLatest).toHaveBeenCalledWith({ limit: 15, before: 20 });
   });
 
+  it('allows scroll growth from cards already present in the public news store', () => {
+    expect(internal.publicNewsStoreHasPreloadedMeshWindow({
+      latestIndexCount: 15,
+      storyCount: 15,
+      loading: false,
+      error: null,
+    }, 15)).toBe(true);
+    expect(internal.shouldRejectScrollGrowthWithoutMeshRefresh({
+      meshIndexCount: 15,
+      initialVisibleCount: 7,
+      newVisibleStoryCount: 8,
+      loadMoreRefreshCallCount: 0,
+      beforeScrollNewsStore: {
+        latestIndexCount: 15,
+        storyCount: 15,
+        loading: false,
+        error: null,
+      },
+    })).toBe(false);
+  });
+
+  it('still rejects scroll growth without mesh refresh when the store lacks the mesh window', () => {
+    expect(internal.publicNewsStoreHasPreloadedMeshWindow({
+      latestIndexCount: 15,
+      storyCount: 7,
+      loading: false,
+      error: null,
+    }, 15)).toBe(false);
+    expect(internal.shouldRejectScrollGrowthWithoutMeshRefresh({
+      meshIndexCount: 15,
+      initialVisibleCount: 7,
+      newVisibleStoryCount: 8,
+      loadMoreRefreshCallCount: 0,
+      beforeScrollNewsStore: {
+        latestIndexCount: 15,
+        storyCount: 7,
+        loading: false,
+        error: null,
+      },
+    })).toBe(true);
+  });
+
   it('verifies relay latest-index pagination with an exclusive older cursor window', async () => {
     const fetchMock = vi.fn(async (url) => {
       const href = String(url);
@@ -502,6 +544,13 @@ describe('public feed browser smoke helpers', () => {
     expect(source).toContain('readPublicRelaySynthesisCandidates({');
     expect(source).toContain('topStories: stories,');
     expect(source).not.toContain('topStories: stories.slice(0, 8)');
+  });
+
+  it('keeps public relay pagination evidence in the final pass summary', async () => {
+    const source = await readFile(new URL('./public-feed-browser-smoke.mjs', import.meta.url), 'utf8');
+
+    expect(source).toContain('publicRelayPaginationReadback,');
+    expect(source).toContain('publicRelayAnalysisFrameCoverage,');
   });
 
   it('discovers accepted public synthesis candidates through the deployed relay REST shape', async () => {

--- a/packages/e2e/src/live/public-feed-composition-freshness-gate.mjs
+++ b/packages/e2e/src/live/public-feed-composition-freshness-gate.mjs
@@ -497,12 +497,18 @@ async function runPublicFeedCompositionFreshnessGate({
     sampledStoryIds: [],
     topStories: [],
     pagination: null,
+    publicRelayHealthReadback: null,
     publicPeerReadback: null,
     restDiagnostics: null,
     sourceHealthEvidence,
   };
 
   try {
+    summary.publicRelayHealthReadback = await publicFeedBrowserSmokeInternal.readPublicRelayHealthReadbacks({
+      origins: publicRelayPeerOriginsFromEnv(env),
+      timeoutMs: Math.min(timeoutMs, 10_000),
+      restDiagnostics,
+    });
     const readback = await publicFeedBrowserSmokeInternal.readPublicRelaySynthesisCandidates({
       baseUrl,
       indexLimit,
@@ -568,6 +574,22 @@ async function runPublicFeedCompositionFreshnessGate({
     return summary;
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
+    if (!summary.publicRelayHealthReadback) {
+      summary.publicRelayHealthReadback = await publicFeedBrowserSmokeInternal.readPublicRelayHealthReadbacks({
+        origins: publicRelayPeerOriginsFromEnv(env),
+        timeoutMs: Math.min(timeoutMs, 10_000),
+        restDiagnostics,
+      }).catch((healthReadbackError) => ({
+        status: 'fail',
+        origins: publicRelayPeerOriginsFromEnv(env),
+        originCount: publicRelayPeerOriginsFromEnv(env).length,
+        requiredRouteSurface: 'vh-relay-http-v1',
+        requiredPublicHttpRoutes: [],
+        failedOrigins: [],
+        readbacks: [],
+        failure: healthReadbackError instanceof Error ? healthReadbackError.message : String(healthReadbackError),
+      }));
+    }
     if (!summary.publicPeerReadback) {
       summary.publicPeerReadback = await readPublicRelayPeerReadbacks({
         env,

--- a/packages/e2e/src/live/public-feed-lifecycle-accountability.mjs
+++ b/packages/e2e/src/live/public-feed-lifecycle-accountability.mjs
@@ -683,6 +683,7 @@ async function runPublicFeedLifecycleAccountability({
     sourceHealthEvidence,
     stories: [],
     failures: [],
+    publicRelayHealthReadback: null,
     publicPeerReadback: null,
     restDiagnostics: null,
   };
@@ -703,6 +704,11 @@ async function runPublicFeedLifecycleAccountability({
   client.markSessionReady();
 
   try {
+    summary.publicRelayHealthReadback = await publicFeedBrowserSmokeInternal.readPublicRelayHealthReadbacks({
+      origins: publicRelayPeerOriginsFromEnv(env),
+      timeoutMs: Math.min(rowTimeoutMs, 10_000),
+      restDiagnostics,
+    });
     const [rawStoryIds, relayLatest, relayHot] = await Promise.all([
       readRawStoryIds(client, sampleLimit, Math.min(timeoutMs, 5_000)).catch(() => []),
       readRelayLatest(baseUrl, sampleLimit, timeoutMs, restDiagnostics),
@@ -973,6 +979,22 @@ async function runPublicFeedLifecycleAccountability({
     return summary;
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
+    if (!summary.publicRelayHealthReadback) {
+      summary.publicRelayHealthReadback = await publicFeedBrowserSmokeInternal.readPublicRelayHealthReadbacks({
+        origins: publicRelayPeerOriginsFromEnv(env),
+        timeoutMs: Math.min(rowTimeoutMs, 10_000),
+        restDiagnostics,
+      }).catch((healthReadbackError) => ({
+        status: 'fail',
+        origins: publicRelayPeerOriginsFromEnv(env),
+        originCount: publicRelayPeerOriginsFromEnv(env).length,
+        requiredRouteSurface: 'vh-relay-http-v1',
+        requiredPublicHttpRoutes: [],
+        failedOrigins: [],
+        readbacks: [],
+        failure: healthReadbackError instanceof Error ? healthReadbackError.message : String(healthReadbackError),
+      }));
+    }
     if (!summary.publicPeerReadback) {
       summary.publicPeerReadback = await readPublicRelayPeerReadbacks({
         env,

--- a/packages/e2e/src/live/relay-server.vitest.mjs
+++ b/packages/e2e/src/live/relay-server.vitest.mjs
@@ -296,6 +296,35 @@ async function writeRelayHotIndexRecord(port, storyId, hotness, metadata = {}) {
   });
 }
 
+async function writeRelaySynthesisLifecycle(port, story, {
+  status = 'pending',
+  frameTableState = 'frame_table_pending',
+  updatedAt = Date.now(),
+  synthesisId = null,
+} = {}) {
+  expect(await requestJson(`http://127.0.0.1:${port}/vh/news/synthesis-lifecycle`, {
+    method: 'POST',
+    body: {
+      record: {
+        schemaVersion: 'vh-news-synthesis-lifecycle-v1',
+        story_id: story.story_id,
+        topic_id: story.topic_id,
+        source_set_revision: story.provenance_hash,
+        source_count: Array.isArray(story.sources) ? story.sources.length : 0,
+        canonical_source_count: Array.isArray(story.sources) ? story.sources.length : 0,
+        status,
+        frame_table_state: frameTableState,
+        retryable: status === 'retryable_failure',
+        ...(synthesisId ? { synthesis_id: synthesisId, epoch: 0 } : {}),
+        updated_at: updatedAt,
+      },
+    },
+  })).toMatchObject({
+    statusCode: 200,
+    body: expect.objectContaining({ ok: true, story_id: story.story_id, status }),
+  });
+}
+
 describe('infra relay server', () => {
   const children = new Set();
   const tempDirs = new Set();
@@ -1609,6 +1638,7 @@ describe('infra relay server', () => {
       VH_RELAY_NEWS_INDEX_STORY_REST_READ_TIMEOUT_MS: '500',
       VH_RELAY_NEWS_STORY_REST_READ_TIMEOUT_MS: '500',
       VH_RELAY_NEWS_INDEX_REST_MAP_FALLBACK: 'true',
+      VH_RELAY_NEWS_INDEX_COMPOSITION_BACKFILL_MIN_LIMIT: '2',
     });
     const stories = [
       makeRelayNewsStory('story-new', 300, [
@@ -1777,6 +1807,86 @@ describe('infra relay server', () => {
     expect(secondPage.body.records).not.toHaveProperty('story-mid');
   }, 60_000);
 
+  it('excludes stale incomplete lifecycle rows from public latest-index when enabled', async () => {
+    const { port } = await startRelay(children, tempDirs, {
+      VH_RELAY_NEWS_INDEX_HIDE_STALE_INCOMPLETE_LIFECYCLE: 'true',
+      VH_RELAY_NEWS_INDEX_INCOMPLETE_LIFECYCLE_STALE_MS: '1000',
+      VH_RELAY_NEWS_INDEX_REST_SCAN_RECORDS: '4',
+      VH_RELAY_NEWS_INDEX_REST_CONCURRENCY: '2',
+    });
+    const now = Date.now();
+    const freshPending = makeRelayNewsStory('story-fresh-pending', now, [
+      {
+        source_id: 'source-fresh-pending',
+        publisher: 'Source Fresh',
+        url: 'https://example.com/fresh-pending',
+        url_hash: 'hash-fresh-pending',
+        published_at: now,
+        title: 'Fresh pending',
+      },
+    ]);
+    const stalePending = makeRelayNewsStory('story-stale-pending', now - 1, [
+      {
+        source_id: 'source-stale-pending',
+        publisher: 'Source Stale',
+        url: 'https://example.com/stale-pending',
+        url_hash: 'hash-stale-pending',
+        published_at: now - 1,
+        title: 'Stale pending',
+      },
+    ]);
+
+    for (const story of [freshPending, stalePending]) {
+      await writeRelayNewsStory(port, story);
+      await writeRelayLatestIndexRecord(port, story.story_id, story.cluster_window_end);
+    }
+    await writeRelaySynthesisLifecycle(port, freshPending, {
+      status: 'pending',
+      updatedAt: now,
+    });
+    await writeRelaySynthesisLifecycle(port, stalePending, {
+      status: 'pending',
+      updatedAt: now - 10_000,
+    });
+
+    const latest = await requestJson(
+      `http://127.0.0.1:${port}/vh/news/latest-index?limit=4&scan_limit=4&include_excluded=true`,
+    );
+    expect(latest).toMatchObject({
+      statusCode: 200,
+      body: expect.objectContaining({
+        ok: true,
+        records: expect.objectContaining({
+          [freshPending.story_id]: expect.objectContaining({
+            story_id: freshPending.story_id,
+          }),
+        }),
+        consistency: expect.objectContaining({
+          excluded_reason_counts: expect.objectContaining({
+            synthesis_lifecycle_incomplete_stale: 1,
+          }),
+          stale_incomplete_lifecycle_filter: expect.objectContaining({
+            enabled: true,
+            stale_window_ms: 1000,
+          }),
+        }),
+        excluded_records: expect.arrayContaining([
+          expect.objectContaining({
+            story_id: stalePending.story_id,
+            reason: 'synthesis_lifecycle_incomplete_stale',
+            lifecycle_status: 'pending',
+          }),
+        ]),
+      }),
+    });
+    expect(latest.body.records).not.toHaveProperty(stalePending.story_id);
+    expect(latest.body.composition).toMatchObject({
+      total_visible: 1,
+      singleton_visible: 1,
+      pending_synthesis: 1,
+    });
+  }, 60_000);
+
   it('backfills a corroborated story into the initial latest-index window without moving the pagination cursor', async () => {
     const { port } = await startRelay(children, tempDirs, {
       VH_RELAY_NEWS_INDEX_REST_MAX_RECORDS: '4',
@@ -1785,6 +1895,7 @@ describe('infra relay server', () => {
       VH_RELAY_NEWS_INDEX_STORY_REST_READ_TIMEOUT_MS: '500',
       VH_RELAY_NEWS_STORY_REST_READ_TIMEOUT_MS: '500',
       VH_RELAY_NEWS_INDEX_REST_MAP_FALLBACK: 'true',
+      VH_RELAY_NEWS_INDEX_COMPOSITION_BACKFILL_MIN_LIMIT: '2',
     });
     const stories = [
       makeRelayNewsStory('story-new-singleton', 400, [
@@ -2469,6 +2580,69 @@ describe('infra relay server', () => {
           },
         }),
       });
+  }, 30_000);
+
+  it('filters stale incomplete lifecycle rows when serving a preferred latest-index snapshot', async () => {
+    const snapshotDir = mkdtempSync(path.join(os.tmpdir(), 'vh-relay-stale-snapshot-test-'));
+    tempDirs.add(snapshotDir);
+    const snapshotFile = path.join(snapshotDir, 'latest-index-snapshot.json');
+    const snapshotEnv = {
+      VH_RELAY_NEWS_INDEX_REST_MAX_RECORDS: '3',
+      VH_RELAY_NEWS_INDEX_REST_SCAN_RECORDS: '3',
+      VH_RELAY_NEWS_INDEX_SNAPSHOT_FILE: snapshotFile,
+      VH_RELAY_NEWS_INDEX_SNAPSHOT_VERIFY_STORY_BODIES: 'false',
+      VH_RELAY_NEWS_INDEX_SNAPSHOT_REFRESH_STORY_STATES: 'false',
+      VH_RELAY_NEWS_INDEX_HIDE_STALE_INCOMPLETE_LIFECYCLE: 'true',
+      VH_RELAY_NEWS_INDEX_INCOMPLETE_LIFECYCLE_STALE_MS: '1000',
+    };
+    const { port: writerPort } = await startRelay(children, tempDirs, snapshotEnv);
+    const now = Date.now();
+    const story = makeRelayNewsStory('story-stale-snapshot-pending', now, [
+      {
+        source_id: 'source-stale-snapshot-pending',
+        publisher: 'Stale Snapshot Source',
+        url: 'https://example.com/stale-snapshot-pending',
+        url_hash: 'hash-stale-snapshot-pending',
+        published_at: now,
+        title: 'Stale snapshot pending',
+      },
+    ]);
+    await writeRelayNewsStory(writerPort, story);
+    await writeRelayLatestIndexRecord(writerPort, story.story_id, story.cluster_window_end);
+    await writeRelaySynthesisLifecycle(writerPort, story, {
+      status: 'pending',
+      updatedAt: now - 10_000,
+    });
+
+    const { port: snapshotPort } = await startRelay(children, tempDirs, {
+      ...snapshotEnv,
+      VH_RELAY_NEWS_INDEX_REST_PREFER_SNAPSHOT: 'true',
+    });
+    const latest = await requestJson(
+      `http://127.0.0.1:${snapshotPort}/vh/news/latest-index?limit=3&scan_limit=3&include_excluded=true`,
+    );
+    expect(latest).toMatchObject({
+      statusCode: 200,
+      body: expect.objectContaining({
+        ok: true,
+        record_count: 0,
+        records: {},
+        consistency: expect.objectContaining({
+          empty_read_cache: expect.objectContaining({
+            served_from: 'preferred_latest_index_snapshot',
+          }),
+          excluded_reason_counts: expect.objectContaining({
+            synthesis_lifecycle_incomplete_stale: 1,
+          }),
+        }),
+        excluded_records: expect.arrayContaining([
+          expect.objectContaining({
+            story_id: story.story_id,
+            reason: 'synthesis_lifecycle_incomplete_stale',
+          }),
+        ]),
+      }),
+    });
   }, 30_000);
 
   it('serves persisted latest-index snapshot stories when the local story body path is sparse', async () => {

--- a/packages/e2e/src/mesh/deployed-wss-peer-config-canary.mjs
+++ b/packages/e2e/src/mesh/deployed-wss-peer-config-canary.mjs
@@ -404,6 +404,21 @@ function peerOrigins(peers) {
   return peers.map((peer) => safeOriginOf(peer)).filter(Boolean);
 }
 
+function publicRelayOriginsFromPeers(peers) {
+  return peers.map((peer) => {
+    try {
+      const url = new URL(peer);
+      url.protocol = 'https:';
+      url.pathname = '';
+      url.search = '';
+      url.hash = '';
+      return url.origin;
+    } catch {
+      return null;
+    }
+  }).filter(Boolean);
+}
+
 function publicInputContainsPrivateMaterial(value, label) {
   const normalized = String(value || '');
   if (/BEGIN [A-Z ]*PRIVATE KEY/.test(normalized) || /\b(privateKey|priv|secretKey)\b/i.test(normalized)) {
@@ -550,8 +565,8 @@ export function parsePublicProofConfig(env = process.env) {
 
   const peerConfigOrigin = safeOriginOf(peerConfigUrl);
   const requiredCspTokens = peerConfigOrigin
-    ? uniqueStrings(["'self'", peerConfigOrigin, ...peerOrigins(peers)])
-    : uniqueStrings(["'self'", ...peerOrigins(peers)]);
+    ? uniqueStrings(["'self'", peerConfigOrigin, ...publicRelayOriginsFromPeers(peers), ...peerOrigins(peers)])
+    : uniqueStrings(["'self'", ...publicRelayOriginsFromPeers(peers), ...peerOrigins(peers)]);
   if (cspConnectSrc.length > 0) {
     failures.push(...cspConnectSrcFailures(cspConnectSrc, requiredCspTokens));
   }

--- a/packages/e2e/src/mesh/deployed-wss-peer-config-canary.vitest.mjs
+++ b/packages/e2e/src/mesh/deployed-wss-peer-config-canary.vitest.mjs
@@ -48,7 +48,7 @@ function validEnv(overrides = {}) {
       'wss://relay-b.mesh.example.com/gun',
       'wss://relay-c.mesh.example.com/gun',
     ]),
-    VH_MESH_PUBLIC_CSP_CONNECT_SRC: "'self' https://config.mesh.example.com wss://relay-a.mesh.example.com wss://relay-b.mesh.example.com wss://relay-c.mesh.example.com",
+    VH_MESH_PUBLIC_CSP_CONNECT_SRC: "'self' https://config.mesh.example.com https://relay-a.mesh.example.com https://relay-b.mesh.example.com https://relay-c.mesh.example.com wss://relay-a.mesh.example.com wss://relay-b.mesh.example.com wss://relay-c.mesh.example.com",
     VH_MESH_PUBLIC_MINIMUM_PEER_COUNT: '3',
     VH_MESH_PUBLIC_QUORUM_REQUIRED: '2',
     VH_MESH_PUBLIC_APP_URL: 'https://app.mesh.example.com/',
@@ -74,6 +74,16 @@ describe('public WSS proof input validation', () => {
     const parsed = parsePublicProofConfig(validEnv());
 
     expect(parsed.ok).toBe(true);
+    expect(parsed.config.requiredCspTokens).toEqual([
+      "'self'",
+      'https://config.mesh.example.com',
+      'https://relay-a.mesh.example.com',
+      'https://relay-b.mesh.example.com',
+      'https://relay-c.mesh.example.com',
+      'wss://relay-a.mesh.example.com',
+      'wss://relay-b.mesh.example.com',
+      'wss://relay-c.mesh.example.com',
+    ]);
     expect(parsed.config.healthEndpoints).toHaveLength(3);
     expect(parsed.config.healthEndpoints[0]).toMatchObject({
       healthz: 'https://relay-a.mesh.example.com/healthz',

--- a/packages/gun-client/src/newsAdapters.test.ts
+++ b/packages/gun-client/src/newsAdapters.test.ts
@@ -1949,6 +1949,21 @@ describe('newsAdapters', () => {
         'story-a': 200,
         'story-b': 200,
       });
+      await expect(
+        readNewsLatestIndexPageWithRelayRestFallback(client, { limit: 2, before: 250 }),
+      ).resolves.toMatchObject({
+        index: {
+          'story-a': 200,
+          'story-b': 200,
+        },
+        directGunLatestIndexCount: 2,
+        relayRestDiagnostics: {
+          endpointsAttempted: [],
+          successCount: 0,
+          nonOkResponses: [],
+          networkFailures: [],
+        },
+      });
     } finally {
       vi.stubGlobal('fetch', originalFetch);
     }

--- a/packages/gun-client/src/newsAdapters.test.ts
+++ b/packages/gun-client/src/newsAdapters.test.ts
@@ -2228,9 +2228,23 @@ describe('newsAdapters', () => {
         nextCursor: 456,
         recordCount: 1,
         directGunLatestIndexCount: 1,
+        relayRestDiagnostics: {
+          endpointsAttempted: ['https://gun-timeout.carboncaste.io/vh/news/latest-index?limit=80'],
+          httpStatusCounts: {},
+          successCount: 0,
+          cloudflare1033Count: 0,
+          vhRelay502Count: 0,
+          networkFailures: [
+            expect.objectContaining({
+              endpoint: 'https://gun-timeout.carboncaste.io/vh/news/latest-index?limit=80',
+              classification: 'timeout',
+              error: 'news-latest-index-relay-rest-read-timeout:11000',
+            }),
+          ],
+        },
       });
       const page = await pending;
-      expect(page.relayRestDiagnostics).toBeUndefined();
+      expect(page.relayRestDiagnostics?.nonOkResponses).toEqual([]);
     } finally {
       vi.useRealTimers();
       vi.unstubAllGlobals();

--- a/packages/gun-client/src/newsAdapters.ts
+++ b/packages/gun-client/src/newsAdapters.ts
@@ -303,6 +303,18 @@ function recordRelayRestNetworkFailure(
   });
 }
 
+function createRelayRestTimeoutDiagnostics(
+  endpoints: readonly string[],
+  label: string,
+  timeoutMs: number,
+): RelayRestReadDiagnostics {
+  const diagnostics = createRelayRestReadDiagnostics(endpoints);
+  for (const endpoint of endpoints) {
+    recordRelayRestNetworkFailure(diagnostics, endpoint, new Error(`${label}-timeout:${timeoutMs}`));
+  }
+  return diagnostics;
+}
+
 function latestIndexWindowNextCursor(index: NewsLatestIndex): number | null {
   const timestamps = Object.values(index)
     .filter((timestamp) => Number.isFinite(timestamp) && timestamp >= 0)
@@ -2057,6 +2069,30 @@ function resolveRelayRestEndpointsFromPeers(client: VennClient, path: string): s
   return endpoints;
 }
 
+function resolveLatestIndexRelayRestRead(
+  client: VennClient,
+  options: NewsLatestIndexReadOptions = {},
+): {
+  readonly limit: number;
+  readonly before: number | null;
+  readonly endpoints: string[];
+} {
+  const limit = normalizeLatestIndexReadLimit(options.limit);
+  const before = normalizeLatestIndexBeforeCursor(options.before);
+  const query = new URLSearchParams({ limit: String(limit) });
+  if (before !== null) {
+    query.set('before', String(before));
+  }
+  return {
+    limit,
+    before,
+    endpoints: resolveRelayRestEndpointsFromPeers(
+      client,
+      `/vh/news/latest-index?${query.toString()}`,
+    ),
+  };
+}
+
 /**
  * Read a StoryBundle through the relay's same-origin REST fallback.
  *
@@ -2415,16 +2451,7 @@ export async function readNewsLatestIndexPageViaRelayRest(
       relayRestDiagnostics: createRelayRestReadDiagnostics([]),
     };
   }
-  const limit = normalizeLatestIndexReadLimit(options.limit);
-  const before = normalizeLatestIndexBeforeCursor(options.before);
-  const query = new URLSearchParams({ limit: String(limit) });
-  if (before !== null) {
-    query.set('before', String(before));
-  }
-  const endpoints = resolveRelayRestEndpointsFromPeers(
-    client,
-    `/vh/news/latest-index?${query.toString()}`,
-  );
+  const { before, endpoints } = resolveLatestIndexRelayRestRead(client, options);
   const relayRestDiagnostics = createRelayRestReadDiagnostics(endpoints);
   if (endpoints.length === 0) {
     return { index: {}, nextCursor: null, recordCount: 0, relayRestDiagnostics };
@@ -2571,10 +2598,23 @@ export async function readNewsLatestIndexPageWithRelayRestFallback(
   client: VennClient,
   options: NewsLatestIndexReadOptions = {},
 ): Promise<NewsLatestIndexPage> {
+  const relayTimeoutMs = RELAY_REST_READ_TIMEOUT_MS + 1_000;
+  const relayTimeoutFallback = typeof fetch === 'function'
+    ? {
+      index: {},
+      nextCursor: null,
+      recordCount: 0,
+      relayRestDiagnostics: createRelayRestTimeoutDiagnostics(
+        resolveLatestIndexRelayRestRead(client, options).endpoints,
+        'news-latest-index-relay-rest-read',
+        relayTimeoutMs,
+      ),
+    }
+    : null;
   const relayed = await timeoutAsNull(
     readNewsLatestIndexPageViaRelayRest(client, options),
-    RELAY_REST_READ_TIMEOUT_MS + 1_000,
-  );
+    relayTimeoutMs,
+  ) ?? relayTimeoutFallback;
   if (relayed && Object.keys(relayed.index).length > 0) {
     return relayed;
   }

--- a/packages/gun-client/src/newsAdapters.ts
+++ b/packages/gun-client/src/newsAdapters.ts
@@ -2599,18 +2599,18 @@ export async function readNewsLatestIndexPageWithRelayRestFallback(
   options: NewsLatestIndexReadOptions = {},
 ): Promise<NewsLatestIndexPage> {
   const relayTimeoutMs = RELAY_REST_READ_TIMEOUT_MS + 1_000;
-  const relayTimeoutFallback = typeof fetch === 'function'
-    ? {
-      index: {},
-      nextCursor: null,
-      recordCount: 0,
-      relayRestDiagnostics: createRelayRestTimeoutDiagnostics(
+  const relayTimeoutFallback = {
+    index: {},
+    nextCursor: null,
+    recordCount: 0,
+    relayRestDiagnostics: typeof fetch === 'function'
+      ? createRelayRestTimeoutDiagnostics(
         resolveLatestIndexRelayRestRead(client, options).endpoints,
         'news-latest-index-relay-rest-read',
         relayTimeoutMs,
-      ),
-    }
-    : null;
+      )
+      : createRelayRestReadDiagnostics([]),
+  };
   const relayed = await timeoutAsNull(
     readNewsLatestIndexPageViaRelayRest(client, options),
     relayTimeoutMs,
@@ -2629,7 +2629,7 @@ export async function readNewsLatestIndexPageWithRelayRestFallback(
     nextCursor: latestIndexWindowNextCursor(index),
     recordCount: Object.keys(index).length,
     directGunLatestIndexCount: Object.keys(index).length,
-    ...(relayed?.relayRestDiagnostics ? { relayRestDiagnostics: relayed.relayRestDiagnostics } : {}),
+    relayRestDiagnostics: relayed.relayRestDiagnostics,
   };
 }
 

--- a/tools/scripts/repair-public-news-system-writer.mjs
+++ b/tools/scripts/repair-public-news-system-writer.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { mkdirSync } from 'node:fs';
-import { mkdir, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
@@ -42,6 +42,7 @@ const DEFAULT_APP_URL = 'https://venn.carboncaste.io';
 const DEFAULT_LIMIT = 120;
 const DEFAULT_REPAIR_MODE = 'gun';
 const DEFAULT_HTTP_TIMEOUT_MS = 15_000;
+const DEFAULT_SOURCE = 'public-latest-index';
 const DEFAULT_ARTIFACT_DIR = path.join(
   process.cwd(),
   '.tmp',
@@ -159,6 +160,70 @@ function parseBooleanEnv(name, fallback = false) {
   if (['1', 'true', 'yes', 'on'].includes(normalized)) return true;
   if (['0', 'false', 'no', 'off'].includes(normalized)) return false;
   throw new Error(`${name} must be a boolean value`);
+}
+
+function storyTimestampFromSnapshot(story, latestIndex) {
+  const indexed = Number(latestIndex?.[story?.story_id]);
+  if (Number.isFinite(indexed)) return Math.max(0, Math.floor(indexed));
+  const clusterWindowEnd = Number(story?.cluster_window_end);
+  if (Number.isFinite(clusterWindowEnd)) return Math.max(0, Math.floor(clusterWindowEnd));
+  const createdAt = Number(story?.created_at);
+  return Number.isFinite(createdAt) ? Math.max(0, Math.floor(createdAt)) : 0;
+}
+
+function storySourceCount(story) {
+  return Array.isArray(story?.primary_sources) && story.primary_sources.length > 0
+    ? story.primary_sources.length
+    : Array.isArray(story?.sources)
+      ? story.sources.length
+      : 0;
+}
+
+function readSnapshotStoryRows(snapshot) {
+  const latestIndex = snapshot?.latestIndex && typeof snapshot.latestIndex === 'object'
+    ? snapshot.latestIndex
+    : {};
+  const hotIndex = snapshot?.hotIndex && typeof snapshot.hotIndex === 'object'
+    ? snapshot.hotIndex
+    : {};
+  const stories = Array.isArray(snapshot?.stories) ? snapshot.stories : [];
+  return stories
+    .filter((story) => story?.story_id && story?.topic_id && Array.isArray(story.sources))
+    .map((story) => ({
+      story,
+      latestActivityAt: storyTimestampFromSnapshot(story, latestIndex),
+      hotness: Number.isFinite(Number(hotIndex[story.story_id])) ? Number(hotIndex[story.story_id]) : null,
+      sourceCount: storySourceCount(story),
+    }))
+    .sort((left, right) =>
+      right.latestActivityAt - left.latestActivityAt
+      || right.sourceCount - left.sourceCount
+      || String(left.story.story_id).localeCompare(String(right.story.story_id)),
+    );
+}
+
+async function readSnapshotStories(snapshotPath, limit, offset) {
+  const snapshot = JSON.parse(await readFile(snapshotPath, 'utf8'));
+  const rows = readSnapshotStoryRows(snapshot);
+  const selected = rows.slice(offset, offset + limit);
+  const stories = {};
+  for (const row of selected) {
+    stories[row.story.story_id] = row.story;
+  }
+  return {
+    source: 'publisher-snapshot',
+    sourceSnapshotPath: snapshotPath,
+    latest: {
+      schemaVersion: snapshot?.schemaVersion ?? null,
+      runId: snapshot?.runId ?? null,
+      generatedAt: snapshot?.generatedAt ?? null,
+      record_count: rows.length,
+      source_key_count: rows.length,
+      records: Object.fromEntries(rows.map((row) => [row.story.story_id, row.latestActivityAt])),
+    },
+    storyIds: selected.map((row) => row.story.story_id),
+    stories,
+  };
 }
 
 function sleep(ms) {
@@ -560,7 +625,7 @@ async function readLatestStories(appUrl, limit, offset, timeoutMs) {
       stories[storyId] = storyPayload.story;
     }
   }
-  return { latest, storyIds, stories };
+  return { source: DEFAULT_SOURCE, sourceSnapshotPath: null, latest, storyIds, stories };
 }
 
 async function repairStoryViaGun({ client, story, lifecycleRecord }) {
@@ -663,6 +728,7 @@ async function main() {
     optionalEnv('VH_PUBLIC_NEWS_REPAIR_HTTP_TIMEOUT_MS'),
     DEFAULT_HTTP_TIMEOUT_MS,
   );
+  const sourceSnapshotPath = optionalEnv('VH_PUBLIC_NEWS_REPAIR_SOURCE_SNAPSHOT_PATH');
   const repairMode = parseRepairMode(optionalEnv('VH_PUBLIC_NEWS_REPAIR_MODE', DEFAULT_REPAIR_MODE));
   const relayOrigins = parseRelayOrigins(optionalEnv('VH_PUBLIC_NEWS_REPAIR_RELAY_ORIGINS'));
   const relayToken = repairMode === 'relay-rest' ? requireEnv('VH_RELAY_DAEMON_TOKEN') : '';
@@ -673,6 +739,7 @@ async function main() {
   repairStepAttempts = parsePositiveInt(optionalEnv('VH_PUBLIC_NEWS_REPAIR_STEP_ATTEMPTS'), 1);
   repairStepRetryMs = parseNonNegativeInt(optionalEnv('VH_PUBLIC_NEWS_REPAIR_STEP_RETRY_MS'), 500);
   repairRemoteSettleMs = parseNonNegativeInt(optionalEnv('VH_PUBLIC_NEWS_REPAIR_REMOTE_SETTLE_MS'), 0);
+  const allowEmptySource = parseBooleanEnv('VH_PUBLIC_NEWS_REPAIR_ALLOW_EMPTY', false);
   const sign = await createSignHook(privateKey);
   const gunPeers = repairMode === 'gun'
     ? parseOptionalJsonEnv(
@@ -696,10 +763,20 @@ async function main() {
       client: createRepairClient({ peers: [peer], pin, writerId, sign }),
     }))
     : [];
-  const { storyIds, stories } = await readLatestStories(appUrl, limit, offset, httpTimeoutMs);
+  const source = sourceSnapshotPath
+    ? await readSnapshotStories(sourceSnapshotPath, limit, offset)
+    : await readLatestStories(appUrl, limit, offset, httpTimeoutMs);
+  const { storyIds, stories } = source;
 
   const repaired = [];
   const failures = [];
+  if (storyIds.length === 0 && !allowEmptySource) {
+    failures.push({
+      story_id: null,
+      repair_step: 'source_selection',
+      reason: 'source-story-selection-empty',
+    });
+  }
   try {
     for (const storyId of storyIds) {
       const story = stories[storyId];
@@ -769,12 +846,15 @@ async function main() {
     require_each_gun_peer: requireEachGunPeer,
     gun_client_isolation: repairMode === 'gun' ? 'unique-local-gun-file-per-repair-client' : null,
     writer_id: writerId,
+    source: source.source,
+    source_snapshot_path: source.sourceSnapshotPath,
     offset,
     limit,
     http_timeout_ms: httpTimeoutMs,
     repair_step_attempts: repairStepAttempts,
     repair_step_retry_ms: repairStepRetryMs,
     repair_remote_settle_ms: repairRemoteSettleMs,
+    source_record_count: Number(source.latest?.record_count ?? Object.keys(source.latest?.records ?? {}).length),
     sampled: storyIds.length,
     repaired_count: repaired.length,
     failure_count: failures.length,


### PR DESCRIPTION
## Summary

Follow-up to merged PR #632 after live verification found the original PR branch was already merged and public release gates were still blocked by runtime credentials/data/topology state.

Changes in this branch:
- Rotates the public news system-writer pin to `vh-public-beta-news-system-writer-v4` as the sole active writer, retaining v1-v3 as retired history.
- Extends `tools/scripts/repair-public-news-system-writer.mjs` so repair can use a real publisher-canary snapshot via `VH_PUBLIC_NEWS_REPAIR_SOURCE_SNAPSHOT_PATH` when public latest-index is empty.
- Makes empty source selection explicit (`source-story-selection-empty`) unless `VH_PUBLIC_NEWS_REPAIR_ALLOW_EMPTY=true` is set.
- Updates the public WSS proof validator so expected CSP includes both WSS peer origins and derived HTTPS relay origins for public `gun-a/b/c` HTTP parity.
- Adds public relay `/healthz` route-surface diagnostics to composition/lifecycle artifacts without changing gate thresholds or accepting failures.
- Preserves low-level Gun latest-index REST timeout diagnostics when relay REST fallback times out and direct Gun fallback proceeds.

## Current head / CI

- PR head: `c085d51f16da981f0de89bfe7ec339c8607cf201`
- Base: `main` at `f7a1d04959db862145ca14e84da16ed8755a0111`
- PR state: draft; not mergeable for release while live public gates remain blocked
- GitHub Actions CI on current head: green (`27320263144`; all CI jobs succeeded)

## Runtime update: A6 + Mac mini topology

The A6 + Mac mini split is intentional and still visible in Cloudflare:
- `venn.carboncaste.io` -> A6 `http://localhost:8080`
- `gun-a.carboncaste.io` -> A6 `http://localhost:8765`
- `gun-b.carboncaste.io` -> A6 `http://localhost:8766`
- `gun-c.carboncaste.io` / `gun-c.venn.carboncaste.io` -> Mac mini `http://192.168.1.56:8767`

Operational repair performed on A6 on 2026-06-11:
- Recreated `vhc-relay-a` and `vhc-relay-b` with their existing `/home/humble/.config/vhc/public-beta-relay-{a,b}.env` files and existing persisted data bind mounts.
- This changed deployed A6 relay-a/b from `VH_RELAY_PEERS=[]` to the intended peer sets:
  - relay-a: `http://127.0.0.1:8766/gun`, `http://192.168.1.56:8767/gun`
  - relay-b: `http://127.0.0.1:8765/gun`, `http://192.168.1.56:8767/gun`
- Public `/healthz` now reports `relay_peer_count: 2` for both `gun-a` and `gun-b`, with `route_surface: vh-relay-http-v1` and all six public HTTP routes listed.
- Mac mini is reachable on SSH and Screen Sharing ports, but current local SSH keys are not authorized and Screen Sharing is at the password prompt. I did not repoint `gun-c` away from the Mac mini.

## Current public matrix

After the A6 peer repair, public HTTP routes are JSON, not Cloudflare 1033 HTML, but release data is still invalid:
- `gun-a /healthz`: 200, relay-a, `route_surface: vh-relay-http-v1`, `relay_peer_count: 2`
- `gun-b /healthz`: 200, relay-b, `route_surface: vh-relay-http-v1`, `relay_peer_count: 2`
- `gun-c /healthz`: 200, relay-c identity, `relay_peer_count: 2`, still missing `route_surface` and `public_http_routes` because it is the Mac mini route surface
- Latest-index remains empty for visible release rows:
  - `venn`: 200, `record_count:0`
  - `gun-a`: 200, `record_count:0`
  - `gun-b`: 200, `record_count:0`, `source_key_count:236`, all scanned rows excluded
  - `gun-c`: 200, `record_count:0`, `source_key_count:236`, all scanned rows excluded
- Hot-index exposes stale/invalid rows on some origins; sampled writer IDs include `vh-e2e-news-daemon-system-writer-v1`, `vh-public-beta-news-system-writer-v1`, and `vh-public-beta-news-system-writer-v2`, all invalid for the deployed active v4 pin.
- `gun-a` hot-index still returned `record_count:0` in the latest matrix, so public peer parity is not yet complete.

## Fresh artifact evidence

Current live gate artifacts after the A6 peer repair:
- Composition freshness: `.tmp/release-evidence/public-feed-composition-freshness/1781147107358/public-feed-composition-freshness-summary.json`
  - failure: `public-relay-latest-index-http-502:vh-relay-502` during this run
  - public relay health now shows `gun-a`/`gun-b` peer count 2, while `gun-c` still lacks route-surface metadata
- Lifecycle accountability: `.tmp/release-evidence/public-feed-lifecycle-accountability/1781147107336/public-feed-lifecycle-accountability-summary.json`
  - failure: `public_feed_lifecycle_readback_failed`
  - `venn` latest-index fetch saw `http-502:vh-relay-502` in this run
  - peer readback still shows empty latest-index/story states
- Fresh propagation: `.tmp/release-evidence/public-feed-fresh-propagation/1781147113364/public-feed-fresh-propagation-summary.json`
  - failed before ingest because StoryCluster OpenAI preflight returned `storycluster-openai-auth-invalid`
  - no fake bundles, accepted synthesis, or test provider output were used
- Publisher canary preflight: `.tmp/release-evidence/public-feed-fresh-propagation/1781147113364/publisher-canary/publisher-canary-summary.json`
  - `outcome: startup_failure`
  - text model: `gpt-4o-mini`; embedding model: `text-embedding-3-small`; base URL: `https://api.openai.com/v1`
  - error text is redacted in artifact

## OpenAI credential state

- The local shell has an `OPENAI_API_KEY`, but the project preflight rejects it with HTTP 401 / `storycluster-openai-auth-invalid`.
- Safari is logged in to the Carbon Caste Inc OpenAI API key page.
- A new key dialog is staged and named `VHC public news StoryCluster 2026-06-11`, but no key has been created yet because creating persistent API access requires explicit confirmation.

## Mesh proof evidence

- Isolated public WSS proof previously passed on clean head `9af5488929ac166cd6d43d2dd94d7ca34cf922d5`, artifact `.tmp/mesh-production-readiness/latest-public-wss-proof/mesh-production-readiness-report.json`.
- Current head is `c085d51f16da981f0de89bfe7ec339c8607cf201`; public-WSS proof must be rerun with the required `VH_MESH_PUBLIC_*` env before it can be counted as current-head release evidence.
- No release-ready claim is made while mesh readiness remains `review_required` or current-head public WSS proof is absent.

## Current blockers

This PR remains draft because the public release gates are not green yet.

- A valid OpenAI project key must be created/installed for the exact StoryCluster/publisher canary runtime, then fresh propagation must publish real v4-signed rows from live RSS/StoryCluster output.
- The Mac mini relay-c route still needs in-place repair or authorized access so `gun-c` exposes the same `vh-relay-http-v1` route metadata as A6 relay-a/b while preserving the intended A6 + Mac mini topology.
- Public latest-index still has zero visible v4-signed rows; hot-index contains stale rows signed by retired/e2e writers and must not be accepted.
- Public feed composition/lifecycle/browser/pagination/stance gates remain blocked until fresh signed rows and accepted synthesis/lifecycle evidence exist on all public relays.

## Verification run so far

Passed locally on this branch/current head:
- `git diff --check`
- `pnpm --filter @vh/gun-client typecheck`
- `pnpm exec vitest run --config vitest.config.ts src/newsAdapters.test.ts` from `packages/gun-client`
- `node tools/scripts/check-diff-coverage.mjs`

Passed on earlier branch heads and still relevant to unchanged files:
- `pnpm --filter @vh/e2e typecheck`
- `node --check packages/e2e/src/live/public-feed-browser-smoke.mjs`
- `node --check packages/e2e/src/live/public-feed-composition-freshness-gate.mjs`
- `node --check packages/e2e/src/live/public-feed-lifecycle-accountability.mjs`
- `pnpm exec vitest run --config vitest.config.ts src/live/public-feed-browser-smoke.vitest.mjs` from `packages/e2e`
- `pnpm --filter @vh/web-pwa typecheck`
- `pnpm --filter @vh/news-aggregator typecheck`
- `pnpm --filter @vh/storycluster-engine typecheck`
- `node --check infra/relay/server.js`
- `node --check tools/scripts/repair-public-news-system-writer.mjs`
- `pnpm check:news-sources:health`
- `pnpm check:storycluster:correctness`
- `pnpm exec vitest run --config vitest.config.ts src/mesh/deployed-wss-peer-config-canary.vitest.mjs` from `packages/e2e`
- `pnpm exec vitest run --config ./vitest.config.ts src/openaiProvider.test.ts` from `services/storycluster-engine`

Failed/blocked on current live runtime:
- `pnpm check:public-feed:fresh-propagation` failed fast on OpenAI preflight: `storycluster-openai-auth-invalid`.
- `pnpm check:public-feed:composition-freshness` failed with VHC relay 502 / no valid latest-index composition evidence.
- `pnpm check:public-feed:lifecycle-accountability` failed with VHC relay 502 / empty latest-index story-state evidence.

## Non-regression boundaries

- Did not loosen system-writer validation.
- Did not make retired writers active.
- Did not accept Cloudflare 530/1033/502 as success.
- Did not use `VH_STORYCLUSTER_USE_TEST_PROVIDER=true` for release evidence.
- Did not fake accepted synthesis or synthetic bundle labels.
- Did not commit or print private keys.
