### PR TITLE
[coord] Add gated StoryCluster state reset

### DIFF
--- a/docs/ops/storycluster-production-service.md
+++ b/docs/ops/storycluster-production-service.md
@@ -131,6 +131,46 @@ VH_STORYCLUSTER_REMOTE_AUTH_SCHEME=Bearer
 The publisher start wrapper still runs the StoryCluster OpenAI preflight, and
 the daemon still verifies StoryCluster health before creating the Gun client.
 
+## Reset Persistent State
+
+StoryCluster persists derived topic state in `VH_STORYCLUSTER_STATE_DIR` and
+cluster vectors in the configured Qdrant collection. A publisher no-write
+diagnostic suppresses mesh writes, but it still calls the StoryCluster service,
+so it can change this derived StoryCluster state. Reset StoryCluster state
+before any live publisher path that must start from current RSS only.
+
+Use the gated reset script. It refuses to run while
+`vh-news-aggregator.service` is active, stops and restarts the StoryCluster
+engine to drop in-memory state, backs up the file store before clearing it,
+deletes the configured Qdrant collection, verifies authenticated `/ready`
+returns `qdrant:...`, and verifies the recreated collection has `0` points.
+It prints only redacted proof.
+
+```bash
+cd /home/humble/VHC
+VH_STORYCLUSTER_RESET_APPROVED=1 \
+  ./tools/scripts/reset-storycluster-production-state.sh
+```
+
+Default backup location:
+
+```bash
+~/.local/state/vhc/storycluster-reset-backups/<timestamp>/storycluster-state.tgz
+```
+
+For Phase 5 publisher recovery, use this cadence unless the diagnostic is
+explicitly pointed at an ephemeral StoryCluster state dir and Qdrant collection:
+
+1. Reset StoryCluster state.
+2. Run the capped publisher no-write diagnostic with a fresh
+   `VH_DAEMON_FEED_RUN_ID`.
+3. Inspect tick shape, not only `selected > 0`: completed tick, no watchdog,
+   sane bundle count, fresh cluster window, no singleton explosion, and recent
+   first selected story IDs.
+4. Reset StoryCluster state again.
+5. Proceed to the gated live publisher start only after the explicit
+   `start Phase 5 now` approval and the publisher preflight gates pass.
+
 ## Abort / Stop
 
 Stopping StoryCluster is read/compute-only and does not write to the mesh:

