### PR TITLE
Defer synthesis until first publisher tick

### DIFF
--- a/docs/ops/news-aggregator-production-service.md
+++ b/docs/ops/news-aggregator-production-service.md
@@ -254,6 +254,14 @@ outside `VH_NEWS_RUNTIME_TRACE`; use those fields for first-publish evidence.
 Set `VH_NEWS_RUNTIME_TICK_WATCHDOG_MS` to emit an in-flight warning with elapsed
 time and last known stage if a tick exceeds the threshold.
 
+Production starts defer publish-time bundle synthesis until the first completed
+runtime tick by default. `VH_NEWS_DAEMON_DEFER_SYNTHESIS_UNTIL_FIRST_TICK_COMPLETE`
+keeps synthesis candidates queued while the raw story/latest/hot/lifecycle batch
+lands and emits its first-publish summary, then starts the synthesis queue
+immediately after that completed summary. Set it to `false` only when first-tick
+caps, synthesis throughput, relay fanout, and the watchdog window have been
+recalibrated together.
+
 ## Env File Surface
 
 Default env file:
@@ -298,6 +306,7 @@ VH_DAEMON_FEED_ARTIFACT_ROOT
 VH_NEWS_DAEMON_LAST_SUCCESS_FILE
 VH_NEWS_RUNTIME_DIAGNOSTIC_FILE
 VH_NEWS_RUNTIME_TICK_WATCHDOG_MS
+VH_NEWS_DAEMON_DEFER_SYNTHESIS_UNTIL_FIRST_TICK_COMPLETE
 VH_NEWS_FEED_MAX_ITEMS_PER_SOURCE
 VH_NEWS_FEED_MAX_ITEMS_TOTAL
 VH_NEWS_RUNTIME_MAX_PUBLISHED_BUNDLES

--- a/docs/ops/news-aggregator.env.example
+++ b/docs/ops/news-aggregator.env.example
@@ -67,6 +67,9 @@ VH_NEWS_FEED_MAX_ITEMS_TOTAL=96
 VH_NEWS_RUNTIME_MAX_PUBLISHED_BUNDLES=96
 VH_NEWS_RUNTIME_FIRST_TICK_MAX_PUBLISHED_BUNDLES=24
 VH_NEWS_RUNTIME_TICK_WATCHDOG_MS=420000
+# Keep publish-time synthesis queued until the first live raw-publication tick
+# completes. Set to false only after recalibrating first-tick caps/watchdog.
+VH_NEWS_DAEMON_DEFER_SYNTHESIS_UNTIL_FIRST_TICK_COMPLETE=true
 VH_BUNDLE_SYNTHESIS_QUEUE_DIR=/home/humble/.local/state/vhc/news-aggregator/bundle-synthesis-queue
 VH_BUNDLE_SYNTHESIS_LIFECYCLE_LEDGER=/home/humble/.local/state/vhc/news-aggregator/bundle-synthesis-queue/synthesis-lifecycle.jsonl
 VITE_NEWS_POLL_INTERVAL_MS=600000

--- a/services/news-aggregator/src/daemon.test.ts
+++ b/services/news-aggregator/src/daemon.test.ts
@@ -675,6 +675,110 @@ describe('news aggregator daemon', () => {
     await daemon.stop();
   });
 
