### PR TITLE
Bound publisher fail-closed restarts

### DIFF
--- a/docs/ops/news-aggregator-production-service.md
+++ b/docs/ops/news-aggregator-production-service.md
@@ -215,6 +215,33 @@ SIGKILL, and fails closed if the process still remains. The daemon also acquires
 creating the mesh client; a direct `pnpm --filter @vh/news-aggregator daemon`
 launch refuses to start while another daemon process owns that pidfile.
 
+The publisher unit must not turn a deliberate write-safety fail-close into an
+unattended restart loop. The daemon exits with code `78` after a critical
+runtime write violation, and `vh-news-aggregator.service` uses
+`Restart=on-failure` plus `RestartPreventExitStatus=78` so that state stays down
+for operator inspection. The unit also sets `StartLimitIntervalSec=10min` and
+`StartLimitBurst=3` as a backstop for genuine process crashes or unexpected
+non-78 failures. Verify the installed unit before an attended start:
+
+```bash
+systemctl --user show vh-news-aggregator.service \
+  -p Restart -p RestartPreventExitStatus -p RestartSecUSec \
+  -p StartLimitIntervalUSec -p StartLimitBurst -p NRestarts \
+  --no-pager
+```
+
+During the attended Scope A start, `active (running)` alone is not sufficient
+evidence. `NRestarts` must remain `0`, and journals must not show repeated
+`runtime error triggered fail-closed stop` lines. If `NRestarts` climbs, the unit
+hits a start limit, or a fail-close line appears, stop and disable the publisher
+before inspecting evidence:
+
+```bash
+systemctl --user stop vh-news-aggregator.service
+systemctl --user disable vh-news-aggregator.service
+journalctl --user -u vh-news-aggregator.service -n 200 --no-pager
+```
+
 The production wrapper applies bounded feed/StoryCluster workload defaults
 unless the env file explicitly overrides them:
 
@@ -634,6 +661,8 @@ Abort or stop the service if any of these occur:
 - StoryCluster health check fails;
 - raw news or raw pending lifecycle relay REST write fanout is below the
   configured quorum target;
+- `NRestarts` increments, systemd reports a start-limit hit, or the journal shows
+  `runtime error triggered fail-closed stop`;
 - snapshot watch reports stale newest-entry age above 6 hours;
 - latest content does not advance after approved start and expected ingest
   cadence.

--- a/infra/systemd/user/vh-news-aggregator.service
+++ b/infra/systemd/user/vh-news-aggregator.service
@@ -3,6 +3,8 @@ Description=VHC News Aggregator Publisher Daemon
 Documentation=file:/home/humble/VHC/docs/ops/news-aggregator-production-service.md
 After=network-online.target vh-storycluster-engine.service
 Wants=network-online.target vh-storycluster-engine.service
+StartLimitIntervalSec=10min
+StartLimitBurst=3
 
 [Service]
 Type=simple
@@ -12,7 +14,8 @@ Environment=VH_NEWS_DAEMON_ENV_FILE=%h/.config/vhc/news-aggregator.env
 Environment=PATH=/home/humble/.local/bin:/usr/local/bin:/usr/bin:/bin
 WorkingDirectory=/home/humble/VHC
 ExecStart=/usr/bin/env bash /home/humble/VHC/tools/scripts/start-news-aggregator-daemon-production.sh
-Restart=always
+Restart=on-failure
+RestartPreventExitStatus=78
 RestartSec=30
 KillSignal=SIGTERM
 TimeoutStopSec=30

--- a/services/news-aggregator/src/daemon.coverage.test.ts
+++ b/services/news-aggregator/src/daemon.coverage.test.ts
@@ -370,6 +370,30 @@ describe('news daemon coverage guards', () => {
     expect(lifecycle.exit).toHaveBeenCalledWith(0);
   });
 
