### PR TITLE
Public news release polish checks

### DIFF
--- a/.github/workflows/public-feed-freshness-monitor.yml
+++ b/.github/workflows/public-feed-freshness-monitor.yml
@@ -1,0 +1,55 @@
+name: Public Feed Freshness Monitor
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '23 * * * *'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: public-feed-freshness-monitor
+  cancel-in-progress: false
+
+jobs:
+  public-feed-freshness:
+    name: Public Feed Freshness
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      CI: true
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      VH_PUBLIC_FEED_FRESHNESS_CHECK_OPENAI_PREFLIGHT: ${{ vars.VH_PUBLIC_FEED_FRESHNESS_CHECK_OPENAI_PREFLIGHT }}
+      VH_PUBLIC_FEED_FRESHNESS_MAX_AGE_MS: ${{ vars.VH_PUBLIC_FEED_FRESHNESS_MAX_AGE_MS }}
+      VH_PUBLIC_FEED_FRESHNESS_ORIGINS: ${{ vars.VH_PUBLIC_FEED_FRESHNESS_ORIGINS }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build StoryCluster provider for optional OpenAI preflight
+        if: env.VH_PUBLIC_FEED_FRESHNESS_CHECK_OPENAI_PREFLIGHT == 'true'
+        run: pnpm --filter @vh/storycluster-engine build
+
+      - name: Run Public Feed Freshness Monitor
+        run: pnpm check:public-feed:freshness-monitor
+
+      - name: Upload Freshness Monitor Artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: public-feed-freshness-monitor
+          path: .tmp/public-feed-freshness/**
+          if-no-files-found: error
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ coverage/
 .tmp/
 packages/e2e/.tmp/
 services/news-aggregator/.tmp/
+output/playwright/
 tools/scripts/vh/data/
 *.lcov
 .nyc_output

--- a/apps/web-pwa/src/components/FeedList.test.tsx
+++ b/apps/web-pwa/src/components/FeedList.test.tsx
@@ -66,9 +66,10 @@ describe('FeedList', () => {
     expect(screen.getByTestId('feed-shell')).toBeInTheDocument();
   });
 
-  it('shows empty state when no items', () => {
+  it('keeps the public relay cold start in loading state when no items are hydrated yet', () => {
     render(<FeedList />);
-    expect(screen.getAllByTestId('feed-empty').length).toBeGreaterThan(0);
+    expect(screen.getByTestId('feed-loading')).toBeInTheDocument();
+    expect(screen.queryByTestId('feed-empty')).not.toBeInTheDocument();
   });
 
   it('renders feed items when present', async () => {

--- a/apps/web-pwa/src/components/feed/FeedContent.test.tsx
+++ b/apps/web-pwa/src/components/feed/FeedContent.test.tsx
@@ -1,0 +1,48 @@
+/* @vitest-environment jsdom */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { describe, expect, it, vi } from 'vitest';
+import React from 'react';
+import { FeedContent } from './FeedContent';
+
+function renderEmptyFeed(overrides: Partial<React.ComponentProps<typeof FeedContent>> = {}) {
+  return render(
+    <FeedContent
+      feed={[]}
+      loading={false}
+      error={null}
+      hasMore={false}
+      loadingMore={false}
+      loadMore={vi.fn()}
+      {...overrides}
+    />,
+  );
+}
+
+describe('FeedContent', () => {
+  it('renders the default empty state when no override is provided', () => {
+    renderEmptyFeed();
+
+    expect(screen.getByTestId('feed-empty')).toBeInTheDocument();
+    expect(screen.getByText('No items to show.')).toBeInTheDocument();
+  });
+
+  it('renders a custom empty state and action', () => {
+    const onAction = vi.fn();
+
+    renderEmptyFeed({
+      emptyState: {
+        title: 'Offline',
+        description: 'Reconnect before refreshing.',
+        actionLabel: 'Retry',
+        onAction,
+      },
+    });
+
+    expect(screen.getByText('Offline')).toBeInTheDocument();
+    expect(screen.getByText('Reconnect before refreshing.')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    expect(onAction).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web-pwa/src/components/feed/FeedContent.tsx
+++ b/apps/web-pwa/src/components/feed/FeedContent.tsx
@@ -15,6 +15,14 @@ export interface FeedContentProps {
   readonly hasMore: boolean;
   readonly loadingMore: boolean;
   readonly loadMore: () => void;
+  readonly emptyState?: FeedEmptyState;
+}
+
+export interface FeedEmptyState {
+  readonly title: string;
+  readonly description?: string;
+  readonly actionLabel?: string;
+  readonly onAction?: () => void;
 }
 
 export const FeedContent: React.FC<FeedContentProps> = ({
@@ -24,6 +32,7 @@ export const FeedContent: React.FC<FeedContentProps> = ({
   hasMore,
   loadingMore,
   loadMore,
+  emptyState,
 }) => {
   const showLoadSentinel = hasMore && !loadingMore;
   const sentinelRef = useIntersectionLoader<HTMLLIElement>({
@@ -56,12 +65,25 @@ export const FeedContent: React.FC<FeedContentProps> = ({
   }
 
   if (feed.length === 0) {
+    const title = emptyState?.title ?? 'No items to show.';
+    const description = emptyState?.description;
+    const showAction = emptyState?.actionLabel && emptyState.onAction;
     return (
       <div
         data-testid="feed-empty"
         className="rounded-[1.5rem] border border-dashed border-slate-200/90 bg-white/82 px-4 py-10 text-center text-sm text-slate-500 shadow-sm shadow-slate-900/5 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-300"
       >
-        No items to show.
+        <p className="font-semibold text-slate-700 dark:text-slate-100">{title}</p>
+        {description && <p className="mx-auto mt-2 max-w-sm">{description}</p>}
+        {showAction && (
+          <button
+            type="button"
+            className="mt-4 rounded-full border border-slate-300/80 bg-white px-4 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-slate-700 transition hover:border-slate-400 hover:bg-slate-100 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:hover:bg-slate-800"
+            onClick={emptyState.onAction}
+          >
+            {emptyState.actionLabel}
+          </button>
+        )}
       </div>
     );
   }

--- a/apps/web-pwa/src/components/feed/FeedShell.test.tsx
+++ b/apps/web-pwa/src/components/feed/FeedShell.test.tsx
@@ -10,6 +10,7 @@ import type { UseDiscoveryFeedResult } from '../../hooks/useDiscoveryFeed';
 import { DEFAULT_FEED_PERSONALIZATION_CONFIG, type FeedItem } from '@vh/data-model';
 import { resetExpandedCardStore } from './expandedCardStore';
 import { useDiscoveryStore } from '../../store/discovery';
+import { useNewsStore } from '../../store/news';
 
 const mockNavigate = vi.fn();
 let mockSearch: Record<string, unknown> = {};
@@ -88,6 +89,13 @@ function makeFeedResult(
   };
 }
 
+function setNavigatorOnlineForTest(online: boolean): void {
+  Object.defineProperty(window.navigator, 'onLine', {
+    configurable: true,
+    get: () => online,
+  });
+}
+
 describe('FeedShell', () => {
   afterEach(() => {
     cleanup();
@@ -95,6 +103,8 @@ describe('FeedShell', () => {
     mockSearch = {};
     resetExpandedCardStore();
     useDiscoveryStore.getState().reset();
+    useNewsStore.getState().reset();
+    setNavigatorOnlineForTest(true);
     localStorage.clear();
     delete (window as Window & { __VH_BOOT_SEARCH__?: string }).__VH_BOOT_SEARCH__;
     window.history.replaceState(window.history.state, '', '/');
@@ -343,10 +353,21 @@ describe('FeedShell', () => {
 
   // ---- Empty state ----
 
-  it('shows empty state when feed is empty', () => {
+  it('keeps an empty public relay cold start in loading state', () => {
     render(<FeedShell feedResult={makeFeedResult({ feed: [] })} />);
+    expect(screen.getByTestId('feed-loading')).toBeInTheDocument();
+    expect(screen.queryByTestId('feed-empty')).not.toBeInTheDocument();
+  });
+
+  it('shows an offline empty state when the browser has no network', () => {
+    setNavigatorOnlineForTest(false);
+
+    render(<FeedShell feedResult={makeFeedResult({ feed: [] })} />);
+
     expect(screen.getByTestId('feed-empty')).toBeInTheDocument();
-    expect(screen.getByText('No items to show.')).toBeInTheDocument();
+    expect(screen.getByText("You're offline")).toBeInTheDocument();
+    expect(screen.getByText('Reconnect to refresh the public news mesh.')).toBeInTheDocument();
+    expect(screen.queryByText('No items to show.')).not.toBeInTheDocument();
   });
 
   // ---- Loading state ----
@@ -355,6 +376,15 @@ describe('FeedShell', () => {
     render(<FeedShell feedResult={makeFeedResult({ loading: true })} />);
     expect(screen.getByTestId('feed-loading')).toBeInTheDocument();
     expect(screen.getByText('Loading feed…')).toBeInTheDocument();
+  });
+
+  it('keeps the feed in loading state while public news is still hydrating', () => {
+    useNewsStore.getState().setLoading(true);
+
+    render(<FeedShell feedResult={makeFeedResult({ feed: [] })} />);
+
+    expect(screen.getByTestId('feed-loading')).toBeInTheDocument();
+    expect(screen.queryByTestId('feed-empty')).not.toBeInTheDocument();
   });
 
   it('does not show feed list while loading', () => {

--- a/apps/web-pwa/src/components/feed/FeedShell.tsx
+++ b/apps/web-pwa/src/components/feed/FeedShell.tsx
@@ -45,6 +45,13 @@ function hasBrowserPublicNewsRelay(): boolean {
   return /^https?:\/\//.test(origin);
 }
 
+function readBrowserOnline(): boolean {
+  if (typeof navigator === 'undefined' || typeof navigator.onLine !== 'boolean') {
+    return true;
+  }
+  return navigator.onLine;
+}
+
 /**
  * Shell container for the V2 discovery feed.
  * Composes route state, feed paging, refresh safety, and feed chrome.
@@ -117,6 +124,7 @@ export const FeedShell: React.FC<FeedShellProps> = ({ feedResult }) => {
   const [newsRefreshLimit, setNewsRefreshLimit] = useState(PUBLIC_NEWS_REFRESH_INITIAL_LIMIT);
   const [meshLoadingMore, setMeshLoadingMore] = useState(false);
   const [meshPaginationExhausted, setMeshPaginationExhausted] = useState(false);
+  const [browserOnline, setBrowserOnline] = useState(readBrowserOnline);
 
   const focusedStoryline = selectedStorylineId ? storylinesById[selectedStorylineId] ?? null : null;
   const directRouteStoryId = useMemo(
@@ -242,7 +250,7 @@ export const FeedShell: React.FC<FeedShellProps> = ({ feedResult }) => {
   );
 
   const handleRefresh = useCallback(async () => {
-    if (refreshing) return;
+    if (refreshing || !browserOnline) return;
     setRefreshing(true);
     setMeshPaginationExhausted(false);
     setNewsRefreshLimit(PUBLIC_NEWS_REFRESH_INITIAL_LIMIT);
@@ -254,7 +262,7 @@ export const FeedShell: React.FC<FeedShellProps> = ({ feedResult }) => {
         setRefreshing(false);
       }
     }
-  }, [applyDeferredFeed, refreshLatest, refreshing]);
+  }, [applyDeferredFeed, browserOnline, refreshLatest, refreshing]);
 
   useEffect(() => {
     return () => {
@@ -263,8 +271,27 @@ export const FeedShell: React.FC<FeedShellProps> = ({ feedResult }) => {
   }, []);
 
   useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const updateBrowserOnline = () => {
+      setBrowserOnline(readBrowserOnline());
+    };
+
+    updateBrowserOnline();
+    window.addEventListener('online', updateBrowserOnline);
+    window.addEventListener('offline', updateBrowserOnline);
+    return () => {
+      window.removeEventListener('online', updateBrowserOnline);
+      window.removeEventListener('offline', updateBrowserOnline);
+    };
+  }, []);
+
+  useEffect(() => {
     if (
       initialPublicNewsRefreshRef.current ||
+      !browserOnline ||
       (!publicNewsClientReady && !publicRelayColdStartReady) ||
       loading ||
       publicNewsLoading
@@ -290,6 +317,7 @@ export const FeedShell: React.FC<FeedShellProps> = ({ feedResult }) => {
       });
   }, [
     applyDeferredFeed,
+    browserOnline,
     loading,
     loadedPublicNewsStoryCount,
     publicNewsClientReady,
@@ -302,6 +330,7 @@ export const FeedShell: React.FC<FeedShellProps> = ({ feedResult }) => {
     typeof publicNewsLatestIndexCursor === 'number' && Number.isFinite(publicNewsLatestIndexCursor);
   const canRequestMorePublicNews =
     !hasMore &&
+    browserOnline &&
     !loading &&
     !error &&
     newsCount > 0 &&
@@ -508,6 +537,15 @@ export const FeedShell: React.FC<FeedShellProps> = ({ feedResult }) => {
     pullTriggeredRef.current = false;
   }, []);
 
+  const feedContentLoading =
+    loading || (browserOnline && pagedFeed.length === 0 && (refreshing || publicNewsLoading));
+  const feedEmptyState = !browserOnline
+    ? {
+        title: "You're offline",
+        description: 'Reconnect to refresh the public news mesh.',
+      }
+    : undefined;
+
   return (
     <div
       className="mx-auto flex max-w-[760px] flex-col gap-4"
@@ -554,11 +592,12 @@ export const FeedShell: React.FC<FeedShellProps> = ({ feedResult }) => {
       <div className="rounded-[1.5rem] border border-white/70 bg-white/70 p-2.5 shadow-[0_22px_58px_-44px_rgba(15,23,42,0.34)] backdrop-blur dark:border-slate-700/70 dark:bg-slate-950/55 sm:p-3">
         <FeedContent
           feed={pagedFeed}
-          loading={loading}
+          loading={feedContentLoading}
           error={error}
           hasMore={hasMore || canRequestMorePublicNews}
           loadingMore={loadingMore || meshLoadingMore}
           loadMore={handleLoadMore}
+          emptyState={feedEmptyState}
         />
       </div>
     </div>

--- a/apps/web-pwa/src/routes/PublicBetaNotFoundState.test.tsx
+++ b/apps/web-pwa/src/routes/PublicBetaNotFoundState.test.tsx
@@ -1,0 +1,19 @@
+/* @vitest-environment jsdom */
+
+import { render, screen, within } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { describe, expect, it } from 'vitest';
+import React from 'react';
+import { PublicBetaNotFoundState } from './PublicBetaNotFoundState';
+
+describe('PublicBetaNotFoundState', () => {
+  it('renders a public-beta-safe not found state with feed and support exits', () => {
+    render(<PublicBetaNotFoundState />);
+
+    const state = screen.getByTestId('public-beta-not-found');
+    expect(within(state).getByRole('heading', { name: 'Page not found' })).toBeInTheDocument();
+    expect(within(state).getByText(/not part of the public news beta surface/i)).toBeInTheDocument();
+    expect(within(state).getByRole('link', { name: 'Back to feed' })).toHaveAttribute('href', '/');
+    expect(within(state).getByRole('link', { name: 'Support' })).toHaveAttribute('href', '/support');
+  });
+});

--- a/apps/web-pwa/src/routes/PublicBetaNotFoundState.tsx
+++ b/apps/web-pwa/src/routes/PublicBetaNotFoundState.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+export const PublicBetaNotFoundState: React.FC = () => (
+  <section
+    data-testid="public-beta-not-found"
+    className="rounded-[1.5rem] border border-slate-200/80 bg-white/86 p-5 text-slate-700 shadow-sm shadow-slate-900/5 dark:border-slate-700 dark:bg-slate-950/70 dark:text-slate-200 sm:p-6"
+  >
+    <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400">
+      Public beta
+    </p>
+    <h1 className="mt-2 text-xl font-semibold text-slate-950 dark:text-slate-50">
+      Page not found
+    </h1>
+    <p className="mt-2 max-w-prose text-sm leading-6 text-slate-600 dark:text-slate-300">
+      That route is not part of the public news beta surface. Return to the feed and keep browsing
+      from the latest published stories.
+    </p>
+    <div className="mt-5 flex flex-wrap gap-3">
+      <a
+        href="/"
+        className="inline-flex items-center justify-center rounded-full border border-slate-300/80 bg-white px-4 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-slate-700 transition hover:border-slate-400 hover:bg-slate-100 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:hover:bg-slate-800"
+      >
+        Back to feed
+      </a>
+      <a
+        href="/support"
+        className="inline-flex items-center justify-center rounded-full border border-transparent bg-slate-900 px-4 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-white transition hover:bg-slate-700 dark:bg-slate-100 dark:text-slate-950 dark:hover:bg-white"
+      >
+        Support
+      </a>
+    </div>
+  </section>
+);
+
+export default PublicBetaNotFoundState;

--- a/apps/web-pwa/src/routes/index.tsx
+++ b/apps/web-pwa/src/routes/index.tsx
@@ -19,6 +19,7 @@ import {
   PublicBetaComplianceIndex,
   PublicBetaCompliancePageView,
 } from './publicBetaCompliance';
+import { PublicBetaNotFoundState } from './PublicBetaNotFoundState';
 
 const RootComponent = () => (
   <RootShell>
@@ -198,7 +199,7 @@ const HermesThreadPage: React.FC = () => {
 
 const rootRoute = createRootRoute({
   component: RootComponent,
-  notFoundComponent: () => <div className="text-slate-700">Not Found</div>
+  notFoundComponent: PublicBetaNotFoundState
 });
 
 const indexRoute = createRoute({

--- a/docs/ops/public-feed-freshness-monitor.md
+++ b/docs/ops/public-feed-freshness-monitor.md
@@ -1,0 +1,62 @@
+# Public Feed Freshness Monitor
+
+## Purpose
+
+The MVP release gates are point-in-time evidence. This monitor is the continuous
+backstop for the deployed public feed after launch: it fails if the newest
+accepted story visible through the public latest-index is older than the
+configured freshness budget, or if the deployed origin/relay health surfaces
+stop responding.
+
+## Scheduled Alert Path
+
+GitHub Actions runs **Public Feed Freshness Monitor** hourly from
+`.github/workflows/public-feed-freshness-monitor.yml`. A red scheduled run is the
+minimum launch alert channel. The failing run uploads
+`.tmp/public-feed-freshness/**`, including
+`.tmp/public-feed-freshness/latest/public-feed-freshness-summary.json`, so the
+operator can inspect the exact stale origin, HTTP failure, or OpenAI preflight
+failure.
+
+Operators should keep GitHub scheduled-workflow failure notifications enabled
+for the release owner account. If this monitor is promoted into PagerDuty or a
+host-local launchd check later, the GitHub Action remains the canonical public
+artifact producer unless this document is updated.
+
+## Command
+
+```bash
+pnpm check:public-feed:freshness-monitor
+```
+
+Default origins:
+
+- `https://venn.carboncaste.io/`
+- `https://gun-a.carboncaste.io/`
+- `https://gun-b.carboncaste.io/`
+- `https://gun-c.carboncaste.io/`
+
+Default freshness SLO: newest latest-index row age <= 6 hours.
+
+## Configuration
+
+| Variable | Default | Notes |
+| --- | --- | --- |
+| `VH_PUBLIC_FEED_FRESHNESS_ORIGINS` | deployed `venn` + `gun-a/b/c` | Comma, whitespace, or JSON array override for staging/manual runs. |
+| `VH_PUBLIC_FEED_FRESHNESS_MAX_AGE_MS` | `21600000` | Set to `0` for a forced-stale failure test. |
+| `VH_PUBLIC_FEED_FRESHNESS_TIMEOUT_MS` | `15000` | Per-request HTTP timeout. |
+| `VH_PUBLIC_FEED_FRESHNESS_INDEX_LIMIT` | `80` | Latest-index page size read from every origin. |
+| `VH_PUBLIC_FEED_FRESHNESS_SCAN_LIMIT` | `120` | Relay scan limit for latest-index reads. |
+| `VH_PUBLIC_FEED_FRESHNESS_CHECK_OPENAI_PREFLIGHT` | `false` | When `true`, the monitor builds StoryCluster and fails on auth/quota/model preflight errors. |
+| `VH_PUBLIC_FEED_FRESHNESS_ARTIFACT_DIR` | `.tmp/public-feed-freshness/<timestamp>` | Override for deterministic local tests. |
+
+## Failure Classes
+
+- `health_unhealthy`: `/healthz` failed, or a relay `/readyz` failed.
+- `latest_index_not_fresh`: latest-index fetch failed, was empty, had no usable
+  timestamp, or the newest row was stale.
+- `openai_preflight_failed`: optional StoryCluster OpenAI preflight did not pass.
+
+Do not convert these failures into warnings for release evidence. A stale feed
+means users are seeing old news, even if the last one-shot MVP gate packet was
+green.

--- a/docs/ops/public-feed-freshness-monitor.md
+++ b/docs/ops/public-feed-freshness-monitor.md
@@ -1,5 +1,10 @@
 # Public Feed Freshness Monitor
 
+> Status: Operational Monitor
+> Owner: VHC Launch Ops
+> Last Reviewed: 2026-06-12
+> Depends On: docs/ops/public-beta-launch-readiness-closeout.md, docs/reports/mesh-readiness-state-of-play-2026-06-12.md
+
 ## Purpose
 
 The MVP release gates are point-in-time evidence. This monitor is the continuous

--- a/docs/ops/public-news-mvp-polish-walkthrough-2026-06-12.md
+++ b/docs/ops/public-news-mvp-polish-walkthrough-2026-06-12.md
@@ -1,5 +1,10 @@
 # Public News MVP Polish Walkthrough - 2026-06-12
 
+> Status: Public Beta Polish Evidence
+> Owner: VHC Launch Ops
+> Last Reviewed: 2026-06-12
+> Depends On: docs/ops/public-feed-freshness-monitor.md, docs/ops/public-news-mvp-release-decisions.md, docs/reports/mesh-readiness-state-of-play-2026-06-12.md
+
 ## Scope
 
 Target: `https://venn.carboncaste.io/`

--- a/docs/ops/public-news-mvp-polish-walkthrough-2026-06-12.md
+++ b/docs/ops/public-news-mvp-polish-walkthrough-2026-06-12.md
@@ -1,0 +1,57 @@
+# Public News MVP Polish Walkthrough - 2026-06-12
+
+## Scope
+
+Target: `https://venn.carboncaste.io/`
+
+Method: automated Playwright browser walkthrough from this workstation after PR
+#635 was merged into `main`. This is not a substitute for a real-phone human QA
+pass; it covers mobile-sized Chromium (`390x844`), desktop Chromium
+(`1440x1200`), bad-route handling, offline reload, and online recovery.
+
+Local screenshot artifacts:
+
+- `output/playwright/vhc-mobile-empty-feed.png`
+- `output/playwright/vhc-mobile-loaded-feed.png`
+- `output/playwright/vhc-mobile-story-expanded.png`
+- `output/playwright/vhc-desktop-feed.png`
+- `output/playwright/vhc-desktop-after-refresh.png`
+- `output/playwright/vhc-bad-route.png`
+- `output/playwright/vhc-offline-feed.png`
+- `output/playwright/vhc-reconnected-feed.png`
+
+## Checklist
+
+| Area | Status | Evidence |
+| --- | --- | --- |
+| Mobile cold load | Pass with caveat | Initial snapshot briefly showed `0 live · 0 news · 0 topics` and `No items to show`; after relay reads completed, mobile populated to `15 live · 15 news · 0 topics`. |
+| Mobile feed scan | Pass | Populated feed rendered singleton and multi-source news cards, source labels, timestamps, engagement counts, and `Scroll for more`. |
+| Mobile story detail | Pass with caveat | Expanded story rendered synthesis summary, generated timestamp, frame/reframe table, report controls, conversation section, and identity-unavailable stance messaging. The frame/reframe table is usable but dense on `390px` wide screens. |
+| Desktop feed | Pass | Desktop rendered 15 news cards with filters, sort controls, hotness, source badges, images, and load-more state. |
+| Refresh | Pass | Refresh updated hotness values and kept the feed populated. |
+| Online recovery after offline | Pass | After returning online and reloading, peers recovered from `0` to `3` and the feed repopulated. |
+| Bad route | Fixed locally, pending deploy | Live `/stories/not-a-real-story` rendered only bare `Not Found`. This branch replaces it with a public-beta not-found state and feed/support exits. |
+| Offline reload | Fixed locally, pending deploy | Live offline reload rendered an empty feed with `Peers: 0` and `No items to show`. This branch adds an explicit offline empty state and keeps public-relay cold start in loading instead of flashing empty content. |
+| Console health | Fail - pre-beta cleanup | Live browser emitted repeated `system-writer-validation-failed` warnings for raw `vh/news/index/latest/*` children with `unknown-signer-id`. This matches the raw latest-root hygiene gap and is user-filtered, but it pollutes console/error telemetry. |
+| Analysis config route | Fail - canary risk | Browser requests to `/api/analyze/config` returned 502 during the walkthrough. The production app canary includes an `api_analyze` downstream surface, so this must be green before canary pass can be claimed. |
+| Real phone | Not run | Requires owner/operator device pass on cellular or throttled network. |
+| Second-device vote convergence | Not run | Requires two real sessions or the existing second-browser canary lane with release credentials. |
+
+## Beta Triage
+
+Blocks polished MVP before public beta:
+
+- Deploy this branch's bad-route and offline empty-state fixes, then repeat the
+  browser walkthrough against `https://venn.carboncaste.io/`.
+- Restore `/api/analyze/config` health or document why the production app canary
+  can still observe the required `api_analyze` surface.
+
+Pre-beta cleanup unless owner accepts console noise:
+
+- Run the raw latest-root hygiene dry run, then owner-approved scrub if the
+  invalid children are confirmed stale telemetry.
+
+Post-beta acceptable:
+
+- Mobile frame/reframe density improvements.
+- Real-device UX refinements discovered by the owner/operator phone pass.

--- a/docs/ops/public-news-mvp-release-decisions.md
+++ b/docs/ops/public-news-mvp-release-decisions.md
@@ -1,0 +1,24 @@
+# Public News MVP Release Decisions
+
+## Status
+
+These decisions are required before broad public-beta claims. This file records
+the current repo-side defaults and the remaining owner sign-off needed; it does
+not grant release approval by itself.
+
+## Decisions
+
+| Decision | Current repo stance | Owner action needed |
+| --- | --- | --- |
+| Retention promise | No committed TTL/eviction promise for stories, syntheses, lifecycle rows, or aggregates. The freshness monitor only proves new accepted rows remain recent. | State the beta retention promise, for example `feed history retained at least N days`, `best-effort beta history`, or `indefinite beta retention`, and decide whether it becomes a gate or monitor. |
+| Live multi-source launch copy | `VH_PUBLIC_FEED_FRESH_PROPAGATION_REQUIRE_MULTI_SOURCE` is available and defaults to `false`. Current launch copy must not claim live breaking-news corroboration unless this flag is run against live RSS and passes. | Choose whether the beta pitch promises live cross-source corroboration. If yes, run fresh propagation with the flag enabled and capture a live multi-source event. |
+| Raw latest-root hygiene bar | User-visible readers filter invalid raw children, but the 2026-06-12 browser walkthrough still emitted raw latest-root `unknown-signer-id` warnings. Scrub tooling remains owner-gated because it writes production mesh state. | Decide whether zero invalid raw latest-root children blocks beta. If yes, approve dry-run evidence and then approve `--apply` scrub separately. |
+| Quorum/host asymmetry | Current known topology has the web origin plus `gun-a` and `gun-b` on A6, with `gun-c` on the Mac mini. A6 loss takes down origin plus 2-of-3 quorum. | Explicitly accept this for controlled beta or schedule peer redistribution before broad beta. |
+
+## Claim Boundary
+
+Until the owner decisions above are recorded as accepted and the release gates
+pass on the final head, launch language must stay inside controlled-beta,
+public-news usability. Do not claim mesh `release_ready`, production app canary
+pass, full-app readiness, test-group readiness, LUMA Silver, verified-human,
+one-human-one-vote, or Sybil resistance from this document.

--- a/docs/ops/public-news-mvp-release-decisions.md
+++ b/docs/ops/public-news-mvp-release-decisions.md
@@ -1,5 +1,10 @@
 # Public News MVP Release Decisions
 
+> Status: Owner Decision Ledger
+> Owner: VHC Product + Launch Ops
+> Last Reviewed: 2026-06-12
+> Depends On: docs/ops/public-beta-launch-readiness-closeout.md, docs/reports/mesh-readiness-state-of-play-2026-06-12.md
+
 ## Status
 
 These decisions are required before broad public-beta claims. This file records

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "check:public-feed:composition-freshness": "pnpm --filter @vh/gun-client build && node ./packages/e2e/src/live/public-feed-composition-freshness-gate.mjs",
     "check:public-feed:lifecycle-accountability": "pnpm --filter @vh/gun-client build && node ./packages/e2e/src/live/public-feed-lifecycle-accountability.mjs",
     "check:public-feed:fresh-propagation": "pnpm --filter @vh/e2e test:live:daemon-feed:build && node ./packages/e2e/src/live/public-feed-fresh-propagation-gate.mjs",
+    "check:public-feed:freshness-monitor": "node ./tools/scripts/public-feed-freshness-monitor.mjs",
     "test:mesh:browser-canary": "VITE_GUN_PEERS='[\"http://127.0.0.1:7788/gun\",\"http://127.0.0.1:7789/gun\",\"http://127.0.0.1:7790/gun\"]' VITE_GUN_PEER_MINIMUM=3 VITE_GUN_PEER_QUORUM_REQUIRED=2 VITE_VH_ALLOW_LOCAL_MESH_PEERS=true VITE_VH_GUN_LOCAL_STORAGE=false VITE_VH_SHOW_HEALTH=true pnpm --filter @vh/web-pwa build && pnpm --filter @vh/e2e test:mesh:browser-canary",
     "test:mesh:signed-peer-config-canary": "node ./packages/e2e/src/mesh/signed-peer-config-canary.mjs",
     "test:mesh:deployed-wss-peer-config": "pnpm --filter @vh/e2e test:mesh:deployed-wss-peer-config",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "check:public-feed:composition-freshness": "pnpm --filter @vh/gun-client build && node ./packages/e2e/src/live/public-feed-composition-freshness-gate.mjs",
     "check:public-feed:lifecycle-accountability": "pnpm --filter @vh/gun-client build && node ./packages/e2e/src/live/public-feed-lifecycle-accountability.mjs",
     "check:public-feed:fresh-propagation": "pnpm --filter @vh/e2e test:live:daemon-feed:build && node ./packages/e2e/src/live/public-feed-fresh-propagation-gate.mjs",
-    "check:public-feed:freshness-monitor": "node ./tools/scripts/public-feed-freshness-monitor.mjs",
+    "check:public-feed:freshness-monitor": "pnpm --filter @vh/gun-client build && node ./tools/scripts/public-feed-freshness-monitor.mjs",
     "test:mesh:browser-canary": "VITE_GUN_PEERS='[\"http://127.0.0.1:7788/gun\",\"http://127.0.0.1:7789/gun\",\"http://127.0.0.1:7790/gun\"]' VITE_GUN_PEER_MINIMUM=3 VITE_GUN_PEER_QUORUM_REQUIRED=2 VITE_VH_ALLOW_LOCAL_MESH_PEERS=true VITE_VH_GUN_LOCAL_STORAGE=false VITE_VH_SHOW_HEALTH=true pnpm --filter @vh/web-pwa build && pnpm --filter @vh/e2e test:mesh:browser-canary",
     "test:mesh:signed-peer-config-canary": "node ./packages/e2e/src/mesh/signed-peer-config-canary.mjs",
     "test:mesh:deployed-wss-peer-config": "pnpm --filter @vh/e2e test:mesh:deployed-wss-peer-config",

--- a/packages/e2e/src/live/public-beta-origin-server.vitest.mjs
+++ b/packages/e2e/src/live/public-beta-origin-server.vitest.mjs
@@ -338,6 +338,115 @@ describe('public beta origin server', () => {
     expect(writeRequests.every((request) => request.headers['x-vh-relay-device-pub'] === 'device-pub')).toBe(true);
   });
 
+  it('passes through relay 4xx JSON for malformed aggregate fanout reads', async () => {
+    const staticDir = await makeStaticRoot();
+    const relayUrls = [];
+    const relayPayloads = [
+      { status: 422, body: { ok: false, error: 'topic_id is required', code: 'missing_topic_id', relay: 'a' } },
+      { status: 400, body: { ok: false, error: 'topic_id is required', code: 'missing_topic_id', relay: 'b' } },
+      { status: 500, body: { ok: false, error: 'relay unavailable', relay: 'c' } },
+    ];
+
+    for (const payload of relayPayloads) {
+      const relay = createServer((_req, res) => {
+        res.writeHead(payload.status, { 'content-type': 'application/json' });
+        res.end(JSON.stringify(payload.body));
+      });
+      relayUrls.push(await listen(relay));
+      cleanup.push(() => new Promise((resolve) => relay.close(resolve)));
+    }
+
+    const origin = await startOrigin({
+      staticDir,
+      peerConfigPath: join(staticDir, 'mesh-peer-config.json'),
+      relayTargets: relayUrls,
+      cspConnectSrc: PUBLIC_CSP_CONNECT_SRC,
+    });
+
+    const response = await fetch(`${origin}/vh/aggregates/point`);
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      ok: false,
+      error: 'topic_id is required',
+      code: 'missing_topic_id',
+      relay: 'b',
+    });
+  });
+
+  it('keeps aggregate fanout network failures as origin 502s', async () => {
+    const staticDir = await makeStaticRoot();
+    const closedPorts = [];
+    for (let index = 0; index < 3; index += 1) {
+      const server = createServer();
+      const url = await listen(server);
+      await new Promise((resolve) => server.close(resolve));
+      closedPorts.push(url);
+    }
+
+    const origin = await startOrigin({
+      staticDir,
+      peerConfigPath: join(staticDir, 'mesh-peer-config.json'),
+      relayTargets: closedPorts,
+      relayFanoutTimeoutMs: 25,
+      cspConnectSrc: PUBLIC_CSP_CONNECT_SRC,
+    });
+
+    const response = await fetch(`${origin}/vh/aggregates/point?topic_id=topic-1&synthesis_id=synth-1&epoch=0&point_id=point-1`);
+    expect(response.status).toBe(502);
+    expect(await response.json()).toMatchObject({ ok: false, error: 'Upstream request failed' });
+  });
+
+  it('prefers aggregate fanout 2xx responses over relay 4xx responses', async () => {
+    const staticDir = await makeStaticRoot();
+    const relayUrls = [];
+    const relayPayloads = [
+      { status: 400, body: { ok: false, error: 'topic_id is required' } },
+      {
+        status: 200,
+        body: {
+          ok: true,
+          aggregate: {
+            point_id: 'point-1',
+            agree: 7,
+            disagree: 0,
+            weight: 7,
+            participants: 7,
+          },
+          row_count: 7,
+        },
+      },
+      { status: 422, body: { ok: false, error: 'invalid point_id' } },
+    ];
+
+    for (const payload of relayPayloads) {
+      const relay = createServer((_req, res) => {
+        res.writeHead(payload.status, { 'content-type': 'application/json' });
+        res.end(JSON.stringify(payload.body));
+      });
+      relayUrls.push(await listen(relay));
+      cleanup.push(() => new Promise((resolve) => relay.close(resolve)));
+    }
+
+    const origin = await startOrigin({
+      staticDir,
+      peerConfigPath: join(staticDir, 'mesh-peer-config.json'),
+      relayTargets: relayUrls,
+      cspConnectSrc: PUBLIC_CSP_CONNECT_SRC,
+    });
+
+    const response = await fetch(`${origin}/vh/aggregates/point?topic_id=topic-1&synthesis_id=synth-1&epoch=0&point_id=point-1`);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      ok: true,
+      aggregate: {
+        point_id: 'point-1',
+        agree: 7,
+        participants: 7,
+      },
+      row_count: 7,
+    });
+  });
+
   it('serves public news and synthesis read fallbacks from the first usable completed relay target', async () => {
     const staticDir = await makeStaticRoot();
     const relayRequests = [];

--- a/packages/e2e/src/live/public-feed-fresh-propagation-gate.mjs
+++ b/packages/e2e/src/live/public-feed-fresh-propagation-gate.mjs
@@ -284,6 +284,7 @@ export function validateFreshPropagationEvidence({
   const consumerRequired = boolEnv(env.VH_PUBLIC_FEED_FRESH_PROPAGATION_REQUIRE_CONSUMER_SMOKE, true);
   const browserConsumerRequired = boolEnv(env.VH_PUBLIC_FEED_FRESH_PROPAGATION_REQUIRE_BROWSER_CONSUMER, true);
   const browserSmokeRequired = boolEnv(env.VH_PUBLIC_FEED_FRESH_PROPAGATION_REQUIRE_PUBLIC_BROWSER_SMOKE, false);
+  const multiSourceRequired = boolEnv(env.VH_PUBLIC_FEED_FRESH_PROPAGATION_REQUIRE_MULTI_SOURCE, false);
   const freshnessWindowMs = freshnessWindowMsFromEnv(env);
 
   if (!publisherSummary || typeof publisherSummary !== 'object') {
@@ -358,6 +359,11 @@ export function validateFreshPropagationEvidence({
   }
   if (readableStories.length <= 0) {
     throw new Error('fresh-propagation-readable-story-body-missing');
+  }
+  const singletonStories = stories.filter((story) => storySources(story).length === 1);
+  const multiSourceStories = stories.filter((story) => storySources(story).length >= 2);
+  if (multiSourceRequired && multiSourceStories.length <= 0) {
+    throw new Error('fresh-propagation-multi-source-missing');
   }
 
   const latestActivityAt = Math.max(
@@ -443,8 +449,8 @@ export function validateFreshPropagationEvidence({
       readableStoryBodyCount: readableStories.length,
       latestIndexCount: Object.keys(latestIndex).length,
       hotIndexCount: Object.keys(hotIndex).length,
-      singletonCount: stories.filter((story) => storySources(story).length === 1).length,
-      multiSourceCount: stories.filter((story) => storySources(story).length >= 2).length,
+      singletonCount: singletonStories.length,
+      multiSourceCount: multiSourceStories.length,
     },
     storyIds: stories.map((story) => story?.story_id).filter(Boolean),
     readableStoryIds: readableStories,
@@ -655,6 +661,7 @@ export async function runPublicFeedFreshPropagationGate({
       requireConsumerSmoke: boolEnv(env.VH_PUBLIC_FEED_FRESH_PROPAGATION_REQUIRE_CONSUMER_SMOKE, true),
       requireBrowserConsumer: boolEnv(env.VH_PUBLIC_FEED_FRESH_PROPAGATION_REQUIRE_BROWSER_CONSUMER, true),
       requirePublicBrowserSmoke: boolEnv(env.VH_PUBLIC_FEED_FRESH_PROPAGATION_REQUIRE_PUBLIC_BROWSER_SMOKE, false),
+      requireMultiSource: boolEnv(env.VH_PUBLIC_FEED_FRESH_PROPAGATION_REQUIRE_MULTI_SOURCE, false),
     },
     status: 'fail',
     publisherRun,

--- a/packages/e2e/src/live/public-feed-fresh-propagation-gate.vitest.mjs
+++ b/packages/e2e/src/live/public-feed-fresh-propagation-gate.vitest.mjs
@@ -211,6 +211,50 @@ describe('public feed fresh propagation gate', () => {
     });
   });
 
+  it('keeps fresh singleton-only propagation valid unless multi-source proof is required', () => {
+    const now = Date.now();
+    const snapshot = publisherSnapshot(now);
+    snapshot.stories = snapshot.stories.map((story) => ({
+      ...story,
+      sources: [story.sources[0]],
+    }));
+
+    expect(validateFreshPropagationEvidence({
+      publisherSummary: publisherSummary(),
+      publisherLogs: publisherLogs(),
+      publisherSnapshot: snapshot,
+      consumerSummary: consumerSummary(),
+      env: {},
+      now,
+    })).toMatchObject({
+      status: 'pass',
+      storyCounts: {
+        singletonCount: 2,
+        multiSourceCount: 0,
+      },
+    });
+  });
+
+  it('rejects fresh singleton-only propagation when multi-source proof is required', () => {
+    const now = Date.now();
+    const snapshot = publisherSnapshot(now);
+    snapshot.stories = snapshot.stories.map((story) => ({
+      ...story,
+      sources: [story.sources[0]],
+    }));
+
+    expect(() => validateFreshPropagationEvidence({
+      publisherSummary: publisherSummary(),
+      publisherLogs: publisherLogs(),
+      publisherSnapshot: snapshot,
+      consumerSummary: consumerSummary(),
+      env: {
+        VH_PUBLIC_FEED_FRESH_PROPAGATION_REQUIRE_MULTI_SOURCE: 'true',
+      },
+      now,
+    })).toThrow('fresh-propagation-multi-source-missing');
+  });
+
   it('rejects fixture-only producer evidence when live RSS is required', () => {
     const summary = publisherSummary();
     summary.sourceHealth.reportSource = 'fixture';

--- a/packages/e2e/src/live/public-feed-freshness-monitor.vitest.mjs
+++ b/packages/e2e/src/live/public-feed-freshness-monitor.vitest.mjs
@@ -1,0 +1,153 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { createServer } from 'node:http';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runPublicFeedFreshnessMonitor } from '../../../../tools/scripts/public-feed-freshness-monitor.mjs';
+
+const cleanup = [];
+
+afterEach(async () => {
+  while (cleanup.length > 0) {
+    const item = cleanup.pop();
+    if (typeof item === 'function') await item();
+  }
+});
+
+function listen(server) {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', reject);
+      const address = server.address();
+      resolve(`http://127.0.0.1:${address.port}`);
+    });
+  });
+}
+
+async function makeRepoRoot() {
+  const root = await mkdtemp(join(tmpdir(), 'vh-freshness-monitor-'));
+  cleanup.push(() => rm(root, { recursive: true, force: true }));
+  return root;
+}
+
+async function startOrigin({
+  timestamp,
+  service = 'vh-public-beta-origin',
+  readyStatus = 200,
+} = {}) {
+  const server = createServer((req, res) => {
+    if (req.url?.startsWith('/healthz')) {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({
+        ok: true,
+        service,
+        relay_id: service === 'vh-relay' ? 'relay-test' : undefined,
+        route_surface: service === 'vh-relay' ? 'vh-relay-http-v1' : undefined,
+        public_http_routes: service === 'vh-relay'
+          ? ['/vh/news/latest-index', '/vh/news/hot-index', '/vh/news/story', '/vh/topics/synthesis']
+          : undefined,
+      }));
+      return;
+    }
+    if (req.url?.startsWith('/readyz')) {
+      res.writeHead(readyStatus, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({
+        ok: readyStatus >= 200 && readyStatus < 300,
+        service: 'vh-relay',
+        route_surface: 'vh-relay-http-v1',
+      }));
+      return;
+    }
+    if (req.url?.startsWith('/vh/news/latest-index')) {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({
+        ok: true,
+        records: {
+          'story-fresh': {
+            story_id: 'story-fresh',
+            latest_activity_at: timestamp,
+            source_count: 2,
+          },
+        },
+      }));
+      return;
+    }
+    res.writeHead(404, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ ok: false, error: 'not_found' }));
+  });
+  const origin = await listen(server);
+  cleanup.push(() => new Promise((resolve) => server.close(resolve)));
+  return origin;
+}
+
+describe('public feed freshness monitor', () => {
+  it('passes when configured origins are healthy and latest-index rows are fresh', async () => {
+    const now = Date.UTC(2026, 5, 12, 12, 0, 0);
+    const repoRoot = await makeRepoRoot();
+    const appOrigin = await startOrigin({ timestamp: now - 5_000 });
+    const relayOrigin = await startOrigin({ timestamp: now - 10_000, service: 'vh-relay' });
+
+    const summary = await runPublicFeedFreshnessMonitor({
+      repoRoot,
+      now,
+      env: {
+        VH_PUBLIC_FEED_FRESHNESS_ORIGINS: `${appOrigin},${relayOrigin}`,
+        VH_PUBLIC_FEED_FRESHNESS_MAX_AGE_MS: String(60_000),
+      },
+    });
+
+    expect(summary.status).toBe('pass');
+    expect(summary.blockers).toEqual([]);
+    expect(summary.healthReadbacks).toHaveLength(2);
+    expect(summary.latestIndexReadbacks.map((readback) => readback.newestStoryId)).toEqual([
+      'story-fresh',
+      'story-fresh',
+    ]);
+  });
+
+  it('fails closed when threshold zero makes the latest-index window stale', async () => {
+    const now = Date.UTC(2026, 5, 12, 12, 0, 0);
+    const repoRoot = await makeRepoRoot();
+    const origin = await startOrigin({ timestamp: now - 1 });
+
+    const summary = await runPublicFeedFreshnessMonitor({
+      repoRoot,
+      now,
+      env: {
+        VH_PUBLIC_FEED_FRESHNESS_ORIGINS: origin,
+        VH_PUBLIC_FEED_FRESHNESS_MAX_AGE_MS: '0',
+      },
+    });
+
+    expect(summary.status).toBe('fail');
+    expect(summary.blockers.join('\n')).toContain('latest_index_stale:1/0');
+  });
+
+  it('fails when the optional StoryCluster OpenAI preflight is required and not passing', async () => {
+    const now = Date.UTC(2026, 5, 12, 12, 0, 0);
+    const repoRoot = await makeRepoRoot();
+    const origin = await startOrigin({ timestamp: now - 1_000 });
+
+    const summary = await runPublicFeedFreshnessMonitor({
+      repoRoot,
+      now,
+      env: {
+        VH_PUBLIC_FEED_FRESHNESS_ORIGINS: origin,
+        VH_PUBLIC_FEED_FRESHNESS_CHECK_OPENAI_PREFLIGHT: 'true',
+      },
+      preflightImpl: async () => ({
+        status: 'fail',
+        code: 'storycluster-openai-auth-invalid',
+        checks: { textModelAuth: 'fail' },
+      }),
+    });
+
+    expect(summary.status).toBe('fail');
+    expect(summary.openAIPreflight).toMatchObject({
+      required: true,
+      status: 'fail',
+      failure: 'openai_preflight_not_passing:storycluster-openai-auth-invalid',
+    });
+  });
+});

--- a/tools/scripts/public-beta-origin-server.mjs
+++ b/tools/scripts/public-beta-origin-server.mjs
@@ -299,6 +299,16 @@ function aggregateScore(payload) {
   ].reduce((score, value, index) => score + Math.max(0, value) / (index + 1), 0);
 }
 
+function selectBestUpstreamHttpError(results) {
+  const errors = results.filter((result) =>
+    result?.ok === true && (result.status < 200 || result.status >= 300));
+  if (errors.length === 0) return null;
+
+  const clientErrors = errors.filter((result) => result.status >= 400 && result.status < 500);
+  const candidates = clientErrors.length > 0 ? clientErrors : errors;
+  return [...candidates].sort((a, b) => a.status - b.status)[0] ?? null;
+}
+
 function selectBestAggregateRead(results) {
   let best = null;
   for (const result of results) {
@@ -310,7 +320,7 @@ function selectBestAggregateRead(results) {
       best = { result, score };
     }
   }
-  return best?.result ?? null;
+  return best?.result ?? selectBestUpstreamHttpError(results);
 }
 
 function selectBestAggregateWrite(results) {
@@ -671,7 +681,9 @@ export function createPublicBetaOriginHandler(options) {
 
 export function startPublicBetaOriginServer(options) {
   const host = options.host || DEFAULT_HOST;
-  const port = Number(options.port || DEFAULT_PORT);
+  const port = options.port === undefined || options.port === null || options.port === ''
+    ? DEFAULT_PORT
+    : Number(options.port);
   const handler = createPublicBetaOriginHandler(options);
   const server = createServer((req, res) => {
     handler(req, res).catch((error) => {

--- a/tools/scripts/public-feed-freshness-monitor.mjs
+++ b/tools/scripts/public-feed-freshness-monitor.mjs
@@ -1,0 +1,431 @@
+#!/usr/bin/env node
+
+import { mkdir, rm, symlink, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { publicFeedBrowserSmokeInternal } from '../../packages/e2e/src/live/public-feed-browser-smoke.mjs';
+import { publicRelayPeerOriginsFromEnv } from '../../packages/e2e/src/live/public-feed-composition-freshness-gate.mjs';
+
+const DEFAULT_REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const DEFAULT_APP_ORIGIN = 'https://venn.carboncaste.io/';
+const DEFAULT_RELAY_ORIGINS = [
+  'https://gun-a.carboncaste.io/',
+  'https://gun-b.carboncaste.io/',
+  'https://gun-c.carboncaste.io/',
+];
+const DEFAULT_MAX_AGE_MS = 6 * 60 * 60 * 1000;
+const DEFAULT_TIMEOUT_MS = 15_000;
+const DEFAULT_INDEX_LIMIT = 80;
+const DEFAULT_SCAN_LIMIT = 120;
+const DEFAULT_OPENAI_TIMEOUT_MS = 120_000;
+const REPORT_SCHEMA_VERSION = 'public-feed-freshness-monitor-v1';
+
+function boolEnv(value, fallback = false) {
+  const normalized = String(value ?? '').trim().toLowerCase();
+  if (!normalized) return fallback;
+  if (['1', 'true', 'yes', 'y', 'on'].includes(normalized)) return true;
+  if (['0', 'false', 'no', 'n', 'off'].includes(normalized)) return false;
+  return fallback;
+}
+
+function positiveInt(value, fallback) {
+  const parsed = Number.parseInt(String(value ?? ''), 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function nonNegativeInt(value, fallback) {
+  const parsed = Number.parseInt(String(value ?? ''), 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+function parseDelimitedValues(value) {
+  const raw = String(value ?? '').trim();
+  if (!raw) return [];
+  if (raw.startsWith('[')) {
+    try {
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) {
+        return parsed.flatMap((item) => parseDelimitedValues(item));
+      }
+    } catch {
+      return [];
+    }
+  }
+  return raw
+    .split(/[,\s]+/)
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function normalizeUrl(value) {
+  const raw = String(value ?? '').trim();
+  if (!raw) return null;
+  try {
+    const url = new URL(raw.includes('://') ? raw : `https://${raw}`);
+    if (url.protocol === 'wss:') url.protocol = 'https:';
+    if (url.protocol === 'ws:') url.protocol = 'http:';
+    if (!['http:', 'https:'].includes(url.protocol)) return null;
+    return url.href.endsWith('/') ? url.href : `${url.href}/`;
+  } catch {
+    return null;
+  }
+}
+
+function uniqueOrigins(origins) {
+  return [...new Set(origins.map(normalizeUrl).filter(Boolean))];
+}
+
+function resolveOrigins(env = process.env) {
+  const explicit = [
+    ...parseDelimitedValues(env.VH_PUBLIC_FEED_FRESHNESS_ORIGINS),
+    ...parseDelimitedValues(env.VH_PUBLIC_FEED_MONITOR_ORIGINS),
+  ];
+  if (explicit.length > 0) return uniqueOrigins(explicit);
+
+  const appOrigin = normalizeUrl(env.VH_PUBLIC_FEED_APP_URL || env.VH_LIVE_BASE_URL || DEFAULT_APP_ORIGIN);
+  const relayOrigins = publicRelayPeerOriginsFromEnv(env);
+  return uniqueOrigins([
+    appOrigin,
+    ...(relayOrigins.length > 0 ? relayOrigins : DEFAULT_RELAY_ORIGINS),
+  ]);
+}
+
+function resolveArtifactDir(env = process.env, repoRoot = DEFAULT_REPO_ROOT, now = Date.now()) {
+  const explicit = String(env.VH_PUBLIC_FEED_FRESHNESS_ARTIFACT_DIR ?? '').trim();
+  if (explicit) return path.isAbsolute(explicit) ? explicit : path.resolve(repoRoot, explicit);
+  return path.join(repoRoot, '.tmp', 'public-feed-freshness', String(now));
+}
+
+async function writeJson(filePath, value) {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+async function updateLatestArtifact(artifactDir, repoRoot) {
+  const latestPath = path.join(repoRoot, '.tmp', 'public-feed-freshness', 'latest');
+  await rm(latestPath, { recursive: true, force: true });
+  try {
+    await symlink(artifactDir, latestPath, 'dir');
+  } catch {
+    await mkdir(latestPath, { recursive: true });
+    await writeJson(path.join(latestPath, 'latest-artifact.json'), { artifactDir });
+  }
+}
+
+async function fetchJsonWithTimeout(url, {
+  timeoutMs,
+  fetchImpl = fetch,
+  label = 'public-feed-freshness-http',
+} = {}) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetchImpl(url, {
+      headers: { accept: 'application/json' },
+      signal: controller.signal,
+    });
+    const text = await response.text();
+    let payload = null;
+    try {
+      payload = text ? JSON.parse(text) : null;
+    } catch (error) {
+      throw new Error(`${label}-json-parse:${error instanceof Error ? error.message : String(error)}`);
+    }
+    if (!response.ok) {
+      throw new Error(`${label}-http-${response.status}:${String(payload?.error ?? response.statusText ?? 'http_error')}`);
+    }
+    return { status: response.status, payload };
+  } catch (error) {
+    const message = error instanceof Error && error.name === 'AbortError'
+      ? `${label}-timeout:${timeoutMs}`
+      : error instanceof Error
+        ? error.message
+        : String(error);
+    throw new Error(message);
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function relayHealthRequired(origin, payload) {
+  if (String(payload?.service ?? '') === 'vh-relay') return true;
+  try {
+    return new URL(origin).hostname.toLowerCase().startsWith('gun-');
+  } catch {
+    return false;
+  }
+}
+
+async function readHealthReadback(origin, {
+  timeoutMs,
+  fetchImpl = fetch,
+} = {}) {
+  const healthUrl = new URL('/healthz', origin).href;
+  const result = {
+    origin,
+    status: 'fail',
+    healthz: {
+      status: 'fail',
+      requestUrl: healthUrl,
+      httpStatus: null,
+      payload: null,
+      failure: null,
+    },
+    readyz: {
+      status: 'skipped',
+      requestUrl: new URL('/readyz', origin).href,
+      httpStatus: null,
+      payload: null,
+      failure: null,
+    },
+    failures: [],
+  };
+
+  try {
+    const health = await fetchJsonWithTimeout(healthUrl, {
+      timeoutMs,
+      fetchImpl,
+      label: 'public-feed-freshness-healthz',
+    });
+    result.healthz = {
+      ...result.healthz,
+      status: 'pass',
+      httpStatus: health.status,
+      payload: health.payload,
+    };
+  } catch (error) {
+    result.healthz.failure = error instanceof Error ? error.message : String(error);
+    result.failures.push(`healthz:${result.healthz.failure}`);
+    return result;
+  }
+
+  if (relayHealthRequired(origin, result.healthz.payload)) {
+    try {
+      const ready = await fetchJsonWithTimeout(result.readyz.requestUrl, {
+        timeoutMs,
+        fetchImpl,
+        label: 'public-feed-freshness-readyz',
+      });
+      result.readyz = {
+        ...result.readyz,
+        status: 'pass',
+        httpStatus: ready.status,
+        payload: ready.payload,
+      };
+    } catch (error) {
+      result.readyz = {
+        ...result.readyz,
+        status: 'fail',
+        failure: error instanceof Error ? error.message : String(error),
+      };
+      result.failures.push(`readyz:${result.readyz.failure}`);
+    }
+  }
+
+  result.status = result.failures.length === 0 ? 'pass' : 'fail';
+  return result;
+}
+
+async function readLatestIndexFreshness(origin, {
+  maxAgeMs,
+  timeoutMs,
+  indexLimit,
+  scanLimit,
+  now,
+  restDiagnostics,
+} = {}) {
+  const readback = {
+    origin,
+    status: 'fail',
+    requestUrl: null,
+    recordCount: 0,
+    newestStoryId: null,
+    newestActivityAt: null,
+    newestActivityAtIso: null,
+    newestAgeMs: null,
+    maxAgeMs,
+    storyIds: [],
+    failures: [],
+  };
+
+  try {
+    const page = await publicFeedBrowserSmokeInternal.readPublicRelayLatestIndexPage({
+      baseUrl: origin,
+      limit: indexLimit,
+      scanLimit,
+      timeoutMs,
+      restDiagnostics,
+    });
+    const newestActivityAt = page.latestActivityValues.length > 0
+      ? Math.max(...page.latestActivityValues)
+      : null;
+    const newestIndex = newestActivityAt === null ? -1 : page.latestActivityValues.indexOf(newestActivityAt);
+    const newestStoryId = newestIndex >= 0 ? page.storyIds[newestIndex] ?? null : null;
+    const newestAgeMs = Number.isFinite(newestActivityAt) ? Math.max(0, now - newestActivityAt) : null;
+
+    readback.requestUrl = page.requestUrl;
+    readback.recordCount = page.recordCount;
+    readback.newestStoryId = newestStoryId;
+    readback.newestActivityAt = newestActivityAt;
+    readback.newestActivityAtIso = Number.isFinite(newestActivityAt)
+      ? new Date(newestActivityAt).toISOString()
+      : null;
+    readback.newestAgeMs = newestAgeMs;
+    readback.storyIds = page.storyIds.slice(0, 10);
+
+    if (page.recordCount <= 0) readback.failures.push('latest_index_empty');
+    if (!Number.isFinite(newestActivityAt)) readback.failures.push('latest_index_timestamp_missing');
+    if (Number.isFinite(newestAgeMs) && newestAgeMs > maxAgeMs) {
+      readback.failures.push(`latest_index_stale:${newestAgeMs}/${maxAgeMs}`);
+    }
+  } catch (error) {
+    readback.failures.push(`latest_index_fetch_failed:${error instanceof Error ? error.message : String(error)}`);
+  }
+
+  readback.status = readback.failures.length === 0 ? 'pass' : 'fail';
+  return readback;
+}
+
+async function runOpenAIPreflight({
+  env,
+  repoRoot,
+  timeoutMs,
+  preflightImpl = null,
+} = {}) {
+  const required = boolEnv(env.VH_PUBLIC_FEED_FRESHNESS_CHECK_OPENAI_PREFLIGHT, false);
+  if (!required) {
+    return { required, status: 'skipped', failure: null, result: null };
+  }
+
+  try {
+    const preflight = preflightImpl
+      ?? (await import(pathToFileURL(path.join(repoRoot, 'services/storycluster-engine/dist/openaiProvider.js')).href))
+        .preflightOpenAIStoryClusterProviderFromEnv;
+    if (typeof preflight !== 'function') {
+      throw new Error('preflight-helper-unavailable');
+    }
+    const result = await preflight({ timeoutMs });
+    return {
+      required,
+      status: result?.status === 'pass' ? 'pass' : 'fail',
+      failure: result?.status === 'pass'
+        ? null
+        : `openai_preflight_not_passing:${result?.code ?? result?.status ?? 'unknown'}`,
+      result,
+    };
+  } catch (error) {
+    return {
+      required,
+      status: 'fail',
+      failure: error instanceof Error ? error.message : String(error),
+      result: null,
+    };
+  }
+}
+
+export async function runPublicFeedFreshnessMonitor({
+  env = process.env,
+  repoRoot = DEFAULT_REPO_ROOT,
+  now = Date.now(),
+  fetchImpl = fetch,
+  preflightImpl = null,
+} = {}) {
+  const artifactDir = resolveArtifactDir(env, repoRoot, now);
+  const summaryPath = path.join(artifactDir, 'public-feed-freshness-summary.json');
+  const origins = resolveOrigins(env);
+  const maxAgeMs = nonNegativeInt(env.VH_PUBLIC_FEED_FRESHNESS_MAX_AGE_MS, DEFAULT_MAX_AGE_MS);
+  const timeoutMs = positiveInt(env.VH_PUBLIC_FEED_FRESHNESS_TIMEOUT_MS, DEFAULT_TIMEOUT_MS);
+  const indexLimit = positiveInt(env.VH_PUBLIC_FEED_FRESHNESS_INDEX_LIMIT, DEFAULT_INDEX_LIMIT);
+  const scanLimit = positiveInt(env.VH_PUBLIC_FEED_FRESHNESS_SCAN_LIMIT, DEFAULT_SCAN_LIMIT);
+  const openAITimeoutMs = positiveInt(
+    env.VH_PUBLIC_FEED_FRESHNESS_OPENAI_TIMEOUT_MS,
+    DEFAULT_OPENAI_TIMEOUT_MS,
+  );
+  const restDiagnostics = publicFeedBrowserSmokeInternal.createRestDiagnosticsRecorder();
+
+  await mkdir(artifactDir, { recursive: true });
+
+  const [healthReadbacks, latestIndexReadbacks, openAIPreflight] = await Promise.all([
+    Promise.all(origins.map((origin) => readHealthReadback(origin, { timeoutMs, fetchImpl }))),
+    Promise.all(origins.map((origin) => readLatestIndexFreshness(origin, {
+      maxAgeMs,
+      timeoutMs,
+      indexLimit,
+      scanLimit,
+      now,
+      restDiagnostics,
+    }))),
+    runOpenAIPreflight({
+      env,
+      repoRoot,
+      timeoutMs: openAITimeoutMs,
+      preflightImpl,
+    }),
+  ]);
+
+  const blockers = [
+    ...healthReadbacks
+      .filter((readback) => readback.status !== 'pass')
+      .map((readback) => `health_unhealthy:${readback.origin}:${readback.failures.join('|')}`),
+    ...latestIndexReadbacks
+      .filter((readback) => readback.status !== 'pass')
+      .map((readback) => `latest_index_not_fresh:${readback.origin}:${readback.failures.join('|')}`),
+    ...(openAIPreflight.status === 'fail' ? [`openai_preflight_failed:${openAIPreflight.failure}`] : []),
+    ...(origins.length === 0 ? ['origins_not_configured'] : []),
+  ];
+
+  const summary = {
+    schemaVersion: REPORT_SCHEMA_VERSION,
+    generatedAt: new Date(now).toISOString(),
+    status: blockers.length === 0 ? 'pass' : 'fail',
+    blockers,
+    artifactDir,
+    artifactPaths: { summaryPath },
+    config: {
+      origins,
+      maxAgeMs,
+      timeoutMs,
+      indexLimit,
+      scanLimit,
+      openAIPreflightRequired: openAIPreflight.required,
+      openAITimeoutMs,
+    },
+    healthReadbacks,
+    latestIndexReadbacks,
+    openAIPreflight,
+    restDiagnostics: restDiagnostics.summary(),
+  };
+
+  await writeJson(summaryPath, summary);
+  await updateLatestArtifact(artifactDir, repoRoot);
+  return summary;
+}
+
+async function main() {
+  const summary = await runPublicFeedFreshnessMonitor();
+  console.info(JSON.stringify({
+    status: summary.status,
+    blockers: summary.blockers,
+    artifact: summary.artifactPaths.summaryPath,
+  }, null, 2));
+  if (summary.status !== 'pass') {
+    process.exit(1);
+  }
+}
+
+export const publicFeedFreshnessMonitorInternal = {
+  boolEnv,
+  parseDelimitedValues,
+  normalizeUrl,
+  resolveOrigins,
+  readHealthReadback,
+  readLatestIndexFreshness,
+  runOpenAIPreflight,
+};
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error('[vh:public-feed-freshness] failed', error);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary

- Pass through upstream relay 4xx JSON for malformed aggregate fanout reads instead of converting every non-2xx fanout result into a synthetic 502.
- Add an hourly public-feed freshness monitor with artifact output, GitHub Actions scheduling, optional OpenAI preflight, and operator docs.
- Add optional `VH_PUBLIC_FEED_FRESH_PROPAGATION_REQUIRE_MULTI_SOURCE` enforcement for launch-copy-sensitive fresh propagation proof.
- Fix two browser-polish defects found in the public walkthrough: bare not-found state and offline/relay-cold-start empty feed flash.
- Record the 2026-06-12 polish walkthrough and owner decision ledger for retention, multi-source copy, raw latest-root hygiene, and quorum asymmetry.

## Verification

- `node --version` -> `v20.20.0`
- `pnpm install --frozen-lockfile`
- `pnpm --dir packages/e2e exec vitest run src/live/public-beta-origin-server.vitest.mjs src/live/public-feed-freshness-monitor.vitest.mjs src/live/public-feed-fresh-propagation-gate.vitest.mjs --config ./vitest.config.ts`
- `pnpm --dir apps/web-pwa exec vitest run src/components/feed/FeedShell.test.tsx src/components/feed/FeedContent.test.tsx src/routes/PublicBetaNotFoundState.test.tsx`
- `pnpm --dir apps/web-pwa typecheck`
- `pnpm --dir apps/web-pwa build`

## Live evidence and remaining blockers

- `pnpm check:public-feed:freshness-monitor` fails correctly against production: all four origins report newest latest-index story `story-e0777f1bdde3` at `2026-06-11T08:52:07.718Z`, age `66,464,312ms` vs the default `21,600,000ms` SLO.
- Live malformed aggregate query remains undeployed on `venn`: `venn` returns `502 text/plain`, while `gun-a`, `gun-b`, and `gun-c` return `400 application/json`.
- The production app walkthrough still observed `/api/analyze/config` returning 502; canary cannot be claimed until the required `api_analyze` surface is restored or explicitly reconciled with the canary contract.
- The canonical 30-minute mesh soak was not claimed here because release evidence must be generated after this branch is merged/deployed on the final clean head.
- `pnpm --dir apps/web-pwa typecheck:test` remains red on unrelated historical test fixture type errors outside this branch's touched tests.
