### PR TITLE
Fail closed on news daemon runtime errors

### DIFF
--- a/docs/ops/news-aggregator-production-service.md
+++ b/docs/ops/news-aggregator-production-service.md
@@ -262,6 +262,15 @@ immediately after that completed summary. Set it to `false` only when first-tick
 caps, synthesis throughput, relay fanout, and the watchdog window have been
 recalibrated together.
 
+Live mode also fail-closes runtime errors by default through
+`VH_NEWS_DAEMON_FAIL_CLOSED_ON_RUNTIME_ERROR=true`. A runtime error, including a
+partial require-all relay REST write, blocks further runtime writes, stops the
+daemon loop, shuts down the process handle, and leaves systemd to report the
+service stopped instead of allowing the write lane to drain more public stories.
+Do not set it to `false` in production unless the incident commander has chosen
+an attended degraded-write experiment and the public-feed rollback plan is
+already active.
+
 ## Env File Surface
 
 Default env file:
@@ -309,6 +318,7 @@ VH_NEWS_DAEMON_LAST_SUCCESS_FILE
 VH_NEWS_RUNTIME_DIAGNOSTIC_FILE
 VH_NEWS_RUNTIME_TICK_WATCHDOG_MS
 VH_NEWS_DAEMON_DEFER_SYNTHESIS_UNTIL_FIRST_TICK_COMPLETE
+VH_NEWS_DAEMON_FAIL_CLOSED_ON_RUNTIME_ERROR
 VH_NEWS_FEED_MAX_ITEMS_PER_SOURCE
 VH_NEWS_FEED_MAX_ITEMS_TOTAL
 VH_NEWS_RUNTIME_MAX_PUBLISHED_BUNDLES

--- a/docs/ops/news-aggregator.env.example
+++ b/docs/ops/news-aggregator.env.example
@@ -72,6 +72,9 @@ VH_NEWS_RUNTIME_TICK_WATCHDOG_MS=420000
 # Keep publish-time synthesis queued until the first live raw-publication tick
 # completes. Set to false only after recalibrating first-tick caps/watchdog.
 VH_NEWS_DAEMON_DEFER_SYNTHESIS_UNTIL_FIRST_TICK_COMPLETE=true
+# Live mode fail-closes on runtime errors by default so a partial require-all
+# relay write cannot drain additional public writes. Leave enabled for prod.
+VH_NEWS_DAEMON_FAIL_CLOSED_ON_RUNTIME_ERROR=true
 VH_BUNDLE_SYNTHESIS_QUEUE_DIR=/home/humble/.local/state/vhc/news-aggregator/bundle-synthesis-queue
 VH_BUNDLE_SYNTHESIS_LIFECYCLE_LEDGER=/home/humble/.local/state/vhc/news-aggregator/bundle-synthesis-queue/synthesis-lifecycle.jsonl
 VITE_NEWS_POLL_INTERVAL_MS=600000

--- a/services/news-aggregator/src/daemon.coverage.test.ts
+++ b/services/news-aggregator/src/daemon.coverage.test.ts
@@ -157,6 +157,7 @@ describe('news daemon coverage guards', () => {
       leaseHolderId: 'vh-news-daemon:test',
       now: () => 1_700_000_000_000,
       random: () => 0.42,
+      failClosedOnRuntimeError: false,
     });
 
     await daemon.start();

--- a/services/news-aggregator/src/daemon.production.test.ts
+++ b/services/news-aggregator/src/daemon.production.test.ts
@@ -225,6 +225,46 @@ describe('news daemon production wiring', () => {
     }
   });
 
