### PR TITLE
Exit daemon CLI after bounded diagnostic stop

### DIFF
--- a/services/news-aggregator/src/daemon.coverage.test.ts
+++ b/services/news-aggregator/src/daemon.coverage.test.ts
@@ -53,10 +53,12 @@ function makeTimerControls() {
 
 function createDeferred<T>() {
   let resolve!: (value: T) => void;
-  const promise = new Promise<T>((res) => {
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
     resolve = res;
+    reject = rej;
   });
-  return { promise, resolve };
+  return { promise, resolve, reject };
 }
 
 async function flushMicrotasks(): Promise<void> {
@@ -340,5 +342,55 @@ describe('news daemon coverage guards', () => {
     expect(logger.info).toHaveBeenCalledWith('[vh:news-daemon] received SIGTERM; shutting down');
     expect(stop).toHaveBeenCalledTimes(1);
     expect(lifecycle.exit).toHaveBeenCalledWith(0);
+  });
+
+  it('exits the CLI when a bounded diagnostic handle closes without a signal', async () => {
+    const closed = createDeferred<void>();
+    const stop = vi.fn(async () => undefined);
+    const startFromEnv = vi.fn(async () => ({
+      stop,
+      closed: closed.promise,
+    }));
+    const lifecycle: Pick<typeof process, 'once' | 'exit'> = {
+      once: vi.fn(() => lifecycle as any) as any,
+      exit: vi.fn(() => undefined as never),
+    };
+    const logger = {
+      info: vi.fn(),
+      error: vi.fn(),
+    };
+
+    await __internal.runFromCli(startFromEnv, lifecycle, logger);
+    closed.resolve();
+    await flushMicrotasks();
+
+    expect(stop).not.toHaveBeenCalled();
+    expect(lifecycle.exit).toHaveBeenCalledTimes(1);
+    expect(lifecycle.exit).toHaveBeenCalledWith(0);
+  });
+
+  it('exits the CLI nonzero when a daemon handle closes with an error', async () => {
+    const closed = createDeferred<void>();
+    const startFromEnv = vi.fn(async () => ({
+      stop: vi.fn(async () => undefined),
+      closed: closed.promise,
+    }));
+    const lifecycle: Pick<typeof process, 'once' | 'exit'> = {
+      once: vi.fn(() => lifecycle as any) as any,
+      exit: vi.fn(() => undefined as never),
+    };
+    const logger = {
+      info: vi.fn(),
+      error: vi.fn(),
+    };
+    const error = new Error('diagnostic stop failed');
+
+    await __internal.runFromCli(startFromEnv, lifecycle, logger);
+    closed.reject(error);
+    await flushMicrotasks();
+
+    expect(logger.error).toHaveBeenCalledWith('[vh:news-daemon] daemon process closed with error', error);
+    expect(lifecycle.exit).toHaveBeenCalledTimes(1);
+    expect(lifecycle.exit).toHaveBeenCalledWith(1);
   });
 });

