### PR TITLE
[codex] Harden Phase 5 user service durability

### DIFF
--- a/docs/ops/analysis-backend-3001.md
+++ b/docs/ops/analysis-backend-3001.md
@@ -2,7 +2,7 @@
 
 > Status: Operational Runbook
 > Owner: VHC Ops
-> Last Reviewed: 2026-06-14
+> Last Reviewed: 2026-06-15
 > Depends On: docs/README.md, docs/CANON_MAP.md
 
 
@@ -36,6 +36,22 @@ A6 runtime note, observed 2026-06-14: `node` is available for `humble` at
 `/home/humble/.local/bin/node`; the user service template includes that path.
 
 ## Install / start (user service)
+
+Enable and verify linger before installing the `humble` user service so the
+analysis backend survives operator logout and reboot:
+
+```bash
+loginctl enable-linger humble
+loginctl show-user humble -p Linger --value
+```
+
+The verification command must print `yes`. The installer fails closed if
+`loginctl` cannot confirm linger is enabled. After install, verify the unit is
+enabled:
+
+```bash
+systemctl --user is-enabled vh-analysis-backend-3001.service
+```
 
 ```bash
 cd /home/humble/VHC

--- a/docs/ops/news-aggregator-production-service.md
+++ b/docs/ops/news-aggregator-production-service.md
@@ -2,7 +2,7 @@
 
 > Status: Operational Runbook
 > Owner: VHC Ops
-> Last Reviewed: 2026-06-14
+> Last Reviewed: 2026-06-15
 > Depends On: docs/ops/NEWS_SOURCE_ADMISSION_RUNBOOK.md, docs/ops/public-feed-freshness-monitor.md, docs/ops/analysis-backend-3001.md, docs/ops/storycluster-production-service.md, docs/ops/public-beta-launch-readiness-closeout.md
 
 ## Purpose
@@ -43,6 +43,36 @@ cd /home/humble/VHC
 
 The installer writes user units and reloads systemd. It does not start publisher
 writes by default.
+
+## User Service Durability
+
+These production surfaces run as `humble` user services and require linger so
+they survive operator logout and host reboot:
+
+```bash
+vh-analysis-backend-3001.service
+vh-storycluster-qdrant.service
+vh-storycluster-engine.service
+vh-news-aggregator.service
+```
+
+Before installing or enabling any Phase 5 user unit, enable and verify linger:
+
+```bash
+loginctl enable-linger humble
+loginctl show-user humble -p Linger --value
+```
+
+The verification command must print `yes`. The installers fail closed if
+`loginctl` cannot confirm linger is enabled. After install, verify the intended
+units are enabled:
+
+```bash
+systemctl --user is-enabled vh-analysis-backend-3001.service
+systemctl --user is-enabled vh-storycluster-qdrant.service
+systemctl --user is-enabled vh-storycluster-engine.service
+systemctl --user is-enabled vh-news-aggregator.service
+```
 
 The publisher requires the managed StoryCluster service to be running before
 publisher start. Install and verify the Qdrant-backed service first:

--- a/docs/ops/storycluster-production-service.md
+++ b/docs/ops/storycluster-production-service.md
@@ -49,6 +49,23 @@ hash, and sorted variable names. Do not print secret values.
 
 ## Install / Start
 
+These units run as `humble` user services. Enable and verify linger before
+installing so Qdrant and StoryCluster survive logout and reboot:
+
+```bash
+loginctl enable-linger humble
+loginctl show-user humble -p Linger --value
+```
+
+The verification command must print `yes`. The installer fails closed if
+`loginctl` cannot confirm linger is enabled. After install, verify both units are
+enabled:
+
+```bash
+systemctl --user is-enabled vh-storycluster-qdrant.service
+systemctl --user is-enabled vh-storycluster-engine.service
+```
+
 Install units without starting:
 
 ```bash

--- a/infra/systemd/user/vh-news-aggregator.service
+++ b/infra/systemd/user/vh-news-aggregator.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=VHC News Aggregator Publisher Daemon
 Documentation=file:/home/humble/VHC/docs/ops/news-aggregator-production-service.md
-After=network-online.target
-Wants=network-online.target
+After=network-online.target vh-storycluster-engine.service
+Wants=network-online.target vh-storycluster-engine.service
 
 [Service]
 Type=simple

--- a/tools/scripts/install-analysis-backend-service.sh
+++ b/tools/scripts/install-analysis-backend-service.sh
@@ -6,6 +6,37 @@ UNIT_DIR="${HOME}/.config/systemd/user"
 UNIT_PATH="${UNIT_DIR}/vh-analysis-backend-3001.service"
 SERVICE_PATH="%h/.local/bin:%h/.hermes/node/bin:/usr/local/bin:/usr/bin:/bin"
 