--- a/tools/scripts/reset-storycluster-production-state.sh
+++ b/tools/scripts/reset-storycluster-production-state.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Reset StoryCluster persistent state so the next clustering run starts clean.
+#
+# Why: the daemon's no-write diagnostic mode suppresses *mesh* writes, but the
+# StoryCluster service still persists topic state (FileClusterStore) and Qdrant
+# vectors on every clustering call. Diagnostic runs therefore pollute StoryCluster
+# state, and a later live tick would publish (capped) bundles selected from that
+# stale/accumulated state. This script clears that state, backup-first and gated,
+# so a live first tick clusters fresh from current RSS.
+#
+# StoryCluster auto-recreates an empty Qdrant collection (ensureCollection) and an
+# empty topic store on the next readiness probe / clustering call.
+#
+# Safe by construction: StoryCluster is a read/compute service (no mesh writes);
+# this script refuses to run while the publisher is active, backs up before
+# clearing, gates on an explicit approval flag, and prints only redacted proof.
+
+ENV_FILE="${VH_STORYCLUSTER_ENV_FILE:-${HOME}/.config/vhc/storycluster.env}"
+DEFAULT_STATE_DIR="${HOME}/.local/state/vhc/storycluster-engine"
+DEFAULT_BACKUP_ROOT="${HOME}/.local/state/vhc/storycluster-reset-backups"
+
+if [[ ! -r "${ENV_FILE}" ]]; then
+  echo "[vh:storycluster:reset] env file is required and must be readable: ${ENV_FILE}" >&2
+  exit 78
+fi
+
+set -a
+# shellcheck disable=SC1090
+source "${ENV_FILE}"
+set +a
+
+# --- gate: explicit approval, distinct from start/diagnostic approvals ---
+if [[ "${VH_STORYCLUSTER_RESET_APPROVED:-}" != "1" ]]; then
+  echo "[vh:storycluster:reset] refusing reset without VH_STORYCLUSTER_RESET_APPROVED=1 in ${ENV_FILE}" >&2
+  exit 78
+fi
+
+STATE_DIR="${VH_STORYCLUSTER_STATE_DIR:-${DEFAULT_STATE_DIR}}"
+BACKUP_ROOT="${VH_STORYCLUSTER_RESET_BACKUP_ROOT:-${DEFAULT_BACKUP_ROOT}}"
+ENGINE_UNIT="${VH_STORYCLUSTER_ENGINE_UNIT:-vh-storycluster-engine.service}"
+PUBLISHER_UNIT="${VH_NEWS_DAEMON_UNIT:-vh-news-aggregator.service}"
+STAMP="${VH_STORYCLUSTER_RESET_STAMP:-$(date -u +%Y%m%dT%H%M%SZ)}"
+QDRANT_HTTP_PORT="${VH_STORYCLUSTER_QDRANT_HTTP_PORT:-6333}"
+export VH_STORYCLUSTER_QDRANT_URL="${VH_STORYCLUSTER_QDRANT_URL:-http://127.0.0.1:${QDRANT_HTTP_PORT}}"
+COLLECTION="${VH_STORYCLUSTER_QDRANT_COLLECTION:-storycluster_coarse_vectors}"
+SERVER_HOST="${VH_STORYCLUSTER_SERVER_HOST:-127.0.0.1}"
+SERVER_PORT="${VH_STORYCLUSTER_SERVER_PORT:-4310}"
+VERIFY_TIMEOUT_MS="${VH_STORYCLUSTER_RESET_VERIFY_TIMEOUT_MS:-120000}"
+
+if [[ "${VH_STORYCLUSTER_VECTOR_BACKEND:-qdrant}" != "qdrant" ]]; then
+  echo "[vh:storycluster:reset] refusing non-qdrant vector backend in production reset" >&2
+  exit 78
+fi
+
+if [[ -z "${VH_STORYCLUSTER_SERVER_AUTH_TOKEN:-}" ]]; then
+  echo "[vh:storycluster:reset] VH_STORYCLUSTER_SERVER_AUTH_TOKEN is required for post-reset /ready verification" >&2
+  exit 78
+fi
+
+if [[ "${STATE_DIR}" != /* ]]; then
+  echo "[vh:storycluster:reset] refusing non-absolute VH_STORYCLUSTER_STATE_DIR" >&2
+  exit 78
+fi
+
+state_dir_trimmed="${STATE_DIR%/}"
+case "${state_dir_trimmed}" in
+  ""|"/"|"${HOME}"|"${HOME}/.local"|"${HOME}/.local/state"|"${HOME}/.local/state/vhc")
+    echo "[vh:storycluster:reset] refusing unsafe VH_STORYCLUSTER_STATE_DIR: ${STATE_DIR}" >&2
+    exit 78
+    ;;
+esac
+
+if [[ "${state_dir_trimmed}" != *storycluster* && "${VH_STORYCLUSTER_RESET_ALLOW_NON_STORYCLUSTER_STATE_DIR:-}" != "1" ]]; then
+  echo "[vh:storycluster:reset] refusing state dir that does not look StoryCluster-scoped: ${STATE_DIR}" >&2
+  exit 78
+fi
+
+if [[ -z "${COLLECTION}" || "${COLLECTION}" == */* ]]; then
+  echo "[vh:storycluster:reset] refusing invalid VH_STORYCLUSTER_QDRANT_COLLECTION" >&2
+  exit 78
+fi
+
+if [[ ! "${VERIFY_TIMEOUT_MS}" =~ ^[0-9]+$ || "${VERIFY_TIMEOUT_MS}" -le 0 ]]; then
+  echo "[vh:storycluster:reset] VH_STORYCLUSTER_RESET_VERIFY_TIMEOUT_MS must be a positive integer" >&2
+  exit 78
+fi
+
+# --- safety: never reset while the publisher could be issuing clustering calls ---
+if command -v systemctl >/dev/null 2>&1 && systemctl --user is-active --quiet "${PUBLISHER_UNIT}" 2>/dev/null; then
+  echo "[vh:storycluster:reset] refusing reset while ${PUBLISHER_UNIT} is active; stop the publisher first" >&2
+  exit 75
+fi
+
+BACKUP_DIR="${BACKUP_ROOT}/${STAMP}"
+mkdir -p "${BACKUP_DIR}"
+
+if ! command -v systemctl >/dev/null 2>&1; then
+  echo "[vh:storycluster:reset] systemctl is required for production reset" >&2
+  exit 78
+fi
+if ! systemctl --user cat "${ENGINE_UNIT}" >/dev/null 2>&1; then
+  echo "[vh:storycluster:reset] required StoryCluster unit is not installed: ${ENGINE_UNIT}" >&2
+  exit 78
+fi
+
+systemctl --user stop "${ENGINE_UNIT}"
+echo "[vh:storycluster:reset] ${ENGINE_UNIT} stopped"
+
+# --- 1. backup the file cluster store before clearing ---
+if [[ -d "${STATE_DIR}" ]]; then
+  tar -czf "${BACKUP_DIR}/storycluster-state.tgz" -C "$(dirname "${STATE_DIR}")" "$(basename "${STATE_DIR}")"
+  echo "[vh:storycluster:reset] state dir backed up"
+fi
+
+# --- 2. capture pre-reset Qdrant point count (proof) ---
+__RESET_COLLECTION="${COLLECTION}" node --input-type=module <<'NODE' || true
+const baseUrl = process.env.VH_STORYCLUSTER_QDRANT_URL?.replace(/\/+$/, '') ?? '';
+const collection = process.env.__RESET_COLLECTION;
+const collectionPath = encodeURIComponent(collection);
+const headers = {};
+if (process.env.VH_STORYCLUSTER_QDRANT_API_KEY) headers['api-key'] = process.env.VH_STORYCLUSTER_QDRANT_API_KEY;
+try {
+  const res = await fetch(`${baseUrl}/collections/${collectionPath}`, { headers });
+  const body = await res.json().catch(() => null);
+  console.info(JSON.stringify({ stage: 'pre_reset', http: res.status, points: body?.result?.points_count ?? null }));
+} catch {
+  console.info(JSON.stringify({ stage: 'pre_reset', http: null, points: null }));
+}
+NODE
+
+# --- 3. clear the file cluster store ---
+if [[ -d "${STATE_DIR}" ]]; then
+  find "${STATE_DIR}" -mindepth 1 -delete 2>/dev/null || true
+fi
+mkdir -p "${STATE_DIR}"
+
+# --- 4. delete the Qdrant collection (auto-recreated empty by ensureCollection) ---
+__RESET_COLLECTION="${COLLECTION}" node --input-type=module <<'NODE'
+const baseUrl = process.env.VH_STORYCLUSTER_QDRANT_URL?.replace(/\/+$/, '') ?? '';
+const collection = process.env.__RESET_COLLECTION;
+const collectionPath = encodeURIComponent(collection);
+const headers = { 'content-type': 'application/json' };
+if (process.env.VH_STORYCLUSTER_QDRANT_API_KEY) headers['api-key'] = process.env.VH_STORYCLUSTER_QDRANT_API_KEY;
+const res = await fetch(`${baseUrl}/collections/${collectionPath}`, { method: 'DELETE', headers });
+console.info(JSON.stringify({ stage: 'delete_collection', http: res.status, collection }));
+// 200 (deleted) and 404 (already absent) are both acceptable end states.
+if (!res.ok && res.status !== 404) process.exit(1);
+NODE
+
+# --- 5. restart StoryCluster so it drops any in-memory topic state ---
+systemctl --user restart "${ENGINE_UNIT}"
+echo "[vh:storycluster:reset] ${ENGINE_UNIT} restarted"
+
+# --- 6. verify: /ready qdrant-backed, collection recreated empty, store empty ---
+VH_STORYCLUSTER_RESET_VERIFY_URL="http://${SERVER_HOST}:${SERVER_PORT}/ready" \
+VH_STORYCLUSTER_RESET_VERIFY_TIMEOUT_MS="${VERIFY_TIMEOUT_MS}" \
+__RESET_COLLECTION="${COLLECTION}" node --input-type=module <<'NODE'
+const readyUrl = process.env.VH_STORYCLUSTER_RESET_VERIFY_URL;
+const baseUrl = process.env.VH_STORYCLUSTER_QDRANT_URL?.replace(/\/+$/, '') ?? '';
+const collection = process.env.__RESET_COLLECTION;
+const collectionPath = encodeURIComponent(collection);
+const authToken = process.env.VH_STORYCLUSTER_SERVER_AUTH_TOKEN;
+const authHeader = (process.env.VH_STORYCLUSTER_SERVER_AUTH_HEADER || 'authorization').toLowerCase();
+const authScheme = process.env.VH_STORYCLUSTER_SERVER_AUTH_SCHEME || 'Bearer';
+const timeoutMs = Number.parseInt(process.env.VH_STORYCLUSTER_RESET_VERIFY_TIMEOUT_MS ?? '120000', 10);
+const qHeaders = {};
+if (process.env.VH_STORYCLUSTER_QDRANT_API_KEY) qHeaders['api-key'] = process.env.VH_STORYCLUSTER_QDRANT_API_KEY;
+
+const deadline = Date.now() + (Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : 120000);
+let readyDetail = null;
+while (Date.now() < deadline) {
+  try {
+    const headers = {};
+    if (authToken) headers[authHeader] = `${authScheme} ${authToken}`;
+    const res = await fetch(readyUrl, { headers });
+    const body = await res.json().catch(() => null);
+    if (res.ok && body?.ok === true && String(body?.detail ?? '').startsWith('qdrant:')) {
+      readyDetail = body.detail;
+      break;
+    }
+  } catch { /* retry */ }
+  await new Promise((r) => setTimeout(r, 1000));
+}
+
+let points = null;
+try {
+  const res = await fetch(`${baseUrl}/collections/${collectionPath}`, { headers: qHeaders });
+  const body = await res.json().catch(() => null);
+  points = body?.result?.points_count ?? null;
+} catch { /* leave null */ }
+
+const ok = readyDetail !== null && points === 0;
+console.info(JSON.stringify({ stage: 'post_reset', ready_detail: readyDetail, collection_points: points, ok }));
+if (!ok) process.exit(1);
+NODE
+
+# --- 7. redacted proof ---
+REMAINING_FILES="$(find "${STATE_DIR}" -type f 2>/dev/null | wc -l | tr -d ' ')"
+if [[ "${REMAINING_FILES}" != "0" ]]; then
+  echo "[vh:storycluster:reset] state dir still contains files after reset: ${REMAINING_FILES}" >&2
+  exit 1
+fi
+echo "[vh:storycluster:reset] reset complete"
+echo "  state_dir_files_remaining: ${REMAINING_FILES}"
+echo "  collection: ${COLLECTION}"
+echo "  backup_dir: ${BACKUP_DIR}"
+echo "  qdrant_url_host: $(printf '%s' "${VH_STORYCLUSTER_QDRANT_URL}" | sed -E 's#^(https?://[^/]+).*#\1#')"

