### PR TITLE
Protect relay write readbacks from snapshot maintenance

### DIFF
--- a/docs/ops/news-aggregator-production-service.md
+++ b/docs/ops/news-aggregator-production-service.md
@@ -447,6 +447,26 @@ The preflight and write logs report `endpoint_count`, `required_success_count`,
 `relay_required_success_count`, and failed relay origin labels without printing
 tokens, pins, or key material.
 
+Relay write readback is intentionally stricter than public latest-index serving.
+The critical write routes (`/vh/news/story`, `/vh/news/latest-index`,
+`/vh/news/hot-index`, and `/vh/news/synthesis-lifecycle`) must confirm the
+write through their live relay readback path. A latest-index snapshot is
+downstream read-through evidence and must not be treated as proof that the
+in-flight write durably landed. Snapshot body verification and story-state
+refresh are optional maintenance work: they are concurrency-capped and pause
+while a critical write readback is active so they cannot starve the single relay
+event loop and turn a locally landed write into a false readback timeout.
+The current safety caps default to
+`VH_RELAY_NEWS_INDEX_SNAPSHOT_STORY_VERIFY_MAX_CONCURRENCY=2` and
+`VH_RELAY_NEWS_INDEX_SNAPSHOT_REFRESH_MAX_CONCURRENCY=1`; leave
+`VH_RELAY_NEWS_INDEX_SNAPSHOT_PAUSE_DURING_WRITE_READBACK=true` unless an
+attended rollback explicitly needs the old behavior for diagnosis.
+Operators should watch `/metrics` counters
+`vh_relay_critical_write_readbacks_started_total`,
+`vh_relay_snapshot_background_pauses_total`, and
+`vh_relay_snapshot_background_concurrency_caps_total` during any post-merge
+soak.
+
 For Scope A launch gating, fail-closed only applies to the quorum-durable raw
 path: `/vh/news/story`, `/vh/news/latest-index`, `/vh/news/hot-index`, and the
 pending `/vh/news/synthesis-lifecycle` write created during raw publication.

--- a/docs/ops/public-news-mvp-release-decisions.md
+++ b/docs/ops/public-news-mvp-release-decisions.md
@@ -2,7 +2,7 @@
 
 > Status: Owner Decision Ledger
 > Owner: VHC Product + Launch Ops
-> Last Reviewed: 2026-06-12
+> Last Reviewed: 2026-06-20
 > Depends On: docs/ops/public-beta-launch-readiness-closeout.md, docs/reports/mesh-readiness-state-of-play-2026-06-12.md
 
 ## Status
@@ -18,7 +18,7 @@ not grant release approval by itself.
 | Retention promise | No committed TTL/eviction promise for stories, syntheses, lifecycle rows, or aggregates. The freshness monitor only proves new accepted rows remain recent. | State the beta retention promise, for example `feed history retained at least N days`, `best-effort beta history`, or `indefinite beta retention`, and decide whether it becomes a gate or monitor. |
 | Live multi-source launch copy | `VH_PUBLIC_FEED_FRESH_PROPAGATION_REQUIRE_MULTI_SOURCE` is available and defaults to `false`. Current launch copy must not claim live breaking-news corroboration unless this flag is run against live RSS and passes. | Choose whether the beta pitch promises live cross-source corroboration. If yes, run fresh propagation with the flag enabled and capture a live multi-source event. |
 | Raw latest-root hygiene bar | User-visible readers filter invalid raw children, but the 2026-06-12 browser walkthrough still emitted raw latest-root `unknown-signer-id` warnings. Scrub tooling remains owner-gated because it writes production mesh state. | Decide whether zero invalid raw latest-root children blocks beta. If yes, approve dry-run evidence and then approve `--apply` scrub separately. |
-| Quorum/host asymmetry | Current known topology has the web origin plus `gun-a` and `gun-b` on A6, with `gun-c` on the Mac mini. A6 loss takes down origin plus 2-of-3 quorum. | Explicitly accept this for controlled beta or schedule peer redistribution before broad beta. |
+| Quorum/host asymmetry | Current verified Phase 5 topology has all three public-news relay containers on A6, with `gun-c` locally redirected to relay C. A6 loss takes down origin plus all three relay votes; this is a known MVP single-host durability risk, not a current A6/Mac-mini split. | Explicitly accept this for controlled beta or schedule peer redistribution before broad beta. |
 
 ## Claim Boundary
 

--- a/infra/relay/server.js
+++ b/infra/relay/server.js
@@ -207,6 +207,15 @@ function criticalWriteReadbacksAreActive() {
     && boolEnv('VH_RELAY_NEWS_INDEX_SNAPSHOT_PAUSE_DURING_WRITE_READBACK', true);
 }
 