+  it('shuts down the production process after a live runtime error', async () => {
+    const tmpDir = mkdtempSync(path.join(os.tmpdir(), 'vh-news-daemon-runtime-error-'));
+    const runtimeHandle = {
+      stop: vi.fn(),
+      isRunning: vi.fn(() => true),
+      lastRun: vi.fn(() => null),
+    };
+    const shutdown = vi.fn().mockResolvedValue(undefined);
+    mocks.startNewsRuntime.mockReturnValue(runtimeHandle);
+    mocks.createNodeMeshClient.mockReturnValue({
+      id: 'mock-client',
+      shutdown,
+    });
+    primeHealthyEnv();
+    vi.stubEnv('VH_NEWS_DAEMON_STATE_DIR', tmpDir);
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('ok', { status: 200 })));
+
+    try {
+      const handle = await startNewsAggregatorDaemonFromEnv();
+      const runtimeConfig = mocks.startNewsRuntime.mock.calls[0]?.[0] as {
+        onError?: (error: unknown) => void;
+        writeStoryBundle?: (client: unknown, bundle: unknown) => Promise<unknown>;
+      };
+
+      runtimeConfig.onError?.(new Error('relay require-all failed'));
+
+      await vi.waitFor(() => expect(runtimeHandle.stop).toHaveBeenCalledTimes(1));
+      await handle.closed;
+      await expect(
+        runtimeConfig.writeStoryBundle?.({ id: 'mock-client' }, { story_id: 'story-after-error' }),
+      ).rejects.toThrow('news daemon runtime writes stopped after runtime error');
+
+      expect(shutdown).toHaveBeenCalledTimes(1);
+      await handle.stop();
+      expect(shutdown).toHaveBeenCalledTimes(1);
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it('defaults no-write diagnostics to one runtime tick and self-stops after writing the summary', async () => {
     const tmpDir = mkdtempSync(path.join(os.tmpdir(), 'vh-news-daemon-bounded-diagnostic-'));
     const runtimeHandle = {

--- a/services/news-aggregator/src/daemon.test.ts
+++ b/services/news-aggregator/src/daemon.test.ts
@@ -779,6 +779,113 @@ describe('news aggregator daemon', () => {
     await daemon.stop();
   });
 
+  it('fails closed after a live runtime error and blocks further public writes', async () => {
+    const logger = makeLogger();
+    const runtimeHandle = makeRuntimeHandle();
+    const timers = makeTimerControls();
+
+    const heldLease = makeLease();
+    const startRuntime = vi.fn(() => runtimeHandle);
+    const readLease = vi.fn().mockResolvedValueOnce(null);
+    const writeLease = vi.fn(async (_client: VennClient, lease: unknown) => lease as NewsIngestionLease);
+    const writeBundle = vi.fn().mockResolvedValue({ story_id: 'story-after-error' });
+    const enrichmentWorker = vi.fn().mockResolvedValue(undefined);
+
+    const daemon = createNewsAggregatorDaemon({
+      client: { id: 'client-runtime-error' } as VennClient,
+      feedSources: [...FEED_SOURCES],
+      topicMapping: { ...TOPIC_MAPPING },
+      startRuntime,
+      readLease,
+      writeLease,
+      writeBundle,
+      enrichmentWorker,
+      logger,
+      setIntervalFn: timers.setIntervalFn,
+      clearIntervalFn: timers.clearIntervalFn,
+      leaseHolderId: heldLease.holder_id,
+      deferEnrichmentUntilFirstTickComplete: true,
+      failClosedOnRuntimeError: true,
+    });
+
+    await daemon.start();
+
+    const runtimeConfig = startRuntime.mock.calls[0]?.[0] as NewsRuntimeConfig;
+    runtimeConfig.onError?.(new Error('relay require-all failed'));
+
+    await vi.waitFor(() => expect(runtimeHandle.stop).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => expect(logger.info).toHaveBeenCalledWith(
+      '[vh:news-daemon] stopped',
+      expect.objectContaining({ reason: 'runtime_error' }),
+    ));
+
+    runtimeConfig.onSynthesisCandidate?.(CANDIDATE);
+    await expect(
+      runtimeConfig.writeStoryBundle?.({ id: 'client-runtime-error' }, { story_id: 'story-after-error' } as any),
+    ).rejects.toThrow('news daemon runtime writes stopped after runtime error');
+
+    expect(daemon.isRunning()).toBe(false);
+    expect(writeBundle).not.toHaveBeenCalled();
+    expect(enrichmentWorker).not.toHaveBeenCalled();
+    expect(timers.clearIntervalFn).toHaveBeenCalledTimes(1);
+    expect(writeLease).toHaveBeenCalledTimes(2);
+    expect(logger.error).toHaveBeenCalledWith(
+      '[vh:news-daemon] runtime error triggered fail-closed stop',
+      expect.objectContaining({ holder_id: heldLease.holder_id }),
+    );
+
+    await daemon.stop();
+  });
+
+  it('continues fail-closed runtime shutdown when lease release fails', async () => {
+    const logger = makeLogger();
+    const runtimeHandle = makeRuntimeHandle();
+    const timers = makeTimerControls();
+
+    const releaseError = new Error('lease release failed');
+    const startRuntime = vi.fn(() => runtimeHandle);
+    const readLease = vi.fn().mockResolvedValueOnce(null);
+    const writeLease = vi.fn()
+      .mockImplementationOnce(async (_client: VennClient, lease: unknown) => lease as NewsIngestionLease)
+      .mockRejectedValueOnce(releaseError);
+    const onFailClosedRuntimeError = vi.fn();
+
+    const daemon = createNewsAggregatorDaemon({
+      client: { id: 'client-runtime-error-release-fail' } as VennClient,
+      feedSources: [...FEED_SOURCES],
+      topicMapping: { ...TOPIC_MAPPING },
+      startRuntime,
+      readLease,
+      writeLease,
+      logger,
+      setIntervalFn: timers.setIntervalFn,
+      clearIntervalFn: timers.clearIntervalFn,
+      leaseHolderId: 'vh-news-daemon:test',
+      failClosedOnRuntimeError: true,
+      onFailClosedRuntimeError,
+    });
+
+    await daemon.start();
+
+    const runtimeConfig = startRuntime.mock.calls[0]?.[0] as NewsRuntimeConfig;
+    const runtimeError = new Error('relay require-all failed');
+    runtimeConfig.onError?.(runtimeError);
+
+    await vi.waitFor(() => expect(onFailClosedRuntimeError).toHaveBeenCalledWith(runtimeError));
+    await expect(
+      runtimeConfig.writeStoryBundle?.({ id: 'client-runtime-error-release-fail' }, { story_id: 'story-after-error' } as any),
+    ).rejects.toThrow('news daemon runtime writes stopped after runtime error');
+
+    expect(daemon.isRunning()).toBe(false);
+    expect(runtimeHandle.stop).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      '[vh:news-daemon] failed to release lease',
+      releaseError,
+    );
+
+    await daemon.stop();
+  });
+
   it('renews lease on heartbeat ticks while running', async () => {
     const logger = makeLogger();
     const runtimeHandle = makeRuntimeHandle();

--- a/services/news-aggregator/src/daemon.ts
+++ b/services/news-aggregator/src/daemon.ts
@@ -129,6 +129,8 @@ export interface NewsAggregatorDaemonConfig {
   onRuntimeTickLimitReached?: (summary: NewsRuntimeTickSummary) => void | Promise<void>;
   runtimeTickWatchdogMs?: number;
   deferEnrichmentUntilFirstTickComplete?: boolean;
+  failClosedOnRuntimeError?: boolean;
+  onFailClosedRuntimeError?: (error: unknown) => void | Promise<void>;
   now?: () => number;
   random?: () => number;
   setIntervalFn?: typeof setInterval;
@@ -162,7 +164,12 @@ export function createNewsAggregatorDaemon(config: NewsAggregatorDaemonConfig): 
   const leaseVerificationWindowMs = Math.max(500, Math.min(5_000, Math.floor(leaseTtlMs / 6)));
   const holderId = resolveLeaseHolderId(config.leaseHolderId);
   const noWrite = config.noWrite === true;
-  const writeLanes = config.writeLanes ?? createDaemonWriteLaneRegistry({ logger, now: nowFn });
+  const failClosedOnRuntimeError = config.failClosedOnRuntimeError ?? !noWrite;
+  const writeLanes = config.writeLanes ?? createDaemonWriteLaneRegistry({
+    logger,
+    now: nowFn,
+    stopClassOnFailure: failClosedOnRuntimeError && !noWrite,
+  });
   const queue = createAsyncEnrichmentQueue(
     config.enrichmentWorker ?? (() => undefined),
     logger,
@@ -187,6 +194,8 @@ export function createNewsAggregatorDaemon(config: NewsAggregatorDaemonConfig): 
   let runtimeHandle: NewsRuntimeHandle | null = null;
   let leaseHeartbeatTimer: ReturnType<typeof setInterval> | null = null;
   let leadershipTickPromise: Promise<void> | null = null;
+  let stopPromise: Promise<void> | null = null;
+  let runtimeWritesBlocked = false;
   let acceptedSynthesisReplayAttempted = false;
   const productFeedReconcileIntervalMs = normalizePositiveIntervalMs(
     config.productFeedReconcileIntervalMs
@@ -227,6 +236,11 @@ export function createNewsAggregatorDaemon(config: NewsAggregatorDaemonConfig): 
     }
     runtimeHandle.stop();
     runtimeHandle = null;
+  };
+  const assertRuntimeWritesAllowed = () => {
+    if (runtimeWritesBlocked) {
+      throw new Error('news daemon runtime writes stopped after runtime error');
+    }
   };
   const startRuntimeIfNeeded = () => {
     if (runtimeHandle?.isRunning()) {
@@ -304,6 +318,7 @@ export function createNewsAggregatorDaemon(config: NewsAggregatorDaemonConfig): 
           });
           return bundle;
         }
+        assertRuntimeWritesAllowed();
         await leaseGuard.assertHeld(nowFn());
         return writeLanes.run('news_bundle', { story_id: storyId ?? null }, async () => {
           const written = await writeBundle(runtimeClient as VennClient, bundle);
@@ -348,6 +363,7 @@ export function createNewsAggregatorDaemon(config: NewsAggregatorDaemonConfig): 
           logger.info('[vh:news-daemon] no-write raw bundle remove suppressed', { story_id: storyId });
           return undefined;
         }
+        assertRuntimeWritesAllowed();
         await leaseGuard.assertHeld(nowFn());
         return writeLanes.run('news_bundle_remove', { story_id: storyId }, async () => {
           return removeBundle(runtimeClient as VennClient, storyId);
@@ -364,6 +380,7 @@ export function createNewsAggregatorDaemon(config: NewsAggregatorDaemonConfig): 
           });
           return storyline;
         }
+        assertRuntimeWritesAllowed();
         await leaseGuard.assertHeld(nowFn());
         return writeLanes.run('storyline', { storyline_id: storylineId ?? null }, async () => {
           return writeNewsStoryline(runtimeClient as VennClient, storyline);
@@ -376,6 +393,7 @@ export function createNewsAggregatorDaemon(config: NewsAggregatorDaemonConfig): 
           });
           return undefined;
         }
+        assertRuntimeWritesAllowed();
         await leaseGuard.assertHeld(nowFn());
         return writeLanes.run('storyline_remove', { storyline_id: storylineId }, async () => {
           return removeNewsStoryline(runtimeClient as VennClient, storylineId);
@@ -389,6 +407,13 @@ export function createNewsAggregatorDaemon(config: NewsAggregatorDaemonConfig): 
           });
           return;
         }
+        if (runtimeWritesBlocked) {
+          logger.warn('[vh:news-daemon] synthesis candidate suppressed after runtime error', {
+            story_id: candidate.story_id,
+            work_item_count: candidate.work_items.length,
+          });
+          return;
+        }
         queue.enqueue(candidate);
         logger.info('[vh:news-daemon] enrichment candidate enqueued', {
           story_id: candidate.story_id,
@@ -397,6 +422,18 @@ export function createNewsAggregatorDaemon(config: NewsAggregatorDaemonConfig): 
       },
       onError(error) {
         logger.warn('[vh:news-daemon] runtime tick failed', error);
+        if (failClosedOnRuntimeError && !noWrite) {
+          runtimeWritesBlocked = true;
+          logger.error('[vh:news-daemon] runtime error triggered fail-closed stop', {
+            holder_id: holderId,
+            error,
+          });
+          void stopInternal('runtime_error')
+            .then(() => config.onFailClosedRuntimeError?.(error))
+            .catch((stopError) => {
+              logger.error('[vh:news-daemon] fail-closed stop after runtime error failed', stopError);
+            });
+        }
       },
       orchestratorOptions,
     });
@@ -565,6 +602,46 @@ export function createNewsAggregatorDaemon(config: NewsAggregatorDaemonConfig): 
       leaseGuard.clear();
     }
   };
