### PR TITLE
Add explicit relay REST write quorum for Phase 5 publishing

### DIFF
--- a/docs/ops/news-aggregator-production-service.md
+++ b/docs/ops/news-aggregator-production-service.md
@@ -262,9 +262,16 @@ immediately after that completed summary. Set it to `false` only when first-tick
 caps, synthesis throughput, relay fanout, and the watchdog window have been
 recalibrated together.
 
+Current Phase 5 public-news MVP scope is **B**: accepted synthesis and frame
+tables on newest cards are launch-required. Raw-fresh, v4-signed, product-visible
+cards with `synthesis_pending` prove the raw publication path but do not satisfy
+the final "done" gate. The attended run must observe synthesis lifecycle advance
+from pending to accepted and accepted synthesis/frame-table rows write to the
+configured relay REST quorum before launch is complete.
+
 Live mode also fail-closes runtime errors by default through
 `VH_NEWS_DAEMON_FAIL_CLOSED_ON_RUNTIME_ERROR=true`. A runtime error, including a
-partial require-all relay REST write, blocks further runtime writes, stops the
+partial relay REST quorum write, blocks further runtime writes, stops the
 daemon loop, shuts down the process handle, and leaves systemd to report the
 service stopped instead of allowing the write lane to drain more public stories.
 Do not set it to `false` in production unless the incident commander has chosen
@@ -301,10 +308,12 @@ VH_NEWS_RELAY_REST_WRITE_FIRST
 VH_NEWS_RELAY_REST_WRITE_ORIGINS
 VH_NEWS_RELAY_REST_WRITE_TOKENS
 VH_NEWS_RELAY_REST_WRITE_REQUIRE_ALL
+VH_NEWS_RELAY_REST_WRITE_MIN_SUCCESS
 VH_NEWS_RELAY_REST_WRITE_TIMEOUT_MS
 VH_BUNDLE_SYNTHESIS_RELAY_WRITE_ORIGINS
 VH_BUNDLE_SYNTHESIS_RELAY_WRITE_TOKENS
 VH_BUNDLE_SYNTHESIS_RELAY_WRITE_REQUIRE_ALL
+VH_BUNDLE_SYNTHESIS_RELAY_WRITE_MIN_SUCCESS
 VH_BUNDLE_SYNTHESIS_WRITE_RELAY_REST
 VH_RELAY_DAEMON_TOKEN
 VH_NEWS_DAEMON_HOLDER_ID
@@ -335,9 +344,35 @@ For production Phase 5 publisher starts, keep `VH_NEWS_RELAY_REST_WRITE_FIRST`
 enabled. The daemon still signs story bodies, latest-index rows, hot-index rows,
 and synthesis lifecycle rows with the public news system writer, but it submits
 those records to the relay REST write-through routes before attempting any
-direct Gun publication. `VH_NEWS_RELAY_REST_WRITE_REQUIRE_ALL=true` is the
-default and should remain set so a partial relay fanout fails closed instead of
-claiming first-publish success from one relay.
+direct Gun publication.
+
+Phase 5 production policy is explicit 2-of-3 relay REST quorum for both raw
+public-news rows and bundle synthesis rows:
+
+```bash
+VH_NEWS_RELAY_REST_WRITE_MIN_SUCCESS=2
+VH_BUNDLE_SYNTHESIS_RELAY_WRITE_MIN_SUCCESS=2
+```
+
+When a `*_MIN_SUCCESS` value is set, it takes precedence over the legacy
+`*_WRITE_REQUIRE_ALL` boolean. The value is a true minimum over the resolved,
+normalized, deduped relay endpoint set. It must be an integer from `1` through
+the resolved endpoint count; invalid values, zero endpoints, or impossible
+thresholds fail closed before publisher start or before the write fanout. It is
+never interpreted as a fallback to one successful relay. If `*_MIN_SUCCESS` is
+absent, legacy behavior is unchanged: `*_WRITE_REQUIRE_ALL=true` requires every
+resolved relay endpoint, while `false` accepts any single validated relay
+success.
+
+Keep `VH_NEWS_RELAY_REST_WRITE_REQUIRE_ALL=true` and
+`VH_BUNDLE_SYNTHESIS_RELAY_WRITE_REQUIRE_ALL=true` in the env file as the
+legacy fallback posture, but treat the explicit `*_MIN_SUCCESS=2` fields as the
+production quorum source of truth. A successful write counts only relay
+responses that pass the route's existing payload validation and readback
+contract where that route provides one; plain HTTP acceptance is not enough.
+The preflight and write logs report `endpoint_count`, `required_success_count`,
+`relay_required_success_count`, and failed relay origin labels without printing
+tokens, pins, or key material.
 
 When relays have different daemon tokens, set `VH_NEWS_RELAY_REST_WRITE_TOKENS`
 to a JSON object mapping each relay origin to its token, for example:
@@ -385,8 +420,9 @@ lease in the daemon state directory instead of relying on direct public GUN
 durable-write readback. It is intended for the single A6 publisher deployment
 where the production wrapper sibling scan, daemon pidfile, and `systemd` unit
 already provide host-level writer exclusion. Public story/latest/hot/lifecycle
-publication remains relay REST write-first with `REQUIRE_ALL=true`; the local
-lease backend does not weaken the public feed write fanout.
+publication remains relay REST write-first with explicit 2-of-3
+`*_MIN_SUCCESS` quorum; the local lease backend does not weaken the public feed
+write fanout.
 
 ## Relay Snapshot Freshness Watch
 
@@ -571,7 +607,7 @@ Abort or stop the service if any of these occur:
 - OpenAI preflight is not `pass`;
 - StoryCluster health check fails;
 - raw news or synthesis relay REST write fanout is below the configured
-  `require_all` target;
+  quorum target;
 - snapshot watch reports stale newest-entry age above 6 hours;
 - latest content does not advance after approved start and expected ingest
   cadence.

--- a/docs/ops/news-aggregator.env.example
+++ b/docs/ops/news-aggregator.env.example
@@ -38,6 +38,7 @@ VH_NEWS_RELAY_REST_WRITE_FIRST=true
 VH_NEWS_RELAY_REST_WRITE_ORIGINS='["https://gun-a.carboncaste.io","https://gun-b.carboncaste.io","https://gun-c.carboncaste.io"]'
 VH_NEWS_RELAY_REST_WRITE_TOKENS='{"https://gun-a.carboncaste.io":"<gun-a-relay-daemon-token>","https://gun-b.carboncaste.io":"<gun-b-relay-daemon-token>","https://gun-c.carboncaste.io":"<gun-c-relay-daemon-token>"}'
 VH_NEWS_RELAY_REST_WRITE_REQUIRE_ALL=true
+VH_NEWS_RELAY_REST_WRITE_MIN_SUCCESS=2
 VH_NEWS_RELAY_REST_WRITE_TIMEOUT_MS=10000
 VH_BUNDLE_SYNTHESIS_ENABLED=true
 VH_BUNDLE_SYNTHESIS_WRITE_RELAY_REST=true
