### PR TITLE
Relax latest-index deploy snapshot count check

### DIFF
--- a/docs/ops/public-beta-image-deploy.md
+++ b/docs/ops/public-beta-image-deploy.md
@@ -26,7 +26,9 @@ re-enable monitors.
   - `news-synthesis-lifecycle-snapshot.json`
   - `topic-synthesis-latest-snapshot.json`
 - Abort if any relay latest-index snapshot is missing, has schema other than
-  `vh-news-latest-index-relay-snapshot-v1`, or has entries other than `15`.
+  `vh-news-latest-index-relay-snapshot-v1`, or has an empty/non-list `entries`
+  array. Do not scrub or rewrite a valid latest-index snapshot solely because
+  its preserved entry count differs from an older runbook example.
 - Run relays with a UID/GID that can write the existing host data dirs.
   Snapshot persistence can otherwise fail without surfacing as a user-facing
   deploy error.
@@ -303,7 +305,7 @@ Abort the deploy if any of these are true:
 - Any relay `GUN_FILE` data mount is not a bind mount to the existing host path.
 - Any relay data dir is empty, unwritable by the intended UID/GID, or missing
   one of the three snapshot files.
-- Any latest-index snapshot has entries other than `15`.
+- Any latest-index snapshot has an empty or non-list `entries` array.
 - The new image platform is not `linux/amd64`.
 - The origin image lacks `apps/web-pwa/dist/index.html` or
   `apps/web-pwa/dist/mesh-peer-config.json`.

--- a/tools/scripts/emit-a6-public-beta-deploy-packet.sh
+++ b/tools/scripts/emit-a6-public-beta-deploy-packet.sh
@@ -322,15 +322,15 @@ lines.push('        with open(path, "r", encoding="utf-8") as handle: payload = 
 lines.push('        if payload.get("schema_version") != schema: raise SystemExit(f"{relay}:{filename}: bad schema {payload.get(\'schema_version\')}")');
 lines.push('        if filename == "news-latest-index-snapshot.json":');
 lines.push('            entries = payload.get("entries")');
-lines.push('            if not isinstance(entries, list) or len(entries) != 15: raise SystemExit(f"{relay}:{filename}: entries={len(entries) if isinstance(entries, list) else \'n/a\'}")');
+lines.push('            if not isinstance(entries, list) or len(entries) == 0: raise SystemExit(f"{relay}:{filename}: entries={len(entries) if isinstance(entries, list) else \'n/a\'}")');
 lines.push('            newest = max((entry.get("record", {}).get("latest_activity_at") or entry.get("story", {}).get("cluster_window_end") or 0) for entry in entries)');
-lines.push('            print(json.dumps({"relay": relay, "file": filename, "size": st.st_size, "mtime": st.st_mtime, "cached_at": payload.get("cached_at"), "newest_entry_age_ms": now - newest}, sort_keys=True))');
+lines.push('            print(json.dumps({"relay": relay, "file": filename, "size": st.st_size, "mtime": st.st_mtime, "cached_at": payload.get("cached_at"), "entry_count": len(entries), "newest_entry_age_ms": now - newest}, sort_keys=True))');
 lines.push('        else:');
 lines.push('            print(json.dumps({"relay": relay, "file": filename, "size": st.st_size, "mtime": st.st_mtime, "cached_at": payload.get("cached_at")}, sort_keys=True))');
 lines.push('PY');
 lines.push('```');
 lines.push('');
-lines.push('Abort if any relay data dir is empty, not a bind mount, not writable by `humble`, has a missing snapshot, has a schema mismatch, or latest-index entries != 15.');
+lines.push('Abort if any relay data dir is empty, not a bind mount, not writable by `humble`, has a missing snapshot, has a schema mismatch, or has an empty/non-list latest-index entries array.');
 lines.push('');
 
 lines.push('## Env Capture');

--- a/tools/scripts/public-beta-image-deploy.test.mjs
+++ b/tools/scripts/public-beta-image-deploy.test.mjs
@@ -414,6 +414,9 @@ test('deploy packet preserves relay bind mounts and rewrites origin env safely',
     assert.match(result.stdout, /\/home\/humble\/\.local\/share\/vhc\/vhc-relay-a\/data:\/data:rw/);
     assert.match(result.stdout, /sudo docker exec vhc-relay-a test -f \/data\/news-latest-index-snapshot\.json/);
     assert.match(result.stdout, /grep -E 'vhc\\-public\\-origin\|vhc\\-relay\\-a\|vhc\\-relay\\-b\|vhc\\-relay\\-c'/);
+    assert.match(result.stdout, /len\(entries\) == 0/);
+    assert.match(result.stdout, /"entry_count": len\(entries\)/);
+    assert.doesNotMatch(result.stdout, /entries != 15/);
     assert.match(result.stdout, /VH_PUBLIC_ORIGIN_ANALYSIS_TARGET=http:\/\/127\.0\.0\.1:3001/);
     assert.match(result.stdout, /vhc-public-beta-relay:new/);
     const originRewriteLine = result.stdout


### PR DESCRIPTION
## Summary
- relax the A6 deploy-packet latest-index snapshot guard from a stale fixed `15` entries check to a schema-valid, non-empty `entries` array check
- emit `entry_count` in the generated read-only precheck output so operators still see the preserved snapshot shape before recreating relays
- update the public beta deploy runbook and deploy-packet test to prevent regressions back to the fixed-count assumption

## Why
The current A6 relay latest-index snapshots are valid and preserved, but contain more than the older runbook example count. A deploy packet must reject missing, malformed, or empty snapshots, not force a scrub or block a relay image restart solely because a valid snapshot retained more entries after prior live attempts.

## Validation
- `node --test tools/scripts/public-beta-image-deploy.test.mjs`
- `git diff --check`
- `node tools/scripts/check-diff-coverage.mjs`
