### PR TITLE
[codex] Split publisher restart source liveness gate

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -168,7 +168,7 @@ jobs:
       - name: Source health applicability
         run: |
           if [ "${{ needs.change-detection.outputs.run-source-health }}" = "true" ]; then
-            echo "Source health: relevant changes detected; running source-health gate."
+            echo "Source health: relevant changes detected; running source-health liveness gate."
           else
             echo "Source health: no relevant changes detected; passing required check."
           fi
@@ -193,7 +193,7 @@ jobs:
 
       - name: Run Source Health Gate
         if: needs.change-detection.outputs.run-source-health == 'true'
-        run: pnpm check:news-sources:health
+        run: pnpm check:news-sources:liveness
 
       - name: Upload Source Health Artifacts
         if: always() && needs.change-detection.outputs.run-source-health == 'true'
@@ -202,6 +202,7 @@ jobs:
           name: news-source-health
           path: |
             services/news-aggregator/.tmp/news-source-admission/latest/source-health-report.json
+            services/news-aggregator/.tmp/news-source-admission/latest/source-health-liveness-report.json
             services/news-aggregator/.tmp/news-source-admission/latest/source-health-trend.json
           if-no-files-found: warn
 

--- a/docs/ops/news-aggregator-production-service.md
+++ b/docs/ops/news-aggregator-production-service.md
@@ -106,9 +106,22 @@ systemctl --user restart vh-news-aggregator.service
 
 1. `VH_NEWS_DAEMON_ENV_FILE` is readable.
 2. `VH_NEWS_DAEMON_START_APPROVED=1` is present in that env file.
-3. `pnpm check:news-sources:health` passes with release-evidence enforcement.
+3. `pnpm check:news-sources:liveness` passes the operational restart gate.
 4. `pnpm --filter @vh/storycluster-engine build` passes.
 5. `preflightOpenAIStoryClusterProviderFromEnv` returns `status: "pass"`.
+
+The liveness preflight writes a regular source-health artifact and a
+`source-health-liveness-report.json`, but it does not enforce the rolling
+release-evidence window. It fails on current operational blockers only:
+
+- global feed-stage outage / latest publication preservation;
+- enabled source count below the configured floor;
+- live contributing source count below the configured floor;
+- zero admitted sources.
+
+Watch/remove candidates and release-evidence failures are reported as restart
+warnings. They remain release/canary concerns unless the current liveness
+blockers above are present.
 
 After these pass, the wrapper writes
 `VH_NEWS_DAEMON_LAST_SUCCESS_FILE` or
@@ -127,6 +140,12 @@ Default env file:
 
 ```bash
 ~/.config/vhc/news-aggregator.env
+```
+
+Template:
+
+```bash
+docs/ops/news-aggregator.env.example
 ```
 
 Required or commonly used names:
