### PR TITLE
Drop image-internal origin path vars from A6 deploy packet env capture

### DIFF
--- a/tools/scripts/emit-a6-public-beta-deploy-packet.sh
+++ b/tools/scripts/emit-a6-public-beta-deploy-packet.sh
@@ -209,7 +209,7 @@ function envCaptureCommand(name, rewriteAnalysisTarget = false) {
   }
   return [
     `sudo docker inspect ${name} --format '{{range .Config.Env}}{{println .}}{{end}}' > ${envPath}.current`,
-    `awk 'BEGIN{done=0} /^VH_PUBLIC_ORIGIN_ANALYSIS_TARGET=/{print "VH_PUBLIC_ORIGIN_ANALYSIS_TARGET=${analysisTarget}"; done=1; next} {print} END{if(!done) print "VH_PUBLIC_ORIGIN_ANALYSIS_TARGET=${analysisTarget}"}' ${envPath}.current > ${envPath}`,
+    `awk 'BEGIN{done=0} /^VH_PUBLIC_ORIGIN_STATIC_DIR=/{next} /^VH_PUBLIC_ORIGIN_PEER_CONFIG_PATH=/{next} /^VH_PUBLIC_ORIGIN_ANALYSIS_TARGET=/{print "VH_PUBLIC_ORIGIN_ANALYSIS_TARGET=${analysisTarget}"; done=1; next} {print} END{if(!done) print "VH_PUBLIC_ORIGIN_ANALYSIS_TARGET=${analysisTarget}"}' ${envPath}.current > ${envPath}`,
     `chmod 600 ${envPath}`,
     `rm -f ${envPath}.current`,
   ].join('\n');

--- a/tools/scripts/public-beta-image-deploy.test.mjs
+++ b/tools/scripts/public-beta-image-deploy.test.mjs
@@ -376,15 +376,24 @@ test('origin provenance recovery completes from inspect JSON and Vite bundle wit
   }
 });
 
