### PR TITLE
Honor captured relay GUN_FILE data mounts

### DIFF
--- a/docs/ops/public-beta-image-deploy.md
+++ b/docs/ops/public-beta-image-deploy.md
@@ -15,11 +15,13 @@ re-enable monitors.
 
 - Build and deploy images for `linux/amd64`; do not rely on the local Docker
   default platform.
-- Preserve relay data bind mounts exactly:
-  - `/home/humble/.local/share/vhc/vhc-relay-a/data:/app/data`
-  - `/home/humble/.local/share/vhc/vhc-relay-b/data:/app/data`
-  - `/home/humble/.local/share/vhc/vhc-relay-c/data:/app/data`
-- Preserve the three relay snapshot files in each `/app/data`:
+- Preserve relay data bind mounts exactly at each relay's `GUN_FILE`
+  destination. Current A6 relays set `GUN_FILE=/data`, so the production-shape
+  bind mounts are:
+  - `/home/humble/.local/share/vhc/vhc-relay-a/data:/data`
+  - `/home/humble/.local/share/vhc/vhc-relay-b/data:/data`
+  - `/home/humble/.local/share/vhc/vhc-relay-c/data:/data`
+- Preserve the three relay snapshot files in each relay `GUN_FILE` directory:
   - `news-latest-index-snapshot.json`
   - `news-synthesis-lifecycle-snapshot.json`
   - `topic-synthesis-latest-snapshot.json`
@@ -38,8 +40,9 @@ re-enable monitors.
 
 - `infra/origin/Dockerfile` builds the Web PWA and origin server image.
 - `infra/relay/Dockerfile` builds the relay image.
-- `infra/docker/docker-compose.public-beta.yml` records the production-shape
-  topology with bind-mounted relay data dirs and image tags supplied by env.
+- `infra/docker/docker-compose.public-beta.yml` records the current A6
+  production-shape topology with bind-mounted relay data dirs at `GUN_FILE=/data`
+  and image tags supplied by env.
 - `tools/scripts/build-public-beta-images.sh` builds origin and relay images
   with a pinned platform and records buildx metadata.
 - `tools/scripts/emit-a6-public-beta-deploy-packet.sh` emits a secret-safe A6
@@ -180,7 +183,7 @@ their values.
 2. Run the direct on-disk relay snapshot precheck for every relay.
 3. Deploy one relay at a time with the existing host data bind mount preserved.
 4. After each relay restart, prove the running image tag/digest and verify the
-   three snapshot files still exist in `/app/data`.
+   three snapshot files still exist in the relay `GUN_FILE` directory.
 5. After all relays prove the #638 image is running, run safe latest-index
    behavior probes:
    - `persist=true` returns JSON 400.
@@ -199,7 +202,7 @@ their values.
 
 Abort the deploy if any of these are true:
 
-- Any relay `/app/data` mount is not a bind mount to the existing host path.
+- Any relay `GUN_FILE` data mount is not a bind mount to the existing host path.
 - Any relay data dir is empty, unwritable by the intended UID/GID, or missing
   one of the three snapshot files.
 - Any latest-index snapshot has entries other than `15`.

--- a/infra/docker/docker-compose.public-beta.yml
+++ b/infra/docker/docker-compose.public-beta.yml
@@ -29,7 +29,7 @@ services:
     environment:
       GUN_PORT: "7777"
       GUN_HOST: "0.0.0.0"
-      GUN_FILE: /app/data
+      GUN_FILE: /data
       GUN_RADISK: "true"
       NODE_ENV: production
       VH_RELAY_ID: public-beta-relay-a
@@ -39,7 +39,7 @@ services:
     volumes:
       - type: bind
         source: ${VH_PUBLIC_BETA_RELAY_A_DATA_DIR:-/home/humble/.local/share/vhc/vhc-relay-a/data}
-        target: /app/data
+        target: /data
     ports:
       - "${VH_PUBLIC_BETA_RELAY_A_PORT:-7777}:7777"
     networks:
@@ -54,7 +54,7 @@ services:
     environment:
       GUN_PORT: "7777"
       GUN_HOST: "0.0.0.0"
-      GUN_FILE: /app/data
+      GUN_FILE: /data
       GUN_RADISK: "true"
       NODE_ENV: production
       VH_RELAY_ID: public-beta-relay-b
@@ -64,7 +64,7 @@ services:
     volumes:
       - type: bind
         source: ${VH_PUBLIC_BETA_RELAY_B_DATA_DIR:-/home/humble/.local/share/vhc/vhc-relay-b/data}
