### PR TITLE
Recover public beta origin provenance safely

### DIFF
--- a/docs/ops/public-beta-image-deploy.md
+++ b/docs/ops/public-beta-image-deploy.md
@@ -45,6 +45,9 @@ re-enable monitors.
   and image tags supplied by env.
 - `tools/scripts/build-public-beta-images.sh` builds origin and relay images
   with a pinned platform and records buildx metadata.
+- `tools/scripts/recover-public-beta-origin-provenance.mjs` creates a private
+  origin build provenance env template from captured origin static artifacts
+  without printing recovered values.
 - `tools/scripts/emit-a6-public-beta-deploy-packet.sh` emits a secret-safe A6
   deploy packet from captured `docker inspect` JSON.
 
@@ -72,8 +75,57 @@ sudo docker history --no-trunc \
 ```
 
 Record env var names only in tickets or PRs. Do not paste values. For the origin
-build, create a private env file outside git from the current deployed image or
-the operator that built it:
+build, first capture the currently deployed static artifact without using public
+HTTP:
+
+```bash
+ssh humble@ccibootstrap
+mkdir -p /tmp/vhc-public-beta-capture
+STATIC_DIR="$(
+  sudo docker inspect vhc-public-origin --format '{{range .Config.Env}}{{println .}}{{end}}' \
+    | awk -F= '/^VH_PUBLIC_ORIGIN_STATIC_DIR=/{print $2; found=1} END{if(!found) print "/app/dist"}'
+)"
+sudo docker exec vhc-public-origin tar -C "${STATIC_DIR}" -cf - . \
+  >/tmp/vhc-public-beta-capture/origin-dist.tar
+exit
+
+mkdir -p ~/.config/vhc
+scp humble@ccibootstrap:/tmp/vhc-public-beta-capture/origin-dist.tar \
+  ~/.config/vhc/origin-dist.tar
+rm -rf ~/.config/vhc/a6-origin-dist
+mkdir -p ~/.config/vhc/a6-origin-dist
+tar -C ~/.config/vhc/a6-origin-dist -xf ~/.config/vhc/origin-dist.tar
+```
+
+Then create a private env file outside git from the captured static artifact:
+
+```bash
+node tools/scripts/recover-public-beta-origin-provenance.mjs \
+  --dist ~/.config/vhc/a6-origin-dist \
+  --output ~/.config/vhc/public-beta-origin-build-provenance.env
+```
+
+The recovery helper writes recovered values to the private env file but prints
+only names, file mode, and hashes. It intentionally leaves non-recoverable
+required values commented as `TODO(operator)`, including CSP connect sources and
+the public news system-writer pin. Fill those from the current deployed build or
+the operator record before attempting the image build. Also review any reported
+`default_names` and `blank_names`; those are behavior-preserving defaults, not
+proof of the exact previous build. `build-public-beta-images.sh` will refuse an
+incomplete provenance file.
+
+If the deployed origin image path differs from `/app/dist`, identify it from:
+
+```bash
+sudo docker inspect vhc-public-origin --format '{{range .Config.Env}}{{println .}}{{end}}' \
+  | grep -E '^VH_PUBLIC_ORIGIN_STATIC_DIR='
+```
+
+Do not paste the value in tickets if it contains anything beyond host-local
+paths; record only the env var name and the fact that it was verified.
+
+If the static artifact is unavailable, fall back to a blank private template and
+fill every value from the operator record:
 
 ```bash
 tools/scripts/build-public-beta-images.sh --print-provenance-template \

--- a/tools/scripts/public-beta-image-deploy.test.mjs
+++ b/tools/scripts/public-beta-image-deploy.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
@@ -10,6 +10,7 @@ const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(SCRIPT_DIR, '../..');
 const BUILD_SCRIPT = path.join(REPO_ROOT, 'tools/scripts/build-public-beta-images.sh');
 const PACKET_SCRIPT = path.join(REPO_ROOT, 'tools/scripts/emit-a6-public-beta-deploy-packet.sh');
