### PR TITLE
Default deploy packet to captured origin name

### DIFF
--- a/docs/ops/public-beta-image-deploy.md
+++ b/docs/ops/public-beta-image-deploy.md
@@ -56,15 +56,15 @@ Capture image/container evidence before any restart:
 ssh humble@ccibootstrap
 mkdir -p /tmp/vhc-public-beta-capture
 sudo docker ps --format '{{.Names}}\t{{.Image}}\t{{.Status}}\t{{.Ports}}' \
-  | grep -E 'vhc-relay|vhc-public-beta-origin'
-sudo docker inspect vhc-public-beta-origin vhc-relay-a vhc-relay-b vhc-relay-c \
+  | grep -E 'vhc-public-origin|vhc-relay-a|vhc-relay-b|vhc-relay-c'
+sudo docker inspect vhc-public-origin vhc-relay-a vhc-relay-b vhc-relay-c \
   >/tmp/vhc-public-beta-capture/containers.json
 sudo docker image inspect \
-  "$(sudo docker inspect -f '{{.Config.Image}}' vhc-public-beta-origin)" \
+  "$(sudo docker inspect -f '{{.Config.Image}}' vhc-public-origin)" \
   "$(sudo docker inspect -f '{{.Config.Image}}' vhc-relay-a)" \
   >/tmp/vhc-public-beta-capture/images.json
 sudo docker history --no-trunc \
-  "$(sudo docker inspect -f '{{.Config.Image}}' vhc-public-beta-origin)" \
+  "$(sudo docker inspect -f '{{.Config.Image}}' vhc-public-origin)" \
   >/tmp/vhc-public-beta-capture/origin-history.txt
 sudo docker history --no-trunc \
   "$(sudo docker inspect -f '{{.Config.Image}}' vhc-relay-a)" \

--- a/tools/scripts/build-public-beta-images.sh
+++ b/tools/scripts/build-public-beta-images.sh
@@ -353,6 +353,7 @@ smoke_relay() {
   tmp="$(mktemp -d)"
   cid="$(docker run -d --rm -P \
     -e NODE_ENV=production \
+    -e GUN_HOST=0.0.0.0 \
     -e GUN_FILE=/data \
     -e GUN_RADISK=true \
     -v "${tmp}:/data" \

--- a/tools/scripts/emit-a6-public-beta-deploy-packet.sh
+++ b/tools/scripts/emit-a6-public-beta-deploy-packet.sh
@@ -6,7 +6,7 @@ INSPECT_JSON=""
 NEW_ORIGIN_IMAGE=""
 NEW_RELAY_IMAGE=""
 ANALYSIS_TARGET="http://127.0.0.1:3001"
-ORIGIN_NAME="vhc-public-beta-origin"
+ORIGIN_NAME="vhc-public-origin"
 RELAY_NAMES="vhc-relay-a,vhc-relay-b,vhc-relay-c"
 OUTPUT_FILE=""
 INCLUDE_RECREATE=false
@@ -25,7 +25,7 @@ Required:
 
 Options:
   --analysis-target <url>     Corrected origin analysis target (default http://127.0.0.1:3001)
-  --origin-name <name>        Origin container name (default vhc-public-beta-origin)
+  --origin-name <name>        Origin container name (default vhc-public-origin)
   --relay-names <a,b,c>       Relay container names (default vhc-relay-a,vhc-relay-b,vhc-relay-c)
   --include-recreate-commands Include docker rm/run commands in the packet
   --output <path>             Write packet to a file instead of stdout
@@ -215,6 +215,14 @@ function envCaptureCommand(name, rewriteAnalysisTarget = false) {
   ].join('\n');
 }
 
+function escapeExtendedRegex(value) {
+  return String(value).replace(/[|\\{}()[\]^$+*?.-]/g, '\\$&');
+}
+
+function shellSingleQuote(value) {
+  return `'${String(value).replace(/'/g, `'\\''`)}'`;
+}
+
 function runCommandFor(name, image, forceRelayUser = false) {
   const container = byName.get(name);
   const envPath = `/tmp/vhc-public-beta-deploy/${name}.env`;
@@ -247,6 +255,7 @@ for (const name of relayNames) {
 }
 
 const lines = [];
+const psPattern = [originName, ...relayNames].map(escapeExtendedRegex).join('|');
 lines.push('# A6 Public-Beta Deploy Packet');
 lines.push('');
 lines.push('Generated from captured `docker inspect` JSON. This packet is secret-safe: it records env var names and uses host-side env-file capture commands without printing values.');
@@ -286,7 +295,7 @@ lines.push('## Read-Only Precheck');
 lines.push('');
 lines.push('```bash');
 lines.push('set -euo pipefail');
-lines.push('sudo docker ps --format "{{.Names}}\\t{{.Image}}\\t{{.Status}}\\t{{.Ports}}" | grep -E "vhc-relay|vhc-public-beta-origin"');
+lines.push(`sudo docker ps --format "{{.Names}}\\t{{.Image}}\\t{{.Status}}\\t{{.Ports}}" | grep -E ${shellSingleQuote(psPattern)}`);
 lines.push('python3 <<\'PY\'');
 lines.push('import json, os, time');
 lines.push('SNAPSHOTS = {');

--- a/tools/scripts/public-beta-image-deploy.test.mjs
+++ b/tools/scripts/public-beta-image-deploy.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
@@ -81,12 +81,18 @@ test('public beta image build dry-run passes build args by name without leaking 
   }
 });
 
