### PR TITLE
Harden relay overload self-defense

### DIFF
--- a/docs/ops/news-aggregator-production-service.md
+++ b/docs/ops/news-aggregator-production-service.md
@@ -35,6 +35,8 @@ Templates:
 - `infra/systemd/user/vh-relay-snapshot-freshness-watch.timer`
 - `infra/systemd/user/vh-news-aggregator-liveness-watch.service`
 - `infra/systemd/user/vh-news-aggregator-liveness-watch.timer`
+- `infra/systemd/user/vh-news-relay-liveness-watch.service`
+- `infra/systemd/user/vh-news-relay-liveness-watch.timer`
 
 Installer:
 
@@ -121,6 +123,22 @@ Enable this only after the attended start has produced current runtime
 diagnostics. It checks the publisher unit state, `NRestarts`, the current
 per-start run marker, and the freshness of the runtime diagnostic artifact.
 
+Relay liveness watch timer:
+
+```bash
+./tools/scripts/install-news-aggregator-production-service.sh --enable-relay-liveness-watch
+systemctl --user status vh-news-relay-liveness-watch.timer --no-pager
+journalctl --user -u vh-news-relay-liveness-watch.service -n 100 --no-pager
+```
+
+Enable this only after relays are intended-live. It checks `/readyz`, `/metrics`,
+Docker restart count, watchdog trips, RSS/heap, event-loop lag, and queued
+critical readbacks. The installed timer also restarts at most one eligible
+unhealthy relay per run (`VH_RELAY_LIVENESS_RESTART_ON_FAIL=true`,
+`VH_RELAY_LIVENESS_RESTART_MAX_PER_RUN=1`) with a 10 minute per-relay cooldown
+so a fully wedged relay can recover without restarting all relays in lockstep. A
+deliberately stopped relay with the timer still enabled is an alert condition.
+
 Approved publisher start packet:
 
 ```bash
@@ -134,11 +152,17 @@ systemctl --user status vh-news-aggregator.service --no-pager
 journalctl --user -u vh-news-aggregator.service -n 200 --no-pager
 ```
 
+The installer imports `VH_NEWS_DAEMON_START_APPROVED=1` into the user systemd
+manager before `enable --now`; a shell-only variable is not enough for
+`ExecStart`. After an abort or deliberate stop, remove the approval from the
+manager too:
+
 Abort / kill switch:
 
 ```bash
 systemctl --user stop vh-news-aggregator.service
 systemctl --user disable vh-news-aggregator.service
+systemctl --user unset-environment VH_NEWS_DAEMON_START_APPROVED
 journalctl --user -u vh-news-aggregator.service -n 200 --no-pager
 ```
 
@@ -452,20 +476,58 @@ The critical write routes (`/vh/news/story`, `/vh/news/latest-index`,
 `/vh/news/hot-index`, and `/vh/news/synthesis-lifecycle`) must confirm the
 write through their live relay readback path. A latest-index snapshot is
 downstream read-through evidence and must not be treated as proof that the
-in-flight write durably landed. Snapshot body verification and story-state
-refresh are optional maintenance work: they are concurrency-capped and pause
-while a critical write readback is active so they cannot starve the single relay
-event loop and turn a locally landed write into a false readback timeout.
-The current safety caps default to
+in-flight write durably landed. The same relay-side admission discipline now
+protects every write->readback surface, including topic synthesis and forum
+writes, so optional lanes cannot stampede the single relay event loop while raw
+publication is proving durability. Topic-synthesis backpressure or readback
+failure remains optional/non-fatal to the publisher under Scope A; relay-side
+bounding does not add it to the publisher fail-closed allow-list.
+
+When the per-relay critical readback admission gate is saturated, the relay
+returns `503` with `error=relay-critical-readback-backpressure` (or
+`relay-critical-readback-queue-timeout`) and `Retry-After`. The gun client
+classifies that response as `relay-backpressure`: it is a failed relay for the
+current fanout and never counts as quorum success, but it is distinct from a
+hard readback-failed `500` for diagnostics. The 2-of-3 quorum requirement is
+unchanged.
+
+Snapshot body verification, story-state refresh, topic synthesis maintenance,
+and other optional background work are maintenance work: they are
+concurrency-capped and pause while a critical write readback is active or queued
+so they cannot starve the single relay event loop and turn a locally landed
+write into a false readback timeout. The current safety caps default to
 `VH_RELAY_NEWS_INDEX_SNAPSHOT_STORY_VERIFY_MAX_CONCURRENCY=2` and
 `VH_RELAY_NEWS_INDEX_SNAPSHOT_REFRESH_MAX_CONCURRENCY=1`; leave
 `VH_RELAY_NEWS_INDEX_SNAPSHOT_PAUSE_DURING_WRITE_READBACK=true` unless an
 attended rollback explicitly needs the old behavior for diagnosis.
+
+Relays also run a resource watchdog in production. It uses
+`perf_hooks.monitorEventLoopDelay()`, RSS, and heap usage thresholds. On breach
+it writes a secret-safe diagnostic bundle under the relay data mount, attempts a
+short best-effort CPU profile, and exits `1` so Docker can restart that relay.
+Deploy packets should recreate relays with bounded `--restart on-failure:5`,
+`--memory 2304m --memory-swap 2304m`, `VH_RELAY_STARTUP_JITTER_MAX_MS=5000`,
+and `VH_RELAY_DIAGNOSTIC_DIR=/data/diagnostics` so repeated overload does not
+become an unbounded synchronized restart loop. The Docker memory ceiling is a
+host-protection backstop above the 1.8 GB RSS watchdog; the watchdog should
+capture and exit first, while the cgroup prevents a fast off-heap spike from
+exhausting A6 memory across all three co-located relays.
+
 Operators should watch `/metrics` counters
 `vh_relay_critical_write_readbacks_started_total`,
+`vh_relay_critical_write_readbacks_queued`,
+`vh_relay_critical_write_readback_backpressure_total`,
+`vh_relay_resource_watchdog_trips_total`,
 `vh_relay_snapshot_background_pauses_total`, and
 `vh_relay_snapshot_background_concurrency_caps_total` during any post-merge
 soak.
+
+During the post-#675 soak, a single relay returning `503`
+`relay-critical-readback-backpressure` is expected graceful load shedding when
+the other two relays satisfy quorum. It must not be counted as success, and it
+must not be treated like a readback `500`. Abort or investigate on any critical
+route `500`, any fail-close, any watchdog trip, two relays shedding at once such
+that quorum falls below 2, or queues that do not drain in idle gaps.
 
 For Scope A launch gating, fail-closed only applies to the quorum-durable raw
 path: `/vh/news/story`, `/vh/news/latest-index`, `/vh/news/hot-index`, and the
@@ -714,6 +776,9 @@ Abort or stop the service if any of these occur:
   `runtime error triggered fail-closed stop`;
 - `news-aggregator-publisher-liveness-watch.mjs` reports a failed unit state,
   increased `NRestarts`, stale diagnostics, or a diagnostic run id mismatch;
+- `news-relay-liveness-watch.mjs` reports a relay restart-count increase,
+  watchdog trip, hot RSS/heap/event-loop lag, or persistent queued critical
+  readbacks;
 - snapshot watch reports stale newest-entry age above 6 hours;
 - latest content does not advance after approved start and expected ingest
   cadence.

--- a/docs/ops/news-aggregator.env.example
+++ b/docs/ops/news-aggregator.env.example
@@ -71,6 +71,16 @@ VH_NEWS_PUBLISHER_LIVENESS_STATE_FILE=/home/humble/.local/state/vhc/news-aggrega
 VH_NEWS_PUBLISHER_LIVENESS_OUTPUT_FILE=/home/humble/.local/state/vhc/news-aggregator/publisher-liveness/latest.json
 VH_NEWS_PUBLISHER_LIVENESS_MAX_DIAGNOSTIC_AGE_MS=1200000
 VH_NEWS_PUBLISHER_LIVENESS_STARTUP_GRACE_MS=900000
+VH_RELAY_LIVENESS_TARGETS=vhc-relay-a=http://127.0.0.1:8765,vhc-relay-b=http://127.0.0.1:8766,vhc-relay-c=http://127.0.0.1:8767
+VH_RELAY_LIVENESS_STATE_FILE=/home/humble/.local/state/vhc/relay-liveness/relay-liveness-watch-state.json
+VH_RELAY_LIVENESS_OUTPUT_FILE=/home/humble/.local/state/vhc/relay-liveness/latest.json
+VH_RELAY_LIVENESS_MAX_RSS_BYTES=1800000000
+VH_RELAY_LIVENESS_MAX_HEAP_USED_BYTES=1300000000
+VH_RELAY_LIVENESS_MAX_EVENT_LOOP_LAG_P99_MS=2500
+VH_RELAY_LIVENESS_MAX_QUEUED_READBACKS=16
+VH_RELAY_LIVENESS_RESTART_ON_FAIL=true
+VH_RELAY_LIVENESS_RESTART_MAX_PER_RUN=1
+VH_RELAY_LIVENESS_RESTART_MIN_INTERVAL_MS=600000
 VH_NEWS_FEED_MAX_ITEMS_PER_SOURCE=8
 VH_NEWS_FEED_MAX_ITEMS_TOTAL=96
 VH_NEWS_RUNTIME_MAX_PUBLISHED_BUNDLES=96
@@ -88,6 +98,17 @@ VH_BUNDLE_SYNTHESIS_QUEUE_DIR=/home/humble/.local/state/vhc/news-aggregator/bund
 VH_BUNDLE_SYNTHESIS_LIFECYCLE_LEDGER=/home/humble/.local/state/vhc/news-aggregator/bundle-synthesis-queue/synthesis-lifecycle.jsonl
 VITE_NEWS_POLL_INTERVAL_MS=600000
 VH_BUNDLE_SYNTHESIS_CATCHUP_INTERVAL_MS=300000
+
+# Relay-container self-defense defaults are applied by the deploy packet when
+# recreating the relay containers. Keep these names aligned if A6 overrides them
+# in relay env files.
+# VH_RELAY_RESOURCE_WATCHDOG_ENABLED=true
+# VH_RELAY_DIAGNOSTIC_DIR=/data/diagnostics
+# VH_RELAY_STARTUP_JITTER_MAX_MS=5000
+# VH_RELAY_DOCKER_MEMORY_LIMIT=2304m
+# VH_RELAY_CRITICAL_WRITE_READBACK_MAX_CONCURRENCY=2
+# VH_RELAY_CRITICAL_WRITE_READBACK_QUEUE_LIMIT=16
+# VH_RELAY_CRITICAL_WRITE_READBACK_QUEUE_TIMEOUT_MS=1000
 
 # Public beta system writer v4.
 VH_NEWS_SYSTEM_WRITER_ID=vh-public-beta-news-system-writer-v4

--- a/docs/ops/public-beta-image-deploy.md
+++ b/docs/ops/public-beta-image-deploy.md
@@ -34,6 +34,19 @@ re-enable monitors.
   deploy error.
 - Set `NODE_ENV=production` on relays so snapshot-first latest-index serving
   stays enabled by default.
+- Run relays with bounded self-recovery: `--restart on-failure:5`,
+  `--memory 2304m --memory-swap 2304m`,
+  `VH_RELAY_RESOURCE_WATCHDOG_ENABLED=true`,
+  `VH_RELAY_DIAGNOSTIC_DIR=/data/diagnostics`, and
+  `VH_RELAY_STARTUP_JITTER_MAX_MS=5000`. Relay watchdog exit is intentionally
+  restartable; publisher fail-closed exit is intentionally not. The memory
+  ceiling sits above the relay's graceful RSS watchdog and below host-exhaustion
+  territory, so a fast off-heap spike is contained to one relay container.
+- Keep relay critical write/readback admission bounded. The deploy packet adds
+  `VH_RELAY_CRITICAL_WRITE_READBACK_MAX_CONCURRENCY=2`,
+  `VH_RELAY_CRITICAL_WRITE_READBACK_QUEUE_LIMIT=16`, and
+  `VH_RELAY_CRITICAL_WRITE_READBACK_QUEUE_TIMEOUT_MS=1000` unless A6 has an
+  explicit reviewed override.
 - Leave relay `GUN_STATS` unset or explicitly `false`. The relay disables GUN's
   package-local stats writer by default; setting `GUN_STATS=true` makes GUN
   write `stats.<basename(GUN_FILE)>` beside `node_modules/gun`, which is not a
@@ -283,7 +296,9 @@ their values.
 2. Run the direct on-disk relay snapshot precheck for every relay.
 3. Deploy one relay at a time with the existing host data bind mount preserved.
 4. After each relay restart, prove the running image tag/digest and verify the
-   three snapshot files still exist in the relay `GUN_FILE` directory.
+   three snapshot files still exist in the relay `GUN_FILE` directory. Confirm
+   the relay env includes the watchdog/admission defaults and Docker shows
+   `RestartPolicy.Name=on-failure` with `MaximumRetryCount=5`.
 5. After all relays prove the #638 image is running, run safe latest-index
    behavior probes:
    - `persist=true` returns JSON 400.
@@ -291,12 +306,16 @@ their values.
 6. Deploy the origin image from the same `main` revision and repoint analysis to
    `http://127.0.0.1:3001`.
 7. Verify local and public `/api/analyze/health` and `/api/analyze/config`.
-8. Only after explicit operator approval, add
-   `VH_NEWS_DAEMON_START_APPROVED=1` to the publisher env file and start the
-   managed publisher.
+8. Only after explicit operator approval, run the publisher installer with
+   `VH_NEWS_DAEMON_START_APPROVED=1`; the installer imports that approval into
+   the user systemd manager before starting `vh-news-aggregator.service`.
 9. Prove latest content advances and synthesis lifecycle/publication evidence
    is fresh.
-10. Re-enable the public freshness monitor and begin soak/canary.
+10. Re-enable the relay liveness, publisher liveness, and public freshness
+   monitors in that order, then begin soak/canary. The relay liveness timer is
+   an active remediation timer once enabled: it can restart one unhealthy relay
+   per run with cooldown, so leave it disabled during intentional relay
+   maintenance.
 
 ## No-Go Criteria
 
