### PR TITLE
Build public feed monitor dependency closure

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "check:public-feed:composition-freshness": "pnpm --filter @vh/gun-client build && node ./packages/e2e/src/live/public-feed-composition-freshness-gate.mjs",
     "check:public-feed:lifecycle-accountability": "pnpm --filter @vh/gun-client build && node ./packages/e2e/src/live/public-feed-lifecycle-accountability.mjs",
     "check:public-feed:fresh-propagation": "pnpm --filter @vh/e2e test:live:daemon-feed:build && node ./packages/e2e/src/live/public-feed-fresh-propagation-gate.mjs",
-    "check:public-feed:freshness-monitor": "pnpm --filter @vh/gun-client build && node ./tools/scripts/public-feed-freshness-monitor.mjs",
+    "check:public-feed:freshness-monitor": "pnpm --filter @vh/gun-client... build && node ./tools/scripts/public-feed-freshness-monitor.mjs",
     "test:mesh:browser-canary": "VITE_GUN_PEERS='[\"http://127.0.0.1:7788/gun\",\"http://127.0.0.1:7789/gun\",\"http://127.0.0.1:7790/gun\"]' VITE_GUN_PEER_MINIMUM=3 VITE_GUN_PEER_QUORUM_REQUIRED=2 VITE_VH_ALLOW_LOCAL_MESH_PEERS=true VITE_VH_GUN_LOCAL_STORAGE=false VITE_VH_SHOW_HEALTH=true pnpm --filter @vh/web-pwa build && pnpm --filter @vh/e2e test:mesh:browser-canary",
     "test:mesh:signed-peer-config-canary": "node ./packages/e2e/src/mesh/signed-peer-config-canary.mjs",
     "test:mesh:deployed-wss-peer-config": "pnpm --filter @vh/e2e test:mesh:deployed-wss-peer-config",


### PR DESCRIPTION
## Summary
- build the `@vh/gun-client` workspace dependency closure before the scheduled public-feed freshness monitor runs
- fixes the post-#636 cold CI crash where `@vh/data-model/dist/index.js` is missing before the monitor can write artifacts

## Verification
- `PATH="/opt/homebrew/opt/node@20/bin:$PATH" node --version` -> `v20.20.0`
- `PATH="/opt/homebrew/opt/node@20/bin:$PATH" pnpm --filter @vh/gun-client... build`
- `PATH="/opt/homebrew/opt/node@20/bin:$PATH" pnpm check:public-feed:freshness-monitor` reached the live monitor and wrote `.tmp/public-feed-freshness/1781320146158/public-feed-freshness-summary.json`; it exited 1 only for the intended stale-feed blockers on venn + gun-a/b/c

## Production Safety
- repo/CI wiring only
- no production writes, deploys, scrubs, soak, or canary runs
