### PR TITLE
[coord] Bound production no-write diagnostics

### DIFF
--- a/docs/ops/news-aggregator-production-service.md
+++ b/docs/ops/news-aggregator-production-service.md
@@ -148,12 +148,14 @@ systemctl --user restart vh-news-aggregator.service
    - live publisher: `VH_NEWS_DAEMON_START_APPROVED=1`;
    - no-write diagnostic: `VH_NEWS_DAEMON_DIAGNOSTIC_NO_WRITE=1` and
      `VH_NEWS_DAEMON_DIAGNOSTIC_APPROVED=1`.
-3. `pnpm check:news-sources:liveness` passes the operational restart gate.
-4. `pnpm --filter @vh/storycluster-engine build` passes.
-5. `preflightOpenAIStoryClusterProviderFromEnv` returns `status: "pass"`.
-6. Authenticated StoryCluster `VH_STORYCLUSTER_REMOTE_HEALTH_URL` returns
+3. No existing `@vh/news-aggregator daemon` / `dist/daemon.js` runtime process
+   is already running for the current user.
+4. `pnpm check:news-sources:liveness` passes the operational restart gate.
+5. `pnpm --filter @vh/storycluster-engine build` passes.
+6. `preflightOpenAIStoryClusterProviderFromEnv` returns `status: "pass"`.
+7. Authenticated StoryCluster `VH_STORYCLUSTER_REMOTE_HEALTH_URL` returns
    `ok: true` with a readiness `detail` beginning with `qdrant:`.
-7. The raw publication readiness preflight passes without writing a canary:
+8. The raw publication readiness preflight passes without writing a canary:
    signer material names are present, `VH_GUN_PEERS` parses, relay health
    endpoints are reachable through read-only `/healthz`, StoryCluster config is
    present, and relay-REST synthesis config is complete when synthesis is
@@ -174,11 +176,14 @@ blockers above are present.
 
 After these pass, the wrapper writes
 `VH_NEWS_DAEMON_LAST_SUCCESS_FILE` or
-`$VH_NEWS_DAEMON_STATE_DIR/last-success.json`, then `exec`s:
+`$VH_NEWS_DAEMON_STATE_DIR/last-success.json`, then starts:
 
 ```bash
 pnpm --filter @vh/news-aggregator daemon
 ```
+
+Live publisher starts `exec` the daemon. No-write diagnostic starts wait for the
+daemon process to exit and then recheck that no sibling daemon process remains.
 
 The daemon itself still verifies StoryCluster health before creating the Gun
 client and starting the runtime; the wrapper readiness check above exists to
@@ -191,6 +196,14 @@ writes/removes, latest/hot/lifecycle writes, relay-REST synthesis writes,
 synthesis queue persistence, replay writes, and product-feed repair writes.
 It still fetches feeds and calls StoryCluster so the tick summary can prove
 nonzero ingest/normalize/cluster/select before a live start is approved.
+
+No-write diagnostics are bounded by default. The wrapper exports
+`VH_NEWS_DAEMON_DIAGNOSTIC_MAX_TICKS=1` unless the env file deliberately
+overrides it, and the daemon self-stops after writing the tick summary and
+cluster-capture artifact for that many ticks. The daemon also acquires
+`$VH_NEWS_DAEMON_PID_FILE` or `$VH_NEWS_DAEMON_STATE_DIR/news-daemon.pid` before
+creating the mesh client; a direct `pnpm --filter @vh/news-aggregator daemon`
+launch refuses to start while another daemon process owns that pidfile.
 
 The production wrapper applies bounded feed/StoryCluster workload defaults
 unless the env file explicitly overrides them:

--- a/docs/ops/news-aggregator-production-service.md
+++ b/docs/ops/news-aggregator-production-service.md
@@ -200,7 +200,17 @@ nonzero ingest/normalize/cluster/select before a live start is approved.
 No-write diagnostics are bounded by default. The wrapper exports
 `VH_NEWS_DAEMON_DIAGNOSTIC_MAX_TICKS=1` unless the env file deliberately
 overrides it, and the daemon self-stops after writing the tick summary and
-cluster-capture artifact for that many ticks. The daemon also acquires
+cluster-capture artifact for that many ticks. The wrapper also applies
+`VH_NEWS_DAEMON_DIAGNOSTIC_MAX_SECONDS=600` by default and, when `timeout` is
+available, runs the diagnostic daemon under that hard wall-clock bound with a
+30-second kill-after grace window. This covers hung ticks that never emit a
+summary and therefore never reach the in-daemon max-ticks stop. If `timeout` is
+not available, the wrapper logs the fallback, relies on the in-daemon max-ticks
+stop, and still runs post-diagnostic sibling cleanup before returning.
+
+After every no-write diagnostic run, the wrapper reaps any remaining sibling
+daemon runtime process with SIGTERM, waits up to 10 seconds, escalates to
+SIGKILL, and fails closed if the process still remains. The daemon also acquires
 `$VH_NEWS_DAEMON_PID_FILE` or `$VH_NEWS_DAEMON_STATE_DIR/news-daemon.pid` before
 creating the mesh client; a direct `pnpm --filter @vh/news-aggregator daemon`
 launch refuses to start while another daemon process owns that pidfile.

--- a/docs/ops/news-aggregator.env.example
+++ b/docs/ops/news-aggregator.env.example
@@ -12,6 +12,7 @@
 # VH_NEWS_DAEMON_DIAGNOSTIC_NO_WRITE=1
 # VH_NEWS_DAEMON_DIAGNOSTIC_APPROVED=1
 # VH_NEWS_DAEMON_DIAGNOSTIC_MAX_TICKS=1
+# VH_NEWS_DAEMON_DIAGNOSTIC_MAX_SECONDS=600
 
 # Public Gun peers used by the daemon client.
 VH_GUN_PEERS='["wss://gun-a.carboncaste.io/gun","wss://gun-b.carboncaste.io/gun","wss://gun-c.carboncaste.io/gun"]'

--- a/docs/ops/news-aggregator.env.example
+++ b/docs/ops/news-aggregator.env.example
@@ -7,9 +7,11 @@
 # VH_NEWS_DAEMON_START_APPROVED=1
 
 # No-write diagnostic approval is separate from live start approval. Add both
-# lines only for an approved diagnostic run that must not mutate the mesh.
+# lines only for an approved diagnostic run that must not mutate the mesh. The
+# production wrapper defaults approved diagnostics to one runtime tick.
 # VH_NEWS_DAEMON_DIAGNOSTIC_NO_WRITE=1
 # VH_NEWS_DAEMON_DIAGNOSTIC_APPROVED=1
+# VH_NEWS_DAEMON_DIAGNOSTIC_MAX_TICKS=1
 
 # Public Gun peers used by the daemon client.
 VH_GUN_PEERS='["wss://gun-a.carboncaste.io/gun","wss://gun-b.carboncaste.io/gun","wss://gun-c.carboncaste.io/gun"]'
@@ -43,6 +45,7 @@ VH_NEWS_DAEMON_HOLDER_ID=vh-news-daemon:a6-public
 VH_NEWS_RUNTIME_LEASE_TTL_MS=120000
 VH_NEWS_INGESTION_LEASE_SCOPE=public-beta
 VH_NEWS_DAEMON_STATE_DIR=/home/humble/.local/state/vhc/news-aggregator
