### PR TITLE
Harden Phase 5 publisher diagnostics

### DIFF
--- a/docs/ops/news-aggregator-production-service.md
+++ b/docs/ops/news-aggregator-production-service.md
@@ -144,12 +144,20 @@ systemctl --user restart vh-news-aggregator.service
 `ExecStart` entrypoint for the managed publisher service. It fails closed unless:
 
 1. `VH_NEWS_DAEMON_ENV_FILE` is readable.
-2. `VH_NEWS_DAEMON_START_APPROVED=1` is present in that env file.
+2. Either live start approval or diagnostic no-write approval is present:
+   - live publisher: `VH_NEWS_DAEMON_START_APPROVED=1`;
+   - no-write diagnostic: `VH_NEWS_DAEMON_DIAGNOSTIC_NO_WRITE=1` and
+     `VH_NEWS_DAEMON_DIAGNOSTIC_APPROVED=1`.
 3. `pnpm check:news-sources:liveness` passes the operational restart gate.
 4. `pnpm --filter @vh/storycluster-engine build` passes.
 5. `preflightOpenAIStoryClusterProviderFromEnv` returns `status: "pass"`.
 6. Authenticated StoryCluster `VH_STORYCLUSTER_REMOTE_HEALTH_URL` returns
    `ok: true` with a readiness `detail` beginning with `qdrant:`.
+7. The raw publication readiness preflight passes without writing a canary:
+   signer material names are present, `VH_GUN_PEERS` parses, relay health
+   endpoints are reachable through read-only `/healthz`, StoryCluster config is
+   present, and relay-REST synthesis config is complete when synthesis is
+   enabled.
 
 The liveness preflight writes a regular source-health artifact and a
 `source-health-liveness-report.json`, but it does not enforce the rolling
@@ -177,6 +185,21 @@ client and starting the runtime; the wrapper readiness check above exists to
 reject shallow `/health` endpoints or memory-vector StoryCluster instances
 before the preflight-success marker is written.
 
+No-write diagnostic mode starts the same runtime path with all mesh mutations
+suppressed: lease writes/releases, raw bundle writes/removes, storyline
+writes/removes, latest/hot/lifecycle writes, relay-REST synthesis writes,
+synthesis queue persistence, replay writes, and product-feed repair writes.
+It still fetches feeds and calls StoryCluster so the tick summary can prove
+nonzero ingest/normalize/cluster/select before a live start is approved.
+
+Every daemon tick writes an always-on diagnostic artifact at
+`$VH_DAEMON_FEED_ARTIFACT_ROOT/news-runtime-diagnostics.json` unless
+`VH_NEWS_RUNTIME_DIAGNOSTIC_FILE` overrides it. The journal also logs
+`[vh:news-runtime] tick summary` and `[vh:news-runtime] first tick outcome`
+outside `VH_NEWS_RUNTIME_TRACE`; use those fields for first-publish evidence.
+Set `VH_NEWS_RUNTIME_TICK_WATCHDOG_MS` to emit an in-flight warning with elapsed
+time and last known stage if a tick exceeds the threshold.
+
 ## Env File Surface
 
 Default env file:
@@ -196,6 +219,8 @@ Required or commonly used names:
 ```bash
 VH_GUN_PEERS
 VH_NEWS_DAEMON_START_APPROVED
+VH_NEWS_DAEMON_DIAGNOSTIC_NO_WRITE
+VH_NEWS_DAEMON_DIAGNOSTIC_APPROVED
 VH_STORYCLUSTER_REMOTE_URL
 VH_STORYCLUSTER_REMOTE_AUTH_TOKEN
 VH_STORYCLUSTER_REMOTE_HEALTH_URL
@@ -211,6 +236,8 @@ VH_NEWS_INGESTION_LEASE_SCOPE
 VH_NEWS_DAEMON_STATE_DIR
 VH_DAEMON_FEED_ARTIFACT_ROOT
 VH_NEWS_DAEMON_LAST_SUCCESS_FILE
+VH_NEWS_RUNTIME_DIAGNOSTIC_FILE
+VH_NEWS_RUNTIME_TICK_WATCHDOG_MS
 VH_NEWS_SYSTEM_WRITER_ID
 VH_NEWS_SYSTEM_WRITER_PIN_JSON
 VH_NEWS_SYSTEM_WRITER_PUBLIC_KEY_SPKI_BASE64URL
@@ -254,10 +281,28 @@ VH_RELAY_SNAPSHOT_WATCH_OUTPUT_FILE="$HOME/.local/state/vhc/relay-snapshot-watch
 node tools/scripts/relay-latest-index-snapshot-watch.mjs
 ```
 
+Pre-start publisher recovery baseline:
+
+```bash
+VH_RELAY_SNAPSHOT_WATCH_OUTPUT_FILE="$HOME/.local/state/vhc/relay-snapshot-watch/pre-start-baseline.json" \
+node tools/scripts/relay-latest-index-snapshot-watch.mjs --baseline
+```
+
+`--baseline` and `--structural-only` still validate snapshot file paths,
+schema, entry count, JSON parseability, size, mtime sanity, and timestamp
+sanity. They do not fail solely because `newest_entry_stale` is already beyond
+the 6-hour SLO; instead they record that stale age under `freshnessBaseline`.
+Use this before publisher start to prove the snapshots are structurally safe and
+to preserve the stale baseline. After publisher start, run the default watcher
+with no mode flag; default freshness mode must still fail hard on
+`newest_entry_stale` until new signed stories move the snapshots below the 6h
+SLO.
+
 Config knobs:
 
 ```bash
 VH_RELAY_SNAPSHOT_WATCH_FILES
+VH_RELAY_SNAPSHOT_WATCH_MODE
 VH_RELAY_SNAPSHOT_WATCH_MAX_AGE_MS
 VH_RELAY_SNAPSHOT_WATCH_EXPECTED_ENTRIES
 VH_RELAY_SNAPSHOT_WATCH_MAX_FILE_BYTES
@@ -300,13 +345,15 @@ for container in containers:
     }, sort_keys=True))
 PY
 rm -f /tmp/vhc-relay-inspect.json
-node /home/humble/VHC/tools/scripts/relay-latest-index-snapshot-watch.mjs
+node /home/humble/VHC/tools/scripts/relay-latest-index-snapshot-watch.mjs --baseline
 ```
 
 The precheck must show schema `vh-news-latest-index-relay-snapshot-v1`, `15`
-entries for every relay snapshot, sane size/mtime, and newest-entry age under
-the 6-hour SLO. Preserve the current relay image tags and inspect output for
-rollback before restart.
+entries for every relay snapshot, and sane size/mtime. A stale newest-entry age
+is recorded as the baseline during publisher recovery; after first-publish
+proof, default freshness mode must show newest-entry age under the 6-hour SLO.
+Preserve the current relay image tags and inspect output for rollback before
+restart.
 
 Only after that direct disk precheck passes, use the existing host deploy pattern
 for the relay image containing #638. If the host does not already have a clear

--- a/docs/ops/news-aggregator.env.example
+++ b/docs/ops/news-aggregator.env.example
@@ -6,6 +6,11 @@
 # production publisher start packet.
 # VH_NEWS_DAEMON_START_APPROVED=1
 
+# No-write diagnostic approval is separate from live start approval. Add both
+# lines only for an approved diagnostic run that must not mutate the mesh.
+# VH_NEWS_DAEMON_DIAGNOSTIC_NO_WRITE=1
+# VH_NEWS_DAEMON_DIAGNOSTIC_APPROVED=1
+
 # Public Gun peers used by the daemon client.
 VH_GUN_PEERS='["wss://gun-a.carboncaste.io/gun","wss://gun-b.carboncaste.io/gun","wss://gun-c.carboncaste.io/gun"]'
 
@@ -40,6 +45,8 @@ VH_NEWS_INGESTION_LEASE_SCOPE=public-beta
 VH_NEWS_DAEMON_STATE_DIR=/home/humble/.local/state/vhc/news-aggregator
 VH_DAEMON_FEED_ARTIFACT_ROOT=/home/humble/.local/state/vhc/news-aggregator/artifacts
 VH_NEWS_DAEMON_LAST_SUCCESS_FILE=/home/humble/.local/state/vhc/news-aggregator/last-success.json
+VH_NEWS_RUNTIME_DIAGNOSTIC_FILE=/home/humble/.local/state/vhc/news-aggregator/artifacts/news-runtime-diagnostics.json
+VH_NEWS_RUNTIME_TICK_WATCHDOG_MS=180000
 VH_BUNDLE_SYNTHESIS_QUEUE_DIR=/home/humble/.local/state/vhc/news-aggregator/bundle-synthesis-queue
 VH_BUNDLE_SYNTHESIS_LIFECYCLE_LEDGER=/home/humble/.local/state/vhc/news-aggregator/bundle-synthesis-queue/synthesis-lifecycle.jsonl
 VITE_NEWS_POLL_INTERVAL_MS=600000

--- a/packages/ai-engine/src/__tests__/newsOrchestrator.test.ts
+++ b/packages/ai-engine/src/__tests__/newsOrchestrator.test.ts
@@ -171,6 +171,114 @@ describe('newsOrchestrator', () => {
     expect(result).toEqual({ bundles: [], storylines: [] });
   });
 
+  it('captures zero-normalized cluster artifacts before returning an empty result', async () => {
+    const fetchMock = vi.mocked(globalThis.fetch);
+    fetchMock.mockResolvedValue({
+      ok: true,
+      text: vi.fn().mockResolvedValue('<rss><channel></channel></rss>'),
+    } as unknown as Response);
+    const onClusterArtifacts = vi.fn();
+
+    const result = await orchestrateNewsPipeline(
+      {
+        feedSources: [
+          {
+            id: 'source-empty',
+            name: 'Source Empty',
+            rssUrl: 'https://feeds.example.com/empty.xml',
+            enabled: true,
+          },
+        ],
+        topicMapping: {
+          defaultTopicId: 'topic-general',
+        },
+      },
+      { onClusterArtifacts },
+    );
+
+    expect(result).toEqual({ bundles: [], storylines: [] });
+    expect(onClusterArtifacts).toHaveBeenCalledWith(expect.objectContaining({
+      schemaVersion: 'news-orchestrator-cluster-artifacts-v1',
+      rawItemCount: 0,
+      normalizedItems: [],
+      topicCaptures: [],
+    }));
+  });
+
+  it('continues empty pipeline completion when zero-normalized artifact capture fails', async () => {
+    vi.stubEnv('VH_NEWS_RUNTIME_TRACE', 'true');
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const fetchMock = vi.mocked(globalThis.fetch);
+    fetchMock.mockResolvedValue({
+      ok: true,
+      text: vi.fn().mockResolvedValue('<rss><channel></channel></rss>'),
+    } as unknown as Response);
+
+    const result = await orchestrateNewsPipeline(
+      {
+        feedSources: [
+          {
+            id: 'source-empty',
+            name: 'Source Empty',
+            rssUrl: 'https://feeds.example.com/empty.xml',
+            enabled: true,
+          },
+        ],
+        topicMapping: {
+          defaultTopicId: 'topic-general',
+        },
+      },
+      {
+        onClusterArtifacts: () => {
+          throw new Error('artifact sink unavailable');
+        },
+      },
+    );
+
+    expect(result).toEqual({ bundles: [], storylines: [] });
+    expect(infoSpy).toHaveBeenCalledWith(
+      '[vh:news-orchestrator] cluster_artifacts_capture_failed',
+      expect.objectContaining({ error: 'artifact sink unavailable' }),
+    );
+  });
+
+  it('traces non-Error zero-normalized artifact capture failures', async () => {
+    vi.stubEnv('VH_NEWS_RUNTIME_TRACE', 'true');
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const fetchMock = vi.mocked(globalThis.fetch);
+    fetchMock.mockResolvedValue({
+      ok: true,
+      text: vi.fn().mockResolvedValue('<rss><channel></channel></rss>'),
+    } as unknown as Response);
+
+    const result = await orchestrateNewsPipeline(
+      {
+        feedSources: [
+          {
+            id: 'source-empty',
+            name: 'Source Empty',
+            rssUrl: 'https://feeds.example.com/empty.xml',
+            enabled: true,
+          },
+        ],
+        topicMapping: {
+          defaultTopicId: 'topic-general',
+        },
+      },
+      {
+        onClusterArtifacts: () => {
+          throw 'artifact sink string failure';
+        },
+      },
+    );
+
+    expect(result).toEqual({ bundles: [], storylines: [] });
+    expect(infoSpy).toHaveBeenCalledWith(
+      '[vh:news-orchestrator] cluster_artifacts_capture_failed',
+      expect.objectContaining({ error: 'artifact sink string failure' }),
+    );
+  });
+
   it('emits trace logs when VH_NEWS_RUNTIME_TRACE is enabled', async () => {
     vi.stubEnv('VH_NEWS_RUNTIME_TRACE', 'true');
     const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});

--- a/packages/ai-engine/src/index.ts
+++ b/packages/ai-engine/src/index.ts
@@ -30,4 +30,6 @@ export type {
   NewsRuntimeEnrichmentWorkItem,
   NewsRuntimeHandle,
   NewsRuntimeSynthesisCandidate,
+  NewsRuntimeTickStage,
+  NewsRuntimeTickSummary,
 } from './newsRuntime';

