### PR TITLE
Add public beta image artifact exporter

### DIFF
--- a/docs/ops/public-beta-image-deploy.md
+++ b/docs/ops/public-beta-image-deploy.md
@@ -45,6 +45,9 @@ re-enable monitors.
   and image tags supplied by env.
 - `tools/scripts/build-public-beta-images.sh` builds origin and relay images
   with a pinned platform and records buildx metadata.
+- `tools/scripts/export-public-beta-image-artifacts.sh` exports already-built
+  images to private tarballs, writes checksums, and emits the approval-only A6
+  image-load packet.
 - `tools/scripts/recover-public-beta-origin-provenance.mjs` creates a private
   origin build provenance env template from captured origin static artifacts
   without printing recovered values.
@@ -205,6 +208,34 @@ tools/scripts/build-public-beta-images.sh \
 For registry publication, add `--push` and use immutable tags or digests in the
 deploy packet. Do not bake relay daemon tokens, OpenAI keys, or system-writer
 private keys into image layers.
+
+## Export Image Artifacts
+
+If A6 is receiving images by direct file transfer rather than a registry push,
+export the locally loaded images with the committed exporter:
+
+```bash
+tools/scripts/export-public-beta-image-artifacts.sh \
+  --origin-image vhc-public-beta-origin:<tag> \
+  --relay-image vhc-public-beta-relay:<tag> \
+  --output-dir .tmp/public-beta-image-artifacts/<tag>
+```
+
+The exporter refuses images whose Docker metadata platform is not
+`linux/amd64`, and by default refuses images whose
+`org.opencontainers.image.revision` label does not match the current checkout.
+It writes:
+
+- `vhc-public-beta-origin_<tag>.tar`
+- `vhc-public-beta-relay_<tag>.tar`
+- `SHA256SUMS`
+- `artifact-manifest.json`
+- `a6-image-load-packet.md`
+
+All files are local artifacts. The emitted load packet contains `scp`,
+`sha256sum -c`, `docker load`, and `docker image inspect` commands only. It is
+not approval to restart containers, deploy relays, deploy origin, run
+latest-index HTTP probes, start publisher writes, or re-enable monitors.
 
 ## Emit Deploy Packet
 

