### PR TITLE
Disable relay Gun stats by default

### DIFF
--- a/docs/ops/public-beta-image-deploy.md
+++ b/docs/ops/public-beta-image-deploy.md
@@ -32,6 +32,10 @@ re-enable monitors.
   deploy error.
 - Set `NODE_ENV=production` on relays so snapshot-first latest-index serving
   stays enabled by default.
+- Leave relay `GUN_STATS` unset or explicitly `false`. The relay disables GUN's
+  package-local stats writer by default; setting `GUN_STATS=true` makes GUN
+  write `stats.<basename(GUN_FILE)>` beside `node_modules/gun`, which is not a
+  production data mount and can produce persistent permission errors.
 - Capture build-time Web PWA `VITE_*` provenance before rebuilding origin.
   Runtime env cannot repair a bundle built against the wrong peer config, CSP,
   system-writer pin, or local-peer policy.

--- a/infra/relay/server.js
+++ b/infra/relay/server.js
@@ -54,6 +54,7 @@ const port = Number(process.env.GUN_PORT || 7777);
 const host = process.env.GUN_HOST || '127.0.0.1';
 const radiskEnabled = process.env.GUN_RADISK !== 'false';
 const gunFile = radiskEnabled ? process.env.GUN_FILE || 'data' : false;
+const gunStatsEnabled = boolEnv('GUN_STATS', false);
 const newsLatestIndexSnapshotFile = process.env.VH_RELAY_NEWS_INDEX_SNAPSHOT_FILE
   || (typeof gunFile === 'string' ? path.join(gunFile, 'news-latest-index-snapshot.json') : '');
 const newsSynthesisLifecycleSnapshotFile = process.env.VH_RELAY_NEWS_LIFECYCLE_SNAPSHOT_FILE