+  it('defers enrichment queue work until the first runtime tick completes', async () => {
+    const logger = makeLogger();
+    const runtimeHandle = makeRuntimeHandle();
+    const timers = makeTimerControls();
+
+    const enrichmentWorker = vi.fn().mockResolvedValue(undefined);
+    const heldLease = makeLease();
+    const startRuntime = vi.fn(() => runtimeHandle);
+    const readLease = vi.fn().mockResolvedValueOnce(null);
+    const writeLease = vi.fn(async () => heldLease);
+    const writeBundle = vi.fn().mockResolvedValue(undefined);
+
+    const daemon = createNewsAggregatorDaemon({
+      client: { id: 'client-deferred-enrichment' } as VennClient,
+      feedSources: [...FEED_SOURCES],
+      topicMapping: { ...TOPIC_MAPPING },
+      startRuntime,
+      readLease,
+      writeLease,
+      writeBundle,
+      enrichmentWorker,
+      deferEnrichmentUntilFirstTickComplete: true,
+      logger,
+      setIntervalFn: timers.setIntervalFn,
+      clearIntervalFn: timers.clearIntervalFn,
+      leaseHolderId: 'vh-news-daemon:test',
+    });
+
+    await daemon.start();
+
+    const runtimeConfig = startRuntime.mock.calls[0]?.[0] as NewsRuntimeConfig;
+    runtimeConfig.onSynthesisCandidate?.(CANDIDATE);
+    await Promise.resolve();
+
+    expect(enrichmentWorker).not.toHaveBeenCalled();
+    expect(daemon.enrichmentQueueStats()).toMatchObject({
+      active: false,
+      pending_depth: 1,
+    });
+
+    await runtimeConfig.onTickSummary?.(makeTickSummary({
+      raw_wrote_count: 1,
+      selected_bundle_count: 1,
+      synthesis_candidate_enqueued_count: 1,
+    }));
+    await Promise.resolve();
+
+    expect(enrichmentWorker).toHaveBeenCalledTimes(1);
+    expect(daemon.enrichmentQueueStats()).toMatchObject({
+      active: true,
+      pending_depth: 0,
+    });
+
+    await daemon.stop();
+  });
+
+  it('keeps deferred enrichment paused when the first runtime tick fails', async () => {
+    const logger = makeLogger();
+    const runtimeHandle = makeRuntimeHandle();
+    const timers = makeTimerControls();
+
+    const enrichmentWorker = vi.fn().mockResolvedValue(undefined);
+    const heldLease = makeLease();
+    const startRuntime = vi.fn(() => runtimeHandle);
+    const readLease = vi.fn().mockResolvedValueOnce(null);
+    const writeLease = vi.fn(async () => heldLease);
+
+    const daemon = createNewsAggregatorDaemon({
+      client: { id: 'client-failed-first-tick' } as VennClient,
+      feedSources: [...FEED_SOURCES],
+      topicMapping: { ...TOPIC_MAPPING },
+      startRuntime,
+      readLease,
+      writeLease,
+      enrichmentWorker,
+      deferEnrichmentUntilFirstTickComplete: true,
+      logger,
+      setIntervalFn: timers.setIntervalFn,
+      clearIntervalFn: timers.clearIntervalFn,
+      leaseHolderId: 'vh-news-daemon:test',
+    });
+
+    await daemon.start();
+
+    const runtimeConfig = startRuntime.mock.calls[0]?.[0] as NewsRuntimeConfig;
+    runtimeConfig.onSynthesisCandidate?.(CANDIDATE);
+    await runtimeConfig.onTickSummary?.(makeTickSummary({
+      status: 'failed',
+      raw_wrote_count: 0,
+      raw_write_failed_count: 1,
+      selected_bundle_count: 1,
+      last_stage: 'failed',
+    }));
+    await Promise.resolve();
+
+    expect(enrichmentWorker).not.toHaveBeenCalled();
+    expect(daemon.enrichmentQueueStats()).toMatchObject({
+      active: false,
+      pending_depth: 1,
+    });
+
+    await daemon.stop();
+  });
+
   it('renews lease on heartbeat ticks while running', async () => {
     const logger = makeLogger();
     const runtimeHandle = makeRuntimeHandle();

--- a/services/news-aggregator/src/daemon.ts
+++ b/services/news-aggregator/src/daemon.ts
@@ -123,6 +123,7 @@ export interface NewsAggregatorDaemonConfig {
   runtimeMaxTicks?: number;
   onRuntimeTickLimitReached?: (summary: NewsRuntimeTickSummary) => void | Promise<void>;
   runtimeTickWatchdogMs?: number;
+  deferEnrichmentUntilFirstTickComplete?: boolean;
   now?: () => number;
   random?: () => number;
   setIntervalFn?: typeof setInterval;
@@ -173,7 +174,10 @@ export function createNewsAggregatorDaemon(config: NewsAggregatorDaemonConfig): 
     noWrite,
   });
   const runtimeMaxTicks = config.runtimeMaxTicks;
+  const deferEnrichmentUntilFirstTickComplete = config.deferEnrichmentUntilFirstTickComplete === true;
   let runtimeTickLimitReached = false;
+  let firstRuntimeTickCompleted = false;
+  let enrichmentQueueDeferredLogged = false;
   let running = false;
   let runtimeHandle: NewsRuntimeHandle | null = null;
   let leaseHeartbeatTimer: ReturnType<typeof setInterval> | null = null;
@@ -269,6 +273,21 @@ export function createNewsAggregatorDaemon(config: NewsAggregatorDaemonConfig): 
           });
           void Promise.resolve(config.onRuntimeTickLimitReached?.(summary)).catch((error) => {
             logger.warn('[vh:news-daemon] runtime tick limit stop callback failed', error);
+          });
+        }
+        if (
+          deferEnrichmentUntilFirstTickComplete
+          && !firstRuntimeTickCompleted
+          && summary.status === 'completed'
+        ) {
+          firstRuntimeTickCompleted = true;
+          queue.start();
+          logger.info('[vh:news-daemon] enrichment queue started after first runtime tick', {
+            holder_id: holderId,
+            tick_sequence: summary.tick_sequence,
+            raw_wrote_count: summary.raw_wrote_count,
+            selected_bundle_count: summary.selected_bundle_count,
+            enrichment_queue: queue.snapshot(),
           });
         }
       },