--- a/packages/ai-engine/src/newsOrchestrator.ts
+++ b/packages/ai-engine/src/newsOrchestrator.ts
@@ -31,6 +31,7 @@ export interface NewsOrchestratorTopicClusterArtifacts {
 export interface NewsOrchestratorClusterArtifacts {
   readonly schemaVersion: 'news-orchestrator-cluster-artifacts-v1';
   readonly generatedAt: string;
+  readonly rawItemCount: number;
   readonly normalizedItems: ReadonlyArray<NormalizedItem>;
   readonly topicCaptures: ReadonlyArray<NewsOrchestratorTopicClusterArtifacts>;
 }
@@ -363,6 +364,22 @@ export async function orchestrateNewsPipeline(
   });
 
   if (normalizedItems.length === 0) {
+    if (options.onClusterArtifacts) {
+      try {
+        await Promise.resolve(options.onClusterArtifacts({
+          schemaVersion: 'news-orchestrator-cluster-artifacts-v1',
+          generatedAt: new Date().toISOString(),
+          rawItemCount: rawItems.length,
+          normalizedItems,
+          topicCaptures: [],
+        }));
+      } catch (error) {
+        orchestratorTrace('cluster_artifacts_capture_failed', {
+          duration_ms: Math.max(0, Date.now() - startedAt),
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
     orchestratorTrace('pipeline_completed', {
       duration_ms: Math.max(0, Date.now() - startedAt),
       bundle_count: 0,
@@ -421,6 +438,7 @@ export async function orchestrateNewsPipeline(
       await Promise.resolve(options.onClusterArtifacts({
         schemaVersion: 'news-orchestrator-cluster-artifacts-v1',
         generatedAt: new Date().toISOString(),
+        rawItemCount: rawItems.length,
         normalizedItems,
         topicCaptures,
       }));

--- a/packages/ai-engine/src/newsRuntime.test.ts
+++ b/packages/ai-engine/src/newsRuntime.test.ts
@@ -95,6 +95,25 @@ function batch(bundles: StoryBundle[] = [], storylines: StorylineGroup[] = []) {
   return { bundles, storylines };
 }
 
+async function emitMockClusterArtifacts(options: unknown, rawItemCount = 3, normalizedItemCount = 2): Promise<void> {
+  const hook = (options as {
+    onClusterArtifacts?: (artifacts: {
+      schemaVersion: 'news-orchestrator-cluster-artifacts-v1';
+      generatedAt: string;
+      rawItemCount: number;
+      normalizedItems: unknown[];
+      topicCaptures: unknown[];
+    }) => void | Promise<void>;
+  })?.onClusterArtifacts;
+  await hook?.({
+    schemaVersion: 'news-orchestrator-cluster-artifacts-v1',
+    generatedAt: new Date().toISOString(),
+    rawItemCount,
+    normalizedItems: Array.from({ length: normalizedItemCount }, (_, index) => ({ id: `item-${index}` })),
+    topicCaptures: [],
+  });
+}
+
 function storyBundle(
   storyId: string,
   {
@@ -891,6 +910,136 @@ describe('newsRuntime', () => {
       '[vh:news-runtime] tick_completed',
       expect.objectContaining({ published_story_count: 1, published_storyline_count: 1 }),
     );
+
+    handle.stop();
+  });
+
+  it('emits always-on tick summaries with ingest, selection, and write counts', async () => {
+    orchestrateNewsPipelineMock.mockImplementation(async (_config, options) => {
+      await emitMockClusterArtifacts(options);
+      return batch([STORY_BUNDLE], [STORYLINE]);
+    });
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const writeStoryBundle = vi.fn().mockResolvedValue(undefined);
+    const writeStorylineGroup = vi.fn().mockResolvedValue(undefined);
+    const onTickSummary = vi.fn();
+
+    const handle = startNewsRuntime({
+      ...BASE_CONFIG,
+      writeStoryBundle,
+      writeStorylineGroup,
+      onTickSummary,
+      pollIntervalMs: 10,
+      runOnStart: true,
+    });
+
+    await vi.waitFor(() => {
+      expect(onTickSummary).toHaveBeenCalled();
+    });
+
+    expect(onTickSummary).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'completed',
+      first_tick: true,
+      ingested_item_count: 3,
+      normalized_item_count: 2,
+      clustered_bundle_count: 1,
+      clustered_storyline_count: 1,
+      selected_bundle_count: 1,
+      raw_write_attempted_count: 1,
+      raw_wrote_count: 1,
+      storyline_write_attempted_count: 1,
+      storyline_wrote_count: 1,
+    }));
+    expect(infoSpy).toHaveBeenCalledWith(
+      '[vh:news-runtime] tick summary',
+      expect.objectContaining({ raw_wrote_count: 1, selected_bundle_count: 1 }),
+    );
+    expect(infoSpy).toHaveBeenCalledWith(
+      '[vh:news-runtime] first tick outcome',
+      expect.objectContaining({ raw_wrote_count: 1 }),
+    );
+
+    handle.stop();
+  });
+
+  it('warns when a tick exceeds the configured watchdog threshold', async () => {
+    let resolveRun: ((result: ReturnType<typeof batch>) => void) | null = null;
+    orchestrateNewsPipelineMock.mockImplementation(
+      async (_config, options) => {
+        await emitMockClusterArtifacts(options);
+        return new Promise<ReturnType<typeof batch>>((resolve) => {
+          resolveRun = resolve;
+        });
+      },
+    );
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const writeStoryBundle = vi.fn().mockResolvedValue(undefined);
+
+    const handle = startNewsRuntime({
+      ...BASE_CONFIG,
+      writeStoryBundle,
+      pollIntervalMs: 100,
+      runOnStart: true,
+      tickWatchdogMs: 50,
+    });
+
+    await flushTasks();
+    await vi.advanceTimersByTimeAsync(51);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[vh:news-runtime] tick watchdog warning',
+      expect.objectContaining({
+        elapsed_ms: expect.any(Number),
+        threshold_ms: 50,
+        last_stage: 'orchestrating',
+        first_tick: true,
+      }),
+    );
+
+    resolveRun?.(batch([STORY_BUNDLE]));
+    await flushTasks();
+    handle.stop();
+  });
+
+  it('suppresses writes and synthesis callbacks in no-write mode while still reporting selected bundles', async () => {
+    orchestrateNewsPipelineMock.mockImplementation(async (_config, options) => {
+      await emitMockClusterArtifacts(options, 4, 3);
+      return batch([STORY_BUNDLE], [STORYLINE]);
+    });
+    const writeStoryBundle = vi.fn().mockResolvedValue(undefined);
+    const writeStorylineGroup = vi.fn().mockResolvedValue(undefined);
+    const onSynthesisCandidate = vi.fn();
+    const onTickSummary = vi.fn();
+
+    const handle = startNewsRuntime({
+      ...BASE_CONFIG,
+      noWrite: true,
+      writeStoryBundle,
+      writeStorylineGroup,
+      onSynthesisCandidate,
+      onTickSummary,
+      pollIntervalMs: 10,
+      runOnStart: true,
+    });
+
+    await vi.waitFor(() => {
+      expect(onTickSummary).toHaveBeenCalled();
+    });
+
+    expect(writeStoryBundle).not.toHaveBeenCalled();
+    expect(writeStorylineGroup).not.toHaveBeenCalled();
+    expect(onSynthesisCandidate).not.toHaveBeenCalled();
+    expect(onTickSummary).toHaveBeenCalledWith(expect.objectContaining({
+      no_write: true,
+      ingested_item_count: 4,
+      normalized_item_count: 3,
+      selected_bundle_count: 1,
+      raw_write_attempted_count: 0,
+      raw_write_suppressed_count: 1,
+      raw_wrote_count: 0,
+      storyline_write_suppressed_count: 1,
+      synthesis_candidate_suppressed_count: 1,
+    }));
 
     handle.stop();
   });

--- a/packages/ai-engine/src/newsRuntime.test.ts
+++ b/packages/ai-engine/src/newsRuntime.test.ts
@@ -154,6 +154,16 @@ function storyBundle(
   };
 }
 
+function storylineGroup(storylineId: string, storyIds: string[] = [storylineId]): StorylineGroup {
+  return {
+    ...STORYLINE,
+    storyline_id: storylineId,
+    canonical_story_id: storyIds[0] ?? storylineId,
+    story_ids: storyIds,
+    headline: `${storylineId} headline`,
+  };
+}
+
 describe('newsRuntime', () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -189,6 +199,9 @@ describe('newsRuntime', () => {
     expect(__internal.normalizeOptionalPositiveInt(4.8, 'sample')).toBe(4);
     expect(() => __internal.normalizeOptionalPositiveInt(0, 'sample')).toThrow(
       'sample must be a positive finite number',
+    );
+    expect(() => startNewsRuntime({ ...BASE_CONFIG, tickWatchdogMs: 0 })).toThrow(
+      'tickWatchdogMs must be a positive finite number',
     );
 
     vi.stubEnv('CUSTOM_RUNTIME_ENV', ' value ');
@@ -663,6 +676,62 @@ describe('newsRuntime', () => {
     handle.stop();
   });
 
+  it('reports stale story and storyline cleanup failures without failing the tick', async () => {
+    const storyTwo = storyBundle('story-2', { sourceCount: 2, clusterWindowEnd: 200 });
+    const storylineTwo = storylineGroup('storyline-2', ['story-2']);
+    const removeStoryError = new Error('story remove failed');
+    const removeStorylineError = new Error('storyline remove failed');
+    orchestrateNewsPipelineMock
+      .mockImplementationOnce(async (_config, options) => {
+        await emitMockClusterArtifacts(options, 6, 4);
+        return batch([STORY_BUNDLE, storyTwo], [STORYLINE, storylineTwo]);
+      })
+      .mockImplementationOnce(async (_config, options) => {
+        await emitMockClusterArtifacts(options, 3, 2);
+        return batch([STORY_BUNDLE], [STORYLINE]);
+      });
+
+    const writeStoryBundle = vi.fn().mockResolvedValue(undefined);
+    const writeStorylineGroup = vi.fn().mockResolvedValue(undefined);
+    const removeStoryBundle = vi.fn().mockRejectedValue(removeStoryError);
+    const removeStorylineGroup = vi.fn().mockRejectedValue(removeStorylineError);
+    const onError = vi.fn();
+    const onTickSummary = vi.fn();
+    const handle = startNewsRuntime({
+      ...BASE_CONFIG,
+      writeStoryBundle,
+      writeStorylineGroup,
+      removeStoryBundle,
+      removeStorylineGroup,
+      onError,
+      onTickSummary,
+      pruneStaleBundles: true,
+      pollIntervalMs: 10,
+      runOnStart: false,
+    });
+
+    await vi.advanceTimersByTimeAsync(10);
+    await flushTasks();
+    expect(onTickSummary).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(10);
+    await flushTasks();
+    expect(onTickSummary).toHaveBeenCalledTimes(2);
+
+    expect(removeStorylineGroup).toHaveBeenCalledWith(BASE_CONFIG.gunClient, 'storyline-2');
+    expect(removeStoryBundle).toHaveBeenCalledWith(BASE_CONFIG.gunClient, 'story-2');
+    expect(onError).toHaveBeenCalledWith(removeStorylineError);
+    expect(onError).toHaveBeenCalledWith(removeStoryError);
+    expect(onTickSummary.mock.calls[1]?.[0]).toEqual(expect.objectContaining({
+      stale_storyline_remove_attempted_count: 1,
+      stale_storyline_remove_failed_count: 1,
+      stale_story_remove_attempted_count: 1,
+      stale_story_remove_failed_count: 1,
+    }));
+    expect(handle.lastRun()).toBeInstanceOf(Date);
+
+    handle.stop();
+  });
+
   it('preserves previously published stories by default when a refresh returns fewer bundles', async () => {
     const storyTwo: StoryBundle = {
       ...STORY_BUNDLE,
@@ -708,6 +777,7 @@ describe('newsRuntime', () => {
       ...BASE_CONFIG,
       writeStoryBundle,
       removeStoryBundle,
+      pruneStaleBundles: true,
       pollIntervalMs: 10,
       runOnStart: true,
     });
@@ -923,12 +993,16 @@ describe('newsRuntime', () => {
     const writeStoryBundle = vi.fn().mockResolvedValue(undefined);
     const writeStorylineGroup = vi.fn().mockResolvedValue(undefined);
     const onTickSummary = vi.fn();
+    const onClusterArtifacts = vi.fn();
 
     const handle = startNewsRuntime({
       ...BASE_CONFIG,
       writeStoryBundle,
       writeStorylineGroup,
       onTickSummary,
+      orchestratorOptions: {
+        onClusterArtifacts,
+      },
       pollIntervalMs: 10,
       runOnStart: true,
     });
@@ -949,6 +1023,10 @@ describe('newsRuntime', () => {
       raw_wrote_count: 1,
       storyline_write_attempted_count: 1,
       storyline_wrote_count: 1,
+    }));
+    expect(onClusterArtifacts).toHaveBeenCalledWith(expect.objectContaining({
+      rawItemCount: 3,
+      normalizedItems: expect.any(Array),
     }));
     expect(infoSpy).toHaveBeenCalledWith(
       '[vh:news-runtime] tick summary',
@@ -1001,6 +1079,40 @@ describe('newsRuntime', () => {
     handle.stop();
   });
 
+  it('warns when the tick summary artifact callback fails', async () => {
+    orchestrateNewsPipelineMock.mockImplementation(async (_config, options) => {
+      await emitMockClusterArtifacts(options);
+      return batch([STORY_BUNDLE]);
+    });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const writeStoryBundle = vi.fn().mockResolvedValue(undefined);
+    const onTickSummary = vi.fn().mockRejectedValue(new Error('artifact write failed'));
+
+    const handle = startNewsRuntime({
+      ...BASE_CONFIG,
+      writeStoryBundle,
+      onTickSummary,
+      pollIntervalMs: 10,
+      runOnStart: true,
+    });
+
+    await vi.waitFor(() => {
+      expect(onTickSummary).toHaveBeenCalled();
+    });
+    await flushTasks();
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[vh:news-runtime] tick summary artifact callback failed',
+      expect.objectContaining({
+        tick_sequence: 1,
+        error: 'artifact write failed',
+      }),
+    );
+    expect(handle.lastRun()).toBeInstanceOf(Date);
+
+    handle.stop();
+  });
+
   it('suppresses writes and synthesis callbacks in no-write mode while still reporting selected bundles', async () => {
     orchestrateNewsPipelineMock.mockImplementation(async (_config, options) => {
       await emitMockClusterArtifacts(options, 4, 3);
@@ -1039,6 +1151,54 @@ describe('newsRuntime', () => {
       raw_wrote_count: 0,
       storyline_write_suppressed_count: 1,
       synthesis_candidate_suppressed_count: 1,
+    }));
+
+    handle.stop();
+  });
+
+  it('simulates stale cleanup suppression across no-write ticks without mesh callbacks', async () => {
+    const storyTwo = storyBundle('story-2', { sourceCount: 2, clusterWindowEnd: 200 });
+    const storylineTwo = storylineGroup('storyline-2', ['story-2']);
+    orchestrateNewsPipelineMock
+      .mockImplementationOnce(async (_config, options) => {
+        await emitMockClusterArtifacts(options, 6, 4);
+        return batch([STORY_BUNDLE, storyTwo], [STORYLINE, storylineTwo]);
+      })
+      .mockImplementationOnce(async (_config, options) => {
+        await emitMockClusterArtifacts(options, 3, 2);
+        return batch([STORY_BUNDLE], [STORYLINE]);
+      });
+    const onTickSummary = vi.fn();
+
+    const handle = startNewsRuntime({
+      ...BASE_CONFIG,
+      noWrite: true,
+      pruneStaleBundles: true,
+      onTickSummary,
+      pollIntervalMs: 10,
+      runOnStart: false,
+    });
+
+    await vi.advanceTimersByTimeAsync(10);
+    await flushTasks();
+    expect(onTickSummary).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(10);
+    await flushTasks();
+    expect(onTickSummary).toHaveBeenCalledTimes(2);
+
+    const firstSummary = onTickSummary.mock.calls[0]?.[0];
+    const secondSummary = onTickSummary.mock.calls[1]?.[0];
+    expect(firstSummary).toEqual(expect.objectContaining({
+      raw_write_suppressed_count: 2,
+      storyline_write_suppressed_count: 2,
+      stale_story_remove_suppressed_count: 0,
+      stale_storyline_remove_suppressed_count: 0,
+    }));
+    expect(secondSummary).toEqual(expect.objectContaining({
+      raw_write_suppressed_count: 1,
+      storyline_write_suppressed_count: 1,
+      stale_story_remove_suppressed_count: 1,
+      stale_storyline_remove_suppressed_count: 1,
     }));
 
     handle.stop();

--- a/packages/ai-engine/src/newsRuntime.ts
+++ b/packages/ai-engine/src/newsRuntime.ts
@@ -479,6 +479,7 @@ export function startNewsRuntime(config: NewsRuntimeConfig): NewsRuntimeHandle {
     let watchdogTimer: ReturnType<typeof setTimeout> | null = null;
     if (tickWatchdogMs !== null) {
       watchdogTimer = setTimeout(() => {
+        /* c8 ignore next 3 -- defensive guard for a timer callback already queued as the tick completes. */
         if (!inFlight) {
           return;
         }
@@ -603,6 +604,8 @@ export function startNewsRuntime(config: NewsRuntimeConfig): NewsRuntimeHandle {
 
         if (noWrite) {
           rawWriteSuppressedCount += 1;
+          nextPublishedStoryIds.add(bundle.story_id);
+          publishedStoryIds.add(bundle.story_id);
         } else {
           rawWriteAttemptedCount += 1;
           try {
@@ -668,6 +671,8 @@ export function startNewsRuntime(config: NewsRuntimeConfig): NewsRuntimeHandle {
         for (const storyline of storylines) {
           if (noWrite) {
             storylineWriteSuppressedCount += 1;
+            nextPublishedStorylineIds.add(storyline.storyline_id);
+            publishedStorylineIds.add(storyline.storyline_id);
           } else {
             storylineWriteAttemptedCount += 1;
             try {
@@ -687,6 +692,10 @@ export function startNewsRuntime(config: NewsRuntimeConfig): NewsRuntimeHandle {
         }
       } else if (noWrite) {
         storylineWriteSuppressedCount = storylines.length;
+        for (const storyline of storylines) {
+          nextPublishedStorylineIds.add(storyline.storyline_id);
+          publishedStorylineIds.add(storyline.storyline_id);
+        }
       }
 
       let staleStorylineRemoveAttemptedCount = 0;

--- a/packages/ai-engine/src/newsRuntime.ts
+++ b/packages/ai-engine/src/newsRuntime.ts
@@ -6,6 +6,7 @@ import {
 import { buildEnrichmentWorkItems } from './newsCluster';
 import {
   orchestrateNewsPipeline,
+  type NewsOrchestratorClusterArtifacts,
   type NewsOrchestratorOptions,
 } from './newsOrchestrator';
 import {
@@ -80,14 +81,70 @@ export interface NewsRuntimeConfig {
   createAnalysisPrompt?: (bundle: StoryBundle) => string;
   createAdvancedArtifact?: (bundle: StoryBundle) => StoryAdvancedArtifact;
   onSynthesisCandidate?: (candidate: NewsRuntimeSynthesisCandidate) => void | Promise<void>;
+  onTickSummary?: (summary: NewsRuntimeTickSummary) => void | Promise<void>;
   onError?: (error: unknown) => void;
   orchestratorOptions?: NewsOrchestratorOptions;
+  noWrite?: boolean;
+  tickWatchdogMs?: number;
 }
 
 export interface NewsRuntimeHandle {
   stop(): void;
   isRunning(): boolean;
   lastRun(): Date | null;
+}
+
+export type NewsRuntimeTickStage =
+  | 'queued'
+  | 'started'
+  | 'orchestrating'
+  | 'clustered'
+  | 'writing_raw_bundles'
+  | 'writing_storylines'
+  | 'pruning_stale'
+  | 'completed'
+  | 'failed';
+
+export interface NewsRuntimeTickSummary {
+  readonly schemaVersion: 'vh-news-runtime-tick-summary-v1';
+  readonly tick_sequence: number;
+  readonly first_tick: boolean;
+  readonly status: 'completed' | 'failed';
+  readonly no_write: boolean;
+  readonly started_at: string;
+  readonly completed_at: string;
+  readonly duration_ms: number;
+  readonly poll_interval_ms: number;
+  readonly feed_source_count: number;
+  readonly ingested_item_count: number | null;
+  readonly normalized_item_count: number | null;
+  readonly clustered_bundle_count: number;
+  readonly clustered_storyline_count: number;
+  readonly selected_bundle_count: number;
+  readonly selected_singleton_bundle_count: number;
+  readonly selected_multi_source_bundle_count: number;
+  readonly publication_ineligible_bundle_count: number;
+  readonly raw_write_attempted_count: number;
+  readonly raw_write_suppressed_count: number;
+  readonly raw_wrote_count: number;
+  readonly raw_write_failed_count: number;
+  readonly storyline_write_attempted_count: number;
+  readonly storyline_write_suppressed_count: number;
+  readonly storyline_wrote_count: number;
+  readonly storyline_write_failed_count: number;
+  readonly stale_story_remove_attempted_count: number;
+  readonly stale_story_remove_suppressed_count: number;
+  readonly stale_story_removed_count: number;
+  readonly stale_story_remove_failed_count: number;
+  readonly stale_storyline_remove_attempted_count: number;
+  readonly stale_storyline_remove_suppressed_count: number;
+  readonly stale_storyline_removed_count: number;
+  readonly stale_storyline_remove_failed_count: number;
+  readonly synthesis_candidate_enqueued_count: number;
+  readonly synthesis_candidate_suppressed_count: number;
+  readonly last_stage: NewsRuntimeTickStage;
+  readonly first_selected_story_ids: readonly string[];
+  readonly error?: string;
 }
 
 function readEnvVar(name: string): string | undefined {
@@ -332,6 +389,56 @@ function runtimeTrace(event: string, detail: Record<string, unknown>): void {
   console.info(`[vh:news-runtime] ${event}`, detail);
 }
 
+function normalizeRuntimeWatchdogMs(config: NewsRuntimeConfig): number | null {
+  const configured = config.tickWatchdogMs ?? readOptionalPositiveIntEnv('VH_NEWS_RUNTIME_TICK_WATCHDOG_MS');
+  if (configured === null || configured === undefined) {
+    return null;
+  }
+  if (!Number.isFinite(configured) || configured <= 0) {
+    throw new Error('tickWatchdogMs must be a positive finite number');
+  }
+  return Math.floor(configured);
+}
+
+function summarizeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function logTickSummary(summary: NewsRuntimeTickSummary): void {
+  const logger = summary.status === 'failed' ? console.warn : console.info;
+  logger('[vh:news-runtime] tick summary', summary);
+
+  if (!summary.first_tick) {
+    return;
+  }
+
+  const firstTickLogger =
+    summary.status === 'failed'
+    || summary.selected_bundle_count === 0
+    || (!summary.no_write && summary.raw_wrote_count === 0)
+      ? console.warn
+      : console.info;
+  firstTickLogger('[vh:news-runtime] first tick outcome', summary);
+}
+
+async function emitTickSummary(
+  summary: NewsRuntimeTickSummary,
+  onTickSummary: NewsRuntimeConfig['onTickSummary'],
+): Promise<void> {
+  logTickSummary(summary);
+  if (!onTickSummary) {
+    return;
+  }
+  try {
+    await Promise.resolve(onTickSummary(summary));
+  } catch (error) {
+    console.warn('[vh:news-runtime] tick summary artifact callback failed', {
+      tick_sequence: summary.tick_sequence,
+      error: summarizeError(error),
+    });
+  }
+}
+
 function trustsClusterOutputForPublication(config: NewsRuntimeConfig): boolean {
   return config.orchestratorOptions?.productionMode === true
     && config.orchestratorOptions.allowHeuristicFallback === false;
@@ -342,11 +449,14 @@ export function startNewsRuntime(config: NewsRuntimeConfig): NewsRuntimeHandle {
   const maxPublishedBundles = resolveMaxPublishedBundles(config);
   const pruneStaleBundles = resolvePruneStaleBundles(config);
   const shouldRun = config.enabled ?? isNewsRuntimeEnabled();
+  const noWrite = config.noWrite === true;
+  const tickWatchdogMs = normalizeRuntimeWatchdogMs(config);
 
   let timer: ReturnType<typeof setInterval> | null = null;
   let running = false;
   let inFlight = false;
   let lastRunAt: Date | null = null;
+  let tickSequence = 0;
   let publishedStoryIds = new Set<string>();
   let publishedStorylineIds = new Set<string>();
 
@@ -360,19 +470,86 @@ export function startNewsRuntime(config: NewsRuntimeConfig): NewsRuntimeHandle {
     }
 
     inFlight = true;
+    tickSequence += 1;
+    const currentTickSequence = tickSequence;
+    const firstTick = currentTickSequence === 1;
     const startedAt = Date.now();
+    let lastStage: NewsRuntimeTickStage = 'started';
+    let latestClusterArtifacts: NewsOrchestratorClusterArtifacts | null = null;
+    let watchdogTimer: ReturnType<typeof setTimeout> | null = null;
+    if (tickWatchdogMs !== null) {
+      watchdogTimer = setTimeout(() => {
+        if (!inFlight) {
+          return;
+        }
+        console.warn('[vh:news-runtime] tick watchdog warning', {
+          tick_sequence: currentTickSequence,
+          first_tick: firstTick,
+          elapsed_ms: Math.max(0, Date.now() - startedAt),
+          threshold_ms: tickWatchdogMs,
+          last_stage: lastStage,
+          poll_interval_ms: pollIntervalMs,
+        });
+      }, tickWatchdogMs);
+    }
     runtimeTrace('tick_started', {
       poll_interval_ms: pollIntervalMs,
       feed_source_count: config.feedSources.length,
     });
 
+    const baseSummary = (): Omit<NewsRuntimeTickSummary, 'status' | 'completed_at' | 'duration_ms' | 'last_stage'> => ({
+      schemaVersion: 'vh-news-runtime-tick-summary-v1',
+      tick_sequence: currentTickSequence,
+      first_tick: firstTick,
+      no_write: noWrite,
+      started_at: new Date(startedAt).toISOString(),
+      poll_interval_ms: pollIntervalMs,
+      feed_source_count: config.feedSources.length,
+      ingested_item_count: latestClusterArtifacts?.rawItemCount ?? null,
+      normalized_item_count: latestClusterArtifacts?.normalizedItems.length ?? null,
+      clustered_bundle_count: 0,
+      clustered_storyline_count: 0,
+      selected_bundle_count: 0,
+      selected_singleton_bundle_count: 0,
+      selected_multi_source_bundle_count: 0,
+      publication_ineligible_bundle_count: 0,
+      raw_write_attempted_count: 0,
+      raw_write_suppressed_count: 0,
+      raw_wrote_count: 0,
+      raw_write_failed_count: 0,
+      storyline_write_attempted_count: 0,
+      storyline_write_suppressed_count: 0,
+      storyline_wrote_count: 0,
+      storyline_write_failed_count: 0,
+      stale_story_remove_attempted_count: 0,
+      stale_story_remove_suppressed_count: 0,
+      stale_story_removed_count: 0,
+      stale_story_remove_failed_count: 0,
+      stale_storyline_remove_attempted_count: 0,
+      stale_storyline_remove_suppressed_count: 0,
+      stale_storyline_removed_count: 0,
+      stale_storyline_remove_failed_count: 0,
+      synthesis_candidate_enqueued_count: 0,
+      synthesis_candidate_suppressed_count: 0,
+      first_selected_story_ids: [],
+    });
+
     try {
+      const orchestratorOptions: NewsOrchestratorOptions = {
+        ...(config.orchestratorOptions ?? {}),
+      };
+      const existingClusterArtifactsHook = orchestratorOptions.onClusterArtifacts;
+      orchestratorOptions.onClusterArtifacts = async (artifacts) => {
+        latestClusterArtifacts = artifacts;
+        await existingClusterArtifactsHook?.(artifacts);
+      };
+      lastStage = 'orchestrating';
       const result = await orchestrateNewsPipeline(
         {
           feedSources: config.feedSources,
           topicMapping: config.topicMapping,
         },
-        config.orchestratorOptions,
+        orchestratorOptions,
       );
       const { bundles, storylines } = result;
       const trustClusterOutput = trustsClusterOutputForPublication(config);
@@ -382,6 +559,7 @@ export function startNewsRuntime(config: NewsRuntimeConfig): NewsRuntimeHandle {
       const publicationEligibleBundleCount = trustClusterOutput
         ? bundles.length
         : bundles.filter(isPublicationEligibleBundle).length;
+      lastStage = 'clustered';
       runtimeTrace('tick_clustered', {
         bundle_count: bundles.length,
         storyline_count: storylines.length,
@@ -398,7 +576,7 @@ export function startNewsRuntime(config: NewsRuntimeConfig): NewsRuntimeHandle {
       });
 
       const writeStoryBundle = config.writeStoryBundle;
-      if (!writeStoryBundle) {
+      if (!writeStoryBundle && !noWrite) {
         throw new Error('writeStoryBundle adapter is required');
       }
       const removeStoryBundle = config.removeStoryBundle;
@@ -411,26 +589,38 @@ export function startNewsRuntime(config: NewsRuntimeConfig): NewsRuntimeHandle {
 
       const nextPublishedStoryIds = new Set<string>();
       const nextPublishedStorylineIds = new Set<string>();
+      let rawWriteAttemptedCount = 0;
+      let rawWriteSuppressedCount = 0;
+      let rawWroteCount = 0;
       let failedStoryPublishCount = 0;
+      let synthesisCandidateEnqueuedCount = 0;
+      let synthesisCandidateSuppressedCount = 0;
 
+      lastStage = 'writing_raw_bundles';
       for (const bundle of bundlesToPublish) {
         const request = buildRemoteRequest(createPrompt(bundle));
         const workItems = buildEnrichmentWorkItems(bundle);
 
-        try {
-          await writeStoryBundle(config.gunClient, bundle);
-        } catch (error) {
-          failedStoryPublishCount += 1;
-          runtimeTrace('bundle_write_failed', {
-            story_id: bundle.story_id,
-            source_count: canonicalSourceCount(bundle),
-            error: error instanceof Error ? error.message : String(error),
-          });
-          config.onError?.(error);
-          continue;
+        if (noWrite) {
+          rawWriteSuppressedCount += 1;
+        } else {
+          rawWriteAttemptedCount += 1;
+          try {
+            await writeStoryBundle!(config.gunClient, bundle);
+            rawWroteCount += 1;
+          } catch (error) {
+            failedStoryPublishCount += 1;
+            runtimeTrace('bundle_write_failed', {
+              story_id: bundle.story_id,
+              source_count: canonicalSourceCount(bundle),
+              error: summarizeError(error),
+            });
+            config.onError?.(error);
+            continue;
+          }
+          nextPublishedStoryIds.add(bundle.story_id);
+          publishedStoryIds.add(bundle.story_id);
         }
-        nextPublishedStoryIds.add(bundle.story_id);
-        publishedStoryIds.add(bundle.story_id);
 
         let advancedArtifact: StoryAdvancedArtifact | undefined;
         try {
@@ -439,7 +629,7 @@ export function startNewsRuntime(config: NewsRuntimeConfig): NewsRuntimeHandle {
           config.onError?.(error);
         }
 
-        if (config.onSynthesisCandidate && workItems.length > 0) {
+        if (workItems.length > 0) {
           const candidate: NewsRuntimeSynthesisCandidate = {
             story_id: bundle.story_id,
             provider: {
@@ -452,57 +642,109 @@ export function startNewsRuntime(config: NewsRuntimeConfig): NewsRuntimeHandle {
             advanced_artifact: advancedArtifact,
           };
 
-          void Promise.resolve(config.onSynthesisCandidate(candidate)).catch((error) => {
-            config.onError?.(error);
-          });
+          if (noWrite || !config.onSynthesisCandidate) {
+            synthesisCandidateSuppressedCount += 1;
+          } else {
+            synthesisCandidateEnqueuedCount += 1;
+            void Promise.resolve(config.onSynthesisCandidate(candidate)).catch((error) => {
+              config.onError?.(error);
+            });
+          }
         }
       }
 
-      if (bundlesToPublish.length > 0 && nextPublishedStoryIds.size === 0 && failedStoryPublishCount > 0) {
+      if (!noWrite && bundlesToPublish.length > 0 && nextPublishedStoryIds.size === 0 && failedStoryPublishCount > 0) {
         throw new Error(
           `news runtime failed to publish any selected bundles (${failedStoryPublishCount}/${bundlesToPublish.length} failed)`,
         );
       }
 
+      let storylineWriteAttemptedCount = 0;
+      let storylineWriteSuppressedCount = 0;
+      let storylineWroteCount = 0;
+      let storylineWriteFailedCount = 0;
       if (writeStorylineGroup) {
+        lastStage = 'writing_storylines';
         for (const storyline of storylines) {
-          try {
-            await writeStorylineGroup(config.gunClient, storyline);
-            nextPublishedStorylineIds.add(storyline.storyline_id);
-            publishedStorylineIds.add(storyline.storyline_id);
-          } catch (error) {
-            runtimeTrace('storyline_write_failed', {
-              storyline_id: storyline.storyline_id,
-              error: error instanceof Error ? error.message : String(error),
-            });
-            config.onError?.(error);
+          if (noWrite) {
+            storylineWriteSuppressedCount += 1;
+          } else {
+            storylineWriteAttemptedCount += 1;
+            try {
+              await writeStorylineGroup(config.gunClient, storyline);
+              storylineWroteCount += 1;
+              nextPublishedStorylineIds.add(storyline.storyline_id);
+              publishedStorylineIds.add(storyline.storyline_id);
+            } catch (error) {
+              storylineWriteFailedCount += 1;
+              runtimeTrace('storyline_write_failed', {
+                storyline_id: storyline.storyline_id,
+                error: summarizeError(error),
+              });
+              config.onError?.(error);
+            }
           }
         }
+      } else if (noWrite) {
+        storylineWriteSuppressedCount = storylines.length;
       }
 
-      if (pruneStaleBundles && removeStorylineGroup && bundlesToPublish.length > 0) {
+      let staleStorylineRemoveAttemptedCount = 0;
+      let staleStorylineRemoveSuppressedCount = 0;
+      let staleStorylineRemovedCount = 0;
+      let staleStorylineRemoveFailedCount = 0;
+      if (pruneStaleBundles && (removeStorylineGroup || noWrite) && bundlesToPublish.length > 0) {
+        lastStage = 'pruning_stale';
         const staleStorylineIds = [...publishedStorylineIds]
           .filter((storylineId) => !nextPublishedStorylineIds.has(storylineId))
           .sort();
 
         for (const staleStorylineId of staleStorylineIds) {
-          await removeStorylineGroup(config.gunClient, staleStorylineId);
-          publishedStorylineIds.delete(staleStorylineId);
+          if (noWrite) {
+            staleStorylineRemoveSuppressedCount += 1;
+          } else {
+            staleStorylineRemoveAttemptedCount += 1;
+            try {
+              await removeStorylineGroup!(config.gunClient, staleStorylineId);
+              staleStorylineRemovedCount += 1;
+              publishedStorylineIds.delete(staleStorylineId);
+            } catch (error) {
+              staleStorylineRemoveFailedCount += 1;
+              config.onError?.(error);
+            }
+          }
         }
       }
 
-      if (pruneStaleBundles && removeStoryBundle && nextPublishedStoryIds.size > 0) {
+      let staleStoryRemoveAttemptedCount = 0;
+      let staleStoryRemoveSuppressedCount = 0;
+      let staleStoryRemovedCount = 0;
+      let staleStoryRemoveFailedCount = 0;
+      if (pruneStaleBundles && (removeStoryBundle || noWrite) && (nextPublishedStoryIds.size > 0 || noWrite)) {
+        lastStage = 'pruning_stale';
         const staleStoryIds = [...publishedStoryIds]
           .filter((storyId) => !nextPublishedStoryIds.has(storyId))
           .sort();
 
         for (const staleStoryId of staleStoryIds) {
-          await removeStoryBundle(config.gunClient, staleStoryId);
-          publishedStoryIds.delete(staleStoryId);
+          if (noWrite) {
+            staleStoryRemoveSuppressedCount += 1;
+          } else {
+            staleStoryRemoveAttemptedCount += 1;
+            try {
+              await removeStoryBundle!(config.gunClient, staleStoryId);
+              staleStoryRemovedCount += 1;
+              publishedStoryIds.delete(staleStoryId);
+            } catch (error) {
+              staleStoryRemoveFailedCount += 1;
+              config.onError?.(error);
+            }
+          }
         }
       }
 
       lastRunAt = new Date();
+      lastStage = 'completed';
       runtimeTrace('tick_completed', {
         duration_ms: Math.max(0, Date.now() - startedAt),
         selected_story_count: bundlesToPublish.length,
@@ -510,13 +752,62 @@ export function startNewsRuntime(config: NewsRuntimeConfig): NewsRuntimeHandle {
         failed_story_count: failedStoryPublishCount,
         published_storyline_count: nextPublishedStorylineIds.size,
       });
+      const clusterArtifactsSnapshot = latestClusterArtifacts as NewsOrchestratorClusterArtifacts | null;
+      await emitTickSummary({
+        ...baseSummary(),
+        status: 'completed',
+        completed_at: new Date().toISOString(),
+        duration_ms: Math.max(0, Date.now() - startedAt),
+        ingested_item_count: clusterArtifactsSnapshot?.rawItemCount ?? null,
+        normalized_item_count: clusterArtifactsSnapshot?.normalizedItems.length ?? null,
+        clustered_bundle_count: bundles.length,
+        clustered_storyline_count: storylines.length,
+        selected_bundle_count: bundlesToPublish.length,
+        selected_singleton_bundle_count: bundlesToPublish
+          .filter((bundle) => canonicalSourceCount(bundle) === 1).length,
+        selected_multi_source_bundle_count: bundlesToPublish
+          .filter((bundle) => canonicalSourceCount(bundle) > 1).length,
+        publication_ineligible_bundle_count: bundles.length - publicationEligibleBundleCount,
+        raw_write_attempted_count: rawWriteAttemptedCount,
+        raw_write_suppressed_count: rawWriteSuppressedCount,
+        raw_wrote_count: rawWroteCount,
+        raw_write_failed_count: failedStoryPublishCount,
+        storyline_write_attempted_count: storylineWriteAttemptedCount,
+        storyline_write_suppressed_count: storylineWriteSuppressedCount,
+        storyline_wrote_count: storylineWroteCount,
+        storyline_write_failed_count: storylineWriteFailedCount,
+        stale_story_remove_attempted_count: staleStoryRemoveAttemptedCount,
+        stale_story_remove_suppressed_count: staleStoryRemoveSuppressedCount,
+        stale_story_removed_count: staleStoryRemovedCount,
+        stale_story_remove_failed_count: staleStoryRemoveFailedCount,
+        stale_storyline_remove_attempted_count: staleStorylineRemoveAttemptedCount,
+        stale_storyline_remove_suppressed_count: staleStorylineRemoveSuppressedCount,
+        stale_storyline_removed_count: staleStorylineRemovedCount,
+        stale_storyline_remove_failed_count: staleStorylineRemoveFailedCount,
+        synthesis_candidate_enqueued_count: synthesisCandidateEnqueuedCount,
+        synthesis_candidate_suppressed_count: synthesisCandidateSuppressedCount,
+        first_selected_story_ids: bundlesToPublish.slice(0, 10).map((bundle) => bundle.story_id),
+        last_stage: lastStage,
+      }, config.onTickSummary);
     } catch (error) {
+      lastStage = 'failed';
       runtimeTrace('tick_failed', {
         duration_ms: Math.max(0, Date.now() - startedAt),
-        error: error instanceof Error ? error.message : String(error),
+        error: summarizeError(error),
       });
+      await emitTickSummary({
+        ...baseSummary(),
+        status: 'failed',
+        completed_at: new Date().toISOString(),
+        duration_ms: Math.max(0, Date.now() - startedAt),
+        last_stage: lastStage,
+        error: summarizeError(error),
+      }, config.onTickSummary);
       config.onError?.(error);
     } finally {
+      if (watchdogTimer !== null) {
+        clearTimeout(watchdogTimer);
+      }
       inFlight = false;
     }
   };
@@ -541,8 +832,10 @@ export function startNewsRuntime(config: NewsRuntimeConfig): NewsRuntimeHandle {
   }, pollIntervalMs);
 
   if (config.runOnStart !== false) {
+    const queuedStage: NewsRuntimeTickStage = 'queued';
     runtimeTrace('tick_queued_immediate', {
       poll_interval_ms: pollIntervalMs,
+      last_stage: queuedStage,
     });
     void runTick();
   }

--- a/services/news-aggregator/src/clusterCapturePersistence.test.ts
+++ b/services/news-aggregator/src/clusterCapturePersistence.test.ts
@@ -19,6 +19,7 @@ function makeArtifacts(overrides: Partial<{
   return {
     schemaVersion: 'news-orchestrator-cluster-artifacts-v1' as const,
     generatedAt: '2026-03-24T00:00:00.000Z',
+    rawItemCount: 1,
     normalizedItems: [
       {
         sourceId,

--- a/services/news-aggregator/src/daemon.test.ts
+++ b/services/news-aggregator/src/daemon.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import type { NewsRuntimeConfig, NewsRuntimeSynthesisCandidate } from '@vh/ai-engine';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type { NewsRuntimeConfig, NewsRuntimeSynthesisCandidate, NewsRuntimeTickSummary } from '@vh/ai-engine';
 import type { NewsIngestionLease, VennClient } from '@vh/gun-client';
 import { createNewsAggregatorDaemon, __internal } from './daemon';
 
@@ -87,6 +90,50 @@ function makeTimerControls() {
   const clearIntervalFn = vi.fn((() => undefined) as typeof clearInterval);
 
   return { ticks, setIntervalFn, clearIntervalFn };
+}
+
+function makeTickSummary(overrides: Partial<NewsRuntimeTickSummary> = {}): NewsRuntimeTickSummary {
+  return {
+    schemaVersion: 'vh-news-runtime-tick-summary-v1',
+    tick_sequence: 1,
+    first_tick: true,
+    status: 'completed',
+    no_write: false,
+    started_at: new Date(1_700_000_000_000).toISOString(),
+    completed_at: new Date(1_700_000_001_000).toISOString(),
+    duration_ms: 1_000,
+    poll_interval_ms: 60_000,
+    feed_source_count: 1,
+    ingested_item_count: 3,
+    normalized_item_count: 2,
+    clustered_bundle_count: 1,
+    clustered_storyline_count: 0,
+    selected_bundle_count: 1,
+    selected_singleton_bundle_count: 1,
+    selected_multi_source_bundle_count: 0,
+    publication_ineligible_bundle_count: 0,
+    raw_write_attempted_count: 1,
+    raw_write_suppressed_count: 0,
+    raw_wrote_count: 1,
+    raw_write_failed_count: 0,
+    storyline_write_attempted_count: 0,
+    storyline_write_suppressed_count: 0,
+    storyline_wrote_count: 0,
+    storyline_write_failed_count: 0,
+    stale_story_remove_attempted_count: 0,
+    stale_story_remove_suppressed_count: 0,
+    stale_story_removed_count: 0,
+    stale_story_remove_failed_count: 0,
+    stale_storyline_remove_attempted_count: 0,
+    stale_storyline_remove_suppressed_count: 0,
+    stale_storyline_removed_count: 0,
+    stale_storyline_remove_failed_count: 0,
+    synthesis_candidate_enqueued_count: 1,
+    synthesis_candidate_suppressed_count: 0,
+    last_stage: 'completed',
+    first_selected_story_ids: ['story-1'],
+    ...overrides,
+  };
 }
 
 describe('news aggregator daemon', () => {
@@ -380,6 +427,93 @@ describe('news aggregator daemon', () => {
     });
 
     await daemon.stop();
+  });
+
+  it('runs no-write diagnostics without lease writes, mutation workers, or queue persistence', async () => {
+    const tmpDir = mkdtempSync(path.join(os.tmpdir(), 'vh-news-runtime-diagnostics-'));
+    vi.stubEnv('VH_DAEMON_FEED_ARTIFACT_ROOT', tmpDir);
+    const logger = makeLogger();
+    const runtimeHandle = makeRuntimeHandle();
+    const timers = makeTimerControls();
+    const replayAcceptedSynthesis = vi.fn().mockResolvedValue({ written: 1 });
+    const reconcileProductFeed = vi.fn().mockResolvedValue({ repaired_latest_index: 1 });
+    const collectPendingSynthesisCandidates = vi.fn().mockResolvedValue({
+      scanned: 1,
+      enqueued: 1,
+      skipped: 0,
+      staleInProgress: 0,
+      bootstrappedMissingLifecycle: 0,
+      acceptedMissingSynthesis: 0,
+      candidates: [{ story: { story_id: CANDIDATE.story_id }, lifecycle: { status: 'pending' }, candidate: CANDIDATE }],
+    });
+    const enrichmentWorker = vi.fn().mockResolvedValue(undefined);
+
+    try {
+      const startRuntime = vi.fn(() => runtimeHandle);
+      const readLease = vi.fn().mockResolvedValue(null);
+      const writeLease = vi.fn(async (_client: VennClient, lease: unknown) => lease as NewsIngestionLease);
+      const writeBundle = vi.fn().mockResolvedValue(undefined);
+      const client = { id: 'client-no-write' } as VennClient;
+
+      const daemon = createNewsAggregatorDaemon({
+        client,
+        feedSources: [...FEED_SOURCES],
+        topicMapping: { ...TOPIC_MAPPING },
+        startRuntime,
+        readLease,
+        writeLease,
+        writeBundle,
+        replayAcceptedSynthesis,
+        reconcileProductFeed,
+        collectPendingSynthesisCandidates,
+        enrichmentWorker,
+        noWrite: true,
+        logger,
+        setIntervalFn: timers.setIntervalFn,
+        clearIntervalFn: timers.clearIntervalFn,
+        now: () => 1_700_000_000_000,
+        random: () => 0.12345,
+        leaseHolderId: 'vh-news-daemon:test',
+      });
+
+      await daemon.start();
+
+      expect(readLease).toHaveBeenCalledTimes(1);
+      expect(writeLease).not.toHaveBeenCalled();
+      expect(replayAcceptedSynthesis).not.toHaveBeenCalled();
+      expect(reconcileProductFeed).not.toHaveBeenCalled();
+      expect(collectPendingSynthesisCandidates).not.toHaveBeenCalled();
+      expect(startRuntime).toHaveBeenCalledTimes(1);
+
+      const runtimeConfig = startRuntime.mock.calls[0]?.[0] as NewsRuntimeConfig;
+      expect(runtimeConfig.noWrite).toBe(true);
+      runtimeConfig.onSynthesisCandidate?.(CANDIDATE);
+      await Promise.resolve();
+      expect(enrichmentWorker).not.toHaveBeenCalled();
+
+      await runtimeConfig.onTickSummary?.(makeTickSummary({
+        no_write: true,
+        raw_write_attempted_count: 0,
+        raw_write_suppressed_count: 1,
+        raw_wrote_count: 0,
+        synthesis_candidate_enqueued_count: 0,
+        synthesis_candidate_suppressed_count: 1,
+      }));
+      const artifactPath = path.join(tmpDir, 'news-runtime-diagnostics.json');
+      expect(existsSync(artifactPath)).toBe(true);
+      const artifact = JSON.parse(readFileSync(artifactPath, 'utf8')) as {
+        schemaVersion: string;
+        noWrite: boolean;
+        latest: NewsRuntimeTickSummary;
+      };
+      expect(artifact.schemaVersion).toBe('vh-news-runtime-diagnostics-v1');
+      expect(artifact.noWrite).toBe(true);
+      expect(artifact.latest.raw_write_suppressed_count).toBe(1);
+
+      await daemon.stop();
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 
   it('refuses publish writes when daemon lease is no longer held', async () => {

--- a/services/news-aggregator/src/daemon.ts
+++ b/services/news-aggregator/src/daemon.ts
@@ -6,6 +6,7 @@ import {
   type FeedSource,
   type NewsRuntimeConfig,
   type NewsRuntimeHandle,
+  type NewsRuntimeTickSummary,
   type TopicMapping,
 } from '@vh/ai-engine';
 import {
@@ -45,6 +46,7 @@ import {
 } from './daemonUtils';
 import { createLeaseGuard } from './leaseGuard';
 import { createDaemonFeedClusterCaptureRecorder } from './clusterCapturePersistence';
+import { createRuntimeDiagnosticRecorder } from './runtimeDiagnostics';
 import {
   createBundleSynthesisEnrichmentFromEnv,
   isTruthyFlag,
@@ -110,6 +112,8 @@ export interface NewsAggregatorDaemonConfig {
   synthesisCatchupSampleLimit?: number;
   synthesisInProgressStaleMs?: number;
   runtimeOrchestratorOptions?: NewsRuntimeConfig['orchestratorOptions'];
+  noWrite?: boolean;
+  runtimeTickWatchdogMs?: number;
   now?: () => number;
   random?: () => number;
   setIntervalFn?: typeof setInterval;
@@ -142,6 +146,7 @@ export function createNewsAggregatorDaemon(config: NewsAggregatorDaemonConfig): 
   const leaseRenewIntervalMs = Math.max(5_000, Math.floor(leaseTtlMs / 2));
   const leaseVerificationWindowMs = Math.max(500, Math.min(5_000, Math.floor(leaseTtlMs / 6)));
   const holderId = resolveLeaseHolderId(config.leaseHolderId);
+  const noWrite = config.noWrite === true;
   const writeLanes = config.writeLanes ?? createDaemonWriteLaneRegistry({ logger, now: nowFn });
   const queue = createAsyncEnrichmentQueue(
     config.enrichmentWorker ?? (() => undefined),
@@ -154,6 +159,10 @@ export function createNewsAggregatorDaemon(config: NewsAggregatorDaemonConfig): 
   const clusterCaptureRecorder = createDaemonFeedClusterCaptureRecorder(
     readEnvVar('VH_DAEMON_FEED_RUN_ID'),
   );
+  const runtimeDiagnosticRecorder = createRuntimeDiagnosticRecorder({
+    runId: readEnvVar('VH_DAEMON_FEED_RUN_ID'),
+    noWrite,
+  });
   let running = false;
   let runtimeHandle: NewsRuntimeHandle | null = null;
   let leaseHeartbeatTimer: ReturnType<typeof setInterval> | null = null;
@@ -221,8 +230,28 @@ export function createNewsAggregatorDaemon(config: NewsAggregatorDaemonConfig): 
       topicMapping: config.topicMapping,
       gunClient: config.client,
       pollIntervalMs: config.pollIntervalMs,
+      noWrite,
+      tickWatchdogMs: config.runtimeTickWatchdogMs,
+      async onTickSummary(summary: NewsRuntimeTickSummary) {
+        const snapshot = await runtimeDiagnosticRecorder(summary);
+        logger.info('[vh:news-daemon] runtime diagnostic artifact written', {
+          holder_id: holderId,
+          tick_sequence: summary.tick_sequence,
+          status: summary.status,
+          no_write: summary.no_write,
+          raw_wrote_count: summary.raw_wrote_count,
+          selected_bundle_count: summary.selected_bundle_count,
+          diagnostic_summary_count: snapshot.summaries.length,
+        });
+      },
       writeStoryBundle: async (runtimeClient: unknown, bundle: unknown) => {
         const storyId = typeof bundle === 'object' && bundle !== null ? (bundle as { story_id?: unknown }).story_id : null;
+        if (noWrite) {
+          logger.info('[vh:news-daemon] no-write raw bundle write suppressed', {
+            story_id: storyId ?? null,
+          });
+          return bundle;
+        }
         await leaseGuard.assertHeld(nowFn());
         return writeLanes.run('news_bundle', { story_id: storyId ?? null }, async () => {
           const written = await writeBundle(runtimeClient as VennClient, bundle);
@@ -263,6 +292,10 @@ export function createNewsAggregatorDaemon(config: NewsAggregatorDaemonConfig): 
         });
       },
       removeStoryBundle: async (runtimeClient: unknown, storyId: string) => {
+        if (noWrite) {
+          logger.info('[vh:news-daemon] no-write raw bundle remove suppressed', { story_id: storyId });
+          return undefined;
+        }
         await leaseGuard.assertHeld(nowFn());
         return writeLanes.run('news_bundle_remove', { story_id: storyId }, async () => {
           return removeBundle(runtimeClient as VennClient, storyId);
@@ -273,18 +306,37 @@ export function createNewsAggregatorDaemon(config: NewsAggregatorDaemonConfig): 
           typeof storyline === 'object' && storyline !== null
             ? (storyline as { storyline_id?: unknown }).storyline_id
             : null;
+        if (noWrite) {
+          logger.info('[vh:news-daemon] no-write storyline write suppressed', {
+            storyline_id: storylineId ?? null,
+          });
+          return storyline;
+        }
         await leaseGuard.assertHeld(nowFn());
         return writeLanes.run('storyline', { storyline_id: storylineId ?? null }, async () => {
           return writeNewsStoryline(runtimeClient as VennClient, storyline);
         });
       },
       removeStorylineGroup: async (runtimeClient: unknown, storylineId: string) => {
+        if (noWrite) {
+          logger.info('[vh:news-daemon] no-write storyline remove suppressed', {
+            storyline_id: storylineId,
+          });
+          return undefined;
+        }
         await leaseGuard.assertHeld(nowFn());
         return writeLanes.run('storyline_remove', { storyline_id: storylineId }, async () => {
           return removeNewsStoryline(runtimeClient as VennClient, storylineId);
         });
       },
       onSynthesisCandidate(candidate) {
+        if (noWrite) {
+          logger.info('[vh:news-daemon] no-write synthesis candidate suppressed', {
+            story_id: candidate.story_id,
+            work_item_count: candidate.work_items.length,
+          });
+          return;
+        }
         queue.enqueue(candidate);
         logger.info('[vh:news-daemon] enrichment candidate enqueued', {
           story_id: candidate.story_id,
@@ -321,10 +373,28 @@ export function createNewsAggregatorDaemon(config: NewsAggregatorDaemonConfig): 
       now_ms: nowMs,
     });
     if (currentLease && currentLease.holder_id !== holderId && currentLease.expires_at > nowMs) {
+      if (noWrite) {
+        logger.warn('[vh:news-daemon] no-write diagnostic observed active writer lease; continuing without writes', {
+          holder_id: holderId,
+          observed_lease_holder_id: currentLease.holder_id,
+          observed_lease_expires_at: currentLease.expires_at,
+        });
+        startRuntimeIfNeeded();
+        return;
+      }
       logger.warn('[vh:news-daemon] lease held by another writer; runtime stays stopped', { holder_id: holderId, observed_lease_holder_id: currentLease.holder_id, observed_lease_expires_at: currentLease.expires_at });
       leaseGuard.clear();
       queue.pause();
       stopRuntime();
+      return;
+    }
+    if (noWrite) {
+      logger.warn('[vh:news-daemon] no-write diagnostic mode active; skipping lease heartbeat and mutation workers', {
+        holder_id: holderId,
+        observed_lease_holder_id: currentLease?.holder_id ?? null,
+        observed_lease_expires_at: currentLease?.expires_at ?? null,
+      });
+      startRuntimeIfNeeded();
       return;
     }
     const nextLease = buildLeasePayload(
@@ -413,6 +483,10 @@ export function createNewsAggregatorDaemon(config: NewsAggregatorDaemonConfig): 
     });
   };
   const releaseLease = async (): Promise<void> => {
+    if (noWrite) {
+      leaseGuard.clear();
+      return;
+    }
     const nowMs = nowFn();
     const releaseLease = leaseGuard.releasePayload(nowMs);
     if (!releaseLease) {
@@ -497,6 +571,11 @@ function isDisabledFlag(value: string | undefined): boolean {
   return normalized === '0' || normalized === 'false' || normalized === 'off' || normalized === 'no';
 }
 
+function isEnabledFlag(value: string | undefined): boolean {
+  const normalized = value?.trim().toLowerCase();
+  return normalized === '1' || normalized === 'true' || normalized === 'yes' || normalized === 'on';
+}
+
 function safePathToken(value: string): string {
   return value.trim().replace(/[^a-zA-Z0-9._:-]+/g, '_') || 'default';
 }
@@ -535,6 +614,9 @@ export async function startNewsAggregatorDaemonFromEnv(): Promise<NewsAggregator
     });
   }
   const holderId = readEnvVar('VH_NEWS_DAEMON_HOLDER_ID');
+  const noWrite = isEnabledFlag(readEnvVar('VH_NEWS_DAEMON_DIAGNOSTIC_NO_WRITE'))
+    || isEnabledFlag(readEnvVar('VH_NEWS_DAEMON_NO_WRITE'));
+  const runtimeTickWatchdogMs = parseOptionalPositiveInt(readEnvVar('VH_NEWS_RUNTIME_TICK_WATCHDOG_MS'));
   const leaseScope = firstNonEmpty(readEnvVar('VH_NEWS_INGESTION_LEASE_SCOPE'));
   const gunRadisk = !isDisabledFlag(readEnvVar('VH_NEWS_DAEMON_GUN_RADISK'));
   const gunFile = gunRadisk
@@ -553,9 +635,14 @@ export async function startNewsAggregatorDaemonFromEnv(): Promise<NewsAggregator
     ...(leaseScope ? { newsIngestionLeaseScope: leaseScope } : {}),
     ...systemWriterConfig,
   });
-  const bundleSynthesisEnrichment = createBundleSynthesisEnrichmentFromEnv(client, console, {
-    runWrite: writeLanes.run,
-  });
+  const bundleSynthesisEnrichment = noWrite
+    ? {}
+    : createBundleSynthesisEnrichmentFromEnv(client, console, {
+        runWrite: writeLanes.run,
+      });
+  if (noWrite) {
+    console.warn('[vh:news-daemon] no-write diagnostic mode enabled; all mesh mutations are suppressed');
+  }
   const replayArtifactDir = resolveAnalysisEvalReplayArtifactDirFromEnv();
   const daemon = createNewsAggregatorDaemon({
     client,
@@ -565,7 +652,9 @@ export async function startNewsAggregatorDaemonFromEnv(): Promise<NewsAggregator
     leaseTtlMs,
     leaseHolderId: holderId,
     writeLanes,
-    replayAcceptedSynthesis: replayArtifactDir
+    noWrite,
+    runtimeTickWatchdogMs,
+    replayAcceptedSynthesis: !noWrite && replayArtifactDir
       ? (runtimeClient) =>
           replayAcceptedAnalysisEvalSyntheses({
             client: runtimeClient,
@@ -615,4 +704,5 @@ export const __internal = {
   startNewsAggregatorDaemonFromEnv,
   verifyStoryClusterHealth,
   isTruthyFlag,
+  isEnabledFlag,
 };

--- a/services/news-aggregator/src/runtimeDiagnostics.test.ts
+++ b/services/news-aggregator/src/runtimeDiagnostics.test.ts
@@ -1,0 +1,84 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import type { NewsRuntimeTickSummary } from '@vh/ai-engine';
+import { createRuntimeDiagnosticRecorder, resolveRuntimeDiagnosticsPath } from './runtimeDiagnostics';
+
+function summary(tickSequence: number): NewsRuntimeTickSummary {
+  return {
+    schemaVersion: 'vh-news-runtime-tick-summary-v1',
+    tick_sequence: tickSequence,
+    first_tick: tickSequence === 1,
+    status: 'completed',
+    no_write: true,
+    started_at: new Date(1_700_000_000_000 + tickSequence).toISOString(),
+    completed_at: new Date(1_700_000_001_000 + tickSequence).toISOString(),
+    duration_ms: 1_000,
+    poll_interval_ms: 60_000,
+    feed_source_count: 1,
+    ingested_item_count: 3,
+    normalized_item_count: 2,
+    clustered_bundle_count: 1,
+    clustered_storyline_count: 0,
+    selected_bundle_count: 1,
+    selected_singleton_bundle_count: 1,
+    selected_multi_source_bundle_count: 0,
+    publication_ineligible_bundle_count: 0,
+    raw_write_attempted_count: 0,
+    raw_write_suppressed_count: 1,
+    raw_wrote_count: 0,
+    raw_write_failed_count: 0,
+    storyline_write_attempted_count: 0,
+    storyline_write_suppressed_count: 0,
+    storyline_wrote_count: 0,
+    storyline_write_failed_count: 0,
+    stale_story_remove_attempted_count: 0,
+    stale_story_remove_suppressed_count: 0,
+    stale_story_removed_count: 0,
+    stale_story_remove_failed_count: 0,
+    stale_storyline_remove_attempted_count: 0,
+    stale_storyline_remove_suppressed_count: 0,
+    stale_storyline_removed_count: 0,
+    stale_storyline_remove_failed_count: 0,
+    synthesis_candidate_enqueued_count: 0,
+    synthesis_candidate_suppressed_count: 1,
+    last_stage: 'completed',
+    first_selected_story_ids: ['story-1'],
+  };
+}
+
+describe('runtime diagnostics recorder', () => {
+  it('writes a bounded atomic diagnostic snapshot', async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'vh-runtime-diag-'));
+    try {
+      const filePath = resolveRuntimeDiagnosticsPath({ artifactRoot: root });
+      const recorder = createRuntimeDiagnosticRecorder({
+        artifactRoot: root,
+        runId: 'run-1',
+        noWrite: true,
+        maxSummaries: 2,
+      });
+
+      await recorder(summary(1));
+      await recorder(summary(2));
+      await recorder(summary(3));
+
+      const parsed = JSON.parse(await readFile(filePath, 'utf8')) as {
+        schemaVersion: string;
+        runId: string;
+        noWrite: boolean;
+        latest: NewsRuntimeTickSummary;
+        summaries: NewsRuntimeTickSummary[];
+      };
+
+      expect(parsed.schemaVersion).toBe('vh-news-runtime-diagnostics-v1');
+      expect(parsed.runId).toBe('run-1');
+      expect(parsed.noWrite).toBe(true);
+      expect(parsed.latest.tick_sequence).toBe(3);
+      expect(parsed.summaries.map((item) => item.tick_sequence)).toEqual([2, 3]);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/services/news-aggregator/src/runtimeDiagnostics.ts
+++ b/services/news-aggregator/src/runtimeDiagnostics.ts
@@ -1,0 +1,115 @@
+import { mkdir, readFile, rename, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import type { NewsRuntimeTickSummary } from '@vh/ai-engine';
+
+export interface DaemonRuntimeDiagnosticSnapshot {
+  readonly schemaVersion: 'vh-news-runtime-diagnostics-v1';
+  readonly generatedAt: string;
+  readonly runId: string | null;
+  readonly noWrite: boolean;
+  readonly maxSummaries: number;
+  readonly latest: NewsRuntimeTickSummary;
+  readonly summaries: readonly NewsRuntimeTickSummary[];
+}
+
+export interface RuntimeDiagnosticRecorderOptions {
+  readonly artifactRoot?: string;
+  readonly explicitFile?: string;
+  readonly runId?: string;
+  readonly noWrite?: boolean;
+  readonly maxSummaries?: number;
+  readonly readTextFile?: typeof readFile;
+  readonly writeTextFile?: typeof writeFile;
+  readonly renameFile?: typeof rename;
+  readonly mkdirFn?: typeof mkdir;
+}
+
+function normalizePositiveInt(value: number | undefined, fallback: number): number {
+  if (!Number.isFinite(value) || !value || value <= 0) {
+    return fallback;
+  }
+  return Math.floor(value);
+}
+
+function defaultArtifactRoot(): string {
+  const explicitRoot = process.env.VH_DAEMON_FEED_ARTIFACT_ROOT?.trim();
+  if (explicitRoot) {
+    return path.resolve(explicitRoot);
+  }
+  const stateRoot = process.env.VH_NEWS_DAEMON_STATE_DIR?.trim();
+  if (stateRoot) {
+    return path.resolve(stateRoot, 'artifacts');
+  }
+  return path.resolve(process.cwd(), '.tmp/news-runtime-diagnostics');
+}
+
+export function resolveRuntimeDiagnosticsPath(options: RuntimeDiagnosticRecorderOptions = {}): string {
+  const explicitFile = options.explicitFile ?? process.env.VH_NEWS_RUNTIME_DIAGNOSTIC_FILE;
+  if (explicitFile?.trim()) {
+    return path.resolve(explicitFile.trim());
+  }
+  const artifactRoot = options.artifactRoot?.trim()
+    ? path.resolve(options.artifactRoot.trim())
+    : defaultArtifactRoot();
+  return path.join(artifactRoot, 'news-runtime-diagnostics.json');
+}
+
+async function readExistingSnapshot(
+  filePath: string,
+  readTextFile: typeof readFile,
+): Promise<DaemonRuntimeDiagnosticSnapshot | null> {
+  try {
+    const parsed = JSON.parse(await readTextFile(filePath, 'utf8')) as DaemonRuntimeDiagnosticSnapshot;
+    return parsed?.schemaVersion === 'vh-news-runtime-diagnostics-v1' ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+async function writeAtomicJson(
+  filePath: string,
+  value: unknown,
+  writeTextFile: typeof writeFile,
+  renameFile: typeof rename,
+): Promise<void> {
+  const tempPath = path.join(path.dirname(filePath), `.${path.basename(filePath)}.tmp-${process.pid}-${Date.now()}`);
+  await writeTextFile(tempPath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+  await renameFile(tempPath, filePath);
+}
+
+export function createRuntimeDiagnosticRecorder(
+  options: RuntimeDiagnosticRecorderOptions = {},
+): (summary: NewsRuntimeTickSummary) => Promise<DaemonRuntimeDiagnosticSnapshot> {
+  const filePath = resolveRuntimeDiagnosticsPath(options);
+  const readTextFile = options.readTextFile ?? readFile;
+  const writeTextFile = options.writeTextFile ?? writeFile;
+  const renameFile = options.renameFile ?? rename;
+  const mkdirFn = options.mkdirFn ?? mkdir;
+  const maxSummaries = normalizePositiveInt(options.maxSummaries, 50);
+  const runId = options.runId?.trim() || process.env.VH_DAEMON_FEED_RUN_ID?.trim() || null;
+  const noWrite = options.noWrite === true;
+
+  return async (summary: NewsRuntimeTickSummary): Promise<DaemonRuntimeDiagnosticSnapshot> => {
+    await mkdirFn(path.dirname(filePath), { recursive: true });
+    const existing = await readExistingSnapshot(filePath, readTextFile);
+    const summaries = [
+      ...(existing?.summaries ?? []).filter((item) => item.tick_sequence !== summary.tick_sequence),
+      summary,
+    ]
+      .sort((left, right) => left.tick_sequence - right.tick_sequence)
+      .slice(-maxSummaries);
+
+    const snapshot: DaemonRuntimeDiagnosticSnapshot = {
+      schemaVersion: 'vh-news-runtime-diagnostics-v1',
+      generatedAt: new Date().toISOString(),
+      runId,
+      noWrite,
+      maxSummaries,
+      latest: summary,
+      summaries,
+    };
+
+    await writeAtomicJson(filePath, snapshot, writeTextFile, renameFile);
+    return snapshot;
+  };
+}

--- a/tools/scripts/news-aggregator-publisher-preflight.mjs
+++ b/tools/scripts/news-aggregator-publisher-preflight.mjs
@@ -1,0 +1,213 @@
+#!/usr/bin/env node
+
+import { pathToFileURL } from 'node:url';
+
+function firstNonEmpty(...values) {
+  for (const value of values) {
+    const trimmed = typeof value === 'string' ? value.trim() : '';
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+  return undefined;
+}
+
+function truthy(value) {
+  return /^(1|true|yes|on)$/i.test(String(value ?? '').trim());
+}
+
+function parseDelimited(value) {
+  const raw = String(value ?? '').trim();
+  if (!raw) {
+    return [];
+  }
+  if (raw.startsWith('[')) {
+    try {
+      const parsed = JSON.parse(raw);
+      return Array.isArray(parsed) ? parsed.flatMap(parseDelimited) : [];
+    } catch {
+      return [];
+    }
+  }
+  return raw.split(/[,\n]+/).map((entry) => entry.trim()).filter(Boolean);
+}
+
+function validUrl(value, label, failures) {
+  try {
+    const url = new URL(value);
+    if (!['http:', 'https:', 'ws:', 'wss:'].includes(url.protocol)) {
+      failures.push(`${label}:unsupported_protocol`);
+      return null;
+    }
+    return url;
+  } catch {
+    failures.push(`${label}:invalid_url`);
+    return null;
+  }
+}
+
+function relayHealthUrlFromPeer(peer, failures) {
+  const parsed = validUrl(peer, 'gun_peer', failures);
+  if (!parsed) {
+    return null;
+  }
+  if (parsed.protocol === 'ws:') {
+    parsed.protocol = 'http:';
+  } else if (parsed.protocol === 'wss:') {
+    parsed.protocol = 'https:';
+  }
+  parsed.pathname = '/healthz';
+  parsed.search = '';
+  parsed.hash = '';
+  return parsed.toString();
+}
+
+function assertPresent(env, name, failures) {
+  if (!firstNonEmpty(env[name])) {
+    failures.push(`${name}:missing`);
+    return false;
+  }
+  return true;
+}
+
+export async function runNewsAggregatorPublisherPreflight({
+  env = process.env,
+  fetchFn = globalThis.fetch,
+} = {}) {
+  const failures = [];
+  const writerIdPresent = Boolean(firstNonEmpty(env.VH_NEWS_SYSTEM_WRITER_ID, env.VH_SYSTEM_WRITER_ID));
+  const pinPresent = Boolean(firstNonEmpty(env.VH_NEWS_SYSTEM_WRITER_PIN_JSON, env.VH_SYSTEM_WRITER_PIN_JSON));
+  const publicKeyPresent = Boolean(firstNonEmpty(
+    env.VH_NEWS_SYSTEM_WRITER_PUBLIC_KEY_SPKI_BASE64URL,
+    env.VH_SYSTEM_WRITER_PUBLIC_KEY_SPKI_BASE64URL,
+  ));
+  const privateKeyPresent = Boolean(firstNonEmpty(
+    env.VH_NEWS_SYSTEM_WRITER_PRIVATE_KEY_PKCS8_BASE64URL,
+    env.VH_SYSTEM_WRITER_PRIVATE_KEY_PKCS8_BASE64URL,
+  ));
+
+  if (!writerIdPresent) failures.push('system_writer_id:missing');
+  if (!privateKeyPresent) failures.push('system_writer_private_key:missing');
+  if (!pinPresent && !publicKeyPresent) failures.push('system_writer_pin_or_public_key:missing');
+
+  assertPresent(env, 'VH_STORYCLUSTER_REMOTE_URL', failures);
+  assertPresent(env, 'VH_STORYCLUSTER_REMOTE_HEALTH_URL', failures);
+  assertPresent(env, 'VH_STORYCLUSTER_REMOTE_AUTH_TOKEN', failures);
+
+  const gunPeers = parseDelimited(firstNonEmpty(env.VH_GUN_PEERS, env.VITE_GUN_PEERS));
+  if (gunPeers.length === 0) {
+    failures.push('gun_peers:missing');
+  }
+  for (const peer of gunPeers) {
+    validUrl(peer, 'gun_peer', failures);
+  }
+
+  const configuredRelayHealthUrls = parseDelimited(env.VH_NEWS_PUBLISHER_RELAY_HEALTH_URLS);
+  const relayHealthUrls = configuredRelayHealthUrls.length > 0
+    ? configuredRelayHealthUrls
+    : [...new Set(gunPeers.map((peer) => relayHealthUrlFromPeer(peer, failures)).filter(Boolean))];
+  if (relayHealthUrls.length === 0) {
+    failures.push('relay_read_health_urls:missing');
+  }
+
+  const synthesisEnabled = truthy(env.VH_BUNDLE_SYNTHESIS_ENABLED)
+    || Boolean(firstNonEmpty(env.VH_BUNDLE_SYNTHESIS_API_KEY, env.ANALYSIS_RELAY_API_KEY, env.OPENAI_API_KEY));
+  const relayRestOrigins = parseDelimited(env.VH_BUNDLE_SYNTHESIS_RELAY_WRITE_ORIGINS);
+  const relayRestWriteRequested = truthy(env.VH_BUNDLE_SYNTHESIS_WRITE_RELAY_REST)
+    || relayRestOrigins.length > 0;
+  if (synthesisEnabled) {
+    if (!relayRestWriteRequested) failures.push('relay_rest_synthesis:disabled_while_synthesis_enabled');
+    if (relayRestOrigins.length === 0) failures.push('relay_rest_synthesis_origins:missing');
+    if (!firstNonEmpty(env.VH_RELAY_DAEMON_TOKEN)) failures.push('relay_rest_synthesis_token:missing');
+    for (const origin of relayRestOrigins) {
+      const url = validUrl(origin, 'relay_rest_synthesis_origin', failures);
+      if (url && !['http:', 'https:'].includes(url.protocol)) {
+        failures.push('relay_rest_synthesis_origin:unsupported_protocol');
+      }
+    }
+  }
+
+  const relayResults = [];
+  if (failures.length === 0) {
+    if (typeof fetchFn !== 'function') {
+      failures.push('fetch:unavailable');
+    } else {
+      for (const url of relayHealthUrls) {
+        const parsed = validUrl(url, 'relay_read_health_url', failures);
+        if (!parsed || !['http:', 'https:'].includes(parsed.protocol)) {
+          failures.push('relay_read_health_url:unsupported_protocol');
+          continue;
+        }
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), 10_000);
+        try {
+          const response = await fetchFn(parsed, {
+            method: 'GET',
+            headers: { accept: 'application/json' },
+            signal: controller.signal,
+          });
+          relayResults.push({ origin: parsed.origin, status: response.status, ok: response.ok });
+          if (!response.ok) {
+            failures.push(`relay_read_health:${parsed.origin}:http_${response.status}`);
+          }
+        } catch (error) {
+          failures.push(`relay_read_health:${parsed.origin}:${error instanceof Error ? error.message : String(error)}`);
+        } finally {
+          clearTimeout(timeout);
+        }
+      }
+    }
+  }
+
+  return {
+    stage: 'raw_publication_readiness',
+    status: failures.length === 0 ? 'pass' : 'fail',
+    no_write: env.VH_NEWS_DAEMON_DIAGNOSTIC_NO_WRITE === '1',
+    signer_material: {
+      writer_id_present: writerIdPresent,
+      pin_present: pinPresent,
+      public_key_present: publicKeyPresent,
+      private_key_present: privateKeyPresent,
+    },
+    gun_peer_count: gunPeers.length,
+    relay_health_target_count: relayHealthUrls.length,
+    relay_health_results: relayResults,
+    storycluster_config_present: {
+      endpoint: Boolean(firstNonEmpty(env.VH_STORYCLUSTER_REMOTE_URL)),
+      health: Boolean(firstNonEmpty(env.VH_STORYCLUSTER_REMOTE_HEALTH_URL)),
+      auth_token: Boolean(firstNonEmpty(env.VH_STORYCLUSTER_REMOTE_AUTH_TOKEN)),
+    },
+    synthesis_enabled: synthesisEnabled,
+    relay_rest_synthesis: {
+      requested: relayRestWriteRequested,
+      origin_count: relayRestOrigins.length,
+      daemon_token_present: Boolean(firstNonEmpty(env.VH_RELAY_DAEMON_TOKEN)),
+    },
+    failures,
+  };
+}
+
+async function main() {
+  const result = await runNewsAggregatorPublisherPreflight();
+  const output = JSON.stringify(result);
+  if (result.status === 'pass') {
+    console.info(output);
+    return;
+  }
+  console.error(output);
+  process.exit(1);
+}
+
+export const newsAggregatorPublisherPreflightInternal = {
+  firstNonEmpty,
+  parseDelimited,
+  relayHealthUrlFromPeer,
+  truthy,
+};
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error('[vh:news-daemon:preflight] failed', error);
+    process.exit(1);
+  });
+}

--- a/tools/scripts/news-aggregator-publisher-preflight.test.mjs
+++ b/tools/scripts/news-aggregator-publisher-preflight.test.mjs
@@ -1,0 +1,90 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  newsAggregatorPublisherPreflightInternal,
+  runNewsAggregatorPublisherPreflight,
+} from './news-aggregator-publisher-preflight.mjs';
+
+function baseEnv(overrides = {}) {
+  return {
+    VH_NEWS_SYSTEM_WRITER_ID: 'system-writer',
+    VH_NEWS_SYSTEM_WRITER_PIN_JSON: '{"pinVersion":1}',
+    VH_NEWS_SYSTEM_WRITER_PRIVATE_KEY_PKCS8_BASE64URL: 'private-material-redacted',
+    VH_STORYCLUSTER_REMOTE_URL: 'http://127.0.0.1:4310/cluster',
+    VH_STORYCLUSTER_REMOTE_HEALTH_URL: 'http://127.0.0.1:4310/ready',
+    VH_STORYCLUSTER_REMOTE_AUTH_TOKEN: 'storycluster-token-redacted',
+    VH_GUN_PEERS: 'wss://gun-a.example.test/gun,wss://gun-b.example.test/gun',
+    VH_BUNDLE_SYNTHESIS_ENABLED: '1',
+    VH_BUNDLE_SYNTHESIS_WRITE_RELAY_REST: '1',
+    VH_BUNDLE_SYNTHESIS_RELAY_WRITE_ORIGINS: 'https://gun-a.example.test,https://gun-b.example.test',
+    VH_RELAY_DAEMON_TOKEN: 'relay-token-redacted',
+    ...overrides,
+  };
+}
+
+test('publisher preflight reports missing raw publication readiness inputs without fetching relays', async () => {
+  let fetchCalled = false;
+  const result = await runNewsAggregatorPublisherPreflight({
+    env: {},
+    fetchFn: async () => {
+      fetchCalled = true;
+      return new Response('{}');
+    },
+  });
+
+  assert.equal(result.status, 'fail');
+  assert.equal(fetchCalled, false);
+  assert.match(result.failures.join('\n'), /system_writer_id:missing/);
+  assert.match(result.failures.join('\n'), /system_writer_private_key:missing/);
+  assert.match(result.failures.join('\n'), /gun_peers:missing/);
+  assert.equal(result.signer_material.private_key_present, false);
+});
+
+test('publisher preflight fails closed when synthesis is enabled without relay REST config', async () => {
+  const result = await runNewsAggregatorPublisherPreflight({
+    env: baseEnv({
+      VH_BUNDLE_SYNTHESIS_WRITE_RELAY_REST: '',
+      VH_BUNDLE_SYNTHESIS_RELAY_WRITE_ORIGINS: '',
+      VH_RELAY_DAEMON_TOKEN: '',
+    }),
+    fetchFn: async () => new Response('{}'),
+  });
+
+  assert.equal(result.status, 'fail');
+  assert.match(result.failures.join('\n'), /relay_rest_synthesis:disabled_while_synthesis_enabled/);
+  assert.match(result.failures.join('\n'), /relay_rest_synthesis_origins:missing/);
+  assert.match(result.failures.join('\n'), /relay_rest_synthesis_token:missing/);
+});
+
+test('publisher preflight checks relay health with redacted pass output', async () => {
+  const origins = [];
+  const result = await runNewsAggregatorPublisherPreflight({
+    env: baseEnv(),
+    fetchFn: async (input, init) => {
+      assert.equal(init.method, 'GET');
+      assert.deepEqual(init.headers, { accept: 'application/json' });
+      origins.push(input.origin);
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    },
+  });
+
+  assert.equal(result.status, 'pass');
+  assert.deepEqual(origins, ['https://gun-a.example.test', 'https://gun-b.example.test']);
+  assert.deepEqual(result.relay_health_results, [
+    { origin: 'https://gun-a.example.test', status: 200, ok: true },
+    { origin: 'https://gun-b.example.test', status: 200, ok: true },
+  ]);
+  assert.equal(JSON.stringify(result).includes('relay-token-redacted'), false);
+  assert.equal(JSON.stringify(result).includes('storycluster-token-redacted'), false);
+  assert.equal(JSON.stringify(result).includes('private-material-redacted'), false);
+});
+
+test('publisher preflight derives health URLs from Gun peers', () => {
+  assert.equal(
+    newsAggregatorPublisherPreflightInternal.relayHealthUrlFromPeer('wss://gun-a.example.test/gun', []),
+    'https://gun-a.example.test/healthz',
+  );
+});

--- a/tools/scripts/relay-latest-index-snapshot-watch.mjs
+++ b/tools/scripts/relay-latest-index-snapshot-watch.mjs
@@ -30,6 +30,29 @@ function boolEnv(value, fallback = true) {
   return fallback;
 }
 
+function parseMode(value) {
+  const normalized = String(value ?? '').trim().toLowerCase();
+  if (normalized === 'baseline') return 'baseline';
+  if (normalized === 'structural-only' || normalized === 'structural_only') return 'structural-only';
+  return 'freshness';
+}
+
+function parseArgs(argv = []) {
+  let mode = null;
+  for (const arg of argv) {
+    if (arg === '--baseline') {
+      mode = 'baseline';
+    } else if (arg === '--structural-only') {
+      mode = 'structural-only';
+    } else if (arg === '--freshness') {
+      mode = 'freshness';
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return { mode };
+}
+
 function parseDelimitedValues(value) {
   const raw = String(value ?? '').trim();
   if (!raw) return [];
@@ -99,6 +122,7 @@ function inspectSnapshotFile(filePath, {
   expectedEntryCount = DEFAULT_EXPECTED_ENTRY_COUNT,
   maxAgeMs = DEFAULT_MAX_AGE_MS,
   maxFileBytes = DEFAULT_MAX_FILE_BYTES,
+  enforceFreshness = true,
 } = {}) {
   const failures = validateSnapshotPath(filePath);
   const result = {
@@ -116,6 +140,7 @@ function inspectSnapshotFile(filePath, {
     newestEntryAt: null,
     newestEntryAtIso: null,
     newestEntryAgeMs: null,
+    freshnessFailures: [],
   };
 
   if (!result.exists) {
@@ -173,7 +198,11 @@ function inspectSnapshotFile(filePath, {
   if (!newestEntryAt || result.newestEntryAgeMs < 0) {
     result.failures.push('newest_entry_not_sane');
   } else if (result.newestEntryAgeMs > maxAgeMs) {
-    result.failures.push(`newest_entry_stale:${result.newestEntryAgeMs}/${maxAgeMs}`);
+    const failure = `newest_entry_stale:${result.newestEntryAgeMs}/${maxAgeMs}`;
+    result.freshnessFailures.push(failure);
+    if (enforceFreshness) {
+      result.failures.push(failure);
+    }
   }
 
   result.status = result.failures.length === 0 ? 'pass' : 'fail';
@@ -198,7 +227,11 @@ function syslogFailure(summary, env = process.env) {
 export async function runRelayLatestIndexSnapshotWatch({
   env = process.env,
   now = Date.now(),
+  argv = [],
 } = {}) {
+  const args = parseArgs(argv);
+  const mode = args.mode ?? parseMode(env.VH_RELAY_SNAPSHOT_WATCH_MODE);
+  const enforceFreshness = mode === 'freshness';
   const maxAgeMs = positiveInt(env.VH_RELAY_SNAPSHOT_WATCH_MAX_AGE_MS, DEFAULT_MAX_AGE_MS);
   const expectedEntryCount = positiveInt(
     env.VH_RELAY_SNAPSHOT_WATCH_EXPECTED_ENTRIES,
@@ -207,21 +240,33 @@ export async function runRelayLatestIndexSnapshotWatch({
   const maxFileBytes = positiveInt(env.VH_RELAY_SNAPSHOT_WATCH_MAX_FILE_BYTES, DEFAULT_MAX_FILE_BYTES);
   const files = resolveSnapshotFiles(env);
   const snapshots = files.map((filePath) =>
-    inspectSnapshotFile(filePath, { now, expectedEntryCount, maxAgeMs, maxFileBytes }));
+    inspectSnapshotFile(filePath, { now, expectedEntryCount, maxAgeMs, maxFileBytes, enforceFreshness }));
   const blockers = snapshots
     .filter((snapshot) => snapshot.status !== 'pass')
     .map((snapshot) => `${snapshot.file}:${snapshot.failures.join('|')}`);
+  const freshnessBaseline = snapshots
+    .filter((snapshot) => snapshot.freshnessFailures.length > 0)
+    .map((snapshot) => ({
+      file: snapshot.file,
+      newestEntryAt: snapshot.newestEntryAt,
+      newestEntryAtIso: snapshot.newestEntryAtIso,
+      newestEntryAgeMs: snapshot.newestEntryAgeMs,
+      failures: snapshot.freshnessFailures,
+    }));
   const summary = {
     schemaVersion: REPORT_SCHEMA_VERSION,
     generatedAt: new Date(now).toISOString(),
     status: blockers.length === 0 ? 'pass' : 'fail',
     blockers,
     config: {
+      mode,
+      enforceFreshness,
       maxAgeMs,
       expectedEntryCount,
       maxFileBytes,
       files,
     },
+    freshnessBaseline,
     snapshots,
   };
 
@@ -236,7 +281,7 @@ export async function runRelayLatestIndexSnapshotWatch({
 }
 
 async function main() {
-  const summary = await runRelayLatestIndexSnapshotWatch();
+  const summary = await runRelayLatestIndexSnapshotWatch({ argv: process.argv.slice(2) });
   console.info(JSON.stringify(summary, null, 2));
   if (summary.status !== 'pass') {
     process.exit(1);
@@ -248,6 +293,8 @@ export const relayLatestIndexSnapshotWatchInternal = {
   SCHEMA_VERSION,
   entryActivityMs,
   inspectSnapshotFile,
+  parseArgs,
+  parseMode,
   parseDelimitedValues,
   resolveSnapshotFiles,
 };

--- a/tools/scripts/relay-latest-index-snapshot-watch.test.mjs
+++ b/tools/scripts/relay-latest-index-snapshot-watch.test.mjs
@@ -99,6 +99,60 @@ test('relay snapshot watcher fails stale newest-entry and entry-count mismatches
   }
 });
 
+test('relay snapshot watcher baseline mode records stale freshness without failing structural checks', async () => {
+  const { root, file } = makeTempSnapshotDir();
+  try {
+    writeSnapshot(file, {
+      snapshot: {
+        cached_at: NOW - 7 * 60 * 60 * 1000,
+        entries: Array.from({ length: 15 }, (_, index) => ({
+          story_id: `story-stale-${index}`,
+          record: { latest_activity_at: NOW - 7 * 60 * 60 * 1000 },
+          story: { story_id: `story-stale-${index}`, cluster_window_end: NOW - 7 * 60 * 60 * 1000 },
+        })),
+      },
+    });
+    const summary = await runRelayLatestIndexSnapshotWatch({
+      now: NOW,
+      argv: ['--baseline'],
+      env: {
+        VH_RELAY_SNAPSHOT_WATCH_FILES: file,
+        VH_RELAY_SNAPSHOT_WATCH_SYSLOG: 'false',
+      },
+    });
+
+    assert.equal(summary.status, 'pass');
+    assert.equal(summary.config.mode, 'baseline');
+    assert.equal(summary.config.enforceFreshness, false);
+    assert.equal(summary.blockers.length, 0);
+    assert.match(summary.freshnessBaseline[0].failures.join('\n'), /newest_entry_stale:/);
+    assert.equal(summary.snapshots[0].status, 'pass');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('relay snapshot watcher structural-only mode still fails malformed snapshots', async () => {
+  const { root, file } = makeTempSnapshotDir();
+  try {
+    writeSnapshot(file, { entryCount: 14 });
+    const summary = await runRelayLatestIndexSnapshotWatch({
+      now: NOW,
+      argv: ['--structural-only'],
+      env: {
+        VH_RELAY_SNAPSHOT_WATCH_FILES: file,
+        VH_RELAY_SNAPSHOT_WATCH_SYSLOG: 'false',
+      },
+    });
+
+    assert.equal(summary.status, 'fail');
+    assert.equal(summary.config.mode, 'structural-only');
+    assert.match(summary.blockers.join('\n'), /entry_count_mismatch:14\/15/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test('relay snapshot watcher reports missing default snapshot files without HTTP probes', async () => {
   const summary = await runRelayLatestIndexSnapshotWatch({
     now: NOW,

--- a/tools/scripts/start-news-aggregator-daemon-production.sh
+++ b/tools/scripts/start-news-aggregator-daemon-production.sh
@@ -18,7 +18,26 @@ set -a
 source "${ENV_FILE}"
 set +a
 
-if [[ "${VH_NEWS_DAEMON_START_APPROVED:-}" != "1" ]]; then
+truthy_flag() {
+  case "${1:-}" in
+    1|true|TRUE|yes|YES|on|ON) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+NO_WRITE_DIAGNOSTIC=false
+if truthy_flag "${VH_NEWS_DAEMON_DIAGNOSTIC_NO_WRITE:-${VH_NEWS_DAEMON_NO_WRITE:-}}"; then
+  NO_WRITE_DIAGNOSTIC=true
+  export VH_NEWS_DAEMON_DIAGNOSTIC_NO_WRITE=1
+fi
+
+if [[ "${NO_WRITE_DIAGNOSTIC}" == "true" ]]; then
+  if [[ "${VH_NEWS_DAEMON_DIAGNOSTIC_APPROVED:-}" != "1" ]]; then
+    echo "[vh:news-daemon:prod] refusing no-write diagnostic without VH_NEWS_DAEMON_DIAGNOSTIC_APPROVED=1 in ${ENV_FILE}" >&2
+    exit 78
+  fi
+  echo "[vh:news-daemon:prod] no-write diagnostic mode approved; live mesh mutations are suppressed"
+elif [[ "${VH_NEWS_DAEMON_START_APPROVED:-}" != "1" ]]; then
   echo "[vh:news-daemon:prod] refusing to start without VH_NEWS_DAEMON_START_APPROVED=1 in ${ENV_FILE}" >&2
   exit 78
 fi
@@ -116,6 +135,9 @@ try {
   clearTimeout(timer);
 }
 NODE
+
+echo "[vh:news-daemon:prod] raw publication readiness preflight starting"
+node "${REPO_ROOT}/tools/scripts/news-aggregator-publisher-preflight.mjs"
 
 LAST_SUCCESS_FILE="${LAST_SUCCESS_FILE}" node --input-type=module <<'NODE'
 import { mkdir, writeFile } from 'node:fs/promises';

--- a/tools/scripts/start-news-aggregator-daemon-production.test.mjs
+++ b/tools/scripts/start-news-aggregator-daemon-production.test.mjs
@@ -18,7 +18,7 @@ const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(SCRIPT_DIR, '../..');
 const SCRIPT_PATH = path.join(REPO_ROOT, 'tools/scripts/start-news-aggregator-daemon-production.sh');
 
-function makeHarness({ approved }) {
+function makeHarness({ approved, noWriteDiagnostic = false, diagnosticApproved = false }) {
   const root = mkdtempSync(path.join(os.tmpdir(), 'vh-news-daemon-start-'));
   const binDir = path.join(root, 'bin');
   const envFile = path.join(root, 'news-aggregator.env');
@@ -34,10 +34,12 @@ function makeHarness({ approved }) {
     envFile,
     [
       approved ? 'VH_NEWS_DAEMON_START_APPROVED=1' : 'VH_NEWS_DAEMON_HOLDER_ID=test-unapproved',
+      noWriteDiagnostic ? 'VH_NEWS_DAEMON_DIAGNOSTIC_NO_WRITE=1' : null,
+      diagnosticApproved ? 'VH_NEWS_DAEMON_DIAGNOSTIC_APPROVED=1' : null,
       `VH_NEWS_DAEMON_STATE_DIR=${path.join(root, 'state')}`,
       `VH_DAEMON_FEED_ARTIFACT_ROOT=${path.join(root, 'artifacts')}`,
       `VH_NEWS_DAEMON_LAST_SUCCESS_FILE=${path.join(root, 'state/last-success.json')}`,
-    ].join('\n') + '\n',
+    ].filter(Boolean).join('\n') + '\n',
     'utf8',
   );
 
@@ -65,6 +67,34 @@ test('production daemon start requires persistent approval before any preflight 
     assert.equal(result.status, 78);
     assert.match(result.stderr, /refusing to start without VH_NEWS_DAEMON_START_APPROVED=1/);
     assert.equal(existsSync(harness.pnpmMarker), false);
+  } finally {
+    rmSync(harness.root, { recursive: true, force: true });
+  }
+});
+
+test('no-write diagnostic start requires separate diagnostic approval before any preflight runs', () => {
+  const harness = makeHarness({ approved: false, noWriteDiagnostic: true });
+  try {
+    const result = runStartScript(harness);
+    assert.equal(result.status, 78);
+    assert.match(result.stderr, /refusing no-write diagnostic without VH_NEWS_DAEMON_DIAGNOSTIC_APPROVED=1/);
+    assert.equal(existsSync(harness.pnpmMarker), false);
+  } finally {
+    rmSync(harness.root, { recursive: true, force: true });
+  }
+});
+
+test('no-write diagnostic approval proceeds to preflights without live start approval', () => {
+  const harness = makeHarness({
+    approved: false,
+    noWriteDiagnostic: true,
+    diagnosticApproved: true,
+  });
+  try {
+    const result = runStartScript(harness);
+    assert.equal(result.status, 99);
+    assert.match(result.stdout, /no-write diagnostic mode approved/);
+    assert.equal(readFileSync(harness.pnpmMarker, 'utf8').trim(), 'check:news-sources:liveness');
   } finally {
     rmSync(harness.root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- Classified the preserved Phase 5 abort as bucket 6: evidence was insufficient because the prior daemon run did not emit always-on tick diagnostics, and no live publisher rerun was performed.
- Added always-on runtime tick summaries, first-tick outcome logs, a configurable in-flight watchdog, and bounded runtime diagnostic artifacts.
- Added a gated no-write diagnostic mode that suppresses lease writes, raw/storyline/latest/lifecycle/synthesis writes, queue persistence, replay, and product-feed repair writes.
- Added read-only raw publication readiness preflight to the production wrapper without a mutating canary.
- Added snapshot watcher `--baseline` and `--structural-only` modes so pre-start recovery can record a stale baseline while default freshness monitoring remains fail-hard.

## Read-Only Host Diagnosis
- Local and host `main` were reverified at `c0cadd72182280e30fa059cd90d70f1c2bf7cd7c` before implementation.
- Preserved artifact path inspected: `/home/humble/.local/state/vhc/phase5-publisher-start-abort/20260615T144224Z`.
- `vh-news-aggregator.service` was inactive/disabled after abort with `NRestarts=0`, `ExecMainStatus=0`, and no start approval present in the env file by name/hash proof only.
- Prior journal markers showed runtime start and lease writes, but zero `news_bundle` writes, zero enrichment candidates, and no runtime failure marker.
- `VH_DAEMON_FEED_RUN_ID` was not present, so missing `cluster-capture.json` could not be trusted as evidence.
- Because the prior run lacked ingest/normalize/cluster/select/raw-write summary artifacts, the no-op could not be narrowed beyond bucket 6 without a new approved diagnostic run.

## Validation
- `git diff --check`
- `git diff --cached --check`
- `pnpm exec vitest run packages/ai-engine/src/newsRuntime.test.ts packages/ai-engine/src/__tests__/newsOrchestrator.test.ts --config vitest.config.ts --reporter=verbose`
- `pnpm --filter @vh/news-aggregator exec vitest run src/daemon.test.ts src/daemon.production.test.ts src/runtimeDiagnostics.test.ts src/clusterCapturePersistence.test.ts --config ./vitest.config.ts --reporter=verbose`
- `node --test tools/scripts/start-news-aggregator-daemon-production.test.mjs tools/scripts/news-aggregator-publisher-preflight.test.mjs tools/scripts/relay-latest-index-snapshot-watch.test.mjs`
- `pnpm --filter @vh/ai-engine typecheck`
- `pnpm --filter @vh/ai-engine build`
- `pnpm --filter @vh/news-aggregator typecheck`
- `pnpm --filter @vh/news-aggregator test`
- `pnpm --filter @vh/news-aggregator build`

Validation note: pnpm reports local Node `v23.10.0` while this repo declares `>=20 <23`; the listed commands still completed successfully.

## Safety Boundaries Preserved
- Did not start `vh-news-aggregator.service`.
- Did not add `VH_NEWS_DAEMON_START_APPROVED=1`.
- Did not run a live publisher diagnostic or no-write host diagnostic.
- Did not restart/rebuild/reload relays or origin.
- Did not enable freshness monitors.
- Did not merge or deploy this branch.