+  it('exits the CLI with the deliberate fail-closed code when the daemon closes cleanly after a runtime violation', async () => {
+    const closed = createDeferred<void>();
+    const startFromEnv = vi.fn(async () => ({
+      stop: vi.fn(async () => undefined),
+      closed: closed.promise,
+      closeExitCode: () => __internal.NEWS_DAEMON_FAIL_CLOSED_EXIT_CODE,
+    }));
+    const lifecycle: Pick<typeof process, 'once' | 'exit'> = {
+      once: vi.fn(() => lifecycle as any) as any,
+      exit: vi.fn(() => undefined as never),
+    };
+    const logger = {
+      info: vi.fn(),
+      error: vi.fn(),
+    };
+
+    await __internal.runFromCli(startFromEnv, lifecycle, logger);
+    closed.resolve();
+    await flushMicrotasks();
+
+    expect(lifecycle.exit).toHaveBeenCalledTimes(1);
+    expect(lifecycle.exit).toHaveBeenCalledWith(__internal.NEWS_DAEMON_FAIL_CLOSED_EXIT_CODE);
+  });
+
   it('exits the CLI nonzero when a daemon handle closes with an error', async () => {
     const closed = createDeferred<void>();
     const startFromEnv = vi.fn(async () => ({
@@ -393,5 +417,31 @@ describe('news daemon coverage guards', () => {
     expect(logger.error).toHaveBeenCalledWith('[vh:news-daemon] daemon process closed with error', error);
     expect(lifecycle.exit).toHaveBeenCalledTimes(1);
     expect(lifecycle.exit).toHaveBeenCalledWith(1);
+  });
+
+  it('preserves the deliberate fail-closed code when shutdown cleanup rejects', async () => {
+    const closed = createDeferred<void>();
+    const startFromEnv = vi.fn(async () => ({
+      stop: vi.fn(async () => undefined),
+      closed: closed.promise,
+      closeExitCode: () => __internal.NEWS_DAEMON_FAIL_CLOSED_EXIT_CODE,
+    }));
+    const lifecycle: Pick<typeof process, 'once' | 'exit'> = {
+      once: vi.fn(() => lifecycle as any) as any,
+      exit: vi.fn(() => undefined as never),
+    };
+    const logger = {
+      info: vi.fn(),
+      error: vi.fn(),
+    };
+    const error = new Error('client shutdown failed after fail-closed stop');
+
+    await __internal.runFromCli(startFromEnv, lifecycle, logger);
+    closed.reject(error);
+    await flushMicrotasks();
+
+    expect(logger.error).toHaveBeenCalledWith('[vh:news-daemon] daemon process closed with error', error);
+    expect(lifecycle.exit).toHaveBeenCalledTimes(1);
+    expect(lifecycle.exit).toHaveBeenCalledWith(__internal.NEWS_DAEMON_FAIL_CLOSED_EXIT_CODE);
   });
 });

--- a/services/news-aggregator/src/daemon.ts
+++ b/services/news-aggregator/src/daemon.ts
@@ -60,7 +60,7 @@ import {
   createBundleSynthesisEnrichmentFromEnv,
   isTruthyFlag,
 } from './bundleSynthesisDaemonConfig';
-import { isDirectExecution, runFromCli } from './daemonCli';
+import { NEWS_DAEMON_FAIL_CLOSED_EXIT_CODE, isDirectExecution, runFromCli } from './daemonCli';
 import {
   createDaemonWriteLaneRegistry,
   type DaemonWriteLaneRegistry,
@@ -710,6 +710,7 @@ export interface NewsAggregatorDaemonProcessHandle {
   daemon: NewsAggregatorDaemonHandle;
   client: VennClient;
   readonly closed: Promise<void>;
+  closeExitCode?(): number;
   stop(): Promise<void>;
 }
 
@@ -949,6 +950,7 @@ export async function startNewsAggregatorDaemonFromEnv(): Promise<NewsAggregator
   let client: VennClient | null = null;
   let processHandle: NewsAggregatorDaemonProcessHandle | null = null;
   let diagnosticStopRequested = false;
+  let closeExitCode = 0;
   let resolveClosed: (() => void) | null = null;
   let rejectClosed: ((error: unknown) => void) | null = null;
   const closed = new Promise<void>((resolve, reject) => {
@@ -1021,6 +1023,7 @@ export async function startNewsAggregatorDaemonFromEnv(): Promise<NewsAggregator
       failClosedOnRuntimeError,
       onFailClosedRuntimeError: (error) => {
         console.error('[vh:news-daemon] fail-closed runtime error shutting down process', error);
+        closeExitCode = NEWS_DAEMON_FAIL_CLOSED_EXIT_CODE;
         setTimeout(() => {
           void processHandle?.stop().catch((stopError) => {
             console.error('[vh:news-daemon] fail-closed process shutdown failed', stopError);
@@ -1051,6 +1054,7 @@ export async function startNewsAggregatorDaemonFromEnv(): Promise<NewsAggregator
       daemon,
       client,
       closed,
+      closeExitCode: () => closeExitCode,
       async stop() {
         if (stopped) {
           return;
@@ -1108,6 +1112,7 @@ export const __internal = {
   parseTopicMapping,
   resolveLeaseHolderId,
   runFromCli,
+  NEWS_DAEMON_FAIL_CLOSED_EXIT_CODE,
   startNewsAggregatorDaemonFromEnv,
   verifyStoryClusterHealth,
   isTruthyFlag,

--- a/services/news-aggregator/src/daemonCli.ts
+++ b/services/news-aggregator/src/daemonCli.ts
@@ -2,9 +2,12 @@ import { pathToFileURL } from 'node:url';
 
 export type ProcessLifecycle = Pick<typeof process, 'once' | 'exit'>;
 export type CliLogger = Pick<Console, 'info' | 'error'>;
+export const NEWS_DAEMON_FAIL_CLOSED_EXIT_CODE = 78;
+
 export interface CliDaemonProcessHandle {
   stop(): Promise<void>;
   readonly closed?: Promise<void>;
+  closeExitCode?(): number;
 }
 
 export function isDirectExecution(metaUrl: string): boolean {
@@ -26,6 +29,13 @@ export async function runFromCli(
 ): Promise<void> {
   const processHandle = await startFromEnv();
   let exiting = false;
+  const closeExitCode = (fallback: number): number => {
+    const code = processHandle.closeExitCode?.();
+    if (typeof code !== 'number') {
+      return fallback;
+    }
+    return Number.isInteger(code) && code >= 0 && code <= 255 ? code : fallback;
+  };
   const exitOnce = (code: number): void => {
     if (exiting) {
       return;
@@ -45,9 +55,9 @@ export async function runFromCli(
     });
   }
   void processHandle.closed?.then(() => {
-    exitOnce(0);
+    exitOnce(closeExitCode(0));
   }, (error) => {
     logger.error('[vh:news-daemon] daemon process closed with error', error);
-    exitOnce(1);
+    exitOnce(closeExitCode(1));
   });
 }

--- a/tools/scripts/install-news-aggregator-production-service.sh
+++ b/tools/scripts/install-news-aggregator-production-service.sh
@@ -62,6 +62,8 @@ Description=VHC News Aggregator Publisher Daemon
 Documentation=file:${REPO_ROOT}/docs/ops/news-aggregator-production-service.md
 After=network-online.target vh-storycluster-engine.service
 Wants=network-online.target vh-storycluster-engine.service
+StartLimitIntervalSec=10min
+StartLimitBurst=3
 
 [Service]
 Type=simple
@@ -70,7 +72,8 @@ Environment=VH_NEWS_DAEMON_ENV_FILE=${ENV_FILE}
 Environment=PATH=${SERVICE_PATH}
 WorkingDirectory=${REPO_ROOT}
 ExecStart=/usr/bin/env bash ${REPO_ROOT}/tools/scripts/start-news-aggregator-daemon-production.sh
-Restart=always
+Restart=on-failure
+RestartPreventExitStatus=78
 RestartSec=30
 KillSignal=SIGTERM
 TimeoutStopSec=30

--- a/tools/scripts/systemd-service-installers.test.mjs
+++ b/tools/scripts/systemd-service-installers.test.mjs
@@ -59,6 +59,19 @@ test('news aggregator installer still gates publisher start on explicit approval
   assert.match(source, /systemctl --user enable --now vh-news-aggregator\.service/);
 });
 
+test('news aggregator publisher unit keeps deliberate fail-closed exits stopped and bounds crash loops', () => {
+  for (const source of [
+    readScript('install-news-aggregator-production-service.sh'),
+    readInfraUnit('vh-news-aggregator.service'),
+  ]) {
+    assert.match(source, /StartLimitIntervalSec=10min/);
+    assert.match(source, /StartLimitBurst=3/);
+    assert.match(source, /Restart=on-failure/);
+    assert.match(source, /RestartPreventExitStatus=78/);
+    assert.match(source, /RestartSec=30/);
+  }
+});
+
 test('news aggregator user unit orders publisher after StoryCluster', () => {
   for (const source of [
     readScript('install-news-aggregator-production-service.sh'),


### PR DESCRIPTION
## Summary
- Make deliberate news publisher fail-closed runtime stops exit with code `78`, including the cleanup-rejection path.
- Change the publisher unit from `Restart=always` to `Restart=on-failure` with `RestartPreventExitStatus=78`, so #668 fail-closed stops remain stopped for operator inspection.
- Add `StartLimitIntervalSec=10min` / `StartLimitBurst=3` as a backstop for genuine non-78 crash loops, and document `NRestarts` as an attended-start abort signal.

## A6 evidence
- A6 currently has no `vh-news-aggregator.service` drop-in.
- Installed unit is `Restart=always`, `RestartSec=30`, `StartLimitIntervalUSec=10s`, `StartLimitBurst=5`, `NRestarts=0`, `ActiveState=inactive`, `UnitFileState=disabled`.
- With `RestartSec=30`, the default 10-second start-limit window does not bound persistent fail-close restarts.
- No publisher start, StoryCluster reset, monitor enable, or live mesh write was performed.

## Scope/safety
- Raw bundle and pending lifecycle writes remain fail-closed in code; this PR only fixes the service-manager behavior after a deliberate fail-close.
- Genuine process failures can still restart, but are bounded by the explicit start limit.
- A deliberate fail-close now stays down instead of being resurrected by systemd.

## Verification
- `PATH="/opt/homebrew/opt/node@20/bin:$PATH" pnpm --filter @vh/news-aggregator exec vitest run src/daemon.coverage.test.ts src/daemon.test.ts src/daemon.production.test.ts --config ./vitest.config.ts` PASS: 3 files, 40 tests.
- `PATH="/opt/homebrew/opt/node@20/bin:$PATH" node --test tools/scripts/systemd-service-installers.test.mjs` PASS: 8 tests.
- `PATH="/opt/homebrew/opt/node@20/bin:$PATH" pnpm --filter @vh/news-aggregator build` PASS.
- `git diff --check` PASS.
- `PATH="/opt/homebrew/opt/node@20/bin:$PATH" node tools/scripts/check-diff-coverage.mjs` PASS: no coverage-eligible source files changed.
- `PATH="/opt/homebrew/opt/node@20/bin:$PATH" pnpm test:quick` PASS: 319 files, 4936 tests.
