### PR TITLE
Make latest-index reads nonmutating

### DIFF
--- a/docs/ops/public-feed-freshness-monitor.md
+++ b/docs/ops/public-feed-freshness-monitor.md
@@ -43,6 +43,24 @@ Default origins:
 
 Default freshness SLO: newest latest-index row age <= 6 hours.
 
+## Latest-Index Snapshot Safety
+
+Freshness monitor latest-index reads are nonmutating. The monitor and browser
+smoke helper add `persist=false` to `/vh/news/latest-index` requests as an
+explicit diagnostic marker, and the relay's default GET path must not refresh
+`news-latest-index-snapshot.json` when it falls through to live Gun records.
+
+Persisted latest-index snapshot refresh is reserved for intentional
+write-through and maintenance code paths, including relay news story,
+latest-index, and synthesis-lifecycle writes. Routine read traffic must not
+poison a served snapshot with an under-scanned window, and must not heal a stale
+served snapshot as a side effect of monitoring.
+
+The stale publisher/feed incident remains separate from this monitor. A passing
+freshness monitor proves the public latest-index read surface is current enough
+at the sampled origins; it does not prove publisher recovery, source ingest
+health, or release readiness.
+
 ## Configuration
 
 | Variable | Default | Notes |

--- a/infra/relay/server.js
+++ b/infra/relay/server.js
@@ -3005,7 +3005,9 @@ async function buildNewsLatestIndexResultFromSnapshot(gun, snapshot, options = {
   selectedEntries = bodyReadbackResult.entries;
   const refreshResult = await refreshSnapshotStoryStates(gun, selectedEntries);
   selectedEntries = refreshResult.entries;
-  persistRefreshedLatestIndexSnapshotEntries(snapshot, options, selectedEntries, refreshResult.info);
+  if (options.persistSnapshotOnRead === true) {
+    persistRefreshedLatestIndexSnapshotEntries(snapshot, options, selectedEntries, refreshResult.info);
+  }
   const records = {};
   const stories = {};
   const storyStates = {};
@@ -3098,7 +3100,13 @@ async function readNewsLatestIndexRecordsWithEmptyRetry(gun, options = {}) {
       if (hasRecords && cacheKey && cacheTtlMs > 0) {
         newsLatestIndexRestCache.set(cacheKey, { cached_at: Date.now(), result });
       }
-      if (hasRecords && Array.isArray(result.snapshotEntries) && result.snapshotEntries.length > 0 && cacheTtlMs > 0) {
+      if (
+        options.persistSnapshotOnRead === true
+        && hasRecords
+        && Array.isArray(result.snapshotEntries)
+        && result.snapshotEntries.length > 0
+        && cacheTtlMs > 0
+      ) {
         const snapshot = {
           cached_at: Date.now(),
           entries: result.snapshotEntries,
@@ -4504,9 +4512,27 @@ const server = http.createServer((req, res) => {
     const scanLimit = parsedUrl.searchParams.get('scan_limit');
     const before = parsedUrl.searchParams.get('before');
     const compositionBackfillMinLimit = parsedUrl.searchParams.get('composition_backfill_min_limit');
+    const persistMode = parsedUrl.searchParams.get('persist');
+    if (persistMode !== null && persistMode !== 'false') {
+      sendJson(res, 400, {
+        ok: false,
+        error: 'latest-index-persist-mode-unsupported',
+        supported_persist_values: ['false'],
+      });
+      return;
+    }
     void readNewsLatestIndexRecordsWithEmptyRetry(
       gun,
-      { limit, includeRoot, includeExcluded, consistencyFilter, scanLimit, before, compositionBackfillMinLimit },
+      {
+        limit,
+        includeRoot,
+        includeExcluded,
+        consistencyFilter,
+        scanLimit,
+        before,
+        compositionBackfillMinLimit,
+        persistSnapshotOnRead: false,
+      },
     )
       .then((result) => {
         const payload = {

--- a/packages/e2e/src/live/public-feed-browser-smoke.mjs
+++ b/packages/e2e/src/live/public-feed-browser-smoke.mjs
@@ -1146,6 +1146,7 @@ async function readPublicRelayLatestIndexPage({
   if (Number.isFinite(scanLimit) && scanLimit > 0) {
     indexUrl.searchParams.set('scan_limit', String(Math.floor(scanLimit)));
   }
+  indexUrl.searchParams.set('persist', 'false');
   const payload = await fetchJsonWithTimeout(
     indexUrl.href,
     timeoutMs,
@@ -1419,6 +1420,7 @@ async function readPublicRelaySynthesisCandidates({
   const root = normalizeUrl(baseUrl || DEFAULT_BASE_URL);
   const indexUrl = new URL('/vh/news/latest-index', root);
   indexUrl.searchParams.set('limit', String(indexLimit));
+  indexUrl.searchParams.set('persist', 'false');
   const index = await fetchJsonWithTimeout(indexUrl.href, timeoutMs, 'public-relay-latest-index', restDiagnostics);
   const storyStates = index?.story_states && typeof index.story_states === 'object'
     ? index.story_states

--- a/packages/e2e/src/live/public-feed-browser-smoke.vitest.mjs
+++ b/packages/e2e/src/live/public-feed-browser-smoke.vitest.mjs
@@ -218,7 +218,7 @@ describe('public feed browser smoke helpers', () => {
   it('verifies relay latest-index pagination with an exclusive older cursor window', async () => {
     const fetchMock = vi.fn(async (url) => {
       const href = String(url);
-      if (href === 'https://venn.example/vh/news/latest-index?limit=2&scan_limit=8') {
+      if (href === 'https://venn.example/vh/news/latest-index?limit=2&scan_limit=8&persist=false') {
         return new Response(JSON.stringify({
           ok: true,
           record_count: 2,
@@ -232,7 +232,7 @@ describe('public feed browser smoke helpers', () => {
           },
         }), { status: 200 });
       }
-      if (href === 'https://venn.example/vh/news/latest-index?limit=2&before=200&scan_limit=8') {
+      if (href === 'https://venn.example/vh/news/latest-index?limit=2&before=200&scan_limit=8&persist=false') {
         return new Response(JSON.stringify({
           ok: true,
           record_count: 1,

--- a/packages/e2e/src/live/public-feed-freshness-monitor.vitest.mjs
+++ b/packages/e2e/src/live/public-feed-freshness-monitor.vitest.mjs
@@ -35,8 +35,10 @@ async function startOrigin({
   timestamp,
   service = 'vh-public-beta-origin',
   readyStatus = 200,
+  requests = [],
 } = {}) {
   const server = createServer((req, res) => {
+    requests.push(req.url ?? '');
     if (req.url?.startsWith('/healthz')) {
       res.writeHead(200, { 'content-type': 'application/json' });
       res.end(JSON.stringify({
@@ -85,8 +87,10 @@ describe('public feed freshness monitor', () => {
   it('passes when configured origins are healthy and latest-index rows are fresh', async () => {
     const now = Date.UTC(2026, 5, 12, 12, 0, 0);
     const repoRoot = await makeRepoRoot();
-    const appOrigin = await startOrigin({ timestamp: now - 5_000 });
-    const relayOrigin = await startOrigin({ timestamp: now - 10_000, service: 'vh-relay' });
+    const appRequests = [];
+    const relayRequests = [];
+    const appOrigin = await startOrigin({ timestamp: now - 5_000, requests: appRequests });
+    const relayOrigin = await startOrigin({ timestamp: now - 10_000, service: 'vh-relay', requests: relayRequests });
 
     const summary = await runPublicFeedFreshnessMonitor({
       repoRoot,
@@ -104,6 +108,9 @@ describe('public feed freshness monitor', () => {
       'story-fresh',
       'story-fresh',
     ]);
+    for (const requestUrl of [...appRequests, ...relayRequests].filter((url) => url.startsWith('/vh/news/latest-index'))) {
+      expect(new URL(requestUrl, 'http://127.0.0.1').searchParams.get('persist')).toBe('false');
+    }
   });
 
   it('fails closed when threshold zero makes the latest-index window stale', async () => {

--- a/packages/e2e/src/live/relay-server.vitest.mjs
+++ b/packages/e2e/src/live/relay-server.vitest.mjs
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import http from 'node:http';
 import os from 'node:os';
 import path from 'node:path';
@@ -2500,6 +2500,132 @@ describe('infra relay server', () => {
       frame_table_ready: 1,
     });
   }, 60_000);
+
+  it('does not persist a latest-index snapshot when a default GET falls through to live Gun records', async () => {
+    const snapshotDir = mkdtempSync(path.join(os.tmpdir(), 'vh-relay-readonly-snapshot-test-'));
+    tempDirs.add(snapshotDir);
+    const snapshotFile = path.join(snapshotDir, 'news-latest-index-snapshot.json');
+    const { port } = await startRelay(children, tempDirs, {
+      VH_RELAY_NEWS_INDEX_REST_MAX_RECORDS: '3',
+      VH_RELAY_NEWS_INDEX_REST_SCAN_RECORDS: '3',
+      VH_RELAY_NEWS_INDEX_REST_PREFER_SNAPSHOT: 'true',
+      VH_RELAY_NEWS_INDEX_SNAPSHOT_FILE: snapshotFile,
+      VH_RELAY_NEWS_INDEX_STORY_REST_READ_TIMEOUT_MS: '500',
+      VH_RELAY_NEWS_STORY_REST_READ_TIMEOUT_MS: '500',
+      VH_RELAY_NEWS_LIFECYCLE_REST_READ_TIMEOUT_MS: '100',
+      VH_RELAY_NEWS_LIFECYCLE_FIELD_REST_READ_TIMEOUT_MS: '100',
+      VH_RELAY_TOPIC_SYNTHESIS_REST_READ_TIMEOUT_MS: '100',
+    });
+    const story = makeRelayNewsStory('story-readonly-live-fallback', 1778993000000, [
+      {
+        source_id: 'source-readonly-live-fallback-a',
+        publisher: 'Read-only Live Fallback A',
+        url: 'https://example.com/readonly-live-fallback-a',
+        url_hash: 'hash-readonly-live-fallback-a',
+        published_at: 1778992999000,
+        title: 'Read-only live fallback story A',
+      },
+      {
+        source_id: 'source-readonly-live-fallback-b',
+        publisher: 'Read-only Live Fallback B',
+        url: 'https://example.com/readonly-live-fallback-b',
+        url_hash: 'hash-readonly-live-fallback-b',
+        published_at: 1778993000000,
+        title: 'Read-only live fallback story B',
+      },
+    ]);
+    await writeRelayNewsStory(port, story);
+    await writeRelayLatestIndexRecord(port, story.story_id, story.cluster_window_end);
+    expect(existsSync(snapshotFile)).toBe(true);
+    const snapshotBefore = readFileSync(snapshotFile, 'utf8');
+
+    const latest = await requestJson(
+      `http://127.0.0.1:${port}/vh/news/latest-index?limit=1&scan_limit=3&consistency=false`,
+    );
+    expect(latest).toMatchObject({
+      statusCode: 200,
+      body: expect.objectContaining({
+        ok: true,
+        record_count: 1,
+        consistency: expect.objectContaining({
+          enabled: false,
+          mode: 'disabled',
+        }),
+        records: {
+          [story.story_id]: expect.objectContaining({
+            story_id: story.story_id,
+            latest_activity_at: story.cluster_window_end,
+          }),
+        },
+      }),
+    });
+    expect(readFileSync(snapshotFile, 'utf8')).toBe(snapshotBefore);
+  }, 30_000);
+
+  it('keeps explicit persist=false latest-index GETs nonmutating', async () => {
+    const snapshotDir = mkdtempSync(path.join(os.tmpdir(), 'vh-relay-persist-false-snapshot-test-'));
+    tempDirs.add(snapshotDir);
+    const snapshotFile = path.join(snapshotDir, 'news-latest-index-snapshot.json');
+    const { port } = await startRelay(children, tempDirs, {
+      VH_RELAY_NEWS_INDEX_REST_MAX_RECORDS: '3',
+      VH_RELAY_NEWS_INDEX_REST_SCAN_RECORDS: '3',
+      VH_RELAY_NEWS_INDEX_REST_PREFER_SNAPSHOT: 'true',
+      VH_RELAY_NEWS_INDEX_SNAPSHOT_FILE: snapshotFile,
+      VH_RELAY_NEWS_INDEX_STORY_REST_READ_TIMEOUT_MS: '500',
+      VH_RELAY_NEWS_STORY_REST_READ_TIMEOUT_MS: '500',
+      VH_RELAY_NEWS_LIFECYCLE_REST_READ_TIMEOUT_MS: '100',
+      VH_RELAY_NEWS_LIFECYCLE_FIELD_REST_READ_TIMEOUT_MS: '100',
+      VH_RELAY_TOPIC_SYNTHESIS_REST_READ_TIMEOUT_MS: '100',
+    });
+    const story = makeRelayNewsStory('story-persist-false-live-fallback', 1778994000000, [
+      {
+        source_id: 'source-persist-false-live-fallback',
+        publisher: 'Persist False Source',
+        url: 'https://example.com/persist-false-live-fallback',
+        url_hash: 'hash-persist-false-live-fallback',
+        published_at: 1778994000000,
+        title: 'Persist false live fallback story',
+      },
+    ]);
+    await writeRelayNewsStory(port, story);
+    await writeRelayLatestIndexRecord(port, story.story_id, story.cluster_window_end);
+    expect(existsSync(snapshotFile)).toBe(true);
+    const snapshotBefore = readFileSync(snapshotFile, 'utf8');
+
+    const latest = await requestJson(
+      `http://127.0.0.1:${port}/vh/news/latest-index?limit=1&scan_limit=3&consistency=false&persist=false`,
+    );
+    expect(latest).toMatchObject({
+      statusCode: 200,
+      body: expect.objectContaining({
+        ok: true,
+        record_count: 1,
+        consistency: expect.objectContaining({
+          enabled: false,
+          mode: 'disabled',
+        }),
+        records: {
+          [story.story_id]: expect.objectContaining({
+            story_id: story.story_id,
+            latest_activity_at: story.cluster_window_end,
+          }),
+        },
+      }),
+    });
+    expect(readFileSync(snapshotFile, 'utf8')).toBe(snapshotBefore);
+  }, 30_000);
+
+  it('rejects mutating latest-index persistence requests on GET', async () => {
+    const { port } = await startRelay(children, tempDirs);
+    await expect(requestJson(`http://127.0.0.1:${port}/vh/news/latest-index?persist=true`))
+      .resolves.toMatchObject({
+        statusCode: 400,
+        body: expect.objectContaining({
+          ok: false,
+          error: 'latest-index-persist-mode-unsupported',
+        }),
+      });
+  }, 30_000);
 
   it('persists latest-index snapshots as news write-through evidence before any latest-index read', async () => {
     const snapshotDir = mkdtempSync(path.join(os.tmpdir(), 'vh-relay-write-through-snapshot-test-'));


### PR DESCRIPTION
## Summary
- Stop routine `GET /vh/news/latest-index` reads from persisting or refreshing the durable latest-index snapshot when they fall through to live Gun records.
- Keep preferred snapshot serving intact, but prevent snapshot-served GETs from writing refreshed story state back to `news-latest-index-snapshot.json`.
- Keep intentional write-through persistence on relay news story, latest-index, and synthesis-lifecycle writes.
- Add explicit `persist=false` latest-index reads in the public freshness monitor/browser-smoke helpers and document the operational boundary.

## Why
During the public feed incident, monitor/read traffic could overwrite or heal the served persisted snapshot as a side effect of a narrow latest-index request. With this change, routine reads can still observe live Gun and use the per-request REST cache, but they cannot re-poison `news-latest-index-snapshot.json` with an under-scanned window or mask the stale publisher/feed condition by refreshing the served snapshot. Publisher recovery remains a separate incident path.

## Tests
- `npx -y -p node@22 -c 'node --check infra/relay/server.js && pnpm --filter @vh/e2e exec vitest run src/live/relay-server.vitest.mjs src/live/public-feed-freshness-monitor.vitest.mjs src/live/public-feed-browser-smoke.vitest.mjs --config ./vitest.config.ts --reporter=dot'`
- `git diff --check`