+test('relay image smoke binds Gun to the container interface', () => {
+  const script = readFileSync(BUILD_SCRIPT, 'utf8');
+  assert.match(script, /smoke_relay\(\) \{[\s\S]*-e GUN_HOST=0\.0\.0\.0/);
+  assert.match(script, /smoke_relay\(\) \{[\s\S]*-v "\$\{tmp\}:\/data"/);
+});
+
 test('deploy packet preserves relay bind mounts and does not print env values', () => {
   const root = mkdtempSync(path.join(os.tmpdir(), 'vh-public-beta-packet-'));
   try {
     const inspectPath = path.join(root, 'inspect.json');
     const containers = [
-      makeContainer('vhc-public-beta-origin', 'vhc-public-beta-origin:old', [
+      makeContainer('vhc-public-origin', 'vhc-public-beta-origin:old', [
         'VH_PUBLIC_ORIGIN_ANALYSIS_TARGET=http://127.0.0.1:2048',
         'SECRET_VALUE=do-not-print',
       ], [], { '8080/tcp': [{ HostIp: '127.0.0.1', HostPort: '8080' }] }),
@@ -109,8 +115,10 @@ test('deploy packet preserves relay bind mounts and does not print env values', 
     assert.match(result.stdout, /GUN_FILE destination: `\/data`/);
     assert.match(result.stdout, /\/home\/humble\/\.local\/share\/vhc\/vhc-relay-a\/data:\/data:rw/);
     assert.match(result.stdout, /sudo docker exec vhc-relay-a test -f \/data\/news-latest-index-snapshot\.json/);
+    assert.match(result.stdout, /grep -E 'vhc\\-public\\-origin\|vhc\\-relay\\-a\|vhc\\-relay\\-b\|vhc\\-relay\\-c'/);
     assert.match(result.stdout, /VH_PUBLIC_ORIGIN_ANALYSIS_TARGET=http:\/\/127\.0\.0\.1:3001/);
     assert.match(result.stdout, /vhc-public-beta-relay:new/);
+    assert.doesNotMatch(result.stdout, /vhc-public-beta-origin\|vhc-relay/);
     assert.doesNotMatch(result.stdout, /do-not-print/);
     assert.doesNotMatch(result.stdout, /http:\/\/127\.0\.0\.1:2048/);
   } finally {


### PR DESCRIPTION
## Summary
- default the A6 deploy packet generator to the observed production origin container name `vhc-public-origin`
- generate the read-only `docker ps` precheck from the selected origin/relay names instead of a stale hard-coded pattern
- update the public-beta image deploy runbook capture commands to match A6

## Validation
- `bash -n tools/scripts/emit-a6-public-beta-deploy-packet.sh tools/scripts/build-public-beta-images.sh`
- `npx -y -p node@22 -c 'node --check tools/scripts/public-beta-image-deploy.test.mjs && node --test tools/scripts/public-beta-image-deploy.test.mjs'`\n- `npx -y -p node@22 -c 'pnpm docs:check'`\n- regenerated `.tmp/a6-public-beta-capture/20260614-0c5fd78f/a6-public-beta-deploy-packet-default-origin.md` from captured A6 inspect JSON without `--origin-name`\n- `git diff --check`\n\nNo production writes or container restarts were performed.