### PR TITLE
Include A6 pnpm shim path in user services

### DIFF
--- a/docs/ops/analysis-backend-3001.md
+++ b/docs/ops/analysis-backend-3001.md
@@ -98,6 +98,11 @@ Vite-proxied checks (when web-pwa dev server is up):
 Do not repoint production origin until the local `:3001` contract is green and
 the operator approves the env change.
 
+The installer writes a user unit with
+`PATH=%h/.local/bin:%h/.hermes/node/bin:/usr/local/bin:/usr/bin:/bin`. This
+matches the A6 `humble` runtime layout where Node may be exposed through
+`~/.local/bin` and package-manager shims may live under `~/.hermes/node/bin`.
+
 Approved host packet:
 
 ```bash

--- a/docs/ops/news-aggregator-production-service.md
+++ b/docs/ops/news-aggregator-production-service.md
@@ -45,13 +45,20 @@ The installer writes user units and reloads systemd. It does not start publisher
 writes by default.
 
 Host runtime prerequisite observed on A6 on 2026-06-14: `node` is available at
-`/home/humble/.local/bin/node`, while `pnpm` was not installed for `humble`.
-Install the repo-pinned pnpm before enabling publisher services:
+`/home/humble/.local/bin/node`, and `pnpm` is available through the
+`/home/humble/.hermes/node/bin` Corepack shims. The installed user units set
+`PATH=%h/.local/bin:%h/.hermes/node/bin:/usr/local/bin:/usr/bin:/bin` so both
+the `node` and `pnpm` shims resolve under systemd. Verify before enabling
+publisher services:
 
 ```bash
