### PR TITLE
Fix public feed terminal load-more state

### DIFF
--- a/apps/web-pwa/src/components/feed/FeedContent.tsx
+++ b/apps/web-pwa/src/components/feed/FeedContent.tsx
@@ -25,8 +25,9 @@ export const FeedContent: React.FC<FeedContentProps> = ({
   loadingMore,
   loadMore,
 }) => {
+  const showLoadSentinel = hasMore && !loadingMore;
   const sentinelRef = useIntersectionLoader<HTMLLIElement>({
-    enabled: hasMore,
+    enabled: showLoadSentinel,
     loading: loadingMore,
     onLoadMore: loadMore,
   });
@@ -72,7 +73,7 @@ export const FeedContent: React.FC<FeedContentProps> = ({
           <FeedItemRow key={getFeedItemKey(item)} item={item} />
         ))}
 
-        {hasMore && (
+        {showLoadSentinel && (
           <li
             ref={sentinelRef}
             data-testid="feed-load-sentinel"

--- a/apps/web-pwa/src/components/feed/FeedShell.lazyLoading.test.tsx
+++ b/apps/web-pwa/src/components/feed/FeedShell.lazyLoading.test.tsx
@@ -264,6 +264,26 @@ describe('FeedShell lazy loading', () => {
     expect(screen.queryByTestId('feed-load-sentinel')).not.toBeInTheDocument();
   });
 
+  it('does not render public load-more sentinel when the relay cursor is exhausted', () => {
+    useNewsStore.setState({
+      stories: [makeSnapshotStory(1, { story_id: 'story-terminal' }) as any],
+      latestIndex: { 'story-terminal': NOW },
+      latestIndexCursor: null,
+    });
+
+    render(<FeedShell feedResult={makeFeedResult([
+      makeFeedItem({
+        topic_id: 'story-terminal',
+        story_id: 'story-terminal',
+        title: 'Terminal public story',
+      }),
+    ])} />);
+
+    expect(screen.getByTestId('feed-item-story-terminal')).toBeInTheDocument();
+    expect(screen.queryByTestId('feed-load-sentinel')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('feed-loading-more')).not.toBeInTheDocument();
+  });
+
   it('requests an older public latest-index cursor window when visible news fits one page', async () => {
     vi.useFakeTimers();
     const originalRefreshLatest = useNewsStore.getState().refreshLatest;

--- a/apps/web-pwa/src/components/feed/FeedShell.tsx
+++ b/apps/web-pwa/src/components/feed/FeedShell.tsx
@@ -298,12 +298,15 @@ export const FeedShell: React.FC<FeedShellProps> = ({ feedResult }) => {
     refreshLatest,
   ]);
 
+  const hasPublicNewsCursor =
+    typeof publicNewsLatestIndexCursor === 'number' && Number.isFinite(publicNewsLatestIndexCursor);
   const canRequestMorePublicNews =
     !hasMore &&
     !loading &&
     !error &&
     newsCount > 0 &&
     loadedPublicNewsStoryCount > 0 &&
+    hasPublicNewsCursor &&
     !meshPaginationExhausted &&
     newsRefreshLimit < PUBLIC_NEWS_REFRESH_MAX_LIMIT;
 
@@ -328,17 +331,17 @@ export const FeedShell: React.FC<FeedShellProps> = ({ feedResult }) => {
     const beforeCursor = typeof publicNewsLatestIndexCursor === 'number' && Number.isFinite(publicNewsLatestIndexCursor)
       ? publicNewsLatestIndexCursor
       : fallbackBeforeCursor;
+    if (beforeCursor === null) {
+      setMeshPaginationExhausted(true);
+      return;
+    }
     const nextLimit = Math.min(
       PUBLIC_NEWS_REFRESH_MAX_LIMIT,
       newsRefreshLimit + PUBLIC_NEWS_REFRESH_LOAD_MORE_STEP,
     );
 
     setMeshLoadingMore(true);
-    void refreshLatest(
-      beforeCursor === null
-        ? nextLimit
-        : { limit: PUBLIC_NEWS_REFRESH_LOAD_MORE_STEP, before: beforeCursor },
-    )
+    void refreshLatest({ limit: PUBLIC_NEWS_REFRESH_LOAD_MORE_STEP, before: beforeCursor })
       .then(() => {
         const nextStories = useNewsStore.getState().stories;
         const discoveredAdditionalStory = nextStories.some(

--- a/infra/relay/server.js
+++ b/infra/relay/server.js
@@ -1891,6 +1891,14 @@ function exclusionReasonCounts(records) {
   }, {});
 }
 
+function latestIndexPageNextCursor(pageEntries, hasMoreVisibleEntries) {
+  if (!hasMoreVisibleEntries) return null;
+  return pageEntries
+    .map((entry) => latestIndexRecordTimestamp(entry.entry?.[1]))
+    .filter((value) => Number.isFinite(value) && value >= 0)
+    .sort((a, b) => a - b)[0] ?? null;
+}
+
 function createFeedCompositionAccumulator(now = Date.now()) {
   return {
     total_visible: 0,
@@ -2395,6 +2403,7 @@ async function readNewsLatestIndexRecords(gun, options = {}) {
       accumulateFeedComposition(composition, entry.story, entry.entry[1], entry.storyState);
     }
   }
+  const truncated = scanSourceKeys.length > keys.length || visibleEntries.length > chronologicalPageEntries.length;
   return {
     root: options.includeRoot ? stripGunMetadata(rawRoot) || {} : undefined,
     sourceKeyCount: sourceKeys.length,
@@ -2404,12 +2413,9 @@ async function readNewsLatestIndexRecords(gun, options = {}) {
         ? visibleEntries.length + excludedRecords.length
         : sourceKeys.length,
     scannedKeyCount: keys.length,
-    truncated: scanSourceKeys.length > keys.length || visibleEntries.length > chronologicalPageEntries.length,
+    truncated,
     before: hasBeforeCursor ? Math.floor(beforeCursor) : null,
-    nextCursor: chronologicalPageEntries
-      .map((entry) => latestIndexRecordTimestamp(entry.entry?.[1]))
-      .filter((value) => Number.isFinite(value) && value >= 0)
-      .sort((a, b) => a - b)[0] ?? null,
+    nextCursor: latestIndexPageNextCursor(chronologicalPageEntries, truncated),
     consistency: {
       enabled: consistencyFilter,
       mode: consistencyFilter ? 'relay_visible_filter' : 'disabled',
@@ -3015,17 +3021,15 @@ async function buildNewsLatestIndexResultFromSnapshot(gun, snapshot, options = {
       accumulateFeedComposition(composition, entry.story, entry.entry[1], entry.storyState);
     }
   }
+  const truncated = visibleEntries.length > chronologicalPageEntries.length;
   return {
     root: null,
     sourceKeyCount: snapshot.sourceKeyCount ?? visibleEntries.length,
     windowSourceKeyCount: visibleEntries.length,
     scannedKeyCount: snapshot.scannedKeyCount ?? visibleEntries.length,
-    truncated: visibleEntries.length > chronologicalPageEntries.length,
+    truncated,
     before: beforeCursor,
-    nextCursor: chronologicalPageEntries
-      .map((entry) => latestIndexRecordTimestamp(entry.entry?.[1]))
-      .filter((value) => Number.isFinite(value) && value >= 0)
-      .sort((a, b) => a - b)[0] ?? null,
+    nextCursor: latestIndexPageNextCursor(chronologicalPageEntries, truncated),
     consistency: {
       ...(snapshot.consistency ?? {}),
       empty_read_cache: cacheInfo,

--- a/packages/e2e/src/live/relay-server.vitest.mjs
+++ b/packages/e2e/src/live/relay-server.vitest.mjs
@@ -1619,7 +1619,7 @@ describe('infra relay server', () => {
         before: 250,
         record_count: 2,
         window_source_key_count: 2,
-        next_cursor: 100,
+        next_cursor: null,
         records: {
           'story-mid': 200,
           'story-old': 100,
@@ -1781,7 +1781,7 @@ describe('infra relay server', () => {
         record_count: 1,
         source_key_count: 3,
         window_source_key_count: 1,
-        next_cursor: 100,
+        next_cursor: null,
         records: {
           'story-old': expect.objectContaining({
             story_id: 'story-old',

--- a/packages/gun-client/src/newsAdapters.test.ts
+++ b/packages/gun-client/src/newsAdapters.test.ts
@@ -1348,6 +1348,53 @@ describe('newsAdapters', () => {
     }
   });
 
+  it('treats invalid explicit relay latest-index cursors as terminal', async () => {
+    const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+    const client = createClient(createFakeMesh(), guard, {
+      peers: ['wss://gun-a.carboncaste.io/gun'],
+    });
+    const embeddedStory = {
+      ...STORY,
+      story_id: 'story-invalid-next-cursor',
+      topic_id: 'd'.repeat(64),
+      cluster_window_end: 222,
+    };
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+      ok: true,
+      record_count: 1,
+      records: {
+        'story-invalid-next-cursor': {
+          story_id: 'story-invalid-next-cursor',
+          latest_activity_at: 222,
+        },
+      },
+      stories: {
+        'story-invalid-next-cursor': embeddedStory,
+      },
+      next_cursor: 'not-a-valid-cursor',
+    }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('location', {
+      href: 'https://venn.carboncaste.io/',
+      origin: 'https://venn.carboncaste.io',
+      protocol: 'https:',
+    });
+
+    try {
+      await expect(readNewsLatestIndexPageViaRelayRest(client)).resolves.toMatchObject({
+        index: { 'story-invalid-next-cursor': 222 },
+        nextCursor: null,
+        recordCount: 1,
+        stories: { 'story-invalid-next-cursor': embeddedStory },
+      });
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   it('keeps relay-embedded latest-index stories when legacy index signatures cannot be revalidated in the browser', async () => {
     const mesh = createFakeMesh();
     const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
@@ -1964,6 +2011,42 @@ describe('newsAdapters', () => {
       });
       expect(fetchMock).toHaveBeenCalledWith(
         'https://venn.carboncaste.io/vh/news/latest-index?limit=2&before=250',
+        expect.objectContaining({ method: 'GET' }),
+      );
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it('readNewsLatestIndexWithRelayRestFallback ignores invalid older cursor windows', async () => {
+    const mesh = createFakeMesh();
+    const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+    const client = createClient(mesh, guard, {
+      peers: ['wss://gun-a.carboncaste.io/gun'],
+    });
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+      ok: true,
+      records: {
+        'story-new': 300,
+        'story-mid': 200,
+      },
+    }), { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('location', {
+      href: 'https://venn.carboncaste.io/',
+      origin: 'https://venn.carboncaste.io',
+      protocol: 'https:',
+    });
+
+    try {
+      await expect(
+        readNewsLatestIndexWithRelayRestFallback(client, { limit: 2, before: Number.NaN }),
+      ).resolves.toEqual({
+        'story-new': 300,
+        'story-mid': 200,
+      });
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://venn.carboncaste.io/vh/news/latest-index?limit=2',
         expect.objectContaining({ method: 'GET' }),
       );
     } finally {

--- a/packages/gun-client/src/newsAdapters.test.ts
+++ b/packages/gun-client/src/newsAdapters.test.ts
@@ -1306,6 +1306,48 @@ describe('newsAdapters', () => {
     }
   });
 
+  it('preserves an explicit terminal relay latest-index cursor', async () => {
+    const mesh = createFakeMesh();
+    const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+    const hooks = await createRealSystemWriterHooks();
+    const client = createClient(mesh, guard, {
+      peers: ['wss://gun-a.carboncaste.io/gun'],
+      systemWriterPin: hooks.pin,
+      systemWriterSign: hooks.sign,
+    });
+
+    await writeNewsLatestIndexEntry(client, 'story-terminal', 321);
+    const record = expectSystemLatestIndexRecord(mesh.writes[0].value, 'story-terminal', 321);
+    const relayedStory = { ...STORY, story_id: 'story-terminal', cluster_window_end: 321 };
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+      ok: true,
+      record_count: 1,
+      truncated: false,
+      next_cursor: null,
+      records: { 'story-terminal': record },
+      stories: { 'story-terminal': relayedStory },
+    }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('location', {
+      href: 'https://venn.carboncaste.io/',
+      origin: 'https://venn.carboncaste.io',
+      protocol: 'https:',
+    });
+
+    try {
+      await expect(readNewsLatestIndexPageViaRelayRest(client)).resolves.toMatchObject({
+        index: { 'story-terminal': 321 },
+        nextCursor: null,
+        recordCount: 1,
+      });
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   it('keeps relay-embedded latest-index stories when legacy index signatures cannot be revalidated in the browser', async () => {
     const mesh = createFakeMesh();
     const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;

--- a/packages/gun-client/src/newsAdapters.ts
+++ b/packages/gun-client/src/newsAdapters.ts
@@ -179,6 +179,9 @@ function normalizeLatestIndexReadLimit(limit: unknown, fallback = RELAY_REST_IND
 }
 
 function normalizeLatestIndexBeforeCursor(before: unknown): number | null {
+  if (before === null || before === undefined || String(before).trim() === '') {
+    return null;
+  }
   const parsed = Number(before);
   return Number.isFinite(parsed) && parsed >= 0 ? Math.floor(parsed) : null;
 }
@@ -323,6 +326,9 @@ function latestIndexWindowNextCursor(index: NewsLatestIndex): number | null {
 }
 
 function normalizeRelayLatestIndexNextCursor(value: unknown): number | null {
+  if (value === null || value === undefined || String(value).trim() === '') {
+    return null;
+  }
   const parsed = Number(value);
   return Number.isFinite(parsed) && parsed >= 0 ? Math.floor(parsed) : null;
 }
@@ -2461,6 +2467,7 @@ export async function readNewsLatestIndexPageViaRelayRest(
   const stories: Record<string, StoryBundle> = {};
   const storyStates: Record<string, Record<string, unknown>> = {};
   let nextCursor: number | null = null;
+  let hasExplicitRelayNextCursor = false;
   let sourceKeyCount: number | undefined;
   let composition: unknown;
   const endpointPayloads = await Promise.all(endpoints.map(async (endpoint) => {
@@ -2559,9 +2566,12 @@ export async function readNewsLatestIndexPageViaRelayRest(
           }
         }
       }
-      const payloadNextCursor = normalizeRelayLatestIndexNextCursor(payload.next_cursor);
-      if (payloadNextCursor !== null) {
-        nextCursor = Math.max(nextCursor ?? payloadNextCursor, payloadNextCursor);
+      if (Object.prototype.hasOwnProperty.call(payload, 'next_cursor')) {
+        hasExplicitRelayNextCursor = true;
+        const payloadNextCursor = normalizeRelayLatestIndexNextCursor(payload.next_cursor);
+        if (payloadNextCursor !== null) {
+          nextCursor = Math.max(nextCursor ?? payloadNextCursor, payloadNextCursor);
+        }
       }
       const payloadSourceKeyCount = Number(payload.source_key_count);
       if (Number.isFinite(payloadSourceKeyCount) && payloadSourceKeyCount >= 0) {
@@ -2576,7 +2586,7 @@ export async function readNewsLatestIndexPageViaRelayRest(
   }
   return {
     index,
-    nextCursor: nextCursor ?? latestIndexWindowNextCursor(index),
+    nextCursor: hasExplicitRelayNextCursor ? nextCursor : latestIndexWindowNextCursor(index),
     recordCount: Object.keys(index).length,
     relayRestDiagnostics,
     ...(sourceKeyCount === undefined ? {} : { sourceKeyCount }),


### PR DESCRIPTION
## Summary
- stop the public relay from emitting a next cursor for terminal latest-index pages
- preserve explicit `next_cursor: null` in the gun-client relay adapter instead of deriving a synthetic cursor
- hide the feed load-more sentinel while loading and require a real public cursor before advertising older public stories

## Root cause
The live relay could return a terminal page with `truncated:false` while still setting `next_cursor` to the oldest item in the current page. The browser adapter also converted explicit null cursors back into an oldest-timestamp cursor. FeedShell then showed `Scroll for more...` and briefly `Loading more...` even when `/vh/news/latest-index?before=<cursor>` had no visible accepted rows to append.

## Verification
- `git diff --check`
- `node --check infra/relay/server.js`
- `pnpm exec vitest run apps/web-pwa/src/components/feed/FeedShell.lazyLoading.test.tsx --pool forks`
- `pnpm exec vitest run packages/gun-client/src/newsAdapters.test.ts --pool forks`
- `pnpm exec vitest run src/live/relay-server.vitest.mjs --config vitest.config.ts --pool forks` from `packages/e2e`
- `pnpm exec vitest run src/live/public-feed-browser-smoke.vitest.mjs --config vitest.config.ts --pool forks` from `packages/e2e`
- `pnpm exec vitest run src/live/public-feed-composition-freshness-gate.vitest.mjs --config vitest.config.ts --pool forks` from `packages/e2e`
- `pnpm --filter @vh/web-pwa typecheck`
- `pnpm --filter @vh/gun-client typecheck`
- `pnpm --filter @vh/e2e typecheck`