+VH_NEWS_DAEMON_PID_FILE=/home/humble/.local/state/vhc/news-aggregator/news-daemon.pid
 VH_DAEMON_FEED_ARTIFACT_ROOT=/home/humble/.local/state/vhc/news-aggregator/artifacts
 VH_NEWS_DAEMON_LAST_SUCCESS_FILE=/home/humble/.local/state/vhc/news-aggregator/last-success.json
 VH_NEWS_RUNTIME_DIAGNOSTIC_FILE=/home/humble/.local/state/vhc/news-aggregator/artifacts/news-runtime-diagnostics.json

--- a/docs/ops/storycluster-production-service.md
+++ b/docs/ops/storycluster-production-service.md
@@ -162,8 +162,9 @@ For Phase 5 publisher recovery, use this cadence unless the diagnostic is
 explicitly pointed at an ephemeral StoryCluster state dir and Qdrant collection:
 
 1. Reset StoryCluster state.
-2. Run the capped publisher no-write diagnostic with a fresh
-   `VH_DAEMON_FEED_RUN_ID`.
+2. Run the capped, self-terminating publisher no-write diagnostic with a fresh
+   `VH_DAEMON_FEED_RUN_ID`; the production wrapper defaults this diagnostic to
+   one runtime tick via `VH_NEWS_DAEMON_DIAGNOSTIC_MAX_TICKS=1`.
 3. Inspect tick shape, not only `selected > 0`: completed tick, no watchdog,
    sane bundle count, fresh cluster window, no singleton explosion, and recent
    first selected story IDs.