+require_user_linger() {
+  local user_name="${VHC_SYSTEMD_USER:-${USER:-}}"
+  if [[ -z "${user_name}" ]]; then
+    user_name="$(id -un)"
+  fi
+
+  if ! command -v loginctl >/dev/null 2>&1; then
+    echo "Unable to verify user linger: loginctl is not available" >&2
+    echo "Before installing user services, run: loginctl enable-linger ${user_name}" >&2
+    return 78
+  fi
+
+  local linger
+  if ! linger="$(loginctl show-user "${user_name}" -p Linger --value 2>/dev/null)"; then
+    echo "Unable to verify user linger for ${user_name}" >&2
+    echo "Before installing user services, run: loginctl enable-linger ${user_name}" >&2
+    return 78
+  fi
+
+  if [[ "${linger}" != "yes" ]]; then
+    echo "User linger is required for durable user services; ${user_name} Linger=${linger:-unset}" >&2
+    echo "Run: loginctl enable-linger ${user_name}" >&2
+    echo "Verify: loginctl show-user ${user_name} -p Linger --value" >&2
+    echo "Required user services: vh-analysis-backend-3001.service vh-storycluster-qdrant.service vh-storycluster-engine.service vh-news-aggregator.service" >&2
+    return 78
+  fi
+
+  echo "Verified user linger for ${user_name}: yes"
+}
+
+require_user_linger
 mkdir -p "${UNIT_DIR}"
 
 cat > "${UNIT_PATH}" <<EOF

--- a/tools/scripts/install-news-aggregator-production-service.sh
+++ b/tools/scripts/install-news-aggregator-production-service.sh
@@ -23,14 +23,45 @@ for arg in "$@"; do
   esac
 done
 
+require_user_linger() {
+  local user_name="${VHC_SYSTEMD_USER:-${USER:-}}"
+  if [[ -z "${user_name}" ]]; then
+    user_name="$(id -un)"
+  fi
+
+  if ! command -v loginctl >/dev/null 2>&1; then
+    echo "Unable to verify user linger: loginctl is not available" >&2
+    echo "Before installing user services, run: loginctl enable-linger ${user_name}" >&2
+    return 78
+  fi
+
+  local linger
+  if ! linger="$(loginctl show-user "${user_name}" -p Linger --value 2>/dev/null)"; then
+    echo "Unable to verify user linger for ${user_name}" >&2
+    echo "Before installing user services, run: loginctl enable-linger ${user_name}" >&2
+    return 78
+  fi
+
+  if [[ "${linger}" != "yes" ]]; then
+    echo "User linger is required for durable user services; ${user_name} Linger=${linger:-unset}" >&2
+    echo "Run: loginctl enable-linger ${user_name}" >&2
+    echo "Verify: loginctl show-user ${user_name} -p Linger --value" >&2
+    echo "Required user services: vh-analysis-backend-3001.service vh-storycluster-qdrant.service vh-storycluster-engine.service vh-news-aggregator.service" >&2
+    return 78
+  fi
+
+  echo "Verified user linger for ${user_name}: yes"
+}
+
+require_user_linger
 mkdir -p "${UNIT_DIR}"
 
 cat >"${UNIT_DIR}/vh-news-aggregator.service" <<EOF
 [Unit]
 Description=VHC News Aggregator Publisher Daemon
 Documentation=file:${REPO_ROOT}/docs/ops/news-aggregator-production-service.md
-After=network-online.target
-Wants=network-online.target
+After=network-online.target vh-storycluster-engine.service
+Wants=network-online.target vh-storycluster-engine.service
 
 [Service]
 Type=simple

--- a/tools/scripts/install-storycluster-production-service.sh
+++ b/tools/scripts/install-storycluster-production-service.sh
@@ -29,6 +29,37 @@ for arg in "$@"; do
   esac
 done
 
+require_user_linger() {
+  local user_name="${VHC_SYSTEMD_USER:-${USER:-}}"
+  if [[ -z "${user_name}" ]]; then
+    user_name="$(id -un)"
+  fi
+
+  if ! command -v loginctl >/dev/null 2>&1; then
+    echo "Unable to verify user linger: loginctl is not available" >&2
+    echo "Before installing user services, run: loginctl enable-linger ${user_name}" >&2
+    return 78
+  fi
+
+  local linger
+  if ! linger="$(loginctl show-user "${user_name}" -p Linger --value 2>/dev/null)"; then
+    echo "Unable to verify user linger for ${user_name}" >&2
+    echo "Before installing user services, run: loginctl enable-linger ${user_name}" >&2
+    return 78
+  fi
+
+  if [[ "${linger}" != "yes" ]]; then
+    echo "User linger is required for durable user services; ${user_name} Linger=${linger:-unset}" >&2
+    echo "Run: loginctl enable-linger ${user_name}" >&2
+    echo "Verify: loginctl show-user ${user_name} -p Linger --value" >&2
+    echo "Required user services: vh-analysis-backend-3001.service vh-storycluster-qdrant.service vh-storycluster-engine.service vh-news-aggregator.service" >&2
+    return 78
+  fi
+
+  echo "Verified user linger for ${user_name}: yes"
+}
+
+require_user_linger
 mkdir -p "${UNIT_DIR}"
 
 cat >"${UNIT_DIR}/vh-storycluster-qdrant.service" <<EOF

