### PR TITLE
Run public beta image smoke with requested platform

### DIFF
--- a/tools/scripts/build-public-beta-images.sh
+++ b/tools/scripts/build-public-beta-images.sh
@@ -326,6 +326,7 @@ smoke_origin() {
   fi
   local cid
   cid="$(docker run -d --rm -P \
+    --platform "${PLATFORM}" \
     -e HOST=0.0.0.0 \
     -e VH_PUBLIC_ORIGIN_RELAY_TARGET=http://127.0.0.1:9 \
     -e VH_PUBLIC_ORIGIN_ANALYSIS_TARGET="${VH_PUBLIC_BETA_SMOKE_ANALYSIS_TARGET:-http://127.0.0.1:3001}" \
@@ -352,6 +353,7 @@ smoke_relay() {
   local tmp cid port
   tmp="$(mktemp -d)"
   cid="$(docker run -d --rm -P \
+    --platform "${PLATFORM}" \
     -e NODE_ENV=production \
     -e GUN_HOST=0.0.0.0 \
     -e GUN_FILE=/data \

--- a/tools/scripts/public-beta-image-deploy.test.mjs
+++ b/tools/scripts/public-beta-image-deploy.test.mjs
@@ -81,8 +81,10 @@ test('public beta image build dry-run passes build args by name without leaking 
   }
 });
 
-test('relay image smoke binds Gun to the container interface', () => {
+test('image smoke runs requested platform and binds relay Gun to the container interface', () => {
   const script = readFileSync(BUILD_SCRIPT, 'utf8');
+  assert.match(script, /smoke_origin\(\) \{[\s\S]*--platform "\$\{PLATFORM\}"/);
+  assert.match(script, /smoke_relay\(\) \{[\s\S]*--platform "\$\{PLATFORM\}"/);
   assert.match(script, /smoke_relay\(\) \{[\s\S]*-e GUN_HOST=0\.0\.0\.0/);
   assert.match(script, /smoke_relay\(\) \{[\s\S]*-v "\$\{tmp\}:\/data"/);
 });


### PR DESCRIPTION
## Summary
- pass `--platform "${PLATFORM}"` to origin and relay local smoke containers
- keep build and smoke validation aligned on `linux/amd64`, especially on arm64 Docker Desktop hosts
- extend the deploy tooling test to lock the platform and relay bind smoke invariants

## Validation
- `bash -n tools/scripts/build-public-beta-images.sh tools/scripts/emit-a6-public-beta-deploy-packet.sh`
- `npx -y -p node@22 -c 'node --check tools/scripts/public-beta-image-deploy.test.mjs && node --test tools/scripts/public-beta-image-deploy.test.mjs'` (4/4 pass)\n- `tools/scripts/build-public-beta-images.sh --relay --tag local-relay-platform-370f4de2 --metadata-dir .tmp/public-beta-image-build/local-relay-platform-370f4de2`\n  - image `vhc-public-beta-relay:local-relay-platform-370f4de2`, `linux/amd64`, digest `sha256:4e5ffa96f6ba134c91bbc272b23bc60e9f134700bfff58ba4f3c1f0f2fbfb881`\n- `tools/scripts/build-public-beta-images.sh --origin --tag local-origin-platform-370f4de2 --metadata-dir .tmp/public-beta-image-build/local-origin-platform-370f4de2 --provenance-env <fixture> --peer-config-file <fixture>`\n  - image `vhc-public-beta-origin:local-origin-platform-370f4de2`, `linux/amd64`, digest `sha256:95755083e6474b6169df23a4b21004ca56d3efb0ca7743c9e380c2cf5699ffc1`\n- `git diff --check`\n\nNo production writes, registry pushes, public latest-index probes, or container restarts were performed.