@@ -4377,6 +4378,7 @@ const server = http.createServer((req, res) => {
       relay_id: relayId,
       uptime_ms: Date.now() - metrics.startedAt,
       radisk_enabled: radiskEnabled,
+      gun_stats_enabled: gunStatsEnabled,
       auth_required: authRequired,
       relay_peer_count: relayPeers.length,
       relay_peers_configured: relayPeers.length > 0,
@@ -4398,6 +4400,7 @@ const server = http.createServer((req, res) => {
       daemon_auth_configured: Boolean(daemonToken),
       user_signature_auth_available: true,
       radisk_enabled: radiskEnabled,
+      gun_stats_enabled: gunStatsEnabled,
       relay_peer_count: relayPeers.length,
       relay_peers_configured: relayPeers.length > 0,
       relay_peer_auth_mode: relayPeerAuthMode,
@@ -4862,6 +4865,7 @@ const gun = Gun({
   web: server,
   radisk: radiskEnabled,
   file: gunFile,
+  stats: gunStatsEnabled,
   axe: false,
   multicast: gunMulticastEnabled,
   peers: relayPeers

--- a/packages/e2e/src/live/relay-server.vitest.mjs
+++ b/packages/e2e/src/live/relay-server.vitest.mjs
@@ -13,6 +13,7 @@ const __dirname = path.dirname(__filename);
 const repoRoot = path.resolve(__dirname, '../../../..');
 const relayServerPath = path.join(repoRoot, 'infra/relay/server.js');
 const gunRequire = createRequire(path.join(repoRoot, 'packages/gun-client/package.json'));
+const gunPackageRoot = path.dirname(gunRequire.resolve('gun/package.json'));
 const Gun = gunRequire('gun');
 const SEA = gunRequire('gun/sea');
 
@@ -226,7 +227,13 @@ function createRelayGunClient(port) {
     localStorage: false,
     radisk: false,
     file: path.join(os.tmpdir(), `vh-relay-client-${process.pid}-${port}-${Date.now()}-${Math.random()}`),
+    stats: false,
   });
+}
+
+function gunStatsFileForGunFile(gunFile) {
+  const file = path.basename(path.resolve(gunFile));
+  return path.join(gunPackageRoot, `stats.${file}`);
 }
 
 function makeRelayNewsStory(storyId, latestActivityAt, sources) {
@@ -365,11 +372,19 @@ describe('infra relay server', () => {
 
     await expect(requestJson(`http://127.0.0.1:${port}/healthz`)).resolves.toMatchObject({
       statusCode: 200,
-      body: expect.objectContaining({ ok: true, service: 'vh-relay' }),
+      body: expect.objectContaining({
+        ok: true,
+        service: 'vh-relay',
+        gun_stats_enabled: false,
+      }),
     });
     await expect(requestJson(`http://127.0.0.1:${port}/readyz`)).resolves.toMatchObject({
       statusCode: 200,
-      body: expect.objectContaining({ ok: true, daemon_auth_configured: false }),
+      body: expect.objectContaining({
+        ok: true,
+        daemon_auth_configured: false,
+        gun_stats_enabled: false,
+      }),
     });
 
     const metrics = await fetchText(`http://127.0.0.1:${port}/metrics`);
@@ -378,6 +393,49 @@ describe('infra relay server', () => {
     expect(metrics.body).toContain('vh_relay_active_connections');
     expect(metrics.body).toContain('vh_relay_radata_bytes');
     expect(metrics.body).toMatch(/vh_relay_process_open_fds \d+/);
+  });
+
+  it('keeps GUN package stats file writes disabled by default', async () => {
+    const gunDir = mkdtempSync(path.join(os.tmpdir(), 'vh-relay-stats-disabled-test-'));
+    tempDirs.add(gunDir);
+    const gunFile = path.join(
+      gunDir,
+      `radisk-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    const statsFile = gunStatsFileForGunFile(gunFile);
+    rmSync(statsFile, { force: true });
+
+    const { port, child } = await startRelay(children, tempDirs, { GUN_FILE: gunFile });
+    await expect(requestJson(`http://127.0.0.1:${port}/readyz`)).resolves.toMatchObject({
+      statusCode: 200,
+      body: expect.objectContaining({
+        ok: true,
+        radisk_enabled: true,
+        gun_stats_enabled: false,
+      }),
+    });
+
+    await delay(5_500);
+
+    expect(existsSync(statsFile)).toBe(false);
+    expect(`${child.stdoutText}\n${child.stderrText}`).not.toContain(path.basename(statsFile));
+    rmSync(statsFile, { force: true });
+  }, 10_000);
+
+  it('reports explicit GUN package stats opt-in for diagnostics', async () => {
+    const { port } = await startRelay(children, tempDirs, {
+      GUN_RADISK: 'false',
+      GUN_STATS: 'true',
+    });
+
+    await expect(requestJson(`http://127.0.0.1:${port}/readyz`)).resolves.toMatchObject({
+      statusCode: 200,
+      body: expect.objectContaining({
+        ok: true,
+        radisk_enabled: false,
+        gun_stats_enabled: true,
+      }),
+    });
   });
 
   it('exposes explicit relay topology metadata when relay peers are configured', async () => {


### PR DESCRIPTION
## Summary
- default relay GUN package stats off via `GUN_STATS=false` semantics and pass `stats` into the relay `Gun()` constructor
- expose `gun_stats_enabled` on `/healthz` and `/readyz`
- add relay regression coverage proving radisk-on relays do not write package-local `stats.*` files by default, plus explicit opt-in visibility
- document the production deploy invariant so relay data stays in `GUN_FILE` mounts, not `node_modules/gun/stats.*`

## Validation
- `pnpm --filter @vh/e2e exec vitest run src/live/relay-server.vitest.mjs --config ./vitest.config.ts --reporter=verbose`
- `node --check infra/relay/server.js`
- `git diff --check`
- `node tools/scripts/check-diff-coverage.mjs`
- `pnpm test:quick`

## Operator note
This PR removes the relay-local `stats.data` permission loop root cause in the relay image code. It does not authorize production relay restarts or Phase 5 live retry by itself; deploy remains an explicit operator gate.