@@ -46,6 +47,7 @@ VH_BUNDLE_SYNTHESIS_RELAY_WRITE_ORIGINS='["https://gun-a.carboncaste.io","https:
 # VH_NEWS_RELAY_REST_WRITE_TOKENS, then falls back to VH_RELAY_DAEMON_TOKEN.
 # VH_BUNDLE_SYNTHESIS_RELAY_WRITE_TOKENS='{"https://gun-a.carboncaste.io":"<gun-a-relay-daemon-token>","https://gun-b.carboncaste.io":"<gun-b-relay-daemon-token>","https://gun-c.carboncaste.io":"<gun-c-relay-daemon-token>"}'
 VH_BUNDLE_SYNTHESIS_RELAY_WRITE_REQUIRE_ALL=true
+VH_BUNDLE_SYNTHESIS_RELAY_WRITE_MIN_SUCCESS=2
 VH_BUNDLE_SYNTHESIS_MODEL=gpt-4o-mini
 VH_BUNDLE_SYNTHESIS_TIMEOUT_MS=120000
 VH_BUNDLE_SYNTHESIS_RATE_PER_MIN=20
@@ -72,8 +74,8 @@ VH_NEWS_RUNTIME_TICK_WATCHDOG_MS=420000
 # Keep publish-time synthesis queued until the first live raw-publication tick
 # completes. Set to false only after recalibrating first-tick caps/watchdog.
 VH_NEWS_DAEMON_DEFER_SYNTHESIS_UNTIL_FIRST_TICK_COMPLETE=true
-# Live mode fail-closes on runtime errors by default so a partial require-all
-# relay write cannot drain additional public writes. Leave enabled for prod.
+# Live mode fail-closes on runtime errors by default so a partial relay REST
+# quorum write cannot drain additional public writes. Leave enabled for prod.
 VH_NEWS_DAEMON_FAIL_CLOSED_ON_RUNTIME_ERROR=true
 VH_BUNDLE_SYNTHESIS_QUEUE_DIR=/home/humble/.local/state/vhc/news-aggregator/bundle-synthesis-queue
 VH_BUNDLE_SYNTHESIS_LIFECYCLE_LEDGER=/home/humble/.local/state/vhc/news-aggregator/bundle-synthesis-queue/synthesis-lifecycle.jsonl

--- a/packages/gun-client/src/newsAdapters.test.ts
+++ b/packages/gun-client/src/newsAdapters.test.ts
@@ -747,6 +747,247 @@ describe('newsAdapters', () => {
     }
   });
 
