### PR TITLE
[coord] Disable node mesh Gun stats writes

### DIFF
--- a/packages/gun-client/src/nodeMeshClient.test.ts
+++ b/packages/gun-client/src/nodeMeshClient.test.ts
@@ -44,6 +44,7 @@ describe('createNodeMeshClient', () => {
       localStorage: false,
       radisk: false,
       file: false,
+      stats: false,
       axe: false,
     });
     expect(client.config.peers).toEqual(['http://127.0.0.1:7777/gun']);
@@ -72,6 +73,7 @@ describe('createNodeMeshClient', () => {
       localStorage: false,
       radisk: true,
       file: expect.stringMatching(/vh-node-mesh-/),
+      stats: false,
       axe: false,
     });
   });
@@ -92,6 +94,7 @@ describe('createNodeMeshClient', () => {
       localStorage: false,
       radisk: false,
       file: false,
+      stats: false,
       axe: false,
     });
   });

--- a/packages/gun-client/src/nodeMeshClient.ts
+++ b/packages/gun-client/src/nodeMeshClient.ts
@@ -105,6 +105,7 @@ export function createNodeMeshClient(config: VennClientConfig = {}): VennClient 
     localStorage: false,
     radisk: gunRadisk,
     file: gunFile,
+    stats: false,
     axe: false,
   } as never) as IGunInstance;
   const mesh = gun.get('vh') as unknown as ChainWithGet<Record<string, unknown>>;


### PR DESCRIPTION
## Summary
- pass stats:false to the stateless Node mesh Gun client
- keep daemon-local Gun radisk/file disabled when configured while also preventing GUN's stats writer from writing under node_modules
- update node mesh client tests for the full no-local-disk Gun option shape

## Validation
- PATH="/opt/homebrew/Cellar/node@20/20.20.0/bin:/Users/bldt/.codex/tmp/arg0/codex-arg0qiuobx:/opt/homebrew/opt/openjdk@17/bin:/Users/bldt/.antigravity/antigravity/bin:/opt/homebrew/opt/ruby/bin:/Users/bldt/.codeium/windsurf/bin:/Library/Frameworks/Python.framework/Versions/3.13/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/Library/Frameworks/Python.framework/Versions/3.13/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/opt/homebrew/lib/ruby/gems/3.4.0/bin:/Users/bldt/.modular/bin:/Users/bldt/development/flutter/bin:/Users/bldt/.pub-cache/bin:/Users/bldt/Library/Android/sdk/emulator:/Users/bldt/Library/Android/sdk/platform-tools:/Applications/Codex.app/Contents/Resources" pnpm --filter @vh/gun-client exec vitest run src/nodeMeshClient.test.ts --config ./vitest.config.ts
- PATH="/opt/homebrew/Cellar/node@20/20.20.0/bin:/Users/bldt/.codex/tmp/arg0/codex-arg0qiuobx:/opt/homebrew/opt/openjdk@17/bin:/Users/bldt/.antigravity/antigravity/bin:/opt/homebrew/opt/ruby/bin:/Users/bldt/.codeium/windsurf/bin:/Library/Frameworks/Python.framework/Versions/3.13/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/Library/Frameworks/Python.framework/Versions/3.13/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/opt/homebrew/lib/ruby/gems/3.4.0/bin:/Users/bldt/.modular/bin:/Users/bldt/development/flutter/bin:/Users/bldt/.pub-cache/bin:/Users/bldt/Library/Android/sdk/emulator:/Users/bldt/Library/Android/sdk/platform-tools:/Applications/Codex.app/Contents/Resources" pnpm --filter @vh/gun-client typecheck
- PATH="/opt/homebrew/Cellar/node@20/20.20.0/bin:/Users/bldt/.codex/tmp/arg0/codex-arg0qiuobx:/opt/homebrew/opt/openjdk@17/bin:/Users/bldt/.antigravity/antigravity/bin:/opt/homebrew/opt/ruby/bin:/Users/bldt/.codeium/windsurf/bin:/Library/Frameworks/Python.framework/Versions/3.13/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/Library/Frameworks/Python.framework/Versions/3.13/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/opt/homebrew/lib/ruby/gems/3.4.0/bin:/Users/bldt/.modular/bin:/Users/bldt/development/flutter/bin:/Users/bldt/.pub-cache/bin:/Users/bldt/Library/Android/sdk/emulator:/Users/bldt/Library/Android/sdk/platform-tools:/Applications/Codex.app/Contents/Resources" pnpm --filter @vh/news-aggregator exec vitest run src/daemon.env.test.ts --config ./vitest.config.ts
- PATH="/opt/homebrew/Cellar/node@20/20.20.0/bin:/Users/bldt/.codex/tmp/arg0/codex-arg0qiuobx:/opt/homebrew/opt/openjdk@17/bin:/Users/bldt/.antigravity/antigravity/bin:/opt/homebrew/opt/ruby/bin:/Users/bldt/.codeium/windsurf/bin:/Library/Frameworks/Python.framework/Versions/3.13/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/Library/Frameworks/Python.framework/Versions/3.13/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/opt/homebrew/lib/ruby/gems/3.4.0/bin:/Users/bldt/.modular/bin:/Users/bldt/development/flutter/bin:/Users/bldt/.pub-cache/bin:/Users/bldt/Library/Android/sdk/emulator:/Users/bldt/Library/Android/sdk/platform-tools:/Applications/Codex.app/Contents/Resources" pnpm typecheck
- PATH="/opt/homebrew/Cellar/node@20/20.20.0/bin:/Users/bldt/.codex/tmp/arg0/codex-arg0qiuobx:/opt/homebrew/opt/openjdk@17/bin:/Users/bldt/.antigravity/antigravity/bin:/opt/homebrew/opt/ruby/bin:/Users/bldt/.codeium/windsurf/bin:/Library/Frameworks/Python.framework/Versions/3.13/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/Library/Frameworks/Python.framework/Versions/3.13/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/opt/homebrew/lib/ruby/gems/3.4.0/bin:/Users/bldt/.modular/bin:/Users/bldt/development/flutter/bin:/Users/bldt/.pub-cache/bin:/Users/bldt/Library/Android/sdk/emulator:/Users/bldt/Library/Android/sdk/platform-tools:/Applications/Codex.app/Contents/Resources" pnpm test:quick