+  const stopInternal = async (reason: string): Promise<void> => {
+    if (stopPromise) {
+      await stopPromise;
+      return;
+    }
+    if (!running && !runtimeHandle) {
+      return;
+    }
+    stopPromise = (async () => {
+      let stopError: unknown;
+      running = false;
+      if (leaseHeartbeatTimer) {
+        clearIntervalFn(leaseHeartbeatTimer);
+        leaseHeartbeatTimer = null;
+      }
+      queue.stop();
+      stopRuntime();
+      try {
+        await releaseLease();
+      } catch (error) {
+        stopError = error;
+        logger.warn('[vh:news-daemon] failed to release lease during stop', {
+          holder_id: holderId,
+          reason,
+          error,
+        });
+      } finally {
+        writeLanes.stop();
+        logger.info('[vh:news-daemon] stopped', { holder_id: holderId, reason });
+      }
+      if (stopError && reason !== 'runtime_error') {
+        throw stopError;
+      }
+    })();
+    try {
+      await stopPromise;
+    } finally {
+      stopPromise = null;
+    }
+  };
   return {
     leaseHolderId: holderId,
     async start() {
@@ -579,19 +656,7 @@ export function createNewsAggregatorDaemon(config: NewsAggregatorDaemonConfig): 
       logger.info('[vh:news-daemon] leadership loop started', { holder_id: holderId, lease_ttl_ms: leaseTtlMs, lease_renew_interval_ms: leaseRenewIntervalMs });
     },
     async stop() {
-      if (!running) {
-        return;
-      }
-      running = false;
-      if (leaseHeartbeatTimer) {
-        clearIntervalFn(leaseHeartbeatTimer);
-        leaseHeartbeatTimer = null;
-      }
-      queue.stop();
-      stopRuntime();
-      await releaseLease();
-      writeLanes.stop();
-      logger.info('[vh:news-daemon] stopped', { holder_id: holderId });
+      await stopInternal('operator');
     },
     isRunning() {
       return running;
@@ -826,6 +891,9 @@ export async function startNewsAggregatorDaemonFromEnv(): Promise<NewsAggregator
   const deferEnrichmentUntilFirstTickComplete = !isDisabledFlag(
     readEnvVar('VH_NEWS_DAEMON_DEFER_SYNTHESIS_UNTIL_FIRST_TICK_COMPLETE'),
   );
+  const failClosedOnRuntimeError = noWrite
+    ? false
+    : !isDisabledFlag(readEnvVar('VH_NEWS_DAEMON_FAIL_CLOSED_ON_RUNTIME_ERROR'));
   const leaseScope = firstNonEmpty(readEnvVar('VH_NEWS_INGESTION_LEASE_SCOPE'));
   const gunRadisk = !isDisabledFlag(readEnvVar('VH_NEWS_DAEMON_GUN_RADISK'));
   const daemonStateDir =
@@ -917,6 +985,15 @@ export async function startNewsAggregatorDaemonFromEnv(): Promise<NewsAggregator
       onRuntimeTickLimitReached: diagnosticMaxTicks ? requestDiagnosticStop : undefined,
       runtimeTickWatchdogMs,
       deferEnrichmentUntilFirstTickComplete: !noWrite && deferEnrichmentUntilFirstTickComplete,
+      failClosedOnRuntimeError,
+      onFailClosedRuntimeError: (error) => {
+        console.error('[vh:news-daemon] fail-closed runtime error shutting down process', error);
+        setTimeout(() => {
+          void processHandle?.stop().catch((stopError) => {
+            console.error('[vh:news-daemon] fail-closed process shutdown failed', stopError);
+          });
+        }, 0);
+      },
       replayAcceptedSynthesis: !noWrite && replayArtifactDir
         ? (runtimeClient) =>
             replayAcceptedAnalysisEvalSyntheses({

--- a/services/news-aggregator/src/daemonWriteLane.test.ts
+++ b/services/news-aggregator/src/daemonWriteLane.test.ts
@@ -68,4 +68,57 @@ describe('daemonWriteLane', () => {
     );
     void first.catch(() => undefined);
   });
+
+  it('stops only the failed write class when configured fail-closed', async () => {
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    let rejectFirst: ((error: Error) => void) | null = null;
+    const lane = createDaemonWriteLaneRegistry({
+      logger,
+      defaultConcurrency: 1,
+      stopClassOnFailure: true,
+    });
+
+    const first = lane.run('news_bundle', { story_id: 'story-1' }, () =>
+      new Promise((_resolve, reject) => {
+        rejectFirst = reject;
+      }),
+    );
+    const secondTask = vi.fn(async () => 'second');
+    const second = lane.run('news_bundle', { story_id: 'story-2' }, secondTask);
+    const lease = lane.run('lease', { operation: 'release' }, async () => 'released');
+
+    await flushMicrotasks();
+    rejectFirst?.(new Error('relay require-all failed'));
+
+    await expect(first).rejects.toThrow('relay require-all failed');
+    await expect(second).rejects.toThrow('daemon write lane stopped after failure: news_bundle');
+    await expect(lease).resolves.toBe('released');
+    await expect(lane.run('news_bundle', { story_id: 'story-3' }, async () => 'late')).rejects.toThrow(
+      'daemon write lane stopped after failure: news_bundle',
+    );
+
+    expect(secondTask).not.toHaveBeenCalled();
+    expect(lane.snapshot()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          write_class: 'news_bundle',
+          stopped: true,
+          failed_count: 1,
+          pending_depth: 0,
+        }),
+        expect.objectContaining({
+          write_class: 'lease',
+          stopped: false,
+          completed_count: 1,
+        }),
+      ]),
+    );
+    expect(logger.error).toHaveBeenCalledWith(
+      '[vh:news-daemon] write lane stopped after failure',
+      expect.objectContaining({
+        write_class: 'news_bundle',
+        rejected_pending_count: 1,
+      }),
+    );
+  });
 });

