### PR TITLE
Support per-origin relay REST daemon tokens

### DIFF
--- a/docs/ops/news-aggregator-production-service.md
+++ b/docs/ops/news-aggregator-production-service.md
@@ -282,9 +282,11 @@ OPENAI_API_KEY
 VH_BUNDLE_SYNTHESIS_ENABLED
 VH_NEWS_RELAY_REST_WRITE_FIRST
 VH_NEWS_RELAY_REST_WRITE_ORIGINS
+VH_NEWS_RELAY_REST_WRITE_TOKENS
 VH_NEWS_RELAY_REST_WRITE_REQUIRE_ALL
 VH_NEWS_RELAY_REST_WRITE_TIMEOUT_MS
 VH_BUNDLE_SYNTHESIS_RELAY_WRITE_ORIGINS
+VH_BUNDLE_SYNTHESIS_RELAY_WRITE_TOKENS
 VH_BUNDLE_SYNTHESIS_RELAY_WRITE_REQUIRE_ALL
 VH_BUNDLE_SYNTHESIS_WRITE_RELAY_REST
 VH_RELAY_DAEMON_TOKEN
@@ -316,12 +318,27 @@ direct Gun publication. `VH_NEWS_RELAY_REST_WRITE_REQUIRE_ALL=true` is the
 default and should remain set so a partial relay fanout fails closed instead of
 claiming first-publish success from one relay.
 
+When relays have different daemon tokens, set `VH_NEWS_RELAY_REST_WRITE_TOKENS`
+to a JSON object mapping each relay origin to its token, for example:
+
+```bash
+VH_NEWS_RELAY_REST_WRITE_TOKENS='{"https://gun-a.carboncaste.io":"<gun-a-token>","https://gun-b.carboncaste.io":"<gun-b-token>","https://gun-c.carboncaste.io":"<gun-c-token>"}'
+```
+
+Raw story/index/lifecycle publication uses the per-origin token for each relay
+before falling back to `VH_RELAY_DAEMON_TOKEN`. Bundle synthesis REST writes use
+`VH_BUNDLE_SYNTHESIS_RELAY_WRITE_TOKENS` when set, then
+`VH_NEWS_RELAY_REST_WRITE_TOKENS`, then the single `VH_RELAY_DAEMON_TOKEN`
+fallback. A single `VH_RELAY_DAEMON_TOKEN` is safe only when all configured
+relays share that same daemon token.
+
 The raw publication readiness preflight also performs an authenticated no-write
 relay REST probe when write-first publication is enabled: it POSTs an empty JSON
-body to `/vh/news/story` with the daemon bearer token and requires the relay to
-reject the body as a validation error after auth. A 401/403/503 response means
-the publisher token does not match the relay daemon token, so live start must
-fail before the first real story write.
+body to `/vh/news/story` with each relay's configured bearer token and requires
+the relay to reject the body as a validation error after auth. A missing
+per-origin token, or a 401/403/503 response, means the publisher token does not
+match the relay daemon token, so live start must fail before the first real story
+write.
 
 ## Lease / Lock Behavior
 

--- a/docs/ops/news-aggregator.env.example
+++ b/docs/ops/news-aggregator.env.example
@@ -36,17 +36,22 @@ OPENAI_API_KEY=<from-storycluster-openai.env>
 # relay snapshots are updated immediately.
 VH_NEWS_RELAY_REST_WRITE_FIRST=true
 VH_NEWS_RELAY_REST_WRITE_ORIGINS='["https://gun-a.carboncaste.io","https://gun-b.carboncaste.io","https://gun-c.carboncaste.io"]'
+VH_NEWS_RELAY_REST_WRITE_TOKENS='{"https://gun-a.carboncaste.io":"<gun-a-relay-daemon-token>","https://gun-b.carboncaste.io":"<gun-b-relay-daemon-token>","https://gun-c.carboncaste.io":"<gun-c-relay-daemon-token>"}'
 VH_NEWS_RELAY_REST_WRITE_REQUIRE_ALL=true
 VH_NEWS_RELAY_REST_WRITE_TIMEOUT_MS=10000
 VH_BUNDLE_SYNTHESIS_ENABLED=true
 VH_BUNDLE_SYNTHESIS_WRITE_RELAY_REST=true
 VH_BUNDLE_SYNTHESIS_RELAY_WRITE_ORIGINS='["https://gun-a.carboncaste.io","https://gun-b.carboncaste.io","https://gun-c.carboncaste.io"]'
+# Optional override for synthesis REST writes. If absent, synthesis uses
+# VH_NEWS_RELAY_REST_WRITE_TOKENS, then falls back to VH_RELAY_DAEMON_TOKEN.
+# VH_BUNDLE_SYNTHESIS_RELAY_WRITE_TOKENS='{"https://gun-a.carboncaste.io":"<gun-a-relay-daemon-token>","https://gun-b.carboncaste.io":"<gun-b-relay-daemon-token>","https://gun-c.carboncaste.io":"<gun-c-relay-daemon-token>"}'
 VH_BUNDLE_SYNTHESIS_RELAY_WRITE_REQUIRE_ALL=true
 VH_BUNDLE_SYNTHESIS_MODEL=gpt-4o-mini
 VH_BUNDLE_SYNTHESIS_TIMEOUT_MS=120000
 VH_BUNDLE_SYNTHESIS_RATE_PER_MIN=20
 VH_BUNDLE_SYNTHESIS_MAX_TOKENS=2400
-VH_RELAY_DAEMON_TOKEN=<from-public-beta-relay-daemon-token-v2.env>
+# Use this single fallback only when every relay shares the same daemon token.
+# VH_RELAY_DAEMON_TOKEN=<shared-public-beta-relay-daemon-token>
 
 # Daemon identity, state, and cadence.
 VH_NEWS_DAEMON_HOLDER_ID=vh-news-daemon:a6-public