@@ -329,3 +348,8 @@ systemctl --user stop vh-news-aggregator.service
 ```
 
 Then remove the approval flag before any restart.
+Also remove the user-manager approval if it was imported:
+
+```bash
+systemctl --user unset-environment VH_NEWS_DAEMON_START_APPROVED
+```

--- a/infra/docker/docker-compose.public-beta.yml
+++ b/infra/docker/docker-compose.public-beta.yml
@@ -22,7 +22,9 @@ services:
 
   relay-a:
     image: ${VH_PUBLIC_BETA_RELAY_IMAGE:?set rebuilt relay image tag or digest}
-    restart: unless-stopped
+    restart: on-failure:5
+    mem_limit: ${VH_PUBLIC_BETA_RELAY_MEMORY_LIMIT:-2304m}
+    memswap_limit: ${VH_PUBLIC_BETA_RELAY_MEMORY_SWAP_LIMIT:-2304m}
     user: ${VH_PUBLIC_BETA_RELAY_UID_GID:?set relay UID:GID, for example humble uid:gid}
     env_file:
       - ${VH_PUBLIC_BETA_RELAY_ENV_FILE:?set relay env file outside git}
@@ -33,6 +35,12 @@ services:
       GUN_RADISK: "true"
       NODE_ENV: production
       VH_RELAY_ID: public-beta-relay-a
+      VH_RELAY_RESOURCE_WATCHDOG_ENABLED: ${VH_RELAY_RESOURCE_WATCHDOG_ENABLED:-true}
+      VH_RELAY_DIAGNOSTIC_DIR: ${VH_RELAY_DIAGNOSTIC_DIR:-/data/diagnostics}
+      VH_RELAY_STARTUP_JITTER_MAX_MS: ${VH_RELAY_STARTUP_JITTER_MAX_MS:-5000}
+      VH_RELAY_CRITICAL_WRITE_READBACK_MAX_CONCURRENCY: ${VH_RELAY_CRITICAL_WRITE_READBACK_MAX_CONCURRENCY:-2}
+      VH_RELAY_CRITICAL_WRITE_READBACK_QUEUE_LIMIT: ${VH_RELAY_CRITICAL_WRITE_READBACK_QUEUE_LIMIT:-16}
+      VH_RELAY_CRITICAL_WRITE_READBACK_QUEUE_TIMEOUT_MS: ${VH_RELAY_CRITICAL_WRITE_READBACK_QUEUE_TIMEOUT_MS:-1000}
       VH_RELAY_PEERS: ${VH_PUBLIC_BETA_RELAY_A_PEERS:?set relay-a peer list}
       VH_RELAY_PEER_AUTH_MODE: ${VH_RELAY_PEER_AUTH_MODE:-private_network_allowlist}
       VH_RELAY_PEER_ALLOWLIST: ${VH_RELAY_PEER_ALLOWLIST:-private}
@@ -47,7 +55,9 @@ services:
 
   relay-b:
     image: ${VH_PUBLIC_BETA_RELAY_IMAGE:?set rebuilt relay image tag or digest}
-    restart: unless-stopped
+    restart: on-failure:5
+    mem_limit: ${VH_PUBLIC_BETA_RELAY_MEMORY_LIMIT:-2304m}
+    memswap_limit: ${VH_PUBLIC_BETA_RELAY_MEMORY_SWAP_LIMIT:-2304m}
     user: ${VH_PUBLIC_BETA_RELAY_UID_GID:?set relay UID:GID, for example humble uid:gid}
     env_file:
       - ${VH_PUBLIC_BETA_RELAY_ENV_FILE:?set relay env file outside git}
@@ -58,6 +68,12 @@ services:
       GUN_RADISK: "true"
       NODE_ENV: production
       VH_RELAY_ID: public-beta-relay-b
+      VH_RELAY_RESOURCE_WATCHDOG_ENABLED: ${VH_RELAY_RESOURCE_WATCHDOG_ENABLED:-true}
+      VH_RELAY_DIAGNOSTIC_DIR: ${VH_RELAY_DIAGNOSTIC_DIR:-/data/diagnostics}
+      VH_RELAY_STARTUP_JITTER_MAX_MS: ${VH_RELAY_STARTUP_JITTER_MAX_MS:-5000}
+      VH_RELAY_CRITICAL_WRITE_READBACK_MAX_CONCURRENCY: ${VH_RELAY_CRITICAL_WRITE_READBACK_MAX_CONCURRENCY:-2}
+      VH_RELAY_CRITICAL_WRITE_READBACK_QUEUE_LIMIT: ${VH_RELAY_CRITICAL_WRITE_READBACK_QUEUE_LIMIT:-16}
+      VH_RELAY_CRITICAL_WRITE_READBACK_QUEUE_TIMEOUT_MS: ${VH_RELAY_CRITICAL_WRITE_READBACK_QUEUE_TIMEOUT_MS:-1000}
       VH_RELAY_PEERS: ${VH_PUBLIC_BETA_RELAY_B_PEERS:?set relay-b peer list}
       VH_RELAY_PEER_AUTH_MODE: ${VH_RELAY_PEER_AUTH_MODE:-private_network_allowlist}
       VH_RELAY_PEER_ALLOWLIST: ${VH_RELAY_PEER_ALLOWLIST:-private}
@@ -72,7 +88,9 @@ services:
 
   relay-c:
     image: ${VH_PUBLIC_BETA_RELAY_IMAGE:?set rebuilt relay image tag or digest}
-    restart: unless-stopped
+    restart: on-failure:5
+    mem_limit: ${VH_PUBLIC_BETA_RELAY_MEMORY_LIMIT:-2304m}
+    memswap_limit: ${VH_PUBLIC_BETA_RELAY_MEMORY_SWAP_LIMIT:-2304m}
     user: ${VH_PUBLIC_BETA_RELAY_UID_GID:?set relay UID:GID, for example humble uid:gid}
     env_file:
       - ${VH_PUBLIC_BETA_RELAY_ENV_FILE:?set relay env file outside git}
@@ -83,6 +101,12 @@ services:
       GUN_RADISK: "true"
       NODE_ENV: production
       VH_RELAY_ID: public-beta-relay-c
+      VH_RELAY_RESOURCE_WATCHDOG_ENABLED: ${VH_RELAY_RESOURCE_WATCHDOG_ENABLED:-true}
+      VH_RELAY_DIAGNOSTIC_DIR: ${VH_RELAY_DIAGNOSTIC_DIR:-/data/diagnostics}
+      VH_RELAY_STARTUP_JITTER_MAX_MS: ${VH_RELAY_STARTUP_JITTER_MAX_MS:-5000}
+      VH_RELAY_CRITICAL_WRITE_READBACK_MAX_CONCURRENCY: ${VH_RELAY_CRITICAL_WRITE_READBACK_MAX_CONCURRENCY:-2}
+      VH_RELAY_CRITICAL_WRITE_READBACK_QUEUE_LIMIT: ${VH_RELAY_CRITICAL_WRITE_READBACK_QUEUE_LIMIT:-16}
+      VH_RELAY_CRITICAL_WRITE_READBACK_QUEUE_TIMEOUT_MS: ${VH_RELAY_CRITICAL_WRITE_READBACK_QUEUE_TIMEOUT_MS:-1000}
       VH_RELAY_PEERS: ${VH_PUBLIC_BETA_RELAY_C_PEERS:?set relay-c peer list}
       VH_RELAY_PEER_AUTH_MODE: ${VH_RELAY_PEER_AUTH_MODE:-private_network_allowlist}
       VH_RELAY_PEER_ALLOWLIST: ${VH_RELAY_PEER_ALLOWLIST:-private}

--- a/infra/relay/Dockerfile
+++ b/infra/relay/Dockerfile
@@ -3,6 +3,7 @@ FROM node:20.16.0-alpine3.19
 WORKDIR /app
 
 ENV NODE_ENV=production
+ENV NODE_OPTIONS=--max-old-space-size=1536
 
 # Install the exact Gun version used in the monorepo
 RUN npm install gun@0.2020.1237

--- a/infra/relay/server.js
+++ b/infra/relay/server.js
@@ -3,6 +3,8 @@ const http = require('http');
 const { createRequire } = require('module');
 const crypto = require('crypto');
 const fs = require('fs');
+const inspector = require('inspector');
+const os = require('os');
 const path = require('path');
 const { monitorEventLoopDelay } = require('perf_hooks');
 
@@ -84,6 +86,11 @@ function numberEnv(name, fallback) {
   return Number.isFinite(value) && value > 0 ? value : fallback;
 }
 
+function nonNegativeNumberEnv(name, fallback) {
+  const value = Number(process.env[name]);
+  return Number.isFinite(value) && value >= 0 ? value : fallback;
+}
+
 function positiveInteger(value, fallback) {
   const parsed = Number(value);
   return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : fallback;
@@ -149,6 +156,32 @@ const newsLatestIndexSnapshotStoryBodyCache = new Map();
 let newsSynthesisLifecycleSnapshotCache = null;
 let topicSynthesisLatestSnapshotCache = null;
 const relayPeers = Array.from(new Set(jsonOrCsvEnv('VH_RELAY_PEERS')));
+const criticalWriteReadbackMaxConcurrency = numberEnv('VH_RELAY_CRITICAL_WRITE_READBACK_MAX_CONCURRENCY', 2);
+const criticalWriteReadbackQueueLimit = nonNegativeNumberEnv('VH_RELAY_CRITICAL_WRITE_READBACK_QUEUE_LIMIT', 16);
+const criticalWriteReadbackQueueTimeoutMs = nonNegativeNumberEnv(
+  'VH_RELAY_CRITICAL_WRITE_READBACK_QUEUE_TIMEOUT_MS',
+  1_000,
+);
+const criticalWriteReadbackRetryAfterSeconds = numberEnv(
+  'VH_RELAY_CRITICAL_WRITE_READBACK_RETRY_AFTER_SECONDS',
+  2,
+);
+const relayResourceWatchdogEnabled = boolEnv(
+  'VH_RELAY_RESOURCE_WATCHDOG_ENABLED',
+  process.env.NODE_ENV === 'production',
+);
+const relayResourceWatchdogIntervalMs = numberEnv('VH_RELAY_RESOURCE_WATCHDOG_INTERVAL_MS', 10_000);
+const relayWatchdogMaxEventLoopLagP99Ms = numberEnv('VH_RELAY_WATCHDOG_MAX_EVENT_LOOP_LAG_P99_MS', 2_500);
+const relayWatchdogMaxRssBytes = numberEnv('VH_RELAY_WATCHDOG_MAX_RSS_BYTES', 1_800_000_000);
+const relayWatchdogMaxHeapUsedBytes = numberEnv('VH_RELAY_WATCHDOG_MAX_HEAP_USED_BYTES', 1_300_000_000);
+const relayWatchdogDiagnosticDir = String(
+  process.env.VH_RELAY_DIAGNOSTIC_DIR
+  || (typeof gunFile === 'string' ? path.join(gunFile, 'diagnostics') : path.join(os.tmpdir(), 'vh-relay-diagnostics')),
+).trim();
+const relayStartupJitterMaxMs = nonNegativeNumberEnv(
+  'VH_RELAY_STARTUP_JITTER_MAX_MS',
+  process.env.NODE_ENV === 'production' ? 5_000 : 0,
+);
 const relayPeerAuthModes = new Set(['none', 'private_network_allowlist', 'peer_bearer_token']);
 const relayPeerAuthMode = String(process.env.VH_RELAY_PEER_AUTH_MODE || 'none').trim() || 'none';
 if (!relayPeerAuthModes.has(relayPeerAuthMode)) {
@@ -179,6 +212,11 @@ const metrics = {
   compactionRuns: 0,
   compactionTombstones: 0,
   criticalWriteReadbacksStarted: new Map(),
+  criticalWriteReadbacksQueued: new Map(),
+  criticalWriteReadbackBackpressure: new Map(),
+  criticalWriteReadbackQueueTimeouts: new Map(),
+  criticalWriteReadbackMaxQueued: 0,
+  relayWatchdogTrips: new Map(),
   snapshotBackgroundPauses: new Map(),
   snapshotBackgroundConcurrencyCaps: new Map(),
 };
@@ -201,10 +239,20 @@ function incMap(map, key, by = 1) {
 }
 
 let activeCriticalWriteReadbacks = 0;
+const queuedCriticalWriteReadbacks = [];
+let relayWatchdogTripped = false;
 
 function criticalWriteReadbacksAreActive() {
-  return activeCriticalWriteReadbacks > 0
+  return (activeCriticalWriteReadbacks > 0 || queuedCriticalWriteReadbacks.length > 0)
     && boolEnv('VH_RELAY_NEWS_INDEX_SNAPSHOT_PAUSE_DURING_WRITE_READBACK', true);
+}
+
+function makeRelayBackpressureError(route, reason = 'relay-backpressure') {
+  incMap(metrics.criticalWriteReadbackBackpressure, route);
+  const error = makeHttpError(503, reason);
+  error.code = 'relay-backpressure';
+  error.retryAfterSeconds = criticalWriteReadbackRetryAfterSeconds;
+  return error;
 }
 
 function forceCriticalWriteReadbackFailure(route) {
@@ -244,13 +292,57 @@ function snapshotBackgroundPauseInfo(operation, selectedCount, concurrency = {})
     selected_count: selectedCount,
     paused_due_to_critical_write_readback: true,
     active_critical_write_readback_count: activeCriticalWriteReadbacks,
+    queued_critical_write_readback_count: queuedCriticalWriteReadbacks.length,
     ...concurrency,
   };
 }
 
+function releaseCriticalWriteReadbackSlot() {
+  activeCriticalWriteReadbacks = Math.max(0, activeCriticalWriteReadbacks - 1);
+  while (
+    activeCriticalWriteReadbacks < criticalWriteReadbackMaxConcurrency
+    && queuedCriticalWriteReadbacks.length > 0
+  ) {
+    const next = queuedCriticalWriteReadbacks.shift();
+    clearTimeout(next.timer);
+    activeCriticalWriteReadbacks += 1;
+    next.resolve(releaseCriticalWriteReadbackSlot);
+  }
+}
+
+function acquireCriticalWriteReadbackSlot(route) {
+  if (activeCriticalWriteReadbacks < criticalWriteReadbackMaxConcurrency) {
+    activeCriticalWriteReadbacks += 1;
+    return Promise.resolve(releaseCriticalWriteReadbackSlot);
+  }
+  if (queuedCriticalWriteReadbacks.length >= criticalWriteReadbackQueueLimit) {
+    throw makeRelayBackpressureError(route, 'relay-critical-readback-backpressure');
+  }
+  incMap(metrics.criticalWriteReadbacksQueued, route);
+  metrics.criticalWriteReadbackMaxQueued = Math.max(
+    metrics.criticalWriteReadbackMaxQueued,
+    queuedCriticalWriteReadbacks.length + 1,
+  );
+  return new Promise((resolve, reject) => {
+    const entry = {
+      route,
+      resolve,
+      reject,
+      timer: null,
+    };
+    entry.timer = setTimeout(() => {
+      const index = queuedCriticalWriteReadbacks.indexOf(entry);
+      if (index >= 0) queuedCriticalWriteReadbacks.splice(index, 1);
+      incMap(metrics.criticalWriteReadbackQueueTimeouts, route);
+      reject(makeRelayBackpressureError(route, 'relay-critical-readback-queue-timeout'));
+    }, criticalWriteReadbackQueueTimeoutMs);
+    queuedCriticalWriteReadbacks.push(entry);
+  });
+}
+
 async function runCriticalWriteReadback(route, storyId, readback) {
   incMap(metrics.criticalWriteReadbacksStarted, route);
-  activeCriticalWriteReadbacks += 1;
+  const release = await acquireCriticalWriteReadbackSlot(route);
   try {
     if (forceCriticalWriteReadbackFailure(route)) {
       logEvent('warn', 'critical_write_readback_test_forced_failure', {
@@ -270,7 +362,7 @@ async function runCriticalWriteReadback(route, storyId, readback) {
     }
     return await readback();
   } finally {
-    activeCriticalWriteReadbacks = Math.max(0, activeCriticalWriteReadbacks - 1);
+    release();
   }
 }
 
@@ -619,6 +711,8 @@ function metricsText() {
   add('vh_relay_compaction_runs_total', metrics.compactionRuns);
   add('vh_relay_compaction_tombstones_total', metrics.compactionTombstones);
   add('vh_relay_critical_write_readbacks_active', activeCriticalWriteReadbacks);
+  add('vh_relay_critical_write_readbacks_queued', queuedCriticalWriteReadbacks.length);
+  add('vh_relay_critical_write_readbacks_max_queued', metrics.criticalWriteReadbackMaxQueued);
   add('vh_relay_radata_bytes', dirSizeBytes(gunFile));
   const memory = process.memoryUsage();
   const openFds = openFileDescriptorCount();
@@ -628,6 +722,8 @@ function metricsText() {
     add('vh_relay_process_open_fds', openFds);
   }
   add('vh_relay_event_loop_lag_p95_ms', Math.round(eventLoopDelay.percentile(95) / 1e6));
+  add('vh_relay_event_loop_lag_p99_ms', Math.round(eventLoopDelay.percentile(99) / 1e6));
+  add('vh_relay_event_loop_lag_max_ms', Math.round(eventLoopDelay.max / 1e6));
   for (const [status, count] of metrics.httpResponses) {
     add('vh_relay_http_responses_total', count, { status });
   }
@@ -643,6 +739,18 @@ function metricsText() {
   for (const [route, count] of metrics.criticalWriteReadbacksStarted) {
     add('vh_relay_critical_write_readbacks_started_total', count, { route });
   }
+  for (const [route, count] of metrics.criticalWriteReadbacksQueued) {
+    add('vh_relay_critical_write_readbacks_queued_total', count, { route });
+  }
+  for (const [route, count] of metrics.criticalWriteReadbackBackpressure) {
+    add('vh_relay_critical_write_readback_backpressure_total', count, { route });
+  }
+  for (const [route, count] of metrics.criticalWriteReadbackQueueTimeouts) {
+    add('vh_relay_critical_write_readback_queue_timeouts_total', count, { route });
+  }
+  for (const [reason, count] of metrics.relayWatchdogTrips) {
+    add('vh_relay_resource_watchdog_trips_total', count, { reason });
+  }
   for (const [operation, count] of metrics.snapshotBackgroundPauses) {
     add('vh_relay_snapshot_background_pauses_total', count, { operation });
   }
@@ -650,6 +758,224 @@ function metricsText() {
     add('vh_relay_snapshot_background_concurrency_caps_total', count, { operation });
   }
   return `${lines.join('\n')}\n`;
+}
+
+function mapToObject(map) {
+  return Object.fromEntries([...map.entries()].sort(([left], [right]) => String(left).localeCompare(String(right))));
+}
+
+function eventLoopDelaySummary() {
+  return {
+    p95_ms: Math.round(eventLoopDelay.percentile(95) / 1e6),
+    p99_ms: Math.round(eventLoopDelay.percentile(99) / 1e6),
+    max_ms: Math.round(eventLoopDelay.max / 1e6),
+    mean_ms: Number.isFinite(eventLoopDelay.mean) ? Math.round(eventLoopDelay.mean / 1e6) : null,
+  };
+}
+
+function safeDiagnosticFileSegment(value) {
+  const cleaned = String(value || 'relay')
+    .replace(/[^A-Za-z0-9_.-]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return cleaned || 'relay';
+}
+
+function relayDiagnosticSnapshot(reason, details = {}) {
+  const memory = process.memoryUsage();
+  return {
+    schema_version: 'vh-relay-self-capture-diagnostics-v1',
+    generated_at: new Date().toISOString(),
+    relay_id: relayId,
+    reason,
+    details,
+    process: {
+      pid: process.pid,
+      node: process.version,
+      uptime_ms: Math.round(process.uptime() * 1000),
+      resource_usage: process.resourceUsage?.() ?? null,
+    },
+    memory: {
+      rss: memory.rss,
+      heap_total: memory.heapTotal,
+      heap_used: memory.heapUsed,
+      external: memory.external,
+      array_buffers: memory.arrayBuffers,
+    },
+    event_loop_delay: eventLoopDelaySummary(),
+    critical_write_readbacks: {
+      active: activeCriticalWriteReadbacks,
+      queued: queuedCriticalWriteReadbacks.length,
+      max_queued: metrics.criticalWriteReadbackMaxQueued,
+      started_by_route: mapToObject(metrics.criticalWriteReadbacksStarted),
+      queued_by_route: mapToObject(metrics.criticalWriteReadbacksQueued),
+      backpressure_by_route: mapToObject(metrics.criticalWriteReadbackBackpressure),
+      queue_timeouts_by_route: mapToObject(metrics.criticalWriteReadbackQueueTimeouts),
+    },
+    write_failures_by_route: mapToObject(metrics.writeFailures),
+    write_attempts_by_route: mapToObject(metrics.writeAttempts),
+    snapshot_background_pauses_by_operation: mapToObject(metrics.snapshotBackgroundPauses),
+    config: {
+      critical_write_readback_max_concurrency: criticalWriteReadbackMaxConcurrency,
+      critical_write_readback_queue_limit: criticalWriteReadbackQueueLimit,
+      critical_write_readback_queue_timeout_ms: criticalWriteReadbackQueueTimeoutMs,
+      watchdog_max_event_loop_lag_p99_ms: relayWatchdogMaxEventLoopLagP99Ms,
+      watchdog_max_rss_bytes: relayWatchdogMaxRssBytes,
+      watchdog_max_heap_used_bytes: relayWatchdogMaxHeapUsedBytes,
+      diagnostic_dir: relayWatchdogDiagnosticDir,
+    },
+  };
+}
+
+function writeRelayDiagnosticBundle(reason, details = {}) {
+  if (!relayWatchdogDiagnosticDir) return { summary_path: null, report_path: null };
+  fs.mkdirSync(relayWatchdogDiagnosticDir, { recursive: true });
+  const base = `${new Date().toISOString().replace(/[:.]/g, '-')}-${safeDiagnosticFileSegment(relayId)}-${safeDiagnosticFileSegment(reason)}`;
+  const summaryPath = path.join(relayWatchdogDiagnosticDir, `${base}.json`);
+  const reportPath = path.join(relayWatchdogDiagnosticDir, `${base}.process-report.json`);
+  fs.writeFileSync(summaryPath, `${JSON.stringify(relayDiagnosticSnapshot(reason, details), null, 2)}\n`, 'utf8');
+  if (process.report && typeof process.report.writeReport === 'function') {
+    try {
+      if (!('excludeEnv' in process.report)) {
+        throw new Error('process.report.excludeEnv unavailable; skipping process report to avoid env leakage');
+      }
+      process.report.excludeEnv = true;
+      process.report.writeReport(reportPath);
+    } catch (error) {
+      fs.writeFileSync(
+        path.join(relayWatchdogDiagnosticDir, `${base}.process-report-error.txt`),
+        String(error instanceof Error ? error.message : error),
+        'utf8',
+      );
+    }
+  }
+  return { summary_path: summaryPath, report_path: fs.existsSync(reportPath) ? reportPath : null, base };
+}
+
+function inspectorPost(session, method, params = {}) {
+  return new Promise((resolve, reject) => {
+    session.post(method, params, (error, result) => {
+      if (error) reject(error);
+      else resolve(result);
+    });
+  });
+}
+
+async function writeBestEffortCpuProfile(base) {
+  if (!boolEnv('VH_RELAY_WATCHDOG_CPU_PROFILE_ENABLED', true) || !relayWatchdogDiagnosticDir || !base) {
+    return null;
+  }
+  const session = new inspector.Session();
+  const outputPath = path.join(relayWatchdogDiagnosticDir, `${base}.cpuprofile`);
+  try {
+    session.connect();
+    await inspectorPost(session, 'Profiler.enable');
+    await inspectorPost(session, 'Profiler.start');
+    await new Promise((resolve) => setTimeout(resolve, numberEnv('VH_RELAY_WATCHDOG_CPU_PROFILE_MS', 250)));
+    const result = await inspectorPost(session, 'Profiler.stop');
+    fs.writeFileSync(outputPath, `${JSON.stringify(result.profile)}\n`, 'utf8');
+    return outputPath;
+  } catch (error) {
+    try {
+      fs.writeFileSync(
+        path.join(relayWatchdogDiagnosticDir, `${base}.cpuprofile-error.txt`),
+        String(error instanceof Error ? error.message : error),
+        'utf8',
+      );
+    } catch {
+      // Best-effort only.
+    }
+    return null;
+  } finally {
+    try {
+      session.disconnect();
+    } catch {
+      // Best-effort only.
+    }
+  }
+}
+
+function relayWatchdogBreach() {
+  if (process.env.NODE_ENV === 'test' && boolEnv('VH_RELAY_TEST_FORCE_WATCHDOG_TRIP', false)) {
+    return { reason: 'test_forced', observed: true, limit: true };
+  }
+  const memory = process.memoryUsage();
+  const delay = eventLoopDelaySummary();
+  if (relayWatchdogMaxEventLoopLagP99Ms > 0 && delay.p99_ms > relayWatchdogMaxEventLoopLagP99Ms) {
+    return { reason: 'event_loop_lag_p99', observed: delay.p99_ms, limit: relayWatchdogMaxEventLoopLagP99Ms };
+  }
+  if (relayWatchdogMaxRssBytes > 0 && memory.rss > relayWatchdogMaxRssBytes) {
+    return { reason: 'rss_bytes', observed: memory.rss, limit: relayWatchdogMaxRssBytes };
+  }
+  if (relayWatchdogMaxHeapUsedBytes > 0 && memory.heapUsed > relayWatchdogMaxHeapUsedBytes) {
+    return { reason: 'heap_used_bytes', observed: memory.heapUsed, limit: relayWatchdogMaxHeapUsedBytes };
+  }
+  return null;
+}
+
+function tripRelayWatchdog(breach) {
+  if (relayWatchdogTripped) return;
+  relayWatchdogTripped = true;
+  incMap(metrics.relayWatchdogTrips, breach.reason);
+  const capture = writeRelayDiagnosticBundle(`watchdog-${breach.reason}`, breach);
+  logEvent('error', 'relay_resource_watchdog_tripped', {
+    relay_id: relayId,
+    reason: breach.reason,
+    observed: breach.observed,
+    limit: breach.limit,
+    diagnostic_summary_path: capture.summary_path,
+    process_report_path: capture.report_path,
+  });
+  const forceExitTimer = setTimeout(() => process.exit(1), numberEnv('VH_RELAY_WATCHDOG_EXIT_GRACE_MS', 750));
+  forceExitTimer.unref?.();
+  writeBestEffortCpuProfile(capture.base)
+    .catch(() => null)
+    .finally(() => {
+      clearTimeout(forceExitTimer);
+      process.exit(1);
+    });
+}
+
+function startRelayResourceWatchdog() {
+  if (!relayResourceWatchdogEnabled && !(process.env.NODE_ENV === 'test' && boolEnv('VH_RELAY_TEST_FORCE_WATCHDOG_TRIP', false))) {
+    return;
+  }
+  const interval = setInterval(() => {
+    const breach = relayWatchdogBreach();
+    if (breach) {
+      tripRelayWatchdog(breach);
+      return;
+    }
+    eventLoopDelay.reset();
+  }, relayResourceWatchdogIntervalMs);
+  interval.unref?.();
+}
+
+function installFatalCaptureHandlers() {
+  const captureAndExit = (reason, error) => {
+    const message = error instanceof Error ? error.message : String(error);
+    const stack = error instanceof Error && typeof error.stack === 'string'
+      ? error.stack.split('\n').slice(0, 8).join('\n')
+      : null;
+    try {
+      const capture = writeRelayDiagnosticBundle(reason, { message, stack });
+      logEvent('error', 'relay_fatal_capture_written', {
+        relay_id: relayId,
+        reason,
+        diagnostic_summary_path: capture.summary_path,
+        process_report_path: capture.report_path,
+      });
+    } catch (captureError) {
+      logEvent('error', 'relay_fatal_capture_failed', {
+        relay_id: relayId,
+        reason,
+        error: captureError instanceof Error ? captureError.message : String(captureError),
+      });
+    } finally {
+      process.exit(1);
+    }
+  };
+  process.on('uncaughtException', (error) => captureAndExit('uncaught-exception', error));
+  process.on('unhandledRejection', (error) => captureAndExit('unhandled-rejection', error));
 }
 
 function sendJson(res, status, body) {
@@ -1322,7 +1648,7 @@ async function readThreadBack(threadChain, threadId) {
   return null;
 }
 
-async function readTopicSynthesisBack(gun, topicId, synthesisId) {
+async function readTopicSynthesisBack(gun, topicId, synthesisId, options = {}) {
   const latestChain = gun.get('vh').get('topics').get(topicId).get('latest');
   const synthesisTimeoutMs = numberEnv('VH_RELAY_TOPIC_SYNTHESIS_REST_READ_TIMEOUT_MS', 1_500);
   const [directRaw, scalarRaw] = await Promise.all([
@@ -1340,6 +1666,9 @@ async function readTopicSynthesisBack(gun, topicId, synthesisId) {
   if (scalar?.topic_id === topicId && scalar?.synthesis_id === synthesisId) {
     return scalar;
   }
+  if (options.allowSnapshotFallback === false) {
+    return null;
+  }
   const snapshot = readTopicSynthesisLatestRecordFromSnapshot(topicId);
   if (snapshot?.synthesis?.synthesis_id === synthesisId) {
     return snapshot.synthesis;
@@ -1347,11 +1676,11 @@ async function readTopicSynthesisBack(gun, topicId, synthesisId) {
   return null;
 }
 
-async function pollTopicSynthesisBack(gun, topicId, synthesisId, timeoutMs = 5_000) {
+async function pollTopicSynthesisBack(gun, topicId, synthesisId, timeoutMs = 5_000, options = {}) {
   const deadline = Date.now() + timeoutMs;
   let latest = null;
   while (Date.now() < deadline) {
-    latest = await readTopicSynthesisBack(gun, topicId, synthesisId);
+    latest = await readTopicSynthesisBack(gun, topicId, synthesisId, options);
     if (latest) return latest;
     await new Promise((resolve) => setTimeout(resolve, 150));
   }
@@ -1668,7 +1997,10 @@ async function pollNewsSynthesisLifecycleBack(gun, storyId, expected, timeoutMs 
   const deadline = Date.now() + timeoutMs;
   let latest = null;
   while (Date.now() < deadline) {
-    latest = await readNewsSynthesisLifecycleRecord(gun, storyId, { timeoutMs: 1_500 });
+    latest = await readNewsSynthesisLifecycleRecord(gun, storyId, {
+      timeoutMs: 1_500,
+      allowSnapshotFallback: false,
+    });
     if (
       latest
       && latest.story_id === storyId
@@ -4302,17 +4634,20 @@ function sanitizeAggregatePointSnapshot(value) {
 
 async function writeForumThread(gun, thread) {
   const clean = sanitizeThread(thread);
-  const threadChain = gun.get('vh').get('forum').get('threads').get(clean.id);
-  const writes = [putWithTimeout(threadChain, clean)];
-  for (const [key, value] of Object.entries(clean)) {
-    writes.push(putWithTimeout(threadChain.get(key), value, 750));
-  }
-  await Promise.allSettled(writes);
-  let readback = await pollThreadBack(threadChain, clean.id, 2_000);
-  if (!readback) {
-    injectGraph(gun, buildThreadGraph(clean));
-    readback = await pollThreadBack(threadChain, clean.id, 5_000);
-  }
+  const readback = await runCriticalWriteReadback('/vh/forum/thread', clean.id, async () => {
+    const threadChain = gun.get('vh').get('forum').get('threads').get(clean.id);
+    const writes = [putWithTimeout(threadChain, clean)];
+    for (const [key, value] of Object.entries(clean)) {
+      writes.push(putWithTimeout(threadChain.get(key), value, 750));
+    }
+    await Promise.allSettled(writes);
+    let observed = await pollThreadBack(threadChain, clean.id, 2_000);
+    if (!observed) {
+      injectGraph(gun, buildThreadGraph(clean));
+      observed = await pollThreadBack(threadChain, clean.id, 5_000);
+    }
+    return observed;
+  });
   if (!readback) {
     throw new Error('thread-readback-failed');
   }
@@ -4321,10 +4656,12 @@ async function writeForumThread(gun, thread) {
 
 async function writeForumComment(gun, comment) {
   const clean = sanitizeComment(comment);
-  const indexRoot = gun.get('vh').get('forum').get('indexes').get('comment_ids').get(encodeURIComponent(clean.threadId));
-  const existingCommentIds = await readCommentIndexIds(indexRoot, clean.threadId);
-  injectGraph(gun, buildCommentGraph(clean, existingCommentIds));
-  const readback = await pollCommentBack(gun, clean.threadId, clean.id, 5_000);
+  const readback = await runCriticalWriteReadback('/vh/forum/comment', clean.id, async () => {
+    const indexRoot = gun.get('vh').get('forum').get('indexes').get('comment_ids').get(encodeURIComponent(clean.threadId));
+    const existingCommentIds = await readCommentIndexIds(indexRoot, clean.threadId);
+    injectGraph(gun, buildCommentGraph(clean, existingCommentIds));
+    return pollCommentBack(gun, clean.threadId, clean.id, 5_000);
+  });
   if (!readback) {
     throw new Error('comment-readback-failed');
   }
@@ -4333,27 +4670,37 @@ async function writeForumComment(gun, comment) {
 
 async function writeTopicSynthesis(gun, synthesis) {
   const clean = sanitizeTopicSynthesis(synthesis);
-  injectGraph(gun, buildTopicSynthesisGraph(clean));
-  upsertTopicSynthesisLatestSnapshot(clean);
-  const readback = await pollTopicSynthesisBack(gun, clean.topic_id, clean.synthesis_id, 5_000);
+  const readback = await runCriticalWriteReadback('/vh/topics/synthesis', clean.synthesis_id, async () => {
+    injectGraph(gun, buildTopicSynthesisGraph(clean));
+    return pollTopicSynthesisBack(
+      gun,
+      clean.topic_id,
+      clean.synthesis_id,
+      5_000,
+      { allowSnapshotFallback: false },
+    );
+  });
   if (!readback) {
     throw new Error('topic-synthesis-readback-failed');
   }
+  upsertTopicSynthesisLatestSnapshot(clean);
   return clean;
 }
 
 async function writeTopicSynthesisCandidate(gun, candidate) {
   const clean = sanitizeTopicSynthesisCandidate(candidate);
-  const candidateChain = gun
-    .get('vh')
-    .get('topics')
-    .get(clean.topic_id)
-    .get('epochs')
-    .get(String(clean.epoch))
-    .get('candidates')
-    .get(clean.candidate_id);
-  injectGraph(gun, buildTopicSynthesisCandidateGraph(clean));
-  const readback = stripGunMetadata(await readOnce(candidateChain, 5_000));
+  const readback = await runCriticalWriteReadback('/vh/topics/synthesis-candidate', clean.candidate_id, async () => {
+    const candidateChain = gun
+      .get('vh')
+      .get('topics')
+      .get(clean.topic_id)
+      .get('epochs')
+      .get(String(clean.epoch))
+      .get('candidates')
+      .get(clean.candidate_id);
+    injectGraph(gun, buildTopicSynthesisCandidateGraph(clean));
+    return stripGunMetadata(await readOnce(candidateChain, 5_000));
+  });
   if (!readback || readback.candidate_id !== clean.candidate_id) {
     throw new Error('topic-synthesis-candidate-readback-failed');
   }
@@ -4362,62 +4709,72 @@ async function writeTopicSynthesisCandidate(gun, candidate) {
 
 async function writeNewsStoryRecord(gun, body) {
   const clean = sanitizeNewsStoryWrite(body);
-  injectGraph(gun, buildNewsStoryGraph(clean));
   const readback = await runCriticalWriteReadback(
     '/vh/news/story',
     clean.story_id,
-    () => pollNewsStoryBack(
-      gun,
-      clean.story_id,
-      numberEnv('VH_RELAY_NEWS_STORY_WRITE_READBACK_TIMEOUT_MS', 5_000),
-    ),
+    async () => {
+      injectGraph(gun, buildNewsStoryGraph(clean));
+      const observed = await pollNewsStoryBack(
+        gun,
+        clean.story_id,
+        numberEnv('VH_RELAY_NEWS_STORY_WRITE_READBACK_TIMEOUT_MS', 5_000),
+      );
+      if (!observed) return null;
+      await upsertNewsLatestIndexSnapshotFromWrite(gun, {
+        storyId: clean.story_id,
+        storyRecord: clean.record,
+        reason: 'story_write',
+      });
+      return observed;
+    },
   );
   if (!readback) {
     throw new Error('news-story-readback-failed');
   }
-  await upsertNewsLatestIndexSnapshotFromWrite(gun, {
-    storyId: clean.story_id,
-    storyRecord: clean.record,
-    reason: 'story_write',
-  });
   return clean;
 }
 
 async function writeNewsLatestIndexRecord(gun, body) {
   const clean = sanitizeNewsLatestIndexWrite(body);
-  injectGraph(gun, buildNewsLatestIndexGraph(clean));
   const readback = await runCriticalWriteReadback(
     '/vh/news/latest-index',
     clean.story_id,
-    () => pollNewsLatestIndexBack(
-      gun,
-      clean.story_id,
-      numberEnv('VH_RELAY_NEWS_LATEST_INDEX_WRITE_READBACK_TIMEOUT_MS', 5_000),
-    ),
+    async () => {
+      injectGraph(gun, buildNewsLatestIndexGraph(clean));
+      const observed = await pollNewsLatestIndexBack(
+        gun,
+        clean.story_id,
+        numberEnv('VH_RELAY_NEWS_LATEST_INDEX_WRITE_READBACK_TIMEOUT_MS', 5_000),
+      );
+      if (!observed) return null;
+      await upsertNewsLatestIndexSnapshotFromWrite(gun, {
+        storyId: clean.story_id,
+        latestRecord: observed,
+        reason: 'latest_index_write',
+      });
+      return observed;
+    },
   );
   if (!readback) {
     throw new Error('news-latest-index-readback-failed');
   }
-  await upsertNewsLatestIndexSnapshotFromWrite(gun, {
-    storyId: clean.story_id,
-    latestRecord: readback,
-    reason: 'latest_index_write',
-  });
   return clean;
 }
 
 async function writeNewsHotIndexRecord(gun, body) {
   const clean = sanitizeNewsHotIndexWrite(body);
-  injectGraph(gun, buildNewsHotIndexGraph(clean));
   const readback = await runCriticalWriteReadback(
     '/vh/news/hot-index',
     clean.story_id,
-    () => pollNewsHotIndexBack(
-      gun,
-      clean.story_id,
-      numberEnv('VH_RELAY_NEWS_HOT_INDEX_WRITE_READBACK_TIMEOUT_MS',
-        numberEnv('VH_RELAY_NEWS_LATEST_INDEX_WRITE_READBACK_TIMEOUT_MS', 5_000)),
-    ),
+    async () => {
+      injectGraph(gun, buildNewsHotIndexGraph(clean));
+      return pollNewsHotIndexBack(
+        gun,
+        clean.story_id,
+        numberEnv('VH_RELAY_NEWS_HOT_INDEX_WRITE_READBACK_TIMEOUT_MS',
+          numberEnv('VH_RELAY_NEWS_LATEST_INDEX_WRITE_READBACK_TIMEOUT_MS', 5_000)),
+      );
+    },
   );
   if (!readback) {
     throw new Error('news-hot-index-readback-failed');
@@ -4427,26 +4784,30 @@ async function writeNewsHotIndexRecord(gun, body) {
 
 async function writeNewsSynthesisLifecycleRecord(gun, body) {
   const clean = sanitizeNewsSynthesisLifecycleWrite(body);
-  injectGraph(gun, buildNewsSynthesisLifecycleGraph(clean));
-  upsertNewsSynthesisLifecycleSnapshot(clean.record);
   const readback = await runCriticalWriteReadback(
     '/vh/news/synthesis-lifecycle',
     clean.story_id,
-    () => pollNewsSynthesisLifecycleBack(
-      gun,
-      clean.story_id,
-      clean.record,
-      numberEnv('VH_RELAY_NEWS_LIFECYCLE_WRITE_READBACK_TIMEOUT_MS', 5_000),
-    ),
+    async () => {
+      injectGraph(gun, buildNewsSynthesisLifecycleGraph(clean));
+      const observed = await pollNewsSynthesisLifecycleBack(
+        gun,
+        clean.story_id,
+        clean.record,
+        numberEnv('VH_RELAY_NEWS_LIFECYCLE_WRITE_READBACK_TIMEOUT_MS', 5_000),
+      );
+      if (!observed) return null;
+      upsertNewsSynthesisLifecycleSnapshot(clean.record);
+      await upsertNewsLatestIndexSnapshotFromWrite(gun, {
+        storyId: clean.story_id,
+        lifecycleRecord: observed,
+        reason: 'synthesis_lifecycle_write',
+      });
+      return observed;
+    },
   );
   if (!readback) {
     throw new Error('news-synthesis-lifecycle-readback-failed');
   }
-  await upsertNewsLatestIndexSnapshotFromWrite(gun, {
-    storyId: clean.story_id,
-    lifecycleRecord: readback,
-    reason: 'synthesis_lifecycle_write',
-  });
   return clean;
 }
 
@@ -4504,7 +4865,9 @@ async function handleWriteRoute(req, res, pathname, kind, write) {
     const message = String(error?.message || '');
     const status = error?.statusCode
       || (/(required|invalid|mismatch|private-field)/.test(message) ? 400 : 500);
-    if (status === 401 || status === 403 || status === 503) {
+    if (error?.code === 'relay-backpressure') {
+      res.setHeader('Retry-After', String(error.retryAfterSeconds ?? criticalWriteReadbackRetryAfterSeconds));
+    } else if (status === 401 || status === 403 || status === 503) {
       metrics.authRejects += 1;
     }
     incMap(metrics.writeFailures, label);
@@ -4512,10 +4875,12 @@ async function handleWriteRoute(req, res, pathname, kind, write) {
       route: label,
       status,
       error: error instanceof Error ? error.message : String(error),
+      ...(error?.code === 'relay-backpressure' ? { retry_after_seconds: error.retryAfterSeconds ?? criticalWriteReadbackRetryAfterSeconds } : {}),
     });
     sendJson(res, status, {
       ok: false,
       error: error instanceof Error ? error.message : String(error),
+      ...(error?.code === 'relay-backpressure' ? { retryable: true, retry_after_seconds: error.retryAfterSeconds ?? criticalWriteReadbackRetryAfterSeconds } : {}),
     });
   }
 }
@@ -4564,6 +4929,10 @@ const server = http.createServer((req, res) => {
       relay_peers_configured: relayPeers.length > 0,
       relay_peer_auth_mode: relayPeerAuthMode,
       active_connections: metrics.activeConnections,
+      critical_write_readbacks_active: activeCriticalWriteReadbacks,
+      critical_write_readbacks_queued: queuedCriticalWriteReadbacks.length,
+      event_loop_delay: eventLoopDelaySummary(),
+      memory: process.memoryUsage(),
       route_surface: 'vh-relay-http-v1',
       public_http_routes: PUBLIC_HTTP_RELAY_ROUTES,
     });
@@ -4585,6 +4954,10 @@ const server = http.createServer((req, res) => {
       relay_peers_configured: relayPeers.length > 0,
       relay_peer_auth_mode: relayPeerAuthMode,
       relay_peer_auth_configured: relayPeerAuthMode !== 'none',
+      critical_write_readbacks_active: activeCriticalWriteReadbacks,
+      critical_write_readbacks_queued: queuedCriticalWriteReadbacks.length,
+      event_loop_delay: eventLoopDelaySummary(),
+      memory: process.memoryUsage(),
       route_surface: 'vh-relay-http-v1',
       public_http_routes: PUBLIC_HTTP_RELAY_ROUTES,
     });
@@ -5133,9 +5506,26 @@ server.prependListener('upgrade', (req, socket) => {
   }
 });
 
-server.listen(port, host, () => {
-  // eslint-disable-next-line no-console
-  console.log(
-    `[vh:relay] Gun relay listening on ${host}:${port} relay_id=${relayId} peer_count=${relayPeers.length} peer_auth=${relayPeerAuthMode}`
-  );
-});
+installFatalCaptureHandlers();
+startRelayResourceWatchdog();
+
+function listen() {
+  server.listen(port, host, () => {
+    // eslint-disable-next-line no-console
+    console.log(
+      `[vh:relay] Gun relay listening on ${host}:${port} relay_id=${relayId} peer_count=${relayPeers.length} peer_auth=${relayPeerAuthMode}`
+    );
+  });
+}
+
+if (relayStartupJitterMaxMs > 0) {
+  const jitterMs = Math.floor(Math.random() * relayStartupJitterMaxMs);
+  logEvent('info', 'relay_startup_jitter', {
+    relay_id: relayId,
+    jitter_ms: jitterMs,
+    max_jitter_ms: relayStartupJitterMaxMs,
+  });
+  setTimeout(listen, jitterMs);
+} else {
+  listen();
+}

--- a/infra/systemd/user/vh-news-relay-liveness-watch.service
+++ b/infra/systemd/user/vh-news-relay-liveness-watch.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=VHC News Relay Liveness Watch
+Documentation=file:/home/humble/VHC/docs/ops/news-aggregator-production-service.md
+
+[Service]
+Type=oneshot
+Environment=VHC_REPO=/home/humble/VHC
+Environment=VH_RELAY_LIVENESS_OUTPUT_FILE=%h/.local/state/vhc/relay-liveness/latest.json
+Environment=VH_RELAY_LIVENESS_RESTART_ON_FAIL=true
+Environment=VH_RELAY_LIVENESS_RESTART_MAX_PER_RUN=1
+Environment=VH_RELAY_LIVENESS_RESTART_MIN_INTERVAL_MS=600000
+Environment=PATH=/home/humble/.local/bin:/usr/local/bin:/usr/bin:/bin
+WorkingDirectory=/home/humble/VHC
+ExecStart=/usr/bin/env node /home/humble/VHC/tools/scripts/news-relay-liveness-watch.mjs

--- a/infra/systemd/user/vh-news-relay-liveness-watch.timer
+++ b/infra/systemd/user/vh-news-relay-liveness-watch.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Run VHC news relay liveness watch every 5 minutes
+
+[Timer]
+OnBootSec=4min
+OnUnitActiveSec=5min
+AccuracySec=1min
+Persistent=true
+Unit=vh-news-relay-liveness-watch.service
+
+[Install]
+WantedBy=timers.target

--- a/packages/e2e/src/live/relay-server.vitest.mjs
+++ b/packages/e2e/src/live/relay-server.vitest.mjs
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import http from 'node:http';
 import os from 'node:os';
 import path from 'node:path';
@@ -76,7 +76,7 @@ function requestJson(url, { method = 'GET', headers = {}, body = undefined } = {
               return raw;
             }
           })();
-          resolve({ statusCode: response.statusCode ?? 0, body: parsedBody, raw });
+          resolve({ statusCode: response.statusCode ?? 0, body: parsedBody, raw, headers: response.headers });
         });
       }
     );
@@ -182,6 +182,17 @@ async function waitForOutput(child, pattern, timeoutMs = 10_000) {
     await new Promise((resolve) => setTimeout(resolve, 50));
   }
   throw new Error(`timed out waiting for output ${pattern}`);
+}
+
+async function waitForExit(child, timeoutMs = 10_000) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (child.exitCode !== null) {
+      return child.exitCode;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error('timed out waiting for relay exit');
 }
 
 function readGunOnce(node, timeoutMs = 5_000) {
@@ -1589,7 +1600,118 @@ describe('infra relay server', () => {
     expect(metrics.body).toContain('vh_relay_critical_write_readbacks_active 0');
   }, 20_000);
 
-  it('keeps critical public-news write readback failures fatal to the route', async () => {
+  it('returns retryable backpressure before injecting a write when critical readbacks are saturated', async () => {
+    const { port, child } = await startRelay(children, tempDirs, {
+      VH_RELAY_CRITICAL_WRITE_READBACK_MAX_CONCURRENCY: '1',
+      VH_RELAY_CRITICAL_WRITE_READBACK_QUEUE_LIMIT: '0',
+      VH_RELAY_CRITICAL_WRITE_READBACK_RETRY_AFTER_SECONDS: '3',
+      VH_RELAY_TEST_CRITICAL_WRITE_READBACK_DELAY_MS: '1200',
+    });
+    const blockingStory = makeRelayNewsStory('story-backpressure-blocking', 1778993051000, [
+      {
+        source_id: 'source-backpressure-blocking',
+        publisher: 'Example News',
+        url: 'https://example.com/backpressure-blocking',
+        url_hash: 'backpressure-blocking',
+        published_at: 1778993051000,
+        title: 'Backpressure blocking story',
+      },
+    ]);
+    const rejectedStory = makeRelayNewsStory('story-backpressure-rejected', 1778993052000, [
+      {
+        source_id: 'source-backpressure-rejected',
+        publisher: 'Example News',
+        url: 'https://example.com/backpressure-rejected',
+        url_hash: 'backpressure-rejected',
+        published_at: 1778993052000,
+        title: 'Backpressure rejected story',
+      },
+    ]);
+
+    const blockingWrite = requestJson(`http://127.0.0.1:${port}/vh/news/story`, {
+      method: 'POST',
+      body: {
+        record: {
+          __story_bundle_json: JSON.stringify(blockingStory),
+          story_id: blockingStory.story_id,
+          created_at: blockingStory.created_at,
+          schemaVersion: blockingStory.schemaVersion,
+        },
+      },
+    });
+    await waitForOutput(
+      child,
+      new RegExp(`critical_write_readback_test_delay.*\\/vh\\/news\\/story.*${blockingStory.story_id}`),
+      5_000,
+    );
+
+    const rejected = await requestJson(`http://127.0.0.1:${port}/vh/news/latest-index`, {
+      method: 'POST',
+      body: { record: makeRelayLatestIndexRecord(rejectedStory) },
+    });
+    expect(rejected).toMatchObject({
+      statusCode: 503,
+      body: expect.objectContaining({
+        ok: false,
+        error: 'relay-critical-readback-backpressure',
+        retryable: true,
+        retry_after_seconds: 3,
+      }),
+    });
+    expect(rejected.headers['retry-after']).toBe('3');
+    await expect(blockingWrite).resolves.toMatchObject({
+      statusCode: 200,
+      body: expect.objectContaining({ ok: true, story_id: blockingStory.story_id }),
+    });
+
+    await expect(requestJson(`http://127.0.0.1:${port}/vh/news/latest-index?limit=5&scan_limit=5`))
+      .resolves.toMatchObject({
+        statusCode: 200,
+        body: expect.not.objectContaining({
+          records: expect.objectContaining({
+            [rejectedStory.story_id]: expect.anything(),
+          }),
+        }),
+      });
+
+    const metrics = await fetchText(`http://127.0.0.1:${port}/metrics`);
+    expect(metrics.body).toContain('vh_relay_critical_write_readback_backpressure_total{route="/vh/news/latest-index"} 1');
+    expect(metrics.body).toContain('vh_relay_write_failures_total{route="/vh/news/latest-index"} 1');
+    expect(metrics.body).toContain('vh_relay_critical_write_readbacks_active 0');
+  }, 20_000);
+
+  it('writes a self-capture diagnostic and exits on a relay watchdog trip', async () => {
+    const diagnosticDir = mkdtempSync(path.join(os.tmpdir(), 'vh-relay-watchdog-diagnostics-'));
+    tempDirs.add(diagnosticDir);
+    const { child } = await startRelay(children, tempDirs, {
+      VH_RELAY_RESOURCE_WATCHDOG_ENABLED: 'true',
+      VH_RELAY_RESOURCE_WATCHDOG_INTERVAL_MS: '50',
+      VH_RELAY_TEST_FORCE_WATCHDOG_TRIP: 'true',
+      VH_RELAY_DIAGNOSTIC_DIR: diagnosticDir,
+      VH_RELAY_WATCHDOG_CPU_PROFILE_ENABLED: 'false',
+    });
+
+    await waitForOutput(child, /relay_resource_watchdog_tripped/, 5_000);
+    await expect(waitForExit(child, 5_000)).resolves.toBe(1);
+
+    const files = readdirSync(diagnosticDir);
+    const summaryFile = files.find((file) => file.endsWith('.json') && !file.endsWith('.process-report.json'));
+    expect(summaryFile).toBeTruthy();
+    const summary = JSON.parse(readFileSync(path.join(diagnosticDir, summaryFile), 'utf8'));
+    expect(summary).toMatchObject({
+      schema_version: 'vh-relay-self-capture-diagnostics-v1',
+      relay_id: expect.any(String),
+      reason: 'watchdog-test_forced',
+      details: expect.objectContaining({ reason: 'test_forced' }),
+      critical_write_readbacks: expect.objectContaining({
+        active: expect.any(Number),
+        queued: expect.any(Number),
+      }),
+    });
+    expect(JSON.stringify(summary)).not.toContain('VH_RELAY_DAEMON_TOKEN');
+  }, 10_000);
+
+  it('keeps critical write readback failures fatal to the route', async () => {
     const routes = [
       {
         route: '/vh/news/story',
@@ -1657,6 +1779,31 @@ describe('infra relay server', () => {
           },
         ]),
         body: (story) => ({ record: makeRelaySynthesisLifecycleRecord(story, { updatedAt: 1778993104500 }) }),
+      },
+      {
+        route: '/vh/topics/synthesis',
+        expectedError: 'topic-synthesis-readback-failed',
+        body: () => ({
+          synthesis: {
+            schemaVersion: 'topic-synthesis-v2',
+            topic_id: 'topic-forced-topic-synthesis',
+            synthesis_id: 'synthesis-forced-topic-synthesis',
+            epoch: 1,
+            created_at: '2026-06-21T12:00:00.000Z',
+          },
+        }),
+      },
+      {
+        route: '/vh/topics/synthesis-candidate',
+        expectedError: 'topic-synthesis-candidate-readback-failed',
+        body: () => ({
+          candidate: {
+            candidate_id: 'candidate-forced-topic-synthesis',
+            topic_id: 'topic-forced-topic-synthesis',
+            epoch: 1,
+            created_at: 1_778_993_105_000,
+          },
+        }),
       },
     ];
     const { port } = await startRelay(children, tempDirs, {

--- a/packages/gun-client/src/newsAdapters.test.ts
+++ b/packages/gun-client/src/newsAdapters.test.ts
@@ -800,6 +800,98 @@ describe('newsAdapters', () => {
     }
   });
 
+  it('classifies relay backpressure as a failed retryable relay without counting it as quorum success', async () => {
+    expect(
+      newsAdapterInternal.classifyRelayRestHttpFailure(
+        503,
+        JSON.stringify({ ok: false, error: 'relay-critical-readback-backpressure', retryable: true }),
+      ),
+    ).toBe('relay-backpressure');
+
+    const restoreRuntimeConfig = withGunClientRuntimeConfig({
+      VH_NEWS_RELAY_REST_WRITE_FIRST: 'true',
+      VH_NEWS_RELAY_REST_WRITE_ORIGINS: '["https://gun-a.example.test","https://gun-b.example.test","https://gun-c.example.test"]',
+      VH_NEWS_RELAY_REST_WRITE_MIN_SUCCESS: '2',
+    });
+    const restoreEnv = withProcessEnv({ VH_RELAY_DAEMON_TOKEN: 'relay-token-redacted' });
+    try {
+      const mesh = createFakeMesh();
+      const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+      const client = createClient(mesh, guard, {
+        peers: ['https://fallback-peer.example.test/gun'],
+      });
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true, story_id: STORY.story_id }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }))
+        .mockResolvedValueOnce(new Response(JSON.stringify({
+          ok: false,
+          error: 'relay-critical-readback-backpressure',
+          retryable: true,
+          retry_after_seconds: 2,
+        }), {
+          status: 503,
+          headers: { 'content-type': 'application/json', 'retry-after': '2' },
+        }))
+        .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true, story_id: 'wrong-story' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }));
+      vi.stubGlobal('fetch', fetchMock);
+
+      await expect(
+        writeNewsLatestIndexEntry(client, STORY.story_id, STORY.cluster_window_end, STORY),
+      ).rejects.toThrow(/failed=https:\/\/gun-b\.example\.test:relay-backpressure/);
+      expect(mesh.writes).toEqual([]);
+    } finally {
+      vi.unstubAllGlobals();
+      restoreEnv();
+      restoreRuntimeConfig();
+    }
+  });
+
+  it('keeps empty and malformed relay error bodies as failed relay outcomes', async () => {
+    const restoreRuntimeConfig = withGunClientRuntimeConfig({
+      VH_NEWS_RELAY_REST_WRITE_FIRST: 'true',
+      VH_NEWS_RELAY_REST_WRITE_ORIGINS: '["https://gun-a.example.test","https://gun-b.example.test","https://gun-c.example.test"]',
+      VH_NEWS_RELAY_REST_WRITE_MIN_SUCCESS: '2',
+    });
+    const restoreEnv = withProcessEnv({ VH_RELAY_DAEMON_TOKEN: 'relay-token-redacted' });
+    try {
+      const mesh = createFakeMesh();
+      const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+      const client = createClient(mesh, guard, {
+        peers: ['https://fallback-peer.example.test/gun'],
+      });
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true, story_id: STORY.story_id }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }))
+        .mockResolvedValueOnce(new Response('', {
+          status: 503,
+          headers: { 'content-type': 'text/plain' },
+        }))
+        .mockResolvedValueOnce(new Response('not-json', {
+          status: 503,
+          headers: { 'content-type': 'text/plain' },
+        }));
+      vi.stubGlobal('fetch', fetchMock);
+
+      await expect(
+        writeNewsLatestIndexEntry(client, STORY.story_id, STORY.cluster_window_end, STORY),
+      ).rejects.toThrow(/failed=https:\/\/gun-b\.example\.test:http-503; https:\/\/gun-c\.example\.test:http-503/);
+      expect(mesh.writes).toEqual([]);
+    } finally {
+      vi.unstubAllGlobals();
+      restoreEnv();
+      restoreRuntimeConfig();
+    }
+  });
+
   it('writeNewsLatestIndexEntry fails explicit 2-of-3 relay REST quorum with one validated success', async () => {
     const restoreRuntimeConfig = withGunClientRuntimeConfig({
       VH_NEWS_RELAY_REST_WRITE_FIRST: 'true',

--- a/packages/gun-client/src/newsAdapters.ts
+++ b/packages/gun-client/src/newsAdapters.ts
@@ -401,6 +401,16 @@ function redactRelayRestExcerpt(value: string): string {
 function classifyRelayRestHttpFailure(status: number, body: string): string {
   const lower = body.toLowerCase();
   if (
+    status === 503
+    && (
+      lower.includes('relay-backpressure')
+      || lower.includes('relay-critical-readback-backpressure')
+      || lower.includes('relay-critical-readback-queue-timeout')
+    )
+  ) {
+    return 'relay-backpressure';
+  }
+  if (
     status === 530 &&
     (lower.includes('error 1033') || lower.includes('cloudflare tunnel') || lower.includes('cloudflare'))
   ) {
@@ -2320,13 +2330,21 @@ async function writeNewsRecordViaRelayRest(input: {
         body: JSON.stringify({ record: input.record }),
         signal: controller.signal,
       });
-      const payload = await response.json().catch(() => null) as Record<string, unknown> | null;
+      const body = await response.text().catch(() => '');
+      const payload = (() => {
+        try {
+          return body.trim() ? JSON.parse(body) as Record<string, unknown> : null;
+        } catch {
+          return null;
+        }
+      })();
       if (response.ok && payload && input.validate(payload)) {
         successCount += 1;
         continue;
       }
+      const classification = classifyRelayRestHttpFailure(response.status, body);
       failedEndpointLabels.push(endpointLabel);
-      failures.push(`${endpointLabel}:http_${response.status}`);
+      failures.push(`${endpointLabel}:${classification}`);
     } catch (error) {
       failedEndpointLabels.push(endpointLabel);
       failures.push(`${endpointLabel}:${error instanceof Error ? error.message : String(error)}`);
@@ -3335,5 +3353,6 @@ export const newsAdapterInternal = {
   resolveNewsRelayRestWriteQuorum,
   shouldRequireAllNewsRelayRestWrites,
   shouldWriteNewsViaRelayRestFirst,
+  classifyRelayRestHttpFailure,
   writeNewsRecordViaRelayRest,
 };

--- a/services/news-aggregator/src/relayRestSynthesisWriters.test.ts
+++ b/services/news-aggregator/src/relayRestSynthesisWriters.test.ts
@@ -115,7 +115,7 @@ const LIFECYCLE: NewsSynthesisLifecycleRecord = {
 function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
   return new Response(JSON.stringify(body), {
     status: init.status ?? 200,
-    headers: { 'content-type': 'application/json' },
+    headers: { 'content-type': 'application/json', ...(init.headers as Record<string, string> | undefined) },
   });
 }
 
@@ -271,6 +271,38 @@ describe('relayRestSynthesisWriters', () => {
     const writers = createRelayRestSynthesisWritersFromEnv(CLIENT_3, console);
     await expect(writers.writeCandidate?.(CLIENT_3, CANDIDATE))
       .rejects.toThrow('Relay REST write failed for /vh/topics/synthesis-candidate: 1/3 succeeded; required=2');
+  });
+
+  it('classifies relay backpressure as a failed retryable relay without turning optional synthesis fatality into success', async () => {
+    vi.stubEnv('VH_BUNDLE_SYNTHESIS_WRITE_RELAY_REST', 'true');
+    vi.stubEnv('VH_BUNDLE_SYNTHESIS_RELAY_WRITE_MIN_SUCCESS', '2');
+    vi.stubEnv('VH_RELAY_DAEMON_TOKEN', 'relay-token');
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({
+        ok: true,
+        topic_id: CANDIDATE.topic_id,
+        candidate_id: CANDIDATE.candidate_id,
+      }))
+      .mockResolvedValueOnce(jsonResponse({
+        ok: false,
+        error: 'relay-critical-readback-backpressure',
+        retryable: true,
+        retry_after_seconds: 2,
+      }, {
+        status: 503,
+        headers: { 'retry-after': '2' },
+      }))
+      .mockResolvedValueOnce(jsonResponse({
+        ok: true,
+        topic_id: CANDIDATE.topic_id,
+        candidate_id: 'wrong-candidate',
+      }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const writers = createRelayRestSynthesisWritersFromEnv(CLIENT_3, console);
+    await expect(writers.writeCandidate?.(CLIENT_3, CANDIDATE))
+      .rejects.toThrow(/failed=https:\/\/gun-b\.example\.test:relay-backpressure/);
   });
 
   it('fails before posting synthesis writes for invalid or impossible explicit quorum', async () => {

--- a/services/news-aggregator/src/relayRestSynthesisWriters.ts
+++ b/services/news-aggregator/src/relayRestSynthesisWriters.ts
@@ -143,6 +143,21 @@ function relayEndpointLabel(endpoint: string): string {
   }
 }
 
+function classifyRelayRestWriteFailure(status: number, body: string): string {
+  const lower = body.toLowerCase();
+  if (
+    status === 503
+    && (
+      lower.includes('relay-backpressure')
+      || lower.includes('relay-critical-readback-backpressure')
+      || lower.includes('relay-critical-readback-queue-timeout')
+    )
+  ) {
+    return 'relay-backpressure';
+  }
+  return `http-${status}`;
+}
+
 function relayAuthHeaders(endpoint: string): Record<string, string> {
   const headers = createRelayDaemonAuthHeadersForEndpoint(endpoint, {
     tokenMapEnvNames: RELAY_TOKEN_MAP_ENV_NAMES,
@@ -193,13 +208,20 @@ async function postJsonToRelays(input: {
         body: JSON.stringify(input.body),
         signal: controller.signal,
       });
-      const payload = await response.json().catch(() => null) as Record<string, unknown> | null;
+      const body = await response.text().catch(() => '');
+      const payload = (() => {
+        try {
+          return body.trim() ? JSON.parse(body) as Record<string, unknown> : null;
+        } catch {
+          return null;
+        }
+      })();
       if (response.ok && payload && input.validate(payload)) {
         successCount += 1;
         continue;
       }
       failedEndpointLabels.push(endpointLabel);
-      failures.push(`${endpointLabel}:http_${response.status}`);
+      failures.push(`${endpointLabel}:${classifyRelayRestWriteFailure(response.status, body)}`);
     } catch (error) {
       failedEndpointLabels.push(endpointLabel);
       failures.push(`${endpointLabel}:${error instanceof Error ? error.message : String(error)}`);

--- a/tools/scripts/emit-a6-public-beta-deploy-packet.sh
+++ b/tools/scripts/emit-a6-public-beta-deploy-packet.sh
@@ -106,6 +106,7 @@ const analysisTarget = process.env.ANALYSIS_TARGET;
 const originName = process.env.ORIGIN_NAME;
 const relayNames = (process.env.RELAY_NAMES || '').split(',').map((name) => name.trim()).filter(Boolean);
 const includeRecreate = process.env.INCLUDE_RECREATE === 'true';
+const relayMemoryLimit = process.env.VH_RELAY_DOCKER_MEMORY_LIMIT || '2304m';
 const containers = JSON.parse(readFileSync(inspectJson, 'utf8'));
 
 function cleanName(container) {
@@ -180,7 +181,10 @@ function dataMount(container) {
   return (container?.Mounts || []).find((mount) => mount.Destination === destination) || null;
 }
 
-function restartFlag(container) {
+function restartFlag(container, options = {}) {
+  if (options.forceRelaySelfRecovery) {
+    return '--restart on-failure:5';
+  }
   const name = container?.HostConfig?.RestartPolicy?.Name;
   if (!name || name === 'no') return '';
   const maximumRetryCount = container?.HostConfig?.RestartPolicy?.MaximumRetryCount;
@@ -188,6 +192,12 @@ function restartFlag(container) {
     return `--restart on-failure:${maximumRetryCount}`;
   }
   return `--restart ${name}`;
+}
+
+function memoryFlags(options = {}) {
+  return options.forceRelaySelfRecovery
+    ? [`--memory ${relayMemoryLimit}`, `--memory-swap ${relayMemoryLimit}`]
+    : [];
 }
 
 function primaryNetworkFlag(container) {
@@ -199,17 +209,31 @@ function shellJoin(parts) {
   return parts.filter(Boolean).join(' \\\n  ');
 }
 
-function envCaptureCommand(name, rewriteAnalysisTarget = false) {
+function envEnsureLine(envPath, name, value) {
+  return `grep -q '^${name}=' ${envPath} || printf '%s\\n' '${name}=${value}' >> ${envPath}`;
+}
+
+function envCaptureCommand(name, rewriteAnalysisTarget = false, relay = false) {
   const envPath = `/tmp/vhc-public-beta-deploy/${name}.env`;
+  const relayDefaults = relay ? [
+    envEnsureLine(envPath, 'VH_RELAY_RESOURCE_WATCHDOG_ENABLED', 'true'),
+    envEnsureLine(envPath, 'VH_RELAY_DIAGNOSTIC_DIR', '/data/diagnostics'),
+    envEnsureLine(envPath, 'VH_RELAY_STARTUP_JITTER_MAX_MS', '5000'),
+    envEnsureLine(envPath, 'VH_RELAY_CRITICAL_WRITE_READBACK_MAX_CONCURRENCY', '2'),
+    envEnsureLine(envPath, 'VH_RELAY_CRITICAL_WRITE_READBACK_QUEUE_LIMIT', '16'),
+    envEnsureLine(envPath, 'VH_RELAY_CRITICAL_WRITE_READBACK_QUEUE_TIMEOUT_MS', '1000'),
+  ] : [];
   if (!rewriteAnalysisTarget) {
     return [
       `sudo docker inspect ${name} --format '{{range .Config.Env}}{{println .}}{{end}}' > ${envPath}`,
+      ...relayDefaults,
       `chmod 600 ${envPath}`,
     ].join('\n');
   }
   return [
     `sudo docker inspect ${name} --format '{{range .Config.Env}}{{println .}}{{end}}' > ${envPath}.current`,
     `awk 'BEGIN{done=0} /^VH_PUBLIC_ORIGIN_STATIC_DIR=/{next} /^VH_PUBLIC_ORIGIN_PEER_CONFIG_PATH=/{next} /^VH_PUBLIC_ORIGIN_ANALYSIS_TARGET=/{print "VH_PUBLIC_ORIGIN_ANALYSIS_TARGET=${analysisTarget}"; done=1; next} {print} END{if(!done) print "VH_PUBLIC_ORIGIN_ANALYSIS_TARGET=${analysisTarget}"}' ${envPath}.current > ${envPath}`,
+    ...relayDefaults,
     `chmod 600 ${envPath}`,
     `rm -f ${envPath}.current`,
   ].join('\n');
@@ -229,7 +253,8 @@ function runCommandFor(name, image, forceRelayUser = false) {
   const parts = [
     'sudo docker run -d',
     `--name ${name}`,
-    restartFlag(container),
+    restartFlag(container, { forceRelaySelfRecovery: forceRelayUser }),
+    ...memoryFlags({ forceRelaySelfRecovery: forceRelayUser }),
     primaryNetworkFlag(container),
     forceRelayUser ? '--user "$(id -u humble):$(id -g humble)"' : '',
     `--env-file ${envPath}`,
@@ -339,7 +364,7 @@ lines.push('```bash');
 lines.push('set -euo pipefail');
 lines.push('install -d -m 700 /tmp/vhc-public-beta-deploy');
 for (const name of relayNames) {
-  lines.push(envCaptureCommand(name));
+  lines.push(envCaptureCommand(name, false, true));
 }
 lines.push(envCaptureCommand(originName, true));
 lines.push('```');

--- a/tools/scripts/install-news-aggregator-production-service.sh
+++ b/tools/scripts/install-news-aggregator-production-service.sh
@@ -7,6 +7,7 @@ ENV_FILE="${VH_NEWS_DAEMON_ENV_FILE:-${HOME}/.config/vhc/news-aggregator.env}"
 SERVICE_PATH="%h/.local/bin:%h/.hermes/node/bin:/usr/local/bin:/usr/bin:/bin"
 ENABLE_WATCH=false
 ENABLE_PUBLISHER_LIVENESS_WATCH=false
+ENABLE_RELAY_LIVENESS_WATCH=false
 START_PUBLISHER=false
 
 for arg in "$@"; do
@@ -16,6 +17,9 @@ for arg in "$@"; do
       ;;
     --enable-publisher-liveness-watch)
       ENABLE_PUBLISHER_LIVENESS_WATCH=true
+      ;;
+    --enable-relay-liveness-watch)
+      ENABLE_RELAY_LIVENESS_WATCH=true
       ;;
     --start-publisher)
       START_PUBLISHER=true
@@ -130,6 +134,38 @@ Unit=vh-news-aggregator-liveness-watch.service
 WantedBy=timers.target
 EOF
 
+cat >"${UNIT_DIR}/vh-news-relay-liveness-watch.service" <<EOF
+[Unit]
+Description=VHC News Relay Liveness Watch
+Documentation=file:${REPO_ROOT}/docs/ops/news-aggregator-production-service.md
+
+[Service]
+Type=oneshot
+Environment=VHC_REPO=${REPO_ROOT}
+Environment=VH_RELAY_LIVENESS_OUTPUT_FILE=%h/.local/state/vhc/relay-liveness/latest.json
+Environment=VH_RELAY_LIVENESS_RESTART_ON_FAIL=true
+Environment=VH_RELAY_LIVENESS_RESTART_MAX_PER_RUN=1
+Environment=VH_RELAY_LIVENESS_RESTART_MIN_INTERVAL_MS=600000
+Environment=PATH=${SERVICE_PATH}
+WorkingDirectory=${REPO_ROOT}
+ExecStart=/usr/bin/env node ${REPO_ROOT}/tools/scripts/news-relay-liveness-watch.mjs
+EOF
+
+cat >"${UNIT_DIR}/vh-news-relay-liveness-watch.timer" <<'EOF'
+[Unit]
+Description=Run VHC news relay liveness watch every 5 minutes
+
+[Timer]
+OnBootSec=4min
+OnUnitActiveSec=5min
+AccuracySec=1min
+Persistent=true
+Unit=vh-news-relay-liveness-watch.service
+
+[Install]
+WantedBy=timers.target
+EOF
+
 cat >"${UNIT_DIR}/vh-relay-snapshot-freshness-watch.timer" <<'EOF'
 [Unit]
 Description=Run VHC relay latest-index snapshot freshness watch every 15 minutes
@@ -153,6 +189,8 @@ echo "  ${UNIT_DIR}/vh-relay-snapshot-freshness-watch.service"
 echo "  ${UNIT_DIR}/vh-relay-snapshot-freshness-watch.timer"
 echo "  ${UNIT_DIR}/vh-news-aggregator-liveness-watch.service"
 echo "  ${UNIT_DIR}/vh-news-aggregator-liveness-watch.timer"
+echo "  ${UNIT_DIR}/vh-news-relay-liveness-watch.service"
+echo "  ${UNIT_DIR}/vh-news-relay-liveness-watch.timer"
 echo "Publisher env file expected at: ${ENV_FILE}"
 
 if [[ "${ENABLE_WATCH}" == "true" ]]; then
@@ -165,13 +203,19 @@ if [[ "${ENABLE_PUBLISHER_LIVENESS_WATCH}" == "true" ]]; then
   echo "Enabled news aggregator publisher liveness timer"
 fi
 
+if [[ "${ENABLE_RELAY_LIVENESS_WATCH}" == "true" ]]; then
+  systemctl --user enable --now vh-news-relay-liveness-watch.timer
+  echo "Enabled news relay liveness timer"
+fi
+
 if [[ "${START_PUBLISHER}" == "true" ]]; then
   if [[ "${VH_NEWS_DAEMON_START_APPROVED:-}" != "1" ]]; then
     echo "--start-publisher requires VH_NEWS_DAEMON_START_APPROVED=1" >&2
     exit 78
   fi
+  systemctl --user set-environment VH_NEWS_DAEMON_START_APPROVED=1
   systemctl --user enable --now vh-news-aggregator.service
-  echo "Enabled and started vh-news-aggregator.service"
+  echo "Enabled and started vh-news-aggregator.service with systemd manager approval env"
 else
   echo "Publisher service installed but not started"
 fi

--- a/tools/scripts/news-relay-liveness-watch.mjs
+++ b/tools/scripts/news-relay-liveness-watch.mjs
@@ -1,0 +1,406 @@
+#!/usr/bin/env node
+
+import { mkdir, writeFile } from 'node:fs/promises';
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const REPORT_SCHEMA_VERSION = 'vh-news-relay-liveness-watch-v1';
+const STATE_SCHEMA_VERSION = 'vh-news-relay-liveness-watch-state-v1';
+const DEFAULT_TARGETS = [
+  { name: 'vhc-relay-a', origin: 'http://127.0.0.1:8765' },
+  { name: 'vhc-relay-b', origin: 'http://127.0.0.1:8766' },
+  { name: 'vhc-relay-c', origin: 'http://127.0.0.1:8767' },
+];
+
+function positiveInt(value, fallback) {
+  const parsed = Number.parseInt(String(value ?? ''), 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function nonNegativeInt(value, fallback) {
+  const parsed = Number.parseInt(String(value ?? ''), 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+function firstNonEmpty(...values) {
+  for (const value of values) {
+    const trimmed = typeof value === 'string' ? value.trim() : '';
+    if (trimmed) return trimmed;
+  }
+  return null;
+}
+
+function boolEnv(value, fallback = true) {
+  const normalized = String(value ?? '').trim().toLowerCase();
+  if (!normalized) return fallback;
+  if (['1', 'true', 'yes', 'y', 'on'].includes(normalized)) return true;
+  if (['0', 'false', 'no', 'n', 'off'].includes(normalized)) return false;
+  return fallback;
+}
+
+function resolveStateDir(env) {
+  return firstNonEmpty(env.VH_RELAY_LIVENESS_STATE_DIR, process.env.HOME
+    ? path.join(process.env.HOME, '.local/state/vhc/relay-liveness')
+    : null) ?? path.resolve('.tmp/relay-liveness');
+}
+
+function resolveStateFile(env) {
+  return firstNonEmpty(
+    env.VH_RELAY_LIVENESS_STATE_FILE,
+    path.join(resolveStateDir(env), 'relay-liveness-watch-state.json'),
+  );
+}
+
+function parseTargets(raw) {
+  const value = String(raw ?? '').trim();
+  if (!value) return DEFAULT_TARGETS;
+  if (value.startsWith('[')) {
+    const parsed = JSON.parse(value);
+    if (!Array.isArray(parsed)) throw new Error('VH_RELAY_LIVENESS_TARGETS JSON must be an array');
+    return parsed.map((entry) => ({
+      name: String(entry.name ?? '').trim(),
+      origin: String(entry.origin ?? entry.url ?? '').trim().replace(/\/+$/, ''),
+    })).filter((entry) => entry.name && entry.origin);
+  }
+  return value.split(',').map((entry) => {
+    const [name, origin] = entry.split('=');
+    return {
+      name: String(name ?? '').trim(),
+      origin: String(origin ?? '').trim().replace(/\/+$/, ''),
+    };
+  }).filter((entry) => entry.name && entry.origin);
+}
+
+function parseJsonFile(filePath, readTextFile = readFileSync) {
+  if (!filePath || !existsSync(filePath)) {
+    return { exists: false, parsed: null, error: null, mtimeMs: null };
+  }
+  try {
+    const stat = statSync(filePath);
+    return {
+      exists: true,
+      parsed: JSON.parse(readTextFile(filePath, 'utf8')),
+      error: null,
+      mtimeMs: stat.mtimeMs,
+    };
+  } catch (error) {
+    return { exists: true, parsed: null, error, mtimeMs: null };
+  }
+}
+
+async function writeJson(filePath, value) {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+function readDockerRestartCount(name, spawnSyncImpl = spawnSync) {
+  const result = spawnSyncImpl('docker', ['inspect', name, '--format', '{{.RestartCount}}'], {
+    encoding: 'utf8',
+  });
+  if (result.status !== 0) {
+    return { restartCount: null, error: String(result.stderr ?? result.stdout ?? '').trim() || 'docker-inspect-failed' };
+  }
+  const parsed = Number.parseInt(String(result.stdout ?? '').trim(), 10);
+  return Number.isFinite(parsed) && parsed >= 0
+    ? { restartCount: parsed, error: null }
+    : { restartCount: null, error: `invalid-restart-count:${String(result.stdout ?? '').trim()}` };
+}
+
+function restartRelayContainer(name, spawnSyncImpl = spawnSync) {
+  const result = spawnSyncImpl('docker', ['restart', name], {
+    encoding: 'utf8',
+  });
+  if (result.status !== 0) {
+    return {
+      ok: false,
+      error: String(result.stderr ?? result.stdout ?? '').trim() || 'docker-restart-failed',
+    };
+  }
+  return { ok: true, error: null };
+}
+
+async function fetchTextWithTimeout(url, timeoutMs, fetchImpl = fetch) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetchImpl(url, { signal: controller.signal });
+    const text = await response.text();
+    return { ok: response.ok, status: response.status, text };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function parseMetricValue(text, metricName, labels = null) {
+  const rows = [];
+  for (const line of String(text ?? '').split('\n')) {
+    if (!line || line.startsWith('#')) continue;
+    const match = line.match(/^([A-Za-z_:][A-Za-z0-9_:]*)(\{[^}]*\})?\s+(-?(?:\d+|\d*\.\d+)(?:e[+-]?\d+)?)$/i);
+    if (!match || match[1] !== metricName) continue;
+    if (labels) {
+      const labelText = match[2] ?? '';
+      const matches = Object.entries(labels).every(([key, value]) => labelText.includes(`${key}="${String(value).replace(/"/g, '\\"')}"`));
+      if (!matches) continue;
+    }
+    rows.push(Number(match[3]));
+  }
+  return rows;
+}
+
+function metricNumber(text, metricName, fallback = null) {
+  const rows = parseMetricValue(text, metricName);
+  return rows.length > 0 && Number.isFinite(rows[0]) ? rows[0] : fallback;
+}
+
+function metricSum(text, metricName) {
+  return parseMetricValue(text, metricName).reduce((sum, value) => sum + (Number.isFinite(value) ? value : 0), 0);
+}
+
+async function inspectRelay(target, {
+  env,
+  fetchImpl,
+  spawnSyncImpl,
+  previous,
+}) {
+  const timeoutMs = positiveInt(env.VH_RELAY_LIVENESS_FETCH_TIMEOUT_MS, 5_000);
+  const maxRssBytes = positiveInt(env.VH_RELAY_LIVENESS_MAX_RSS_BYTES, 1_800_000_000);
+  const maxHeapUsedBytes = positiveInt(env.VH_RELAY_LIVENESS_MAX_HEAP_USED_BYTES, 1_300_000_000);
+  const maxLagP99Ms = positiveInt(env.VH_RELAY_LIVENESS_MAX_EVENT_LOOP_LAG_P99_MS, 2_500);
+  const maxQueuedReadbacks = Number.parseInt(String(env.VH_RELAY_LIVENESS_MAX_QUEUED_READBACKS ?? '16'), 10);
+  const blockers = [];
+  const warnings = [];
+  const docker = readDockerRestartCount(target.name, spawnSyncImpl);
+  if (docker.error) blockers.push(`docker_inspect_failed:${docker.error}`);
+  const previousRestartCount = Number.isFinite(previous?.restartCount) ? previous.restartCount : null;
+  if (previousRestartCount !== null && docker.restartCount !== null && docker.restartCount > previousRestartCount) {
+    blockers.push(`restart_count_increased:${previousRestartCount}/${docker.restartCount}`);
+  }
+
+  let readyz = null;
+  try {
+    const response = await fetchTextWithTimeout(`${target.origin}/readyz`, timeoutMs, fetchImpl);
+    readyz = { status: response.status, ok: false };
+    try {
+      readyz.body = JSON.parse(response.text);
+      readyz.ok = Boolean(readyz.body?.ok);
+    } catch {
+      readyz.body = null;
+    }
+    if (!response.ok || !readyz.ok) blockers.push(`readyz_unhealthy:${response.status}`);
+  } catch (error) {
+    blockers.push(`readyz_failed:${error instanceof Error ? error.message : String(error)}`);
+  }
+
+  let metrics = null;
+  try {
+    const response = await fetchTextWithTimeout(`${target.origin}/metrics`, timeoutMs, fetchImpl);
+    if (!response.ok) {
+      blockers.push(`metrics_unhealthy:${response.status}`);
+    }
+    const text = response.text;
+    const watchdogTrips = metricSum(text, 'vh_relay_resource_watchdog_trips_total');
+    const previousWatchdogTrips = Number.isFinite(previous?.watchdogTrips) ? previous.watchdogTrips : 0;
+    metrics = {
+      rssBytes: metricNumber(text, 'vh_relay_process_rss_bytes'),
+      heapUsedBytes: metricNumber(text, 'vh_relay_process_heap_used_bytes'),
+      eventLoopLagP99Ms: metricNumber(text, 'vh_relay_event_loop_lag_p99_ms'),
+      eventLoopLagMaxMs: metricNumber(text, 'vh_relay_event_loop_lag_max_ms'),
+      criticalReadbacksActive: metricNumber(text, 'vh_relay_critical_write_readbacks_active', 0),
+      criticalReadbacksQueued: metricNumber(text, 'vh_relay_critical_write_readbacks_queued', 0),
+      watchdogTrips,
+    };
+    if (metrics.rssBytes !== null && metrics.rssBytes > maxRssBytes) blockers.push(`rss_hot:${metrics.rssBytes}/${maxRssBytes}`);
+    if (metrics.heapUsedBytes !== null && metrics.heapUsedBytes > maxHeapUsedBytes) blockers.push(`heap_hot:${metrics.heapUsedBytes}/${maxHeapUsedBytes}`);
+    if (metrics.eventLoopLagP99Ms !== null && metrics.eventLoopLagP99Ms > maxLagP99Ms) blockers.push(`event_loop_lag_hot:${metrics.eventLoopLagP99Ms}/${maxLagP99Ms}`);
+    if (Number.isFinite(maxQueuedReadbacks) && metrics.criticalReadbacksQueued > maxQueuedReadbacks) {
+      blockers.push(`critical_readbacks_queued:${metrics.criticalReadbacksQueued}/${maxQueuedReadbacks}`);
+    }
+    if (watchdogTrips > previousWatchdogTrips) {
+      blockers.push(`watchdog_trips_increased:${previousWatchdogTrips}/${watchdogTrips}`);
+    }
+  } catch (error) {
+    blockers.push(`metrics_failed:${error instanceof Error ? error.message : String(error)}`);
+  }
+
+  return {
+    name: target.name,
+    origin: target.origin,
+    status: blockers.length === 0 ? 'pass' : 'fail',
+    blockers,
+    warnings,
+    docker,
+    readyz,
+    metrics,
+  };
+}
+
+function relayRestartEligibleBlockers(blockers) {
+  return blockers.filter((blocker) =>
+    blocker.startsWith('readyz_failed:')
+    || blocker.startsWith('readyz_unhealthy:')
+    || blocker.startsWith('metrics_failed:')
+    || blocker.startsWith('metrics_unhealthy:')
+    || blocker.startsWith('rss_hot:')
+    || blocker.startsWith('heap_hot:')
+    || blocker.startsWith('event_loop_lag_hot:')
+    || blocker.startsWith('critical_readbacks_queued:'));
+}
+
+function restartRelaysForLivenessFailures({
+  env,
+  relays,
+  previousByRelay,
+  now,
+  spawnSyncImpl,
+}) {
+  if (!boolEnv(env.VH_RELAY_LIVENESS_RESTART_ON_FAIL, false)) return [];
+  const maxPerRun = positiveInt(env.VH_RELAY_LIVENESS_RESTART_MAX_PER_RUN, 1);
+  const cooldownMs = nonNegativeInt(env.VH_RELAY_LIVENESS_RESTART_MIN_INTERVAL_MS, 10 * 60_000);
+  const remediations = [];
+  let attempted = 0;
+  for (const relay of relays) {
+    const restartBlockers = relayRestartEligibleBlockers(relay.blockers);
+    if (restartBlockers.length === 0) continue;
+    const previous = previousByRelay.get(relay.name);
+    const lastRemediationAtMs = Number(previous?.lastRemediationAtMs);
+    if (Number.isFinite(lastRemediationAtMs) && cooldownMs > 0 && now - lastRemediationAtMs < cooldownMs) {
+      remediations.push({
+        relay: relay.name,
+        action: 'docker_restart',
+        status: 'skipped_cooldown',
+        blockers: restartBlockers,
+        lastRemediationAtMs,
+        cooldownMs,
+      });
+      continue;
+    }
+    if (attempted >= maxPerRun) {
+      remediations.push({
+        relay: relay.name,
+        action: 'docker_restart',
+        status: 'skipped_max_per_run',
+        blockers: restartBlockers,
+        maxPerRun,
+      });
+      continue;
+    }
+    const restart = restartRelayContainer(relay.name, spawnSyncImpl);
+    attempted += 1;
+    remediations.push({
+      relay: relay.name,
+      action: 'docker_restart',
+      status: restart.ok ? 'started' : 'failed',
+      blockers: restartBlockers,
+      error: restart.error,
+      remediatedAtMs: restart.ok ? now : null,
+    });
+  }
+  return remediations;
+}
+
+function syslogFailure(summary, env = process.env, spawnSyncImpl = spawnSync) {
+  if (!boolEnv(env.VH_RELAY_LIVENESS_SYSLOG, true)) return;
+  const message = `vh relay liveness ${summary.status}: ${summary.blockers.join('; ')}`;
+  spawnSyncImpl('logger', ['-t', 'vh-relay-liveness-watch', message.slice(0, 950)], {
+    stdio: 'ignore',
+  });
+}
+
+export async function runNewsRelayLivenessWatch({
+  env = process.env,
+  now = Date.now(),
+  fetchImpl = fetch,
+  spawnSyncImpl = spawnSync,
+  readTextFile = readFileSync,
+} = {}) {
+  const targets = parseTargets(env.VH_RELAY_LIVENESS_TARGETS);
+  const stateFile = resolveStateFile(env);
+  const outputFile = firstNonEmpty(env.VH_RELAY_LIVENESS_OUTPUT_FILE);
+  const previousState = parseJsonFile(stateFile, readTextFile);
+  const previousByRelay = new Map(
+    Array.isArray(previousState.parsed?.relays)
+      ? previousState.parsed.relays.map((relay) => [relay.name, relay])
+      : [],
+  );
+
+  const relays = [];
+  for (const target of targets) {
+    relays.push(await inspectRelay(target, {
+      env,
+      fetchImpl,
+      spawnSyncImpl,
+      previous: previousByRelay.get(target.name),
+    }));
+  }
+  const blockers = relays.flatMap((relay) => relay.blockers.map((blocker) => `${relay.name}:${blocker}`));
+  const remediations = restartRelaysForLivenessFailures({
+    env,
+    relays,
+    previousByRelay,
+    now,
+    spawnSyncImpl,
+  });
+  const summary = {
+    schemaVersion: REPORT_SCHEMA_VERSION,
+    generatedAt: new Date(now).toISOString(),
+    status: blockers.length === 0 ? 'pass' : 'fail',
+    blockers,
+    relays,
+    remediations,
+    config: {
+      targets,
+      stateFile,
+      outputFile,
+      restartOnFail: boolEnv(env.VH_RELAY_LIVENESS_RESTART_ON_FAIL, false),
+      restartMaxPerRun: positiveInt(env.VH_RELAY_LIVENESS_RESTART_MAX_PER_RUN, 1),
+      restartMinIntervalMs: nonNegativeInt(env.VH_RELAY_LIVENESS_RESTART_MIN_INTERVAL_MS, 10 * 60_000),
+    },
+  };
+
+  await writeJson(stateFile, {
+    schemaVersion: STATE_SCHEMA_VERSION,
+    generatedAt: summary.generatedAt,
+    relays: relays.map((relay) => ({
+      name: relay.name,
+      restartCount: relay.docker.restartCount,
+      watchdogTrips: relay.metrics?.watchdogTrips ?? 0,
+      lastRemediationAtMs: remediations.find((entry) =>
+        entry.relay === relay.name && entry.status === 'started')?.remediatedAtMs
+        ?? previousByRelay.get(relay.name)?.lastRemediationAtMs
+        ?? null,
+    })),
+  });
+  if (outputFile) {
+    await writeJson(outputFile, summary);
+  }
+  if (summary.status !== 'pass') {
+    syslogFailure(summary, env, spawnSyncImpl);
+  }
+  return summary;
+}
+
+async function main() {
+  const summary = await runNewsRelayLivenessWatch();
+  console.info(JSON.stringify(summary, null, 2));
+  if (summary.status !== 'pass') {
+    process.exit(1);
+  }
+}
+
+export const newsRelayLivenessWatchInternal = {
+  REPORT_SCHEMA_VERSION,
+  STATE_SCHEMA_VERSION,
+  parseMetricValue,
+  parseTargets,
+  relayRestartEligibleBlockers,
+  resolveStateFile,
+};
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error('[vh:relay-liveness-watch] failed', error);
+    process.exit(1);
+  });
+}

--- a/tools/scripts/news-relay-liveness-watch.test.mjs
+++ b/tools/scripts/news-relay-liveness-watch.test.mjs
@@ -1,0 +1,273 @@
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { runNewsRelayLivenessWatch } from './news-relay-liveness-watch.mjs';
+
+const NOW = Date.now();
+
+function makeTempState() {
+  const root = mkdtempSync(path.join(os.tmpdir(), 'vh-relay-liveness-'));
+  const stateFile = path.join(root, 'state.json');
+  const outputFile = path.join(root, 'latest.json');
+  return { root, stateFile, outputFile };
+}
+
+function writeJson(filePath, value) {
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+function baseEnv(paths) {
+  return {
+    VH_RELAY_LIVENESS_TARGETS: 'vhc-relay-a=http://127.0.0.1:8765,vhc-relay-b=http://127.0.0.1:8766',
+    VH_RELAY_LIVENESS_STATE_FILE: paths.stateFile,
+    VH_RELAY_LIVENESS_OUTPUT_FILE: paths.outputFile,
+    VH_RELAY_LIVENESS_SYSLOG: 'false',
+  };
+}
+
+function metrics({
+  rss = 120_000_000,
+  heap = 80_000_000,
+  lagP99 = 25,
+  queued = 0,
+  watchdogTrips = 0,
+} = {}) {
+  return [
+    `vh_relay_process_rss_bytes ${rss}`,
+    `vh_relay_process_heap_used_bytes ${heap}`,
+    `vh_relay_event_loop_lag_p99_ms ${lagP99}`,
+    'vh_relay_event_loop_lag_max_ms 40',
+    'vh_relay_critical_write_readbacks_active 0',
+    `vh_relay_critical_write_readbacks_queued ${queued}`,
+    `vh_relay_resource_watchdog_trips_total{reason="rss_bytes"} ${watchdogTrips}`,
+    '',
+  ].join('\n');
+}
+
+function makeFetch(responses) {
+  return async (url) => {
+    const text = responses.get(String(url));
+    if (text === undefined) {
+      return new Response('missing', { status: 404 });
+    }
+    return new Response(text, {
+      status: 200,
+      headers: { 'content-type': String(url).endsWith('/metrics') ? 'text/plain' : 'application/json' },
+    });
+  };
+}
+
+function makeSpawn(restarts = {}, calls = [], restartFailures = {}) {
+  return (command, args) => {
+    calls.push({ command, args: [...args] });
+    if (command === 'docker' && args[0] === 'inspect') {
+      return {
+        status: 0,
+        stdout: `${restarts[args[1]] ?? 0}\n`,
+        stderr: '',
+      };
+    }
+    if (command === 'docker' && args[0] === 'restart') {
+      if (restartFailures[args[1]]) {
+        return { status: 1, stdout: '', stderr: restartFailures[args[1]] };
+      }
+      return { status: 0, stdout: `${args[1]}\n`, stderr: '' };
+    }
+    return { status: 0, stdout: '', stderr: '' };
+  };
+}
+
+test('relay liveness passes for healthy readyz, metrics, and stable restart counts', async () => {
+  const paths = makeTempState();
+  try {
+    const responses = new Map([
+      ['http://127.0.0.1:8765/readyz', JSON.stringify({ ok: true })],
+      ['http://127.0.0.1:8765/metrics', metrics()],
+      ['http://127.0.0.1:8766/readyz', JSON.stringify({ ok: true })],
+      ['http://127.0.0.1:8766/metrics', metrics()],
+    ]);
+    const summary = await runNewsRelayLivenessWatch({
+      now: NOW,
+      env: baseEnv(paths),
+      fetchImpl: makeFetch(responses),
+      spawnSyncImpl: makeSpawn({ 'vhc-relay-a': 0, 'vhc-relay-b': 0 }),
+    });
+
+    assert.equal(summary.status, 'pass');
+    assert.equal(summary.relays.length, 2);
+  } finally {
+    rmSync(paths.root, { recursive: true, force: true });
+  }
+});
+
+test('relay liveness fails hot metrics even when readyz is healthy', async () => {
+  const paths = makeTempState();
+  try {
+    const responses = new Map([
+      ['http://127.0.0.1:8765/readyz', JSON.stringify({ ok: true })],
+      ['http://127.0.0.1:8765/metrics', metrics({ rss: 2_000_000_000, lagP99: 3_000 })],
+      ['http://127.0.0.1:8766/readyz', JSON.stringify({ ok: true })],
+      ['http://127.0.0.1:8766/metrics', metrics()],
+    ]);
+    const summary = await runNewsRelayLivenessWatch({
+      now: NOW,
+      env: baseEnv(paths),
+      fetchImpl: makeFetch(responses),
+      spawnSyncImpl: makeSpawn(),
+    });
+
+    assert.equal(summary.status, 'fail');
+    assert.match(summary.blockers.join('\n'), /vhc-relay-a:rss_hot:/);
+    assert.match(summary.blockers.join('\n'), /vhc-relay-a:event_loop_lag_hot:/);
+  } finally {
+    rmSync(paths.root, { recursive: true, force: true });
+  }
+});
+
+test('relay liveness fails restart and watchdog-trip increases from baseline', async () => {
+  const paths = makeTempState();
+  try {
+    writeJson(paths.stateFile, {
+      schemaVersion: 'vh-news-relay-liveness-watch-state-v1',
+      generatedAt: new Date(NOW - 60_000).toISOString(),
+      relays: [
+        { name: 'vhc-relay-a', restartCount: 1, watchdogTrips: 0 },
+        { name: 'vhc-relay-b', restartCount: 0, watchdogTrips: 0 },
+      ],
+    });
+    const responses = new Map([
+      ['http://127.0.0.1:8765/readyz', JSON.stringify({ ok: true })],
+      ['http://127.0.0.1:8765/metrics', metrics({ watchdogTrips: 1 })],
+      ['http://127.0.0.1:8766/readyz', JSON.stringify({ ok: true })],
+      ['http://127.0.0.1:8766/metrics', metrics()],
+    ]);
+    const summary = await runNewsRelayLivenessWatch({
+      now: NOW,
+      env: baseEnv(paths),
+      fetchImpl: makeFetch(responses),
+      spawnSyncImpl: makeSpawn({ 'vhc-relay-a': 2, 'vhc-relay-b': 0 }),
+    });
+
+    assert.equal(summary.status, 'fail');
+    assert.match(summary.blockers.join('\n'), /vhc-relay-a:restart_count_increased:1\/2/);
+    assert.match(summary.blockers.join('\n'), /vhc-relay-a:watchdog_trips_increased:0\/1/);
+  } finally {
+    rmSync(paths.root, { recursive: true, force: true });
+  }
+});
+
+test('relay liveness restarts at most one eligible hot relay when remediation is enabled', async () => {
+  const paths = makeTempState();
+  try {
+    const calls = [];
+    const responses = new Map([
+      ['http://127.0.0.1:8765/readyz', JSON.stringify({ ok: true })],
+      ['http://127.0.0.1:8765/metrics', metrics({ rss: 2_000_000_000 })],
+      ['http://127.0.0.1:8766/readyz', JSON.stringify({ ok: true })],
+      ['http://127.0.0.1:8766/metrics', metrics({ lagP99: 3_000 })],
+    ]);
+    const summary = await runNewsRelayLivenessWatch({
+      now: NOW,
+      env: {
+        ...baseEnv(paths),
+        VH_RELAY_LIVENESS_RESTART_ON_FAIL: 'true',
+        VH_RELAY_LIVENESS_RESTART_MAX_PER_RUN: '1',
+      },
+      fetchImpl: makeFetch(responses),
+      spawnSyncImpl: makeSpawn({ 'vhc-relay-a': 0, 'vhc-relay-b': 0 }, calls),
+    });
+
+    assert.equal(summary.status, 'fail');
+    assert.deepEqual(
+      calls.filter((call) => call.command === 'docker' && call.args[0] === 'restart').map((call) => call.args),
+      [['restart', 'vhc-relay-a']],
+    );
+    assert.equal(summary.remediations.find((entry) => entry.relay === 'vhc-relay-a')?.status, 'started');
+    assert.equal(summary.remediations.find((entry) => entry.relay === 'vhc-relay-b')?.status, 'skipped_max_per_run');
+    const state = JSON.parse(readFileSync(paths.stateFile, 'utf8'));
+    assert.equal(state.relays.find((entry) => entry.name === 'vhc-relay-a')?.lastRemediationAtMs, NOW);
+  } finally {
+    rmSync(paths.root, { recursive: true, force: true });
+  }
+});
+
+test('relay liveness remediation observes cooldown and ignores restart evidence alone', async () => {
+  const paths = makeTempState();
+  try {
+    writeJson(paths.stateFile, {
+      schemaVersion: 'vh-news-relay-liveness-watch-state-v1',
+      generatedAt: new Date(NOW - 60_000).toISOString(),
+      relays: [
+        { name: 'vhc-relay-a', restartCount: 0, watchdogTrips: 0, lastRemediationAtMs: NOW - 30_000 },
+        { name: 'vhc-relay-b', restartCount: 0, watchdogTrips: 0, lastRemediationAtMs: null },
+      ],
+    });
+    const calls = [];
+    const responses = new Map([
+      ['http://127.0.0.1:8765/readyz', JSON.stringify({ ok: true })],
+      ['http://127.0.0.1:8765/metrics', metrics({ rss: 2_000_000_000 })],
+      ['http://127.0.0.1:8766/readyz', JSON.stringify({ ok: true })],
+      ['http://127.0.0.1:8766/metrics', metrics({ watchdogTrips: 1 })],
+    ]);
+    const summary = await runNewsRelayLivenessWatch({
+      now: NOW,
+      env: {
+        ...baseEnv(paths),
+        VH_RELAY_LIVENESS_RESTART_ON_FAIL: 'true',
+        VH_RELAY_LIVENESS_RESTART_MIN_INTERVAL_MS: '600000',
+      },
+      fetchImpl: makeFetch(responses),
+      spawnSyncImpl: makeSpawn({ 'vhc-relay-a': 0, 'vhc-relay-b': 1 }, calls),
+    });
+
+    assert.equal(summary.status, 'fail');
+    assert.deepEqual(
+      calls.filter((call) => call.command === 'docker' && call.args[0] === 'restart'),
+      [],
+    );
+    assert.equal(summary.remediations.find((entry) => entry.relay === 'vhc-relay-a')?.status, 'skipped_cooldown');
+    assert.equal(summary.remediations.find((entry) => entry.relay === 'vhc-relay-b'), undefined);
+  } finally {
+    rmSync(paths.root, { recursive: true, force: true });
+  }
+});
+
+test('relay liveness does not attempt a second relay restart after a failed restart command', async () => {
+  const paths = makeTempState();
+  try {
+    const calls = [];
+    const responses = new Map([
+      ['http://127.0.0.1:8765/readyz', JSON.stringify({ ok: true })],
+      ['http://127.0.0.1:8765/metrics', metrics({ rss: 2_000_000_000 })],
+      ['http://127.0.0.1:8766/readyz', JSON.stringify({ ok: true })],
+      ['http://127.0.0.1:8766/metrics', metrics({ heap: 1_400_000_000 })],
+    ]);
+    const summary = await runNewsRelayLivenessWatch({
+      now: NOW,
+      env: {
+        ...baseEnv(paths),
+        VH_RELAY_LIVENESS_RESTART_ON_FAIL: 'true',
+        VH_RELAY_LIVENESS_RESTART_MAX_PER_RUN: '1',
+      },
+      fetchImpl: makeFetch(responses),
+      spawnSyncImpl: makeSpawn(
+        { 'vhc-relay-a': 0, 'vhc-relay-b': 0 },
+        calls,
+        { 'vhc-relay-a': 'permission denied' },
+      ),
+    });
+
+    assert.equal(summary.status, 'fail');
+    assert.deepEqual(
+      calls.filter((call) => call.command === 'docker' && call.args[0] === 'restart').map((call) => call.args),
+      [['restart', 'vhc-relay-a']],
+    );
+    assert.equal(summary.remediations.find((entry) => entry.relay === 'vhc-relay-a')?.status, 'failed');
+    assert.equal(summary.remediations.find((entry) => entry.relay === 'vhc-relay-b')?.status, 'skipped_max_per_run');
+  } finally {
+    rmSync(paths.root, { recursive: true, force: true });
+  }
+});

--- a/tools/scripts/public-beta-image-deploy.test.mjs
+++ b/tools/scripts/public-beta-image-deploy.test.mjs
@@ -12,6 +12,7 @@ const BUILD_SCRIPT = path.join(REPO_ROOT, 'tools/scripts/build-public-beta-image
 const EXPORT_SCRIPT = path.join(REPO_ROOT, 'tools/scripts/export-public-beta-image-artifacts.sh');
 const PACKET_SCRIPT = path.join(REPO_ROOT, 'tools/scripts/emit-a6-public-beta-deploy-packet.sh');
 const RECOVER_PROVENANCE_SCRIPT = path.join(REPO_ROOT, 'tools/scripts/recover-public-beta-origin-provenance.mjs');
+const PUBLIC_BETA_COMPOSE = path.join(REPO_ROOT, 'infra/docker/docker-compose.public-beta.yml');
 
 function run(command, args, options = {}) {
   return spawnSync(command, args, {
@@ -419,6 +420,13 @@ test('deploy packet preserves relay bind mounts and rewrites origin env safely',
     assert.doesNotMatch(result.stdout, /entries != 15/);
     assert.match(result.stdout, /VH_PUBLIC_ORIGIN_ANALYSIS_TARGET=http:\/\/127\.0\.0\.1:3001/);
     assert.match(result.stdout, /vhc-public-beta-relay:new/);
+    assert.match(result.stdout, /--restart on-failure:5/);
+    assert.match(result.stdout, /--memory 2304m/);
+    assert.match(result.stdout, /--memory-swap 2304m/);
+    assert.match(result.stdout, /VH_RELAY_RESOURCE_WATCHDOG_ENABLED=true/);
+    assert.match(result.stdout, /VH_RELAY_DIAGNOSTIC_DIR=\/data\/diagnostics/);
+    assert.match(result.stdout, /VH_RELAY_STARTUP_JITTER_MAX_MS=5000/);
+    assert.match(result.stdout, /VH_RELAY_CRITICAL_WRITE_READBACK_MAX_CONCURRENCY=2/);
     const originRewriteLine = result.stdout
       .split('\n')
       .find((line) => line.startsWith("awk '") && line.includes('VH_PUBLIC_ORIGIN_ANALYSIS_TARGET'));
@@ -444,6 +452,20 @@ test('deploy packet preserves relay bind mounts and rewrites origin env safely',
     assert.doesNotMatch(result.stdout, /http:\/\/127\.0\.0\.1:2048/);
   } finally {
     rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('public beta compose bounds relay restart and memory self-defense', () => {
+  const compose = readFileSync(PUBLIC_BETA_COMPOSE, 'utf8');
+  for (const relay of ['relay-a', 'relay-b', 'relay-c']) {
+    const blockMatch = compose.match(new RegExp(`  ${relay}:\\n([\\s\\S]*?)(?=\\n  (?:relay-|origin:)|\\nnetworks:)`));
+    assert.ok(blockMatch, `${relay} service missing`);
+    const block = blockMatch[1];
+    assert.match(block, /restart: on-failure:5/);
+    assert.match(block, /mem_limit: \$\{VH_PUBLIC_BETA_RELAY_MEMORY_LIMIT:-2304m\}/);
+    assert.match(block, /memswap_limit: \$\{VH_PUBLIC_BETA_RELAY_MEMORY_SWAP_LIMIT:-2304m\}/);
+    assert.match(block, /VH_RELAY_RESOURCE_WATCHDOG_ENABLED: \$\{VH_RELAY_RESOURCE_WATCHDOG_ENABLED:-true\}/);
+    assert.match(block, /VH_RELAY_CRITICAL_WRITE_READBACK_MAX_CONCURRENCY: \$\{VH_RELAY_CRITICAL_WRITE_READBACK_MAX_CONCURRENCY:-2\}/);
   }
 });
 

--- a/tools/scripts/systemd-service-installers.test.mjs
+++ b/tools/scripts/systemd-service-installers.test.mjs
@@ -60,6 +60,7 @@ test('news aggregator installer still gates publisher start on explicit approval
   assert.match(source, /if \[\[ "\$\{START_PUBLISHER\}" == "true" \]\]/);
   assert.match(source, /VH_NEWS_DAEMON_START_APPROVED:-/);
   assert.match(source, /--start-publisher requires VH_NEWS_DAEMON_START_APPROVED=1/);
+  assert.match(source, /systemctl --user set-environment VH_NEWS_DAEMON_START_APPROVED=1/);
   assert.match(source, /systemctl --user enable --now vh-news-aggregator\.service/);
 });
 
@@ -99,6 +100,28 @@ test('news aggregator installer writes publisher liveness watch units without en
   assert.match(service, /source "%h\/\.config\/vhc\/news-aggregator\.env"/);
   assert.match(timer, /OnUnitActiveSec=5min/);
   assert.match(timer, /Unit=vh-news-aggregator-liveness-watch\.service/);
+});
+
+test('news aggregator installer writes relay liveness watch units without enabling them by default', () => {
+  const source = readScript('install-news-aggregator-production-service.sh');
+  const service = readInfraUnit('vh-news-relay-liveness-watch.service');
+  const timer = readInfraUnit('vh-news-relay-liveness-watch.timer');
+
+  assert.match(source, /vh-news-relay-liveness-watch\.service/);
+  assert.match(source, /vh-news-relay-liveness-watch\.timer/);
+  assert.match(source, /--enable-relay-liveness-watch/);
+  assert.match(source, /if \[\[ "\$\{ENABLE_RELAY_LIVENESS_WATCH\}" == "true" \]\]/);
+  assert.match(source, /systemctl --user enable --now vh-news-relay-liveness-watch\.timer/);
+
+  for (const unitSource of [source, service]) {
+    assert.match(unitSource, /news-relay-liveness-watch\.mjs/);
+    assert.match(unitSource, /VH_RELAY_LIVENESS_OUTPUT_FILE/);
+    assert.match(unitSource, /VH_RELAY_LIVENESS_RESTART_ON_FAIL=true/);
+    assert.match(unitSource, /VH_RELAY_LIVENESS_RESTART_MAX_PER_RUN=1/);
+    assert.match(unitSource, /VH_RELAY_LIVENESS_RESTART_MIN_INTERVAL_MS=600000/);
+  }
+  assert.match(timer, /OnUnitActiveSec=5min/);
+  assert.match(timer, /Unit=vh-news-relay-liveness-watch\.service/);
 });
 
 test('news aggregator user unit orders publisher after StoryCluster', () => {


### PR DESCRIPTION
## Summary

#675 hardens the public beta relay path against the single-relay overload mode found in the Phase 5 soak. It makes critical write readbacks admission-controlled, pauses optional/background relay work while critical readbacks are active or queued, extends the #674 readback protection to all audited write->readback surfaces, and adds relay self-capture/self-recovery for CPU/RSS/event-loop-lag runaway states.

The follow-up pre-soak checks are included in this head:

- Docker relay memory is bounded above the graceful RSS watchdog: relay recreate now passes `--memory 2304m --memory-swap 2304m`, and the committed public-beta compose file uses matching `mem_limit` / `memswap_limit` plus `restart: on-failure:5`.
- The relay liveness timer is active remediation, not just alerting: the installed systemd service enables one eligible relay restart per run with a 10-minute per-relay cooldown. The script remains non-remediating by default for ad hoc dry runs unless `VH_RELAY_LIVENESS_RESTART_ON_FAIL=true` is set.

## Safety Contract

- 2-of-3 quorum is preserved exactly. A relay backpressure response is `503 relay-critical-readback-backpressure` with `Retry-After`; the gun client classifies it as a retryable per-relay failure, never success, so quorum still requires two genuine 2xx readback-confirmed writes.
- Critical readback failures still return 500. `allowSnapshotFallback:false` remains the write contract for the critical readback proof.
- #671/#672/#673 publisher fail-close behavior remains intact. Optional enrichment remains non-fatal to the publisher; relay-side bounding does not make topic-synthesis fatal at the daemon layer.
- Relay overload now sheds/degrades instead of melting: bounded active readbacks, bounded queue, fast 503 backpressure, maintenance pause while active/queued, synchronous diagnostic capture, then `exit(1)` for Docker restart on watchdog breach.
- No live host actions were performed by this PR. No publisher start, relay restart, StoryCluster reset, queue scrub, or live mesh write.

## Implementation Notes

- Admission control covers critical write readbacks with default max concurrency 2, queue limit 16, and queue timeout 1000 ms.
- Background/optional relay work pauses when critical readbacks are active or queued, including snapshot body verify, story-state refresh, topic-synthesis maintenance, aggregate-voter style background checks, and the audited maintenance paths.
- The watchdog uses `perf_hooks.monitorEventLoopDelay()` plus RSS/heap thresholds. It writes secret-safe diagnostics before exit, including `process.report` with environment excluded, heap/RSS stats, event-loop-lag histogram, counters, and best-effort CPU profiling.
- Relay startup uses jitter so three co-located relays do not restart in lockstep.
- External relay liveness watches `/readyz`, metrics, RSS/heap/event-loop-lag, restart counters, watchdog trips, and can restart one eligible hot relay per timer invocation when enabled.

## Verification

Local verification on Node 20:

```text
node --check tools/scripts/news-relay-liveness-watch.mjs
PASS

bash -n tools/scripts/emit-a6-public-beta-deploy-packet.sh tools/scripts/install-news-aggregator-production-service.sh
PASS

node --test tools/scripts/news-relay-liveness-watch.test.mjs tools/scripts/systemd-service-installers.test.mjs tools/scripts/public-beta-image-deploy.test.mjs
PASS: 24 tests

git diff --check
PASS

node tools/scripts/check-diff-coverage.mjs
PASS: 319 files, 4938 tests with coverage; changed packages/gun-client/src/newsAdapters.ts at 100% lines and 100% branches
```

Earlier targeted #675 verification remains covered in this branch: relay admission/backpressure tests, gun-client classification/quorum tests, watchdog capture tests, route-coverage/gating tests, installer/deploy packet tests, and the existing publisher fail-close regressions.

## Soak Semantics After Deploy

Expected and OK: a single relay returning 503 backpressure while the other two relays satisfy quorum. That is graceful load shedding.

Abort/investigate: any critical readback 500, any publisher fail-close, two relays shedding simultaneously causing quorum below 2, any watchdog trip, relay queues that do not drain in idle gaps, or RSS/event-loop-lag that fails to settle between bursts.