@@ -377,7 +396,18 @@ export function createNewsAggregatorDaemon(config: NewsAggregatorDaemonConfig): 
       orchestratorOptions,
     });
     if (runtimeHandle.isRunning()) {
-      queue.start();
+      if (deferEnrichmentUntilFirstTickComplete && !firstRuntimeTickCompleted) {
+        queue.pause();
+        if (!enrichmentQueueDeferredLogged) {
+          enrichmentQueueDeferredLogged = true;
+          logger.info('[vh:news-daemon] enrichment queue deferred until first runtime tick completes', {
+            holder_id: holderId,
+            enrichment_queue: queue.snapshot(),
+          });
+        }
+      } else {
+        queue.start();
+      }
       logger.info('[vh:news-daemon] runtime started', {
         holder_id: holderId,
         poll_interval_ms: config.pollIntervalMs ?? null,
@@ -720,6 +750,9 @@ export async function startNewsAggregatorDaemonFromEnv(): Promise<NewsAggregator
     ? parseOptionalPositiveInt(readEnvVar('VH_NEWS_DAEMON_DIAGNOSTIC_MAX_TICKS')) ?? 1
     : undefined;
   const runtimeTickWatchdogMs = parseOptionalPositiveInt(readEnvVar('VH_NEWS_RUNTIME_TICK_WATCHDOG_MS'));
+  const deferEnrichmentUntilFirstTickComplete = !isDisabledFlag(
+    readEnvVar('VH_NEWS_DAEMON_DEFER_SYNTHESIS_UNTIL_FIRST_TICK_COMPLETE'),
+  );
   const leaseScope = firstNonEmpty(readEnvVar('VH_NEWS_INGESTION_LEASE_SCOPE'));
   const gunRadisk = !isDisabledFlag(readEnvVar('VH_NEWS_DAEMON_GUN_RADISK'));
   const daemonStateDir =
@@ -808,6 +841,7 @@ export async function startNewsAggregatorDaemonFromEnv(): Promise<NewsAggregator
       runtimeMaxTicks: diagnosticMaxTicks,
       onRuntimeTickLimitReached: diagnosticMaxTicks ? requestDiagnosticStop : undefined,
       runtimeTickWatchdogMs,
+      deferEnrichmentUntilFirstTickComplete: !noWrite && deferEnrichmentUntilFirstTickComplete,
       replayAcceptedSynthesis: !noWrite && replayArtifactDir
         ? (runtimeClient) =>
             replayAcceptedAnalysisEvalSyntheses({


### PR DESCRIPTION
## Summary
- defer the news daemon enrichment/synthesis queue until the first completed runtime tick in production env starts
- keep synthesis candidates queued during the raw first-publish batch, then start synthesis immediately after the tick summary
- document VH_NEWS_DAEMON_DEFER_SYNTHESIS_UNTIL_FIRST_TICK_COMPLETE in ops docs/env example

## Why
The attended Phase 5 live start hit the 420s tick watchdog in `writing_raw_bundles` while relay fanout itself was succeeding. Synthesis lifecycle/synthesis work was contending on the same write lane during the first raw-publication batch. This preserves first-publish proof as the first milestone without disabling synthesis after that proof lands.

## Validation
- pnpm --filter @vh/news-aggregator exec vitest run src/daemon.test.ts --config ./vitest.config.ts
- pnpm --filter @vh/news-aggregator typecheck
- node tools/scripts/check-diff-coverage.mjs
- git diff --check
- pnpm test:quick (319 files, 4924 tests)