@@ -310,11 +329,23 @@ curl -sS -i https://venn.carboncaste.io/api/analyze/health
 curl -sS -i https://venn.carboncaste.io/api/analyze/config
 ```
 
+## Release Evidence Gate
+
+`pnpm check:news-sources:health` remains the release-grade source-health gate.
+It enforces the rolling release-evidence window and should stay in release
+readiness, canary, and Phase 6 evidence chains. Pull-request CI and publisher
+restart use `pnpm check:news-sources:liveness` so normal engineering validation
+and incident recovery are not blocked on the live release-evidence window. The
+release-grade command is intentionally not the publisher restart preflight
+because a long publisher outage can otherwise create a deadlock: the feed cannot
+restart until it has recent release-evidence runs, but it cannot generate those
+runs while the publisher is stopped.
+
 ## Publisher Start Abort Criteria
 
 Abort or stop the service if any of these occur:
 
-- source-health preflight fails or reports non-pass release evidence;
+- source-health liveness preflight fails;
 - OpenAI preflight is not `pass`;
 - StoryCluster health check fails;
 - relay REST write fanout is below the configured `require_all` target;
@@ -322,6 +353,7 @@ Abort or stop the service if any of these occur:
 - latest content does not advance after approved start and expected ingest
   cadence.
 
-After an approved start, release evidence still requires fresh content advance,
-synthesis lifecycle/publication evidence, public canary, and soak. The service
-starting successfully is not a release-ready claim.
+After an approved start, release evidence still requires
+`pnpm check:news-sources:health`, fresh content advance, synthesis
+lifecycle/publication evidence, public canary, and soak. The service starting
+successfully is not a release-ready claim.

--- a/docs/ops/news-aggregator.env.example
+++ b/docs/ops/news-aggregator.env.example
@@ -1,0 +1,51 @@
+# VHC News Aggregator production publisher env template.
+# Keep the real file outside git at ~/.config/vhc/news-aggregator.env with mode 600.
+# Do not commit real secrets or rendered key material.
+
+# Start approval is intentionally absent by default. Add only during an approved
+# production publisher start packet.
+# VH_NEWS_DAEMON_START_APPROVED=1
+
+# Public Gun peers used by the daemon client.
+VH_GUN_PEERS='["wss://gun-a.carboncaste.io/gun","wss://gun-b.carboncaste.io/gun","wss://gun-c.carboncaste.io/gun"]'
+
+# StoryCluster remote endpoint and auth.
+VH_STORYCLUSTER_REMOTE_URL=https://<storycluster-origin>/cluster
+VH_STORYCLUSTER_REMOTE_HEALTH_URL=https://<storycluster-origin>/health
+VH_STORYCLUSTER_REMOTE_AUTH_TOKEN=<from-storycluster-public-beta-auth-token-v1.txt>
+VH_STORYCLUSTER_REMOTE_AUTH_HEADER=authorization
+VH_STORYCLUSTER_REMOTE_AUTH_SCHEME=Bearer
+VH_STORYCLUSTER_REMOTE_TIMEOUT_MS=300000
+VH_STORYCLUSTER_REMOTE_MAX_ITEMS_PER_REQUEST=24
+
+# OpenAI provider used by StoryCluster and bundle synthesis.
+OPENAI_API_KEY=<from-storycluster-openai.env>
+
+# Bundle synthesis and relay REST write fanout.
+VH_BUNDLE_SYNTHESIS_ENABLED=true
+VH_BUNDLE_SYNTHESIS_WRITE_RELAY_REST=true
+VH_BUNDLE_SYNTHESIS_RELAY_WRITE_ORIGINS='["https://gun-a.carboncaste.io","https://gun-b.carboncaste.io","https://gun-c.carboncaste.io"]'
+VH_BUNDLE_SYNTHESIS_RELAY_WRITE_REQUIRE_ALL=true
+VH_BUNDLE_SYNTHESIS_MODEL=gpt-4o-mini
+VH_BUNDLE_SYNTHESIS_TIMEOUT_MS=120000
+VH_BUNDLE_SYNTHESIS_RATE_PER_MIN=20
+VH_BUNDLE_SYNTHESIS_MAX_TOKENS=2400
+VH_RELAY_DAEMON_TOKEN=<from-public-beta-relay-daemon-token-v2.env>
+
+# Daemon identity, state, and cadence.
+VH_NEWS_DAEMON_HOLDER_ID=vh-news-daemon:a6-public
+VH_NEWS_RUNTIME_LEASE_TTL_MS=120000
+VH_NEWS_INGESTION_LEASE_SCOPE=public-beta
+VH_NEWS_DAEMON_STATE_DIR=/home/humble/.local/state/vhc/news-aggregator
+VH_DAEMON_FEED_ARTIFACT_ROOT=/home/humble/.local/state/vhc/news-aggregator/artifacts
+VH_NEWS_DAEMON_LAST_SUCCESS_FILE=/home/humble/.local/state/vhc/news-aggregator/last-success.json
+VH_BUNDLE_SYNTHESIS_QUEUE_DIR=/home/humble/.local/state/vhc/news-aggregator/bundle-synthesis-queue
+VH_BUNDLE_SYNTHESIS_LIFECYCLE_LEDGER=/home/humble/.local/state/vhc/news-aggregator/bundle-synthesis-queue/synthesis-lifecycle.jsonl
+VITE_NEWS_POLL_INTERVAL_MS=600000
+VH_BUNDLE_SYNTHESIS_CATCHUP_INTERVAL_MS=300000
+
+# Public beta system writer v4.
+VH_NEWS_SYSTEM_WRITER_ID=vh-public-beta-news-system-writer-v4
+VH_NEWS_SYSTEM_WRITER_PIN_JSON=<one-line-luma-public-v1-pin-json-containing-active-v4-writer>
+VH_NEWS_SYSTEM_WRITER_PUBLIC_KEY_SPKI_BASE64URL=<from-public-beta-news-system-writer-v4.env>
+VH_NEWS_SYSTEM_WRITER_PRIVATE_KEY_PKCS8_BASE64URL=<from-public-beta-news-system-writer-v4.env>

--- a/docs/ops/phase5-public-beta-publisher-liveness-preflight-2026-06-15.md
+++ b/docs/ops/phase5-public-beta-publisher-liveness-preflight-2026-06-15.md
@@ -1,0 +1,117 @@
+# Phase 5 Publisher Liveness Preflight Design Note - 2026-06-15
+
+> Status: Phase 5 Operational Design Note
+> Owner: VHC Ops
+> Last Reviewed: 2026-06-15
+> Depends On: docs/ops/news-aggregator-production-service.md, docs/ops/NEWS_SOURCE_ADMISSION_RUNBOOK.md, docs/ops/public-feed-freshness-monitor.md
+
+## Context
+
+The A6 Phase 5 publisher start attempt on 2026-06-14 failed closed before any
+approval flag or publisher write. That was correct behavior: no
+`VH_NEWS_DAEMON_START_APPROVED=1` was added, `vh-news-aggregator.service` stayed
+inactive, competing writer proof was clean, and the public freshness monitor
+remained `disabled_manually`.
+
+The abort exposed two different source-health concerns that were previously
+coupled in the same start preflight:
+
+- operational restart liveness: can the publisher fetch enough source surface
+  and publish current content now?
+- release evidence: has the source slate accumulated a clean rolling evidence
+  window for release/canary claims?
+
+`pnpm check:news-sources:health` is the second gate. It intentionally enforces
+rolling release evidence, but that makes it the wrong first gate for incident
+restart after a long dark period because the stopped publisher cannot generate
+the evidence window it is blocked on.
+
+## A6 Diagnostic
+
+The non-enforcing report path was run on A6:
+
+```bash
+pnpm --filter @vh/news-aggregator report:source-health
+```
+
+Latest diagnostic artifact:
+
+```text
+/home/humble/VHC/services/news-aggregator/.tmp/news-source-admission/1781486424909/source-health-report.json
+```
+
+Result summary:
+
+```text
+readinessStatus: blocked
+releaseEvidence.status: fail
+releaseEvidence.reasons:
+  - insufficient_release_evidence_window
+  - blocked_run_within_release_window
+  - non_ready_runs_exceed_threshold
+  - latest_run_not_ready
+runAssessment.globalFeedStageFailure: false
+runAssessment.latestPublicationAction: publish_latest
+enabledSourceCount: 24
+contributingSourceCount: 25
+corroboratingSourceCount: 25
+removeSourceIds:
+  - bigbendsentinel-border-wall
+```
+
+`bigbendsentinel-border-wall` was a real current source-health remove candidate,
+not only a slate-reset artifact:
+
+```text
+status: rejected
+decision: remove
+reasons:
+  - fetch-failed
+feedRead: HTTP 200 XML, 10 item fragments, 4 extracted links
+readableSampleRate: 0
+readableSampleCount: 0
+lifecycle sourceDomain: bigbendsentinel.com
+lifecycle status: failing
+lastErrorMessage: HTTP 500 while fetching article
+```
+
+This is a source admission follow-up. It is not evidence of a global source
+outage, and it should not deadlock publisher recovery while the rest of the
+slate has sufficient live contribution.
+
+## Design
+
+Publisher start now uses:
+
+```bash
+pnpm check:news-sources:liveness
+```
+
+The liveness gate writes the normal source-health artifact plus
+`source-health-liveness-report.json`, then fails only on current restart
+blockers:
+
+- global feed-stage outage / latest publication preservation;
+- enabled source count below the configured floor;
+- live contributing source count below the configured floor;
+- zero admitted sources.
+
+Release evidence failures, watch candidates, remove candidates, lifecycle
+instability, and zero-contribution enabled source counts are reported as
+warnings in the liveness report. They remain release/canary or source-admission
+work, not publisher-start blockers by themselves.
+
+The release-grade gate remains unchanged:
+
+```bash
+pnpm check:news-sources:health
+```
+
+That command still enforces the rolling evidence window and belongs in Phase 6,
+canary, and release-readiness chains.
+
+Pull-request CI also uses the liveness command for the required Source Health
+job. That keeps ordinary source-health code and wrapper changes blocked on
+current source liveness without treating an unfilled release-evidence window as
+a PR failure. Release/readiness commands continue to call the full evidence
+gate directly.

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "check:luma:mvp-production-readiness": "node ./packages/e2e/src/luma/mvp-production-readiness.mjs",
     "report:news-sources:admission": "pnpm --filter @vh/news-aggregator report:source-admission",
     "report:news-sources:health": "NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter @vh/news-aggregator report:source-health",
+    "check:news-sources:liveness": "NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter @vh/news-aggregator check:source-health:liveness",
     "scout:news-sources:candidates": "NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter @vh/news-aggregator report:source-scout",
     "check:news-sources:health": "NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter @vh/news-aggregator check:source-health",
     "catchup:public-synthesis": "pnpm --filter @vh/news-aggregator catchup:public-synthesis",

--- a/services/news-aggregator/package.json
+++ b/services/news-aggregator/package.json
@@ -10,6 +10,7 @@
     "build:source-health-deps": "pnpm --filter @vh/types build && pnpm --filter @vh/crypto build && pnpm --filter @vh/data-model build && pnpm --filter @vh/luma-sdk build && pnpm --filter @vh/gun-client build && pnpm --filter @vh/ai-engine build",
     "report:source-admission": "pnpm build:source-health-deps && pnpm build && node --loader ../../tools/node/esm-resolve-loader.mjs dist/sourceAdmissionReport.js",
     "report:source-health": "pnpm build:source-health-deps && pnpm build && node --loader ../../tools/node/esm-resolve-loader.mjs dist/sourceHealthReport.js",
+    "check:source-health:liveness": "pnpm build:source-health-deps && pnpm build && node --loader ../../tools/node/esm-resolve-loader.mjs dist/sourceHealthLivenessReport.js",
     "report:source-scout": "pnpm build:source-health-deps && pnpm build && node --loader ../../tools/node/esm-resolve-loader.mjs dist/sourceCandidateScout.js",
     "replay:bundle-synthesis-lifecycle": "pnpm build:source-health-deps && pnpm build && node --loader ../../tools/node/esm-resolve-loader.mjs dist/synthesisLifecycleReplay.js",
     "catchup:public-synthesis": "pnpm build:source-health-deps && pnpm build && node --loader ../../tools/node/esm-resolve-loader.mjs dist/publicSynthesisCatchup.js",

--- a/services/news-aggregator/src/bundleSynthesisDaemonConfig.test.ts
+++ b/services/news-aggregator/src/bundleSynthesisDaemonConfig.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   computeStoryHotness,
   writeNewsHotIndexEntry,
@@ -55,6 +55,13 @@ const STORY: StoryBundle = {
 };
 
 describe('bundleSynthesisDaemonConfig', () => {
+  beforeEach(() => {
+    vi.stubEnv('ANALYSIS_RELAY_API_KEY', '');
+    vi.stubEnv('OPENAI_API_KEY', '');
+    vi.stubEnv('VH_BUNDLE_SYNTHESIS_API_KEY', '');
+    vi.stubEnv('VH_BUNDLE_SYNTHESIS_ENABLED', '');
+  });
+
   afterEach(() => {
     vi.unstubAllEnvs();
     vi.clearAllMocks();

--- a/services/news-aggregator/src/packageScripts.test.ts
+++ b/services/news-aggregator/src/packageScripts.test.ts
@@ -14,4 +14,21 @@ describe('package scripts', () => {
     expect(buildScript).toContain('pnpm --filter @vh/gun-client build');
     expect(buildScript?.indexOf('@vh/luma-sdk')).toBeLessThan(buildScript?.indexOf('@vh/gun-client'));
   });
+
+  it('keeps release evidence and restart liveness as separate source-health scripts', () => {
+    const packageJsonPath = path.resolve(__dirname, '../package.json');
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as {
+      scripts?: Record<string, string>;
+    };
+
+    expect(packageJson.scripts?.['check:source-health']).toContain(
+      'VH_NEWS_SOURCE_HEALTH_ENFORCE_RELEASE_EVIDENCE=1',
+    );
+    expect(packageJson.scripts?.['check:source-health:liveness']).toContain(
+      'sourceHealthLivenessReport.js',
+    );
+    expect(packageJson.scripts?.['check:source-health:liveness']).not.toContain(
+      'VH_NEWS_SOURCE_HEALTH_ENFORCE_RELEASE_EVIDENCE=1',
+    );
+  });
 });

--- a/services/news-aggregator/src/sourceHealthCiWorkflow.test.ts
+++ b/services/news-aggregator/src/sourceHealthCiWorkflow.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+function readSourceHealthWorkflowJob(): string {
+  const workflowPath = path.resolve(__dirname, '../../../.github/workflows/main.yml');
+  const workflow = readFileSync(workflowPath, 'utf8');
+  const match = workflow.match(/\n  source-health:\n(?<job>[\s\S]*?)\n  storycluster-correctness:/);
+  if (!match?.groups?.job) {
+    throw new Error('Unable to locate source-health job in .github/workflows/main.yml');
+  }
+  return match.groups.job;
+}
+
+describe('source health CI workflow', () => {
+  it('uses the operational liveness gate instead of the release evidence gate for PR validation', () => {
+    const job = readSourceHealthWorkflowJob();
+
+    expect(job).toContain('run: pnpm check:news-sources:liveness');
+    expect(job).toContain('source-health-liveness-report.json');
+    expect(job).not.toContain('run: pnpm check:news-sources:health');
+  });
+});

--- a/services/news-aggregator/src/sourceHealthLivenessReport.test.ts
+++ b/services/news-aggregator/src/sourceHealthLivenessReport.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from 'vitest';
+import {
+  SOURCE_HEALTH_POLICY_VERSION,
+  SOURCE_HEALTH_REPORT_SCHEMA_VERSION,
+  type SourceHealthReport,
+} from './sourceHealthReport';
+import {
+  SOURCE_HEALTH_LIVENESS_REPORT_SCHEMA_VERSION,
+  buildSourceHealthLivenessReport,
+} from './sourceHealthLivenessReport';
+
+const BASE_THRESHOLDS: SourceHealthReport['thresholds'] = {
+  keepMinReadableSampleRate: 1,
+  maxWatchSourceCount: 0,
+  minEnabledSourceCount: 1,
+  removeRejectedNonFeedOutage: true,
+  requireHealthyLifecycleForKeep: true,
+  historyLookbackRunCount: 8,
+  watchEscalationRunCount: 3,
+  readmissionKeepRunCount: 2,
+  releaseEvidenceWindowRunCount: 5,
+  maxNonReadyRunsInWindow: 1,
+  minContributingSourceCount: 1,
+};
+
+function makeSourceHealthReport(
+  overrides: Partial<SourceHealthReport> = {},
+): SourceHealthReport {
+  const report: SourceHealthReport = {
+    schemaVersion: SOURCE_HEALTH_REPORT_SCHEMA_VERSION,
+    policyVersion: SOURCE_HEALTH_POLICY_VERSION,
+    generatedAt: '2026-06-15T00:00:00.000Z',
+    readinessStatus: 'blocked',
+    recommendedAction: 'prune_remove_candidates',
+    sourceCount: 25,
+    keepSourceIds: ['fox-latest'],
+    watchSourceIds: [],
+    removeSourceIds: ['bigbendsentinel-border-wall'],
+    thresholds: BASE_THRESHOLDS,
+    observability: {
+      enabledSourceCount: 24,
+      keepSourceCount: 24,
+      watchSourceCount: 0,
+      removeSourceCount: 1,
+      admittedSourceCount: 24,
+      rejectedSourceCount: 1,
+      inconclusiveSourceCount: 0,
+      unstableLifecycleSourceCount: 1,
+      historyEscalatedSourceCount: 0,
+      pendingReadmissionSourceCount: 0,
+      contributingSourceCount: 25,
+      corroboratingSourceCount: 25,
+      zeroContributionEnabledSourceCount: 0,
+      reasonCounts: { 'fetch-failed': 1 },
+    },
+    feedContribution: {
+      schemaVersion: 'news-source-feed-contribution-report-v1',
+      generatedAt: '2026-06-15T00:00:00.000Z',
+      snapshotMode: 'heuristic_live_feed_snapshot',
+      sourceCount: 25,
+      totalIngestedItemCount: 25,
+      totalNormalizedItemCount: 25,
+      totalBundleCount: 12,
+      totalSingletonBundleCount: 1,
+      totalCorroboratedBundleCount: 11,
+      contributingSourceIds: ['fox-latest'],
+      corroboratingSourceIds: ['fox-latest'],
+      zeroContributionSourceIds: [],
+      sources: [],
+    },
+    historySummary: {
+      lookbackRunCount: 8,
+      priorReportCount: 1,
+      escalatedSourceIds: [],
+      pendingReadmissionSourceIds: [],
+    },
+    releaseEvidence: {
+      status: 'fail',
+      recommendedAction: 'hold_release_for_trend_recovery',
+      reasons: [
+        'insufficient_release_evidence_window',
+        'blocked_run_within_release_window',
+        'latest_run_not_ready',
+      ],
+      recentWindowRunCount: 2,
+      recentReadyRunCount: 0,
+      recentReviewRunCount: 0,
+      recentBlockedRunCount: 2,
+      latestNewWatchSourceIds: [],
+      latestNewRemoveSourceIds: [],
+    },
+    runAssessment: {
+      globalFeedStageFailure: false,
+      latestPublicationAction: 'publish_latest',
+      latestPublicationSkipReason: null,
+    },
+    runtimePolicy: {
+      enabledSourceIds: ['fox-latest'],
+      watchSourceIds: [],
+      removeSourceIds: ['bigbendsentinel-border-wall'],
+    },
+    sources: [],
+    paths: {
+      artifactDir: '/tmp/source-health/run',
+      admissionReportPath: '/tmp/source-health/run/source-admission-report.json',
+      sourceHealthReportPath: '/tmp/source-health/run/source-health-report.json',
+      sourceHealthTrendPath: '/tmp/source-health/run/source-health-trend.json',
+      latestArtifactDir: '/tmp/source-health/latest',
+      latestAdmissionReportPath: '/tmp/source-health/latest/source-admission-report.json',
+      latestSourceHealthReportPath: '/tmp/source-health/latest/source-health-report.json',
+      latestSourceHealthTrendPath: '/tmp/source-health/latest/source-health-trend.json',
+    },
+  };
+
+  return {
+    ...report,
+    ...overrides,
+    thresholds: {
+      ...report.thresholds,
+      ...(overrides.thresholds ?? {}),
+    },
+    observability: {
+      ...report.observability,
+      ...(overrides.observability ?? {}),
+    },
+    releaseEvidence: {
+      ...report.releaseEvidence,
+      ...(overrides.releaseEvidence ?? {}),
+    },
+    runAssessment: {
+      ...report.runAssessment,
+      ...(overrides.runAssessment ?? {}),
+    },
+    runtimePolicy: {
+      ...report.runtimePolicy,
+      ...(overrides.runtimePolicy ?? {}),
+    },
+  };
+}
+
+describe('sourceHealthLivenessReport', () => {
+  it('passes restart liveness when release evidence is blocked by history and a single source remove candidate exists', () => {
+    const liveness = buildSourceHealthLivenessReport(makeSourceHealthReport());
+
+    expect(liveness.schemaVersion).toBe(SOURCE_HEALTH_LIVENESS_REPORT_SCHEMA_VERSION);
+    expect(liveness.status).toBe('pass');
+    expect(liveness.blockers).toEqual([]);
+    expect(liveness.warnings).toContain(
+      'release_evidence_fail_non_blocking:insufficient_release_evidence_window,blocked_run_within_release_window,latest_run_not_ready',
+    );
+    expect(liveness.warnings).toContain('source_remove_candidates_present:bigbendsentinel-border-wall');
+    expect(liveness.restartGate).toMatchObject({
+      globalFeedStageFailure: false,
+      latestPublicationAction: 'publish_latest',
+      enabledSourceCount: 24,
+      contributingSourceCount: 25,
+    });
+  });
+
+  it('fails restart liveness for a current global feed-stage outage', () => {
+    const liveness = buildSourceHealthLivenessReport(
+      makeSourceHealthReport({
+        runAssessment: {
+          globalFeedStageFailure: true,
+          latestPublicationAction: 'preserve_previous_latest',
+          latestPublicationSkipReason: 'all_sources_failed_at_feed_stage',
+        },
+      }),
+    );
+
+    expect(liveness.status).toBe('fail');
+    expect(liveness.blockers).toContain('global_feed_stage_failure');
+  });
+
+  it('fails restart liveness when the current slate cannot meet minimum live-source counts', () => {
+    const liveness = buildSourceHealthLivenessReport(
+      makeSourceHealthReport({
+        observability: {
+          enabledSourceCount: 0,
+          contributingSourceCount: 0,
+          admittedSourceCount: 0,
+        },
+      }),
+    );
+
+    expect(liveness.status).toBe('fail');
+    expect(liveness.blockers).toEqual([
+      'enabled_source_count_below_min:0/1',
+      'contributing_source_count_below_min:0/1',
+      'admitted_source_count_zero',
+    ]);
+  });
+});

--- a/services/news-aggregator/src/sourceHealthLivenessReport.ts
+++ b/services/news-aggregator/src/sourceHealthLivenessReport.ts
@@ -1,0 +1,224 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  writeSourceHealthArtifact,
+  type SourceHealthArtifactOptions,
+  type SourceHealthReport,
+} from './sourceHealthReport';
+
+export const SOURCE_HEALTH_LIVENESS_REPORT_SCHEMA_VERSION =
+  'news-source-health-liveness-report-v1';
+
+export type SourceHealthLivenessStatus = 'pass' | 'fail';
+
+export interface SourceHealthLivenessReport {
+  readonly schemaVersion: typeof SOURCE_HEALTH_LIVENESS_REPORT_SCHEMA_VERSION;
+  readonly generatedAt: string;
+  readonly status: SourceHealthLivenessStatus;
+  readonly blockers: readonly string[];
+  readonly warnings: readonly string[];
+  readonly sourceHealthReportPath: string;
+  readonly releaseEvidenceStatus: SourceHealthReport['releaseEvidence']['status'];
+  readonly releaseEvidenceReasons: readonly string[];
+  readonly restartGate: {
+    readonly globalFeedStageFailure: boolean;
+    readonly latestPublicationAction: SourceHealthReport['runAssessment']['latestPublicationAction'];
+    readonly enabledSourceCount: number;
+    readonly minEnabledSourceCount: number;
+    readonly contributingSourceCount: number;
+    readonly minContributingSourceCount: number;
+    readonly admittedSourceCount: number;
+    readonly rejectedSourceCount: number;
+    readonly inconclusiveSourceCount: number;
+    readonly removeSourceCount: number;
+    readonly watchSourceCount: number;
+    readonly unstableLifecycleSourceCount: number;
+    readonly zeroContributionEnabledSourceCount: number;
+  };
+  readonly sourceIds: {
+    readonly enabled: readonly string[];
+    readonly keep: readonly string[];
+    readonly watch: readonly string[];
+    readonly remove: readonly string[];
+  };
+}
+
+export interface SourceHealthLivenessArtifact {
+  readonly sourceHealthReportPath: string;
+  readonly sourceHealthLivenessReportPath: string;
+  readonly latestSourceHealthLivenessReportPath: string;
+  readonly sourceHealthReport: SourceHealthReport;
+  readonly livenessReport: SourceHealthLivenessReport;
+}
+
+function listWarning(prefix: string, values: readonly string[]): string | null {
+  if (values.length === 0) {
+    return null;
+  }
+  return `${prefix}:${values.join(',')}`;
+}
+
+function compact(values: ReadonlyArray<string | null>): string[] {
+  return values.filter((value): value is string => Boolean(value));
+}
+
+export function buildSourceHealthLivenessReport(
+  sourceHealthReport: SourceHealthReport,
+): SourceHealthLivenessReport {
+  const blockers: string[] = [];
+  const warnings: string[] = [];
+  const { observability, thresholds, runAssessment, releaseEvidence } = sourceHealthReport;
+
+  if (
+    runAssessment.globalFeedStageFailure
+    || runAssessment.latestPublicationAction !== 'publish_latest'
+  ) {
+    blockers.push('global_feed_stage_failure');
+  }
+  if (observability.enabledSourceCount < thresholds.minEnabledSourceCount) {
+    blockers.push(
+      `enabled_source_count_below_min:${observability.enabledSourceCount}/${thresholds.minEnabledSourceCount}`,
+    );
+  }
+  if (observability.contributingSourceCount < thresholds.minContributingSourceCount) {
+    blockers.push(
+      `contributing_source_count_below_min:${observability.contributingSourceCount}/${thresholds.minContributingSourceCount}`,
+    );
+  }
+  if (observability.admittedSourceCount <= 0) {
+    blockers.push('admitted_source_count_zero');
+  }
+
+  warnings.push(...compact([
+    releaseEvidence.status === 'pass'
+      ? null
+      : `release_evidence_${releaseEvidence.status}_non_blocking:${releaseEvidence.reasons.join(',') || 'no_reasons'}`,
+    listWarning('source_watch_candidates_present', sourceHealthReport.watchSourceIds),
+    listWarning('source_remove_candidates_present', sourceHealthReport.removeSourceIds),
+    observability.unstableLifecycleSourceCount > 0
+      ? `unstable_lifecycle_sources_present:${observability.unstableLifecycleSourceCount}`
+      : null,
+    observability.zeroContributionEnabledSourceCount > 0
+      ? `zero_contribution_enabled_sources_present:${observability.zeroContributionEnabledSourceCount}`
+      : null,
+  ]));
+
+  return {
+    schemaVersion: SOURCE_HEALTH_LIVENESS_REPORT_SCHEMA_VERSION,
+    generatedAt: new Date().toISOString(),
+    status: blockers.length === 0 ? 'pass' : 'fail',
+    blockers,
+    warnings,
+    sourceHealthReportPath: sourceHealthReport.paths.sourceHealthReportPath,
+    releaseEvidenceStatus: releaseEvidence.status,
+    releaseEvidenceReasons: releaseEvidence.reasons,
+    restartGate: {
+      globalFeedStageFailure: runAssessment.globalFeedStageFailure,
+      latestPublicationAction: runAssessment.latestPublicationAction,
+      enabledSourceCount: observability.enabledSourceCount,
+      minEnabledSourceCount: thresholds.minEnabledSourceCount,
+      contributingSourceCount: observability.contributingSourceCount,
+      minContributingSourceCount: thresholds.minContributingSourceCount,
+      admittedSourceCount: observability.admittedSourceCount,
+      rejectedSourceCount: observability.rejectedSourceCount,
+      inconclusiveSourceCount: observability.inconclusiveSourceCount,
+      removeSourceCount: observability.removeSourceCount,
+      watchSourceCount: observability.watchSourceCount,
+      unstableLifecycleSourceCount: observability.unstableLifecycleSourceCount,
+      zeroContributionEnabledSourceCount: observability.zeroContributionEnabledSourceCount,
+    },
+    sourceIds: {
+      enabled: sourceHealthReport.runtimePolicy.enabledSourceIds,
+      keep: sourceHealthReport.keepSourceIds,
+      watch: sourceHealthReport.watchSourceIds,
+      remove: sourceHealthReport.removeSourceIds,
+    },
+  };
+}
+
+export async function writeSourceHealthLivenessArtifact(
+  options: SourceHealthArtifactOptions = {},
+): Promise<SourceHealthLivenessArtifact> {
+  const artifact = await writeSourceHealthArtifact(options);
+  const livenessReport = buildSourceHealthLivenessReport(artifact.sourceHealthReport);
+  const sourceHealthLivenessReportPath = path.join(
+    artifact.artifactDir,
+    'source-health-liveness-report.json',
+  );
+  const latestSourceHealthLivenessReportPath = path.join(
+    artifact.latestArtifactDir,
+    'source-health-liveness-report.json',
+  );
+
+  writeFileSync(
+    sourceHealthLivenessReportPath,
+    `${JSON.stringify(livenessReport, null, 2)}\n`,
+    'utf8',
+  );
+  if (artifact.sourceHealthReport.runAssessment.latestPublicationAction === 'publish_latest') {
+    mkdirSync(artifact.latestArtifactDir, { recursive: true });
+    writeFileSync(
+      latestSourceHealthLivenessReportPath,
+      `${JSON.stringify(livenessReport, null, 2)}\n`,
+      'utf8',
+    );
+  }
+
+  return {
+    sourceHealthReportPath: artifact.sourceHealthReportPath,
+    sourceHealthLivenessReportPath,
+    latestSourceHealthLivenessReportPath,
+    sourceHealthReport: artifact.sourceHealthReport,
+    livenessReport,
+  };
+}
+
+function logSourceHealthLivenessArtifact(
+  artifact: SourceHealthLivenessArtifact,
+): void {
+  console.info('[vh:news-source-liveness] report written', {
+    sourceHealthReportPath: artifact.sourceHealthReportPath,
+    sourceHealthLivenessReportPath: artifact.sourceHealthLivenessReportPath,
+    latestSourceHealthLivenessReportPath: artifact.latestSourceHealthLivenessReportPath,
+    status: artifact.livenessReport.status,
+    blockers: artifact.livenessReport.blockers,
+    warnings: artifact.livenessReport.warnings,
+    restartGate: artifact.livenessReport.restartGate,
+    releaseEvidenceStatus: artifact.livenessReport.releaseEvidenceStatus,
+    releaseEvidenceReasons: artifact.livenessReport.releaseEvidenceReasons,
+  });
+}
+
+function isDirectExecution(): boolean {
+  if (!process.argv[1]) {
+    return false;
+  }
+  return fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+}
+
+/* c8 ignore start */
+async function main(): Promise<void> {
+  const artifact = await writeSourceHealthLivenessArtifact();
+  logSourceHealthLivenessArtifact(artifact);
+  if (artifact.livenessReport.status !== 'pass') {
+    throw new Error(
+      `source-health liveness ${artifact.livenessReport.status}: ${artifact.livenessReport.blockers.join(', ') || 'no blockers provided'}`,
+    );
+  }
+}
+
+if (isDirectExecution()) {
+  try {
+    await main();
+    process.exit(0);
+  } catch (error) {
+    console.error(error);
+    process.exit(1);
+  }
+}
+/* c8 ignore stop */
+
+export const sourceHealthLivenessReportInternal = {
+  isDirectExecution,
+};

--- a/tools/scripts/start-news-aggregator-daemon-production.sh
+++ b/tools/scripts/start-news-aggregator-daemon-production.sh
@@ -32,8 +32,8 @@ OPENAI_PREFLIGHT_TIMEOUT_MS="${VH_NEWS_PUBLISHER_OPENAI_PREFLIGHT_TIMEOUT_MS:-12
 
 mkdir -p "${VH_NEWS_DAEMON_STATE_DIR}" "${VH_DAEMON_FEED_ARTIFACT_ROOT}" "$(dirname "${LAST_SUCCESS_FILE}")"
 
-echo "[vh:news-daemon:prod] source-health preflight starting"
-pnpm check:news-sources:health
+echo "[vh:news-daemon:prod] source-health liveness preflight starting"
+pnpm check:news-sources:liveness
 
 echo "[vh:news-daemon:prod] StoryCluster OpenAI preflight build starting"
 pnpm --filter @vh/storycluster-engine build

--- a/tools/scripts/start-news-aggregator-daemon-production.test.mjs
+++ b/tools/scripts/start-news-aggregator-daemon-production.test.mjs
@@ -75,8 +75,8 @@ test('production daemon start proceeds to preflights when env file contains appr
   try {
     const result = runStartScript(harness);
     assert.equal(result.status, 99);
-    assert.match(result.stdout, /source-health preflight starting/);
-    assert.equal(readFileSync(harness.pnpmMarker, 'utf8').trim(), 'check:news-sources:health');
+    assert.match(result.stdout, /source-health liveness preflight starting/);
+    assert.equal(readFileSync(harness.pnpmMarker, 'utf8').trim(), 'check:news-sources:liveness');
   } finally {
     rmSync(harness.root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

- Add `check:source-health:liveness` / `check:news-sources:liveness` as the operational source gate for publisher restart and PR-time Source Health validation.
- Re-scope `tools/scripts/start-news-aggregator-daemon-production.sh` to use the liveness gate before StoryCluster/OpenAI preflights.
- Re-scope `.github/workflows/main.yml` Source Health to liveness and upload `source-health-liveness-report.json`, while keeping the release-evidence command intact.
- Keep `check:news-sources:health` as the release-grade evidence gate for Phase 6/canary/readiness, and document the split.
- Add a production env template and a Phase 5 design note capturing the A6 non-enforcing source-health diagnostic.

## Root Cause

The production start wrapper was using the release-evidence source-health gate as an operational restart preflight. After a long publisher outage, that creates a deadlock: the publisher cannot restart until it has a recent clean release evidence window, but it cannot generate that window while stopped.

The same issue showed up in PR CI: normal source-health code changes were blocked by live release-window state. This PR keeps the release-grade command unchanged for explicit release/readiness chains, but moves operational restart and PR validation to current liveness.

The new liveness report still builds on the canonical source-health report, but fails only on current restart blockers: global feed-stage outage or preserve-latest action, enabled source count below the configured floor, contributing source count below the configured floor, or zero admitted sources. Release evidence failures and watch/remove candidates remain visible warnings.

## A6 Diagnostic

Read-only A6 source-health diagnostic wrote:

`/home/humble/VHC/services/news-aggregator/.tmp/news-source-admission/1781486424909/source-health-report.json`

Summary: release evidence was blocked, but current source liveness was not globally down. `bigbendsentinel-border-wall` was a real remove candidate from article fetch/readability failure: RSS returned HTTP 200 XML with items, but article samples were HTTP 500 and readable sample count was zero. That is a source-admission follow-up, not a publisher restart blocker by itself.

## Validation

Local:

- `git diff --check`
- `pnpm docs:check`
- `pnpm lint`
- `pnpm --filter @vh/news-aggregator typecheck`
- `pnpm --filter @vh/news-aggregator exec vitest run src/sourceHealthCiWorkflow.test.ts src/sourceHealthLivenessReport.test.ts src/sourceHealthReport.test.ts src/packageScripts.test.ts --config ./vitest.config.ts`
- `pnpm --filter @vh/news-aggregator check:source-health:liveness`
- `pnpm --filter @vh/news-aggregator test`

GitHub Actions on head `48cf6270`: all 9 checks passed.