--- a/services/news-aggregator/src/daemon.production.test.ts
+++ b/services/news-aggregator/src/daemon.production.test.ts
@@ -1,4 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type { NewsRuntimeTickSummary } from '@vh/ai-engine';
 
 const mocks = vi.hoisted(() => ({
   startNewsRuntime: vi.fn(),
@@ -44,6 +48,57 @@ import {
 function primeHealthyEnv(): void {
   vi.stubEnv('VH_STORYCLUSTER_REMOTE_URL', 'https://storycluster.example.com/cluster');
   vi.stubEnv('VH_STORYCLUSTER_REMOTE_AUTH_TOKEN', 'token-123');
+}
+
+function makeTickSummary(overrides: Partial<NewsRuntimeTickSummary> = {}): NewsRuntimeTickSummary {
+  return {
+    schemaVersion: 'vh-news-runtime-tick-summary-v1',
+    tick_sequence: 1,
+    first_tick: true,
+    status: 'completed',
+    no_write: true,
+    started_at: new Date(1_700_000_000_000).toISOString(),
+    completed_at: new Date(1_700_000_001_000).toISOString(),
+    duration_ms: 1_000,
+    poll_interval_ms: 600_000,
+    feed_source_count: 1,
+    published_bundle_limit: 24,
+    ingested_item_count: 3,
+    normalized_item_count: 2,
+    clustered_bundle_count: 1,
+    clustered_storyline_count: 0,
+    selected_bundle_count: 1,
+    selected_singleton_bundle_count: 1,
+    selected_multi_source_bundle_count: 0,
+    publication_ineligible_bundle_count: 0,
+    raw_write_attempted_count: 0,
+    raw_write_suppressed_count: 1,
+    raw_wrote_count: 0,
+    raw_write_failed_count: 0,
+    storyline_write_attempted_count: 0,
+    storyline_write_suppressed_count: 0,
+    storyline_wrote_count: 0,
+    storyline_write_failed_count: 0,
+    stale_story_remove_attempted_count: 0,
+    stale_story_remove_suppressed_count: 0,
+    stale_story_removed_count: 0,
+    stale_story_remove_failed_count: 0,
+    stale_storyline_remove_attempted_count: 0,
+    stale_storyline_remove_suppressed_count: 0,
+    stale_storyline_removed_count: 0,
+    stale_storyline_remove_failed_count: 0,
+    synthesis_candidate_enqueued_count: 0,
+    synthesis_candidate_suppressed_count: 1,
+    first_selected_story_ids: ['story-1'],
+    last_stage: 'completed',
+    ...overrides,
+  };
+}
+
+function waitForScheduledStop(): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
 }
 
 describe('news daemon production wiring', () => {
@@ -167,6 +222,103 @@ describe('news daemon production wiring', () => {
       });
     } finally {
       await handle.stop();
+    }
+  });
+
+  it('defaults no-write diagnostics to one runtime tick and self-stops after writing the summary', async () => {
+    const tmpDir = mkdtempSync(path.join(os.tmpdir(), 'vh-news-daemon-bounded-diagnostic-'));
+    const runtimeHandle = {
+      stop: vi.fn(),
+      isRunning: vi.fn(() => true),
+      lastRun: vi.fn(() => null),
+    };
+    const shutdown = vi.fn().mockResolvedValue(undefined);
+    mocks.startNewsRuntime.mockReturnValue(runtimeHandle);
+    mocks.createNodeMeshClient.mockReturnValue({
+      id: 'mock-client',
+      shutdown,
+    });
+    primeHealthyEnv();
+    vi.stubEnv('VH_NEWS_DAEMON_DIAGNOSTIC_NO_WRITE', '1');
+    vi.stubEnv('VH_NEWS_DAEMON_STATE_DIR', tmpDir);
+    vi.stubEnv('VH_DAEMON_FEED_ARTIFACT_ROOT', path.join(tmpDir, 'artifacts'));
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('ok', { status: 200 })));
+
+    try {
+      const handle = await startNewsAggregatorDaemonFromEnv();
+      const runtimeConfig = mocks.startNewsRuntime.mock.calls[0]?.[0] as {
+        noWrite?: boolean;
+        onTickSummary?: (summary: NewsRuntimeTickSummary) => Promise<void>;
+      };
+
+      expect(runtimeConfig.noWrite).toBe(true);
+      await runtimeConfig.onTickSummary?.(makeTickSummary({ tick_sequence: 1 }));
+      await vi.waitFor(() => expect(runtimeHandle.stop).toHaveBeenCalledTimes(1));
+      await vi.waitFor(() => expect(shutdown).toHaveBeenCalledTimes(1));
+
+      await handle.stop();
+      expect(runtimeHandle.stop).toHaveBeenCalledTimes(1);
+      expect(shutdown).toHaveBeenCalledTimes(1);
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('honors an explicit no-write diagnostic tick limit before self-stopping', async () => {
+    const tmpDir = mkdtempSync(path.join(os.tmpdir(), 'vh-news-daemon-bounded-diagnostic-'));
+    const runtimeHandle = {
+      stop: vi.fn(),
+      isRunning: vi.fn(() => true),
+      lastRun: vi.fn(() => null),
+    };
+    const shutdown = vi.fn().mockResolvedValue(undefined);
+    mocks.startNewsRuntime.mockReturnValue(runtimeHandle);
+    mocks.createNodeMeshClient.mockReturnValue({
+      id: 'mock-client',
+      shutdown,
+    });
+    primeHealthyEnv();
+    vi.stubEnv('VH_NEWS_DAEMON_DIAGNOSTIC_NO_WRITE', '1');
+    vi.stubEnv('VH_NEWS_DAEMON_DIAGNOSTIC_MAX_TICKS', '2');
+    vi.stubEnv('VH_NEWS_DAEMON_STATE_DIR', tmpDir);
+    vi.stubEnv('VH_DAEMON_FEED_ARTIFACT_ROOT', path.join(tmpDir, 'artifacts'));
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('ok', { status: 200 })));
+
+    try {
+      const handle = await startNewsAggregatorDaemonFromEnv();
+      const runtimeConfig = mocks.startNewsRuntime.mock.calls[0]?.[0] as {
+        onTickSummary?: (summary: NewsRuntimeTickSummary) => Promise<void>;
+      };
+
+      await runtimeConfig.onTickSummary?.(makeTickSummary({ tick_sequence: 1 }));
+      await waitForScheduledStop();
+      expect(runtimeHandle.stop).not.toHaveBeenCalled();
+
+      await runtimeConfig.onTickSummary?.(makeTickSummary({ tick_sequence: 2 }));
+      await vi.waitFor(() => expect(runtimeHandle.stop).toHaveBeenCalledTimes(1));
+      await vi.waitFor(() => expect(shutdown).toHaveBeenCalledTimes(1));
+
+      await handle.stop();
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses direct daemon startup when the process pidfile is held', async () => {
+    const tmpDir = mkdtempSync(path.join(os.tmpdir(), 'vh-news-daemon-held-lock-'));
+    try {
+      writeFileSync(path.join(tmpDir, 'news-daemon.pid'), `${process.pid}\n`, 'utf8');
+      primeHealthyEnv();
+      vi.stubEnv('VH_NEWS_DAEMON_STATE_DIR', tmpDir);
+      vi.stubGlobal('fetch', vi.fn(async () => new Response('ok', { status: 200 })));
+
+      await expect(startNewsAggregatorDaemonFromEnv()).rejects.toThrow(
+        `news daemon process lock is held by pid ${process.pid}`,
+      );
+      expect(mocks.createNodeMeshClient).not.toHaveBeenCalled();
+      expect(mocks.startNewsRuntime).not.toHaveBeenCalled();
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
     }
   });
 

--- a/services/news-aggregator/src/daemon.ts
+++ b/services/news-aggregator/src/daemon.ts
@@ -1,4 +1,11 @@
-import { mkdirSync } from 'node:fs';
+import {
+  closeSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import {
@@ -113,6 +120,8 @@ export interface NewsAggregatorDaemonConfig {
   synthesisInProgressStaleMs?: number;
   runtimeOrchestratorOptions?: NewsRuntimeConfig['orchestratorOptions'];
   noWrite?: boolean;
+  runtimeMaxTicks?: number;
+  onRuntimeTickLimitReached?: (summary: NewsRuntimeTickSummary) => void | Promise<void>;
   runtimeTickWatchdogMs?: number;
   now?: () => number;
   random?: () => number;
@@ -163,6 +172,8 @@ export function createNewsAggregatorDaemon(config: NewsAggregatorDaemonConfig): 
     runId: readEnvVar('VH_DAEMON_FEED_RUN_ID'),
     noWrite,
   });
+  const runtimeMaxTicks = config.runtimeMaxTicks;
+  let runtimeTickLimitReached = false;
   let running = false;
   let runtimeHandle: NewsRuntimeHandle | null = null;
   let leaseHeartbeatTimer: ReturnType<typeof setInterval> | null = null;
@@ -243,6 +254,23 @@ export function createNewsAggregatorDaemon(config: NewsAggregatorDaemonConfig): 
           selected_bundle_count: summary.selected_bundle_count,
           diagnostic_summary_count: snapshot.summaries.length,
         });
+        if (
+          runtimeMaxTicks
+          && summary.tick_sequence >= runtimeMaxTicks
+          && !runtimeTickLimitReached
+        ) {
+          runtimeTickLimitReached = true;
+          logger.info('[vh:news-daemon] runtime tick limit reached', {
+            holder_id: holderId,
+            tick_sequence: summary.tick_sequence,
+            max_ticks: runtimeMaxTicks,
+            status: summary.status,
+            no_write: summary.no_write,
+          });
+          void Promise.resolve(config.onRuntimeTickLimitReached?.(summary)).catch((error) => {
+            logger.warn('[vh:news-daemon] runtime tick limit stop callback failed', error);
+          });
+        }
       },
       writeStoryBundle: async (runtimeClient: unknown, bundle: unknown) => {
         const storyId = typeof bundle === 'object' && bundle !== null ? (bundle as { story_id?: unknown }).story_id : null;
@@ -580,6 +608,77 @@ function safePathToken(value: string): string {
   return value.trim().replace(/[^a-zA-Z0-9._:-]+/g, '_') || 'default';
 }
 
+interface DaemonProcessLock {
+  readonly filePath: string;
+  release(): void;
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (error && typeof error === 'object' && 'code' in error && error.code === 'ESRCH') {
+      return false;
+    }
+    return true;
+  }
+}
+
+function readLockPid(filePath: string): number | null {
+  try {
+    const raw = readFileSync(filePath, 'utf8');
+    const parsed = Number.parseInt(raw.trim(), 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function acquireDaemonProcessLock(filePath: string, logger: LoggerLike): DaemonProcessLock {
+  mkdirSync(path.dirname(filePath), { recursive: true });
+
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      const fd = openSync(filePath, 'wx', 0o600);
+      try {
+        writeFileSync(fd, `${process.pid}\n`, 'utf8');
+      } finally {
+        closeSync(fd);
+      }
+      return {
+        filePath,
+        release() {
+          const lockPid = readLockPid(filePath);
+          if (lockPid === process.pid) {
+            rmSync(filePath, { force: true });
+          }
+        },
+      };
+    } catch (error) {
+      if (
+        !error
+        || typeof error !== 'object'
+        || !('code' in error)
+        || error.code !== 'EEXIST'
+      ) {
+        throw error;
+      }
+      const existingPid = readLockPid(filePath);
+      if (existingPid && isProcessAlive(existingPid)) {
+        throw new Error(`news daemon process lock is held by pid ${existingPid}`);
+      }
+      logger.warn('[vh:news-daemon] removing stale process lock', {
+        lock_file: filePath,
+        existing_pid: existingPid,
+      });
+      rmSync(filePath, { force: true });
+    }
+  }
+
+  throw new Error(`unable to acquire news daemon process lock: ${filePath}`);
+}
+
 function resolveNewsDaemonGunFile(holderId: string | undefined): string {
   const stateRoot =
     firstNonEmpty(
@@ -616,9 +715,21 @@ export async function startNewsAggregatorDaemonFromEnv(): Promise<NewsAggregator
   const holderId = readEnvVar('VH_NEWS_DAEMON_HOLDER_ID');
   const noWrite = isEnabledFlag(readEnvVar('VH_NEWS_DAEMON_DIAGNOSTIC_NO_WRITE'))
     || isEnabledFlag(readEnvVar('VH_NEWS_DAEMON_NO_WRITE'));
+  const diagnosticMaxTicks = noWrite
+    ? parseOptionalPositiveInt(readEnvVar('VH_NEWS_DAEMON_DIAGNOSTIC_MAX_TICKS')) ?? 1
+    : undefined;
   const runtimeTickWatchdogMs = parseOptionalPositiveInt(readEnvVar('VH_NEWS_RUNTIME_TICK_WATCHDOG_MS'));
   const leaseScope = firstNonEmpty(readEnvVar('VH_NEWS_INGESTION_LEASE_SCOPE'));
   const gunRadisk = !isDisabledFlag(readEnvVar('VH_NEWS_DAEMON_GUN_RADISK'));
+  const daemonStateDir =
+    firstNonEmpty(
+      readEnvVar('VH_NEWS_DAEMON_STATE_DIR'),
+      readEnvVar('VH_DAEMON_FEED_ARTIFACT_ROOT'),
+    ) ?? path.join(os.tmpdir(), 'vh-news-daemon');
+  const processLock = acquireDaemonProcessLock(
+    firstNonEmpty(readEnvVar('VH_NEWS_DAEMON_PID_FILE')) ?? path.join(daemonStateDir, 'news-daemon.pid'),
+    console,
+  );
   const gunFile = gunRadisk
     ? firstNonEmpty(readEnvVar('VH_NEWS_DAEMON_GUN_FILE')) ?? resolveNewsDaemonGunFile(holderId)
     : false;
@@ -626,62 +737,111 @@ export async function startNewsAggregatorDaemonFromEnv(): Promise<NewsAggregator
     mkdirSync(path.dirname(gunFile), { recursive: true });
   }
   const writeLanes = createDaemonWriteLaneRegistry({ logger: console });
-  const systemWriterConfig = await resolveSystemWriterClientConfigFromEnv();
-  const client = createNodeMeshClient({
-    peers: gunPeers.length > 0 ? gunPeers : undefined,
-    requireSession: false,
-    gunRadisk,
-    gunFile,
-    ...(leaseScope ? { newsIngestionLeaseScope: leaseScope } : {}),
-    ...systemWriterConfig,
-  });
-  const bundleSynthesisEnrichment = noWrite
-    ? {}
-    : createBundleSynthesisEnrichmentFromEnv(client, console, {
-        runWrite: writeLanes.run,
+  let client: VennClient | null = null;
+  let processHandle: NewsAggregatorDaemonProcessHandle | null = null;
+  let diagnosticStopRequested = false;
+  try {
+    const systemWriterConfig = await resolveSystemWriterClientConfigFromEnv();
+    client = createNodeMeshClient({
+      peers: gunPeers.length > 0 ? gunPeers : undefined,
+      requireSession: false,
+      gunRadisk,
+      gunFile,
+      ...(leaseScope ? { newsIngestionLeaseScope: leaseScope } : {}),
+      ...systemWriterConfig,
+    });
+    const bundleSynthesisEnrichment = noWrite
+      ? {}
+      : createBundleSynthesisEnrichmentFromEnv(client, console, {
+          runWrite: writeLanes.run,
+        });
+    if (noWrite) {
+      console.warn('[vh:news-daemon] no-write diagnostic mode enabled; all mesh mutations are suppressed', {
+        diagnostic_max_ticks: diagnosticMaxTicks ?? null,
       });
-  if (noWrite) {
-    console.warn('[vh:news-daemon] no-write diagnostic mode enabled; all mesh mutations are suppressed');
-  }
-  const replayArtifactDir = resolveAnalysisEvalReplayArtifactDirFromEnv();
-  const daemon = createNewsAggregatorDaemon({
-    client,
-    feedSources,
-    topicMapping,
-    pollIntervalMs,
-    leaseTtlMs,
-    leaseHolderId: holderId,
-    writeLanes,
-    noWrite,
-    runtimeTickWatchdogMs,
-    replayAcceptedSynthesis: !noWrite && replayArtifactDir
-      ? (runtimeClient) =>
-          replayAcceptedAnalysisEvalSyntheses({
-            client: runtimeClient,
-            artifactDir: replayArtifactDir,
-            logger: console,
-            runWrite: writeLanes.run,
+    }
+    const replayArtifactDir = resolveAnalysisEvalReplayArtifactDirFromEnv();
+    const requestDiagnosticStop = (summary: NewsRuntimeTickSummary) => {
+      if (!noWrite || !diagnosticMaxTicks || diagnosticStopRequested) {
+        return;
+      }
+      diagnosticStopRequested = true;
+      setTimeout(() => {
+        void processHandle?.stop()
+          .then(() => {
+            console.info('[vh:news-daemon] bounded no-write diagnostic stopped after tick limit', {
+              tick_sequence: summary.tick_sequence,
+              max_ticks: diagnosticMaxTicks,
+              status: summary.status,
+            });
           })
-      : undefined,
-    ...bundleSynthesisEnrichment,
-    runtimeOrchestratorOptions: {
-      productionMode: true,
-      allowHeuristicFallback: false,
-      remoteClusterEndpoint: storyCluster.endpointUrl,
-      remoteClusterTimeoutMs: storyCluster.timeoutMs,
-      remoteClusterMaxItemsPerRequest: storyCluster.maxItemsPerRequest,
-      remoteClusterHeaders: storyCluster.headers,
-    } as RuntimeOrchestratorOptions,
-  });
-  await daemon.start();
-  return {
-    daemon,
-    client,
-    async stop() {
-      await daemon.stop();
-      await client.shutdown();
-    },
-  };
+          .catch((error) => {
+            console.warn('[vh:news-daemon] bounded no-write diagnostic stop failed', error);
+          });
+      }, 0);
+    };
+    const daemon = createNewsAggregatorDaemon({
+      client,
+      feedSources,
+      topicMapping,
+      pollIntervalMs,
+      leaseTtlMs,
+      leaseHolderId: holderId,
+      writeLanes,
+      noWrite,
+      runtimeMaxTicks: diagnosticMaxTicks,
+      onRuntimeTickLimitReached: diagnosticMaxTicks ? requestDiagnosticStop : undefined,
+      runtimeTickWatchdogMs,
+      replayAcceptedSynthesis: !noWrite && replayArtifactDir
+        ? (runtimeClient) =>
+            replayAcceptedAnalysisEvalSyntheses({
+              client: runtimeClient,
+              artifactDir: replayArtifactDir,
+              logger: console,
+              runWrite: writeLanes.run,
+            })
+        : undefined,
+      ...bundleSynthesisEnrichment,
+      runtimeOrchestratorOptions: {
+        productionMode: true,
+        allowHeuristicFallback: false,
+        remoteClusterEndpoint: storyCluster.endpointUrl,
+        remoteClusterTimeoutMs: storyCluster.timeoutMs,
+        remoteClusterMaxItemsPerRequest: storyCluster.maxItemsPerRequest,
+        remoteClusterHeaders: storyCluster.headers,
+      } as RuntimeOrchestratorOptions,
+    });
+    let stopped = false;
+    processHandle = {
+      daemon,
+      client,
+      async stop() {
+        if (stopped) {
+          return;
+        }
+        stopped = true;
+        try {
+          await daemon.stop();
+          await client?.shutdown();
+        } finally {
+          processLock.release();
+        }
+      },
+    };
+    await daemon.start();
+    return processHandle;
+  } catch (error) {
+    if (processHandle) {
+      await processHandle?.stop();
+    } else {
+      try {
+        await client?.shutdown();
+      } finally {
+        processLock.release();
+      }
+    }
+    throw error;
+  }
 }
 
 /* c8 ignore start */

--- a/tools/scripts/start-news-aggregator-daemon-production.sh
+++ b/tools/scripts/start-news-aggregator-daemon-production.sh
@@ -25,6 +25,33 @@ truthy_flag() {
   esac
 }
 
+find_news_daemon_sibling_pids() {
+  ps -axo pid=,comm=,command= 2>/dev/null \
+    | awk -v self_pid="$$" '
+        $1 != self_pid && $2 == "node" && (index($0, "@vh/news-aggregator daemon") || index($0, "dist/daemon.js")) { print $1 }
+      ' \
+    | tr '\n' ' '
+}
+
+redact_process_line() {
+  sed -E 's/([A-Z0-9_]*(KEY|TOKEN|SECRET|PRIVATE|PIN|OPENAI)[A-Z0-9_]*=)[^[:space:]]+/\1[redacted]/g'
+}
+
+require_no_news_daemon_siblings() {
+  local context="${1:-preflight}"
+  local pids
+  pids="$(find_news_daemon_sibling_pids)"
+  if [[ -z "${pids// }" ]]; then
+    return 0
+  fi
+
+  echo "[vh:news-daemon:prod] refusing ${context}: existing news daemon runtime process(es): ${pids}" >&2
+  for pid in ${pids}; do
+    ps -p "${pid}" -o pid=,comm=,command= 2>/dev/null | redact_process_line >&2 || true
+  done
+  return 75
+}
+
 NO_WRITE_DIAGNOSTIC=false
 if truthy_flag "${VH_NEWS_DAEMON_DIAGNOSTIC_NO_WRITE:-${VH_NEWS_DAEMON_NO_WRITE:-}}"; then
   NO_WRITE_DIAGNOSTIC=true
@@ -37,10 +64,13 @@ if [[ "${NO_WRITE_DIAGNOSTIC}" == "true" ]]; then
     exit 78
   fi
   echo "[vh:news-daemon:prod] no-write diagnostic mode approved; live mesh mutations are suppressed"
+  export VH_NEWS_DAEMON_DIAGNOSTIC_MAX_TICKS="${VH_NEWS_DAEMON_DIAGNOSTIC_MAX_TICKS:-1}"
 elif [[ "${VH_NEWS_DAEMON_START_APPROVED:-}" != "1" ]]; then
   echo "[vh:news-daemon:prod] refusing to start without VH_NEWS_DAEMON_START_APPROVED=1 in ${ENV_FILE}" >&2
   exit 78
 fi
+
+require_no_news_daemon_siblings "start"
 
 export VH_NEWS_DAEMON_STATE_DIR="${VH_NEWS_DAEMON_STATE_DIR:-${STATE_DIR}}"
 export VH_DAEMON_FEED_ARTIFACT_ROOT="${VH_DAEMON_FEED_ARTIFACT_ROOT:-${ARTIFACT_ROOT}}"
@@ -164,4 +194,12 @@ await writeFile(filePath, `${JSON.stringify({
 NODE
 
 echo "[vh:news-daemon:prod] preflights passed; starting canonical @vh/news-aggregator daemon"
+if [[ "${NO_WRITE_DIAGNOSTIC}" == "true" ]]; then
+  set +e
+  pnpm --filter @vh/news-aggregator daemon
+  daemon_status=$?
+  set -e
+  require_no_news_daemon_siblings "post-diagnostic"
+  exit "${daemon_status}"
+fi
 exec pnpm --filter @vh/news-aggregator daemon

--- a/tools/scripts/start-news-aggregator-daemon-production.sh
+++ b/tools/scripts/start-news-aggregator-daemon-production.sh
@@ -52,6 +52,33 @@ require_no_news_daemon_siblings() {
   return 75
 }
 
+# Guarantee no diagnostic daemon outlives this wrapper, even if a tick hung
+# (a hung tick never emits a summary, so the in-daemon max-ticks stop never
+# fires). SIGTERM first for a graceful lease release, then SIGKILL any survivor.
+reap_news_daemon_siblings() {
+  local context="${1:-cleanup}"
+  local pids attempt
+  pids="$(find_news_daemon_sibling_pids)"
+  if [[ -z "${pids// }" ]]; then
+    return 0
+  fi
+  echo "[vh:news-daemon:prod] reaping ${context} news daemon runtime process(es): ${pids}" >&2
+  for pid in ${pids}; do kill -TERM "${pid}" 2>/dev/null || true; done
+  for attempt in 1 2 3 4 5 6 7 8 9 10; do
+    pids="$(find_news_daemon_sibling_pids)"
+    [[ -z "${pids// }" ]] && return 0
+    sleep 1
+  done
+  pids="$(find_news_daemon_sibling_pids)"
+  for pid in ${pids}; do kill -KILL "${pid}" 2>/dev/null || true; done
+  sleep 1
+  pids="$(find_news_daemon_sibling_pids)"
+  if [[ -n "${pids// }" ]]; then
+    echo "[vh:news-daemon:prod] failed to reap ${context} news daemon runtime process(es) after SIGKILL: ${pids}" >&2
+    return 75
+  fi
+}
+
 NO_WRITE_DIAGNOSTIC=false
 if truthy_flag "${VH_NEWS_DAEMON_DIAGNOSTIC_NO_WRITE:-${VH_NEWS_DAEMON_NO_WRITE:-}}"; then
   NO_WRITE_DIAGNOSTIC=true
@@ -65,6 +92,15 @@ if [[ "${NO_WRITE_DIAGNOSTIC}" == "true" ]]; then
   fi
   echo "[vh:news-daemon:prod] no-write diagnostic mode approved; live mesh mutations are suppressed"
   export VH_NEWS_DAEMON_DIAGNOSTIC_MAX_TICKS="${VH_NEWS_DAEMON_DIAGNOSTIC_MAX_TICKS:-1}"
+  # Hard wall-clock bound so a hung tick (which never reaches the in-daemon
+  # max-ticks stop) cannot orphan. Default sits above one healthy capped tick
+  # (~160-235s) and above the 420s tick watchdog so a hang still logs its warning.
+  DIAGNOSTIC_MAX_SECONDS="${VH_NEWS_DAEMON_DIAGNOSTIC_MAX_SECONDS:-600}"
+  if [[ ! "${DIAGNOSTIC_MAX_SECONDS}" =~ ^[0-9]+$ || "${DIAGNOSTIC_MAX_SECONDS}" -le 0 ]]; then
+    echo "[vh:news-daemon:prod] VH_NEWS_DAEMON_DIAGNOSTIC_MAX_SECONDS must be a positive integer" >&2
+    exit 78
+  fi
+  DIAGNOSTIC_TIMEOUT_BIN="${VH_NEWS_DAEMON_DIAGNOSTIC_TIMEOUT_BIN:-timeout}"
 elif [[ "${VH_NEWS_DAEMON_START_APPROVED:-}" != "1" ]]; then
   echo "[vh:news-daemon:prod] refusing to start without VH_NEWS_DAEMON_START_APPROVED=1 in ${ENV_FILE}" >&2
   exit 78
@@ -196,10 +232,19 @@ NODE
 echo "[vh:news-daemon:prod] preflights passed; starting canonical @vh/news-aggregator daemon"
 if [[ "${NO_WRITE_DIAGNOSTIC}" == "true" ]]; then
   set +e
-  pnpm --filter @vh/news-aggregator daemon
+  if command -v "${DIAGNOSTIC_TIMEOUT_BIN}" >/dev/null 2>&1; then
+    "${DIAGNOSTIC_TIMEOUT_BIN}" --signal=TERM --kill-after=30s "${DIAGNOSTIC_MAX_SECONDS}" pnpm --filter @vh/news-aggregator daemon
+  else
+    echo "[vh:news-daemon:prod] '${DIAGNOSTIC_TIMEOUT_BIN}' unavailable; relying on in-daemon max-ticks + post-run reap" >&2
+    pnpm --filter @vh/news-aggregator daemon
+  fi
   daemon_status=$?
   set -e
-  require_no_news_daemon_siblings "post-diagnostic"
+  if [[ "${daemon_status}" == "124" ]]; then
+    echo "[vh:news-daemon:prod] no-write diagnostic hit the ${DIAGNOSTIC_MAX_SECONDS}s wall-clock bound (likely a hung tick); reaping" >&2
+  fi
+  # Guarantee no orphan survives this wrapper regardless of how the daemon exited.
+  reap_news_daemon_siblings "post-diagnostic"
   exit "${daemon_status}"
 fi
 exec pnpm --filter @vh/news-aggregator daemon

--- a/tools/scripts/start-news-aggregator-daemon-production.test.mjs
+++ b/tools/scripts/start-news-aggregator-daemon-production.test.mjs
@@ -24,12 +24,25 @@ function makeHarness({
   diagnosticApproved = false,
   extraEnv = [],
   psOutput = null,
+  psOutputs = null,
+  pnpmStatuses = [99],
+  stubNode = false,
+  nodeStatus = 0,
+  timeoutStatus = null,
+  stubSleep = false,
 }) {
   const root = mkdtempSync(path.join(os.tmpdir(), 'vh-news-daemon-start-'));
   const binDir = path.join(root, 'bin');
   const envFile = path.join(root, 'news-aggregator.env');
   const pnpmMarker = path.join(root, 'pnpm-called.txt');
+  const pnpmStatusFile = path.join(root, 'pnpm-statuses.txt');
+  const nodeMarker = path.join(root, 'node-called.txt');
+  const timeoutMarker = path.join(root, 'timeout-called.txt');
+  const sleepMarker = path.join(root, 'sleep-called.txt');
+  const psOutputDir = path.join(root, 'ps-outputs');
+  const psIndexFile = path.join(root, 'ps-index.txt');
   mkdirSync(binDir, { recursive: true });
+  writeFileSync(pnpmStatusFile, pnpmStatuses.join('\n') + '\n', 'utf8');
   writeFileSync(
     path.join(binDir, 'pnpm'),
     [
@@ -44,20 +57,77 @@ function makeHarness({
       'if [[ -n "${VH_NEWS_DAEMON_DIAGNOSTIC_MAX_TICKS:-}" ]]; then',
       '  printf "VH_NEWS_DAEMON_DIAGNOSTIC_MAX_TICKS=%s\\n" "${VH_NEWS_DAEMON_DIAGNOSTIC_MAX_TICKS}" >> "${VH_TEST_PNPM_MARKER:?}"',
       'fi',
-      'exit 99',
+      'status=0',
+      'if [[ -s "${VH_TEST_PNPM_STATUS_FILE:?}" ]]; then',
+      '  status="$(sed -n \'1p\' "${VH_TEST_PNPM_STATUS_FILE:?}")"',
+      '  sed \'1d\' "${VH_TEST_PNPM_STATUS_FILE:?}" > "${VH_TEST_PNPM_STATUS_FILE:?}.next"',
+      '  mv "${VH_TEST_PNPM_STATUS_FILE:?}.next" "${VH_TEST_PNPM_STATUS_FILE:?}"',
+      'fi',
+      '[[ -n "${status}" ]] || status=0',
+      'exit "${status}"',
       '',
     ].join('\n'),
     'utf8',
   );
   chmodSync(path.join(binDir, 'pnpm'), 0o755);
-  if (psOutput !== null) {
+  if (stubNode) {
+    writeFileSync(
+      path.join(binDir, 'node'),
+      [
+        '#!/usr/bin/env bash',
+        'printf "node_args=%s\\n" "$*" >> "${VH_TEST_NODE_MARKER:?}"',
+        'exit "${VH_TEST_NODE_STATUS:?}"',
+        '',
+      ].join('\n'),
+      'utf8',
+    );
+    chmodSync(path.join(binDir, 'node'), 0o755);
+  }
+  if (timeoutStatus !== null) {
+    writeFileSync(
+      path.join(binDir, 'timeout'),
+      [
+        '#!/usr/bin/env bash',
+        'printf "timeout_args=%s\\n" "$*" >> "${VH_TEST_TIMEOUT_MARKER:?}"',
+        'exit "${VH_TEST_TIMEOUT_STATUS:?}"',
+        '',
+      ].join('\n'),
+      'utf8',
+    );
+    chmodSync(path.join(binDir, 'timeout'), 0o755);
+  }
+  if (stubSleep) {
+    writeFileSync(
+      path.join(binDir, 'sleep'),
+      [
+        '#!/usr/bin/env bash',
+        'printf "sleep_args=%s\\n" "$*" >> "${VH_TEST_SLEEP_MARKER:?}"',
+        'exit 0',
+        '',
+      ].join('\n'),
+      'utf8',
+    );
+    chmodSync(path.join(binDir, 'sleep'), 0o755);
+  }
+  const psSequence = psOutputs ?? (psOutput !== null ? [psOutput] : null);
+  if (psSequence !== null) {
+    mkdirSync(psOutputDir, { recursive: true });
+    psSequence.forEach((output, index) => {
+      const body = output.trimEnd();
+      writeFileSync(path.join(psOutputDir, `${index}.txt`), body ? `${body}\n` : '', 'utf8');
+    });
+    const lastBody = psSequence.at(-1)?.trimEnd() ?? '';
+    writeFileSync(path.join(psOutputDir, 'last.txt'), lastBody ? `${lastBody}\n` : '', 'utf8');
+    writeFileSync(psIndexFile, '0\n', 'utf8');
     writeFileSync(
       path.join(binDir, 'ps'),
       [
         '#!/usr/bin/env bash',
-        'cat <<\'VH_PS_OUTPUT\'',
-        psOutput.trimEnd(),
-        'VH_PS_OUTPUT',
+        'index="$(cat "${VH_TEST_PS_INDEX_FILE:?}" 2>/dev/null || printf 0)"',
+        'file="${VH_TEST_PS_OUTPUT_DIR:?}/${index}.txt"',
+        'if [[ ! -e "${file}" ]]; then file="${VH_TEST_PS_OUTPUT_DIR:?}/last.txt"; fi',
+        'cat "${file}"',
+        'printf "%s\\n" "$((index + 1))" > "${VH_TEST_PS_INDEX_FILE:?}"',
         '',
       ].join('\n'),
       'utf8',
@@ -78,7 +148,20 @@ function makeHarness({
     'utf8',
   );
 
-  return { root, binDir, envFile, pnpmMarker };
+  return {
+    root,
+    binDir,
+    envFile,
+    pnpmMarker,
+    pnpmStatusFile,
+    nodeMarker,
+    nodeStatus,
+    timeoutMarker,
+    timeoutStatus,
+    sleepMarker,
+    psOutputDir: psSequence !== null ? psOutputDir : null,
+    psIndexFile: psSequence !== null ? psIndexFile : null,
+  };
 }
 
 function readPnpmMarker(filePath) {
@@ -86,16 +169,27 @@ function readPnpmMarker(filePath) {
 }
 
 function runStartScript(harness) {
+  const env = {
+    ...process.env,
+    PATH: `${harness.binDir}${path.delimiter}${process.env.PATH ?? ''}`,
+    VHC_REPO: REPO_ROOT,
+    VH_NEWS_DAEMON_ENV_FILE: harness.envFile,
+    VH_TEST_PNPM_MARKER: harness.pnpmMarker,
+    VH_TEST_PNPM_STATUS_FILE: harness.pnpmStatusFile,
+    VH_TEST_NODE_MARKER: harness.nodeMarker,
+    VH_TEST_NODE_STATUS: String(harness.nodeStatus),
+    VH_TEST_TIMEOUT_MARKER: harness.timeoutMarker,
+    VH_TEST_TIMEOUT_STATUS: String(harness.timeoutStatus ?? 0),
+    VH_TEST_SLEEP_MARKER: harness.sleepMarker,
+  };
+  if (harness.psOutputDir !== null) {
+    env.VH_TEST_PS_OUTPUT_DIR = harness.psOutputDir;
+    env.VH_TEST_PS_INDEX_FILE = harness.psIndexFile;
+  }
   return spawnSync('bash', [SCRIPT_PATH], {
     cwd: REPO_ROOT,
     encoding: 'utf8',
-    env: {
-      ...process.env,
-      PATH: `${harness.binDir}${path.delimiter}${process.env.PATH ?? ''}`,
-      VHC_REPO: REPO_ROOT,
-      VH_NEWS_DAEMON_ENV_FILE: harness.envFile,
-      VH_TEST_PNPM_MARKER: harness.pnpmMarker,
-    },
+    env,
   });
 }
 
@@ -159,6 +253,97 @@ test('no-write diagnostic approval preserves explicit max tick override', () => 
   }
 });
 
+test('no-write diagnostic rejects a non-positive wall-clock bound before preflights', () => {
+  const harness = makeHarness({
+    approved: false,
+    noWriteDiagnostic: true,
+    diagnosticApproved: true,
+    extraEnv: ['VH_NEWS_DAEMON_DIAGNOSTIC_MAX_SECONDS=0'],
+  });
+  try {
+    const result = runStartScript(harness);
+    assert.equal(result.status, 78);
+    assert.match(result.stderr, /VH_NEWS_DAEMON_DIAGNOSTIC_MAX_SECONDS must be a positive integer/);
+    assert.equal(existsSync(harness.pnpmMarker), false);
+  } finally {
+    rmSync(harness.root, { recursive: true, force: true });
+  }
+});
+
+test('no-write diagnostic launches through timeout with the configured wall-clock bound', () => {
+  const harness = makeHarness({
+    approved: false,
+    noWriteDiagnostic: true,
+    diagnosticApproved: true,
+    extraEnv: ['VH_NEWS_DAEMON_DIAGNOSTIC_MAX_SECONDS=12'],
+    pnpmStatuses: [0, 0],
+    stubNode: true,
+    timeoutStatus: 124,
+  });
+  try {
+    const result = runStartScript(harness);
+    assert.equal(result.status, 124);
+    assert.match(result.stderr, /no-write diagnostic hit the 12s wall-clock bound/);
+    assert.deepEqual(readPnpmMarker(harness.pnpmMarker).filter((line) => line.startsWith('args=')), [
+      'args=check:news-sources:liveness',
+      'args=--filter @vh/storycluster-engine build',
+    ]);
+    assert.deepEqual(readFileSync(harness.timeoutMarker, 'utf8').trim().split('\n'), [
+      'timeout_args=--signal=TERM --kill-after=30s 12 pnpm --filter @vh/news-aggregator daemon',
+    ]);
+  } finally {
+    rmSync(harness.root, { recursive: true, force: true });
+  }
+});
+
+test('no-write diagnostic falls back to in-daemon max-ticks when timeout is unavailable', () => {
+  const harness = makeHarness({
+    approved: false,
+    noWriteDiagnostic: true,
+    diagnosticApproved: true,
+    extraEnv: ['VH_NEWS_DAEMON_DIAGNOSTIC_TIMEOUT_BIN=missing-timeout-bin'],
+    pnpmStatuses: [0, 0, 17],
+    stubNode: true,
+    timeoutStatus: 44,
+  });
+  try {
+    const result = runStartScript(harness);
+    assert.equal(result.status, 17);
+    assert.match(result.stderr, /'missing-timeout-bin' unavailable; relying on in-daemon max-ticks \+ post-run reap/);
+    assert.equal(existsSync(harness.timeoutMarker), false);
+    assert.deepEqual(readPnpmMarker(harness.pnpmMarker).filter((line) => line.startsWith('args=')), [
+      'args=check:news-sources:liveness',
+      'args=--filter @vh/storycluster-engine build',
+      'args=--filter @vh/news-aggregator daemon',
+    ]);
+  } finally {
+    rmSync(harness.root, { recursive: true, force: true });
+  }
+});
+
+test('no-write diagnostic fails closed if post-run daemon reaping cannot clear a sibling', () => {
+  const sibling = '123 node node --loader ../../tools/node/esm-resolve-loader.mjs dist/daemon.js';
+  const harness = makeHarness({
+    approved: false,
+    noWriteDiagnostic: true,
+    diagnosticApproved: true,
+    pnpmStatuses: [0, 0],
+    stubNode: true,
+    timeoutStatus: 124,
+    psOutputs: ['', sibling],
+    stubSleep: true,
+  });
+  try {
+    const result = runStartScript(harness);
+    assert.equal(result.status, 75);
+    assert.match(result.stderr, /reaping post-diagnostic news daemon runtime process/);
+    assert.match(result.stderr, /failed to reap post-diagnostic news daemon runtime process/);
+    assert.equal(readFileSync(harness.sleepMarker, 'utf8').trim().split('\n').length, 11);
+  } finally {
+    rmSync(harness.root, { recursive: true, force: true });
+  }
+});
+
 test('production daemon start refuses an existing sibling daemon before preflights', () => {
   const harness = makeHarness({
     approved: true,
@@ -169,6 +354,27 @@ test('production daemon start refuses an existing sibling daemon before prefligh
     assert.equal(result.status, 75);
     assert.match(result.stderr, /refusing start: existing news daemon runtime process/);
     assert.equal(existsSync(harness.pnpmMarker), false);
+  } finally {
+    rmSync(harness.root, { recursive: true, force: true });
+  }
+});
+
+test('live production daemon start still execs pnpm directly without timeout wrapping', () => {
+  const harness = makeHarness({
+    approved: true,
+    pnpmStatuses: [0, 0, 17],
+    stubNode: true,
+    timeoutStatus: 44,
+  });
+  try {
+    const result = runStartScript(harness);
+    assert.equal(result.status, 17);
+    assert.equal(existsSync(harness.timeoutMarker), false);
+    assert.deepEqual(readPnpmMarker(harness.pnpmMarker).filter((line) => line.startsWith('args=')), [
+      'args=check:news-sources:liveness',
+      'args=--filter @vh/storycluster-engine build',
+      'args=--filter @vh/news-aggregator daemon',
+    ]);
   } finally {
     rmSync(harness.root, { recursive: true, force: true });
   }

--- a/tools/scripts/start-news-aggregator-daemon-production.test.mjs
+++ b/tools/scripts/start-news-aggregator-daemon-production.test.mjs
@@ -18,7 +18,13 @@ const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(SCRIPT_DIR, '../..');
 const SCRIPT_PATH = path.join(REPO_ROOT, 'tools/scripts/start-news-aggregator-daemon-production.sh');
 
-function makeHarness({ approved, noWriteDiagnostic = false, diagnosticApproved = false, extraEnv = [] }) {
+function makeHarness({
+  approved,
+  noWriteDiagnostic = false,
+  diagnosticApproved = false,
+  extraEnv = [],
+  psOutput = null,
+}) {
   const root = mkdtempSync(path.join(os.tmpdir(), 'vh-news-daemon-start-'));
   const binDir = path.join(root, 'bin');
   const envFile = path.join(root, 'news-aggregator.env');
@@ -35,12 +41,29 @@ function makeHarness({ approved, noWriteDiagnostic = false, diagnosticApproved =
       'printf "VH_NEWS_RUNTIME_MAX_PUBLISHED_BUNDLES=%s\\n" "${VH_NEWS_RUNTIME_MAX_PUBLISHED_BUNDLES:-}" >> "${VH_TEST_PNPM_MARKER:?}"',
       'printf "VH_NEWS_RUNTIME_FIRST_TICK_MAX_PUBLISHED_BUNDLES=%s\\n" "${VH_NEWS_RUNTIME_FIRST_TICK_MAX_PUBLISHED_BUNDLES:-}" >> "${VH_TEST_PNPM_MARKER:?}"',
       'printf "VH_NEWS_RUNTIME_TICK_WATCHDOG_MS=%s\\n" "${VH_NEWS_RUNTIME_TICK_WATCHDOG_MS:-}" >> "${VH_TEST_PNPM_MARKER:?}"',
+      'if [[ -n "${VH_NEWS_DAEMON_DIAGNOSTIC_MAX_TICKS:-}" ]]; then',
+      '  printf "VH_NEWS_DAEMON_DIAGNOSTIC_MAX_TICKS=%s\\n" "${VH_NEWS_DAEMON_DIAGNOSTIC_MAX_TICKS}" >> "${VH_TEST_PNPM_MARKER:?}"',
+      'fi',
       'exit 99',
       '',
     ].join('\n'),
     'utf8',
   );
   chmodSync(path.join(binDir, 'pnpm'), 0o755);
+  if (psOutput !== null) {
+    writeFileSync(
+      path.join(binDir, 'ps'),
+      [
+        '#!/usr/bin/env bash',
+        'cat <<\'VH_PS_OUTPUT\'',
+        psOutput.trimEnd(),
+        'VH_PS_OUTPUT',
+        '',
+      ].join('\n'),
+      'utf8',
+    );
+    chmodSync(path.join(binDir, 'ps'), 0o755);
+  }
   writeFileSync(
     envFile,
     [
@@ -110,7 +133,42 @@ test('no-write diagnostic approval proceeds to preflights without live start app
     const result = runStartScript(harness);
     assert.equal(result.status, 99);
     assert.match(result.stdout, /no-write diagnostic mode approved/);
-    assert.equal(readPnpmMarker(harness.pnpmMarker)[0], 'args=check:news-sources:liveness');
+    assert.deepEqual(readPnpmMarker(harness.pnpmMarker).slice(0, 2), [
+      'args=check:news-sources:liveness',
+      'VH_NEWS_FEED_MAX_ITEMS_PER_SOURCE=8',
+    ]);
+    assert.ok(readPnpmMarker(harness.pnpmMarker).includes('VH_NEWS_DAEMON_DIAGNOSTIC_MAX_TICKS=1'));
+  } finally {
+    rmSync(harness.root, { recursive: true, force: true });
+  }
+});
+
+test('no-write diagnostic approval preserves explicit max tick override', () => {
+  const harness = makeHarness({
+    approved: false,
+    noWriteDiagnostic: true,
+    diagnosticApproved: true,
+    extraEnv: ['VH_NEWS_DAEMON_DIAGNOSTIC_MAX_TICKS=3'],
+  });
+  try {
+    const result = runStartScript(harness);
+    assert.equal(result.status, 99);
+    assert.ok(readPnpmMarker(harness.pnpmMarker).includes('VH_NEWS_DAEMON_DIAGNOSTIC_MAX_TICKS=3'));
+  } finally {
+    rmSync(harness.root, { recursive: true, force: true });
+  }
+});
+
+test('production daemon start refuses an existing sibling daemon before preflights', () => {
+  const harness = makeHarness({
+    approved: true,
+    psOutput: '123 node node --loader ../../tools/node/esm-resolve-loader.mjs dist/daemon.js',
+  });
+  try {
+    const result = runStartScript(harness);
+    assert.equal(result.status, 75);
+    assert.match(result.stderr, /refusing start: existing news daemon runtime process/);
+    assert.equal(existsSync(harness.pnpmMarker), false);
   } finally {
     rmSync(harness.root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

This PR closes the WS-B2 safety gap exposed during the Phase 5 pre-start gate: production no-write diagnostics used the same continuous daemon runtime as the live publisher, so a manually launched diagnostic could keep ticking after the attended run and continue mutating StoryCluster-derived state.

Changes:
- Default approved no-write diagnostics to `VH_NEWS_DAEMON_DIAGNOSTIC_MAX_TICKS=1` in the production wrapper.
- Make the daemon self-stop after the configured diagnostic tick limit once the runtime summary/artifacts have been written.
- Add a daemon pidfile lock (`VH_NEWS_DAEMON_PID_FILE` or `$VH_NEWS_DAEMON_STATE_DIR/news-daemon.pid`) so direct `pnpm --filter @vh/news-aggregator daemon` launches refuse a second runtime.
- Add a production wrapper sibling-process guard before preflights and a post-diagnostic sibling recheck.
- Document the bounded diagnostic lifecycle and pidfile/env surface.

## Root Cause

The no-write diagnostic suppressed mesh writes, but it was still a continuous daemon. Because it did not have a run-once mode and the ingestion lease is not a StoryCluster side-effect lock, separate diagnostic processes could run concurrent tick loops and keep calling StoryCluster.

## Validation

- `node tools/scripts/start-news-aggregator-daemon-production.test.mjs`
- `bash -n tools/scripts/start-news-aggregator-daemon-production.sh`
- `git diff --check`
- `PATH="/opt/homebrew/Cellar/node@20/20.20.0/bin:$PATH" pnpm --filter @vh/news-aggregator typecheck`
- `PATH="/opt/homebrew/Cellar/node@20/20.20.0/bin:$PATH" pnpm --filter @vh/news-aggregator exec vitest run src/daemon.production.test.ts --config ./vitest.config.ts`
- `PATH="/opt/homebrew/Cellar/node@20/20.20.0/bin:$PATH" pnpm --filter @vh/news-aggregator exec vitest run src/daemon.test.ts src/daemon.production.test.ts src/daemon.env.test.ts --config ./vitest.config.ts`
- `PATH="/opt/homebrew/Cellar/node@20/20.20.0/bin:$PATH" pnpm typecheck`
- `PATH="/opt/homebrew/Cellar/node@20/20.20.0/bin:$PATH" pnpm test:quick` (319 files, 4909 tests)

## A6 Read-Only Verification

- No current daemon processes after the prior abort cleanup.
- `crontab -l` has zero news daemon refs.
- `systemctl --user list-timers --all` has zero news daemon refs.
- Only expected daemon-related user units were found: disabled `vh-news-aggregator.service` and the read-only relay snapshot watch service.