+function forceCriticalWriteReadbackFailure(route) {
+  if (process.env.NODE_ENV !== 'test') return false;
+  const configuredRoutes = String(process.env.VH_RELAY_TEST_FORCE_CRITICAL_WRITE_READBACK_FAILURE_ROUTES || '')
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+  return configuredRoutes.includes('*') || configuredRoutes.includes(route);
+}
+
 function cappedBackgroundConcurrency({
   operation,
   envName,
@@ -243,6 +252,13 @@ async function runCriticalWriteReadback(route, storyId, readback) {
   incMap(metrics.criticalWriteReadbacksStarted, route);
   activeCriticalWriteReadbacks += 1;
   try {
+    if (forceCriticalWriteReadbackFailure(route)) {
+      logEvent('warn', 'critical_write_readback_test_forced_failure', {
+        route,
+        story_id: storyId,
+      });
+      return null;
+    }
     const testDelayMs = numberEnv('VH_RELAY_TEST_CRITICAL_WRITE_READBACK_DELAY_MS', 0);
     if (testDelayMs > 0) {
       logEvent('info', 'critical_write_readback_test_delay', {

--- a/infra/relay/server.js
+++ b/infra/relay/server.js
@@ -178,6 +178,9 @@ const metrics = {
   wsByteDrops: 0,
   compactionRuns: 0,
   compactionTombstones: 0,
+  criticalWriteReadbacksStarted: new Map(),
+  snapshotBackgroundPauses: new Map(),
+  snapshotBackgroundConcurrencyCaps: new Map(),
 };
 const eventLoopDelay = monitorEventLoopDelay({ resolution: 20 });
 eventLoopDelay.enable();
@@ -195,6 +198,64 @@ const PUBLIC_HTTP_RELAY_ROUTES = [
 
 function incMap(map, key, by = 1) {
   map.set(key, (map.get(key) || 0) + by);
+}
+
+let activeCriticalWriteReadbacks = 0;
+
+function criticalWriteReadbacksAreActive() {
+  return activeCriticalWriteReadbacks > 0
+    && boolEnv('VH_RELAY_NEWS_INDEX_SNAPSHOT_PAUSE_DURING_WRITE_READBACK', true);
+}
+
+function cappedBackgroundConcurrency({
+  operation,
+  envName,
+  fallback,
+  maxEnvName,
+  maxFallback,
+}) {
+  const requested = Math.max(1, numberEnv(envName, fallback));
+  const max = Math.max(1, numberEnv(maxEnvName, maxFallback));
+  const effective = Math.min(requested, max);
+  if (effective < requested) {
+    incMap(metrics.snapshotBackgroundConcurrencyCaps, operation);
+  }
+  return {
+    requested,
+    max,
+    effective,
+    capped: effective < requested,
+  };
+}
+
+function snapshotBackgroundPauseInfo(operation, selectedCount, concurrency = {}) {
+  incMap(metrics.snapshotBackgroundPauses, operation);
+  return {
+    enabled: true,
+    selected_count: selectedCount,
+    paused_due_to_critical_write_readback: true,
+    active_critical_write_readback_count: activeCriticalWriteReadbacks,
+    ...concurrency,
+  };
+}
+
+async function runCriticalWriteReadback(route, storyId, readback) {
+  incMap(metrics.criticalWriteReadbacksStarted, route);
+  activeCriticalWriteReadbacks += 1;
+  try {
+    const testDelayMs = numberEnv('VH_RELAY_TEST_CRITICAL_WRITE_READBACK_DELAY_MS', 0);
+    if (testDelayMs > 0) {
+      logEvent('info', 'critical_write_readback_test_delay', {
+        route,
+        story_id: storyId,
+        delay_ms: testDelayMs,
+      });
+      await new Promise((resolve) => setTimeout(resolve, testDelayMs));
+    }
+    return await readback();
+  } finally {
+    activeCriticalWriteReadbacks = Math.max(0, activeCriticalWriteReadbacks - 1);
+  }
 }
 
 function logEvent(level, event, fields = {}) {
@@ -541,6 +602,7 @@ function metricsText() {
   add('vh_relay_ws_byte_drops_total', metrics.wsByteDrops);
   add('vh_relay_compaction_runs_total', metrics.compactionRuns);
   add('vh_relay_compaction_tombstones_total', metrics.compactionTombstones);
+  add('vh_relay_critical_write_readbacks_active', activeCriticalWriteReadbacks);
   add('vh_relay_radata_bytes', dirSizeBytes(gunFile));
   const memory = process.memoryUsage();
   const openFds = openFileDescriptorCount();
@@ -561,6 +623,15 @@ function metricsText() {
   }
   for (const [route, count] of metrics.writeFailures) {
     add('vh_relay_write_failures_total', count, { route });
+  }
+  for (const [route, count] of metrics.criticalWriteReadbacksStarted) {
+    add('vh_relay_critical_write_readbacks_started_total', count, { route });
+  }
+  for (const [operation, count] of metrics.snapshotBackgroundPauses) {
+    add('vh_relay_snapshot_background_pauses_total', count, { operation });
+  }
+  for (const [operation, count] of metrics.snapshotBackgroundConcurrencyCaps) {
+    add('vh_relay_snapshot_background_concurrency_caps_total', count, { operation });
   }
   return `${lines.join('\n')}\n`;
 }
@@ -2820,6 +2891,13 @@ function shouldRefreshSnapshotEntryStoryState(entry) {
 }
 
 async function verifySnapshotStoryBodies(gun, entries) {
+  const concurrency = cappedBackgroundConcurrency({
+    operation: 'story_body_verify',
+    envName: 'VH_RELAY_NEWS_INDEX_SNAPSHOT_STORY_VERIFY_CONCURRENCY',
+    fallback: 4,
+    maxEnvName: 'VH_RELAY_NEWS_INDEX_SNAPSHOT_STORY_VERIFY_MAX_CONCURRENCY',
+    maxFallback: 2,
+  });
   if (!boolEnv('VH_RELAY_NEWS_INDEX_SNAPSHOT_VERIFY_STORY_BODIES', true)) {
     return {
       entries,
@@ -2828,15 +2906,38 @@ async function verifySnapshotStoryBodies(gun, entries) {
         selected_count: entries.length,
         verified_count: 0,
         dropped_count: 0,
+        requested_concurrency: concurrency.requested,
+        effective_concurrency: 0,
+        max_concurrency: concurrency.max,
+        concurrency_capped: concurrency.capped,
       },
     };
   }
-  const concurrency = Math.max(1, numberEnv('VH_RELAY_NEWS_INDEX_SNAPSHOT_STORY_VERIFY_CONCURRENCY', 4));
+  if (criticalWriteReadbacksAreActive()) {
+    return {
+      entries,
+      info: {
+        ...snapshotBackgroundPauseInfo('story_body_verify', entries.length, {
+          requested_concurrency: concurrency.requested,
+          effective_concurrency: 0,
+          max_concurrency: concurrency.max,
+          concurrency_capped: concurrency.capped,
+        }),
+        verified_count: 0,
+        dropped_count: 0,
+        cached_count: 0,
+        skipped_count: entries.length,
+      },
+    };
+  }
   const timeoutMs = numberEnv('VH_RELAY_NEWS_INDEX_STORY_REST_READ_TIMEOUT_MS', 2_500);
   const cacheTtlMs = Math.max(0, numberEnv('VH_RELAY_NEWS_INDEX_SNAPSHOT_STORY_VERIFY_CACHE_TTL_MS', 5 * 60_000));
-  const checked = await mapWithConcurrency(entries, concurrency, async (entry) => {
+  const checked = await mapWithConcurrency(entries, concurrency.effective, async (entry) => {
     const storyId = String(entry?.entry?.[0] ?? entry?.story?.story_id ?? '').trim();
     if (!storyId) return { entry: null, verified: false };
+    if (criticalWriteReadbacksAreActive()) {
+      return { entry, verified: false, skipped: true };
+    }
     const cached = newsLatestIndexSnapshotStoryBodyCache.get(storyId);
     if (cached && cacheTtlMs > 0 && Date.now() - cached.checked_at <= cacheTtlMs) {
       return cached.story
@@ -2849,6 +2950,13 @@ async function verifySnapshotStoryBodies(gun, entries) {
           cached: true,
         }
         : { entry: null, verified: false, cached: true };
+    }
+    const testDelayMs = numberEnv('VH_RELAY_TEST_SNAPSHOT_BACKGROUND_READ_DELAY_MS', 0);
+    if (testDelayMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, testDelayMs));
+    }
+    if (criticalWriteReadbacksAreActive()) {
+      return { entry, verified: false, skipped: true };
     }
     const storyResult = await readNewsStoryRecord(gun, storyId, { timeoutMs }).catch(() => null);
     if (!storyResult?.story) {
@@ -2877,11 +2985,23 @@ async function verifySnapshotStoryBodies(gun, entries) {
       verified_count: checked.filter((result) => result.verified).length,
       dropped_count: checked.filter((result) => !result.entry).length,
       cached_count: checked.filter((result) => result.cached).length,
+      skipped_count: checked.filter((result) => result.skipped).length,
+      requested_concurrency: concurrency.requested,
+      effective_concurrency: concurrency.effective,
+      max_concurrency: concurrency.max,
+      concurrency_capped: concurrency.capped,
     },
   };
 }
 
 async function refreshSnapshotStoryStates(gun, entries) {
+  const concurrency = cappedBackgroundConcurrency({
+    operation: 'story_state_refresh',
+    envName: 'VH_RELAY_NEWS_INDEX_SNAPSHOT_REFRESH_CONCURRENCY',
+    fallback: 3,
+    maxEnvName: 'VH_RELAY_NEWS_INDEX_SNAPSHOT_REFRESH_MAX_CONCURRENCY',
+    maxFallback: 1,
+  });
   if (!boolEnv('VH_RELAY_NEWS_INDEX_SNAPSHOT_REFRESH_STORY_STATES', true)) {
     return {
       entries,
@@ -2889,15 +3009,38 @@ async function refreshSnapshotStoryStates(gun, entries) {
         enabled: false,
         selected_count: entries.length,
         refreshed_count: 0,
+        requested_concurrency: concurrency.requested,
+        effective_concurrency: 0,
+        max_concurrency: concurrency.max,
+        concurrency_capped: concurrency.capped,
+      },
+    };
+  }
+  if (criticalWriteReadbacksAreActive()) {
+    return {
+      entries,
+      info: {
+        ...snapshotBackgroundPauseInfo('story_state_refresh', entries.length, {
+          requested_concurrency: concurrency.requested,
+          effective_concurrency: 0,
+          max_concurrency: concurrency.max,
+          concurrency_capped: concurrency.capped,
+        }),
+        candidate_count: 0,
+        refreshed_count: 0,
+        skipped_count: entries.length,
       },
     };
   }
   const refreshCandidates = entries
     .map((entry, index) => ({ entry, index }))
     .filter(({ entry }) => shouldRefreshSnapshotEntryStoryState(entry));
-  const concurrency = Math.max(1, numberEnv('VH_RELAY_NEWS_INDEX_SNAPSHOT_REFRESH_CONCURRENCY', 3));
-  const refreshed = await mapWithConcurrency(refreshCandidates, concurrency, ({ entry }) =>
-    refreshSnapshotEntryStoryState(gun, entry));
+  const refreshed = await mapWithConcurrency(refreshCandidates, concurrency.effective, ({ entry }) => {
+    if (criticalWriteReadbacksAreActive()) {
+      return { entry, refreshed: false, skipped: true };
+    }
+    return refreshSnapshotEntryStoryState(gun, entry);
+  });
   const nextEntries = [...entries];
   for (let index = 0; index < refreshed.length; index += 1) {
     nextEntries[refreshCandidates[index].index] = refreshed[index].entry;
@@ -2909,6 +3052,11 @@ async function refreshSnapshotStoryStates(gun, entries) {
       selected_count: entries.length,
       candidate_count: refreshCandidates.length,
       refreshed_count: refreshed.filter((result) => result.refreshed).length,
+      skipped_count: refreshed.filter((result) => result.skipped).length,
+      requested_concurrency: concurrency.requested,
+      effective_concurrency: concurrency.effective,
+      max_concurrency: concurrency.max,
+      concurrency_capped: concurrency.capped,
     },
   };
 }
@@ -4199,10 +4347,14 @@ async function writeTopicSynthesisCandidate(gun, candidate) {
 async function writeNewsStoryRecord(gun, body) {
   const clean = sanitizeNewsStoryWrite(body);
   injectGraph(gun, buildNewsStoryGraph(clean));
-  const readback = await pollNewsStoryBack(
-    gun,
+  const readback = await runCriticalWriteReadback(
+    '/vh/news/story',
     clean.story_id,
-    numberEnv('VH_RELAY_NEWS_STORY_WRITE_READBACK_TIMEOUT_MS', 5_000),
+    () => pollNewsStoryBack(
+      gun,
+      clean.story_id,
+      numberEnv('VH_RELAY_NEWS_STORY_WRITE_READBACK_TIMEOUT_MS', 5_000),
+    ),
   );
   if (!readback) {
     throw new Error('news-story-readback-failed');
@@ -4218,10 +4370,14 @@ async function writeNewsStoryRecord(gun, body) {
 async function writeNewsLatestIndexRecord(gun, body) {
   const clean = sanitizeNewsLatestIndexWrite(body);
   injectGraph(gun, buildNewsLatestIndexGraph(clean));
-  const readback = await pollNewsLatestIndexBack(
-    gun,
+  const readback = await runCriticalWriteReadback(
+    '/vh/news/latest-index',
     clean.story_id,
-    numberEnv('VH_RELAY_NEWS_LATEST_INDEX_WRITE_READBACK_TIMEOUT_MS', 5_000),
+    () => pollNewsLatestIndexBack(
+      gun,
+      clean.story_id,
+      numberEnv('VH_RELAY_NEWS_LATEST_INDEX_WRITE_READBACK_TIMEOUT_MS', 5_000),
+    ),
   );
   if (!readback) {
     throw new Error('news-latest-index-readback-failed');
@@ -4237,11 +4393,15 @@ async function writeNewsLatestIndexRecord(gun, body) {
 async function writeNewsHotIndexRecord(gun, body) {
   const clean = sanitizeNewsHotIndexWrite(body);
   injectGraph(gun, buildNewsHotIndexGraph(clean));
-  const readback = await pollNewsHotIndexBack(
-    gun,
+  const readback = await runCriticalWriteReadback(
+    '/vh/news/hot-index',
     clean.story_id,
-    numberEnv('VH_RELAY_NEWS_HOT_INDEX_WRITE_READBACK_TIMEOUT_MS',
-      numberEnv('VH_RELAY_NEWS_LATEST_INDEX_WRITE_READBACK_TIMEOUT_MS', 5_000)),
+    () => pollNewsHotIndexBack(
+      gun,
+      clean.story_id,
+      numberEnv('VH_RELAY_NEWS_HOT_INDEX_WRITE_READBACK_TIMEOUT_MS',
+        numberEnv('VH_RELAY_NEWS_LATEST_INDEX_WRITE_READBACK_TIMEOUT_MS', 5_000)),
+    ),
   );
   if (!readback) {
     throw new Error('news-hot-index-readback-failed');
@@ -4253,11 +4413,15 @@ async function writeNewsSynthesisLifecycleRecord(gun, body) {
   const clean = sanitizeNewsSynthesisLifecycleWrite(body);
   injectGraph(gun, buildNewsSynthesisLifecycleGraph(clean));
   upsertNewsSynthesisLifecycleSnapshot(clean.record);
-  const readback = await pollNewsSynthesisLifecycleBack(
-    gun,
+  const readback = await runCriticalWriteReadback(
+    '/vh/news/synthesis-lifecycle',
     clean.story_id,
-    clean.record,
-    numberEnv('VH_RELAY_NEWS_LIFECYCLE_WRITE_READBACK_TIMEOUT_MS', 5_000),
+    () => pollNewsSynthesisLifecycleBack(
+      gun,
+      clean.story_id,
+      clean.record,
+      numberEnv('VH_RELAY_NEWS_LIFECYCLE_WRITE_READBACK_TIMEOUT_MS', 5_000),
+    ),
   );
   if (!readback) {
     throw new Error('news-synthesis-lifecycle-readback-failed');

--- a/packages/e2e/src/live/relay-server.vitest.mjs
+++ b/packages/e2e/src/live/relay-server.vitest.mjs
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import http from 'node:http';
 import os from 'node:os';
 import path from 'node:path';
@@ -88,6 +88,10 @@ function requestJson(url, { method = 'GET', headers = {}, body = undefined } = {
 
 function delay(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function escapeRegExp(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 function websocketUpgradeStatus(port, pathname = '/gun') {
@@ -253,6 +257,71 @@ function makeRelayNewsStory(storyId, latestActivityAt, sources) {
     provenance_hash: `prov-${storyId}`,
     created_at: latestActivityAt - 20,
   };
+}
+
+function makeRelayLatestIndexRecord(story, latestActivityAt = story.cluster_window_end) {
+  return {
+    story_id: story.story_id,
+    latest_activity_at: latestActivityAt,
+    product_state_schema_version: 'vh-news-product-feed-index-v1',
+    topic_id: story.topic_id,
+    source_set_revision: story.provenance_hash,
+    source_count: Array.isArray(story.sources) ? story.sources.length : 0,
+    canonical_source_count: Array.isArray(story.sources) ? story.sources.length : 0,
+    story_created_at: story.created_at,
+    cluster_window_start: story.cluster_window_start,
+  };
+}
+
+function makeRelaySynthesisLifecycleRecord(story, {
+  status = 'pending',
+  frameTableState = 'frame_table_pending',
+  updatedAt = Date.now(),
+  synthesisId = null,
+} = {}) {
+  return {
+    schemaVersion: 'vh-news-synthesis-lifecycle-v1',
+    story_id: story.story_id,
+    topic_id: story.topic_id,
+    source_set_revision: story.provenance_hash,
+    source_count: Array.isArray(story.sources) ? story.sources.length : 0,
+    canonical_source_count: Array.isArray(story.sources) ? story.sources.length : 0,
+    status,
+    frame_table_state: frameTableState,
+    retryable: status === 'retryable_failure',
+    ...(synthesisId ? { synthesis_id: synthesisId, epoch: 0 } : {}),
+    updated_at: updatedAt,
+  };
+}
+
+function writeLatestIndexSnapshotFile(snapshotFile, story) {
+  const record = makeRelayLatestIndexRecord(story);
+  writeFileSync(
+    snapshotFile,
+    `${JSON.stringify({
+      schema_version: 'vh-news-latest-index-relay-snapshot-v1',
+      snapshot_key: JSON.stringify({ consistencyFilter: true }),
+      cached_at: Date.now(),
+      source_key_count: 1,
+      scanned_key_count: 1,
+      consistency: {},
+      repaired_records: [],
+      entries: [{
+        story_id: story.story_id,
+        record,
+        story,
+        story_state: {
+          synthesis_state: 'synthesis_pending',
+          frame_table_state: 'frame_table_pending',
+          lifecycle_status: 'pending',
+          lifecycle_source_set_revision: story.provenance_hash,
+          lifecycle_updated_at: Date.now(),
+          terminal_unavailable_reason: null,
+          retryable: false,
+        },
+      }],
+    })}\n`,
+  );
 }
 
 async function writeRelayNewsStory(port, story) {
@@ -1335,6 +1404,160 @@ describe('infra relay server', () => {
         }),
       });
   });
+
+  it('pauses snapshot maintenance while critical public-news write readbacks are active', async () => {
+    const snapshotDir = mkdtempSync(path.join(os.tmpdir(), 'vh-relay-critical-readback-test-'));
+    tempDirs.add(snapshotDir);
+    const snapshotFile = path.join(snapshotDir, 'latest-index-snapshot.json');
+    const seedStory = makeRelayNewsStory('story-critical-readback-seed', 1778993000000, [
+      {
+        source_id: 'source-critical-readback-seed',
+        publisher: 'Example News',
+        url: 'https://example.com/critical-readback-seed',
+        url_hash: 'critical-readback-seed',
+        published_at: 1778993000000,
+        title: 'Critical readback seed story',
+      },
+    ]);
+    writeLatestIndexSnapshotFile(snapshotFile, seedStory);
+
+    const { port, child } = await startRelay(children, tempDirs, {
+      VH_RELAY_NEWS_INDEX_SNAPSHOT_FILE: snapshotFile,
+      VH_RELAY_NEWS_INDEX_REST_PREFER_SNAPSHOT: 'true',
+      VH_RELAY_NEWS_INDEX_SNAPSHOT_VERIFY_STORY_BODIES: 'true',
+      VH_RELAY_NEWS_INDEX_SNAPSHOT_REFRESH_STORY_STATES: 'true',
+      VH_RELAY_NEWS_INDEX_SNAPSHOT_STORY_VERIFY_CONCURRENCY: '12',
+      VH_RELAY_NEWS_INDEX_SNAPSHOT_REFRESH_CONCURRENCY: '12',
+      VH_RELAY_TEST_CRITICAL_WRITE_READBACK_DELAY_MS: '1200',
+      VH_RELAY_TEST_SNAPSHOT_BACKGROUND_READ_DELAY_MS: '25',
+    });
+
+    const cases = [
+      {
+        route: '/vh/news/story',
+        story: makeRelayNewsStory('story-critical-readback-story', 1778993001000, [
+          {
+            source_id: 'source-critical-readback-story',
+            publisher: 'Example News',
+            url: 'https://example.com/critical-readback-story',
+            url_hash: 'critical-readback-story',
+            published_at: 1778993001000,
+            title: 'Critical readback story write',
+          },
+        ]),
+        body: (story) => ({
+          record: {
+            __story_bundle_json: JSON.stringify(story),
+            story_id: story.story_id,
+            created_at: story.created_at,
+            schemaVersion: story.schemaVersion,
+          },
+        }),
+      },
+      {
+        route: '/vh/news/latest-index',
+        story: makeRelayNewsStory('story-critical-readback-latest', 1778993002000, [
+          {
+            source_id: 'source-critical-readback-latest',
+            publisher: 'Example News',
+            url: 'https://example.com/critical-readback-latest',
+            url_hash: 'critical-readback-latest',
+            published_at: 1778993002000,
+            title: 'Critical readback latest-index write',
+          },
+        ]),
+        body: (story) => ({ record: makeRelayLatestIndexRecord(story) }),
+      },
+      {
+        route: '/vh/news/hot-index',
+        story: makeRelayNewsStory('story-critical-readback-hot', 1778993003000, [
+          {
+            source_id: 'source-critical-readback-hot',
+            publisher: 'Example News',
+            url: 'https://example.com/critical-readback-hot',
+            url_hash: 'critical-readback-hot',
+            published_at: 1778993003000,
+            title: 'Critical readback hot-index write',
+          },
+        ]),
+        body: (story) => ({ record: { story_id: story.story_id, hotness: 0.9 } }),
+      },
+      {
+        route: '/vh/news/synthesis-lifecycle',
+        story: makeRelayNewsStory('story-critical-readback-lifecycle', 1778993004000, [
+          {
+            source_id: 'source-critical-readback-lifecycle',
+            publisher: 'Example News',
+            url: 'https://example.com/critical-readback-lifecycle',
+            url_hash: 'critical-readback-lifecycle',
+            published_at: 1778993004000,
+            title: 'Critical readback lifecycle write',
+          },
+        ]),
+        body: (story) => ({ record: makeRelaySynthesisLifecycleRecord(story, { updatedAt: 1778993004500 }) }),
+      },
+    ];
+
+    for (const testCase of cases) {
+      const write = requestJson(`http://127.0.0.1:${port}${testCase.route}`, {
+        method: 'POST',
+        body: testCase.body(testCase.story),
+      });
+      await waitForOutput(
+        child,
+        new RegExp(`critical_write_readback_test_delay.*${escapeRegExp(testCase.route)}.*${testCase.story.story_id}`),
+        5_000,
+      );
+
+      const latest = await requestJson(`http://127.0.0.1:${port}/vh/news/latest-index?limit=2&scan_limit=2`);
+      expect(latest).toMatchObject({
+        statusCode: 200,
+        body: expect.objectContaining({
+          ok: true,
+          consistency: expect.objectContaining({
+            snapshot_story_body_readback: expect.objectContaining({
+              enabled: true,
+              paused_due_to_critical_write_readback: true,
+              requested_concurrency: 12,
+              effective_concurrency: 0,
+              max_concurrency: 2,
+              concurrency_capped: true,
+              dropped_count: 0,
+              skipped_count: expect.any(Number),
+            }),
+            snapshot_story_state_refresh: expect.objectContaining({
+              enabled: true,
+              paused_due_to_critical_write_readback: true,
+              requested_concurrency: 12,
+              effective_concurrency: 0,
+              max_concurrency: 1,
+              concurrency_capped: true,
+              refreshed_count: 0,
+              skipped_count: expect.any(Number),
+            }),
+          }),
+        }),
+      });
+
+      await expect(write).resolves.toMatchObject({
+        statusCode: 200,
+        body: expect.objectContaining({ ok: true, story_id: testCase.story.story_id }),
+      });
+    }
+
+    const metrics = await fetchText(`http://127.0.0.1:${port}/metrics`);
+    expect(metrics.statusCode).toBe(200);
+    for (const testCase of cases) {
+      expect(metrics.body).toContain(
+        `vh_relay_critical_write_readbacks_started_total{route="${testCase.route}"} 1`,
+      );
+    }
+    expect(metrics.body).toContain('vh_relay_snapshot_background_pauses_total{operation="story_body_verify"} 4');
+    expect(metrics.body).toContain('vh_relay_snapshot_background_pauses_total{operation="story_state_refresh"} 4');
+    expect(metrics.body).toContain('vh_relay_snapshot_background_concurrency_caps_total{operation="story_body_verify"}');
+    expect(metrics.body).toContain('vh_relay_snapshot_background_concurrency_caps_total{operation="story_state_refresh"}');
+    expect(metrics.body).toContain('vh_relay_critical_write_readbacks_active 0');
+  }, 20_000);
 
   it('bounds latest-index relay fallback response shape and omits the root unless requested', async () => {
     const { port } = await startRelay(children, tempDirs, {

--- a/packages/e2e/src/live/relay-server.vitest.mjs
+++ b/packages/e2e/src/live/relay-server.vitest.mjs
@@ -1543,6 +1543,36 @@ describe('infra relay server', () => {
         statusCode: 200,
         body: expect.objectContaining({ ok: true, story_id: testCase.story.story_id }),
       });
+
+      const resumedLatest = await requestJson(`http://127.0.0.1:${port}/vh/news/latest-index?limit=2&scan_limit=2`);
+      expect(resumedLatest).toMatchObject({
+        statusCode: 200,
+        body: expect.objectContaining({
+          ok: true,
+          consistency: expect.objectContaining({
+            snapshot_story_body_readback: expect.objectContaining({
+              enabled: true,
+              requested_concurrency: 12,
+              effective_concurrency: 2,
+              max_concurrency: 2,
+              concurrency_capped: true,
+              verified_count: expect.any(Number),
+            }),
+            snapshot_story_state_refresh: expect.objectContaining({
+              enabled: true,
+              requested_concurrency: 12,
+              effective_concurrency: 1,
+              max_concurrency: 1,
+              concurrency_capped: true,
+            }),
+          }),
+        }),
+      });
+      const resumedBodyReadback = resumedLatest.body.consistency.snapshot_story_body_readback;
+      const resumedStateRefresh = resumedLatest.body.consistency.snapshot_story_state_refresh;
+      expect(resumedBodyReadback).not.toHaveProperty('paused_due_to_critical_write_readback');
+      expect(resumedStateRefresh).not.toHaveProperty('paused_due_to_critical_write_readback');
+      expect(resumedBodyReadback.verified_count).toBeGreaterThan(0);
     }
 
     const metrics = await fetchText(`http://127.0.0.1:${port}/metrics`);
@@ -1558,6 +1588,104 @@ describe('infra relay server', () => {
     expect(metrics.body).toContain('vh_relay_snapshot_background_concurrency_caps_total{operation="story_state_refresh"}');
     expect(metrics.body).toContain('vh_relay_critical_write_readbacks_active 0');
   }, 20_000);
+
+  it('keeps critical public-news write readback failures fatal to the route', async () => {
+    const routes = [
+      {
+        route: '/vh/news/story',
+        expectedError: 'news-story-readback-failed',
+        story: makeRelayNewsStory('story-forced-readback-failure-story', 1778993101000, [
+          {
+            source_id: 'source-forced-readback-failure-story',
+            publisher: 'Example News',
+            url: 'https://example.com/forced-readback-failure-story',
+            url_hash: 'forced-readback-failure-story',
+            published_at: 1778993101000,
+            title: 'Forced readback failure story write',
+          },
+        ]),
+        body: (story) => ({
+          record: {
+            __story_bundle_json: JSON.stringify(story),
+            story_id: story.story_id,
+            created_at: story.created_at,
+            schemaVersion: story.schemaVersion,
+          },
+        }),
+      },
+      {
+        route: '/vh/news/latest-index',
+        expectedError: 'news-latest-index-readback-failed',
+        story: makeRelayNewsStory('story-forced-readback-failure-latest', 1778993102000, [
+          {
+            source_id: 'source-forced-readback-failure-latest',
+            publisher: 'Example News',
+            url: 'https://example.com/forced-readback-failure-latest',
+            url_hash: 'forced-readback-failure-latest',
+            published_at: 1778993102000,
+            title: 'Forced readback failure latest-index write',
+          },
+        ]),
+        body: (story) => ({ record: makeRelayLatestIndexRecord(story) }),
+      },
+      {
+        route: '/vh/news/hot-index',
+        expectedError: 'news-hot-index-readback-failed',
+        story: makeRelayNewsStory('story-forced-readback-failure-hot', 1778993103000, [
+          {
+            source_id: 'source-forced-readback-failure-hot',
+            publisher: 'Example News',
+            url: 'https://example.com/forced-readback-failure-hot',
+            url_hash: 'forced-readback-failure-hot',
+            published_at: 1778993103000,
+            title: 'Forced readback failure hot-index write',
+          },
+        ]),
+        body: (story) => ({ record: { story_id: story.story_id, hotness: 0.9 } }),
+      },
+      {
+        route: '/vh/news/synthesis-lifecycle',
+        expectedError: 'news-synthesis-lifecycle-readback-failed',
+        story: makeRelayNewsStory('story-forced-readback-failure-lifecycle', 1778993104000, [
+          {
+            source_id: 'source-forced-readback-failure-lifecycle',
+            publisher: 'Example News',
+            url: 'https://example.com/forced-readback-failure-lifecycle',
+            url_hash: 'forced-readback-failure-lifecycle',
+            published_at: 1778993104000,
+            title: 'Forced readback failure lifecycle write',
+          },
+        ]),
+        body: (story) => ({ record: makeRelaySynthesisLifecycleRecord(story, { updatedAt: 1778993104500 }) }),
+      },
+    ];
+    const { port } = await startRelay(children, tempDirs, {
+      VH_RELAY_TEST_FORCE_CRITICAL_WRITE_READBACK_FAILURE_ROUTES: routes.map((entry) => entry.route).join(','),
+    });
+
+    for (const testCase of routes) {
+      await expect(requestJson(`http://127.0.0.1:${port}${testCase.route}`, {
+        method: 'POST',
+        body: testCase.body(testCase.story),
+      })).resolves.toMatchObject({
+        statusCode: 500,
+        body: expect.objectContaining({
+          ok: false,
+          error: testCase.expectedError,
+        }),
+      });
+    }
+
+    const metrics = await fetchText(`http://127.0.0.1:${port}/metrics`);
+    expect(metrics.statusCode).toBe(200);
+    for (const testCase of routes) {
+      expect(metrics.body).toContain(`vh_relay_write_failures_total{route="${testCase.route}"} 1`);
+      expect(metrics.body).toContain(
+        `vh_relay_critical_write_readbacks_started_total{route="${testCase.route}"} 1`,
+      );
+    }
+    expect(metrics.body).toContain('vh_relay_critical_write_readbacks_active 0');
+  });
 
   it('bounds latest-index relay fallback response shape and omits the root unless requested', async () => {
     const { port } = await startRelay(children, tempDirs, {


### PR DESCRIPTION
## Summary
- track active critical public-news write readbacks across story, latest-index, hot-index, and synthesis-lifecycle relay routes
- cap snapshot body-verify and story-state-refresh concurrency, and pause that optional maintenance while critical write readbacks are active
- preserve the live relay readback contract: latest-index snapshots remain downstream read evidence, not write-success proof
- add metrics for active/started critical readbacks plus snapshot maintenance pauses and concurrency caps
- correct stale topology docs: current Phase 5 evidence has all three relays on A6 with gun-c locally redirected

## Safety
- no quorum weakening; publisher still requires the configured 2-of-3 relay REST success count
- no switch to snapshot-as-write-proof; critical writes still must pass payload validation and route readback
- forced readback failures still return route-level 500s for story, latest-index, hot-index, and synthesis-lifecycle
- no live host action, no publisher start, no relay restart, no StoryCluster reset, and no mesh writes performed in this PR

## Verification
- `PATH="/opt/homebrew/opt/node@20/bin:$PATH" node --check infra/relay/server.js`
- `PATH="/opt/homebrew/opt/node@20/bin:$PATH" node --check packages/e2e/src/live/relay-server.vitest.mjs`
- `PATH="/opt/homebrew/opt/node@20/bin:$PATH" pnpm --filter @vh/e2e exec vitest run src/live/relay-server.vitest.mjs --config ./vitest.config.ts` -> 1 file, 40 tests passed
- `PATH="/opt/homebrew/opt/node@20/bin:$PATH" pnpm test:quick` -> 319 files, 4,936 tests passed
- `git diff --check`
- `PATH="/opt/homebrew/opt/node@20/bin:$PATH" node tools/scripts/check-diff-coverage.mjs` -> PASS

## Added hardening after review
- asserts snapshot maintenance resumes after critical readbacks clear: unpaused, nonzero effective concurrency, and verified story bodies
- adds a table-driven forced-readback-failure regression proving all four critical write routes stay fatal with HTTP 500

## Post-merge validation
The deterministic tests model the coordination mechanism, but live proof still needs an operator-owned A6 soak: N ticks over M minutes, watching relay `write_route_failed` logs plus `vh_relay_critical_write_readbacks_started_total`, `vh_relay_snapshot_background_pauses_total`, and `vh_relay_snapshot_background_concurrency_caps_total`. Do not treat green CI alone as sustained-load proof.
