### PR TITLE
Route news publication through relay REST writes

### DIFF
--- a/docs/ops/news-aggregator-production-service.md
+++ b/docs/ops/news-aggregator-production-service.md
@@ -280,6 +280,10 @@ VH_STORYCLUSTER_REMOTE_AUTH_TOKEN
 VH_STORYCLUSTER_REMOTE_HEALTH_URL
 OPENAI_API_KEY
 VH_BUNDLE_SYNTHESIS_ENABLED
+VH_NEWS_RELAY_REST_WRITE_FIRST
+VH_NEWS_RELAY_REST_WRITE_ORIGINS
+VH_NEWS_RELAY_REST_WRITE_REQUIRE_ALL
+VH_NEWS_RELAY_REST_WRITE_TIMEOUT_MS
 VH_BUNDLE_SYNTHESIS_RELAY_WRITE_ORIGINS
 VH_BUNDLE_SYNTHESIS_RELAY_WRITE_REQUIRE_ALL
 VH_BUNDLE_SYNTHESIS_WRITE_RELAY_REST
@@ -303,6 +307,14 @@ VH_NEWS_SYSTEM_WRITER_PRIVATE_KEY_PKCS8_BASE64URL
 ```
 
 Do not paste values into tickets, PRs, or evidence docs.
+
+For production Phase 5 publisher starts, keep `VH_NEWS_RELAY_REST_WRITE_FIRST`
+enabled. The daemon still signs story bodies, latest-index rows, hot-index rows,
+and synthesis lifecycle rows with the public news system writer, but it submits
+those records to the relay REST write-through routes before attempting any
+direct Gun publication. `VH_NEWS_RELAY_REST_WRITE_REQUIRE_ALL=true` is the
+default and should remain set so a partial relay fanout fails closed instead of
+claiming first-publish success from one relay.
 
 ## Lease / Lock Behavior
 
@@ -496,7 +508,8 @@ Abort or stop the service if any of these occur:
 - source-health liveness preflight fails;
 - OpenAI preflight is not `pass`;
 - StoryCluster health check fails;
-- relay REST write fanout is below the configured `require_all` target;
+- raw news or synthesis relay REST write fanout is below the configured
+  `require_all` target;
 - snapshot watch reports stale newest-entry age above 6 hours;
 - latest content does not advance after approved start and expected ingest
   cadence.

--- a/docs/ops/news-aggregator.env.example
+++ b/docs/ops/news-aggregator.env.example
@@ -30,7 +30,14 @@ VH_STORYCLUSTER_REMOTE_MAX_ITEMS_PER_REQUEST=24
 # OpenAI provider used by StoryCluster and bundle synthesis.
 OPENAI_API_KEY=<from-storycluster-openai.env>
 
-# Bundle synthesis and relay REST write fanout.
+# Raw public story/index/lifecycle publication and bundle synthesis relay REST
+# write fanout. Raw publication uses the same signed system-writer records as
+# direct Gun writes, but posts them through the relay write-through routes so
+# relay snapshots are updated immediately.
+VH_NEWS_RELAY_REST_WRITE_FIRST=true
+VH_NEWS_RELAY_REST_WRITE_ORIGINS='["https://gun-a.carboncaste.io","https://gun-b.carboncaste.io","https://gun-c.carboncaste.io"]'
+VH_NEWS_RELAY_REST_WRITE_REQUIRE_ALL=true
+VH_NEWS_RELAY_REST_WRITE_TIMEOUT_MS=10000
 VH_BUNDLE_SYNTHESIS_ENABLED=true
 VH_BUNDLE_SYNTHESIS_WRITE_RELAY_REST=true
 VH_BUNDLE_SYNTHESIS_RELAY_WRITE_ORIGINS='["https://gun-a.carboncaste.io","https://gun-b.carboncaste.io","https://gun-c.carboncaste.io"]'

--- a/packages/gun-client/src/newsAdapters.test.ts
+++ b/packages/gun-client/src/newsAdapters.test.ts
@@ -266,6 +266,43 @@ function createClient(
   };
 }
 
+function withGunClientRuntimeConfig(config: Record<string, unknown>): () => void {
+  const target = globalThis as { __VH_GUN_CLIENT_CONFIG__?: Record<string, unknown> | undefined };
+  const previous = target.__VH_GUN_CLIENT_CONFIG__;
+  target.__VH_GUN_CLIENT_CONFIG__ = {
+    ...(previous ?? {}),
+    ...config,
+  };
+  return () => {
+    if (previous === undefined) {
+      delete target.__VH_GUN_CLIENT_CONFIG__;
+      return;
+    }
+    target.__VH_GUN_CLIENT_CONFIG__ = previous;
+  };
+}
+
+function withProcessEnv(config: Record<string, string | undefined>): () => void {
+  const previous = new Map<string, string | undefined>();
+  for (const [key, value] of Object.entries(config)) {
+    previous.set(key, process.env[key]);
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  return () => {
+    for (const [key, value] of previous) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  };
+}
+
 function bytesToBase64Url(bytes: Uint8Array): string {
   return Buffer.from(bytes).toString('base64url');
 }
@@ -515,6 +552,234 @@ describe('newsAdapters', () => {
     expect(
       JSON.parse((mesh.writes[0].value as Record<string, unknown>).__story_bundle_json as string)
     ).toEqual(STORY);
+  });
+
+  it('writeNewsBundle writes signed story and indexes through relay REST first when configured', async () => {
+    const restoreRuntimeConfig = withGunClientRuntimeConfig({
+      VH_NEWS_RELAY_REST_WRITE_FIRST: 'true',
+    });
+    const restoreEnv = withProcessEnv({ VH_RELAY_DAEMON_TOKEN: 'relay-token-redacted' });
+    const info = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+    try {
+      const mesh = createFakeMesh();
+      mesh.setRead('news/stories/story-123', STORY);
+      const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+      const client = createClient(mesh, guard, {
+        peers: ['wss://gun-a.example.test/gun'],
+      });
+      const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const path = new URL(String(input)).pathname;
+        const body = JSON.parse(String(init?.body ?? '{}')) as { record?: Record<string, unknown> };
+        const storyId = body.record?.story_id;
+        return new Response(JSON.stringify({
+          ok: true,
+          story_id: storyId,
+          ...(path === '/vh/news/synthesis-lifecycle' ? { status: body.record?.status } : {}),
+        }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      });
+      vi.stubGlobal('fetch', fetchMock);
+
+      await expect(writeNewsBundle(client, STORY)).resolves.toEqual(STORY);
+
+      expect(mesh.writes).toEqual([]);
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+      expect(fetchMock.mock.calls.map(([input]) => new URL(String(input)).href)).toEqual([
+        'https://gun-a.example.test/vh/news/story',
+        'https://gun-a.example.test/vh/news/latest-index',
+        'https://gun-a.example.test/vh/news/hot-index',
+      ]);
+      for (const [, init] of fetchMock.mock.calls) {
+        expect(init?.method).toBe('POST');
+        expect(init?.headers).toEqual(expect.objectContaining({
+          'content-type': 'application/json',
+          Authorization: 'Bearer relay-token-redacted',
+        }));
+      }
+      const storyBody = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body ?? '{}')) as {
+        record?: SystemWriterStoryBundleRecord;
+      };
+      expect(expectSystemStoryRecord(storyBody.record)).toMatchObject({
+        story_id: STORY.story_id,
+        _systemWriterId: TEST_SYSTEM_WRITER_ID,
+      });
+      const latestBody = JSON.parse(String(fetchMock.mock.calls[1]?.[1]?.body ?? '{}')) as {
+        record?: SystemWriterLatestIndexRecord;
+      };
+      expect(expectSystemLatestIndexRecord(latestBody.record, STORY.story_id, STORY.cluster_window_end, STORY))
+        .toMatchObject({
+          story_id: STORY.story_id,
+          source_set_revision: STORY.provenance_hash,
+        });
+      const hotBody = JSON.parse(String(fetchMock.mock.calls[2]?.[1]?.body ?? '{}')) as {
+        record?: SystemWriterHotIndexRecord;
+      };
+      expect(expectSystemHotIndexRecord(hotBody.record, STORY.story_id, computeStoryHotness(STORY), STORY))
+        .toMatchObject({
+          story_id: STORY.story_id,
+          source_set_revision: STORY.provenance_hash,
+        });
+    } finally {
+      info.mockRestore();
+      vi.unstubAllGlobals();
+      restoreEnv();
+      restoreRuntimeConfig();
+    }
+  });
+
+  it('writeNewsSynthesisLifecycleStatus uses relay REST write-first with signed lifecycle records', async () => {
+    const restoreRuntimeConfig = withGunClientRuntimeConfig({
+      VH_NEWS_RELAY_REST_WRITE_FIRST: 'true',
+    });
+    const restoreEnv = withProcessEnv({ VH_RELAY_DAEMON_TOKEN: 'relay-token-redacted' });
+    const info = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+    try {
+      const mesh = createFakeMesh();
+      const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+      const client = createClient(mesh, guard, {
+        peers: ['https://gun-a.example.test/gun'],
+      });
+      const lifecycle = buildNewsSynthesisLifecycleRecord({
+        story: STORY,
+        status: 'pending',
+        updatedAt: 1_700_000_050_000,
+      });
+      const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+        const body = JSON.parse(String(init?.body ?? '{}')) as { record?: Record<string, unknown> };
+        return new Response(JSON.stringify({
+          ok: true,
+          story_id: body.record?.story_id,
+          status: body.record?.status,
+        }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      });
+      vi.stubGlobal('fetch', fetchMock);
+
+      await expect(writeNewsSynthesisLifecycleStatus(client, lifecycle)).resolves.toEqual(lifecycle);
+
+      expect(mesh.writes).toEqual([]);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(new URL(String(fetchMock.mock.calls[0]?.[0])).href)
+        .toBe('https://gun-a.example.test/vh/news/synthesis-lifecycle');
+      const body = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body ?? '{}')) as {
+        record?: Record<string, unknown>;
+      };
+      expect(body.record).toMatchObject({
+        story_id: STORY.story_id,
+        status: 'pending',
+        _systemWriterId: TEST_SYSTEM_WRITER_ID,
+      });
+    } finally {
+      info.mockRestore();
+      vi.unstubAllGlobals();
+      restoreEnv();
+      restoreRuntimeConfig();
+    }
+  });
+
+  it('writeNewsStory fails closed for relay REST write-first without daemon token', async () => {
+    const restoreRuntimeConfig = withGunClientRuntimeConfig({
+      VH_NEWS_RELAY_REST_WRITE_FIRST: 'true',
+    });
+    const restoreEnv = withProcessEnv({ VH_RELAY_DAEMON_TOKEN: undefined });
+    try {
+      const mesh = createFakeMesh();
+      mesh.setRead('news/stories/story-123', STORY);
+      const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+      const client = createClient(mesh, guard, {
+        peers: ['https://gun-a.example.test/gun'],
+      });
+      const fetchMock = vi.fn();
+      vi.stubGlobal('fetch', fetchMock);
+
+      await expect(writeNewsStory(client, STORY)).rejects.toThrow(
+        'VH_RELAY_DAEMON_TOKEN is required for relay REST news writes',
+      );
+      expect(mesh.writes).toEqual([]);
+      expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      vi.unstubAllGlobals();
+      restoreEnv();
+      restoreRuntimeConfig();
+    }
+  });
+
+  it('writeNewsLatestIndexEntry requires all relay REST targets by default', async () => {
+    const restoreRuntimeConfig = withGunClientRuntimeConfig({
+      VH_NEWS_RELAY_REST_WRITE_FIRST: 'true',
+      VH_NEWS_RELAY_REST_WRITE_ORIGINS: '["https://gun-a.example.test","https://gun-b.example.test"]',
+    });
+    const restoreEnv = withProcessEnv({ VH_RELAY_DAEMON_TOKEN: 'relay-token-redacted' });
+    try {
+      const mesh = createFakeMesh();
+      const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+      const client = createClient(mesh, guard, {
+        peers: ['https://fallback-peer.example.test/gun'],
+      });
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true, story_id: STORY.story_id }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }))
+        .mockResolvedValueOnce(new Response(JSON.stringify({ ok: false }), {
+          status: 503,
+          headers: { 'content-type': 'application/json' },
+        }));
+      vi.stubGlobal('fetch', fetchMock);
+
+      await expect(
+        writeNewsLatestIndexEntry(client, STORY.story_id, STORY.cluster_window_end, STORY),
+      ).rejects.toThrow('Relay REST news write failed for /vh/news/latest-index: 1/2 succeeded');
+      expect(mesh.writes).toEqual([]);
+      expect(fetchMock.mock.calls.map(([input]) => new URL(String(input)).origin)).toEqual([
+        'https://gun-a.example.test',
+        'https://gun-b.example.test',
+      ]);
+    } finally {
+      vi.unstubAllGlobals();
+      restoreEnv();
+      restoreRuntimeConfig();
+    }
+  });
+
+  it('reads news relay write-first flags from import, process, and global config sources', () => {
+    const target = globalThis as { __VH_IMPORT_META_ENV__?: Record<string, unknown> | undefined };
+    const previousImportMetaEnv = target.__VH_IMPORT_META_ENV__;
+    const previousProcessValue = process.env.VH_NEWS_RELAY_REST_WRITE_FIRST;
+    const restoreGlobalConfig = withGunClientRuntimeConfig({
+      VH_NEWS_RELAY_REST_WRITE_FIRST: 'off',
+    });
+
+    try {
+      target.__VH_IMPORT_META_ENV__ = {
+        VITE_VH_NEWS_RELAY_REST_WRITE_FIRST: 'yes',
+      };
+      expect(newsAdapterInternal.shouldWriteNewsViaRelayRestFirst()).toBe(true);
+
+      target.__VH_IMPORT_META_ENV__ = {};
+      process.env.VH_NEWS_RELAY_REST_WRITE_FIRST = 'false';
+      expect(newsAdapterInternal.shouldWriteNewsViaRelayRestFirst()).toBe(false);
+
+      delete process.env.VH_NEWS_RELAY_REST_WRITE_FIRST;
+      expect(newsAdapterInternal.shouldWriteNewsViaRelayRestFirst()).toBe(false);
+    } finally {
+      if (previousImportMetaEnv === undefined) {
+        delete target.__VH_IMPORT_META_ENV__;
+      } else {
+        target.__VH_IMPORT_META_ENV__ = previousImportMetaEnv;
+      }
+      if (previousProcessValue === undefined) {
+        delete process.env.VH_NEWS_RELAY_REST_WRITE_FIRST;
+      } else {
+        process.env.VH_NEWS_RELAY_REST_WRITE_FIRST = previousProcessValue;
+      }
+      restoreGlobalConfig();
+    }
   });
 
   it('writes and reads signed synthesis lifecycle records for story source revisions', async () => {

--- a/packages/gun-client/src/newsAdapters.test.ts
+++ b/packages/gun-client/src/newsAdapters.test.ts
@@ -747,6 +747,105 @@ describe('newsAdapters', () => {
     }
   });
 
+  it('resolves news relay write endpoints from runtime origins and falls back after invalid JSON', () => {
+    const mesh = createFakeMesh();
+    const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+    const client = createClient(mesh, guard, {
+      peers: ['wss://fallback.example.test/gun'],
+    });
+    const restoreCommaOrigins = withGunClientRuntimeConfig({
+      VH_NEWS_RELAY_REST_WRITE_ORIGINS: 'https://gun-a.example.test,mailto:bad,https://gun-a.example.test',
+    });
+    try {
+      expect(newsAdapterInternal.resolveRelayRestWriteEndpoints(client, '/vh/news/story')).toEqual([
+        'https://gun-a.example.test/vh/news/story',
+      ]);
+    } finally {
+      restoreCommaOrigins();
+    }
+
+    const restoreInvalidJsonOrigins = withGunClientRuntimeConfig({
+      VH_NEWS_RELAY_REST_WRITE_ORIGINS: '[',
+    });
+    try {
+      expect(newsAdapterInternal.resolveRelayRestWriteEndpoints(client, '/vh/news/hot-index')).toEqual([
+        'https://fallback.example.test/vh/news/hot-index',
+      ]);
+    } finally {
+      restoreInvalidJsonOrigins();
+    }
+  });
+
+  it('writeNewsRecordViaRelayRest fails closed when fetch is unavailable or endpoints are missing', async () => {
+    const restoreEnv = withProcessEnv({ VH_RELAY_DAEMON_TOKEN: 'relay-token-redacted' });
+    try {
+      const mesh = createFakeMesh();
+      const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+      const client = createClient(mesh, guard, { peers: ['https://gun-a.example.test/gun'] });
+      vi.stubGlobal('fetch', undefined);
+
+      await expect(newsAdapterInternal.writeNewsRecordViaRelayRest({
+        client,
+        path: '/vh/news/story',
+        record: { story_id: STORY.story_id },
+        writeClass: 'news-story',
+        validate: () => true,
+      })).rejects.toThrow('fetch is required for relay REST news writes');
+
+      vi.stubGlobal('fetch', vi.fn());
+      await expect(newsAdapterInternal.writeNewsRecordViaRelayRest({
+        client: createClient(mesh, guard, { peers: [] }),
+        path: '/vh/news/story',
+        record: { story_id: STORY.story_id },
+        writeClass: 'news-story',
+        validate: () => true,
+      })).rejects.toThrow('No relay REST endpoints configured for /vh/news/story');
+    } finally {
+      vi.unstubAllGlobals();
+      restoreEnv();
+    }
+  });
+
+  it('writeNewsRecordViaRelayRest records thrown fetch failures in the fail-closed error', async () => {
+    const restoreEnv = withProcessEnv({ VH_RELAY_DAEMON_TOKEN: 'relay-token-redacted' });
+    const restoreRuntimeConfig = withGunClientRuntimeConfig({
+      VH_NEWS_RELAY_REST_WRITE_REQUIRE_ALL: 'false',
+    });
+    try {
+      const mesh = createFakeMesh();
+      const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+      const client = createClient(mesh, guard, {
+        peers: ['https://gun-a.example.test/gun'],
+      });
+      vi.stubGlobal('fetch', vi.fn(async () => {
+        throw new Error('relay offline');
+      }));
+
+      await expect(newsAdapterInternal.writeNewsRecordViaRelayRest({
+        client,
+        path: '/vh/news/story',
+        record: { story_id: STORY.story_id },
+        writeClass: 'news-story',
+        validate: () => true,
+      })).rejects.toThrow('relay offline');
+      vi.stubGlobal('fetch', vi.fn(async () => {
+        throw 'relay offline string';
+      }));
+      await expect(newsAdapterInternal.writeNewsRecordViaRelayRest({
+        client,
+        path: '/vh/news/story',
+        record: { story_id: STORY.story_id },
+        writeClass: 'news-story',
+        validate: () => true,
+      })).rejects.toThrow('relay offline string');
+      expect(newsAdapterInternal.shouldRequireAllNewsRelayRestWrites()).toBe(false);
+    } finally {
+      vi.unstubAllGlobals();
+      restoreRuntimeConfig();
+      restoreEnv();
+    }
+  });
+
   it('reads news relay write-first flags from import, process, and global config sources', () => {
     const target = globalThis as { __VH_IMPORT_META_ENV__?: Record<string, unknown> | undefined };
     const previousImportMetaEnv = target.__VH_IMPORT_META_ENV__;

--- a/packages/gun-client/src/newsAdapters.ts
+++ b/packages/gun-client/src/newsAdapters.ts
@@ -243,8 +243,7 @@ function parseRuntimeList(value: string | undefined): string[] {
   const rawValues = value.trim().startsWith('[')
     ? (() => {
         try {
-          const parsed = JSON.parse(value);
-          return Array.isArray(parsed) ? parsed : [];
+          return JSON.parse(value) as unknown[];
         } catch {
           return [];
         }

--- a/packages/gun-client/src/newsAdapters.ts
+++ b/packages/gun-client/src/newsAdapters.ts
@@ -18,6 +18,7 @@ import {
 } from './systemWriter';
 import type { VennClient } from './types';
 import { resolveRelayRestEndpointFromPeer } from './relayRestFallback';
+import { createRelayDaemonAuthHeaders } from './relayAuth';
 
 export type NewsLatestIndex = Record<string, number>;
 export type NewsHotIndex = Record<string, number>;
@@ -157,6 +158,16 @@ const RELAY_REST_READ_TIMEOUT_MS = readGunTimeoutMs(
   ['VITE_VH_NEWS_RELAY_REST_READ_TIMEOUT_MS', 'VH_NEWS_RELAY_REST_READ_TIMEOUT_MS'],
   10_000,
 );
+const RELAY_REST_WRITE_TIMEOUT_MS = readGunTimeoutMs(
+  [
+    'VITE_VH_NEWS_RELAY_REST_WRITE_TIMEOUT_MS',
+    'VH_NEWS_RELAY_REST_WRITE_TIMEOUT_MS',
+    'VITE_VH_RELAY_REST_FALLBACK_TIMEOUT_MS',
+    'VH_RELAY_REST_FALLBACK_TIMEOUT_MS',
+  ],
+  10_000,
+  100,
+);
 const RELAY_REST_INDEX_LIMIT = readGunTimeoutMs(
   ['VITE_VH_NEWS_RELAY_REST_INDEX_LIMIT', 'VH_NEWS_RELAY_REST_INDEX_LIMIT'],
   80,
@@ -169,6 +180,100 @@ const SECRET_TEXT_PATTERNS = [
   /\bBearer\s+[A-Za-z0-9._~+/=-]+/gi,
   /"?(?:api[_-]?key|token|authorization|secret)"?\s*[:=]\s*"[^"]+"/gi,
 ] as const;
+const RELAY_REST_NEWS_WRITE_FIRST_ENV = [
+  'VITE_VH_NEWS_RELAY_REST_WRITE_FIRST',
+  'VH_NEWS_RELAY_REST_WRITE_FIRST',
+] as const;
+const RELAY_REST_NEWS_WRITE_ORIGINS_ENV = [
+  'VITE_VH_NEWS_RELAY_REST_WRITE_ORIGINS',
+  'VH_NEWS_RELAY_REST_WRITE_ORIGINS',
+  'VITE_VH_BUNDLE_SYNTHESIS_RELAY_WRITE_ORIGINS',
+  'VH_BUNDLE_SYNTHESIS_RELAY_WRITE_ORIGINS',
+] as const;
+const RELAY_REST_NEWS_WRITE_REQUIRE_ALL_ENV = [
+  'VITE_VH_NEWS_RELAY_REST_WRITE_REQUIRE_ALL',
+  'VH_NEWS_RELAY_REST_WRITE_REQUIRE_ALL',
+] as const;
+
+type NewsRelayRestWritePath =
+  | '/vh/news/story'
+  | '/vh/news/latest-index'
+  | '/vh/news/hot-index'
+  | '/vh/news/synthesis-lifecycle';
+
+function readNewsRuntimeString(name: string): string | undefined {
+  const importMetaEnv = (
+    globalThis as { __VH_IMPORT_META_ENV__?: Record<string, unknown> | undefined }
+  ).__VH_IMPORT_META_ENV__ ?? (import.meta as unknown as { env?: Record<string, unknown> }).env;
+  const importMetaValue = importMetaEnv?.[name];
+  if (typeof importMetaValue === 'string' && importMetaValue.trim().length > 0) {
+    return importMetaValue.trim();
+  }
+
+  if (typeof process !== 'undefined') {
+    const processValue = process.env?.[name];
+    if (typeof processValue === 'string' && processValue.trim().length > 0) {
+      return processValue.trim();
+    }
+  }
+
+  const globalValue = (globalThis as { __VH_GUN_CLIENT_CONFIG__?: Record<string, unknown> })
+    .__VH_GUN_CLIENT_CONFIG__?.[name];
+  if (typeof globalValue === 'string' && globalValue.trim().length > 0) {
+    return globalValue.trim();
+  }
+
+  return undefined;
+}
+
+function readNewsRuntimeBoolean(names: readonly string[], fallback = false): boolean {
+  for (const name of names) {
+    const raw = readNewsRuntimeString(name);
+    if (!raw) continue;
+    if (/^(1|true|yes|on)$/i.test(raw)) return true;
+    if (/^(0|false|no|off)$/i.test(raw)) return false;
+  }
+  return fallback;
+}
+
+function parseRuntimeList(value: string | undefined): string[] {
+  if (!value) {
+    return [];
+  }
+  const rawValues = value.trim().startsWith('[')
+    ? (() => {
+        try {
+          const parsed = JSON.parse(value);
+          return Array.isArray(parsed) ? parsed : [];
+        } catch {
+          return [];
+        }
+      })()
+    : value.split(',');
+  return rawValues.map((entry) => String(entry).trim()).filter(Boolean);
+}
+
+function readFirstRuntimeList(names: readonly string[]): string[] {
+  for (const name of names) {
+    const parsed = parseRuntimeList(readNewsRuntimeString(name));
+    if (parsed.length > 0) {
+      return parsed;
+    }
+  }
+  return [];
+}
+
+function uniqueStrings(values: readonly string[]): string[] {
+  return [...new Set(values)];
+}
+
+function shouldWriteNewsViaRelayRestFirst(): boolean {
+  return readNewsRuntimeBoolean(RELAY_REST_NEWS_WRITE_FIRST_ENV, false);
+}
+
+function shouldRequireAllNewsRelayRestWrites(): boolean {
+  return readNewsRuntimeBoolean(RELAY_REST_NEWS_WRITE_REQUIRE_ALL_ENV, true);
+}
 
 function normalizeLatestIndexReadLimit(limit: unknown, fallback = RELAY_REST_INDEX_LIMIT): number {
   const parsed = Number(limit);
@@ -1755,7 +1860,9 @@ function sanitizeStoryBundle(data: unknown): StoryBundle {
 }
 
 async function enforceCreatedAtFirstWriteWins(client: VennClient, story: StoryBundle): Promise<StoryBundle> {
-  const existing = await readNewsStory(client, story.story_id);
+  const existing = shouldWriteNewsViaRelayRestFirst()
+    ? await readNewsStoryWithRelayRestFallback(client, story.story_id)
+    : await readNewsStory(client, story.story_id);
   if (!existing) {
     return story;
   }
@@ -2075,6 +2182,86 @@ function resolveRelayRestEndpointsFromPeers(client: VennClient, path: string): s
   return endpoints;
 }
 
+function resolveRelayRestWriteEndpoints(client: VennClient, path: NewsRelayRestWritePath): string[] {
+  const configuredOrigins = readFirstRuntimeList(RELAY_REST_NEWS_WRITE_ORIGINS_ENV);
+  const peers = configuredOrigins.length > 0 ? configuredOrigins : client.config.peers;
+  return uniqueStrings(
+    peers.flatMap((peer) => {
+      const endpoint = resolveRelayRestEndpointFromPeer(peer, path);
+      return endpoint ? [endpoint] : [];
+    }),
+  );
+}
+
+function requireNewsRelayDaemonAuthHeaders(): Record<string, string> {
+  const headers = createRelayDaemonAuthHeaders();
+  if (!headers.Authorization) {
+    throw new Error('VH_RELAY_DAEMON_TOKEN is required for relay REST news writes');
+  }
+  return headers;
+}
+
+async function writeNewsRecordViaRelayRest(input: {
+  readonly client: VennClient;
+  readonly path: NewsRelayRestWritePath;
+  readonly record: Record<string, unknown>;
+  readonly writeClass: string;
+  readonly validate: (payload: Record<string, unknown>) => boolean;
+}): Promise<void> {
+  if (typeof fetch !== 'function') {
+    throw new Error('fetch is required for relay REST news writes');
+  }
+  const endpoints = resolveRelayRestWriteEndpoints(input.client, input.path);
+  if (endpoints.length === 0) {
+    throw new Error(`No relay REST endpoints configured for ${input.path}`);
+  }
+  const headers = requireNewsRelayDaemonAuthHeaders();
+  const requireAll = shouldRequireAllNewsRelayRestWrites();
+  const failures: string[] = [];
+  let successCount = 0;
+
+  for (const endpoint of endpoints) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), RELAY_REST_WRITE_TIMEOUT_MS);
+    try {
+      const response = await fetch(endpoint, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          ...headers,
+        },
+        body: JSON.stringify({ record: input.record }),
+        signal: controller.signal,
+      });
+      const payload = await response.json().catch(() => null) as Record<string, unknown> | null;
+      if (response.ok && payload && input.validate(payload)) {
+        successCount += 1;
+        continue;
+      }
+      failures.push(`${endpoint}:http_${response.status}`);
+    } catch (error) {
+      failures.push(`${endpoint}:${error instanceof Error ? error.message : String(error)}`);
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  if (successCount > 0 && (!requireAll || successCount === endpoints.length)) {
+    console.info('[vh:news] relay REST write completed', {
+      write_class: input.writeClass,
+      path: input.path,
+      relay_success_count: successCount,
+      relay_target_count: endpoints.length,
+      require_all: requireAll,
+    });
+    return;
+  }
+
+  throw new Error(
+    `Relay REST news write failed for ${input.path}: ${successCount}/${endpoints.length} succeeded; ${failures.join('; ')}`,
+  );
+}
+
 function resolveLatestIndexRelayRestRead(
   client: VennClient,
   options: NewsLatestIndexReadOptions = {},
@@ -2190,6 +2377,16 @@ export async function writeNewsStory(client: VennClient, story: unknown): Promis
   await assertCanonicalNewsTopicId(sanitized);
   const normalized = await enforceCreatedAtFirstWriteWins(client, sanitized);
   const encoded = await buildSystemWriterStoryRecord(client, normalized);
+  if (shouldWriteNewsViaRelayRestFirst()) {
+    await writeNewsRecordViaRelayRest({
+      client,
+      path: '/vh/news/story',
+      record: encoded,
+      writeClass: 'news-story',
+      validate: (payload) => payload.ok === true && payload.story_id === normalized.story_id,
+    });
+    return normalized;
+  }
   await putWithAck(
     getNewsStoryChain(client, normalized.story_id) as unknown as ChainWithGet<Record<string, unknown>>,
     encoded,
@@ -2344,6 +2541,19 @@ export async function writeNewsSynthesisLifecycleStatus(
     throw new Error('news synthesis lifecycle record is invalid');
   }
   const encoded = await buildSystemWriterSynthesisLifecycleRecord(client, sanitized);
+  if (shouldWriteNewsViaRelayRestFirst()) {
+    await writeNewsRecordViaRelayRest({
+      client,
+      path: '/vh/news/synthesis-lifecycle',
+      record: encoded,
+      writeClass: 'news-synthesis-lifecycle',
+      validate: (payload) =>
+        payload.ok === true
+        && payload.story_id === sanitized.story_id
+        && payload.status === sanitized.status,
+    });
+    return sanitized;
+  }
   await putWithAck(
     getNewsSynthesisLifecycleChain(client, sanitized.story_id) as unknown as ChainWithGet<Record<string, unknown>>,
     encoded,
@@ -2796,6 +3006,16 @@ export async function writeNewsLatestIndexEntry(
   const encoded = await buildSystemWriterLatestIndexRecord(client, normalizedId, normalizedLatestTimestamp, story);
   const chain = getNewsLatestIndexChain(client).get(normalizedId) as unknown as ChainWithGet<Record<string, unknown>>;
   const expectedMetadata = story ? latestIndexProductMetadataForStory(story) : null;
+  if (shouldWriteNewsViaRelayRestFirst()) {
+    await writeNewsRecordViaRelayRest({
+      client,
+      path: '/vh/news/latest-index',
+      record: encoded,
+      writeClass: 'news-latest-index',
+      validate: (payload) => payload.ok === true && payload.story_id === normalizedId,
+    });
+    return;
+  }
   await putWithAck(chain, encoded, {
     writeClass: 'news-latest-index',
     timeoutError: 'news latest-index write timed out and readback did not confirm persistence',
@@ -2863,6 +3083,16 @@ export async function writeNewsHotIndexEntry(
   const encoded = await buildSystemWriterHotIndexRecord(client, normalizedId, normalizedHotness, story);
   const chain = getNewsHotIndexChain(client).get(normalizedId) as unknown as ChainWithGet<Record<string, unknown>>;
   const expectedMetadata = story ? latestIndexProductMetadataForStory(story) : null;
+  if (shouldWriteNewsViaRelayRestFirst()) {
+    await writeNewsRecordViaRelayRest({
+      client,
+      path: '/vh/news/hot-index',
+      record: encoded,
+      writeClass: 'news-hot-index',
+      validate: (payload) => payload.ok === true && payload.story_id === normalizedId,
+    });
+    return normalizedHotness;
+  }
   await putWithAck(chain, encoded, {
     writeClass: 'news-hot-index',
     timeoutError: 'news hot-index write timed out and readback did not confirm persistence',
@@ -3008,4 +3238,8 @@ export const newsAdapterInternal = {
   parseNewsSynthesisLifecycleFromRelayPayload,
   parseLatestIndexEntryPayload,
   parseHotIndexEntryPayload,
+  resolveRelayRestWriteEndpoints,
+  shouldRequireAllNewsRelayRestWrites,
+  shouldWriteNewsViaRelayRestFirst,
+  writeNewsRecordViaRelayRest,
 };

--- a/tools/scripts/news-aggregator-publisher-preflight.mjs
+++ b/tools/scripts/news-aggregator-publisher-preflight.mjs
@@ -115,6 +115,8 @@ export async function runNewsAggregatorPublisherPreflight({
   const relayRestOrigins = parseDelimited(env.VH_BUNDLE_SYNTHESIS_RELAY_WRITE_ORIGINS);
   const relayRestWriteRequested = truthy(env.VH_BUNDLE_SYNTHESIS_WRITE_RELAY_REST)
     || relayRestOrigins.length > 0;
+  const newsRelayRestOrigins = parseDelimited(env.VH_NEWS_RELAY_REST_WRITE_ORIGINS);
+  const newsRelayRestWriteFirst = truthy(env.VH_NEWS_RELAY_REST_WRITE_FIRST);
   if (synthesisEnabled) {
     if (!relayRestWriteRequested) failures.push('relay_rest_synthesis:disabled_while_synthesis_enabled');
     if (relayRestOrigins.length === 0) failures.push('relay_rest_synthesis_origins:missing');
@@ -123,6 +125,15 @@ export async function runNewsAggregatorPublisherPreflight({
       const url = validUrl(origin, 'relay_rest_synthesis_origin', failures);
       if (url && !['http:', 'https:'].includes(url.protocol)) {
         failures.push('relay_rest_synthesis_origin:unsupported_protocol');
+      }
+    }
+  }
+  if (newsRelayRestWriteFirst) {
+    if (!firstNonEmpty(env.VH_RELAY_DAEMON_TOKEN)) failures.push('relay_rest_news_token:missing');
+    for (const origin of newsRelayRestOrigins) {
+      const url = validUrl(origin, 'relay_rest_news_origin', failures);
+      if (url && !['http:', 'https:', 'ws:', 'wss:'].includes(url.protocol)) {
+        failures.push('relay_rest_news_origin:unsupported_protocol');
       }
     }
   }
@@ -181,6 +192,12 @@ export async function runNewsAggregatorPublisherPreflight({
     relay_rest_synthesis: {
       requested: relayRestWriteRequested,
       origin_count: relayRestOrigins.length,
+      daemon_token_present: Boolean(firstNonEmpty(env.VH_RELAY_DAEMON_TOKEN)),
+    },
+    relay_rest_news_publication: {
+      write_first: newsRelayRestWriteFirst,
+      origin_count: newsRelayRestOrigins.length,
+      require_all: !/^(0|false|no|off)$/i.test(String(env.VH_NEWS_RELAY_REST_WRITE_REQUIRE_ALL ?? '').trim()),
       daemon_token_present: Boolean(firstNonEmpty(env.VH_RELAY_DAEMON_TOKEN)),
     },
     failures,

--- a/tools/scripts/news-aggregator-publisher-preflight.test.mjs
+++ b/tools/scripts/news-aggregator-publisher-preflight.test.mjs
@@ -56,10 +56,31 @@ test('publisher preflight fails closed when synthesis is enabled without relay R
   assert.match(result.failures.join('\n'), /relay_rest_synthesis_token:missing/);
 });
 
+test('publisher preflight fails closed when news relay REST write-first lacks daemon token', async () => {
+  const result = await runNewsAggregatorPublisherPreflight({
+    env: baseEnv({
+      VH_NEWS_RELAY_REST_WRITE_FIRST: 'true',
+      VH_NEWS_RELAY_REST_WRITE_ORIGINS: 'https://gun-a.example.test',
+      VH_RELAY_DAEMON_TOKEN: '',
+      VH_BUNDLE_SYNTHESIS_ENABLED: '',
+    }),
+    fetchFn: async () => new Response('{}'),
+  });
+
+  assert.equal(result.status, 'fail');
+  assert.match(result.failures.join('\n'), /relay_rest_news_token:missing/);
+  assert.equal(result.relay_rest_news_publication.write_first, true);
+  assert.equal(result.relay_rest_news_publication.origin_count, 1);
+  assert.equal(result.relay_rest_news_publication.daemon_token_present, false);
+});
+
 test('publisher preflight checks relay health with redacted pass output', async () => {
   const origins = [];
   const result = await runNewsAggregatorPublisherPreflight({
-    env: baseEnv(),
+    env: baseEnv({
+      VH_NEWS_RELAY_REST_WRITE_FIRST: 'true',
+      VH_NEWS_RELAY_REST_WRITE_ORIGINS: 'https://gun-a.example.test,https://gun-b.example.test',
+    }),
     fetchFn: async (input, init) => {
       assert.equal(init.method, 'GET');
       assert.deepEqual(init.headers, { accept: 'application/json' });
@@ -80,6 +101,12 @@ test('publisher preflight checks relay health with redacted pass output', async 
   assert.equal(JSON.stringify(result).includes('relay-token-redacted'), false);
   assert.equal(JSON.stringify(result).includes('storycluster-token-redacted'), false);
   assert.equal(JSON.stringify(result).includes('private-material-redacted'), false);
+  assert.deepEqual(result.relay_rest_news_publication, {
+    write_first: true,
+    origin_count: 2,
+    require_all: true,
+    daemon_token_present: true,
+  });
 });
 
 test('publisher preflight derives health URLs from Gun peers', () => {


### PR DESCRIPTION
## Summary
- add `VH_NEWS_RELAY_REST_WRITE_FIRST` support for raw public news publication
- write signed story, latest-index, hot-index, and synthesis lifecycle records through relay REST write-through routes when enabled
- fail closed without `VH_RELAY_DAEMON_TOKEN` or when require-all relay fanout is not met
- extend publisher preflight and ops docs/env template for the raw news relay REST publication path

## Why
The first attended Phase 5 live tick failed before first-publish proof because direct Gun story writes timed out and readback did not confirm persistence. The relay REST write-through path already persists signed story/index/lifecycle records and snapshots; this moves raw news publication onto that explicit path instead of depending on the flaky direct WSS writer.

## Verification
- `PATH="/opt/homebrew/Cellar/node@20/20.20.0/bin:$PATH" pnpm --filter @vh/gun-client exec vitest run src/newsAdapters.test.ts --config ./vitest.config.ts`
- `PATH="/opt/homebrew/Cellar/node@20/20.20.0/bin:$PATH" node --test tools/scripts/news-aggregator-publisher-preflight.test.mjs`
- `PATH="/opt/homebrew/Cellar/node@20/20.20.0/bin:$PATH" pnpm --filter @vh/gun-client typecheck`
- `PATH="/opt/homebrew/Cellar/node@20/20.20.0/bin:$PATH" pnpm --filter @vh/news-aggregator typecheck`
- `git diff --check`
- `PATH="/opt/homebrew/Cellar/node@20/20.20.0/bin:$PATH" pnpm typecheck`
- `PATH="/opt/homebrew/Cellar/node@20/20.20.0/bin:$PATH" pnpm --filter @vh/e2e exec vitest run src/live/relay-server.vitest.mjs --config ./vitest.config.ts`
- `PATH="/opt/homebrew/Cellar/node@20/20.20.0/bin:$PATH" pnpm test:quick`
