### PR TITLE
Fail closed on relay REST auth mismatch

### DIFF
--- a/docs/ops/news-aggregator-production-service.md
+++ b/docs/ops/news-aggregator-production-service.md
@@ -316,6 +316,13 @@ direct Gun publication. `VH_NEWS_RELAY_REST_WRITE_REQUIRE_ALL=true` is the
 default and should remain set so a partial relay fanout fails closed instead of
 claiming first-publish success from one relay.
 
+The raw publication readiness preflight also performs an authenticated no-write
+relay REST probe when write-first publication is enabled: it POSTs an empty JSON
+body to `/vh/news/story` with the daemon bearer token and requires the relay to
+reject the body as a validation error after auth. A 401/403/503 response means
+the publisher token does not match the relay daemon token, so live start must
+fail before the first real story write.
+
 ## Lease / Lock Behavior
 
 The daemon writes and renews the shared `NewsIngestionLease` before starting the

--- a/tools/scripts/news-aggregator-publisher-preflight.mjs
+++ b/tools/scripts/news-aggregator-publisher-preflight.mjs
@@ -62,12 +62,59 @@ function relayHealthUrlFromPeer(peer, failures) {
   return parsed.toString();
 }
 
+function relayRestWriteUrlFromOrigin(origin, path, label, failures) {
+  const parsed = validUrl(origin, label, failures);
+  if (!parsed) {
+    return null;
+  }
+  if (parsed.protocol === 'ws:') {
+    parsed.protocol = 'http:';
+  } else if (parsed.protocol === 'wss:') {
+    parsed.protocol = 'https:';
+  }
+  if (!['http:', 'https:'].includes(parsed.protocol)) {
+    failures.push(`${label}:unsupported_protocol`);
+    return null;
+  }
+  parsed.pathname = path;
+  parsed.search = '';
+  parsed.hash = '';
+  return parsed.toString();
+}
+
 function assertPresent(env, name, failures) {
   if (!firstNonEmpty(env[name])) {
     failures.push(`${name}:missing`);
     return false;
   }
   return true;
+}
+
+async function probeNewsRelayRestAuth(url, token, fetchFn) {
+  const parsed = new URL(url);
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 10_000);
+  try {
+    const response = await fetchFn(parsed, {
+      method: 'POST',
+      headers: {
+        accept: 'application/json',
+        authorization: `Bearer ${token}`,
+        'content-type': 'application/json',
+      },
+      body: '{}',
+      signal: controller.signal,
+    });
+    const body = await response.json().catch(() => ({}));
+    return {
+      origin: parsed.origin,
+      status: response.status,
+      authenticated: response.status === 400 && /required|invalid/i.test(String(body?.error ?? '')),
+      error: typeof body?.error === 'string' ? body.error : null,
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
 }
 
 export async function runNewsAggregatorPublisherPreflight({
@@ -117,6 +164,20 @@ export async function runNewsAggregatorPublisherPreflight({
     || relayRestOrigins.length > 0;
   const newsRelayRestOrigins = parseDelimited(env.VH_NEWS_RELAY_REST_WRITE_ORIGINS);
   const newsRelayRestWriteFirst = truthy(env.VH_NEWS_RELAY_REST_WRITE_FIRST);
+  const newsRelayRestWriteOriginInputs = newsRelayRestWriteFirst
+    ? (
+        newsRelayRestOrigins.length > 0
+          ? newsRelayRestOrigins
+          : relayRestOrigins.length > 0
+            ? relayRestOrigins
+            : gunPeers
+      )
+    : [];
+  const newsRelayRestWriteAuthUrls = newsRelayRestWriteFirst
+    ? [...new Set(newsRelayRestWriteOriginInputs
+      .map((origin) => relayRestWriteUrlFromOrigin(origin, '/vh/news/story', 'relay_rest_news_origin', failures))
+      .filter(Boolean))]
+    : [];
   if (synthesisEnabled) {
     if (!relayRestWriteRequested) failures.push('relay_rest_synthesis:disabled_while_synthesis_enabled');
     if (relayRestOrigins.length === 0) failures.push('relay_rest_synthesis_origins:missing');
@@ -130,15 +191,13 @@ export async function runNewsAggregatorPublisherPreflight({
   }
   if (newsRelayRestWriteFirst) {
     if (!firstNonEmpty(env.VH_RELAY_DAEMON_TOKEN)) failures.push('relay_rest_news_token:missing');
-    for (const origin of newsRelayRestOrigins) {
-      const url = validUrl(origin, 'relay_rest_news_origin', failures);
-      if (url && !['http:', 'https:', 'ws:', 'wss:'].includes(url.protocol)) {
-        failures.push('relay_rest_news_origin:unsupported_protocol');
-      }
+    if (newsRelayRestWriteAuthUrls.length === 0) {
+      failures.push('relay_rest_news_auth_targets:missing');
     }
   }
 
   const relayResults = [];
+  const newsRelayRestAuthResults = [];
   if (failures.length === 0) {
     if (typeof fetchFn !== 'function') {
       failures.push('fetch:unavailable');
@@ -165,6 +224,21 @@ export async function runNewsAggregatorPublisherPreflight({
           failures.push(`relay_read_health:${parsed.origin}:${error instanceof Error ? error.message : String(error)}`);
         } finally {
           clearTimeout(timeout);
+        }
+      }
+      if (newsRelayRestWriteFirst) {
+        const token = firstNonEmpty(env.VH_RELAY_DAEMON_TOKEN);
+        for (const url of newsRelayRestWriteAuthUrls) {
+          try {
+            const result = await probeNewsRelayRestAuth(url, token, fetchFn);
+            newsRelayRestAuthResults.push(result);
+            if (!result.authenticated) {
+              failures.push(`relay_rest_news_auth:${result.origin}:http_${result.status}`);
+            }
+          } catch (error) {
+            const origin = new URL(url).origin;
+            failures.push(`relay_rest_news_auth:${origin}:${error instanceof Error ? error.message : String(error)}`);
+          }
         }
       }
     }
@@ -196,9 +270,10 @@ export async function runNewsAggregatorPublisherPreflight({
     },
     relay_rest_news_publication: {
       write_first: newsRelayRestWriteFirst,
-      origin_count: newsRelayRestOrigins.length,
+      origin_count: newsRelayRestWriteAuthUrls.length,
       require_all: !/^(0|false|no|off)$/i.test(String(env.VH_NEWS_RELAY_REST_WRITE_REQUIRE_ALL ?? '').trim()),
       daemon_token_present: Boolean(firstNonEmpty(env.VH_RELAY_DAEMON_TOKEN)),
+      auth_probe_results: newsRelayRestAuthResults,
     },
     failures,
   };
@@ -219,6 +294,7 @@ export const newsAggregatorPublisherPreflightInternal = {
   firstNonEmpty,
   parseDelimited,
   relayHealthUrlFromPeer,
+  relayRestWriteUrlFromOrigin,
   truthy,
 };
 

--- a/tools/scripts/news-aggregator-publisher-preflight.test.mjs
+++ b/tools/scripts/news-aggregator-publisher-preflight.test.mjs
@@ -75,16 +75,25 @@ test('publisher preflight fails closed when news relay REST write-first lacks da
 });
 
 test('publisher preflight checks relay health with redacted pass output', async () => {
-  const origins = [];
+  const calls = [];
   const result = await runNewsAggregatorPublisherPreflight({
     env: baseEnv({
       VH_NEWS_RELAY_REST_WRITE_FIRST: 'true',
       VH_NEWS_RELAY_REST_WRITE_ORIGINS: 'https://gun-a.example.test,https://gun-b.example.test',
     }),
     fetchFn: async (input, init) => {
+      calls.push({ origin: input.origin, pathname: input.pathname, method: init.method, headers: init.headers });
+      if (init.method === 'POST') {
+        assert.equal(input.pathname, '/vh/news/story');
+        assert.equal(init.body, '{}');
+        assert.equal(init.headers.authorization, 'Bearer relay-token-redacted');
+        return new Response(JSON.stringify({ ok: false, error: 'news-story-record-required' }), {
+          status: 400,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
       assert.equal(init.method, 'GET');
       assert.deepEqual(init.headers, { accept: 'application/json' });
-      origins.push(input.origin);
       return new Response(JSON.stringify({ ok: true }), {
         status: 200,
         headers: { 'content-type': 'application/json' },
@@ -93,7 +102,12 @@ test('publisher preflight checks relay health with redacted pass output', async 
   });
 
   assert.equal(result.status, 'pass');
-  assert.deepEqual(origins, ['https://gun-a.example.test', 'https://gun-b.example.test']);
+  assert.deepEqual(calls.map(({ origin, pathname, method }) => ({ origin, pathname, method })), [
+    { origin: 'https://gun-a.example.test', pathname: '/healthz', method: 'GET' },
+    { origin: 'https://gun-b.example.test', pathname: '/healthz', method: 'GET' },
+    { origin: 'https://gun-a.example.test', pathname: '/vh/news/story', method: 'POST' },
+    { origin: 'https://gun-b.example.test', pathname: '/vh/news/story', method: 'POST' },
+  ]);
   assert.deepEqual(result.relay_health_results, [
     { origin: 'https://gun-a.example.test', status: 200, ok: true },
     { origin: 'https://gun-b.example.test', status: 200, ok: true },
@@ -106,12 +120,71 @@ test('publisher preflight checks relay health with redacted pass output', async 
     origin_count: 2,
     require_all: true,
     daemon_token_present: true,
+    auth_probe_results: [
+      {
+        origin: 'https://gun-a.example.test',
+        status: 400,
+        authenticated: true,
+        error: 'news-story-record-required',
+      },
+      {
+        origin: 'https://gun-b.example.test',
+        status: 400,
+        authenticated: true,
+        error: 'news-story-record-required',
+      },
+    ],
   });
+});
+
+test('publisher preflight fails closed when relay REST news auth rejects the daemon token', async () => {
+  const result = await runNewsAggregatorPublisherPreflight({
+    env: baseEnv({
+      VH_NEWS_RELAY_REST_WRITE_FIRST: 'true',
+      VH_NEWS_RELAY_REST_WRITE_ORIGINS: 'https://gun-a.example.test',
+    }),
+    fetchFn: async (input, init) => {
+      if (init.method === 'POST') {
+        return new Response(JSON.stringify({ ok: false, error: 'daemon-token-required' }), {
+          status: 401,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    },
+  });
+
+  assert.equal(result.status, 'fail');
+  assert.match(result.failures.join('\n'), /relay_rest_news_auth:https:\/\/gun-a\.example\.test:http_401/);
+  assert.deepEqual(result.relay_rest_news_publication.auth_probe_results, [
+    {
+      origin: 'https://gun-a.example.test',
+      status: 401,
+      authenticated: false,
+      error: 'daemon-token-required',
+    },
+  ]);
+  assert.equal(JSON.stringify(result).includes('relay-token-redacted'), false);
 });
 
 test('publisher preflight derives health URLs from Gun peers', () => {
   assert.equal(
     newsAggregatorPublisherPreflightInternal.relayHealthUrlFromPeer('wss://gun-a.example.test/gun', []),
     'https://gun-a.example.test/healthz',
+  );
+});
+
+test('publisher preflight derives news write auth probe URLs from relay origins', () => {
+  assert.equal(
+    newsAggregatorPublisherPreflightInternal.relayRestWriteUrlFromOrigin(
+      'wss://gun-a.example.test/gun',
+      '/vh/news/story',
+      'relay_rest_news_origin',
+      [],
+    ),
+    'https://gun-a.example.test/vh/news/story',
   );
 });


### PR DESCRIPTION
## Summary
- add an authenticated no-write relay REST auth probe to the news publisher preflight
- fail before live start when the daemon token reaches relay write-through routes as 401/403/503
- document the probe in the production service runbook

## Verification
- PATH="/opt/homebrew/Cellar/node@20/20.20.0/bin:/Users/bldt/.codex/tmp/arg0/codex-arg0qiuobx:/opt/homebrew/opt/openjdk@17/bin:/Users/bldt/.antigravity/antigravity/bin:/opt/homebrew/opt/ruby/bin:/Users/bldt/.codeium/windsurf/bin:/Library/Frameworks/Python.framework/Versions/3.13/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/Library/Frameworks/Python.framework/Versions/3.13/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/opt/homebrew/lib/ruby/gems/3.4.0/bin:/Users/bldt/.modular/bin:/Users/bldt/development/flutter/bin:/Users/bldt/.pub-cache/bin:/Users/bldt/Library/Android/sdk/emulator:/Users/bldt/Library/Android/sdk/platform-tools:/Applications/Codex.app/Contents/Resources" node --test tools/scripts/news-aggregator-publisher-preflight.test.mjs
- git diff --check
- PATH="/opt/homebrew/Cellar/node@20/20.20.0/bin:/Users/bldt/.codex/tmp/arg0/codex-arg0qiuobx:/opt/homebrew/opt/openjdk@17/bin:/Users/bldt/.antigravity/antigravity/bin:/opt/homebrew/opt/ruby/bin:/Users/bldt/.codeium/windsurf/bin:/Library/Frameworks/Python.framework/Versions/3.13/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/Library/Frameworks/Python.framework/Versions/3.13/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/opt/homebrew/lib/ruby/gems/3.4.0/bin:/Users/bldt/.modular/bin:/Users/bldt/development/flutter/bin:/Users/bldt/.pub-cache/bin:/Users/bldt/Library/Android/sdk/emulator:/Users/bldt/Library/Android/sdk/platform-tools:/Applications/Codex.app/Contents/Resources" pnpm test:quick