--- a/tools/scripts/export-public-beta-image-artifacts.sh
+++ b/tools/scripts/export-public-beta-image-artifacts.sh
@@ -1,0 +1,281 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DEFAULT_PLATFORM="linux/amd64"
+PLATFORM="${DEFAULT_PLATFORM}"
+ORIGIN_IMAGE=""
+RELAY_IMAGE=""
+OUTPUT_DIR=""
+REMOTE_DIR=""
+SSH_HOST="humble@ccibootstrap"
+SOURCE_REVISION=""
+SKIP_REVISION_CHECK=false
+
+usage() {
+  cat <<'EOF'
+Usage: tools/scripts/export-public-beta-image-artifacts.sh [options]
+
+Export already-built public-beta origin and relay Docker images as tarballs,
+write checksums and a secret-safe A6 image-load packet. This script is local
+only: it does not SSH, scp, docker load on A6, restart containers, or start
+publisher writes.
+
+Required:
+  --origin-image <image>      Local origin image tag/digest to export
+  --relay-image <image>       Local relay image tag/digest to export
+
+Options:
+  --output-dir <path>         Artifact output dir (default .tmp/public-beta-image-artifacts/<origin-tag>)
+  --remote-dir <path>         Remote staging dir in emitted packet (default /tmp/vhc-public-beta-images/<output-dir-basename>)
+  --ssh-host <host>           SSH target used in emitted packet (default humble@ccibootstrap)
+  --platform <platform>       Required image platform (default linux/amd64)
+  --source-revision <sha>     Required OCI revision label (default current git HEAD)
+  --skip-revision-check       Do not require a matching OCI revision label
+  -h, --help                  Show this help
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --origin-image)
+      ORIGIN_IMAGE="${2:-}"
+      shift 2
+      ;;
+    --relay-image)
+      RELAY_IMAGE="${2:-}"
+      shift 2
+      ;;
+    --output-dir)
+      OUTPUT_DIR="${2:-}"
+      shift 2
+      ;;
+    --remote-dir)
+      REMOTE_DIR="${2:-}"
+      shift 2
+      ;;
+    --ssh-host)
+      SSH_HOST="${2:-}"
+      shift 2
+      ;;
+    --platform)
+      PLATFORM="${2:-}"
+      shift 2
+      ;;
+    --source-revision)
+      SOURCE_REVISION="${2:-}"
+      shift 2
+      ;;
+    --skip-revision-check)
+      SKIP_REVISION_CHECK=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 64
+      ;;
+  esac
+done
+
+if [[ -z "${ORIGIN_IMAGE}" || -z "${RELAY_IMAGE}" ]]; then
+  echo "--origin-image and --relay-image are required" >&2
+  exit 64
+fi
+if [[ -z "${PLATFORM}" ]]; then
+  echo "--platform must not be empty" >&2
+  exit 64
+fi
+if [[ "${SKIP_REVISION_CHECK}" != "true" && -z "${SOURCE_REVISION}" ]]; then
+  SOURCE_REVISION="$(git -C "${ROOT}" rev-parse HEAD)"
+fi
+
+safe_name() {
+  printf '%s' "$1" | sed -E 's#[^A-Za-z0-9._-]+#_#g'
+}
+
+bash_quote() {
+  printf '%q' "$1"
+}
+
+file_bytes() {
+  wc -c < "$1" | tr -d '[:space:]'
+}
+
+file_mode() {
+  stat -f '%Lp' "$1" 2>/dev/null || stat -c '%a' "$1"
+}
+
+inspect_image() {
+  local label="$1"
+  local image="$2"
+  local line id os_name arch revision created
+  line="$(docker image inspect "${image}" --format '{{.Id}}|{{.Os}}|{{.Architecture}}|{{index .Config.Labels "org.opencontainers.image.revision"}}|{{.Created}}')"
+  IFS='|' read -r id os_name arch revision created <<<"${line}"
+  if [[ "${revision}" == "<no value>" ]]; then
+    revision=""
+  fi
+  local actual_platform="${os_name}/${arch}"
+  if [[ "${actual_platform}" != "${PLATFORM}" ]]; then
+    printf '%s image platform mismatch: expected %s, got %s (%s)\n' "${label}" "${PLATFORM}" "${actual_platform}" "${image}" >&2
+    exit 78
+  fi
+  if [[ "${SKIP_REVISION_CHECK}" != "true" && "${revision}" != "${SOURCE_REVISION}" ]]; then
+    printf '%s image revision mismatch: expected %s, got %s (%s)\n' "${label}" "${SOURCE_REVISION}" "${revision:-<empty>}" "${image}" >&2
+    exit 78
+  fi
+  printf '%s\t%s\t%s\t%s\t%s\n' "${id}" "${os_name}" "${arch}" "${revision}" "${created}"
+}
+
+if [[ -z "${OUTPUT_DIR}" ]]; then
+  OUTPUT_DIR="${ROOT}/.tmp/public-beta-image-artifacts/$(safe_name "${ORIGIN_IMAGE}")"
+fi
+if [[ "${OUTPUT_DIR}" != /* ]]; then
+  OUTPUT_DIR="${ROOT}/${OUTPUT_DIR}"
+fi
+if [[ -z "${REMOTE_DIR}" ]]; then
+  REMOTE_DIR="/tmp/vhc-public-beta-images/$(basename "${OUTPUT_DIR}")"
+fi
+
+mkdir -p "${OUTPUT_DIR}"
+chmod 700 "${OUTPUT_DIR}"
+
+origin_file="$(safe_name "${ORIGIN_IMAGE}").tar"
+relay_file="$(safe_name "${RELAY_IMAGE}").tar"
+origin_tar="${OUTPUT_DIR}/${origin_file}"
+relay_tar="${OUTPUT_DIR}/${relay_file}"
+checksums_file="${OUTPUT_DIR}/SHA256SUMS"
+manifest_file="${OUTPUT_DIR}/artifact-manifest.json"
+packet_file="${OUTPUT_DIR}/a6-image-load-packet.md"
+
+origin_meta="$(inspect_image "origin" "${ORIGIN_IMAGE}")"
+IFS=$'\t' read -r origin_id origin_os origin_arch origin_revision origin_created <<<"${origin_meta}"
+relay_meta="$(inspect_image "relay" "${RELAY_IMAGE}")"
+IFS=$'\t' read -r relay_id relay_os relay_arch relay_revision relay_created <<<"${relay_meta}"
+
+docker save -o "${origin_tar}.tmp" "${ORIGIN_IMAGE}"
+mv "${origin_tar}.tmp" "${origin_tar}"
+chmod 600 "${origin_tar}"
+docker save -o "${relay_tar}.tmp" "${RELAY_IMAGE}"
+mv "${relay_tar}.tmp" "${relay_tar}"
+chmod 600 "${relay_tar}"
+
+(
+  cd "${OUTPUT_DIR}"
+  shasum -a 256 "${origin_file}" "${relay_file}" > "${checksums_file}"
+)
+chmod 600 "${checksums_file}"
+
+origin_sha="$(awk -v file="${origin_file}" '$2 == file {print $1}' "${checksums_file}")"
+relay_sha="$(awk -v file="${relay_file}" '$2 == file {print $1}' "${checksums_file}")"
+
+ARTIFACT_SCHEMA="vh-public-beta-local-image-artifact-manifest-v1" \
+GENERATED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+SOURCE_REVISION_VALUE="${SOURCE_REVISION}" \
+PLATFORM_VALUE="${PLATFORM}" \
+ORIGIN_IMAGE="${ORIGIN_IMAGE}" \
+ORIGIN_FILE="${origin_tar}" \
+ORIGIN_BYTES="$(file_bytes "${origin_tar}")" \
+ORIGIN_MODE="$(file_mode "${origin_tar}")" \
+ORIGIN_SHA="${origin_sha}" \
+ORIGIN_ID="${origin_id}" \
+ORIGIN_OS="${origin_os}" \
+ORIGIN_ARCH="${origin_arch}" \
+ORIGIN_REVISION="${origin_revision}" \
+ORIGIN_CREATED="${origin_created}" \
+RELAY_IMAGE="${RELAY_IMAGE}" \
+RELAY_FILE="${relay_tar}" \
+RELAY_BYTES="$(file_bytes "${relay_tar}")" \
+RELAY_MODE="$(file_mode "${relay_tar}")" \
+RELAY_SHA="${relay_sha}" \
+RELAY_ID="${relay_id}" \
+RELAY_OS="${relay_os}" \
+RELAY_ARCH="${relay_arch}" \
+RELAY_REVISION="${relay_revision}" \
+RELAY_CREATED="${relay_created}" \
+node --input-type=module > "${manifest_file}" <<'NODE'
+const env = process.env;
+const image = (kind) => ({
+  image: env[`${kind}_IMAGE`],
+  file: env[`${kind}_FILE`],
+  bytes: Number(env[`${kind}_BYTES`]),
+  mode: env[`${kind}_MODE`],
+  sha256: env[`${kind}_SHA`],
+  image_id: env[`${kind}_ID`],
+  os: env[`${kind}_OS`],
+  architecture: env[`${kind}_ARCH`],
+  revision: env[`${kind}_REVISION`],
+  created: env[`${kind}_CREATED`],
+});
+
+console.log(JSON.stringify({
+  schema_version: env.ARTIFACT_SCHEMA,
+  generated_at: env.GENERATED_AT,
+  source_revision: env.SOURCE_REVISION_VALUE || null,
+  revision_check_skipped: !env.SOURCE_REVISION_VALUE,
+  platform: env.PLATFORM_VALUE,
+  production_actions_performed: false,
+  images: [image('ORIGIN'), image('RELAY')],
+  load_command: 'docker load -i <tar-file>',
+  approval_required_before_host_load_or_deploy: true,
+}, null, 2));
+NODE
+chmod 600 "${manifest_file}"
+
+{
+  cat <<EOF
+# A6 Public-Beta Image Load Packet
+
+This packet is approval-required. It only loads Docker images onto A6; it does not recreate, restart, or stop any containers.
+
+## Local Artifacts
+
+- ${ORIGIN_IMAGE}: \`${origin_tar}\`
+  - sha256: \`${origin_sha}\`
+  - platform: \`${origin_os}/${origin_arch}\`
+  - revision: \`${origin_revision:-<empty>}\`
+- ${RELAY_IMAGE}: \`${relay_tar}\`
+  - sha256: \`${relay_sha}\`
+  - platform: \`${relay_os}/${relay_arch}\`
+  - revision: \`${relay_revision:-<empty>}\`
+
+## Approval-Only Commands
+
+\`\`\`bash
+set -euo pipefail
+SSH_HOST=$(bash_quote "${SSH_HOST}")
+REMOTE_DIR=$(bash_quote "${REMOTE_DIR}")
+ssh "\${SSH_HOST}" "mkdir -p \${REMOTE_DIR} && chmod 700 \${REMOTE_DIR}"
+scp $(bash_quote "${origin_tar}") "\${SSH_HOST}:\${REMOTE_DIR}/${origin_file}"
+scp $(bash_quote "${relay_tar}") "\${SSH_HOST}:\${REMOTE_DIR}/${relay_file}"
+scp $(bash_quote "${checksums_file}") "\${SSH_HOST}:\${REMOTE_DIR}/SHA256SUMS"
+ssh "\${SSH_HOST}" "cd \${REMOTE_DIR} && sha256sum -c SHA256SUMS"
+ssh "\${SSH_HOST}" "docker load -i \${REMOTE_DIR}/${origin_file}"
+ssh "\${SSH_HOST}" "docker load -i \${REMOTE_DIR}/${relay_file}"
+ssh "\${SSH_HOST}" 'docker image inspect ${ORIGIN_IMAGE} ${RELAY_IMAGE} --format "{{.RepoTags}} {{.Id}} {{.Os}}/{{.Architecture}} {{index .Config.Labels \"org.opencontainers.image.revision\"}}"'
+\`\`\`
+
+## Abort Criteria
+
+- Abort if \`sha256sum -c SHA256SUMS\` fails.
+- Abort if either loaded image is not \`${PLATFORM}\`.
+- Abort if either loaded image revision is not \`${SOURCE_REVISION:-<revision-check-skipped>}\`.
+- Loading images is not approval to restart relays, deploy origin, start publisher writes, run latest-index HTTP probes, or re-enable monitors.
+EOF
+} > "${packet_file}"
+chmod 600 "${packet_file}"
+
+cat <<EOF
+artifact_dir=${OUTPUT_DIR}
+origin_tar=${origin_tar}
+relay_tar=${relay_tar}
+checksums=${checksums_file}
+manifest=${manifest_file}
+load_packet=${packet_file}
+origin_sha256=${origin_sha}
+relay_sha256=${relay_sha}
+EOF

--- a/tools/scripts/public-beta-image-deploy.test.mjs
+++ b/tools/scripts/public-beta-image-deploy.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
@@ -9,6 +9,7 @@ import { fileURLToPath } from 'node:url';
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(SCRIPT_DIR, '../..');
 const BUILD_SCRIPT = path.join(REPO_ROOT, 'tools/scripts/build-public-beta-images.sh');
+const EXPORT_SCRIPT = path.join(REPO_ROOT, 'tools/scripts/export-public-beta-image-artifacts.sh');
 const PACKET_SCRIPT = path.join(REPO_ROOT, 'tools/scripts/emit-a6-public-beta-deploy-packet.sh');
 const RECOVER_PROVENANCE_SCRIPT = path.join(REPO_ROOT, 'tools/scripts/recover-public-beta-origin-provenance.mjs');
 
@@ -88,6 +89,117 @@ test('image smoke runs requested platform and binds relay Gun to the container i
   assert.match(script, /smoke_relay\(\) \{[\s\S]*--platform "\$\{PLATFORM\}"/);
   assert.match(script, /smoke_relay\(\) \{[\s\S]*-e GUN_HOST=0\.0\.0\.0/);
   assert.match(script, /smoke_relay\(\) \{[\s\S]*-v "\$\{tmp\}:\/data"/);
+});
+
+test('image artifact exporter validates platform and emits approval-only load packet', () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), 'vh-public-beta-export-'));
+  try {
+    const bin = path.join(root, 'bin');
+    const out = path.join(root, 'artifacts');
+    const relativeOut = path.relative(REPO_ROOT, out);
+    mkdirSync(bin);
+    const fakeDocker = path.join(bin, 'docker');
+    writeFileSync(
+      fakeDocker,
+      `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "\${1:-}" == "image" && "\${2:-}" == "inspect" ]]; then
+  image="\${3:-}"
+  arch="\${FAKE_DOCKER_ARCH:-amd64}"
+  revision="\${FAKE_DOCKER_REVISION:-test-revision}"
+  case "\${image}" in
+    *origin*) id="sha256:origin-image-id" ;;
+    *relay*) id="sha256:relay-image-id" ;;
+    *) id="sha256:unknown-image-id" ;;
+  esac
+  printf '%s|linux|%s|%s|2026-06-14T00:00:00Z\\n' "\${id}" "\${arch}" "\${revision}"
+  exit 0
+fi
+if [[ "\${1:-}" == "save" ]]; then
+  out=""
+  image=""
+  shift
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -o) out="\${2:-}"; shift 2 ;;
+      *) image="$1"; shift ;;
+    esac
+  done
+  test -n "\${out}"
+  printf 'fake docker tar for %s\\n' "\${image}" > "\${out}"
+  exit 0
+fi
+echo "unexpected fake docker invocation: $*" >&2
+exit 2
+`,
+      'utf8',
+    );
+    chmodSync(fakeDocker, 0o755);
+
+    const env = {
+      ...process.env,
+      PATH: `${bin}:${process.env.PATH}`,
+      FAKE_DOCKER_REVISION: 'test-revision',
+    };
+    const result = run('bash', [
+      EXPORT_SCRIPT,
+      '--origin-image',
+      'vhc-public-beta-origin:test-tag',
+      '--relay-image',
+      'vhc-public-beta-relay:test-tag',
+      '--output-dir',
+      relativeOut,
+      '--remote-dir',
+      '/tmp/vhc-public-beta-images/test-tag',
+      '--source-revision',
+      'test-revision',
+    ], { env });
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /artifact_dir=/);
+    assert.match(result.stdout, /load_packet=/);
+
+    const packet = readFileSync(path.join(out, 'a6-image-load-packet.md'), 'utf8');
+    assert.match(packet, /approval-required/);
+    assert.match(packet, /sha256sum -c SHA256SUMS/);
+    assert.match(packet, /docker load -i/);
+    assert.match(packet, /Loading images is not approval to restart relays/);
+    assert.doesNotMatch(packet, /SECRET|TOKEN|do-not-print/);
+
+    const checksums = readFileSync(path.join(out, 'SHA256SUMS'), 'utf8');
+    assert.match(checksums, /^[-a-f0-9]+  vhc-public-beta-origin_test-tag\.tar$/m);
+    assert.match(checksums, /^[-a-f0-9]+  vhc-public-beta-relay_test-tag\.tar$/m);
+    assert.equal(statSync(path.join(out, 'vhc-public-beta-origin_test-tag.tar')).mode & 0o777, 0o600);
+    assert.equal(statSync(path.join(out, 'vhc-public-beta-relay_test-tag.tar')).mode & 0o777, 0o600);
+    assert.equal(statSync(path.join(out, 'artifact-manifest.json')).mode & 0o777, 0o600);
+
+    const manifest = JSON.parse(readFileSync(path.join(out, 'artifact-manifest.json'), 'utf8'));
+    assert.equal(manifest.schema_version, 'vh-public-beta-local-image-artifact-manifest-v1');
+    assert.equal(manifest.production_actions_performed, false);
+    assert.equal(manifest.approval_required_before_host_load_or_deploy, true);
+    assert.equal(manifest.platform, 'linux/amd64');
+    assert.equal(manifest.images[0].revision, 'test-revision');
+
+    const badPlatform = run('bash', [
+      EXPORT_SCRIPT,
+      '--origin-image',
+      'vhc-public-beta-origin:test-tag',
+      '--relay-image',
+      'vhc-public-beta-relay:test-tag',
+      '--output-dir',
+      path.join(root, 'bad-platform'),
+      '--source-revision',
+      'test-revision',
+    ], {
+      env: {
+        ...env,
+        FAKE_DOCKER_ARCH: 'arm64',
+      },
+    });
+    assert.equal(badPlatform.status, 78);
+    assert.match(badPlatform.stderr, /platform mismatch/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });
 
 test('origin provenance recovery writes private env without printing recovered values', () => {


### PR DESCRIPTION
## Summary

- add `tools/scripts/export-public-beta-image-artifacts.sh` to export already-built public-beta origin/relay images as private tarballs
- emit `SHA256SUMS`, `artifact-manifest.json`, and an approval-only A6 image-load packet from committed tooling instead of shell history
- document the artifact export step in the public-beta image deploy runbook

## Safety

- local-only script: no SSH, scp, remote `docker load`, container restart, publisher start, latest-index probe, or monitor action is executed
- validates image platform defaults to `linux/amd64`
- validates OCI revision label defaults to current checkout revision unless explicitly skipped
- generated packet states loading images is not approval to deploy relays/origin, start publisher writes, probe latest-index, or re-enable monitors

## Validation

- `bash -n tools/scripts/export-public-beta-image-artifacts.sh tools/scripts/build-public-beta-images.sh tools/scripts/emit-a6-public-beta-deploy-packet.sh tools/scripts/install-analysis-backend-service.sh tools/scripts/install-news-aggregator-production-service.sh tools/scripts/start-news-aggregator-daemon-production.sh`
- `npx -y -p node@22 -c 'node --test tools/scripts/public-beta-image-deploy.test.mjs tools/scripts/systemd-service-installers.test.mjs tools/scripts/start-news-aggregator-daemon-production.test.mjs tools/scripts/vh-analysis-backend-3001.test.mjs tools/scripts/relay-latest-index-snapshot-watch.test.mjs'`
- `git diff --check`
- regenerated local A6 image artifacts for `20260614-main-v0f48ee02-amd64` with the new exporter and verified `shasum -a 256 -c SHA256SUMS`

## Production State

No production writes or host deploy actions were performed.