--- a/services/news-aggregator/src/daemonWriteLane.ts
+++ b/services/news-aggregator/src/daemonWriteLane.ts
@@ -7,6 +7,7 @@ export interface DaemonWriteLaneSnapshot {
   completed_count: number;
   failed_count: number;
   p95_ms: number | null;
+  stopped: boolean;
 }
 
 export interface DaemonWriteLaneRegistry {
@@ -32,6 +33,7 @@ interface LaneState {
   completedCount: number;
   failedCount: number;
   durations: number[];
+  stopped: boolean;
 }
 
 export interface DaemonWriteLaneOptions {
@@ -40,6 +42,7 @@ export interface DaemonWriteLaneOptions {
   defaultConcurrency?: number;
   classConcurrency?: Record<string, number | undefined>;
   maxSamples?: number;
+  stopClassOnFailure?: boolean;
 }
 
 function normalizeConcurrency(value: number | undefined, fallback: number): number {
@@ -79,6 +82,7 @@ export function createDaemonWriteLaneRegistry(
       completedCount: 0,
       failedCount: 0,
       durations: [],
+      stopped: false,
     };
     lanes.set(writeClass, created);
     return created;
@@ -100,6 +104,9 @@ export function createDaemonWriteLaneRegistry(
       return;
     }
     const state = stateFor(writeClass);
+    if (state.stopped) {
+      return;
+    }
     const maxInFlight = concurrencyFor(writeClass);
     while (state.inFlight < maxInFlight && state.pending.length > 0) {
       const item = state.pending.shift();
@@ -146,6 +153,19 @@ export function createDaemonWriteLaneRegistry(
             ...item.attributes,
             error,
           });
+          if (options.stopClassOnFailure && !state.stopped) {
+            state.stopped = true;
+            const pending = state.pending.splice(0);
+            for (const pendingItem of pending) {
+              pendingItem.reject(new Error(`daemon write lane stopped after failure: ${writeClass}`));
+            }
+            logger.error('[vh:news-daemon] write lane stopped after failure', {
+              write_class: writeClass,
+              rejected_pending_count: pending.length,
+              failed_count: state.failedCount,
+              ...item.attributes,
+            });
+          }
           item.reject(error);
         })
         .finally(() => {
@@ -161,6 +181,9 @@ export function createDaemonWriteLaneRegistry(
         return Promise.reject(new Error(`daemon write lane stopped: ${writeClass}`));
       }
       const state = stateFor(writeClass);
+      if (state.stopped) {
+        return Promise.reject(new Error(`daemon write lane stopped after failure: ${writeClass}`));
+      }
       return new Promise<T>((resolve, reject) => {
         state.pending.push({
           attributes,
@@ -188,6 +211,7 @@ export function createDaemonWriteLaneRegistry(
           completed_count: state.completedCount,
           failed_count: state.failedCount,
           p95_ms: p95(state.durations),
+          stopped: state.stopped,
         }));
     },
 


### PR DESCRIPTION
## Summary
- fail-close live news daemon runtime errors by blocking subsequent runtime writes and stopping the daemon loop
- stop the failed write-lane class immediately so queued writes cannot drain after a require-all relay failure
- wire production runtime-error shutdown through the process handle so mesh client shutdown and pidfile release happen
- document VH_NEWS_DAEMON_FAIL_CLOSED_ON_RUNTIME_ERROR and keep no-write diagnostics on their bounded diagnostic path

## Live context
During the attended Phase 5 start after relay deployment, the publisher wrote initial public records but the first runtime tick hit a require-all latest-index failure: 2/3 relays succeeded and gun-a aborted. The service was stopped and disabled manually; this PR makes that failure mode stop itself before further public writes drain.

## Verification
- pnpm --filter @vh/news-aggregator exec vitest run src/daemonWriteLane.test.ts src/daemon.test.ts src/daemon.coverage.test.ts src/daemon.production.test.ts --config ./vitest.config.ts
- pnpm --filter @vh/news-aggregator build
- pnpm --filter @vh/news-aggregator test
- git diff --check
- node tools/scripts/check-diff-coverage.mjs
- pnpm test:quick