--- a/packages/gun-client/src/newsAdapters.test.ts
+++ b/packages/gun-client/src/newsAdapters.test.ts
@@ -697,7 +697,7 @@ describe('newsAdapters', () => {
       vi.stubGlobal('fetch', fetchMock);
 
       await expect(writeNewsStory(client, STORY)).rejects.toThrow(
-        'VH_RELAY_DAEMON_TOKEN is required for relay REST news writes',
+        'VH_RELAY_DAEMON_TOKEN or VH_NEWS_RELAY_REST_WRITE_TOKENS[https://gun-a.example.test] is required for relay REST news writes',
       );
       expect(mesh.writes).toEqual([]);
       expect(fetchMock).not.toHaveBeenCalled();
@@ -740,6 +740,87 @@ describe('newsAdapters', () => {
         'https://gun-a.example.test',
         'https://gun-b.example.test',
       ]);
+    } finally {
+      vi.unstubAllGlobals();
+      restoreEnv();
+      restoreRuntimeConfig();
+    }
+  });
+
+  it('writeNewsRecordViaRelayRest uses per-origin daemon tokens when relays differ', async () => {
+    const restoreRuntimeConfig = withGunClientRuntimeConfig({
+      VH_NEWS_RELAY_REST_WRITE_ORIGINS: '["https://gun-a.example.test","https://gun-b.example.test"]',
+    });
+    const restoreEnv = withProcessEnv({
+      VH_RELAY_DAEMON_TOKEN: undefined,
+      VH_NEWS_RELAY_REST_WRITE_TOKENS: JSON.stringify({
+        'https://gun-a.example.test': 'token-a',
+        'https://gun-b.example.test': 'token-b',
+      }),
+    });
+    try {
+      const mesh = createFakeMesh();
+      const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+      const client = createClient(mesh, guard, {
+        peers: ['https://fallback-peer.example.test/gun'],
+      });
+      const fetchMock = vi.fn(async () => new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }));
+      vi.stubGlobal('fetch', fetchMock);
+
+      await expect(newsAdapterInternal.writeNewsRecordViaRelayRest({
+        client,
+        path: '/vh/news/story',
+        record: { story_id: STORY.story_id },
+        writeClass: 'news-story',
+        validate: (payload) => payload.ok === true,
+      })).resolves.toBeUndefined();
+
+      expect(fetchMock.mock.calls.map(([input, init]) => ({
+        origin: new URL(String(input)).origin,
+        auth: (init?.headers as Record<string, string>).Authorization,
+      }))).toEqual([
+        { origin: 'https://gun-a.example.test', auth: 'Bearer token-a' },
+        { origin: 'https://gun-b.example.test', auth: 'Bearer token-b' },
+      ]);
+    } finally {
+      vi.unstubAllGlobals();
+      restoreEnv();
+      restoreRuntimeConfig();
+    }
+  });
+
+  it('writeNewsRecordViaRelayRest fails before posting when a relay token map is incomplete', async () => {
+    const restoreRuntimeConfig = withGunClientRuntimeConfig({
+      VH_NEWS_RELAY_REST_WRITE_ORIGINS: '["https://gun-a.example.test","https://gun-b.example.test"]',
+    });
+    const restoreEnv = withProcessEnv({
+      VH_RELAY_DAEMON_TOKEN: undefined,
+      VH_NEWS_RELAY_REST_WRITE_TOKENS: JSON.stringify({
+        'https://gun-a.example.test': 'token-a',
+      }),
+    });
+    try {
+      const mesh = createFakeMesh();
+      const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+      const client = createClient(mesh, guard, {
+        peers: ['https://fallback-peer.example.test/gun'],
+      });
+      const fetchMock = vi.fn();
+      vi.stubGlobal('fetch', fetchMock);
+
+      await expect(newsAdapterInternal.writeNewsRecordViaRelayRest({
+        client,
+        path: '/vh/news/story',
+        record: { story_id: STORY.story_id },
+        writeClass: 'news-story',
+        validate: (payload) => payload.ok === true,
+      })).rejects.toThrow(
+        'VH_RELAY_DAEMON_TOKEN or VH_NEWS_RELAY_REST_WRITE_TOKENS[https://gun-b.example.test] is required for relay REST news writes',
+      );
+      expect(fetchMock).not.toHaveBeenCalled();
     } finally {
       vi.unstubAllGlobals();
       restoreEnv();

--- a/packages/gun-client/src/newsAdapters.ts
+++ b/packages/gun-client/src/newsAdapters.ts
@@ -18,7 +18,9 @@ import {
 } from './systemWriter';
 import type { VennClient } from './types';
 import { resolveRelayRestEndpointFromPeer } from './relayRestFallback';
-import { createRelayDaemonAuthHeaders } from './relayAuth';
+import {
+  createRelayDaemonAuthHeadersForEndpoint,
+} from './relayAuth';
 
 export type NewsLatestIndex = Record<string, number>;
 export type NewsHotIndex = Record<string, number>;
@@ -193,6 +195,10 @@ const RELAY_REST_NEWS_WRITE_ORIGINS_ENV = [
 const RELAY_REST_NEWS_WRITE_REQUIRE_ALL_ENV = [
   'VITE_VH_NEWS_RELAY_REST_WRITE_REQUIRE_ALL',
   'VH_NEWS_RELAY_REST_WRITE_REQUIRE_ALL',
+] as const;
+const RELAY_REST_NEWS_WRITE_TOKEN_MAP_ENV = [
+  'VITE_VH_NEWS_RELAY_REST_WRITE_TOKENS',
+  'VH_NEWS_RELAY_REST_WRITE_TOKENS',
 ] as const;
 
 type NewsRelayRestWritePath =
@@ -2192,10 +2198,15 @@ function resolveRelayRestWriteEndpoints(client: VennClient, path: NewsRelayRestW
   );
 }
 
-function requireNewsRelayDaemonAuthHeaders(): Record<string, string> {
-  const headers = createRelayDaemonAuthHeaders();
+function requireNewsRelayDaemonAuthHeaders(endpoint: string): Record<string, string> {
+  const headers = createRelayDaemonAuthHeadersForEndpoint(endpoint, {
+    tokenMapEnvNames: RELAY_REST_NEWS_WRITE_TOKEN_MAP_ENV,
+  });
   if (!headers.Authorization) {
-    throw new Error('VH_RELAY_DAEMON_TOKEN is required for relay REST news writes');
+    const origin = new URL(endpoint).origin;
+    throw new Error(
+      `VH_RELAY_DAEMON_TOKEN or VH_NEWS_RELAY_REST_WRITE_TOKENS[${origin}] is required for relay REST news writes`,
+    );
   }
   return headers;
 }
@@ -2214,12 +2225,15 @@ async function writeNewsRecordViaRelayRest(input: {
   if (endpoints.length === 0) {
     throw new Error(`No relay REST endpoints configured for ${input.path}`);
   }
-  const headers = requireNewsRelayDaemonAuthHeaders();
+  const relayTargets = endpoints.map((endpoint) => ({
+    endpoint,
+    headers: requireNewsRelayDaemonAuthHeaders(endpoint),
+  }));
   const requireAll = shouldRequireAllNewsRelayRestWrites();
   const failures: string[] = [];
   let successCount = 0;
 
-  for (const endpoint of endpoints) {
+  for (const { endpoint, headers } of relayTargets) {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), RELAY_REST_WRITE_TIMEOUT_MS);
     try {

--- a/packages/gun-client/src/relayAuth.test.ts
+++ b/packages/gun-client/src/relayAuth.test.ts
@@ -1,11 +1,19 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import SEA from 'gun/sea.js';
-import { createRelayDaemonAuthHeaders, createRelayUserSignatureHeaders } from './relayAuth';
+import {
+  createRelayDaemonAuthHeaders,
+  createRelayDaemonAuthHeadersForEndpoint,
+  createRelayUserSignatureHeaders,
+  normalizeRelayDaemonAuthOrigin,
+  readRelayDaemonTokenMap,
+  resolveRelayDaemonTokenForEndpoint,
+} from './relayAuth';
 
 describe('relayAuth', () => {
   afterEach(() => {
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
   });
 
   it('creates daemon bearer headers from server-side env', () => {
@@ -32,6 +40,116 @@ describe('relayAuth', () => {
       if (previousVite === undefined) delete process.env.VITE_VH_RELAY_DAEMON_TOKEN;
       else process.env.VITE_VH_RELAY_DAEMON_TOKEN = previousVite;
     }
+  });
+
+  it('creates per-origin daemon bearer headers from a token map with single-token fallback', () => {
+    vi.stubEnv('VH_NEWS_RELAY_REST_WRITE_TOKENS', JSON.stringify({
+      'https://gun-a.example.test': 'token-a',
+      'wss://gun-b.example.test/gun': 'token-b',
+    }));
+    vi.stubEnv('VH_RELAY_DAEMON_TOKEN', 'fallback-token');
+
+    expect(createRelayDaemonAuthHeadersForEndpoint(
+      'https://gun-a.example.test/vh/news/story',
+      { tokenMapEnvNames: ['VH_NEWS_RELAY_REST_WRITE_TOKENS'] },
+    )).toEqual({ Authorization: 'Bearer token-a' });
+    expect(createRelayDaemonAuthHeadersForEndpoint(
+      'https://gun-b.example.test/vh/news/story',
+      { tokenMapEnvNames: ['VH_NEWS_RELAY_REST_WRITE_TOKENS'] },
+    )).toEqual({ Authorization: 'Bearer token-b' });
+    expect(createRelayDaemonAuthHeadersForEndpoint(
+      'https://gun-c.example.test/vh/news/story',
+      { tokenMapEnvNames: ['VH_NEWS_RELAY_REST_WRITE_TOKENS'] },
+    )).toEqual({ Authorization: 'Bearer fallback-token' });
+  });
+
+  it('normalizes relay auth origins across websocket and HTTPS inputs', () => {
+    expect(normalizeRelayDaemonAuthOrigin('ws://gun-a.example.test/gun')).toBe('http://gun-a.example.test');
+    expect(normalizeRelayDaemonAuthOrigin('wss://gun-a.example.test/gun')).toBe('https://gun-a.example.test');
+    expect(normalizeRelayDaemonAuthOrigin('https://gun-a.example.test/vh/news/story')).toBe(
+      'https://gun-a.example.test',
+    );
+    expect(normalizeRelayDaemonAuthOrigin('mailto:bad')).toBeNull();
+    expect(normalizeRelayDaemonAuthOrigin('not a url')).toBeNull();
+  });
+
+  it('supports alternate token env sources and custom fallback env names', () => {
+    vi.stubEnv('VH_RELAY_DAEMON_TOKEN', '');
+    vi.stubEnv('VITE_VH_RELAY_DAEMON_TOKEN', '');
+    const target = globalThis as {
+      __VH_GUN_CLIENT_CONFIG__?: Record<string, unknown> | undefined;
+      __VH_IMPORT_META_ENV__?: Record<string, unknown> | undefined;
+    };
+    const previousGlobalConfig = target.__VH_GUN_CLIENT_CONFIG__;
+    const previousImportMetaEnv = target.__VH_IMPORT_META_ENV__;
+    try {
+      target.__VH_IMPORT_META_ENV__ = { VITE_VH_RELAY_DAEMON_TOKEN: 'vite-token' };
+      expect(createRelayDaemonAuthHeaders()).toEqual({ Authorization: 'Bearer vite-token' });
+
+      target.__VH_IMPORT_META_ENV__ = undefined;
+      target.__VH_GUN_CLIENT_CONFIG__ = { VH_RELAY_DAEMON_TOKEN: 'global-token' };
+      expect(createRelayDaemonAuthHeaders()).toEqual({ Authorization: 'Bearer global-token' });
+
+      vi.stubEnv('CUSTOM_RELAY_TOKEN', 'custom-token');
+      expect(resolveRelayDaemonTokenForEndpoint('not a url', {
+        tokenEnvNames: ['CUSTOM_RELAY_TOKEN'],
+      })).toBe('custom-token');
+      expect(resolveRelayDaemonTokenForEndpoint('https://gun-a.example.test/vh/news/story', {
+        tokenEnvNames: ['CUSTOM_RELAY_TOKEN'],
+      })).toBe('custom-token');
+    } finally {
+      target.__VH_GUN_CLIENT_CONFIG__ = previousGlobalConfig;
+      target.__VH_IMPORT_META_ENV__ = previousImportMetaEnv;
+    }
+  });
+
+  it('parses relay daemon token maps from arrays and delimited entries', () => {
+    vi.stubEnv('ARRAY_RELAY_TOKENS', JSON.stringify([
+      'https://gun-a.example.test=token-a',
+      { origin: 'wss://gun-b.example.test/gun', token: 'token-b' },
+      { url: 'https://gun-c.example.test/path', token: 'token-c' },
+    ]));
+    expect([...readRelayDaemonTokenMap(['ARRAY_RELAY_TOKENS'])]).toEqual([
+      ['https://gun-a.example.test', 'token-a'],
+      ['https://gun-b.example.test', 'token-b'],
+      ['https://gun-c.example.test', 'token-c'],
+    ]);
+
+    vi.stubEnv(
+      'DELIMITED_RELAY_TOKENS',
+      'https://gun-a.example.test=primary-a,\nhttps://gun-d.example.test=token-d',
+    );
+    vi.stubEnv('FALLBACK_RELAY_TOKENS', JSON.stringify({
+      'https://gun-a.example.test': 'fallback-a',
+      'https://gun-e.example.test': 'token-e',
+    }));
+    expect([...readRelayDaemonTokenMap(['DELIMITED_RELAY_TOKENS', 'FALLBACK_RELAY_TOKENS'])]).toEqual([
+      ['https://gun-a.example.test', 'primary-a'],
+      ['https://gun-d.example.test', 'token-d'],
+      ['https://gun-e.example.test', 'token-e'],
+    ]);
+  });
+
+  it('fails closed for malformed relay daemon token map entries', () => {
+    vi.stubEnv('BAD_RELAY_TOKEN_MAP', JSON.stringify({ 'mailto:bad': 'token' }));
+    expect(() => readRelayDaemonTokenMap(['BAD_RELAY_TOKEN_MAP']))
+      .toThrow('BAD_RELAY_TOKEN_MAP contains an invalid relay origin/token entry');
+
+    vi.stubEnv('BAD_RELAY_TOKEN_MAP', JSON.stringify(['https://gun-a.example.test']));
+    expect(() => readRelayDaemonTokenMap(['BAD_RELAY_TOKEN_MAP']))
+      .toThrow('BAD_RELAY_TOKEN_MAP contains an invalid relay token entry');
+
+    vi.stubEnv('BAD_RELAY_TOKEN_MAP', JSON.stringify([false]));
+    expect(() => readRelayDaemonTokenMap(['BAD_RELAY_TOKEN_MAP']))
+      .toThrow('BAD_RELAY_TOKEN_MAP contains an invalid relay token entry');
+
+    vi.stubEnv('BAD_RELAY_TOKEN_MAP', JSON.stringify([{ origin: null, token: null }]));
+    expect(() => readRelayDaemonTokenMap(['BAD_RELAY_TOKEN_MAP']))
+      .toThrow('BAD_RELAY_TOKEN_MAP contains an invalid relay origin/token entry');
+
+    vi.stubEnv('BAD_RELAY_TOKEN_MAP', 'https://gun-a.example.test');
+    expect(() => readRelayDaemonTokenMap(['BAD_RELAY_TOKEN_MAP']))
+      .toThrow('BAD_RELAY_TOKEN_MAP contains an invalid relay token entry');
   });
 
   it('does not create user signature headers without a complete device pair', async () => {

--- a/packages/gun-client/src/relayAuth.ts
+++ b/packages/gun-client/src/relayAuth.ts
@@ -5,21 +5,192 @@ export interface RelayDevicePair {
   readonly priv: string;
 }
 
+export interface RelayDaemonAuthHeaderOptions {
+  readonly tokenEnvNames?: readonly string[];
+  readonly tokenMapEnvNames?: readonly string[];
+}
+
+const DEFAULT_RELAY_DAEMON_TOKEN_ENV_NAMES = [
+  'VH_RELAY_DAEMON_TOKEN',
+  'VITE_VH_RELAY_DAEMON_TOKEN',
+] as const;
+
 function envValue(name: string): string {
   const viteValue = (() => {
     try {
-      return (import.meta as any).env?.[name];
+      const injectedEnv = (globalThis as {
+        __VH_IMPORT_META_ENV__?: Record<string, unknown> | undefined;
+      }).__VH_IMPORT_META_ENV__;
+      return injectedEnv?.[name] ?? (import.meta as any).env?.[name];
     } /* v8 ignore next 3 -- import.meta access can throw in legacy hosts; Vitest cannot trigger that runtime. */ catch {
       return undefined;
     }
   })();
   /* v8 ignore next -- browser builds may not expose process; Vitest always does. */
   const processValue = typeof process !== 'undefined' ? process.env?.[name] : undefined;
-  return String(viteValue ?? processValue ?? '').trim();
+  const globalValue = (globalThis as {
+    __VH_GUN_CLIENT_CONFIG__?: Record<string, unknown> | undefined;
+  }).__VH_GUN_CLIENT_CONFIG__?.[name];
+  for (const value of [viteValue, processValue, globalValue]) {
+    const trimmed = String(value ?? '').trim();
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+  return '';
+}
+
+function tokenEnvNames(options: RelayDaemonAuthHeaderOptions = {}): readonly string[] {
+  return options.tokenEnvNames?.length
+    ? options.tokenEnvNames
+    : DEFAULT_RELAY_DAEMON_TOKEN_ENV_NAMES;
+}
+
+function readFirstToken(options: RelayDaemonAuthHeaderOptions = {}): string {
+  for (const name of tokenEnvNames(options)) {
+    const token = envValue(name);
+    if (token) {
+      return token;
+    }
+  }
+  return '';
+}
+
+export function normalizeRelayDaemonAuthOrigin(value: string): string | null {
+  try {
+    const parsed = new URL(value);
+    if (parsed.protocol === 'ws:') {
+      parsed.protocol = 'http:';
+    } else if (parsed.protocol === 'wss:') {
+      parsed.protocol = 'https:';
+    }
+    if (!['http:', 'https:'].includes(parsed.protocol)) {
+      return null;
+    }
+    parsed.pathname = '/';
+    parsed.search = '';
+    parsed.hash = '';
+    return parsed.origin;
+  } catch {
+    return null;
+  }
+}
+
+function parseRelayDaemonTokenMapEntry(
+  map: Map<string, string>,
+  origin: unknown,
+  token: unknown,
+  sourceName: string,
+): void {
+  const normalizedOrigin = normalizeRelayDaemonAuthOrigin(String(origin ?? '').trim());
+  const normalizedToken = String(token ?? '').trim();
+  if (!normalizedOrigin || !normalizedToken) {
+    throw new Error(`${sourceName} contains an invalid relay origin/token entry`);
+  }
+  if (!map.has(normalizedOrigin)) {
+    map.set(normalizedOrigin, normalizedToken);
+  }
+}
+
+function parseRelayDaemonTokenMapValue(value: string, sourceName: string): Map<string, string> {
+  const map = new Map<string, string>();
+  const trimmed = value.trim();
+
+  if (trimmed.startsWith('{')) {
+    const parsed = JSON.parse(trimmed) as Record<string, unknown>;
+    for (const [origin, token] of Object.entries(parsed)) {
+      parseRelayDaemonTokenMapEntry(map, origin, token, sourceName);
+    }
+    return map;
+  }
+
+  if (trimmed.startsWith('[')) {
+    const parsed = JSON.parse(trimmed) as unknown[];
+    for (const entry of parsed) {
+      if (typeof entry === 'string') {
+        const separator = entry.indexOf('=');
+        if (separator <= 0) {
+          throw new Error(`${sourceName} contains an invalid relay token entry`);
+        }
+        parseRelayDaemonTokenMapEntry(
+          map,
+          entry.slice(0, separator),
+          entry.slice(separator + 1),
+          sourceName,
+        );
+        continue;
+      }
+      if (entry && typeof entry === 'object') {
+        const record = entry as Record<string, unknown>;
+        parseRelayDaemonTokenMapEntry(
+          map,
+          record.origin ?? record.url,
+          record.token,
+          sourceName,
+        );
+        continue;
+      }
+      throw new Error(`${sourceName} contains an invalid relay token entry`);
+    }
+    return map;
+  }
+
+  for (const entry of trimmed.split(/[,\n]+/).map((part) => part.trim()).filter(Boolean)) {
+    const separator = entry.indexOf('=');
+    if (separator <= 0) {
+      throw new Error(`${sourceName} contains an invalid relay token entry`);
+    }
+    parseRelayDaemonTokenMapEntry(
+      map,
+      entry.slice(0, separator),
+      entry.slice(separator + 1),
+      sourceName,
+    );
+  }
+  return map;
+}
+
+export function readRelayDaemonTokenMap(
+  tokenMapEnvNames: readonly string[] = [],
+): Map<string, string> {
+  const merged = new Map<string, string>();
+  for (const name of tokenMapEnvNames) {
+    const raw = envValue(name);
+    if (!raw) {
+      continue;
+    }
+    const parsed = parseRelayDaemonTokenMapValue(raw, name);
+    for (const [origin, token] of parsed) {
+      if (!merged.has(origin)) {
+        merged.set(origin, token);
+      }
+    }
+  }
+  return merged;
+}
+
+export function resolveRelayDaemonTokenForEndpoint(
+  endpoint: string,
+  options: RelayDaemonAuthHeaderOptions = {},
+): string {
+  const origin = normalizeRelayDaemonAuthOrigin(endpoint);
+  if (!origin) {
+    return readFirstToken(options);
+  }
+  const tokenMap = readRelayDaemonTokenMap(options.tokenMapEnvNames ?? []);
+  return tokenMap.get(origin) ?? readFirstToken(options);
 }
 
 export function createRelayDaemonAuthHeaders(): Record<string, string> {
-  const token = envValue('VH_RELAY_DAEMON_TOKEN') || envValue('VITE_VH_RELAY_DAEMON_TOKEN');
+  const token = readFirstToken();
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+export function createRelayDaemonAuthHeadersForEndpoint(
+  endpoint: string,
+  options: RelayDaemonAuthHeaderOptions = {},
+): Record<string, string> {
+  const token = resolveRelayDaemonTokenForEndpoint(endpoint, options);
   return token ? { Authorization: `Bearer ${token}` } : {};
 }
 

--- a/services/news-aggregator/src/relayRestSynthesisWriters.test.ts
+++ b/services/news-aggregator/src/relayRestSynthesisWriters.test.ts
@@ -112,6 +112,7 @@ function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
 describe('relayRestSynthesisWriters', () => {
   afterEach(() => {
     vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
 
@@ -126,7 +127,9 @@ describe('relayRestSynthesisWriters', () => {
     vi.stubEnv('VH_BUNDLE_SYNTHESIS_WRITE_RELAY_REST', 'true');
 
     expect(() => createRelayRestSynthesisWritersFromEnv(CLIENT))
-      .toThrow('VH_RELAY_DAEMON_TOKEN is required');
+      .toThrow(
+        'VH_RELAY_DAEMON_TOKEN or VH_BUNDLE_SYNTHESIS_RELAY_WRITE_TOKENS[https://gun-a.example.test] is required',
+      );
   });
 
   it('posts candidate, accepted synthesis, and lifecycle rows to every configured relay endpoint', async () => {
@@ -185,6 +188,47 @@ describe('relayRestSynthesisWriters', () => {
     expect(postCalls.every(([, init]) => (
       (init?.headers as Record<string, string>).Authorization === 'Bearer relay-token'
     ))).toBe(true);
+  });
+
+  it('posts synthesis rows with per-origin daemon tokens from the news relay token map', async () => {
+    vi.stubEnv('VH_BUNDLE_SYNTHESIS_WRITE_RELAY_REST', 'true');
+    vi.stubEnv('VH_NEWS_RELAY_REST_WRITE_TOKENS', JSON.stringify({
+      'https://gun-a.example.test': 'token-a',
+      'https://gun-b.example.test': 'token-b',
+    }));
+    const fetchMock = vi.fn(async () => jsonResponse({
+      ok: true,
+      topic_id: CANDIDATE.topic_id,
+      candidate_id: CANDIDATE.candidate_id,
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const writers = createRelayRestSynthesisWritersFromEnv(CLIENT, console);
+
+    await expect(writers.writeCandidate?.(CLIENT, CANDIDATE)).resolves.toEqual(CANDIDATE);
+
+    expect(fetchMock.mock.calls.map(([url, init]) => ({
+      origin: new URL(String(url)).origin,
+      auth: (init?.headers as Record<string, string>).Authorization,
+    }))).toEqual([
+      { origin: 'https://gun-a.example.test', auth: 'Bearer token-a' },
+      { origin: 'https://gun-b.example.test', auth: 'Bearer token-b' },
+    ]);
+  });
+
+  it('fails before posting when synthesis relay token coverage is incomplete', () => {
+    vi.stubEnv('VH_BUNDLE_SYNTHESIS_WRITE_RELAY_REST', 'true');
+    vi.stubEnv('VH_NEWS_RELAY_REST_WRITE_TOKENS', JSON.stringify({
+      'https://gun-a.example.test': 'token-a',
+    }));
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    expect(() => createRelayRestSynthesisWritersFromEnv(CLIENT))
+      .toThrow(
+        'VH_RELAY_DAEMON_TOKEN or VH_BUNDLE_SYNTHESIS_RELAY_WRITE_TOKENS[https://gun-b.example.test] is required',
+      );
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('honors the latest synthesis ownership guard before relay writes', async () => {

--- a/services/news-aggregator/src/relayRestSynthesisWriters.ts
+++ b/services/news-aggregator/src/relayRestSynthesisWriters.ts
@@ -1,7 +1,8 @@
 import type { CandidateSynthesis, TopicSynthesisV2 } from '@vh/data-model';
 import { CandidateSynthesisSchema, TopicSynthesisV2Schema } from '@vh/data-model';
 import {
-  createRelayDaemonAuthHeaders,
+  createRelayDaemonAuthHeadersForEndpoint,
+  normalizeRelayDaemonAuthOrigin,
   resolveRelayRestEndpointFromPeer,
   type NewsSynthesisLifecycleRecord,
   type SafeLatestSynthesisWriteOptions,
@@ -13,6 +14,10 @@ import type { LoggerLike } from './daemonUtils';
 const WRITE_RELAY_REST_ENV = 'VH_BUNDLE_SYNTHESIS_WRITE_RELAY_REST';
 const WRITE_RELAY_ORIGINS_ENV = 'VH_BUNDLE_SYNTHESIS_RELAY_WRITE_ORIGINS';
 const REQUIRE_ALL_ENV = 'VH_BUNDLE_SYNTHESIS_RELAY_WRITE_REQUIRE_ALL';
+const RELAY_TOKEN_MAP_ENV_NAMES = [
+  'VH_BUNDLE_SYNTHESIS_RELAY_WRITE_TOKENS',
+  'VH_NEWS_RELAY_REST_WRITE_TOKENS',
+] as const;
 const DEFAULT_RELAY_WRITE_TIMEOUT_MS = 10_000;
 
 export interface RelayRestSynthesisWriters {
@@ -79,10 +84,15 @@ function shouldRequireAllRelayWrites(): boolean {
   return true;
 }
 
-function relayAuthHeaders(): Record<string, string> {
-  const headers = createRelayDaemonAuthHeaders();
+function relayAuthHeaders(endpoint: string): Record<string, string> {
+  const headers = createRelayDaemonAuthHeadersForEndpoint(endpoint, {
+    tokenMapEnvNames: RELAY_TOKEN_MAP_ENV_NAMES,
+  });
   if (!headers.Authorization) {
-    throw new Error('VH_RELAY_DAEMON_TOKEN is required for relay REST bundle synthesis writes');
+    const origin = normalizeRelayDaemonAuthOrigin(endpoint) ?? endpoint;
+    throw new Error(
+      `VH_RELAY_DAEMON_TOKEN or VH_BUNDLE_SYNTHESIS_RELAY_WRITE_TOKENS[${origin}] is required for relay REST bundle synthesis writes`,
+    );
   }
   return headers;
 }
@@ -102,11 +112,14 @@ async function postJsonToRelays(input: {
     throw new Error(`No relay REST endpoints configured for ${input.path}`);
   }
   const requireAll = shouldRequireAllRelayWrites();
-  const headers = relayAuthHeaders();
+  const relayTargets = endpoints.map((endpoint) => ({
+    endpoint,
+    headers: relayAuthHeaders(endpoint),
+  }));
   const failures: string[] = [];
   let successCount = 0;
 
-  for (const endpoint of endpoints) {
+  for (const { endpoint, headers } of relayTargets) {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), DEFAULT_RELAY_WRITE_TIMEOUT_MS);
     try {
@@ -216,10 +229,11 @@ export function createRelayRestSynthesisWritersFromEnv(
   if (!shouldEnableRelayRestSynthesisWritesFromEnv()) {
     return {};
   }
-  relayAuthHeaders();
-  if (resolveRelayEndpoints(client, '/vh/topics/synthesis').length === 0) {
+  const synthesisEndpoints = resolveRelayEndpoints(client, '/vh/topics/synthesis');
+  if (synthesisEndpoints.length === 0) {
     throw new Error('No relay REST endpoints configured for bundle synthesis writes');
   }
+  synthesisEndpoints.forEach((endpoint) => relayAuthHeaders(endpoint));
 
   return {
     async writeCandidate(writeClient, candidate) {

--- a/tools/scripts/news-aggregator-publisher-preflight.mjs
+++ b/tools/scripts/news-aggregator-publisher-preflight.mjs
@@ -90,6 +90,147 @@ function assertPresent(env, name, failures) {
   return true;
 }
 
+function normalizeRelayTokenOrigin(value) {
+  try {
+    const parsed = new URL(value);
+    if (parsed.protocol === 'ws:') {
+      parsed.protocol = 'http:';
+    } else if (parsed.protocol === 'wss:') {
+      parsed.protocol = 'https:';
+    }
+    if (!['http:', 'https:'].includes(parsed.protocol)) {
+      return null;
+    }
+    parsed.pathname = '/';
+    parsed.search = '';
+    parsed.hash = '';
+    return parsed.origin;
+  } catch {
+    return null;
+  }
+}
+
+function addRelayTokenMapEntry(map, origin, token, sourceName, failures) {
+  const normalizedOrigin = normalizeRelayTokenOrigin(String(origin ?? '').trim());
+  const normalizedToken = String(token ?? '').trim();
+  if (!normalizedOrigin || !normalizedToken) {
+    failures.push(`${sourceName}:invalid_entry`);
+    return;
+  }
+  if (!map.has(normalizedOrigin)) {
+    map.set(normalizedOrigin, normalizedToken);
+  }
+}
+
+function parseRelayTokenMapValue(value, sourceName, failures) {
+  const map = new Map();
+  const trimmed = String(value ?? '').trim();
+  if (!trimmed) {
+    return map;
+  }
+
+  if (trimmed.startsWith('{')) {
+    let parsed;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch {
+      failures.push(`${sourceName}:invalid_json`);
+      return map;
+    }
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      failures.push(`${sourceName}:expected_object`);
+      return map;
+    }
+    for (const [origin, token] of Object.entries(parsed)) {
+      addRelayTokenMapEntry(map, origin, token, sourceName, failures);
+    }
+    return map;
+  }
+
+  if (trimmed.startsWith('[')) {
+    let parsed;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch {
+      failures.push(`${sourceName}:invalid_json`);
+      return map;
+    }
+    if (!Array.isArray(parsed)) {
+      failures.push(`${sourceName}:expected_array`);
+      return map;
+    }
+    for (const entry of parsed) {
+      if (typeof entry === 'string') {
+        const separator = entry.indexOf('=');
+        if (separator <= 0) {
+          failures.push(`${sourceName}:invalid_entry`);
+          continue;
+        }
+        addRelayTokenMapEntry(map, entry.slice(0, separator), entry.slice(separator + 1), sourceName, failures);
+        continue;
+      }
+      if (entry && typeof entry === 'object') {
+        addRelayTokenMapEntry(map, entry.origin ?? entry.url, entry.token, sourceName, failures);
+        continue;
+      }
+      failures.push(`${sourceName}:invalid_entry`);
+    }
+    return map;
+  }
+
+  for (const entry of trimmed.split(/[,\n]+/).map((part) => part.trim()).filter(Boolean)) {
+    const separator = entry.indexOf('=');
+    if (separator <= 0) {
+      failures.push(`${sourceName}:invalid_entry`);
+      continue;
+    }
+    addRelayTokenMapEntry(map, entry.slice(0, separator), entry.slice(separator + 1), sourceName, failures);
+  }
+  return map;
+}
+
+function readRelayTokenMap(env, names, failures) {
+  const merged = new Map();
+  for (const name of names) {
+    const raw = firstNonEmpty(env[name]);
+    if (!raw) {
+      continue;
+    }
+    const parsed = parseRelayTokenMapValue(raw, name, failures);
+    for (const [origin, token] of parsed) {
+      if (!merged.has(origin)) {
+        merged.set(origin, token);
+      }
+    }
+  }
+  return merged;
+}
+
+function relayTokenForUrl(url, tokenMap, fallbackToken) {
+  const origin = new URL(url).origin;
+  return tokenMap.get(origin) ?? fallbackToken;
+}
+
+function collectMissingRelayTokens({
+  failures,
+  failurePrefix,
+  urls,
+  tokenMap,
+  fallbackToken,
+}) {
+  const tokensByUrl = new Map();
+  for (const url of urls) {
+    const origin = new URL(url).origin;
+    const token = relayTokenForUrl(url, tokenMap, fallbackToken);
+    if (!token) {
+      failures.push(`${failurePrefix}:${origin}:missing`);
+      continue;
+    }
+    tokensByUrl.set(url, token);
+  }
+  return tokensByUrl;
+}
+
 async function probeNewsRelayRestAuth(url, token, fetchFn) {
   const parsed = new URL(url);
   const controller = new AbortController();
@@ -164,6 +305,22 @@ export async function runNewsAggregatorPublisherPreflight({
     || relayRestOrigins.length > 0;
   const newsRelayRestOrigins = parseDelimited(env.VH_NEWS_RELAY_REST_WRITE_ORIGINS);
   const newsRelayRestWriteFirst = truthy(env.VH_NEWS_RELAY_REST_WRITE_FIRST);
+  const fallbackRelayDaemonToken = firstNonEmpty(env.VH_RELAY_DAEMON_TOKEN);
+  const newsRelayRestTokenMap = readRelayTokenMap(
+    env,
+    ['VH_NEWS_RELAY_REST_WRITE_TOKENS', 'VITE_VH_NEWS_RELAY_REST_WRITE_TOKENS'],
+    failures,
+  );
+  const synthesisRelayRestTokenMap = readRelayTokenMap(
+    env,
+    [
+      'VH_BUNDLE_SYNTHESIS_RELAY_WRITE_TOKENS',
+      'VH_NEWS_RELAY_REST_WRITE_TOKENS',
+      'VITE_VH_BUNDLE_SYNTHESIS_RELAY_WRITE_TOKENS',
+      'VITE_VH_NEWS_RELAY_REST_WRITE_TOKENS',
+    ],
+    failures,
+  );
   const newsRelayRestWriteOriginInputs = newsRelayRestWriteFirst
     ? (
         newsRelayRestOrigins.length > 0
@@ -178,10 +335,34 @@ export async function runNewsAggregatorPublisherPreflight({
       .map((origin) => relayRestWriteUrlFromOrigin(origin, '/vh/news/story', 'relay_rest_news_origin', failures))
       .filter(Boolean))]
     : [];
+  const synthesisRelayRestAuthUrls = [...new Set(relayRestOrigins
+    .map((origin) => relayRestWriteUrlFromOrigin(
+      origin,
+      '/vh/topics/synthesis',
+      'relay_rest_synthesis_origin',
+      failures,
+    ))
+    .filter(Boolean))];
+  const synthesisRelayTokensByUrl = collectMissingRelayTokens({
+    failures,
+    failurePrefix: 'relay_rest_synthesis_token',
+    urls: synthesisEnabled ? synthesisRelayRestAuthUrls : [],
+    tokenMap: synthesisRelayRestTokenMap,
+    fallbackToken: fallbackRelayDaemonToken,
+  });
+  const newsRelayTokensByUrl = collectMissingRelayTokens({
+    failures,
+    failurePrefix: 'relay_rest_news_token',
+    urls: newsRelayRestWriteFirst ? newsRelayRestWriteAuthUrls : [],
+    tokenMap: newsRelayRestTokenMap,
+    fallbackToken: fallbackRelayDaemonToken,
+  });
   if (synthesisEnabled) {
     if (!relayRestWriteRequested) failures.push('relay_rest_synthesis:disabled_while_synthesis_enabled');
     if (relayRestOrigins.length === 0) failures.push('relay_rest_synthesis_origins:missing');
-    if (!firstNonEmpty(env.VH_RELAY_DAEMON_TOKEN)) failures.push('relay_rest_synthesis_token:missing');
+    if (!fallbackRelayDaemonToken && synthesisRelayRestTokenMap.size === 0) {
+      failures.push('relay_rest_synthesis_token:missing');
+    }
     for (const origin of relayRestOrigins) {
       const url = validUrl(origin, 'relay_rest_synthesis_origin', failures);
       if (url && !['http:', 'https:'].includes(url.protocol)) {
@@ -190,7 +371,9 @@ export async function runNewsAggregatorPublisherPreflight({
     }
   }
   if (newsRelayRestWriteFirst) {
-    if (!firstNonEmpty(env.VH_RELAY_DAEMON_TOKEN)) failures.push('relay_rest_news_token:missing');
+    if (!fallbackRelayDaemonToken && newsRelayRestTokenMap.size === 0) {
+      failures.push('relay_rest_news_token:missing');
+    }
     if (newsRelayRestWriteAuthUrls.length === 0) {
       failures.push('relay_rest_news_auth_targets:missing');
     }
@@ -227,8 +410,11 @@ export async function runNewsAggregatorPublisherPreflight({
         }
       }
       if (newsRelayRestWriteFirst) {
-        const token = firstNonEmpty(env.VH_RELAY_DAEMON_TOKEN);
         for (const url of newsRelayRestWriteAuthUrls) {
+          const token = newsRelayTokensByUrl.get(url);
+          if (!token) {
+            continue;
+          }
           try {
             const result = await probeNewsRelayRestAuth(url, token, fetchFn);
             newsRelayRestAuthResults.push(result);
@@ -266,13 +452,21 @@ export async function runNewsAggregatorPublisherPreflight({
     relay_rest_synthesis: {
       requested: relayRestWriteRequested,
       origin_count: relayRestOrigins.length,
-      daemon_token_present: Boolean(firstNonEmpty(env.VH_RELAY_DAEMON_TOKEN)),
+      daemon_token_present: Boolean(fallbackRelayDaemonToken),
+      per_origin_token_count: synthesisRelayRestTokenMap.size,
+      all_target_tokens_present: synthesisEnabled
+        ? synthesisRelayTokensByUrl.size === synthesisRelayRestAuthUrls.length
+        : true,
     },
     relay_rest_news_publication: {
       write_first: newsRelayRestWriteFirst,
       origin_count: newsRelayRestWriteAuthUrls.length,
       require_all: !/^(0|false|no|off)$/i.test(String(env.VH_NEWS_RELAY_REST_WRITE_REQUIRE_ALL ?? '').trim()),
-      daemon_token_present: Boolean(firstNonEmpty(env.VH_RELAY_DAEMON_TOKEN)),
+      daemon_token_present: Boolean(fallbackRelayDaemonToken),
+      per_origin_token_count: newsRelayRestTokenMap.size,
+      all_target_tokens_present: newsRelayRestWriteFirst
+        ? newsRelayTokensByUrl.size === newsRelayRestWriteAuthUrls.length
+        : true,
       auth_probe_results: newsRelayRestAuthResults,
     },
     failures,

--- a/tools/scripts/news-aggregator-publisher-preflight.test.mjs
+++ b/tools/scripts/news-aggregator-publisher-preflight.test.mjs
@@ -72,6 +72,8 @@ test('publisher preflight fails closed when news relay REST write-first lacks da
   assert.equal(result.relay_rest_news_publication.write_first, true);
   assert.equal(result.relay_rest_news_publication.origin_count, 1);
   assert.equal(result.relay_rest_news_publication.daemon_token_present, false);
+  assert.equal(result.relay_rest_news_publication.per_origin_token_count, 0);
+  assert.equal(result.relay_rest_news_publication.all_target_tokens_present, false);
 });
 
 test('publisher preflight checks relay health with redacted pass output', async () => {
@@ -120,6 +122,8 @@ test('publisher preflight checks relay health with redacted pass output', async 
     origin_count: 2,
     require_all: true,
     daemon_token_present: true,
+    per_origin_token_count: 0,
+    all_target_tokens_present: true,
     auth_probe_results: [
       {
         origin: 'https://gun-a.example.test',
@@ -168,6 +172,76 @@ test('publisher preflight fails closed when relay REST news auth rejects the dae
     },
   ]);
   assert.equal(JSON.stringify(result).includes('relay-token-redacted'), false);
+});
+
+test('publisher preflight probes relay REST news auth with per-origin daemon tokens', async () => {
+  const calls = [];
+  const result = await runNewsAggregatorPublisherPreflight({
+    env: baseEnv({
+      VH_NEWS_RELAY_REST_WRITE_FIRST: 'true',
+      VH_NEWS_RELAY_REST_WRITE_ORIGINS: 'https://gun-a.example.test,https://gun-b.example.test',
+      VH_RELAY_DAEMON_TOKEN: '',
+      VH_NEWS_RELAY_REST_WRITE_TOKENS: JSON.stringify({
+        'https://gun-a.example.test': 'token-a',
+        'https://gun-b.example.test': 'token-b',
+      }),
+      VH_BUNDLE_SYNTHESIS_RELAY_WRITE_TOKENS: JSON.stringify({
+        'https://gun-a.example.test': 'token-a',
+        'https://gun-b.example.test': 'token-b',
+      }),
+    }),
+    fetchFn: async (input, init) => {
+      calls.push({ origin: input.origin, method: init.method, authorization: init.headers.authorization });
+      if (init.method === 'POST') {
+        return new Response(JSON.stringify({ ok: false, error: 'news-story-record-required' }), {
+          status: 400,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    },
+  });
+
+  assert.equal(result.status, 'pass');
+  assert.deepEqual(calls.filter(({ method }) => method === 'POST'), [
+    { origin: 'https://gun-a.example.test', method: 'POST', authorization: 'Bearer token-a' },
+    { origin: 'https://gun-b.example.test', method: 'POST', authorization: 'Bearer token-b' },
+  ]);
+  assert.equal(result.relay_rest_news_publication.daemon_token_present, false);
+  assert.equal(result.relay_rest_news_publication.per_origin_token_count, 2);
+  assert.equal(result.relay_rest_news_publication.all_target_tokens_present, true);
+  assert.equal(result.relay_rest_synthesis.per_origin_token_count, 2);
+  assert.equal(result.relay_rest_synthesis.all_target_tokens_present, true);
+  assert.equal(JSON.stringify(result).includes('token-a'), false);
+  assert.equal(JSON.stringify(result).includes('token-b'), false);
+});
+
+test('publisher preflight fails closed when a per-origin relay REST news token is missing', async () => {
+  let fetchCalled = false;
+  const result = await runNewsAggregatorPublisherPreflight({
+    env: baseEnv({
+      VH_NEWS_RELAY_REST_WRITE_FIRST: 'true',
+      VH_NEWS_RELAY_REST_WRITE_ORIGINS: 'https://gun-a.example.test,https://gun-b.example.test',
+      VH_RELAY_DAEMON_TOKEN: '',
+      VH_NEWS_RELAY_REST_WRITE_TOKENS: JSON.stringify({
+        'https://gun-a.example.test': 'token-a',
+      }),
+      VH_BUNDLE_SYNTHESIS_ENABLED: '',
+    }),
+    fetchFn: async () => {
+      fetchCalled = true;
+      return new Response('{}');
+    },
+  });
+
+  assert.equal(result.status, 'fail');
+  assert.equal(fetchCalled, false);
+  assert.match(result.failures.join('\n'), /relay_rest_news_token:https:\/\/gun-b\.example\.test:missing/);
+  assert.equal(result.relay_rest_news_publication.per_origin_token_count, 1);
+  assert.equal(result.relay_rest_news_publication.all_target_tokens_present, false);
 });
 
 test('publisher preflight derives health URLs from Gun peers', () => {


### PR DESCRIPTION
## Summary

- Add endpoint-aware relay daemon auth helpers with JSON origin-token map support and single-token fallback.
- Use per-origin tokens for public news relay REST story/index/lifecycle writes and bundle synthesis REST writes.
- Extend the production publisher preflight so it fails before launch when any target relay lacks a matching token, and probes each relay with its own bearer token.
- Document `VH_NEWS_RELAY_REST_WRITE_TOKENS` and the synthesis fallback behavior in the production env docs.

## Why

A6 relays currently have different `VH_RELAY_DAEMON_TOKEN` values. A single publisher token cannot satisfy `VH_NEWS_RELAY_REST_WRITE_REQUIRE_ALL=true`, so live publication correctly failed with 401s on every relay. The publisher needs origin-specific daemon auth for all relay REST fanout paths.

## Validation

- `PATH="/opt/homebrew/Cellar/node@20/20.20.0/bin:$PATH" node --test tools/scripts/news-aggregator-publisher-preflight.test.mjs`
- `PATH="/opt/homebrew/Cellar/node@20/20.20.0/bin:$PATH" pnpm --filter @vh/gun-client exec vitest run src/relayAuth.test.ts src/newsAdapters.test.ts --config ./vitest.config.ts`
- `PATH="/opt/homebrew/Cellar/node@20/20.20.0/bin:$PATH" pnpm --filter @vh/news-aggregator exec vitest run src/relayRestSynthesisWriters.test.ts src/bundleSynthesisDaemonConfig.test.ts --config ./vitest.config.ts`
- `PATH="/opt/homebrew/Cellar/node@20/20.20.0/bin:$PATH" pnpm --filter @vh/gun-client typecheck`
- `PATH="/opt/homebrew/Cellar/node@20/20.20.0/bin:$PATH" pnpm --filter @vh/news-aggregator typecheck`
- `git diff --check`
- `PATH="/opt/homebrew/Cellar/node@20/20.20.0/bin:$PATH" node tools/scripts/check-diff-coverage.mjs` (319 files, 4924 tests, 100% diff line + branch coverage for changed source files)
- `PATH="/opt/homebrew/Cellar/node@20/20.20.0/bin:$PATH" pnpm test:quick` (before the coverage fix: first run hit one unrelated `useSentimentState` timing timeout; isolated rerun passed 70/70; second full run passed 319 files, 4921 tests)