### PR TITLE
Complete public beta origin provenance recovery

### DIFF
--- a/docs/ops/public-beta-image-deploy.md
+++ b/docs/ops/public-beta-image-deploy.md
@@ -92,6 +92,8 @@ exit
 mkdir -p ~/.config/vhc
 scp humble@ccibootstrap:/tmp/vhc-public-beta-capture/origin-dist.tar \
   ~/.config/vhc/origin-dist.tar
+scp humble@ccibootstrap:/tmp/vhc-public-beta-capture/containers.json \
+  ~/.config/vhc/containers.json
 rm -rf ~/.config/vhc/a6-origin-dist
 mkdir -p ~/.config/vhc/a6-origin-dist
 tar -C ~/.config/vhc/a6-origin-dist -xf ~/.config/vhc/origin-dist.tar
@@ -102,17 +104,26 @@ Then create a private env file outside git from the captured static artifact:
 ```bash
 node tools/scripts/recover-public-beta-origin-provenance.mjs \
   --dist ~/.config/vhc/a6-origin-dist \
+  --inspect-json ~/.config/vhc/containers.json \
   --output ~/.config/vhc/public-beta-origin-build-provenance.env
 ```
 
 The recovery helper writes recovered values to the private env file but prints
-only names, file mode, and hashes. It intentionally leaves non-recoverable
-required values commented as `TODO(operator)`, including CSP connect sources and
-the public news system-writer pin. Fill those from the current deployed build or
-the operator record before attempting the image build. Also review any reported
-`default_names` and `blank_names`; those are behavior-preserving defaults, not
-proof of the exact previous build. `build-public-beta-images.sh` will refuse an
-incomplete provenance file.
+only names, file mode, and hashes. With both `--dist` and `--inspect-json`, it
+recovers:
+
+- signed peer config public key, minimum peer count, and quorum from
+  `mesh-peer-config.json`;
+- `VITE_VH_CSP_CONNECT_SRC` from the current origin container's
+  `VH_PUBLIC_ORIGIN_CSP_CONNECT_SRC`;
+- `VITE_NEWS_SYSTEM_WRITER_PIN_JSON` from captured Vite JS chunks.
+
+It does not print those values. It intentionally leaves any non-recoverable
+required values commented as `TODO(operator)`, and
+`build-public-beta-images.sh` will refuse an incomplete provenance file. Even
+when the helper reports `build_ready=yes`, review any reported `default_names`
+and `blank_names`; those are behavior-preserving defaults, not proof of the
+exact previous build.
 
 If the deployed origin image path differs from `/app/dist`, identify it from:
 

--- a/tools/scripts/public-beta-image-deploy.test.mjs
+++ b/tools/scripts/public-beta-image-deploy.test.mjs
@@ -166,6 +166,104 @@ test('origin provenance recovery writes private env without printing recovered v
   }
 });
 