+const RECOVER_PROVENANCE_SCRIPT = path.join(REPO_ROOT, 'tools/scripts/recover-public-beta-origin-provenance.mjs');
 
 function run(command, args, options = {}) {
   return spawnSync(command, args, {
@@ -87,6 +88,82 @@ test('image smoke runs requested platform and binds relay Gun to the container i
   assert.match(script, /smoke_relay\(\) \{[\s\S]*--platform "\$\{PLATFORM\}"/);
   assert.match(script, /smoke_relay\(\) \{[\s\S]*-e GUN_HOST=0\.0\.0\.0/);
   assert.match(script, /smoke_relay\(\) \{[\s\S]*-v "\$\{tmp\}:\/data"/);
+});
+
+test('origin provenance recovery writes private env without printing recovered values', () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), 'vh-public-beta-provenance-'));
+  try {
+    const dist = path.join(root, 'dist');
+    const output = path.join(root, 'origin-provenance.env');
+    const signerPub = 'public-signer-value-that-must-not-print';
+    const peerConfig = {
+      payload: {
+        schemaVersion: 'mesh-peer-config-v1',
+        configId: 'prod-public-beta',
+        peers: [
+          'wss://relay-a.example/gun',
+          'wss://relay-b.example/gun',
+          'wss://relay-c.example/gun',
+        ],
+        minimumPeerCount: 3,
+        quorumRequired: 2,
+        issuedAt: 1,
+        expiresAt: 9999999999999,
+      },
+      signature: 'public-signature-value-that-must-not-print',
+      signerPub,
+    };
+    mkdirSync(dist);
+    writeFileSync(path.join(dist, 'index.html'), '<html></html>\n', 'utf8');
+    writeFileSync(path.join(dist, 'mesh-peer-config.json'), JSON.stringify(peerConfig), 'utf8');
+
+    const result = run('node', [
+      RECOVER_PROVENANCE_SCRIPT,
+      '--dist',
+      dist,
+      '--output',
+      output,
+    ]);
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /wrote_provenance_env=/);
+    assert.match(result.stdout, /mode=600/);
+    assert.match(result.stdout, /inferred_names: .*VITE_GUN_PEER_CONFIG_PUBLIC_KEY/);
+    assert.match(result.stdout, /todo_names: .*VITE_VH_CSP_CONNECT_SRC/);
+    assert.match(result.stdout, /todo_names: .*VITE_NEWS_SYSTEM_WRITER_PIN_JSON/);
+    assert.match(result.stdout, /build_ready=no/);
+    assert.doesNotMatch(result.stdout, new RegExp(signerPub));
+    assert.doesNotMatch(result.stdout, /relay-a\.example/);
+    assert.doesNotMatch(result.stderr, new RegExp(signerPub));
+
+    const mode = statSync(output).mode & 0o777;
+    assert.equal(mode, 0o600);
+    const env = readFileSync(output, 'utf8');
+    assert.match(env, new RegExp(`VITE_GUN_PEER_CONFIG_PUBLIC_KEY=${signerPub}`));
+    assert.match(env, /VITE_GUN_PEERS=\n/);
+    assert.match(env, /VITE_GUN_PEER_CONFIG_URL=\n/);
+    assert.match(env, /VITE_GUN_PEER_MINIMUM=3/);
+    assert.match(env, /VITE_GUN_PEER_QUORUM_REQUIRED=2/);
+    assert.match(env, /# TODO\(operator\): set VITE_VH_CSP_CONNECT_SRC/);
+    assert.match(env, /# TODO\(operator\): set VITE_NEWS_SYSTEM_WRITER_PIN_JSON/);
+
+    const buildResult = run('bash', [
+      BUILD_SCRIPT,
+      '--origin',
+      '--dry-run',
+      '--skip-smoke',
+      '--tag',
+      'test-tag',
+      '--provenance-env',
+      output,
+      '--peer-config-file',
+      path.join(dist, 'mesh-peer-config.json'),
+    ]);
+    assert.equal(buildResult.status, 78);
+    assert.match(buildResult.stderr, /VITE_VH_CSP_CONNECT_SRC/);
+    assert.match(buildResult.stderr, /VITE_NEWS_SYSTEM_WRITER_PIN_JSON/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });
 
 test('deploy packet preserves relay bind mounts and does not print env values', () => {

--- a/tools/scripts/recover-public-beta-origin-provenance.mjs
+++ b/tools/scripts/recover-public-beta-origin-provenance.mjs
@@ -1,0 +1,308 @@
+#!/usr/bin/env node
+import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, statSync, writeFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const BUILD_SCRIPT = join(SCRIPT_DIR, 'build-public-beta-images.sh');
+
+const PUBLIC_BETA_DEFAULTS = new Map([
+  ['VITE_VH_STRICT_PEER_CONFIG', 'true'],
+  ['VITE_VH_ALLOW_LOCAL_MESH_PEERS', 'false'],
+  ['VITE_VH_CSP_STRICT_CONNECT_SRC', 'true'],
+  ['VITE_VH_ANALYSIS_PIPELINE', 'true'],
+  ['VITE_NEWS_RUNTIME_ENABLED', 'true'],
+  ['VITE_NEWS_RUNTIME_ROLE', 'consumer'],
+  ['VITE_NEWS_BRIDGE_ENABLED', 'true'],
+  ['VITE_SYNTHESIS_BRIDGE_ENABLED', 'true'],
+  ['VITE_VH_GUN_LOCAL_STORAGE', 'false'],
+  ['VITE_LUMA_PROFILE', 'public-beta'],
+  ['VITE_LUMA_DEV_FALLBACK', 'false'],
+  ['VITE_CONSTITUENCY_PROOF_REAL', 'true'],
+  ['VITE_E2E_MODE', 'false'],
+]);
+
+const OPTIONAL_BLANKS = new Set([
+  'VITE_GUN_PEERS',
+  'VITE_GUN_PEER_CONFIG_URL',
+  'VITE_NEWS_EXTRACTION_SERVICE_URL',
+  'VITE_ATTESTATION_URL',
+]);
+
+const DELIBERATE_TODOS = new Set([
+  'VITE_VH_CSP_CONNECT_SRC',
+  'VITE_NEWS_SYSTEM_WRITER_PIN_JSON',
+]);
+
+function usage() {
+  console.error(`Usage: tools/scripts/recover-public-beta-origin-provenance.mjs --output <path> [options]
+
+Create a private, shell-compatible origin build provenance env file from
+captured production origin artifacts without printing any recovered values.
+
+Options:
+  --dist <path>              Captured origin static dist directory
+  --peer-config-file <path>  Signed mesh-peer-config.json (defaults to <dist>/mesh-peer-config.json)
+  --output <path>            Private env file to write
+  --force                    Overwrite an existing output file
+  -h, --help                 Show this help
+
+The output intentionally leaves non-recoverable required values commented as
+TODOs so build-public-beta-images.sh refuses to build until an operator fills
+and reviews them outside git.`);
+}
+
+function parseArgs(argv) {
+  const args = {
+    dist: '',
+    peerConfigFile: '',
+    output: '',
+    force: false,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--dist') {
+      args.dist = argv[++index] || '';
+    } else if (arg === '--peer-config-file') {
+      args.peerConfigFile = argv[++index] || '';
+    } else if (arg === '--output') {
+      args.output = argv[++index] || '';
+    } else if (arg === '--force') {
+      args.force = true;
+    } else if (arg === '-h' || arg === '--help') {
+      usage();
+      process.exit(0);
+    } else {
+      console.error(`Unknown option: ${arg}`);
+      usage();
+      process.exit(64);
+    }
+  }
+  return args;
+}
+
+function parseBashArray(text, name) {
+  const match = text.match(new RegExp(`${name}=\\(\\n([\\s\\S]*?)\\n\\)`));
+  if (!match) {
+    throw new Error(`Unable to locate ${name} in ${BUILD_SCRIPT}`);
+  }
+  return match[1]
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith('#'))
+    .map((line) => line.replace(/^['"]|['"]$/g, ''));
+}
+
+function readBuildContract() {
+  const text = readFileSync(BUILD_SCRIPT, 'utf8');
+  return {
+    buildArgNames: parseBashArray(text, 'ORIGIN_BUILD_ARG_NAMES'),
+    requiredNonemptyNames: new Set(parseBashArray(text, 'REQUIRED_NONEMPTY_ORIGIN_VARS')),
+  };
+}
+
+function parsePeerConfig(raw) {
+  const parsed = JSON.parse(raw);
+  if (!parsed || typeof parsed !== 'object') {
+    throw new Error('mesh-peer-config.json must be a JSON object');
+  }
+  const envelope = parsed;
+  const payload = 'payload' in envelope
+    ? (typeof envelope.payload === 'string' ? JSON.parse(envelope.payload) : envelope.payload)
+    : envelope;
+  if (!payload || typeof payload !== 'object') {
+    throw new Error('mesh-peer-config.json payload must be an object');
+  }
+  return {
+    payload,
+    signerPub: typeof envelope.signerPub === 'string' && envelope.signerPub.trim() ? envelope.signerPub.trim() : '',
+    signed: typeof envelope.signature === 'string' && envelope.signature.trim().length > 0,
+  };
+}
+
+function safePositiveInteger(value) {
+  return Number.isSafeInteger(value) && value > 0 ? String(value) : '';
+}
+
+function sha256Text(text) {
+  return createHash('sha256').update(text).digest('hex');
+}
+
+function sha256File(path) {
+  return sha256Text(readFileSync(path));
+}
+
+function quoteShell(value) {
+  if (value === '') return '';
+  if (/^[A-Za-z0-9_./:@%+=,-]+$/.test(value)) {
+    return value;
+  }
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function putValue(values, name, value, source) {
+  if (!value && value !== '') return;
+  values.set(name, { value, source });
+}
+
+function recoverValues(peerConfig) {
+  const values = new Map();
+  putValue(values, 'VITE_GUN_PEERS', '', 'blank-preserve-signed-peer-config');
+  putValue(values, 'VITE_GUN_PEER_CONFIG_URL', '', 'blank-defaults-to-/mesh-peer-config.json');
+  putValue(values, 'VITE_NEWS_EXTRACTION_SERVICE_URL', '', 'operator-blank-ok');
+  putValue(values, 'VITE_ATTESTATION_URL', '', 'operator-blank-ok');
+
+  if (peerConfig.signerPub) {
+    putValue(values, 'VITE_GUN_PEER_CONFIG_PUBLIC_KEY', peerConfig.signerPub, 'signed-peer-config.signerPub');
+  }
+  const minimumPeerCount = safePositiveInteger(peerConfig.payload.minimumPeerCount);
+  if (minimumPeerCount) {
+    putValue(values, 'VITE_GUN_PEER_MINIMUM', minimumPeerCount, 'signed-peer-config.payload.minimumPeerCount');
+  }
+  const quorumRequired = safePositiveInteger(peerConfig.payload.quorumRequired);
+  if (quorumRequired) {
+    putValue(values, 'VITE_GUN_PEER_QUORUM_REQUIRED', quorumRequired, 'signed-peer-config.payload.quorumRequired');
+  }
+
+  for (const [name, value] of PUBLIC_BETA_DEFAULTS) {
+    putValue(values, name, value, 'public-beta-default-review-required');
+  }
+  return values;
+}
+
+function renderEnvFile({ buildArgNames, requiredNonemptyNames, values, peerConfigSha, distIndexSha }) {
+  const lines = [
+    '# Generated by tools/scripts/recover-public-beta-origin-provenance.mjs',
+    '# Keep this file outside git. It contains build-time production provenance.',
+    '# The generator never prints recovered values; review this file locally before use.',
+    `# mesh_peer_config_sha256=${peerConfigSha}`,
+    ...(distIndexSha ? [`# dist_index_sha256=${distIndexSha}`] : []),
+    '#',
+    '# Lines beginning with TODO are intentionally commented out. Fill them from',
+    '# the current deployed origin/operator record before running the image build.',
+    '',
+  ];
+
+  const todos = [];
+  const inferred = [];
+  const defaults = [];
+  const blanks = [];
+
+  for (const name of buildArgNames) {
+    const entry = values.get(name);
+    if (entry) {
+      if (entry.source.startsWith('signed-peer-config')) inferred.push(name);
+      if (entry.source.startsWith('public-beta-default')) defaults.push(name);
+      if (entry.source.startsWith('blank') || entry.source === 'operator-blank-ok') blanks.push(name);
+      lines.push(`# source: ${entry.source}`);
+      lines.push(`${name}=${quoteShell(entry.value)}`);
+      lines.push('');
+      continue;
+    }
+
+    const required = requiredNonemptyNames.has(name) || DELIBERATE_TODOS.has(name);
+    if (required) {
+      todos.push(name);
+      lines.push(`# TODO(operator): set ${name} from the current deployed origin build provenance.`);
+      lines.push(`# ${name}=`);
+      lines.push('');
+    } else if (OPTIONAL_BLANKS.has(name)) {
+      blanks.push(name);
+      lines.push('# source: operator-blank-ok');
+      lines.push(`${name}=`);
+      lines.push('');
+    } else {
+      todos.push(name);
+      lines.push(`# TODO(operator): review whether ${name} should be blank or set.`);
+      lines.push(`# ${name}=`);
+      lines.push('');
+    }
+  }
+
+  return {
+    text: lines.join('\n'),
+    summary: {
+      inferred,
+      defaults,
+      blanks,
+      todos,
+      buildReady: todos.length === 0,
+      operatorReviewRequired: todos.length > 0 || defaults.length > 0 || blanks.length > 0,
+    },
+  };
+}
+
+function printNameList(label, names) {
+  console.log(`${label}: ${names.length ? names.join(', ') : '(none)'}`);
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (!args.output) {
+    usage();
+    process.exit(64);
+  }
+  const output = resolve(args.output);
+  if (existsSync(output) && !args.force) {
+    console.error(`Refusing to overwrite existing output without --force: ${output}`);
+    process.exit(73);
+  }
+
+  const dist = args.dist ? resolve(args.dist) : '';
+  if (dist) {
+    const stat = statSync(dist, { throwIfNoEntry: false });
+    if (!stat?.isDirectory()) {
+      console.error(`--dist must be a directory: ${dist}`);
+      process.exit(66);
+    }
+  }
+
+  const peerConfigCandidate = args.peerConfigFile || (dist ? join(dist, 'mesh-peer-config.json') : '');
+  if (!peerConfigCandidate) {
+    console.error('--peer-config-file is required unless --dist contains mesh-peer-config.json');
+    process.exit(66);
+  }
+  const peerConfigFile = resolve(peerConfigCandidate);
+  if (!existsSync(peerConfigFile)) {
+    console.error('--peer-config-file is required unless --dist contains mesh-peer-config.json');
+    process.exit(66);
+  }
+
+  const peerConfigRaw = readFileSync(peerConfigFile, 'utf8');
+  const peerConfig = parsePeerConfig(peerConfigRaw);
+  const contract = readBuildContract();
+  const values = recoverValues(peerConfig);
+  const distIndexPath = dist ? join(dist, 'index.html') : '';
+  const distIndexSha = distIndexPath && existsSync(distIndexPath) ? sha256File(distIndexPath) : '';
+  const rendered = renderEnvFile({
+    ...contract,
+    values,
+    peerConfigSha: sha256Text(peerConfigRaw),
+    distIndexSha,
+  });
+
+  mkdirSync(dirname(output), { recursive: true, mode: 0o700 });
+  const tmp = `${output}.tmp-${process.pid}`;
+  writeFileSync(tmp, rendered.text, { mode: 0o600, flag: 'wx' });
+  chmodSync(tmp, 0o600);
+  renameSync(tmp, output);
+
+  console.log(`wrote_provenance_env=${output}`);
+  console.log(`mode=${(statSync(output).mode & 0o777).toString(8)}`);
+  console.log(`sha256=${sha256File(output)}`);
+  console.log(`signed_peer_config=${peerConfig.signed ? 'yes' : 'no'}`);
+  printNameList('inferred_names', rendered.summary.inferred);
+  printNameList('default_names', rendered.summary.defaults);
+  printNameList('blank_names', rendered.summary.blanks);
+  printNameList('todo_names', rendered.summary.todos);
+  console.log(`build_ready=${rendered.summary.buildReady ? 'yes' : 'no'}`);
+  console.log(`operator_review_required=${rendered.summary.operatorReviewRequired ? 'yes' : 'no'}`);
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add a filesystem-only origin provenance recovery helper that writes private env files without printing recovered values
- keep signed peer-config resolution intact by leaving VITE_GUN_PEERS blank and marking non-recoverable required inputs as TODOs
- document the A6 static artifact capture flow and add regression coverage for no-value-leak summaries plus build refusal on incomplete provenance

## Validation
- node --check tools/scripts/recover-public-beta-origin-provenance.mjs
- bash -n tools/scripts/build-public-beta-images.sh tools/scripts/emit-a6-public-beta-deploy-packet.sh tools/scripts/install-analysis-backend-service.sh tools/scripts/install-news-aggregator-production-service.sh tools/scripts/start-news-aggregator-daemon-production.sh
- npx -y -p node@22 -c 'node --test tools/scripts/public-beta-image-deploy.test.mjs tools/scripts/systemd-service-installers.test.mjs tools/scripts/start-news-aggregator-daemon-production.test.mjs tools/scripts/vh-analysis-backend-3001.test.mjs tools/scripts/relay-latest-index-snapshot-watch.test.mjs'\n- git diff --check\n\n## Production impact\nNo production writes, deploys, publisher starts, monitor changes, latest-index HTTP probes, or service restarts were performed.\n