+  it('writeNewsLatestIndexEntry accepts explicit 2-of-3 relay REST quorum', async () => {
+    const restoreRuntimeConfig = withGunClientRuntimeConfig({
+      VH_NEWS_RELAY_REST_WRITE_FIRST: 'true',
+      VH_NEWS_RELAY_REST_WRITE_ORIGINS: '["https://gun-a.example.test","https://gun-b.example.test","https://gun-c.example.test"]',
+      VH_NEWS_RELAY_REST_WRITE_REQUIRE_ALL: 'true',
+      VH_NEWS_RELAY_REST_WRITE_MIN_SUCCESS: '2',
+    });
+    const restoreEnv = withProcessEnv({ VH_RELAY_DAEMON_TOKEN: 'relay-token-redacted' });
+    const info = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+    try {
+      const mesh = createFakeMesh();
+      const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+      const client = createClient(mesh, guard, {
+        peers: ['https://fallback-peer.example.test/gun'],
+      });
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true, story_id: STORY.story_id }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }))
+        .mockResolvedValueOnce(new Response(JSON.stringify({ ok: false }), {
+          status: 503,
+          headers: { 'content-type': 'application/json' },
+        }))
+        .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true, story_id: STORY.story_id }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }));
+      vi.stubGlobal('fetch', fetchMock);
+
+      await expect(
+        writeNewsLatestIndexEntry(client, STORY.story_id, STORY.cluster_window_end, STORY),
+      ).resolves.toBeUndefined();
+
+      expect(mesh.writes).toEqual([]);
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+      expect(info).toHaveBeenCalledWith('[vh:news] relay REST write completed', expect.objectContaining({
+        path: '/vh/news/latest-index',
+        relay_success_count: 2,
+        relay_target_count: 3,
+        relay_required_success_count: 2,
+        relay_failed_endpoint_labels: ['https://gun-b.example.test'],
+        min_success_configured: true,
+      }));
+    } finally {
+      info.mockRestore();
+      vi.unstubAllGlobals();
+      restoreEnv();
+      restoreRuntimeConfig();
+    }
+  });
+
+  it('writeNewsLatestIndexEntry fails explicit 2-of-3 relay REST quorum with one validated success', async () => {
+    const restoreRuntimeConfig = withGunClientRuntimeConfig({
+      VH_NEWS_RELAY_REST_WRITE_FIRST: 'true',
+      VH_NEWS_RELAY_REST_WRITE_ORIGINS: '["https://gun-a.example.test","https://gun-b.example.test","https://gun-c.example.test"]',
+      VH_NEWS_RELAY_REST_WRITE_MIN_SUCCESS: '2',
+    });
+    const restoreEnv = withProcessEnv({ VH_RELAY_DAEMON_TOKEN: 'relay-token-redacted' });
+    try {
+      const mesh = createFakeMesh();
+      const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+      const client = createClient(mesh, guard, {
+        peers: ['https://fallback-peer.example.test/gun'],
+      });
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true, story_id: STORY.story_id }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }))
+        .mockResolvedValueOnce(new Response(JSON.stringify({ ok: false }), {
+          status: 503,
+          headers: { 'content-type': 'application/json' },
+        }))
+        .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true, story_id: 'wrong-story' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }));
+      vi.stubGlobal('fetch', fetchMock);
+
+      await expect(
+        writeNewsLatestIndexEntry(client, STORY.story_id, STORY.cluster_window_end, STORY),
+      ).rejects.toThrow(
+        'Relay REST news write failed for /vh/news/latest-index: 1/3 succeeded; required=2',
+      );
+      expect(mesh.writes).toEqual([]);
+    } finally {
+      vi.unstubAllGlobals();
+      restoreEnv();
+      restoreRuntimeConfig();
+    }
+  });
+
+  it('writeNewsRecordViaRelayRest fails before posting for invalid or impossible explicit quorum', async () => {
+    const restoreEnv = withProcessEnv({ VH_RELAY_DAEMON_TOKEN: 'relay-token-redacted' });
+    try {
+      const mesh = createFakeMesh();
+      const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+      const client = createClient(mesh, guard, {
+        peers: ['https://gun-a.example.test/gun', 'https://gun-b.example.test/gun'],
+      });
+      const fetchMock = vi.fn();
+      vi.stubGlobal('fetch', fetchMock);
+
+      const restoreInvalidConfig = withGunClientRuntimeConfig({
+        VH_NEWS_RELAY_REST_WRITE_MIN_SUCCESS: '2.5',
+      });
+      try {
+        await expect(newsAdapterInternal.writeNewsRecordViaRelayRest({
+          client,
+          path: '/vh/news/story',
+          record: { story_id: STORY.story_id },
+          writeClass: 'news-story',
+          validate: () => true,
+        })).rejects.toThrow('Invalid VH_NEWS_RELAY_REST_WRITE_MIN_SUCCESS');
+      } finally {
+        restoreInvalidConfig();
+      }
+
+      const restoreImpossibleConfig = withGunClientRuntimeConfig({
+        VH_NEWS_RELAY_REST_WRITE_MIN_SUCCESS: '3',
+      });
+      try {
+        await expect(newsAdapterInternal.writeNewsRecordViaRelayRest({
+          client,
+          path: '/vh/news/story',
+          record: { story_id: STORY.story_id },
+          writeClass: 'news-story',
+          validate: () => true,
+        })).rejects.toThrow('Impossible VH_NEWS_RELAY_REST_WRITE_MIN_SUCCESS=3: only 2 relay REST endpoint(s) resolved');
+      } finally {
+        restoreImpossibleConfig();
+      }
+
+      expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      vi.unstubAllGlobals();
+      restoreEnv();
+    }
+  });
+
+  it('resolves relay REST quorum edge cases without posting', () => {
+    expect(() => newsAdapterInternal.resolveNewsRelayRestWriteQuorum(0))
+      .toThrow('Relay REST news write quorum requires at least one resolved endpoint');
+    expect(newsAdapterInternal.relayRestEndpointLabel('not a url')).toBe('invalid-relay-endpoint');
+
+    const restoreZeroConfig = withGunClientRuntimeConfig({
+      VH_NEWS_RELAY_REST_WRITE_MIN_SUCCESS: '0',
+    });
+    try {
+      expect(() => newsAdapterInternal.resolveNewsRelayRestWriteQuorum(2))
+        .toThrow('Invalid VH_NEWS_RELAY_REST_WRITE_MIN_SUCCESS');
+    } finally {
+      restoreZeroConfig();
+    }
+  });
+
+  it('writeNewsRecordViaRelayRest preserves legacy require_all=false one-success behavior', async () => {
+    const restoreRuntimeConfig = withGunClientRuntimeConfig({
+      VH_NEWS_RELAY_REST_WRITE_ORIGINS: '["https://gun-a.example.test","https://gun-b.example.test"]',
+      VH_NEWS_RELAY_REST_WRITE_REQUIRE_ALL: 'false',
+    });
+    const restoreEnv = withProcessEnv({ VH_RELAY_DAEMON_TOKEN: 'relay-token-redacted' });
+    const info = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+    try {
+      const mesh = createFakeMesh();
+      const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+      const client = createClient(mesh, guard, {
+        peers: ['https://fallback-peer.example.test/gun'],
+      });
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }))
+        .mockResolvedValueOnce(new Response(JSON.stringify({ ok: false }), {
+          status: 503,
+          headers: { 'content-type': 'application/json' },
+        }));
+      vi.stubGlobal('fetch', fetchMock);
+
+      await expect(newsAdapterInternal.writeNewsRecordViaRelayRest({
+        client,
+        path: '/vh/news/story',
+        record: { story_id: STORY.story_id },
+        writeClass: 'news-story',
+        validate: (payload) => payload.ok === true,
+      })).resolves.toBeUndefined();
+
+      expect(info).toHaveBeenCalledWith('[vh:news] relay REST write completed', expect.objectContaining({
+        relay_success_count: 1,
+        relay_target_count: 2,
+        relay_required_success_count: 1,
+        require_all: false,
+        min_success_configured: false,
+      }));
+    } finally {
+      info.mockRestore();
+      vi.unstubAllGlobals();
+      restoreEnv();
+      restoreRuntimeConfig();
+    }
+  });
+
+  it('writeNewsRecordViaRelayRest rejects impossible quorum after runtime endpoints shrink', async () => {
+    const restoreRuntimeConfig = withGunClientRuntimeConfig({
+      VH_NEWS_RELAY_REST_WRITE_ORIGINS: 'https://gun-a.example.test,mailto:bad,https://gun-b.example.test,https://gun-a.example.test',
+      VH_NEWS_RELAY_REST_WRITE_MIN_SUCCESS: '3',
+    });
+    const restoreEnv = withProcessEnv({ VH_RELAY_DAEMON_TOKEN: 'relay-token-redacted' });
+    try {
+      const mesh = createFakeMesh();
+      const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+      const client = createClient(mesh, guard, {
+        peers: ['https://fallback-peer.example.test/gun'],
+      });
+      const fetchMock = vi.fn();
+      vi.stubGlobal('fetch', fetchMock);
+
+      expect(newsAdapterInternal.resolveRelayRestWriteEndpoints(client, '/vh/news/story')).toEqual([
+        'https://gun-a.example.test/vh/news/story',
+        'https://gun-b.example.test/vh/news/story',
+      ]);
+      await expect(newsAdapterInternal.writeNewsRecordViaRelayRest({
+        client,
+        path: '/vh/news/story',
+        record: { story_id: STORY.story_id },
+        writeClass: 'news-story',
+        validate: () => true,
+      })).rejects.toThrow('Impossible VH_NEWS_RELAY_REST_WRITE_MIN_SUCCESS=3: only 2 relay REST endpoint(s) resolved');
+      expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      vi.unstubAllGlobals();
+      restoreEnv();
+      restoreRuntimeConfig();
+    }
+  });
+
   it('writeNewsRecordViaRelayRest uses per-origin daemon tokens when relays differ', async () => {
     const restoreRuntimeConfig = withGunClientRuntimeConfig({
       VH_NEWS_RELAY_REST_WRITE_ORIGINS: '["https://gun-a.example.test","https://gun-b.example.test"]',

--- a/packages/gun-client/src/newsAdapters.ts
+++ b/packages/gun-client/src/newsAdapters.ts
@@ -196,6 +196,10 @@ const RELAY_REST_NEWS_WRITE_REQUIRE_ALL_ENV = [
   'VITE_VH_NEWS_RELAY_REST_WRITE_REQUIRE_ALL',
   'VH_NEWS_RELAY_REST_WRITE_REQUIRE_ALL',
 ] as const;
+const RELAY_REST_NEWS_WRITE_MIN_SUCCESS_ENV = [
+  'VITE_VH_NEWS_RELAY_REST_WRITE_MIN_SUCCESS',
+  'VH_NEWS_RELAY_REST_WRITE_MIN_SUCCESS',
+] as const;
 const RELAY_REST_NEWS_WRITE_TOKEN_MAP_ENV = [
   'VITE_VH_NEWS_RELAY_REST_WRITE_TOKENS',
   'VH_NEWS_RELAY_REST_WRITE_TOKENS',
@@ -268,6 +272,16 @@ function readFirstRuntimeList(names: readonly string[]): string[] {
   return [];
 }
 
+function readFirstRuntimeString(names: readonly string[]): string | undefined {
+  for (const name of names) {
+    const raw = readNewsRuntimeString(name);
+    if (raw) {
+      return raw;
+    }
+  }
+  return undefined;
+}
+
 function uniqueStrings(values: readonly string[]): string[] {
   return [...new Set(values)];
 }
@@ -278,6 +292,64 @@ function shouldWriteNewsViaRelayRestFirst(): boolean {
 
 function shouldRequireAllNewsRelayRestWrites(): boolean {
   return readNewsRuntimeBoolean(RELAY_REST_NEWS_WRITE_REQUIRE_ALL_ENV, true);
+}
+
+interface RelayRestWriteQuorum {
+  readonly requiredSuccessCount: number;
+  readonly minSuccessConfigured: boolean;
+  readonly requireAll: boolean;
+}
+
+function parseRelayRestMinSuccess(raw: string | undefined): number | null | undefined {
+  if (!raw) {
+    return undefined;
+  }
+  if (!/^[0-9]+$/.test(raw)) {
+    return null;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isSafeInteger(parsed) && parsed >= 1 ? parsed : null;
+}
+
+function resolveNewsRelayRestWriteQuorum(endpointCount: number): RelayRestWriteQuorum {
+  const rawMinSuccess = readFirstRuntimeString(RELAY_REST_NEWS_WRITE_MIN_SUCCESS_ENV);
+  const parsedMinSuccess = parseRelayRestMinSuccess(rawMinSuccess);
+  const requireAll = shouldRequireAllNewsRelayRestWrites();
+
+  if (endpointCount <= 0) {
+    throw new Error('Relay REST news write quorum requires at least one resolved endpoint');
+  }
+  if (parsedMinSuccess === null) {
+    throw new Error(
+      `Invalid VH_NEWS_RELAY_REST_WRITE_MIN_SUCCESS: expected integer 1..${endpointCount}, received ${JSON.stringify(rawMinSuccess)}`,
+    );
+  }
+  if (parsedMinSuccess !== undefined) {
+    if (parsedMinSuccess > endpointCount) {
+      throw new Error(
+        `Impossible VH_NEWS_RELAY_REST_WRITE_MIN_SUCCESS=${parsedMinSuccess}: only ${endpointCount} relay REST endpoint(s) resolved`,
+      );
+    }
+    return {
+      requiredSuccessCount: parsedMinSuccess,
+      minSuccessConfigured: true,
+      requireAll,
+    };
+  }
+
+  return {
+    requiredSuccessCount: requireAll ? endpointCount : 1,
+    minSuccessConfigured: false,
+    requireAll,
+  };
+}
+
+function relayRestEndpointLabel(endpoint: string): string {
+  try {
+    return new URL(endpoint).origin;
+  } catch {
+    return 'invalid-relay-endpoint';
+  }
 }
 
 function normalizeLatestIndexReadLimit(limit: unknown, fallback = RELAY_REST_INDEX_LIMIT): number {
@@ -2225,15 +2297,17 @@ async function writeNewsRecordViaRelayRest(input: {
   if (endpoints.length === 0) {
     throw new Error(`No relay REST endpoints configured for ${input.path}`);
   }
+  const quorum = resolveNewsRelayRestWriteQuorum(endpoints.length);
   const relayTargets = endpoints.map((endpoint) => ({
     endpoint,
     headers: requireNewsRelayDaemonAuthHeaders(endpoint),
   }));
-  const requireAll = shouldRequireAllNewsRelayRestWrites();
   const failures: string[] = [];
+  const failedEndpointLabels: string[] = [];
   let successCount = 0;
 
   for (const { endpoint, headers } of relayTargets) {
+    const endpointLabel = relayRestEndpointLabel(endpoint);
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), RELAY_REST_WRITE_TIMEOUT_MS);
     try {
@@ -2251,27 +2325,32 @@ async function writeNewsRecordViaRelayRest(input: {
         successCount += 1;
         continue;
       }
-      failures.push(`${endpoint}:http_${response.status}`);
+      failedEndpointLabels.push(endpointLabel);
+      failures.push(`${endpointLabel}:http_${response.status}`);
     } catch (error) {
-      failures.push(`${endpoint}:${error instanceof Error ? error.message : String(error)}`);
+      failedEndpointLabels.push(endpointLabel);
+      failures.push(`${endpointLabel}:${error instanceof Error ? error.message : String(error)}`);
     } finally {
       clearTimeout(timeout);
     }
   }
 
-  if (successCount > 0 && (!requireAll || successCount === endpoints.length)) {
+  if (successCount >= quorum.requiredSuccessCount) {
     console.info('[vh:news] relay REST write completed', {
       write_class: input.writeClass,
       path: input.path,
       relay_success_count: successCount,
       relay_target_count: endpoints.length,
-      require_all: requireAll,
+      relay_required_success_count: quorum.requiredSuccessCount,
+      relay_failed_endpoint_labels: failedEndpointLabels,
+      require_all: quorum.requireAll,
+      min_success_configured: quorum.minSuccessConfigured,
     });
     return;
   }
 
   throw new Error(
-    `Relay REST news write failed for ${input.path}: ${successCount}/${endpoints.length} succeeded; ${failures.join('; ')}`,
+    `Relay REST news write failed for ${input.path}: ${successCount}/${endpoints.length} succeeded; required=${quorum.requiredSuccessCount}; failed=${failures.join('; ')}`,
   );
 }
 
@@ -3251,7 +3330,9 @@ export const newsAdapterInternal = {
   parseNewsSynthesisLifecycleFromRelayPayload,
   parseLatestIndexEntryPayload,
   parseHotIndexEntryPayload,
+  relayRestEndpointLabel,
   resolveRelayRestWriteEndpoints,
+  resolveNewsRelayRestWriteQuorum,
   shouldRequireAllNewsRelayRestWrites,
   shouldWriteNewsViaRelayRestFirst,
   writeNewsRecordViaRelayRest,

--- a/services/news-aggregator/src/relayRestSynthesisWriters.test.ts
+++ b/services/news-aggregator/src/relayRestSynthesisWriters.test.ts
@@ -15,6 +15,16 @@ const CLIENT = {
   },
 } as VennClient;
 
+const CLIENT_3 = {
+  config: {
+    peers: [
+      'wss://gun-a.example.test/gun',
+      'wss://gun-b.example.test/gun',
+      'wss://gun-c.example.test/gun',
+    ],
+  },
+} as VennClient;
+
 const SYNTHESIS: TopicSynthesisV2 = {
   schemaVersion: 'topic-synthesis-v2',
   topic_id: 'topic-1',
@@ -188,6 +198,142 @@ describe('relayRestSynthesisWriters', () => {
     expect(postCalls.every(([, init]) => (
       (init?.headers as Record<string, string>).Authorization === 'Bearer relay-token'
     ))).toBe(true);
+  });
+
+  it('accepts explicit 2-of-3 quorum for accepted synthesis writes', async () => {
+    vi.stubEnv('VH_BUNDLE_SYNTHESIS_WRITE_RELAY_REST', 'true');
+    vi.stubEnv('VH_BUNDLE_SYNTHESIS_RELAY_WRITE_MIN_SUCCESS', '2');
+    vi.stubEnv('VH_BUNDLE_SYNTHESIS_RELAY_WRITE_REQUIRE_ALL', 'true');
+    vi.stubEnv('VH_RELAY_DAEMON_TOKEN', 'relay-token');
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (init?.method === 'GET' && url.includes('/vh/topics/synthesis?')) {
+        return jsonResponse({ ok: false, error: 'topic-synthesis-not-found' }, { status: 404 });
+      }
+      if (init?.method === 'POST' && url.includes('gun-a')) {
+        return jsonResponse({
+          ok: true,
+          topic_id: SYNTHESIS.topic_id,
+          synthesis_id: SYNTHESIS.synthesis_id,
+        });
+      }
+      if (init?.method === 'POST' && url.includes('gun-b')) {
+        return jsonResponse({ ok: false }, { status: 503 });
+      }
+      if (init?.method === 'POST' && url.includes('gun-c')) {
+        return jsonResponse({
+          ok: true,
+          topic_id: SYNTHESIS.topic_id,
+          synthesis_id: SYNTHESIS.synthesis_id,
+        });
+      }
+      return jsonResponse({ ok: false }, { status: 500 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const writers = createRelayRestSynthesisWritersFromEnv(CLIENT_3, logger);
+    await expect(writers.writeLatest?.(CLIENT_3, SYNTHESIS)).resolves.toMatchObject({
+      status: 'written',
+      synthesis: SYNTHESIS,
+      previous: null,
+    });
+
+    expect(logger.info).toHaveBeenCalledWith('[vh:bundle-synthesis] relay REST write completed', expect.objectContaining({
+      path: '/vh/topics/synthesis',
+      relay_success_count: 2,
+      relay_target_count: 3,
+      relay_required_success_count: 2,
+      relay_failed_endpoint_labels: ['https://gun-b.example.test'],
+      min_success_configured: true,
+    }));
+  });
+
+  it('fails explicit 2-of-3 quorum for synthesis writes with one validated success', async () => {
+    vi.stubEnv('VH_BUNDLE_SYNTHESIS_WRITE_RELAY_REST', 'true');
+    vi.stubEnv('VH_BUNDLE_SYNTHESIS_RELAY_WRITE_MIN_SUCCESS', '2');
+    vi.stubEnv('VH_RELAY_DAEMON_TOKEN', 'relay-token');
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({
+        ok: true,
+        topic_id: CANDIDATE.topic_id,
+        candidate_id: CANDIDATE.candidate_id,
+      }))
+      .mockResolvedValueOnce(jsonResponse({ ok: false }, { status: 503 }))
+      .mockResolvedValueOnce(jsonResponse({
+        ok: true,
+        topic_id: CANDIDATE.topic_id,
+        candidate_id: 'wrong-candidate',
+      }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const writers = createRelayRestSynthesisWritersFromEnv(CLIENT_3, console);
+    await expect(writers.writeCandidate?.(CLIENT_3, CANDIDATE))
+      .rejects.toThrow('Relay REST write failed for /vh/topics/synthesis-candidate: 1/3 succeeded; required=2');
+  });
+
+  it('fails before posting synthesis writes for invalid or impossible explicit quorum', async () => {
+    vi.stubEnv('VH_BUNDLE_SYNTHESIS_WRITE_RELAY_REST', 'true');
+    vi.stubEnv('VH_RELAY_DAEMON_TOKEN', 'relay-token');
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    vi.stubEnv('VH_BUNDLE_SYNTHESIS_RELAY_WRITE_MIN_SUCCESS', '0');
+    let writers = createRelayRestSynthesisWritersFromEnv(CLIENT, console);
+    await expect(writers.writeCandidate?.(CLIENT, CANDIDATE))
+      .rejects.toThrow('Invalid VH_BUNDLE_SYNTHESIS_RELAY_WRITE_MIN_SUCCESS');
+
+    vi.stubEnv('VH_BUNDLE_SYNTHESIS_RELAY_WRITE_MIN_SUCCESS', '3');
+    writers = createRelayRestSynthesisWritersFromEnv(CLIENT, console);
+    await expect(writers.writeCandidate?.(CLIENT, CANDIDATE))
+      .rejects.toThrow('Impossible VH_BUNDLE_SYNTHESIS_RELAY_WRITE_MIN_SUCCESS=3: only 2 relay REST endpoint(s) resolved');
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('preserves legacy synthesis require_all=false one-success behavior when min success is absent', async () => {
+    vi.stubEnv('VH_BUNDLE_SYNTHESIS_WRITE_RELAY_REST', 'true');
+    vi.stubEnv('VH_BUNDLE_SYNTHESIS_RELAY_WRITE_REQUIRE_ALL', 'false');
+    vi.stubEnv('VH_RELAY_DAEMON_TOKEN', 'relay-token');
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({
+        ok: true,
+        topic_id: CANDIDATE.topic_id,
+        candidate_id: CANDIDATE.candidate_id,
+      }))
+      .mockResolvedValueOnce(jsonResponse({ ok: false }, { status: 503 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const writers = createRelayRestSynthesisWritersFromEnv(CLIENT, logger);
+    await expect(writers.writeCandidate?.(CLIENT, CANDIDATE)).resolves.toEqual(CANDIDATE);
+
+    expect(logger.info).toHaveBeenCalledWith('[vh:bundle-synthesis] relay REST write completed', expect.objectContaining({
+      relay_success_count: 1,
+      relay_target_count: 2,
+      relay_required_success_count: 1,
+      require_all: false,
+      min_success_configured: false,
+    }));
+  });
+
+  it('rejects impossible synthesis quorum after runtime endpoints shrink', async () => {
+    vi.stubEnv('VH_BUNDLE_SYNTHESIS_WRITE_RELAY_REST', 'true');
+    vi.stubEnv(
+      'VH_BUNDLE_SYNTHESIS_RELAY_WRITE_ORIGINS',
+      'https://gun-a.example.test,mailto:bad,https://gun-b.example.test,https://gun-a.example.test',
+    );
+    vi.stubEnv('VH_BUNDLE_SYNTHESIS_RELAY_WRITE_MIN_SUCCESS', '3');
+    vi.stubEnv('VH_RELAY_DAEMON_TOKEN', 'relay-token');
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const writers = createRelayRestSynthesisWritersFromEnv(CLIENT_3, console);
+    await expect(writers.writeLifecycle?.(CLIENT_3, LIFECYCLE))
+      .rejects.toThrow('Impossible VH_BUNDLE_SYNTHESIS_RELAY_WRITE_MIN_SUCCESS=3: only 2 relay REST endpoint(s) resolved');
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('posts synthesis rows with per-origin daemon tokens from the news relay token map', async () => {

--- a/services/news-aggregator/src/relayRestSynthesisWriters.ts
+++ b/services/news-aggregator/src/relayRestSynthesisWriters.ts
@@ -14,6 +14,7 @@ import type { LoggerLike } from './daemonUtils';
 const WRITE_RELAY_REST_ENV = 'VH_BUNDLE_SYNTHESIS_WRITE_RELAY_REST';
 const WRITE_RELAY_ORIGINS_ENV = 'VH_BUNDLE_SYNTHESIS_RELAY_WRITE_ORIGINS';
 const REQUIRE_ALL_ENV = 'VH_BUNDLE_SYNTHESIS_RELAY_WRITE_REQUIRE_ALL';
+const MIN_SUCCESS_ENV = 'VH_BUNDLE_SYNTHESIS_RELAY_WRITE_MIN_SUCCESS';
 const RELAY_TOKEN_MAP_ENV_NAMES = [
   'VH_BUNDLE_SYNTHESIS_RELAY_WRITE_TOKENS',
   'VH_NEWS_RELAY_REST_WRITE_TOKENS',
@@ -84,6 +85,64 @@ function shouldRequireAllRelayWrites(): boolean {
   return true;
 }
 
+interface RelayRestWriteQuorum {
+  readonly requiredSuccessCount: number;
+  readonly minSuccessConfigured: boolean;
+  readonly requireAll: boolean;
+}
+
+function parseMinSuccess(raw: string | undefined): number | null | undefined {
+  if (!raw) {
+    return undefined;
+  }
+  if (!/^[0-9]+$/.test(raw)) {
+    return null;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isSafeInteger(parsed) && parsed >= 1 ? parsed : null;
+}
+
+function resolveRelayWriteQuorum(endpointCount: number): RelayRestWriteQuorum {
+  const rawMinSuccess = readEnv(MIN_SUCCESS_ENV);
+  const parsedMinSuccess = parseMinSuccess(rawMinSuccess);
+  const requireAll = shouldRequireAllRelayWrites();
+
+  if (endpointCount <= 0) {
+    throw new Error('Relay REST bundle synthesis write quorum requires at least one resolved endpoint');
+  }
+  if (parsedMinSuccess === null) {
+    throw new Error(
+      `Invalid ${MIN_SUCCESS_ENV}: expected integer 1..${endpointCount}, received ${JSON.stringify(rawMinSuccess)}`,
+    );
+  }
+  if (parsedMinSuccess !== undefined) {
+    if (parsedMinSuccess > endpointCount) {
+      throw new Error(
+        `Impossible ${MIN_SUCCESS_ENV}=${parsedMinSuccess}: only ${endpointCount} relay REST endpoint(s) resolved`,
+      );
+    }
+    return {
+      requiredSuccessCount: parsedMinSuccess,
+      minSuccessConfigured: true,
+      requireAll,
+    };
+  }
+
+  return {
+    requiredSuccessCount: requireAll ? endpointCount : 1,
+    minSuccessConfigured: false,
+    requireAll,
+  };
+}
+
+function relayEndpointLabel(endpoint: string): string {
+  try {
+    return new URL(endpoint).origin;
+  } catch {
+    return 'invalid-relay-endpoint';
+  }
+}
+
 function relayAuthHeaders(endpoint: string): Record<string, string> {
   const headers = createRelayDaemonAuthHeadersForEndpoint(endpoint, {
     tokenMapEnvNames: RELAY_TOKEN_MAP_ENV_NAMES,
@@ -111,15 +170,17 @@ async function postJsonToRelays(input: {
   if (endpoints.length === 0) {
     throw new Error(`No relay REST endpoints configured for ${input.path}`);
   }
-  const requireAll = shouldRequireAllRelayWrites();
+  const quorum = resolveRelayWriteQuorum(endpoints.length);
   const relayTargets = endpoints.map((endpoint) => ({
     endpoint,
     headers: relayAuthHeaders(endpoint),
   }));
   const failures: string[] = [];
+  const failedEndpointLabels: string[] = [];
   let successCount = 0;
 
   for (const { endpoint, headers } of relayTargets) {
+    const endpointLabel = relayEndpointLabel(endpoint);
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), DEFAULT_RELAY_WRITE_TIMEOUT_MS);
     try {
@@ -137,26 +198,31 @@ async function postJsonToRelays(input: {
         successCount += 1;
         continue;
       }
-      failures.push(`${endpoint}:http_${response.status}`);
+      failedEndpointLabels.push(endpointLabel);
+      failures.push(`${endpointLabel}:http_${response.status}`);
     } catch (error) {
-      failures.push(`${endpoint}:${error instanceof Error ? error.message : String(error)}`);
+      failedEndpointLabels.push(endpointLabel);
+      failures.push(`${endpointLabel}:${error instanceof Error ? error.message : String(error)}`);
     } finally {
       clearTimeout(timeout);
     }
   }
 
-  if (successCount > 0 && (!requireAll || successCount === endpoints.length)) {
+  if (successCount >= quorum.requiredSuccessCount) {
     input.logger.info('[vh:bundle-synthesis] relay REST write completed', {
       path: input.path,
       relay_success_count: successCount,
       relay_target_count: endpoints.length,
-      require_all: requireAll,
+      relay_required_success_count: quorum.requiredSuccessCount,
+      relay_failed_endpoint_labels: failedEndpointLabels,
+      require_all: quorum.requireAll,
+      min_success_configured: quorum.minSuccessConfigured,
     });
     return;
   }
 
   throw new Error(
-    `Relay REST write failed for ${input.path}: ${successCount}/${endpoints.length} succeeded; ${failures.join('; ')}`,
+    `Relay REST write failed for ${input.path}: ${successCount}/${endpoints.length} succeeded; required=${quorum.requiredSuccessCount}; failed=${failures.join('; ')}`,
   );
 }
 

--- a/tools/scripts/news-aggregator-publisher-preflight.mjs
+++ b/tools/scripts/news-aggregator-publisher-preflight.mjs
@@ -16,6 +16,10 @@ function truthy(value) {
   return /^(1|true|yes|on)$/i.test(String(value ?? '').trim());
 }
 
+function explicitlyFalse(value) {
+  return /^(0|false|no|off)$/i.test(String(value ?? '').trim());
+}
+
 function parseDelimited(value) {
   const raw = String(value ?? '').trim();
   if (!raw) {
@@ -211,6 +215,59 @@ function relayTokenForUrl(url, tokenMap, fallbackToken) {
   return tokenMap.get(origin) ?? fallbackToken;
 }
 
+function parseMinSuccess(value, failurePrefix, endpointCount, failures) {
+  const raw = String(value ?? '').trim();
+  if (!raw) {
+    return { configured: false, value: null };
+  }
+  if (!/^[0-9]+$/.test(raw)) {
+    failures.push(`${failurePrefix}:invalid`);
+    return { configured: true, value: null };
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isSafeInteger(parsed) || parsed < 1) {
+    failures.push(`${failurePrefix}:invalid`);
+    return { configured: true, value: null };
+  }
+  if (parsed > endpointCount) {
+    failures.push(`${failurePrefix}:impossible:${parsed}_gt_${endpointCount}`);
+  }
+  return { configured: true, value: parsed };
+}
+
+function relayRequiredSuccessCount({
+  active,
+  endpointCount,
+  minSuccessRaw,
+  requireAll,
+  failurePrefix,
+  failures,
+}) {
+  const parsed = parseMinSuccess(minSuccessRaw, failurePrefix, endpointCount, failures);
+  if (!active || endpointCount <= 0) {
+    return {
+      min_success: parsed.value,
+      min_success_configured: parsed.configured,
+      endpoint_count: endpointCount,
+      required_success_count: 0,
+    };
+  }
+  if (parsed.configured) {
+    return {
+      min_success: parsed.value,
+      min_success_configured: true,
+      endpoint_count: endpointCount,
+      required_success_count: parsed.value ?? 0,
+    };
+  }
+  return {
+    min_success: null,
+    min_success_configured: false,
+    endpoint_count: endpointCount,
+    required_success_count: requireAll ? endpointCount : 1,
+  };
+}
+
 function collectMissingRelayTokens({
   failures,
   failurePrefix,
@@ -305,6 +362,8 @@ export async function runNewsAggregatorPublisherPreflight({
     || relayRestOrigins.length > 0;
   const newsRelayRestOrigins = parseDelimited(env.VH_NEWS_RELAY_REST_WRITE_ORIGINS);
   const newsRelayRestWriteFirst = truthy(env.VH_NEWS_RELAY_REST_WRITE_FIRST);
+  const newsRelayRestRequireAll = !explicitlyFalse(env.VH_NEWS_RELAY_REST_WRITE_REQUIRE_ALL);
+  const synthesisRelayRestRequireAll = !explicitlyFalse(env.VH_BUNDLE_SYNTHESIS_RELAY_WRITE_REQUIRE_ALL);
   const fallbackRelayDaemonToken = firstNonEmpty(env.VH_RELAY_DAEMON_TOKEN);
   const newsRelayRestTokenMap = readRelayTokenMap(
     env,
@@ -343,6 +402,25 @@ export async function runNewsAggregatorPublisherPreflight({
       failures,
     ))
     .filter(Boolean))];
+  const newsRelayRestQuorum = relayRequiredSuccessCount({
+    active: newsRelayRestWriteFirst,
+    endpointCount: newsRelayRestWriteAuthUrls.length,
+    minSuccessRaw: firstNonEmpty(
+      env.VH_NEWS_RELAY_REST_WRITE_MIN_SUCCESS,
+      env.VITE_VH_NEWS_RELAY_REST_WRITE_MIN_SUCCESS,
+    ),
+    requireAll: newsRelayRestRequireAll,
+    failurePrefix: 'relay_rest_news_min_success',
+    failures,
+  });
+  const synthesisRelayRestQuorum = relayRequiredSuccessCount({
+    active: synthesisEnabled,
+    endpointCount: synthesisRelayRestAuthUrls.length,
+    minSuccessRaw: env.VH_BUNDLE_SYNTHESIS_RELAY_WRITE_MIN_SUCCESS,
+    requireAll: synthesisRelayRestRequireAll,
+    failurePrefix: 'relay_rest_synthesis_min_success',
+    failures,
+  });
   const synthesisRelayTokensByUrl = collectMissingRelayTokens({
     failures,
     failurePrefix: 'relay_rest_synthesis_token',
@@ -452,6 +530,11 @@ export async function runNewsAggregatorPublisherPreflight({
     relay_rest_synthesis: {
       requested: relayRestWriteRequested,
       origin_count: relayRestOrigins.length,
+      endpoint_count: synthesisRelayRestQuorum.endpoint_count,
+      require_all: synthesisRelayRestRequireAll,
+      min_success: synthesisRelayRestQuorum.min_success,
+      min_success_configured: synthesisRelayRestQuorum.min_success_configured,
+      required_success_count: synthesisRelayRestQuorum.required_success_count,
       daemon_token_present: Boolean(fallbackRelayDaemonToken),
       per_origin_token_count: synthesisRelayRestTokenMap.size,
       all_target_tokens_present: synthesisEnabled
@@ -461,7 +544,11 @@ export async function runNewsAggregatorPublisherPreflight({
     relay_rest_news_publication: {
       write_first: newsRelayRestWriteFirst,
       origin_count: newsRelayRestWriteAuthUrls.length,
-      require_all: !/^(0|false|no|off)$/i.test(String(env.VH_NEWS_RELAY_REST_WRITE_REQUIRE_ALL ?? '').trim()),
+      endpoint_count: newsRelayRestQuorum.endpoint_count,
+      require_all: newsRelayRestRequireAll,
+      min_success: newsRelayRestQuorum.min_success,
+      min_success_configured: newsRelayRestQuorum.min_success_configured,
+      required_success_count: newsRelayRestQuorum.required_success_count,
       daemon_token_present: Boolean(fallbackRelayDaemonToken),
       per_origin_token_count: newsRelayRestTokenMap.size,
       all_target_tokens_present: newsRelayRestWriteFirst
@@ -489,6 +576,7 @@ export const newsAggregatorPublisherPreflightInternal = {
   parseDelimited,
   relayHealthUrlFromPeer,
   relayRestWriteUrlFromOrigin,
+  relayRequiredSuccessCount,
   truthy,
 };
 

--- a/tools/scripts/news-aggregator-publisher-preflight.test.mjs
+++ b/tools/scripts/news-aggregator-publisher-preflight.test.mjs
@@ -120,7 +120,11 @@ test('publisher preflight checks relay health with redacted pass output', async 
   assert.deepEqual(result.relay_rest_news_publication, {
     write_first: true,
     origin_count: 2,
+    endpoint_count: 2,
     require_all: true,
+    min_success: null,
+    min_success_configured: false,
+    required_success_count: 2,
     daemon_token_present: true,
     per_origin_token_count: 0,
     all_target_tokens_present: true,
@@ -139,6 +143,80 @@ test('publisher preflight checks relay health with redacted pass output', async 
       },
     ],
   });
+});
+
+test('publisher preflight reports raw and synthesis explicit relay REST quorum', async () => {
+  const result = await runNewsAggregatorPublisherPreflight({
+    env: baseEnv({
+      VH_NEWS_RELAY_REST_WRITE_FIRST: 'true',
+      VH_NEWS_RELAY_REST_WRITE_ORIGINS: 'https://gun-a.example.test,https://gun-b.example.test,https://gun-c.example.test',
+      VH_NEWS_RELAY_REST_WRITE_REQUIRE_ALL: 'true',
+      VH_NEWS_RELAY_REST_WRITE_MIN_SUCCESS: '2',
+      VH_BUNDLE_SYNTHESIS_RELAY_WRITE_ORIGINS: 'https://gun-a.example.test,https://gun-b.example.test,https://gun-c.example.test',
+      VH_BUNDLE_SYNTHESIS_RELAY_WRITE_REQUIRE_ALL: 'true',
+      VH_BUNDLE_SYNTHESIS_RELAY_WRITE_MIN_SUCCESS: '2',
+    }),
+    fetchFn: async (input, init) => {
+      if (init.method === 'POST') {
+        return new Response(JSON.stringify({ ok: false, error: 'news-story-record-required' }), {
+          status: 400,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    },
+  });
+
+  assert.equal(result.status, 'pass');
+  assert.deepEqual({
+    endpoint_count: result.relay_rest_news_publication.endpoint_count,
+    min_success: result.relay_rest_news_publication.min_success,
+    min_success_configured: result.relay_rest_news_publication.min_success_configured,
+    required_success_count: result.relay_rest_news_publication.required_success_count,
+  }, {
+    endpoint_count: 3,
+    min_success: 2,
+    min_success_configured: true,
+    required_success_count: 2,
+  });
+  assert.deepEqual({
+    endpoint_count: result.relay_rest_synthesis.endpoint_count,
+    min_success: result.relay_rest_synthesis.min_success,
+    min_success_configured: result.relay_rest_synthesis.min_success_configured,
+    required_success_count: result.relay_rest_synthesis.required_success_count,
+  }, {
+    endpoint_count: 3,
+    min_success: 2,
+    min_success_configured: true,
+    required_success_count: 2,
+  });
+});
+
+test('publisher preflight fails closed on invalid or impossible relay REST quorum', async () => {
+  let fetchCalled = false;
+  const result = await runNewsAggregatorPublisherPreflight({
+    env: baseEnv({
+      VH_NEWS_RELAY_REST_WRITE_FIRST: 'true',
+      VH_NEWS_RELAY_REST_WRITE_ORIGINS: 'https://gun-a.example.test,https://gun-b.example.test',
+      VH_NEWS_RELAY_REST_WRITE_MIN_SUCCESS: '3',
+      VH_BUNDLE_SYNTHESIS_RELAY_WRITE_ORIGINS: 'https://gun-a.example.test,https://gun-b.example.test',
+      VH_BUNDLE_SYNTHESIS_RELAY_WRITE_MIN_SUCCESS: 'two',
+    }),
+    fetchFn: async () => {
+      fetchCalled = true;
+      return new Response('{}');
+    },
+  });
+
+  assert.equal(result.status, 'fail');
+  assert.equal(fetchCalled, false);
+  assert.match(result.failures.join('\n'), /relay_rest_news_min_success:impossible:3_gt_2/);
+  assert.match(result.failures.join('\n'), /relay_rest_synthesis_min_success:invalid/);
+  assert.equal(result.relay_rest_news_publication.required_success_count, 3);
+  assert.equal(result.relay_rest_synthesis.required_success_count, 0);
 });
 
 test('publisher preflight fails closed when relay REST news auth rejects the daemon token', async () => {


### PR DESCRIPTION
## Summary

Adds explicit relay REST write quorum controls for both Phase 5 public-news write surfaces:

- raw news story/latest/hot/lifecycle writes in `packages/gun-client/src/newsAdapters.ts`
- bundle synthesis candidate/latest/lifecycle writes in `services/news-aggregator/src/relayRestSynthesisWriters.ts`
- publisher preflight reporting/fail-closed validation in `tools/scripts/news-aggregator-publisher-preflight.mjs`
- ops docs/env template for the production 2-of-3 policy

New env knobs:

- `VH_NEWS_RELAY_REST_WRITE_MIN_SUCCESS=2`
- `VITE_VH_NEWS_RELAY_REST_WRITE_MIN_SUCCESS=2`
- `VH_BUNDLE_SYNTHESIS_RELAY_WRITE_MIN_SUCCESS=2`

## Safety rationale

This is explicit 2-of-3, never 1-of-N. When `*_MIN_SUCCESS` is set, it overrides legacy `*_WRITE_REQUIRE_ALL` and is validated as an integer in `1..resolved_endpoint_count` after origin normalization/filtering/deduping. Zero endpoints, invalid values, and impossible quorum fail closed before posting.

When `*_MIN_SUCCESS` is unset, legacy behavior is unchanged: `require_all=true` still requires every resolved endpoint, and `require_all=false` still means at least one validated relay success.

Quorum counts only fully successful per-relay responses that pass the existing route payload validation/readback contract where the relay route provides it. Plain HTTP acceptance is not enough. Logs/errors include `relay_required_success_count` and failed relay origin labels without printing tokens/pins/key material.

This preserves #668 fail-closed runtime behavior: write errors still propagate as runtime failures and stop the daemon instead of letting the old write lane continue draining after an error.

MVP synthesis scope is recorded as B in the production runbook: accepted synthesis/frame tables on newest cards are launch-required, so `synthesis_pending` raw cards alone do not satisfy the final done gate.

## Verification

All commands run with Node `v20.20.0` via `PATH=/opt/homebrew/opt/node@20/bin:$PATH`.

- `pnpm --filter @vh/gun-client exec vitest run src/newsAdapters.test.ts --config ./vitest.config.ts` passed: 1 file, 152 tests.
- `pnpm --filter @vh/news-aggregator exec vitest run src/relayRestSynthesisWriters.test.ts --config ./vitest.config.ts` passed: 1 file, 11 tests.
- `node --test tools/scripts/news-aggregator-publisher-preflight.test.mjs` passed: 11 tests.
- `pnpm --filter @vh/news-aggregator exec vitest run src/daemonWriteLane.test.ts src/daemon.test.ts src/daemon.coverage.test.ts src/daemon.production.test.ts --config ./vitest.config.ts` passed: 4 files, 40 tests.
- `pnpm --filter @vh/gun-client build` passed.
- `pnpm --filter @vh/news-aggregator build` passed.
- `git diff --check` passed.
- `node tools/scripts/check-diff-coverage.mjs` passed: no coverage-eligible source files changed.
- `pnpm test:quick` passed: 319 files, 4,929 tests.

## Docs changed

- `docs/ops/news-aggregator.env.example` sets raw and synthesis min success to `2`.
- `docs/ops/news-aggregator-production-service.md` documents the production 2-of-3 policy, precedence over `require_all`, secret-safe proof fields, and scope B launch implications.