+test('origin provenance recovery completes from inspect JSON and Vite bundle without printing values', () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), 'vh-public-beta-provenance-complete-'));
+  try {
+    const dist = path.join(root, 'dist');
+    const output = path.join(root, 'origin-provenance.env');
+    const inspectPath = path.join(root, 'inspect.json');
+    const signerPub = 'complete-public-signer-value-that-must-not-print';
+    const cspConnectSrc = "'self' https://origin.example wss://relay-a.example";
+    const pin = {
+      pinVersion: 1,
+      schemaEpoch: 'luma-public-v1',
+      maxProtocolVersion: 'luma-public-v1',
+      signatureSuite: 'jcs-ed25519-sha256-v1',
+      writers: [{
+        id: 'vh-public-beta-news-system-writer-v1',
+        status: 'active',
+        publicKey: { encoding: 'spki-base64url', material: 'public-material-that-must-not-print' },
+      }],
+    };
+    const peerConfig = {
+      payload: {
+        schemaVersion: 'mesh-peer-config-v1',
+        configId: 'prod-public-beta',
+        peers: [
+          'wss://relay-a.example/gun',
+          'wss://relay-b.example/gun',
+          'wss://relay-c.example/gun',
+        ],
+        minimumPeerCount: 3,
+        quorumRequired: 2,
+        issuedAt: 1,
+        expiresAt: 9999999999999,
+      },
+      signature: 'complete-public-signature-value-that-must-not-print',
+      signerPub,
+    };
+    mkdirSync(path.join(dist, 'assets'), { recursive: true });
+    writeFileSync(path.join(dist, 'index.html'), '<script type="module" src="/assets/index.js"></script>\n', 'utf8');
+    writeFileSync(path.join(dist, 'mesh-peer-config.json'), JSON.stringify(peerConfig), 'utf8');
+    writeFileSync(
+      path.join(dist, 'assets', 'index.js'),
+      `const env={VITE_NEWS_SYSTEM_WRITER_PIN_JSON:${JSON.stringify(JSON.stringify(pin))}};\n`,
+      'utf8',
+    );
+    writeFileSync(
+      inspectPath,
+      JSON.stringify([
+        makeContainer('vhc-public-origin', 'vhc-public-beta-origin:old', [
+          `VH_PUBLIC_ORIGIN_CSP_CONNECT_SRC=${cspConnectSrc}`,
+        ], [], {}),
+      ]),
+      'utf8',
+    );
+
+    const result = run('node', [
+      RECOVER_PROVENANCE_SCRIPT,
+      '--dist',
+      dist,
+      '--inspect-json',
+      inspectPath,
+      '--output',
+      output,
+    ]);
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /inferred_names: .*VITE_NEWS_SYSTEM_WRITER_PIN_JSON/);
+    assert.match(result.stdout, /inferred_names: .*VITE_VH_CSP_CONNECT_SRC/);
+    assert.match(result.stdout, /todo_names: \(none\)/);
+    assert.match(result.stdout, /build_ready=yes/);
+    assert.doesNotMatch(result.stdout, new RegExp(signerPub));
+    assert.doesNotMatch(result.stdout, /origin\.example/);
+    assert.doesNotMatch(result.stdout, /public-material-that-must-not-print/);
+
+    const env = readFileSync(output, 'utf8');
+    assert.match(env, /VITE_VH_CSP_CONNECT_SRC='/);
+    assert.match(env, /VITE_NEWS_SYSTEM_WRITER_PIN_JSON='/);
+    assert.match(env, /complete-public-signer-value-that-must-not-print/);
+    assert.match(env, /public-material-that-must-not-print/);
+
+    const buildResult = run('bash', [
+      BUILD_SCRIPT,
+      '--origin',
+      '--dry-run',
+      '--skip-smoke',
+      '--tag',
+      'test-tag',
+      '--provenance-env',
+      output,
+      '--peer-config-file',
+      path.join(dist, 'mesh-peer-config.json'),
+    ]);
+    assert.equal(buildResult.status, 0, buildResult.stderr);
+    assert.doesNotMatch(buildResult.stdout, /origin\.example/);
+    assert.doesNotMatch(buildResult.stdout, /public-material-that-must-not-print/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test('deploy packet preserves relay bind mounts and does not print env values', () => {
   const root = mkdtempSync(path.join(os.tmpdir(), 'vh-public-beta-packet-'));
   try {

--- a/tools/scripts/recover-public-beta-origin-provenance.mjs
+++ b/tools/scripts/recover-public-beta-origin-provenance.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, statSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, mkdirSync, readFileSync, readdirSync, renameSync, statSync, writeFileSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -44,6 +44,8 @@ captured production origin artifacts without printing any recovered values.
 Options:
   --dist <path>              Captured origin static dist directory
   --peer-config-file <path>  Signed mesh-peer-config.json (defaults to <dist>/mesh-peer-config.json)
+  --inspect-json <path>      Captured docker inspect JSON for runtime CSP env
+  --origin-name <name>       Origin container name in inspect JSON (default vhc-public-origin)
   --output <path>            Private env file to write
   --force                    Overwrite an existing output file
   -h, --help                 Show this help
@@ -57,6 +59,8 @@ function parseArgs(argv) {
   const args = {
     dist: '',
     peerConfigFile: '',
+    inspectJson: '',
+    originName: 'vhc-public-origin',
     output: '',
     force: false,
   };
@@ -66,6 +70,10 @@ function parseArgs(argv) {
       args.dist = argv[++index] || '';
     } else if (arg === '--peer-config-file') {
       args.peerConfigFile = argv[++index] || '';
+    } else if (arg === '--inspect-json') {
+      args.inspectJson = argv[++index] || '';
+    } else if (arg === '--origin-name') {
+      args.originName = argv[++index] || '';
     } else if (arg === '--output') {
       args.output = argv[++index] || '';
     } else if (arg === '--force') {
@@ -121,6 +129,174 @@ function parsePeerConfig(raw) {
   };
 }
 
+function cleanContainerName(container) {
+  return String(container?.Name || '').replace(/^\//, '');
+}
+
+function envMapFromContainer(container) {
+  const out = new Map();
+  for (const entry of container?.Config?.Env || []) {
+    const text = String(entry);
+    const index = text.indexOf('=');
+    if (index <= 0) continue;
+    out.set(text.slice(0, index), text.slice(index + 1));
+  }
+  return out;
+}
+
+function recoverOriginRuntimeValues(inspectJsonPath, originName) {
+  if (!inspectJsonPath) return new Map();
+  const containers = JSON.parse(readFileSync(inspectJsonPath, 'utf8'));
+  if (!Array.isArray(containers)) {
+    throw new Error('--inspect-json must contain docker inspect array output');
+  }
+  const container = containers.find((candidate) => cleanContainerName(candidate) === originName);
+  if (!container) {
+    throw new Error(`--inspect-json does not contain origin container ${originName}`);
+  }
+  const env = envMapFromContainer(container);
+  const out = new Map();
+  const cspConnectSrc = env.get('VH_PUBLIC_ORIGIN_CSP_CONNECT_SRC')?.trim();
+  if (cspConnectSrc) {
+    out.set('VITE_VH_CSP_CONNECT_SRC', {
+      value: cspConnectSrc,
+      source: 'docker-inspect.VH_PUBLIC_ORIGIN_CSP_CONNECT_SRC',
+    });
+  }
+  return out;
+}
+
+function extractViteEnvString(source, name) {
+  const marker = `${name}:`;
+  const markerIndex = source.indexOf(marker);
+  if (markerIndex < 0) return null;
+  let cursor = markerIndex + marker.length;
+  while (/\s/.test(source[cursor] ?? '')) cursor += 1;
+  const quote = source[cursor];
+  if (quote !== '"' && quote !== "'") return null;
+  let escaped = false;
+  for (let end = cursor + 1; end < source.length; end += 1) {
+    const char = source[end];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (char === '\\') {
+      escaped = true;
+      continue;
+    }
+    if (char === quote) {
+      const literal = source.slice(cursor, end + 1);
+      return Function('"use strict"; return (' + literal + ');')();
+    }
+  }
+  return null;
+}
+
+function walkFiles(dir, out = []) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const file = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walkFiles(file, out);
+    } else {
+      out.push(file);
+    }
+  }
+  return out;
+}
+
+function assertPublicSystemWriterPin(pin) {
+  if (!pin || typeof pin !== 'object') {
+    throw new Error('extracted system-writer pin must be a JSON object');
+  }
+  if (pin.pinVersion !== 1) {
+    throw new Error('extracted system-writer pin must use pinVersion 1');
+  }
+  if (pin.schemaEpoch !== 'luma-public-v1') {
+    throw new Error('extracted system-writer pin must target luma-public-v1');
+  }
+  if (pin.signatureSuite !== 'jcs-ed25519-sha256-v1') {
+    throw new Error('extracted system-writer pin must use jcs-ed25519-sha256-v1');
+  }
+  if (!Array.isArray(pin.writers) || pin.writers.length === 0) {
+    throw new Error('extracted system-writer pin must include writers');
+  }
+  for (const writer of pin.writers) {
+    if (!writer || typeof writer !== 'object') {
+      throw new Error('extracted system-writer pin writer must be an object');
+    }
+    if (typeof writer.id !== 'string' || !writer.id.trim()) {
+      throw new Error('extracted system-writer pin writer id must be nonempty');
+    }
+    if (writer.status !== 'active' && writer.status !== 'retired') {
+      throw new Error('extracted system-writer pin writer status must be active or retired');
+    }
+    if (writer.publicKey?.encoding !== 'spki-base64url') {
+      throw new Error('extracted system-writer pin public key must use spki-base64url');
+    }
+    if (typeof writer.publicKey?.material !== 'string' || !writer.publicKey.material.trim()) {
+      throw new Error('extracted system-writer pin public key material must be nonempty');
+    }
+  }
+  assertNoPrivateMaterial(pin, 'system-writer pin');
+}
+
+function assertNoPrivateMaterial(value, label) {
+  if (Array.isArray(value)) {
+    value.forEach((entry, index) => assertNoPrivateMaterial(entry, `${label}[${index}]`));
+    return;
+  }
+  if (value && typeof value === 'object') {
+    for (const [key, nested] of Object.entries(value)) {
+      const normalized = key.toLowerCase();
+      if (
+        normalized.includes('private')
+        || normalized.includes('secret')
+        || normalized.includes('seed')
+        || normalized.includes('mnemonic')
+        || normalized.includes('signingkey')
+      ) {
+        throw new Error(`${label} contains private-material-shaped key ${key}`);
+      }
+      assertNoPrivateMaterial(nested, `${label}.${key}`);
+    }
+    return;
+  }
+  if (typeof value === 'string' && /BEGIN (?:OPENSSH |EC |RSA |)PRIVATE KEY/.test(value)) {
+    throw new Error(`${label} contains PEM private key material`);
+  }
+}
+
+function recoverBundleValues(dist) {
+  if (!dist) return new Map();
+  const out = new Map();
+  const files = walkFiles(dist)
+    .filter((file) => /\.js$/i.test(file))
+    .filter((file) => statSync(file).size <= 8_000_000)
+    .sort();
+  const candidates = [];
+  for (const file of files) {
+    const source = readFileSync(file, 'utf8');
+    const pinJson = extractViteEnvString(source, 'VITE_NEWS_SYSTEM_WRITER_PIN_JSON')
+      || extractViteEnvString(source, 'VITE_SYSTEM_WRITER_PIN_JSON');
+    if (!pinJson) continue;
+    const pin = JSON.parse(pinJson);
+    assertPublicSystemWriterPin(pin);
+    candidates.push({ file, pinJson });
+  }
+  const uniquePinJson = Array.from(new Set(candidates.map((candidate) => candidate.pinJson)));
+  if (uniquePinJson.length > 1) {
+    throw new Error('captured bundle contains multiple distinct system-writer pins');
+  }
+  if (uniquePinJson.length === 1) {
+    out.set('VITE_NEWS_SYSTEM_WRITER_PIN_JSON', {
+      value: uniquePinJson[0],
+      source: `vite-bundle.${candidates.length}-chunk-match`,
+    });
+  }
+  return out;
+}
+
 function safePositiveInteger(value) {
   return Number.isSafeInteger(value) && value > 0 ? String(value) : '';
 }
@@ -146,7 +322,13 @@ function putValue(values, name, value, source) {
   values.set(name, { value, source });
 }
 
-function recoverValues(peerConfig) {
+function mergeRecoveredValues(target, values) {
+  for (const [name, entry] of values) {
+    target.set(name, entry);
+  }
+}
+
+function recoverValues(peerConfig, extraValues = []) {
   const values = new Map();
   putValue(values, 'VITE_GUN_PEERS', '', 'blank-preserve-signed-peer-config');
   putValue(values, 'VITE_GUN_PEER_CONFIG_URL', '', 'blank-defaults-to-/mesh-peer-config.json');
@@ -167,6 +349,9 @@ function recoverValues(peerConfig) {
 
   for (const [name, value] of PUBLIC_BETA_DEFAULTS) {
     putValue(values, name, value, 'public-beta-default-review-required');
+  }
+  for (const extra of extraValues) {
+    mergeRecoveredValues(values, extra);
   }
   return values;
 }
@@ -192,7 +377,11 @@ function renderEnvFile({ buildArgNames, requiredNonemptyNames, values, peerConfi
   for (const name of buildArgNames) {
     const entry = values.get(name);
     if (entry) {
-      if (entry.source.startsWith('signed-peer-config')) inferred.push(name);
+      if (
+        entry.source.startsWith('signed-peer-config')
+        || entry.source.startsWith('docker-inspect')
+        || entry.source.startsWith('vite-bundle')
+      ) inferred.push(name);
       if (entry.source.startsWith('public-beta-default')) defaults.push(name);
       if (entry.source.startsWith('blank') || entry.source === 'operator-blank-ok') blanks.push(name);
       lines.push(`# source: ${entry.source}`);
@@ -272,7 +461,10 @@ function main() {
   const peerConfigRaw = readFileSync(peerConfigFile, 'utf8');
   const peerConfig = parsePeerConfig(peerConfigRaw);
   const contract = readBuildContract();
-  const values = recoverValues(peerConfig);
+  const values = recoverValues(peerConfig, [
+    recoverOriginRuntimeValues(args.inspectJson ? resolve(args.inspectJson) : '', args.originName),
+    recoverBundleValues(dist),
+  ]);
   const distIndexPath = dist ? join(dist, 'index.html') : '';
   const distIndexSha = distIndexPath && existsSync(distIndexPath) ? sha256File(distIndexPath) : '';
   const rendered = renderEnvFile({


### PR DESCRIPTION
## Summary
- recover origin CSP build input from captured docker inspect JSON without printing the value
- recover the public news system-writer pin from captured Vite chunks without printing the value
- keep recovered provenance private, validate pin shape/no private material, and prove build-public-beta-images accepts the complete env file by name-only dry run

## Captured-artifact proof
- ran recovery against `.tmp/a6-public-beta-capture/20260614-f2c9fff0/origin-dist` plus captured `containers.json`
- result printed names/hashes only, `todo_names: (none)`, `build_ready=yes`, `operator_review_required=yes`
- dry-run origin build accepted the recovered private env and printed only `--build-arg` names

## Validation
- node --check tools/scripts/recover-public-beta-origin-provenance.mjs
- bash -n tools/scripts/build-public-beta-images.sh tools/scripts/emit-a6-public-beta-deploy-packet.sh tools/scripts/install-analysis-backend-service.sh tools/scripts/install-news-aggregator-production-service.sh tools/scripts/start-news-aggregator-daemon-production.sh
- npx -y -p node@22 -c 'node --test tools/scripts/public-beta-image-deploy.test.mjs tools/scripts/systemd-service-installers.test.mjs tools/scripts/start-news-aggregator-daemon-production.test.mjs tools/scripts/vh-analysis-backend-3001.test.mjs tools/scripts/relay-latest-index-snapshot-watch.test.mjs'\n- git diff --check\n\n## Production impact\nNo production writes, deploys, publisher starts, monitor changes, latest-index HTTP probes, or service restarts were performed.\n