-        target: /app/data
+        target: /data
     ports:
       - "${VH_PUBLIC_BETA_RELAY_B_PORT:-7778}:7777"
     networks:
@@ -79,7 +79,7 @@ services:
     environment:
       GUN_PORT: "7777"
       GUN_HOST: "0.0.0.0"
-      GUN_FILE: /app/data
+      GUN_FILE: /data
       GUN_RADISK: "true"
       NODE_ENV: production
       VH_RELAY_ID: public-beta-relay-c
@@ -89,7 +89,7 @@ services:
     volumes:
       - type: bind
         source: ${VH_PUBLIC_BETA_RELAY_C_DATA_DIR:-/home/humble/.local/share/vhc/vhc-relay-c/data}
-        target: /app/data
+        target: /data
     ports:
       - "${VH_PUBLIC_BETA_RELAY_C_PORT:-7779}:7777"
     networks:

--- a/tools/scripts/build-public-beta-images.sh
+++ b/tools/scripts/build-public-beta-images.sh
@@ -353,9 +353,9 @@ smoke_relay() {
   tmp="$(mktemp -d)"
   cid="$(docker run -d --rm -P \
     -e NODE_ENV=production \
-    -e GUN_FILE=/app/data \
+    -e GUN_FILE=/data \
     -e GUN_RADISK=true \
-    -v "${tmp}:/app/data" \
+    -v "${tmp}:/data" \
     "${RELAY_IMAGE}")"
   trap 'docker rm -f "${cid}" >/dev/null 2>&1 || true; rm -rf "${tmp}"' RETURN
   port="$(docker port "${cid}" 7777/tcp | awk -F: 'NR==1 {print $NF}')"

--- a/tools/scripts/emit-a6-public-beta-deploy-packet.sh
+++ b/tools/scripts/emit-a6-public-beta-deploy-packet.sh
@@ -153,8 +153,31 @@ function mountFlags(container) {
   return flags;
 }
 
+function envMap(container) {
+  const out = new Map();
+  for (const entry of container?.Config?.Env || []) {
+    const text = String(entry);
+    const index = text.indexOf('=');
+    if (index <= 0) continue;
+    out.set(text.slice(0, index), text.slice(index + 1));
+  }
+  return out;
+}
+
+function envValue(container, name) {
+  return envMap(container).get(name) || '';
+}
+
+function gunFileDestination(container) {
+  const gunFile = envValue(container, 'GUN_FILE').trim();
+  if (!gunFile || gunFile === 'data') return '/app/data';
+  if (gunFile.startsWith('/')) return gunFile.replace(/\/+$/, '') || '/';
+  return `/app/${gunFile.replace(/^\.?\//, '').replace(/\/+$/, '')}`;
+}
+
 function dataMount(container) {
-  return (container?.Mounts || []).find((mount) => mount.Destination === '/app/data') || null;
+  const destination = gunFileDestination(container);
+  return (container?.Mounts || []).find((mount) => mount.Destination === destination) || null;
 }
 
 function restartFlag(container) {
@@ -211,13 +234,15 @@ function runCommandFor(name, image, forceRelayUser = false) {
 
 const blockers = [];
 for (const name of relayNames) {
-  const mount = dataMount(byName.get(name));
+  const container = byName.get(name);
+  const mount = dataMount(container);
+  const destination = gunFileDestination(container);
   if (!mount) {
-    blockers.push(`${name}: missing /app/data mount`);
+    blockers.push(`${name}: missing ${destination} mount for GUN_FILE`);
   } else if (mount.Type !== 'bind') {
-    blockers.push(`${name}: /app/data mount is ${mount.Type}, expected bind`);
+    blockers.push(`${name}: ${destination} mount is ${mount.Type}, expected bind`);
   } else if (!mount.Source.includes(`/vhc-${name}/data`) && !mount.Source.endsWith(`/${name}/data`)) {
-    blockers.push(`${name}: /app/data source is unusual: ${mount.Source}`);
+    blockers.push(`${name}: ${destination} source is unusual: ${mount.Source}`);
   }
 }
 
@@ -236,12 +261,14 @@ lines.push('## Current Containers');
 lines.push('');
 for (const name of requiredNames) {
   const container = byName.get(name);
+  const dataDestination = relayNames.includes(name) ? gunFileDestination(container) : null;
   lines.push(`### ${name}`);
   lines.push('');
   lines.push(`- current image tag: \`${container.Config?.Image || 'unknown'}\``);
   lines.push(`- current image id: \`${container.Image || 'unknown'}\``);
   lines.push(`- networks: \`${networkNames(container).join(', ') || 'none'}\``);
   lines.push(`- env names: \`${envNames(container).join(', ')}\``);
+  if (dataDestination) lines.push(`- GUN_FILE destination: \`${dataDestination}\``);
   lines.push(`- mounts: \`${mountFlags(container).join(' ; ') || 'none'}\``);
   lines.push('');
 }
@@ -316,10 +343,11 @@ if (includeRecreate) {
   lines.push('');
   lines.push('```bash');
   for (const name of relayNames) {
+    const dataDestination = gunFileDestination(byName.get(name));
     lines.push(`sudo docker rm -f ${name}`);
     lines.push(runCommandFor(name, newRelayImage, true));
     lines.push(`sudo docker inspect ${name} --format '{{.Config.Image}} {{.Image}}'`);
-    lines.push(`sudo docker exec ${name} test -f /app/data/news-latest-index-snapshot.json`);
+    lines.push(`sudo docker exec ${name} test -f ${dataDestination}/news-latest-index-snapshot.json`);
   }
   lines.push('```');
   lines.push('');

--- a/tools/scripts/public-beta-image-deploy.test.mjs
+++ b/tools/scripts/public-beta-image-deploy.test.mjs
@@ -106,7 +106,9 @@ test('deploy packet preserves relay bind mounts and does not print env values', 
       '--include-recreate-commands',
     ]);
     assert.equal(result.status, 0, result.stderr);
-    assert.match(result.stdout, /\/home\/humble\/\.local\/share\/vhc\/vhc-relay-a\/data:\/app\/data:rw/);
+    assert.match(result.stdout, /GUN_FILE destination: `\/data`/);
+    assert.match(result.stdout, /\/home\/humble\/\.local\/share\/vhc\/vhc-relay-a\/data:\/data:rw/);
+    assert.match(result.stdout, /sudo docker exec vhc-relay-a test -f \/data\/news-latest-index-snapshot\.json/);
     assert.match(result.stdout, /VH_PUBLIC_ORIGIN_ANALYSIS_TARGET=http:\/\/127\.0\.0\.1:3001/);
     assert.match(result.stdout, /vhc-public-beta-relay:new/);
     assert.doesNotMatch(result.stdout, /do-not-print/);
@@ -119,11 +121,12 @@ test('deploy packet preserves relay bind mounts and does not print env values', 
 function makeRelay(name, dataDir) {
   return makeContainer(name, 'vhc-public-beta-relay:old', [
     'NODE_ENV=production',
+    'GUN_FILE=/data',
     'VH_RELAY_DAEMON_TOKEN=do-not-print',
   ], [{
     Type: 'bind',
     Source: dataDir,
-    Destination: '/app/data',
+    Destination: '/data',
     Mode: 'rw',
     RW: true,
   }], { '7777/tcp': [{ HostIp: '127.0.0.1', HostPort: '7777' }] });


### PR DESCRIPTION
## Summary
- make the A6 deploy packet emitter resolve the relay data bind mount from captured `GUN_FILE` instead of hardcoding `/app/data`
- update the public-beta compose/runbook to match current A6 relays, which set `GUN_FILE=/data` and mount host data dirs at `/data`
- align relay image smoke and packet tests with the `/data` destination

## Why
Read-only A6 capture from merged #640 showed current relays mount `/home/humble/.local/share/vhc/vhc-relay-{a,b,c}/data` at `/data`, not `/app/data`. The previous packet emitter correctly refused to proceed, but the repo needed to model this host reality.

## Validation
- `bash -n tools/scripts/build-public-beta-images.sh tools/scripts/emit-a6-public-beta-deploy-packet.sh`
- `npx -y -p node@22 -c 'node --check tools/scripts/public-beta-image-deploy.test.mjs && node --test tools/scripts/public-beta-image-deploy.test.mjs'`\n- `npx -y -p node@22 -c 'pnpm docs:check'`\n- `docker compose -f infra/docker/docker-compose.public-beta.yml config` with placeholder non-secret env\n- `git diff --check` / `git diff --cached --check`\n- regenerated `.tmp/a6-public-beta-capture/20260614-82545ba3/a6-public-beta-deploy-packet.md`; no packet blockers, records `GUN_FILE destination: /data` for all relays\n\n## Production safety\nNo production deploys, restarts, writes, publisher starts, latest-index HTTP probes, catchup/republish, scrubs, or monitor changes were run. Host activity was read-only docker inspect/history plus direct on-disk snapshot parsing.