--- a/tools/scripts/reset-storycluster-production-state.test.mjs
+++ b/tools/scripts/reset-storycluster-production-state.test.mjs
@@ -1,0 +1,329 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
+import { createServer } from 'node:http';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(SCRIPT_DIR, '../..');
+const RESET_SCRIPT = path.join(REPO_ROOT, 'tools/scripts/reset-storycluster-production-state.sh');
+
+function writeSystemctlMock(bin, logPath) {
+  writeFileSync(
+    path.join(bin, 'systemctl'),
+    `#!/usr/bin/env bash
+echo "$@" >> "${logPath}"
+if [[ "$*" == "--user is-active --quiet vh-news-aggregator.service" ]]; then
+  if [[ "\${MOCK_PUBLISHER_ACTIVE:-0}" == "1" ]]; then
+    exit 0
+  fi
+  exit 3
+fi
+if [[ "$*" == "--user cat vh-storycluster-engine.service" ]]; then
+  exit 0
+fi
+if [[ "$*" == "--user stop vh-storycluster-engine.service" ]]; then
+  exit 0
+fi
+if [[ "$*" == "--user restart vh-storycluster-engine.service" ]]; then
+  exit 0
+fi
+exit 0
+`,
+    { mode: 0o755 },
+  );
+}
+
+function writeEnvFile(filePath, entries) {
+  writeFileSync(
+    filePath,
+    `${Object.entries(entries).map(([key, value]) => `${key}=${value}`).join('\n')}\n`,
+    { mode: 0o600 },
+  );
+}
+
+function runReset(env) {
+  return new Promise((resolve) => {
+    const child = spawn('bash', [RESET_SCRIPT], {
+      cwd: REPO_ROOT,
+      env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on('close', (status, signal) => {
+      resolve({ status, signal, stdout, stderr });
+    });
+  });
+}
+
+function listen(server) {
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      resolve(server.address().port);
+    });
+  });
+}
+
+function close(server) {
+  return new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}
+
+function json(res, status, body) {
+  res.writeHead(status, { 'content-type': 'application/json' });
+  res.end(`${JSON.stringify(body)}\n`);
+}
+
+function createQdrantHarness({ collection, apiKey, omitPostResetPointCount = false }) {
+  let points = 7;
+  let deleted = false;
+  const requests = [];
+  const errors = [];
+  const collectionPath = `/collections/${encodeURIComponent(collection)}`;
+  const server = createServer((req, res) => {
+    requests.push({ method: req.method, url: req.url, apiKey: req.headers['api-key'] });
+    if (req.headers['api-key'] !== apiKey) {
+      errors.push(`missing qdrant api-key for ${req.method} ${req.url}`);
+      json(res, 401, { status: 'unauthorized' });
+      return;
+    }
+    if (req.url !== collectionPath) {
+      errors.push(`unexpected qdrant path ${req.method} ${req.url}`);
+      json(res, 404, { status: 'not_found' });
+      return;
+    }
+    if (req.method === 'GET') {
+      if (deleted && omitPostResetPointCount) {
+        json(res, 200, { result: {} });
+        return;
+      }
+      json(res, 200, { result: { points_count: points } });
+      return;
+    }
+    if (req.method === 'DELETE') {
+      deleted = true;
+      points = 0;
+      json(res, 200, { status: 'ok' });
+      return;
+    }
+    errors.push(`unexpected qdrant method ${req.method}`);
+    json(res, 405, { status: 'method_not_allowed' });
+  });
+  return {
+    server,
+    requests,
+    errors,
+    get deleted() {
+      return deleted;
+    },
+  };
+}
+
+function createReadyHarness({ collection, token }) {
+  const requests = [];
+  const errors = [];
+  const server = createServer((req, res) => {
+    requests.push({ method: req.method, url: req.url, authorization: req.headers.authorization });
+    if (req.url !== '/ready') {
+      errors.push(`unexpected ready path ${req.method} ${req.url}`);
+      json(res, 404, { ok: false });
+      return;
+    }
+    if (req.headers.authorization !== `Bearer ${token}`) {
+      errors.push(`missing ready authorization for ${req.method} ${req.url}`);
+      json(res, 401, { ok: false });
+      return;
+    }
+    json(res, 200, { ok: true, service: 'storycluster-engine', detail: `qdrant:${collection}` });
+  });
+  return { server, requests, errors };
+}
+
+test('storycluster reset refuses without explicit approval', async () => {
+  const home = mkdtempSync(path.join(tmpdir(), 'vh-storycluster-reset-no-approval-'));
+  const envFile = path.join(home, 'storycluster.env');
+  mkdirSync(path.dirname(envFile), { recursive: true });
+  writeEnvFile(envFile, {
+    NODE_ENV: 'production',
+    VH_STORYCLUSTER_VECTOR_BACKEND: 'qdrant',
+    VH_STORYCLUSTER_SERVER_AUTH_TOKEN: 'ready-secret',
+  });
+
+  try {
+    const result = await runReset({
+      ...process.env,
+      HOME: home,
+      VH_STORYCLUSTER_ENV_FILE: envFile,
+    });
+    assert.equal(result.status, 78);
+    assert.match(result.stderr, /VH_STORYCLUSTER_RESET_APPROVED=1/);
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test('storycluster reset refuses while publisher unit is active', async () => {
+  const home = mkdtempSync(path.join(tmpdir(), 'vh-storycluster-reset-active-'));
+  const bin = path.join(home, 'bin');
+  const envFile = path.join(home, 'storycluster.env');
+  const systemctlLog = path.join(home, 'systemctl.log');
+  mkdirSync(bin, { recursive: true });
+  writeSystemctlMock(bin, systemctlLog);
+  const stateDir = path.join(home, 'storycluster-state');
+  mkdirSync(stateDir, { recursive: true });
+  writeEnvFile(envFile, {
+    NODE_ENV: 'production',
+    VH_STORYCLUSTER_RESET_APPROVED: '1',
+    VH_STORYCLUSTER_VECTOR_BACKEND: 'qdrant',
+    VH_STORYCLUSTER_STATE_DIR: stateDir,
+    VH_STORYCLUSTER_SERVER_AUTH_TOKEN: 'ready-secret',
+  });
+
+  try {
+    const result = await runReset({
+      ...process.env,
+      HOME: home,
+      PATH: `${bin}:${process.env.PATH}`,
+      MOCK_PUBLISHER_ACTIVE: '1',
+      VH_STORYCLUSTER_ENV_FILE: envFile,
+    });
+    assert.equal(result.status, 75);
+    assert.match(result.stderr, /refusing reset while vh-news-aggregator\.service is active/);
+    assert.match(readFileSync(systemctlLog, 'utf8'), /is-active --quiet vh-news-aggregator\.service/);
+    assert.doesNotMatch(readFileSync(systemctlLog, 'utf8'), /stop vh-storycluster-engine\.service/);
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test('storycluster reset backs up state, clears file store and qdrant collection, restarts engine, and redacts secrets', async () => {
+  const home = mkdtempSync(path.join(tmpdir(), 'vh-storycluster-reset-success-'));
+  const bin = path.join(home, 'bin');
+  const envFile = path.join(home, 'storycluster.env');
+  const systemctlLog = path.join(home, 'systemctl.log');
+  const stateDir = path.join(home, 'storycluster-state');
+  const backupRoot = path.join(home, 'backups');
+  const collection = 'storycluster_test_vectors';
+  const readyToken = 'ready-secret-token';
+  const qdrantKey = 'qdrant-secret-key';
+  mkdirSync(bin, { recursive: true });
+  mkdirSync(stateDir, { recursive: true });
+  writeFileSync(path.join(stateDir, 'topic.json'), '{"clusters":[{"story_id":"old"}]}\n');
+  writeSystemctlMock(bin, systemctlLog);
+  const qdrant = createQdrantHarness({ collection, apiKey: qdrantKey });
+  const ready = createReadyHarness({ collection, token: readyToken });
+  const qdrantPort = await listen(qdrant.server);
+  const readyPort = await listen(ready.server);
+
+  try {
+    writeEnvFile(envFile, {
+      NODE_ENV: 'production',
+      VH_STORYCLUSTER_RESET_APPROVED: '1',
+      VH_STORYCLUSTER_VECTOR_BACKEND: 'qdrant',
+      VH_STORYCLUSTER_STATE_DIR: stateDir,
+      VH_STORYCLUSTER_RESET_BACKUP_ROOT: backupRoot,
+      VH_STORYCLUSTER_RESET_STAMP: '20260616T000000Z',
+      VH_STORYCLUSTER_QDRANT_URL: `http://127.0.0.1:${qdrantPort}`,
+      VH_STORYCLUSTER_QDRANT_COLLECTION: collection,
+      VH_STORYCLUSTER_QDRANT_API_KEY: qdrantKey,
+      VH_STORYCLUSTER_SERVER_HOST: '127.0.0.1',
+      VH_STORYCLUSTER_SERVER_PORT: String(readyPort),
+      VH_STORYCLUSTER_SERVER_AUTH_TOKEN: readyToken,
+      VH_STORYCLUSTER_RESET_VERIFY_TIMEOUT_MS: '5000',
+    });
+
+    const result = await runReset({
+      ...process.env,
+      HOME: home,
+      PATH: `${bin}:${process.env.PATH}`,
+      VH_STORYCLUSTER_ENV_FILE: envFile,
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(qdrant.deleted, true);
+    assert.equal(qdrant.errors.join('\n'), '');
+    assert.equal(ready.errors.join('\n'), '');
+    assert.ok(qdrant.requests.some((request) => request.method === 'DELETE' && request.url === `/collections/${collection}`));
+    assert.ok(ready.requests.some((request) => request.authorization === `Bearer ${readyToken}`));
+    assert.equal(readdirSync(stateDir).length, 0);
+    assert.equal(existsSync(path.join(backupRoot, '20260616T000000Z', 'storycluster-state.tgz')), true);
+    const systemctlOutput = readFileSync(systemctlLog, 'utf8');
+    assert.match(systemctlOutput, /stop vh-storycluster-engine\.service/);
+    assert.match(systemctlOutput, /restart vh-storycluster-engine\.service/);
+    assert.ok(systemctlOutput.indexOf('stop vh-storycluster-engine.service') < systemctlOutput.indexOf('restart vh-storycluster-engine.service'));
+    assert.doesNotMatch(`${result.stdout}\n${result.stderr}`, new RegExp(readyToken));
+    assert.doesNotMatch(`${result.stdout}\n${result.stderr}`, new RegExp(qdrantKey));
+    assert.match(result.stdout, /state_dir_files_remaining: 0/);
+    assert.match(result.stdout, /collection: storycluster_test_vectors/);
+  } finally {
+    await close(qdrant.server);
+    await close(ready.server);
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test('storycluster reset fails closed when post-reset qdrant point count is not proven empty', async () => {
+  const home = mkdtempSync(path.join(tmpdir(), 'vh-storycluster-reset-unknown-points-'));
+  const bin = path.join(home, 'bin');
+  const envFile = path.join(home, 'storycluster.env');
+  const systemctlLog = path.join(home, 'systemctl.log');
+  const stateDir = path.join(home, 'storycluster-state');
+  const collection = 'storycluster_test_vectors';
+  const readyToken = 'ready-secret-token';
+  const qdrantKey = 'qdrant-secret-key';
+  mkdirSync(bin, { recursive: true });
+  mkdirSync(stateDir, { recursive: true });
+  writeFileSync(path.join(stateDir, 'topic.json'), '{"clusters":[{"story_id":"old"}]}\n');
+  writeSystemctlMock(bin, systemctlLog);
+  const qdrant = createQdrantHarness({ collection, apiKey: qdrantKey, omitPostResetPointCount: true });
+  const ready = createReadyHarness({ collection, token: readyToken });
+  const qdrantPort = await listen(qdrant.server);
+  const readyPort = await listen(ready.server);
+
+  try {
+    writeEnvFile(envFile, {
+      NODE_ENV: 'production',
+      VH_STORYCLUSTER_RESET_APPROVED: '1',
+      VH_STORYCLUSTER_VECTOR_BACKEND: 'qdrant',
+      VH_STORYCLUSTER_STATE_DIR: stateDir,
+      VH_STORYCLUSTER_QDRANT_URL: `http://127.0.0.1:${qdrantPort}`,
+      VH_STORYCLUSTER_QDRANT_COLLECTION: collection,
+      VH_STORYCLUSTER_QDRANT_API_KEY: qdrantKey,
+      VH_STORYCLUSTER_SERVER_HOST: '127.0.0.1',
+      VH_STORYCLUSTER_SERVER_PORT: String(readyPort),
+      VH_STORYCLUSTER_SERVER_AUTH_TOKEN: readyToken,
+      VH_STORYCLUSTER_RESET_VERIFY_TIMEOUT_MS: '5000',
+    });
+
+    const result = await runReset({
+      ...process.env,
+      HOME: home,
+      PATH: `${bin}:${process.env.PATH}`,
+      VH_STORYCLUSTER_ENV_FILE: envFile,
+    });
+
+    assert.equal(result.status, 1);
+    assert.match(result.stdout, /"stage":"post_reset"/);
+    assert.match(result.stdout, /"collection_points":null/);
+    assert.match(result.stdout, /"ok":false/);
+  } finally {
+    await close(qdrant.server);
+    await close(ready.server);
+    await rm(home, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- Add a gated `reset-storycluster-production-state.sh` for Phase 5 recovery that refuses active publisher state, backs up the StoryCluster file store, clears the configured Qdrant collection, restarts the managed StoryCluster engine, and verifies `/ready` plus `points=0` before reporting success.
- Add focused integration-style script tests with local fake Qdrant and StoryCluster `/ready` servers covering approval gating, active-publisher refusal, backup/delete/restart/redaction, and fail-closed unknown point counts.
- Document the reset cadence: reset -> capped no-write diagnostic -> inspect tick shape -> reset again -> live start only after explicit `start Phase 5 now`.

## Safety
- This does not start the publisher, add publisher approval, touch relays/origin, or write to Gun/mesh surfaces.
- The script mutates only StoryCluster derived state after `VH_STORYCLUSTER_RESET_APPROVED=1` and refuses to proceed unless the managed engine unit can be stopped/restarted.
- Output is intentionally redacted: no auth token or API key values are printed.

## Validation
- `bash -n tools/scripts/reset-storycluster-production-state.sh`
- `node --test tools/scripts/reset-storycluster-production-state.test.mjs`
- `node --test tools/scripts/storycluster-production-service.test.mjs tools/scripts/systemd-service-installers.test.mjs tools/scripts/start-news-aggregator-daemon-production.test.mjs`
- `git diff --check`
- `pnpm docs:check` (passes; local warning only because Node v23.10.0 is outside repo engine `>=20 <23`)
- `pnpm lint:loc` still fails on existing long files under `.claude/worktrees/*` and existing repo baseline entries, not on this change
- `shellcheck` is not installed in this environment