-test('deploy packet preserves relay bind mounts and does not print env values', () => {
+test('deploy packet preserves relay bind mounts and rewrites origin env safely', () => {
   const root = mkdtempSync(path.join(os.tmpdir(), 'vh-public-beta-packet-'));
   try {
     const inspectPath = path.join(root, 'inspect.json');
+    const staleOriginEnv = [
+      'VH_PUBLIC_ORIGIN_STATIC_DIR=/app/dist',
+      'VH_PUBLIC_ORIGIN_PEER_CONFIG_PATH=/app/dist/mesh-peer-config.json',
+      'VH_PUBLIC_ORIGIN_ANALYSIS_TARGET=http://127.0.0.1:2048',
+      'HOST=127.0.0.1',
+      'PORT=8080',
+      'NODE_ENV=production',
+      'VH_PUBLIC_ORIGIN_FAIL_IF_MISSING_STATIC=true',
+      'VH_PUBLIC_ORIGIN_RELAY_TARGETS=http://127.0.0.1:8777,http://127.0.0.1:8778,http://127.0.0.1:8779',
+      "VH_PUBLIC_ORIGIN_CSP_CONNECT_SRC='self' https://venn.carboncaste.io wss://gun-a.carboncaste.io",
+      'SECRET_VALUE=do-not-print',
+    ];
     const containers = [
-      makeContainer('vhc-public-origin', 'vhc-public-beta-origin:old', [
-        'VH_PUBLIC_ORIGIN_ANALYSIS_TARGET=http://127.0.0.1:2048',
-        'SECRET_VALUE=do-not-print',
-      ], [], { '8080/tcp': [{ HostIp: '127.0.0.1', HostPort: '8080' }] }),
+      makeContainer('vhc-public-origin', 'vhc-public-beta-origin:old', staleOriginEnv, [], { '8080/tcp': [{ HostIp: '127.0.0.1', HostPort: '8080' }] }),
       makeRelay('vhc-relay-a', '/home/humble/.local/share/vhc/vhc-relay-a/data'),
       makeRelay('vhc-relay-b', '/home/humble/.local/share/vhc/vhc-relay-b/data'),
       makeRelay('vhc-relay-c', '/home/humble/.local/share/vhc/vhc-relay-c/data'),
@@ -407,8 +416,28 @@ test('deploy packet preserves relay bind mounts and does not print env values', 
     assert.match(result.stdout, /grep -E 'vhc\\-public\\-origin\|vhc\\-relay\\-a\|vhc\\-relay\\-b\|vhc\\-relay\\-c'/);
     assert.match(result.stdout, /VH_PUBLIC_ORIGIN_ANALYSIS_TARGET=http:\/\/127\.0\.0\.1:3001/);
     assert.match(result.stdout, /vhc-public-beta-relay:new/);
+    const originRewriteLine = result.stdout
+      .split('\n')
+      .find((line) => line.startsWith("awk '") && line.includes('VH_PUBLIC_ORIGIN_ANALYSIS_TARGET'));
+    assert.ok(originRewriteLine, result.stdout);
+    assert.match(originRewriteLine, /\/\^VH_PUBLIC_ORIGIN_STATIC_DIR=\//);
+    assert.match(originRewriteLine, /\/\^VH_PUBLIC_ORIGIN_PEER_CONFIG_PATH=\//);
+    const originRewriteMatch = originRewriteLine.match(/^awk '([^']+)' \/tmp\/vhc-public-beta-deploy\/vhc-public-origin\.env\.current > \/tmp\/vhc-public-beta-deploy\/vhc-public-origin\.env$/);
+    assert.ok(originRewriteMatch, originRewriteLine);
+    const currentEnvPath = path.join(root, 'vhc-public-origin.env.current');
+    writeFileSync(currentEnvPath, `${staleOriginEnv.join('\n')}\n`, 'utf8');
+    const transformed = run('awk', [originRewriteMatch[1], currentEnvPath]);
+    assert.equal(transformed.status, 0, transformed.stderr);
+    assert.doesNotMatch(transformed.stdout, /^VH_PUBLIC_ORIGIN_STATIC_DIR=/m);
+    assert.doesNotMatch(transformed.stdout, /^VH_PUBLIC_ORIGIN_PEER_CONFIG_PATH=/m);
+    assert.match(transformed.stdout, /^VH_PUBLIC_ORIGIN_ANALYSIS_TARGET=http:\/\/127\.0\.0\.1:3001$/m);
+    assert.match(transformed.stdout, /^HOST=127\.0\.0\.1$/m);
+    assert.match(transformed.stdout, /^PORT=8080$/m);
+    assert.match(transformed.stdout, /^VH_PUBLIC_ORIGIN_RELAY_TARGETS=http:\/\/127\.0\.0\.1:8777,http:\/\/127\.0\.0\.1:8778,http:\/\/127\.0\.0\.1:8779$/m);
+    assert.match(transformed.stdout, /^VH_PUBLIC_ORIGIN_CSP_CONNECT_SRC='self' https:\/\/venn\.carboncaste\.io wss:\/\/gun-a\.carboncaste\.io$/m);
     assert.doesNotMatch(result.stdout, /vhc-public-beta-origin\|vhc-relay/);
     assert.doesNotMatch(result.stdout, /do-not-print/);
+    assert.doesNotMatch(result.stdout, /\/app\/dist/);
     assert.doesNotMatch(result.stdout, /http:\/\/127\.0\.0\.1:2048/);
   } finally {
     rmSync(root, { recursive: true, force: true });


### PR DESCRIPTION
## Problem
The A6 origin deploy packet (`emit-a6-public-beta-deploy-packet.sh`) replayed the **old** origin container's full env onto the new image via `--env-file`, correcting only `VH_PUBLIC_ORIGIN_ANALYSIS_TARGET`. The old container carried `VH_PUBLIC_ORIGIN_STATIC_DIR=/app/dist` (old image layout), which overrode the new image's baked `ENV` (`/app/apps/web-pwa/dist`). With `FAIL_IF_MISSING_STATIC=true`, the new origin crash-looped on `ENOENT: /app/dist/index.html` (Phase 4 abort, then clean rollback to `pr632`).

## Fix
The env transform now drops the two image-internal filesystem path vars so the new image's baked `ENV` owns its own layout:
- `VH_PUBLIC_ORIGIN_STATIC_DIR`
- `VH_PUBLIC_ORIGIN_PEER_CONFIG_PATH`

These are provably the only image-internal path vars the origin server reads. Functional config (`HOST`/`PORT`, CSP, relay targets) is still preserved, and `VH_PUBLIC_ORIGIN_ANALYSIS_TARGET` is still rewritten to `:3001`.

## Test
Regression test runs the generated env transform against a stale `/app/dist` fixture and asserts the two path vars are dropped, the analyze target is rewritten, and `HOST`/`PORT`/relay targets/CSP are preserved — without printing secret values.

## Validation
Re-deployed origin on A6 came up healthy (`static_dir_present`/`peer_config_present` true); public `/api/analyze/*` → 200; malformed aggregate → 400 (not 502); feed = 15; read-only browser proof confirmed app equivalence (15 rows, WSS to gun-a/b/c, synthesis rendered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)