-bash -lc 'npm install -g pnpm@9.7.1'
-bash -lc 'node -v && pnpm -v'
+cd /home/humble/VHC
+PATH="$HOME/.local/bin:$HOME/.hermes/node/bin:/usr/local/bin:/usr/bin:/bin" node -v
+PATH="$HOME/.local/bin:$HOME/.hermes/node/bin:/usr/local/bin:/usr/bin:/bin" pnpm -v
 ```
+
+Run the `pnpm -v` check from the repo root so Corepack applies the
+`packageManager` pin from `package.json`.
 
 Read-only relay snapshot watch timer:
 

--- a/tools/scripts/install-analysis-backend-service.sh
+++ b/tools/scripts/install-analysis-backend-service.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 UNIT_DIR="${HOME}/.config/systemd/user"
 UNIT_PATH="${UNIT_DIR}/vh-analysis-backend-3001.service"
+SERVICE_PATH="%h/.local/bin:%h/.hermes/node/bin:/usr/local/bin:/usr/bin:/bin"
 
 mkdir -p "${UNIT_DIR}"
 
@@ -16,7 +17,7 @@ Wants=network-online.target
 [Service]
 Type=simple
 Environment=VHC_REPO=${REPO_ROOT}
-Environment=PATH=%h/.local/bin:/usr/local/bin:/usr/bin:/bin
+Environment=PATH=${SERVICE_PATH}
 Environment=HOST=127.0.0.1
 Environment=PORT=3001
 Environment=ARTICLE_TEXT_MAX_CHARS=24000

--- a/tools/scripts/install-news-aggregator-production-service.sh
+++ b/tools/scripts/install-news-aggregator-production-service.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 UNIT_DIR="${HOME}/.config/systemd/user"
 ENV_FILE="${VH_NEWS_DAEMON_ENV_FILE:-${HOME}/.config/vhc/news-aggregator.env}"
+SERVICE_PATH="%h/.local/bin:%h/.hermes/node/bin:/usr/local/bin:/usr/bin:/bin"
 ENABLE_WATCH=false
 START_PUBLISHER=false
 
@@ -35,7 +36,7 @@ Wants=network-online.target
 Type=simple
 Environment=VHC_REPO=${REPO_ROOT}
 Environment=VH_NEWS_DAEMON_ENV_FILE=${ENV_FILE}
-Environment=PATH=%h/.local/bin:/usr/local/bin:/usr/bin:/bin
+Environment=PATH=${SERVICE_PATH}
 WorkingDirectory=${REPO_ROOT}
 ExecStart=/usr/bin/env bash ${REPO_ROOT}/tools/scripts/start-news-aggregator-daemon-production.sh
 Restart=always
@@ -56,7 +57,7 @@ Documentation=file:${REPO_ROOT}/docs/ops/news-aggregator-production-service.md
 Type=oneshot
 Environment=VHC_REPO=${REPO_ROOT}
 Environment=VH_RELAY_SNAPSHOT_WATCH_OUTPUT_FILE=%h/.local/state/vhc/relay-snapshot-watch/latest.json
-Environment=PATH=%h/.local/bin:/usr/local/bin:/usr/bin:/bin
+Environment=PATH=${SERVICE_PATH}
 WorkingDirectory=${REPO_ROOT}
 ExecStart=/usr/bin/env node ${REPO_ROOT}/tools/scripts/relay-latest-index-snapshot-watch.mjs
 EOF

--- a/tools/scripts/systemd-service-installers.test.mjs
+++ b/tools/scripts/systemd-service-installers.test.mjs
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(SCRIPT_DIR, '../..');
+const SERVICE_PATH = '%h/.local/bin:%h/.hermes/node/bin:/usr/local/bin:/usr/bin:/bin';
+
+function readScript(name) {
+  return readFileSync(path.join(REPO_ROOT, 'tools/scripts', name), 'utf8');
+}
+
+test('systemd installers include A6 node and pnpm paths', () => {
+  for (const scriptName of [
+    'install-analysis-backend-service.sh',
+    'install-news-aggregator-production-service.sh',
+  ]) {
+    const source = readScript(scriptName);
+    assert.match(source, new RegExp(`SERVICE_PATH="${SERVICE_PATH.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}"`));
+    assert.match(source, /Environment=PATH=\$\{SERVICE_PATH\}/);
+  }
+});
+
+test('news aggregator installer still gates publisher start on explicit approval', () => {
+  const source = readScript('install-news-aggregator-production-service.sh');
+  assert.match(source, /if \[\[ "\$\{START_PUBLISHER\}" == "true" \]\]/);
+  assert.match(source, /VH_NEWS_DAEMON_START_APPROVED:-/);
+  assert.match(source, /--start-publisher requires VH_NEWS_DAEMON_START_APPROVED=1/);
+  assert.match(source, /systemctl --user enable --now vh-news-aggregator\.service/);
+});


### PR DESCRIPTION
## Summary
- add `%h/.hermes/node/bin` to the analysis, publisher, and relay snapshot watch user-service PATHs
- document the observed A6 `humble` runtime layout and repo-root Corepack version check
- add installer regression tests so the PATH and publisher approval gate do not drift

## Host evidence
- A6 non-interactive default PATH did not expose `node` or `pnpm`
- `/home/humble/.local/bin/node` exists and reports Node `v22.22.2` on `linux/x64`
- `/home/humble/.hermes/node/bin/pnpm` exists through Corepack shims
- current user units are not installed yet (`not-found` / inactive), so this only updates repo-side install output

## Validation
- `bash -n tools/scripts/install-analysis-backend-service.sh tools/scripts/install-news-aggregator-production-service.sh tools/scripts/start-news-aggregator-daemon-production.sh`
- `npx -y -p node@22 -c 'node --check tools/scripts/systemd-service-installers.test.mjs && node --test tools/scripts/systemd-service-installers.test.mjs'`\n- `bash -n ... && npx -y -p node@22 -c 'node --test tools/scripts/systemd-service-installers.test.mjs tools/scripts/start-news-aggregator-daemon-production.test.mjs tools/scripts/vh-analysis-backend-3001.test.mjs tools/scripts/relay-latest-index-snapshot-watch.test.mjs'` (11/11 pass)\n- `npx -y -p node@22 -c 'pnpm docs:check'`\n- `git diff --check`\n\nNo production service install, publisher start, monitor enable, container restart, registry push, or latest-index HTTP probe was performed.