--- a/tools/scripts/storycluster-production-service.test.mjs
+++ b/tools/scripts/storycluster-production-service.test.mjs
@@ -11,6 +11,20 @@ const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(SCRIPT_DIR, '../..');
 const INSTALLER = path.join(REPO_ROOT, 'tools/scripts/install-storycluster-production-service.sh');
 
+function writeLoginctlMock(bin) {
+  writeFileSync(
+    path.join(bin, 'loginctl'),
+    `#!/usr/bin/env bash
+if [[ "$1" == "show-user" && "$3" == "-p" && "$4" == "Linger" && "$5" == "--value" ]]; then
+  echo "yes"
+  exit 0
+fi
+exit 1
+`,
+    { mode: 0o755 },
+  );
+}
+
 test('storycluster installer renders user units without starting services by default', async () => {
   const home = mkdtempSync(path.join(tmpdir(), 'vh-storycluster-home-'));
   const bin = path.join(home, 'bin');
@@ -25,6 +39,7 @@ exit 0
 `,
     { mode: 0o755 },
   );
+  writeLoginctlMock(bin);
 
   const result = spawnSync('bash', [INSTALLER], {
     cwd: REPO_ROOT,
@@ -70,6 +85,7 @@ test('storycluster installer refuses to start engine without env file', async ()
     '#!/usr/bin/env bash\nexit 0\n',
     { mode: 0o755 },
   );
+  writeLoginctlMock(bin);
 
   const result = spawnSync('bash', [INSTALLER, '--start-storycluster'], {
     cwd: REPO_ROOT,

--- a/tools/scripts/systemd-service-installers.test.mjs
+++ b/tools/scripts/systemd-service-installers.test.mjs
@@ -12,6 +12,10 @@ function readScript(name) {
   return readFileSync(path.join(REPO_ROOT, 'tools/scripts', name), 'utf8');
 }
 
+function readInfraUnit(name) {
+  return readFileSync(path.join(REPO_ROOT, 'infra/systemd/user', name), 'utf8');
+}
+
 test('systemd installers include A6 node and pnpm paths', () => {
   for (const scriptName of [
     'install-analysis-backend-service.sh',
@@ -53,6 +57,30 @@ test('news aggregator installer still gates publisher start on explicit approval
   assert.match(source, /VH_NEWS_DAEMON_START_APPROVED:-/);
   assert.match(source, /--start-publisher requires VH_NEWS_DAEMON_START_APPROVED=1/);
   assert.match(source, /systemctl --user enable --now vh-news-aggregator\.service/);
+});
+
+test('news aggregator user unit orders publisher after StoryCluster', () => {
+  for (const source of [
+    readScript('install-news-aggregator-production-service.sh'),
+    readInfraUnit('vh-news-aggregator.service'),
+  ]) {
+    assert.match(source, /After=network-online\.target vh-storycluster-engine\.service/);
+    assert.match(source, /Wants=network-online\.target vh-storycluster-engine\.service/);
+  }
+});
+
+test('installers fail closed unless user linger is enabled', () => {
+  for (const scriptName of [
+    'install-analysis-backend-service.sh',
+    'install-news-aggregator-production-service.sh',
+    'install-storycluster-production-service.sh',
+  ]) {
+    const source = readScript(scriptName);
+    assert.match(source, /loginctl show-user "\$\{user_name\}" -p Linger --value/);
+    assert.match(source, /loginctl enable-linger \$\{user_name\}/);
+    assert.match(source, /User linger is required for durable user services/);
+    assert.match(source, /vh-analysis-backend-3001\.service vh-storycluster-qdrant\.service vh-storycluster-engine\.service vh-news-aggregator\.service/);
+  }
 });
 
 test('news aggregator production start requires qdrant-backed StoryCluster readiness', () => {


### PR DESCRIPTION
## Summary

- Order the managed news publisher after `vh-storycluster-engine.service` in both the installer-generated unit and checked-in user unit template.
- Add fail-closed `loginctl` linger verification to the analysis backend, StoryCluster, and news publisher user-service installers.
- Document the Phase 5 linger prerequisite and enabled-unit verification for `vh-analysis-backend-3001`, `vh-storycluster-qdrant`, `vh-storycluster-engine`, and `vh-news-aggregator`.
- Extend focused installer tests for StoryCluster ordering, publisher ordering, and linger checks.

## Validation

- `bash -n tools/scripts/install-news-aggregator-production-service.sh tools/scripts/install-storycluster-production-service.sh tools/scripts/install-analysis-backend-service.sh`
- `node --test tools/scripts/systemd-service-installers.test.mjs tools/scripts/storycluster-production-service.test.mjs`
- `git diff --check`

## Operational Note

This keeps publisher start fail-closed: the publisher unit can still be installed without writes, and `--start-publisher` still requires `VH_NEWS_DAEMON_START_APPROVED=1`. The installer now also refuses to enable user units unless linger is confirmed.
