### PR TITLE
Make Phase 5 optional enrichment nonfatal

### DIFF
--- a/apps/web-pwa/src/components/feed/NewsCard.storyline.test.tsx
+++ b/apps/web-pwa/src/components/feed/NewsCard.storyline.test.tsx
@@ -8,6 +8,7 @@ import { useNewsStore } from '../../store/news';
 import { useDiscoveryStore } from '../../store/discovery';
 import { useSynthesisStore } from '../../store/synthesis';
 import { NewsCard } from './NewsCard';
+import { resetExpandedCardStore } from './expandedCardStore';
 
 vi.mock('./newsCardAnalysis', () => ({
   synthesizeStoryFromAnalysisPipeline: vi.fn(),
@@ -92,6 +93,7 @@ describe('NewsCard related coverage', () => {
     useNewsStore.getState().reset();
     useDiscoveryStore.getState().reset();
     useSynthesisStore.getState().reset();
+    resetExpandedCardStore();
     vi.stubEnv('VITE_VH_ANALYSIS_PIPELINE', 'false');
   });
 
@@ -101,6 +103,7 @@ describe('NewsCard related coverage', () => {
     useNewsStore.getState().reset();
     useDiscoveryStore.getState().reset();
     useSynthesisStore.getState().reset();
+    resetExpandedCardStore();
   });
 
   it('renders related coverage from the storyline separately from canonical sources', async () => {
@@ -145,6 +148,28 @@ describe('NewsCard related coverage', () => {
 
     expect(useDiscoveryStore.getState().selectedStorylineId).toBe('storyline-transit');
     expect(screen.queryByTestId('news-card-back-news-1')).not.toBeInTheDocument();
+  });
+
+  it('renders normally when a raw card has a dangling storyline id', async () => {
+    useNewsStore.getState().setStories([makeStory()]);
+    useNewsStore.getState().setStorylines([]);
+
+    render(<NewsCard item={makeItem()} />);
+
+    expect(screen.getByTestId('news-card-news-1')).toHaveAttribute(
+      'data-storyline-id',
+      'storyline-transit',
+    );
+    expect(screen.getByTestId('news-card-front-news-1')).toBeInTheDocument();
+    expect(screen.queryByTestId('news-card-storyline-news-1')).not.toBeInTheDocument();
+    expect(useDiscoveryStore.getState().selectedStorylineId).toBeNull();
+
+    fireEvent.click(screen.getByTestId('news-card-headline-news-1'));
+
+    expect(await screen.findByTestId('news-card-back-news-1')).toBeInTheDocument();
+    expect(screen.queryByTestId('news-card-storyline-headline-news-1')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('news-card-related-coverage-news-1')).not.toBeInTheDocument();
+    expect(useDiscoveryStore.getState().selectedStorylineId).toBeNull();
   });
 
   it('opens from the card shell and closes with Escape without changing canonical source links', async () => {

--- a/docs/ops/news-aggregator-production-service.md
+++ b/docs/ops/news-aggregator-production-service.md
@@ -274,16 +274,21 @@ immediately after that completed summary. Set it to `false` only when first-tick
 caps, synthesis throughput, relay fanout, and the watchdog window have been
 recalibrated together.
 
-Current Phase 5 public-news MVP scope is **B**: accepted synthesis and frame
-tables on newest cards are launch-required. Raw-fresh, v4-signed, product-visible
-cards with `synthesis_pending` prove the raw publication path but do not satisfy
-the final "done" gate. The attended run must observe synthesis lifecycle advance
-from pending to accepted and accepted synthesis/frame-table rows write to the
-configured relay REST quorum before launch is complete.
+Current Phase 5 Scope A is raw-fresh, v4-signed, product-visible news cards.
+Raw bundle publication and the publish-time pending lifecycle row
+(`synthesis_pending` / `frame_table_pending`) are critical and fail-closed
+because they ride the relay REST write-through path with the configured 2-of-3
+quorum. Accepted synthesis, frame tables, storyline overlays, and stale storyline
+cleanup are post-launch enrichment for Scope A. Their failures must be counted in
+tick summaries and logged with safe identifiers and reasons, but they must not
+halt raw publication.
 
 Live mode also fail-closes runtime errors by default through
-`VH_NEWS_DAEMON_FAIL_CLOSED_ON_RUNTIME_ERROR=true`. A runtime error, including a
-partial relay REST quorum write, blocks further runtime writes, stops the
+`VH_NEWS_DAEMON_FAIL_CLOSED_ON_RUNTIME_ERROR=true`, but runtime write criticality
+is an explicit allow-list. Only raw bundle publication and the raw pending
+lifecycle write route to the fatal runtime `onError` path. Future write surfaces
+default to non-fatal telemetry unless they are deliberately added to that
+critical set. A critical runtime error blocks further runtime writes, stops the
 daemon loop, shuts down the process handle, and leaves systemd to report the
 service stopped instead of allowing the write lane to drain more public stories.
 Do not set it to `false` in production unless the incident commander has chosen
@@ -358,8 +363,8 @@ and synthesis lifecycle rows with the public news system writer, but it submits
 those records to the relay REST write-through routes before attempting any
 direct Gun publication.
 
-Phase 5 production policy is explicit 2-of-3 relay REST quorum for both raw
-public-news rows and bundle synthesis rows:
+Phase 5 production policy is explicit 2-of-3 relay REST quorum for raw
+public-news rows, the raw pending lifecycle row, and bundle synthesis rows:
 
 ```bash
 VH_NEWS_RELAY_REST_WRITE_MIN_SUCCESS=2
@@ -385,6 +390,15 @@ contract where that route provides one; plain HTTP acceptance is not enough.
 The preflight and write logs report `endpoint_count`, `required_success_count`,
 `relay_required_success_count`, and failed relay origin labels without printing
 tokens, pins, or key material.
+
+For Scope A launch gating, fail-closed only applies to the quorum-durable raw
+path: `/vh/news/story`, `/vh/news/latest-index`, `/vh/news/hot-index`, and the
+pending `/vh/news/synthesis-lifecycle` write created during raw publication.
+Storyline writes/removes still use direct Gun durability/readback and are
+therefore optional telemetry in this phase. Accepted synthesis writes keep their
+ledger, dead-letter, and audit behavior, but accepted synthesis availability is
+not a Scope A raw-feed gate. Migrating storyline persistence to relay REST quorum
+is a separate post-launch durability task.
 
 When relays have different daemon tokens, set `VH_NEWS_RELAY_REST_WRITE_TOKENS`
 to a JSON object mapping each relay origin to its token, for example:
@@ -618,13 +632,14 @@ Abort or stop the service if any of these occur:
 - source-health liveness preflight fails;
 - OpenAI preflight is not `pass`;
 - StoryCluster health check fails;
-- raw news or synthesis relay REST write fanout is below the configured
-  quorum target;
+- raw news or raw pending lifecycle relay REST write fanout is below the
+  configured quorum target;
 - snapshot watch reports stale newest-entry age above 6 hours;
 - latest content does not advance after approved start and expected ingest
   cadence.
 
 After an approved start, release evidence still requires
-`pnpm check:news-sources:health`, fresh content advance, synthesis
-lifecycle/publication evidence, public canary, and soak. The service starting
-successfully is not a release-ready claim.
+`pnpm check:news-sources:health`, fresh content advance, pending lifecycle
+evidence, public canary, and soak. Accepted synthesis and storyline enrichment
+evidence remain post-launch quality checks, not Scope A raw-feed start gates. The
+service starting successfully is not a release-ready claim.

--- a/packages/ai-engine/src/index.ts
+++ b/packages/ai-engine/src/index.ts
@@ -29,6 +29,8 @@ export type {
   NewsRuntimeConfig,
   NewsRuntimeEnrichmentWorkItem,
   NewsRuntimeHandle,
+  NewsRuntimeNonFatalErrorContext,
+  NewsRuntimeNonFatalErrorKind,
   NewsRuntimeSynthesisCandidate,
   NewsRuntimeTickStage,
   NewsRuntimeTickSummary,

--- a/packages/ai-engine/src/newsRuntime.storylines.test.ts
+++ b/packages/ai-engine/src/newsRuntime.storylines.test.ts
@@ -132,6 +132,7 @@ describe('newsRuntime storylines', () => {
     orchestrateNewsPipelineMock.mockResolvedValue(batch([STORY], [STORYLINE]));
 
     const onError = vi.fn();
+    const onNonFatalError = vi.fn();
     const writeStorylineGroup = vi.fn().mockRejectedValue(storylineError);
     const writeStoryBundle = vi.fn().mockResolvedValue(undefined);
 
@@ -140,6 +141,7 @@ describe('newsRuntime storylines', () => {
       writeStoryBundle,
       writeStorylineGroup,
       onError,
+      onNonFatalError,
       runOnStart: true,
       pollIntervalMs: 10,
     });
@@ -148,8 +150,63 @@ describe('newsRuntime storylines', () => {
 
     expect(writeStoryBundle).toHaveBeenCalledWith(BASE_CONFIG.gunClient, STORY);
     expect(writeStorylineGroup).toHaveBeenCalledWith(BASE_CONFIG.gunClient, STORYLINE);
-    expect(onError).toHaveBeenCalledWith(storylineError);
+    expect(onError).not.toHaveBeenCalled();
+    expect(onNonFatalError).toHaveBeenCalledWith(
+      storylineError,
+      expect.objectContaining({
+        kind: 'storyline_write_failed',
+        storyline_id: STORYLINE.storyline_id,
+        story_count: STORYLINE.story_ids.length,
+      }),
+    );
     expect(handle.lastRun()).toBeInstanceOf(Date);
+
+    handle.stop();
+  });
+
+  it('keeps publishing future raw bundles after optional storyline write rejection', async () => {
+    const nextStory = {
+      ...STORY,
+      story_id: 'story-2',
+      headline: 'Second headline',
+      provenance_hash: 'provhash-2',
+      created_at: STORY.created_at + 1,
+    };
+    orchestrateNewsPipelineMock
+      .mockResolvedValueOnce(batch([STORY], [STORYLINE]))
+      .mockResolvedValueOnce(batch([nextStory], []));
+
+    const onError = vi.fn();
+    const onNonFatalError = vi.fn();
+    const writeStorylineGroup = vi
+      .fn()
+      .mockRejectedValue(new Error('daemon write lane stopped after failure: storyline'));
+    const writeStoryBundle = vi.fn().mockResolvedValue(undefined);
+
+    const handle = startNewsRuntime({
+      ...BASE_CONFIG,
+      writeStoryBundle,
+      writeStorylineGroup,
+      onError,
+      onNonFatalError,
+      runOnStart: true,
+      pollIntervalMs: 10,
+    });
+
+    await flushTasks();
+    await vi.advanceTimersByTimeAsync(10);
+    await flushTasks();
+
+    expect(writeStoryBundle).toHaveBeenCalledWith(BASE_CONFIG.gunClient, STORY);
+    expect(writeStoryBundle).toHaveBeenCalledWith(BASE_CONFIG.gunClient, nextStory);
+    expect(onError).not.toHaveBeenCalled();
+    expect(onNonFatalError).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({
+        kind: 'storyline_write_failed',
+        storyline_id: STORYLINE.storyline_id,
+      }),
+    );
 
     handle.stop();
   });

--- a/packages/ai-engine/src/newsRuntime.test.ts
+++ b/packages/ai-engine/src/newsRuntime.test.ts
@@ -504,7 +504,7 @@ describe('newsRuntime', () => {
     handle.stop();
   });
 
-  it('continues concurrent raw publishing after a failed write and reports async enrichment errors', async () => {
+  it('continues concurrent raw publishing after a failed write and reports async enrichment as non-fatal', async () => {
     const failed = storyBundle('write-fails', { sourceCount: 2, clusterWindowEnd: 200 });
     const succeeds = storyBundle('write-succeeds', { sourceCount: 1, clusterWindowEnd: 100 });
     const writeError = new Error('relay quorum failed');
@@ -518,12 +518,14 @@ describe('newsRuntime', () => {
       }
     });
     const onError = vi.fn();
+    const onNonFatalError = vi.fn();
     const onSynthesisCandidate = vi.fn().mockRejectedValue(enrichmentError);
     const onTickSummary = vi.fn();
     const handle = startNewsRuntime({
       ...BASE_CONFIG,
       writeStoryBundle,
       onError,
+      onNonFatalError,
       onSynthesisCandidate,
       onTickSummary,
       createAdvancedArtifact: () => {
@@ -538,7 +540,14 @@ describe('newsRuntime', () => {
       expect(onTickSummary).toHaveBeenCalled();
     });
     await vi.waitFor(() => {
-      expect(onError).toHaveBeenCalledWith(enrichmentError);
+      expect(onNonFatalError).toHaveBeenCalledWith(
+        enrichmentError,
+        expect.objectContaining({
+          kind: 'synthesis_candidate_enqueue_failed',
+          story_id: 'write-succeeds',
+          work_item_count: 2,
+        }),
+      );
     });
 
     expect(writeStoryBundle.mock.calls.map((call) => call[1].story_id)).toEqual([
@@ -546,7 +555,14 @@ describe('newsRuntime', () => {
       'write-succeeds',
     ]);
     expect(onError).toHaveBeenCalledWith(writeError);
-    expect(onError).toHaveBeenCalledWith(artifactError);
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onNonFatalError).toHaveBeenCalledWith(
+      artifactError,
+      expect.objectContaining({
+        kind: 'advanced_artifact_failed',
+        story_id: 'write-succeeds',
+      }),
+    );
     expect(onSynthesisCandidate).toHaveBeenCalledTimes(1);
     expect(onSynthesisCandidate).toHaveBeenCalledWith(expect.objectContaining({
       story_id: 'write-succeeds',
@@ -902,7 +918,7 @@ describe('newsRuntime', () => {
     handle.stop();
   });
 
-  it('reports stale story and storyline cleanup failures without failing the tick', async () => {
+  it('reports stale story and storyline cleanup failures as non-fatal telemetry without failing the tick', async () => {
     const storyTwo = storyBundle('story-2', { sourceCount: 2, clusterWindowEnd: 200 });
     const storylineTwo = storylineGroup('storyline-2', ['story-2']);
     const removeStoryError = new Error('story remove failed');
@@ -922,6 +938,7 @@ describe('newsRuntime', () => {
     const removeStoryBundle = vi.fn().mockRejectedValue(removeStoryError);
     const removeStorylineGroup = vi.fn().mockRejectedValue(removeStorylineError);
     const onError = vi.fn();
+    const onNonFatalError = vi.fn();
     const onTickSummary = vi.fn();
     const handle = startNewsRuntime({
       ...BASE_CONFIG,
@@ -930,6 +947,7 @@ describe('newsRuntime', () => {
       removeStoryBundle,
       removeStorylineGroup,
       onError,
+      onNonFatalError,
       onTickSummary,
       pruneStaleBundles: true,
       pollIntervalMs: 10,
@@ -945,9 +963,23 @@ describe('newsRuntime', () => {
 
     expect(removeStorylineGroup).toHaveBeenCalledWith(BASE_CONFIG.gunClient, 'storyline-2');
     expect(removeStoryBundle).toHaveBeenCalledWith(BASE_CONFIG.gunClient, 'story-2');
-    expect(onError).toHaveBeenCalledWith(removeStorylineError);
-    expect(onError).toHaveBeenCalledWith(removeStoryError);
+    expect(onError).not.toHaveBeenCalled();
+    expect(onNonFatalError).toHaveBeenCalledWith(
+      removeStorylineError,
+      expect.objectContaining({
+        kind: 'stale_storyline_remove_failed',
+        storyline_id: 'storyline-2',
+      }),
+    );
+    expect(onNonFatalError).toHaveBeenCalledWith(
+      removeStoryError,
+      expect.objectContaining({
+        kind: 'stale_story_remove_failed',
+        story_id: 'story-2',
+      }),
+    );
     expect(onTickSummary.mock.calls[1]?.[0]).toEqual(expect.objectContaining({
+      status: 'completed',
       stale_storyline_remove_attempted_count: 1,
       stale_storyline_remove_failed_count: 1,
       stale_story_remove_attempted_count: 1,
@@ -1018,17 +1050,22 @@ describe('newsRuntime', () => {
     handle.stop();
   });
 
-  it('reports storyline write failures and continues the tick', async () => {
+  it('reports storyline write failures as non-fatal telemetry and continues the tick', async () => {
     orchestrateNewsPipelineMock.mockResolvedValue(batch([STORY_BUNDLE], [STORYLINE]));
 
+    const storylineError = new Error('storyline write failed');
     const writeStoryBundle = vi.fn().mockResolvedValue(undefined);
-    const writeStorylineGroup = vi.fn().mockRejectedValue(new Error('storyline write failed'));
+    const writeStorylineGroup = vi.fn().mockRejectedValue(storylineError);
     const onError = vi.fn();
+    const onNonFatalError = vi.fn();
+    const onTickSummary = vi.fn();
     const handle = startNewsRuntime({
       ...BASE_CONFIG,
       writeStoryBundle,
       writeStorylineGroup,
       onError,
+      onNonFatalError,
+      onTickSummary,
       pollIntervalMs: 10,
       runOnStart: true,
     });
@@ -1036,7 +1073,23 @@ describe('newsRuntime', () => {
     await flushTasks();
 
     expect(writeStorylineGroup).toHaveBeenCalledWith(BASE_CONFIG.gunClient, STORYLINE);
-    expect(onError).toHaveBeenCalledWith(expect.objectContaining({ message: 'storyline write failed' }));
+    expect(onError).not.toHaveBeenCalled();
+    expect(onNonFatalError).toHaveBeenCalledWith(
+      storylineError,
+      expect.objectContaining({
+        kind: 'storyline_write_failed',
+        storyline_id: STORYLINE.storyline_id,
+        story_count: STORYLINE.story_ids.length,
+        reason: 'storyline write failed',
+      }),
+    );
+    expect(onTickSummary).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'completed',
+      raw_wrote_count: 1,
+      storyline_write_attempted_count: 1,
+      storyline_wrote_count: 0,
+      storyline_write_failed_count: 1,
+    }));
     expect(handle.lastRun()).toBeInstanceOf(Date);
 
     handle.stop();
@@ -1048,6 +1101,7 @@ describe('newsRuntime', () => {
     const writeStoryBundle = vi.fn().mockResolvedValue(undefined);
     const writeStorylineGroup = vi.fn().mockRejectedValue('storyline string failure');
     const onError = vi.fn();
+    const onNonFatalError = vi.fn();
     const traceSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
     vi.stubEnv('VH_NEWS_RUNTIME_TRACE', 'true');
     const handle = startNewsRuntime({
@@ -1055,6 +1109,7 @@ describe('newsRuntime', () => {
       writeStoryBundle,
       writeStorylineGroup,
       onError,
+      onNonFatalError,
       pollIntervalMs: 10,
       runOnStart: true,
     });
@@ -1062,10 +1117,20 @@ describe('newsRuntime', () => {
     await flushTasks();
 
     expect(traceSpy).toHaveBeenCalledWith('[vh:news-runtime] storyline_write_failed', {
+      kind: 'storyline_write_failed',
       storyline_id: STORYLINE.storyline_id,
-      error: 'storyline string failure',
+      story_count: STORYLINE.story_ids.length,
+      reason: 'storyline string failure',
     });
-    expect(onError).toHaveBeenCalledWith('storyline string failure');
+    expect(onError).not.toHaveBeenCalled();
+    expect(onNonFatalError).toHaveBeenCalledWith(
+      'storyline string failure',
+      expect.objectContaining({
+        kind: 'storyline_write_failed',
+        storyline_id: STORYLINE.storyline_id,
+        reason: 'storyline string failure',
+      }),
+    );
 
     handle.stop();
   });
@@ -1107,6 +1172,38 @@ describe('newsRuntime', () => {
     expect(onError).toHaveBeenCalledWith(runtimeError);
     expect(handle.lastRun()).toBeNull();
     handle.stop();
+    handle.stop();
+  });
+
+  it('treats raw pending lifecycle adapter failures as fatal raw write failures', async () => {
+    const lifecycleError = new Error('raw pending synthesis lifecycle quorum failed');
+    orchestrateNewsPipelineMock.mockResolvedValue(batch([STORY_BUNDLE]));
+
+    const onError = vi.fn();
+    const onNonFatalError = vi.fn();
+    const writeStoryBundle = vi.fn().mockRejectedValue(lifecycleError);
+    const onTickSummary = vi.fn();
+    const handle = startNewsRuntime({
+      ...BASE_CONFIG,
+      writeStoryBundle,
+      onError,
+      onNonFatalError,
+      onTickSummary,
+      pollIntervalMs: 10,
+      runOnStart: true,
+    });
+
+    await flushTasks();
+
+    expect(writeStoryBundle).toHaveBeenCalledWith(BASE_CONFIG.gunClient, STORY_BUNDLE);
+    expect(onError).toHaveBeenCalledWith(lifecycleError);
+    expect(onNonFatalError).not.toHaveBeenCalled();
+    expect(onTickSummary).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'failed',
+      raw_write_failed_count: 0,
+      error: expect.stringContaining('failed to publish any selected bundles'),
+    }));
+
     handle.stop();
   });
 
@@ -1577,12 +1674,14 @@ describe('newsRuntime', () => {
 
     const writeStoryBundle = vi.fn().mockResolvedValue(undefined);
     const onError = vi.fn();
+    const onNonFatalError = vi.fn();
     const onSynthesisCandidate = vi.fn();
 
     const handle = startNewsRuntime({
       ...BASE_CONFIG,
       writeStoryBundle,
       onError,
+      onNonFatalError,
       onSynthesisCandidate,
       createAdvancedArtifact: () => {
         throw new Error('advanced artifact failed');
@@ -1595,8 +1694,15 @@ describe('newsRuntime', () => {
 
     expect(writeStoryBundle).toHaveBeenCalledWith(BASE_CONFIG.gunClient, STORY_BUNDLE);
     expect(handle.lastRun()).toBeInstanceOf(Date);
-    expect(onError).toHaveBeenCalledWith(expect.any(Error));
-    expect(String(onError.mock.calls[0]?.[0])).toContain('advanced artifact failed');
+    expect(onError).not.toHaveBeenCalled();
+    expect(onNonFatalError).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({
+        kind: 'advanced_artifact_failed',
+        story_id: STORY_BUNDLE.story_id,
+        reason: 'advanced artifact failed',
+      }),
+    );
     expect(onSynthesisCandidate).toHaveBeenCalledWith(
       expect.objectContaining({
         story_id: 'story-1',
@@ -1612,12 +1718,15 @@ describe('newsRuntime', () => {
 
     const writeStoryBundle = vi.fn().mockResolvedValue(undefined);
     const onError = vi.fn();
-    const onSynthesisCandidate = vi.fn().mockRejectedValue(new Error('enrichment timeout'));
+    const onNonFatalError = vi.fn();
+    const enrichmentError = new Error('enrichment timeout');
+    const onSynthesisCandidate = vi.fn().mockRejectedValue(enrichmentError);
 
     const handle = startNewsRuntime({
       ...BASE_CONFIG,
       writeStoryBundle,
       onError,
+      onNonFatalError,
       onSynthesisCandidate,
       runOnStart: true,
       pollIntervalMs: 30,
@@ -1628,8 +1737,15 @@ describe('newsRuntime', () => {
 
     expect(writeStoryBundle).toHaveBeenCalledWith(BASE_CONFIG.gunClient, STORY_BUNDLE);
     expect(handle.lastRun()).toBeInstanceOf(Date);
-    expect(onError).toHaveBeenCalledWith(expect.any(Error));
-    expect(String(onError.mock.calls[0]?.[0])).toContain('enrichment timeout');
+    expect(onError).not.toHaveBeenCalled();
+    expect(onNonFatalError).toHaveBeenCalledWith(
+      enrichmentError,
+      expect.objectContaining({
+        kind: 'synthesis_candidate_enqueue_failed',
+        story_id: STORY_BUNDLE.story_id,
+        reason: 'enrichment timeout',
+      }),
+    );
 
     handle.stop();
   });

--- a/packages/ai-engine/src/newsRuntime.ts
+++ b/packages/ai-engine/src/newsRuntime.ts
@@ -65,6 +65,22 @@ export interface NewsRuntimeSynthesisCandidate {
   advanced_artifact?: StoryAdvancedArtifact;
 }
 
+export type NewsRuntimeNonFatalErrorKind =
+  | 'advanced_artifact_failed'
+  | 'synthesis_candidate_enqueue_failed'
+  | 'storyline_write_failed'
+  | 'stale_storyline_remove_failed'
+  | 'stale_story_remove_failed';
+
+export interface NewsRuntimeNonFatalErrorContext {
+  readonly kind: NewsRuntimeNonFatalErrorKind;
+  readonly reason: string;
+  readonly story_id?: string;
+  readonly storyline_id?: string;
+  readonly story_count?: number;
+  readonly work_item_count?: number;
+}
+
 export interface NewsRuntimeConfig {
   feedSources: FeedSource[];
   topicMapping: TopicMapping;
@@ -85,6 +101,7 @@ export interface NewsRuntimeConfig {
   onSynthesisCandidate?: (candidate: NewsRuntimeSynthesisCandidate) => void | Promise<void>;
   onTickSummary?: (summary: NewsRuntimeTickSummary) => void | Promise<void>;
   onError?: (error: unknown) => void;
+  onNonFatalError?: (error: unknown, context: NewsRuntimeNonFatalErrorContext) => void;
   orchestratorOptions?: NewsOrchestratorOptions;
   noWrite?: boolean;
   tickWatchdogMs?: number;
@@ -452,6 +469,19 @@ function summarizeError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+function reportNonFatalError(
+  config: NewsRuntimeConfig,
+  error: unknown,
+  context: Omit<NewsRuntimeNonFatalErrorContext, 'reason'>,
+): NewsRuntimeNonFatalErrorContext {
+  const fullContext = {
+    ...context,
+    reason: summarizeError(error),
+  };
+  config.onNonFatalError?.(error, fullContext);
+  return fullContext;
+}
+
 function logTickSummary(summary: NewsRuntimeTickSummary): void {
   const logger = summary.status === 'failed' ? console.warn : console.info;
   logger('[vh:news-runtime] tick summary', summary);
@@ -691,7 +721,11 @@ export function startNewsRuntime(config: NewsRuntimeConfig): NewsRuntimeHandle {
           try {
             advancedArtifact = createAdvancedArtifact(bundle);
           } catch (error) {
-            config.onError?.(error);
+            const context = reportNonFatalError(config, error, {
+              kind: 'advanced_artifact_failed',
+              story_id: bundle.story_id,
+            });
+            runtimeTrace(context.kind, { ...context });
           }
 
           if (workItems.length > 0) {
@@ -712,7 +746,12 @@ export function startNewsRuntime(config: NewsRuntimeConfig): NewsRuntimeHandle {
             } else {
               synthesisCandidateEnqueuedCount += 1;
               void Promise.resolve(config.onSynthesisCandidate(candidate)).catch((error) => {
-                config.onError?.(error);
+                const context = reportNonFatalError(config, error, {
+                  kind: 'synthesis_candidate_enqueue_failed',
+                  story_id: candidate.story_id,
+                  work_item_count: candidate.work_items.length,
+                });
+                runtimeTrace(context.kind, { ...context });
               });
             }
           }
@@ -749,7 +788,11 @@ export function startNewsRuntime(config: NewsRuntimeConfig): NewsRuntimeHandle {
           try {
             advancedArtifact = createAdvancedArtifact(bundle);
           } catch (error) {
-            config.onError?.(error);
+            const context = reportNonFatalError(config, error, {
+              kind: 'advanced_artifact_failed',
+              story_id: bundle.story_id,
+            });
+            runtimeTrace(context.kind, { ...context });
           }
 
           if (workItems.length > 0) {
@@ -770,7 +813,12 @@ export function startNewsRuntime(config: NewsRuntimeConfig): NewsRuntimeHandle {
             } else {
               synthesisCandidateEnqueuedCount += 1;
               void Promise.resolve(config.onSynthesisCandidate(candidate)).catch((error) => {
-                config.onError?.(error);
+                const context = reportNonFatalError(config, error, {
+                  kind: 'synthesis_candidate_enqueue_failed',
+                  story_id: candidate.story_id,
+                  work_item_count: candidate.work_items.length,
+                });
+                runtimeTrace(context.kind, { ...context });
               });
             }
           }
@@ -803,11 +851,12 @@ export function startNewsRuntime(config: NewsRuntimeConfig): NewsRuntimeHandle {
               publishedStorylineIds.add(storyline.storyline_id);
             } catch (error) {
               storylineWriteFailedCount += 1;
-              runtimeTrace('storyline_write_failed', {
+              const context = reportNonFatalError(config, error, {
+                kind: 'storyline_write_failed',
                 storyline_id: storyline.storyline_id,
-                error: summarizeError(error),
+                story_count: storyline.story_ids.length,
               });
-              config.onError?.(error);
+              runtimeTrace(context.kind, { ...context });
             }
           }
         }
@@ -840,7 +889,11 @@ export function startNewsRuntime(config: NewsRuntimeConfig): NewsRuntimeHandle {
               publishedStorylineIds.delete(staleStorylineId);
             } catch (error) {
               staleStorylineRemoveFailedCount += 1;
-              config.onError?.(error);
+              const context = reportNonFatalError(config, error, {
+                kind: 'stale_storyline_remove_failed',
+                storyline_id: staleStorylineId,
+              });
+              runtimeTrace(context.kind, { ...context });
             }
           }
         }
@@ -867,7 +920,11 @@ export function startNewsRuntime(config: NewsRuntimeConfig): NewsRuntimeHandle {
               publishedStoryIds.delete(staleStoryId);
             } catch (error) {
               staleStoryRemoveFailedCount += 1;
-              config.onError?.(error);
+              const context = reportNonFatalError(config, error, {
+                kind: 'stale_story_remove_failed',
+                story_id: staleStoryId,
+              });
+              runtimeTrace(context.kind, { ...context });
             }
           }
         }

--- a/services/news-aggregator/src/daemon.production.test.ts
+++ b/services/news-aggregator/src/daemon.production.test.ts
@@ -415,6 +415,65 @@ describe('news daemon production wiring', () => {
     }
   });
 
+  it('keeps raw pending lifecycle write failures on the fatal runtime path', async () => {
+    const tmpDir = mkdtempSync(path.join(os.tmpdir(), 'vh-news-daemon-lifecycle-fatal-'));
+    const runtimeHandle = {
+      stop: vi.fn(),
+      isRunning: vi.fn(() => true),
+      lastRun: vi.fn(() => null),
+    };
+    const lifecycleError = new Error('Relay REST news write failed for /vh/news/synthesis-lifecycle: 1/3 succeeded; required=2');
+    mocks.startNewsRuntime.mockReturnValue(runtimeHandle);
+    mocks.writeNewsSynthesisLifecycleStatus.mockRejectedValue(lifecycleError);
+    primeHealthyEnv();
+    vi.stubEnv('VH_NEWS_DAEMON_STATE_DIR', tmpDir);
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('ok', { status: 200 })));
+
+    try {
+      const handle = await startNewsAggregatorDaemonFromEnv();
+      const runtimeConfig = mocks.startNewsRuntime.mock.calls[0]?.[0] as {
+        onError?: (error: unknown) => void;
+        writeStoryBundle?: (client: unknown, bundle: unknown) => Promise<unknown>;
+      };
+      const bundle = {
+        schemaVersion: 'story-bundle-v0',
+        story_id: 'story-lifecycle-fails',
+        topic_id: '308ac348f442396b471a6ca99b1d2ec2c61f8dff417a9d7fdfbc73d9bf5081b7',
+        headline: 'Lifecycle fails',
+        cluster_window_start: 100,
+        cluster_window_end: 123,
+        sources: [{
+          source_id: 'src-1',
+          publisher: 'Publisher',
+          url: 'https://example.com/lifecycle-fails',
+          url_hash: 'hash-lifecycle-fails',
+          title: 'Lifecycle fails',
+        }],
+        cluster_features: {
+          entity_keys: ['lifecycle'],
+          time_bucket: '2026-05-30T12',
+          semantic_signature: 'sig-lifecycle',
+        },
+        provenance_hash: 'prov-lifecycle',
+        created_at: 100,
+      };
+
+      await expect(runtimeConfig.writeStoryBundle?.({ id: 'mock-client' }, bundle)).rejects.toThrow(
+        '/vh/news/synthesis-lifecycle',
+      );
+      runtimeConfig.onError?.(lifecycleError);
+
+      await vi.waitFor(() => expect(runtimeHandle.stop).toHaveBeenCalledTimes(1));
+      await expect(
+        runtimeConfig.writeStoryBundle?.({ id: 'mock-client' }, { story_id: 'story-after-lifecycle-error' }),
+      ).rejects.toThrow('news daemon runtime writes stopped after runtime error');
+
+      await handle.stop();
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it('does not downgrade accepted synthesis lifecycle when republishing an unchanged source set', async () => {
     primeHealthyEnv();
     vi.stubGlobal('fetch', vi.fn(async () => new Response('ok', { status: 200 })));

--- a/services/news-aggregator/src/daemon.storylines.test.ts
+++ b/services/news-aggregator/src/daemon.storylines.test.ts
@@ -17,6 +17,7 @@ vi.mock('@vh/gun-client', async () => {
 });
 
 import { createNewsAggregatorDaemon } from './daemon';
+import type { DaemonWriteLaneRegistry } from './daemonWriteLane';
 
 const FEED_SOURCES = [
   {
@@ -121,6 +122,220 @@ describe('news daemon storyline adapters', () => {
     expect(gunMocks.removeNewsStoryline).toHaveBeenCalledWith(
       { id: 'client-storyline' },
       STORYLINE.storyline_id,
+    );
+
+    await daemon.stop();
+  });
+
+  it('keeps fail-closed state open after runtime reports a storyline write failure as non-fatal', async () => {
+    const logger = makeLogger();
+    const timers = makeTimerControls();
+    const runtimeHandle = {
+      stop: vi.fn(),
+      isRunning: vi.fn(() => true),
+      lastRun: vi.fn(() => null),
+    };
+    const storylineError = new Error('storyline write timed out and readback did not confirm persistence');
+
+    const startRuntime = vi.fn(() => runtimeHandle);
+    const readLease = vi.fn().mockResolvedValueOnce(null).mockResolvedValue(makeLease());
+    const writeLease = vi.fn().mockResolvedValue(makeLease());
+    const writeBundle = vi.fn(async (_client: VennClient, bundle: unknown) => bundle);
+    gunMocks.writeNewsStoryline.mockRejectedValue(storylineError);
+
+    const daemon = createNewsAggregatorDaemon({
+      client: { id: 'client-storyline-nonfatal' } as VennClient,
+      feedSources: [...FEED_SOURCES],
+      topicMapping: { ...TOPIC_MAPPING },
+      startRuntime,
+      readLease,
+      writeLease,
+      writeBundle,
+      logger,
+      setIntervalFn: timers.setIntervalFn,
+      clearIntervalFn: timers.clearIntervalFn,
+      leaseHolderId: 'vh-news-daemon:test',
+      now: () => 1_700_000_000_000,
+      random: () => 0.42,
+      failClosedOnRuntimeError: true,
+    });
+
+    await daemon.start();
+
+    const runtimeConfig = startRuntime.mock.calls[0]?.[0] as NewsRuntimeConfig;
+    await expect(runtimeConfig.writeStorylineGroup?.({ id: 'client-storyline-nonfatal' }, STORYLINE))
+      .rejects.toThrow('storyline write timed out');
+    runtimeConfig.onNonFatalError?.(storylineError, {
+      kind: 'storyline_write_failed',
+      reason: storylineError.message,
+      storyline_id: STORYLINE.storyline_id,
+      story_count: STORYLINE.story_ids.length,
+    });
+
+    await expect(
+      runtimeConfig.writeStoryBundle?.({ id: 'client-storyline-nonfatal' }, { story_id: 'story-after-storyline' } as any),
+    ).resolves.toEqual({ story_id: 'story-after-storyline' });
+
+    expect(daemon.isRunning()).toBe(true);
+    expect(runtimeHandle.stop).not.toHaveBeenCalled();
+    expect(writeBundle).toHaveBeenCalledWith(
+      { id: 'client-storyline-nonfatal' },
+      { story_id: 'story-after-storyline' },
+    );
+    expect(logger.warn).toHaveBeenCalledWith(
+      '[vh:news-daemon] runtime non-fatal enrichment failure',
+      expect.objectContaining({
+        kind: 'storyline_write_failed',
+        storyline_id: STORYLINE.storyline_id,
+        story_count: STORYLINE.story_ids.length,
+        reason: storylineError.message,
+      }),
+    );
+    expect(logger.error).not.toHaveBeenCalledWith(
+      '[vh:news-daemon] runtime error triggered fail-closed stop',
+      expect.anything(),
+    );
+
+    await daemon.stop();
+  });
+
+  it('keeps storyline remove failures non-fatal and allows later raw writes', async () => {
+    const logger = makeLogger();
+    const timers = makeTimerControls();
+    const runtimeHandle = {
+      stop: vi.fn(),
+      isRunning: vi.fn(() => true),
+      lastRun: vi.fn(() => null),
+    };
+    const removeError = new Error('storyline clear timed out and readback did not confirm removal');
+
+    const startRuntime = vi.fn(() => runtimeHandle);
+    const readLease = vi.fn().mockResolvedValueOnce(null).mockResolvedValue(makeLease());
+    const writeLease = vi.fn().mockResolvedValue(makeLease());
+    const writeBundle = vi.fn(async (_client: VennClient, bundle: unknown) => bundle);
+    gunMocks.removeNewsStoryline.mockRejectedValue(removeError);
+
+    const daemon = createNewsAggregatorDaemon({
+      client: { id: 'client-storyline-remove' } as VennClient,
+      feedSources: [...FEED_SOURCES],
+      topicMapping: { ...TOPIC_MAPPING },
+      startRuntime,
+      readLease,
+      writeLease,
+      writeBundle,
+      logger,
+      setIntervalFn: timers.setIntervalFn,
+      clearIntervalFn: timers.clearIntervalFn,
+      leaseHolderId: 'vh-news-daemon:test',
+      now: () => 1_700_000_000_000,
+      random: () => 0.42,
+      failClosedOnRuntimeError: true,
+    });
+
+    await daemon.start();
+
+    const runtimeConfig = startRuntime.mock.calls[0]?.[0] as NewsRuntimeConfig;
+    await expect(runtimeConfig.removeStorylineGroup?.({ id: 'client-storyline-remove' }, STORYLINE.storyline_id))
+      .rejects.toThrow('storyline clear timed out');
+    runtimeConfig.onNonFatalError?.(removeError, {
+      kind: 'stale_storyline_remove_failed',
+      reason: removeError.message,
+      storyline_id: STORYLINE.storyline_id,
+    });
+
+    await expect(
+      runtimeConfig.writeStoryBundle?.({ id: 'client-storyline-remove' }, { story_id: 'story-after-remove' } as any),
+    ).resolves.toEqual({ story_id: 'story-after-remove' });
+
+    expect(daemon.isRunning()).toBe(true);
+    expect(runtimeHandle.stop).not.toHaveBeenCalled();
+    expect(writeBundle).toHaveBeenCalledWith(
+      { id: 'client-storyline-remove' },
+      { story_id: 'story-after-remove' },
+    );
+    expect(logger.warn).toHaveBeenCalledWith(
+      '[vh:news-daemon] runtime non-fatal enrichment failure',
+      expect.objectContaining({
+        kind: 'stale_storyline_remove_failed',
+        storyline_id: STORYLINE.storyline_id,
+        reason: removeError.message,
+      }),
+    );
+
+    await daemon.stop();
+  });
+
+  it('treats stopped storyline lane rejections as optional telemetry', async () => {
+    const logger = makeLogger();
+    const timers = makeTimerControls();
+    const runtimeHandle = {
+      stop: vi.fn(),
+      isRunning: vi.fn(() => true),
+      lastRun: vi.fn(() => null),
+    };
+    const laneStoppedError = new Error('daemon write lane stopped after failure: storyline');
+
+    const startRuntime = vi.fn(() => runtimeHandle);
+    const readLease = vi.fn().mockResolvedValueOnce(null).mockResolvedValue(makeLease());
+    const writeLease = vi.fn().mockResolvedValue(makeLease());
+    const writeBundle = vi.fn(async (_client: VennClient, bundle: unknown) => bundle);
+    const writeLanes: DaemonWriteLaneRegistry = {
+      run: vi.fn(async <T,>(writeClass: string, _attributes: Record<string, unknown>, task: () => Promise<T>) => {
+        if (writeClass === 'storyline') {
+          throw laneStoppedError;
+        }
+        return task();
+      }),
+      snapshot: vi.fn(() => []),
+      stop: vi.fn(),
+    };
+
+    const daemon = createNewsAggregatorDaemon({
+      client: { id: 'client-storyline-stopped' } as VennClient,
+      feedSources: [...FEED_SOURCES],
+      topicMapping: { ...TOPIC_MAPPING },
+      startRuntime,
+      readLease,
+      writeLease,
+      writeBundle,
+      writeLanes,
+      logger,
+      setIntervalFn: timers.setIntervalFn,
+      clearIntervalFn: timers.clearIntervalFn,
+      leaseHolderId: 'vh-news-daemon:test',
+      now: () => 1_700_000_000_000,
+      random: () => 0.42,
+      failClosedOnRuntimeError: true,
+    });
+
+    await daemon.start();
+
+    const runtimeConfig = startRuntime.mock.calls[0]?.[0] as NewsRuntimeConfig;
+    await expect(runtimeConfig.writeStorylineGroup?.({ id: 'client-storyline-stopped' }, STORYLINE))
+      .rejects.toThrow('daemon write lane stopped after failure: storyline');
+    runtimeConfig.onNonFatalError?.(laneStoppedError, {
+      kind: 'storyline_write_failed',
+      reason: laneStoppedError.message,
+      storyline_id: STORYLINE.storyline_id,
+      story_count: STORYLINE.story_ids.length,
+    });
+
+    await expect(
+      runtimeConfig.writeStoryBundle?.({ id: 'client-storyline-stopped' }, { story_id: 'story-after-stopped-lane' } as any),
+    ).resolves.toEqual({ story_id: 'story-after-stopped-lane' });
+
+    expect(runtimeHandle.stop).not.toHaveBeenCalled();
+    expect(writeBundle).toHaveBeenCalledWith(
+      { id: 'client-storyline-stopped' },
+      { story_id: 'story-after-stopped-lane' },
+    );
+    expect(logger.warn).toHaveBeenCalledWith(
+      '[vh:news-daemon] runtime non-fatal enrichment failure',
+      expect.objectContaining({
+        kind: 'storyline_write_failed',
+        storyline_id: STORYLINE.storyline_id,
+        reason: laneStoppedError.message,
+      }),
     );
 
     await daemon.stop();

--- a/services/news-aggregator/src/daemon.ts
+++ b/services/news-aggregator/src/daemon.ts
@@ -14,6 +14,7 @@ import {
   type FeedSource,
   type NewsRuntimeConfig,
   type NewsRuntimeHandle,
+  type NewsRuntimeNonFatalErrorContext,
   type NewsRuntimeTickSummary,
   type TopicMapping,
 } from '@vh/ai-engine';
@@ -89,6 +90,25 @@ function hasReadableMesh(client: VennClient): boolean {
 
 const DEFAULT_PRODUCT_FEED_RECONCILE_INTERVAL_MS = 10 * 60 * 1000;
 const DEFAULT_SYNTHESIS_CATCHUP_INTERVAL_MS = 5 * 60 * 1000;
+const FAIL_CLOSED_RUNTIME_WRITE_CLASSES = new Set([
+  'news_bundle',
+  'news_synthesis_lifecycle',
+]);
+
+function shouldStopFailClosedRuntimeWriteClass(writeClass: string): boolean {
+  return FAIL_CLOSED_RUNTIME_WRITE_CLASSES.has(writeClass);
+}
+
+function nonFatalRuntimeErrorFields(context: NewsRuntimeNonFatalErrorContext): Record<string, unknown> {
+  return {
+    kind: context.kind,
+    reason: context.reason,
+    story_id: context.story_id ?? null,
+    storyline_id: context.storyline_id ?? null,
+    story_count: context.story_count ?? null,
+    work_item_count: context.work_item_count ?? null,
+  };
+}
 
 function normalizePositiveIntervalMs(value: unknown, fallback: number): number {
   const parsed = Number(value);
@@ -168,7 +188,9 @@ export function createNewsAggregatorDaemon(config: NewsAggregatorDaemonConfig): 
   const writeLanes = config.writeLanes ?? createDaemonWriteLaneRegistry({
     logger,
     now: nowFn,
-    stopClassOnFailure: failClosedOnRuntimeError && !noWrite,
+    stopClassOnFailure: failClosedOnRuntimeError && !noWrite
+      ? shouldStopFailClosedRuntimeWriteClass
+      : false,
   });
   const queue = createAsyncEnrichmentQueue(
     config.enrichmentWorker ?? (() => undefined),
@@ -418,6 +440,12 @@ export function createNewsAggregatorDaemon(config: NewsAggregatorDaemonConfig): 
         logger.info('[vh:news-daemon] enrichment candidate enqueued', {
           story_id: candidate.story_id,
           ...queue.snapshot(),
+        });
+      },
+      onNonFatalError(_error, context) {
+        logger.warn('[vh:news-daemon] runtime non-fatal enrichment failure', {
+          holder_id: holderId,
+          ...nonFatalRuntimeErrorFields(context),
         });
       },
       onError(error) {
@@ -912,7 +940,12 @@ export async function startNewsAggregatorDaemonFromEnv(): Promise<NewsAggregator
   if (typeof gunFile === 'string') {
     mkdirSync(path.dirname(gunFile), { recursive: true });
   }
-  const writeLanes = createDaemonWriteLaneRegistry({ logger: console });
+  const writeLanes = createDaemonWriteLaneRegistry({
+    logger: console,
+    stopClassOnFailure: failClosedOnRuntimeError && !noWrite
+      ? shouldStopFailClosedRuntimeWriteClass
+      : false,
+  });
   let client: VennClient | null = null;
   let processHandle: NewsAggregatorDaemonProcessHandle | null = null;
   let diagnosticStopRequested = false;

--- a/services/news-aggregator/src/daemonWriteLane.test.ts
+++ b/services/news-aggregator/src/daemonWriteLane.test.ts
@@ -121,4 +121,47 @@ describe('daemonWriteLane', () => {
       }),
     );
   });
+
+  it('uses predicate stop policy so optional classes keep accepting writes after failures', async () => {
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    const lane = createDaemonWriteLaneRegistry({
+      logger,
+      defaultConcurrency: 1,
+      stopClassOnFailure: (writeClass) => writeClass === 'news_bundle',
+    });
+
+    await expect(
+      lane.run('storyline', { storyline_id: 'storyline-1' }, async () => {
+        throw new Error('storyline write timed out');
+      }),
+    ).rejects.toThrow('storyline write timed out');
+    await expect(
+      lane.run('storyline', { storyline_id: 'storyline-2' }, async () => 'optional-later'),
+    ).resolves.toBe('optional-later');
+
+    await expect(
+      lane.run('news_bundle', { story_id: 'story-1' }, async () => {
+        throw new Error('relay quorum failed');
+      }),
+    ).rejects.toThrow('relay quorum failed');
+    await expect(
+      lane.run('news_bundle', { story_id: 'story-2' }, async () => 'blocked'),
+    ).rejects.toThrow('daemon write lane stopped after failure: news_bundle');
+
+    expect(lane.snapshot()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          write_class: 'storyline',
+          stopped: false,
+          failed_count: 1,
+          completed_count: 1,
+        }),
+        expect.objectContaining({
+          write_class: 'news_bundle',
+          stopped: true,
+          failed_count: 1,
+        }),
+      ]),
+    );
+  });
 });

--- a/services/news-aggregator/src/daemonWriteLane.ts
+++ b/services/news-aggregator/src/daemonWriteLane.ts
@@ -42,7 +42,7 @@ export interface DaemonWriteLaneOptions {
   defaultConcurrency?: number;
   classConcurrency?: Record<string, number | undefined>;
   maxSamples?: number;
-  stopClassOnFailure?: boolean;
+  stopClassOnFailure?: boolean | ((writeClass: string) => boolean);
 }
 
 function normalizeConcurrency(value: number | undefined, fallback: number): number {
@@ -90,6 +90,13 @@ export function createDaemonWriteLaneRegistry(
 
   const concurrencyFor = (writeClass: string): number =>
     normalizeConcurrency(options.classConcurrency?.[writeClass], defaultConcurrency);
+
+  const shouldStopClassOnFailure = (writeClass: string): boolean => {
+    if (typeof options.stopClassOnFailure === 'function') {
+      return options.stopClassOnFailure(writeClass);
+    }
+    return options.stopClassOnFailure === true;
+  };
 
   const recordDuration = (state: LaneState, durationMs: number): number | null => {
     state.durations.push(durationMs);
@@ -153,7 +160,7 @@ export function createDaemonWriteLaneRegistry(
             ...item.attributes,
             error,
           });
-          if (options.stopClassOnFailure && !state.stopped) {
+          if (shouldStopClassOnFailure(writeClass) && !state.stopped) {
             state.stopped = true;
             const pending = state.pending.splice(0);
             for (const pendingItem of pending) {


### PR DESCRIPTION
## Summary
- Keep the Scope A raw path fail-closed: raw bundle publication and publish-time pending lifecycle writes remain fatal and continue to use the relay REST 2-of-3 quorum-durable path.
- Route optional storyline writes/removes, advanced artifact failures, and async synthesis candidate enqueue failures to non-fatal telemetry instead of the daemon fatal `onError` path.
- Make runtime write criticality an explicit allow-list: only `news_bundle` and `news_synthesis_lifecycle` stop fail-closed write lanes; future write classes default to non-fatal unless deliberately added.
- Verify dangling `storyline_id` product behavior: a raw card renders normally when `storylinesById[id]` is absent, with no overlay/error state.

## Non-goals / boundaries
- No relay quorum weakening; 2-of-3 quorum behavior is preserved.
- No live host writes, publisher start, monitor re-enable, queue scrub, relay/origin restart, A6 env change, or mesh write was performed.
- No storyline REST migration in this PR; storyline relay-REST quorum migration remains post-launch durability work.

## Verification
All passing commands were run with Node 20 via `PATH="/opt/homebrew/opt/node@20/bin:$PATH"`.

- `pnpm install --frozen-lockfile` PASS.
- Requested ai-engine package-local command failed before test discovery because `packages/ai-engine/vitest.config.ts` does not exist; repo-root equivalent passed: `pnpm exec vitest run packages/ai-engine/src/newsRuntime.test.ts packages/ai-engine/src/newsRuntime.storylines.test.ts packages/ai-engine/src/newsRuntime.staleCleanup.test.ts --config ./vitest.config.ts` PASS, 3 files / 52 tests.
- `pnpm --filter @vh/news-aggregator exec vitest run src/daemon.test.ts src/daemon.storylines.test.ts src/daemonWriteLane.test.ts src/daemon.coverage.test.ts src/daemon.production.test.ts --config ./vitest.config.ts` PASS, 5 files / 46 tests.
- `pnpm --filter @vh/gun-client exec vitest run src/newsAdapters.test.ts src/storylineAdapters.test.ts --config ./vitest.config.ts` PASS, 2 files / 167 tests.
- Requested web-pwa package-local command failed before test discovery because `apps/web-pwa/vitest.config.ts` does not exist; repo-root equivalent passed: `pnpm exec vitest run apps/web-pwa/src/components/feed/NewsCard.storyline.test.tsx apps/web-pwa/src/store/news --config ./vitest.config.ts` PASS, 16 files / 194 tests.
- `pnpm --filter @vh/ai-engine build` PASS.
- `pnpm --filter @vh/news-aggregator build` PASS.
- `git diff --check` PASS.
- `node tools/scripts/check-diff-coverage.mjs` PASS: no coverage-eligible source files changed.
- `pnpm test:quick` PASS, 319 files / 4936 tests.