--- a/services/news-aggregator/src/daemon.production.test.ts
+++ b/services/news-aggregator/src/daemon.production.test.ts
@@ -255,6 +255,7 @@ describe('news daemon production wiring', () => {
       await runtimeConfig.onTickSummary?.(makeTickSummary({ tick_sequence: 1 }));
       await vi.waitFor(() => expect(runtimeHandle.stop).toHaveBeenCalledTimes(1));
       await vi.waitFor(() => expect(shutdown).toHaveBeenCalledTimes(1));
+      await handle.closed;
 
       await handle.stop();
       expect(runtimeHandle.stop).toHaveBeenCalledTimes(1);
@@ -297,6 +298,7 @@ describe('news daemon production wiring', () => {
       await runtimeConfig.onTickSummary?.(makeTickSummary({ tick_sequence: 2 }));
       await vi.waitFor(() => expect(runtimeHandle.stop).toHaveBeenCalledTimes(1));
       await vi.waitFor(() => expect(shutdown).toHaveBeenCalledTimes(1));
+      await handle.closed;
 
       await handle.stop();
     } finally {

--- a/services/news-aggregator/src/daemon.ts
+++ b/services/news-aggregator/src/daemon.ts
@@ -581,6 +581,7 @@ export function createNewsAggregatorDaemon(config: NewsAggregatorDaemonConfig): 
 export interface NewsAggregatorDaemonProcessHandle {
   daemon: NewsAggregatorDaemonHandle;
   client: VennClient;
+  readonly closed: Promise<void>;
   stop(): Promise<void>;
 }
 
@@ -740,6 +741,21 @@ export async function startNewsAggregatorDaemonFromEnv(): Promise<NewsAggregator
   let client: VennClient | null = null;
   let processHandle: NewsAggregatorDaemonProcessHandle | null = null;
   let diagnosticStopRequested = false;
+  let resolveClosed: (() => void) | null = null;
+  let rejectClosed: ((error: unknown) => void) | null = null;
+  const closed = new Promise<void>((resolve, reject) => {
+    resolveClosed = resolve;
+    rejectClosed = reject;
+  });
+  const settleClosed = (error?: unknown) => {
+    if (error === undefined) {
+      resolveClosed?.();
+    } else {
+      rejectClosed?.(error);
+    }
+    resolveClosed = null;
+    rejectClosed = null;
+  };
   try {
     const systemWriterConfig = await resolveSystemWriterClientConfigFromEnv();
     client = createNodeMeshClient({
@@ -815,16 +831,28 @@ export async function startNewsAggregatorDaemonFromEnv(): Promise<NewsAggregator
     processHandle = {
       daemon,
       client,
+      closed,
       async stop() {
         if (stopped) {
           return;
         }
         stopped = true;
+        let stopError: unknown;
         try {
           await daemon.stop();
           await client?.shutdown();
+        } catch (error) {
+          stopError = error;
+          throw error;
         } finally {
-          processLock.release();
+          try {
+            processLock.release();
+          } catch (error) {
+            stopError ??= error;
+            throw error;
+          } finally {
+            settleClosed(stopError);
+          }
         }
       },
     };

--- a/services/news-aggregator/src/daemonCli.ts
+++ b/services/news-aggregator/src/daemonCli.ts
@@ -4,6 +4,7 @@ export type ProcessLifecycle = Pick<typeof process, 'once' | 'exit'>;
 export type CliLogger = Pick<Console, 'info' | 'error'>;
 export interface CliDaemonProcessHandle {
   stop(): Promise<void>;
+  readonly closed?: Promise<void>;
 }
 
 export function isDirectExecution(metaUrl: string): boolean {
@@ -24,6 +25,14 @@ export async function runFromCli(
   logger: CliLogger = console,
 ): Promise<void> {
   const processHandle = await startFromEnv();
+  let exiting = false;
+  const exitOnce = (code: number): void => {
+    if (exiting) {
+      return;
+    }
+    exiting = true;
+    lifecycle.exit(code);
+  };
   const shutdown = async (signal: string): Promise<void> => {
     logger.info(`[vh:news-daemon] received ${signal}; shutting down`);
     await processHandle.stop();
@@ -31,8 +40,14 @@ export async function runFromCli(
   for (const signal of ['SIGINT', 'SIGTERM'] as const) {
     lifecycle.once(signal, () => {
       void shutdown(signal).finally(() => {
-        lifecycle.exit(0);
+        exitOnce(0);
       });
     });
   }
+  void processHandle.closed?.then(() => {
+    exitOnce(0);
+  }, (error) => {
+    logger.error('[vh:news-daemon] daemon process closed with error', error);
+    exitOnce(1);
+  });
 }


### PR DESCRIPTION
## Summary
- expose a daemon process `closed` promise that resolves after stop/shutdown/pidfile release
- make the CLI exit when a bounded no-write diagnostic self-stops without SIGTERM
- exit nonzero if the daemon close path fails

## Validation
- `PATH="/opt/homebrew/Cellar/node@20/20.20.0/bin:$PATH" pnpm --filter @vh/news-aggregator exec vitest run src/daemon.coverage.test.ts src/daemon.production.test.ts --config ./vitest.config.ts`
- `PATH="/opt/homebrew/Cellar/node@20/20.20.0/bin:$PATH" pnpm --filter @vh/news-aggregator typecheck`
- `git diff --check`
- `PATH="/opt/homebrew/Cellar/node@20/20.20.0/bin:$PATH" pnpm typecheck`
- `PATH="/opt/homebrew/Cellar/node@20/20.20.0/bin:$PATH" pnpm test:quick`

## Phase 5 note
The patched no-write diagnostic on A6 produced a clean tick shape with no EACCES, but the old CLI did not self-exit after the diagnostic stop. This PR fixes that final CLI lifecycle gap before another reset/diagnostic/live gate attempt.