### PR TITLE
Isolate publisher lease renewals from maintenance

### DIFF
--- a/docs/ops/news-aggregator-production-service.md
+++ b/docs/ops/news-aggregator-production-service.md
@@ -565,6 +565,13 @@ write.
 The daemon writes and renews the shared `NewsIngestionLease` before starting the
 runtime. If another holder has a live lease, this daemon stops its runtime and
 waits for the next leadership tick. On shutdown it attempts to release its lease.
+Lease renewal is intentionally isolated from post-leadership maintenance:
+accepted synthesis replay, product-feed reconciliation, and pending synthesis
+catch-up run as non-overlapping background work after the heartbeat and runtime
+start. A slow or wedged maintenance pass must be skipped on later heartbeats
+rather than blocking lease renewal. Treat `news daemon lease expired` during a
+healthy relay soak as a publisher bug in that isolation contract, not as relay
+quorum loss.
 
 Recommended production holder:
 

--- a/services/news-aggregator/src/daemon.test.ts
+++ b/services/news-aggregator/src/daemon.test.ts
@@ -92,6 +92,22 @@ function makeTimerControls() {
   return { ticks, setIntervalFn, clearIntervalFn };
 }
 
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, resolve, reject };
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
 function makeTickSummary(overrides: Partial<NewsRuntimeTickSummary> = {}): NewsRuntimeTickSummary {
   return {
     schemaVersion: 'vh-news-runtime-tick-summary-v1',
@@ -266,7 +282,7 @@ describe('news aggregator daemon', () => {
 
     expect(replayAcceptedSynthesis).toHaveBeenCalledTimes(1);
     expect(replayAcceptedSynthesis).toHaveBeenCalledWith({ id: 'client-replay' });
-    expect(replayAcceptedSynthesis.mock.invocationCallOrder[0]).toBeLessThan(
+    expect(replayAcceptedSynthesis.mock.invocationCallOrder[0]).toBeGreaterThan(
       startRuntime.mock.invocationCallOrder[0],
     );
 
@@ -310,7 +326,7 @@ describe('news aggregator daemon', () => {
 
     expect(reconcileProductFeed).toHaveBeenCalledTimes(1);
     expect(reconcileProductFeed).toHaveBeenCalledWith({ id: 'client-reconcile' });
-    expect(reconcileProductFeed.mock.invocationCallOrder[0]).toBeLessThan(
+    expect(reconcileProductFeed.mock.invocationCallOrder[0]).toBeGreaterThan(
       startRuntime.mock.invocationCallOrder[0],
     );
 
@@ -420,13 +436,127 @@ describe('news aggregator daemon', () => {
       now: expect.any(Function),
       staleInProgressMs: 123_456,
     });
-    expect(collectPendingSynthesisCandidates.mock.invocationCallOrder[0]).toBeLessThan(
+    expect(collectPendingSynthesisCandidates.mock.invocationCallOrder[0]).toBeGreaterThan(
       startRuntime.mock.invocationCallOrder[0],
     );
     await vi.waitFor(() => {
       expect(enrichmentWorker).toHaveBeenCalledWith(CANDIDATE);
     });
 
+    await daemon.stop();
+  });
+
+  it('continues renewing the lease while product feed reconciliation remains in flight', async () => {
+    const logger = makeLogger();
+    const runtimeHandle = makeRuntimeHandle();
+    const timers = makeTimerControls();
+    const deferredReconcile = createDeferred<{ repaired_latest_index: number }>();
+    const reconcileProductFeed = vi.fn(() => deferredReconcile.promise);
+    let nowMs = 1_700_000_000_000;
+
+    const startRuntime = vi.fn(() => runtimeHandle);
+    const readLease = vi.fn().mockResolvedValue(null);
+    const writeLease = vi.fn(async (_client: VennClient, lease: unknown) => lease as NewsIngestionLease);
+
+    const daemon = createNewsAggregatorDaemon({
+      client: { id: 'client-reconcile-hung' } as VennClient,
+      feedSources: [...FEED_SOURCES],
+      topicMapping: { ...TOPIC_MAPPING },
+      startRuntime,
+      readLease,
+      writeLease,
+      reconcileProductFeed,
+      productFeedReconcileIntervalMs: 1_000,
+      logger,
+      setIntervalFn: timers.setIntervalFn,
+      clearIntervalFn: timers.clearIntervalFn,
+      now: () => nowMs,
+      random: () => 0.12345,
+      leaseHolderId: 'vh-news-daemon:test',
+    });
+
+    await daemon.start();
+    expect(writeLease).toHaveBeenCalledTimes(1);
+    expect(reconcileProductFeed).toHaveBeenCalledTimes(1);
+
+    nowMs += 60_000;
+    timers.ticks[0]?.();
+    await vi.waitFor(() => {
+      expect(writeLease).toHaveBeenCalledTimes(2);
+    });
+
+    expect(writeLease).toHaveBeenCalledTimes(2);
+    expect(reconcileProductFeed).toHaveBeenCalledTimes(1);
+
+    deferredReconcile.resolve({ repaired_latest_index: 0 });
+    await flushMicrotasks();
+    await daemon.stop();
+  });
+
+  it('continues renewing the lease while pending synthesis catch-up remains in flight', async () => {
+    const logger = makeLogger();
+    const runtimeHandle = makeRuntimeHandle();
+    const timers = makeTimerControls();
+    const deferredCatchup = createDeferred<{
+      scanned: number;
+      enqueued: number;
+      skipped: number;
+      staleInProgress: number;
+      bootstrappedMissingLifecycle: number;
+      acceptedMissingSynthesis: number;
+      candidates: readonly [];
+    }>();
+    const reconcileProductFeed = vi.fn().mockResolvedValue({ repaired_latest_index: 0 });
+    const collectPendingSynthesisCandidates = vi.fn(() => deferredCatchup.promise);
+    const enrichmentWorker = vi.fn().mockResolvedValue(undefined);
+    let nowMs = 1_700_000_000_000;
+
+    const startRuntime = vi.fn(() => runtimeHandle);
+    const readLease = vi.fn().mockResolvedValue(null);
+    const writeLease = vi.fn(async (_client: VennClient, lease: unknown) => lease as NewsIngestionLease);
+
+    const daemon = createNewsAggregatorDaemon({
+      client: { id: 'client-catchup-hung' } as VennClient,
+      feedSources: [...FEED_SOURCES],
+      topicMapping: { ...TOPIC_MAPPING },
+      startRuntime,
+      readLease,
+      writeLease,
+      reconcileProductFeed,
+      collectPendingSynthesisCandidates,
+      enrichmentWorker,
+      synthesisCatchupIntervalMs: 1_000,
+      logger,
+      setIntervalFn: timers.setIntervalFn,
+      clearIntervalFn: timers.clearIntervalFn,
+      now: () => nowMs,
+      random: () => 0.12345,
+      leaseHolderId: 'vh-news-daemon:test',
+    });
+
+    await daemon.start();
+    await flushMicrotasks();
+    expect(writeLease).toHaveBeenCalledTimes(1);
+    expect(collectPendingSynthesisCandidates).toHaveBeenCalledTimes(1);
+
+    nowMs += 60_000;
+    timers.ticks[0]?.();
+    await flushMicrotasks();
+
+    expect(writeLease).toHaveBeenCalledTimes(2);
+    expect(collectPendingSynthesisCandidates).toHaveBeenCalledTimes(1);
+    expect(enrichmentWorker).not.toHaveBeenCalled();
+
+    deferredCatchup.resolve({
+      scanned: 0,
+      enqueued: 0,
+      skipped: 0,
+      staleInProgress: 0,
+      bootstrappedMissingLifecycle: 0,
+      acceptedMissingSynthesis: 0,
+      candidates: [],
+    });
+    await flushMicrotasks();
     await daemon.stop();
   });
 

--- a/services/news-aggregator/src/daemon.ts
+++ b/services/news-aggregator/src/daemon.ts
@@ -216,6 +216,7 @@ export function createNewsAggregatorDaemon(config: NewsAggregatorDaemonConfig): 
   let runtimeHandle: NewsRuntimeHandle | null = null;
   let leaseHeartbeatTimer: ReturnType<typeof setInterval> | null = null;
   let leadershipTickPromise: Promise<void> | null = null;
+  let leadershipMaintenancePromise: Promise<void> | null = null;
   let stopPromise: Promise<void> | null = null;
   let runtimeWritesBlocked = false;
   let acceptedSynthesisReplayAttempted = false;
@@ -495,6 +496,91 @@ export function createNewsAggregatorDaemon(config: NewsAggregatorDaemonConfig): 
     runtimeHandle = null;
     logger.warn('[vh:news-daemon] runtime did not start (disabled or rejected)');
   };
+  const runLeadershipMaintenance = async (nowMs: number): Promise<void> => {
+    if (!running || noWrite) {
+      return;
+    }
+    if (!acceptedSynthesisReplayAttempted && config.replayAcceptedSynthesis) {
+      acceptedSynthesisReplayAttempted = true;
+      try {
+        await config.replayAcceptedSynthesis(config.client);
+      } catch (error) {
+        logger.warn('[vh:news-daemon] accepted synthesis replay failed', error);
+      }
+    }
+    if (!running) {
+      return;
+    }
+    if (nowMs >= nextProductFeedReconciliationAt) {
+      nextProductFeedReconciliationAt = nowMs + productFeedReconcileIntervalMs;
+      try {
+        const result = await reconcileProductFeed(config.client);
+        logger.info('[vh:news-daemon] product feed reconciliation attempted', {
+          holder_id: holderId,
+          next_reconcile_at: nextProductFeedReconciliationAt,
+          interval_ms: productFeedReconcileIntervalMs,
+          result,
+        });
+      } catch (error) {
+        logger.warn('[vh:news-daemon] product feed reconciliation failed', error);
+      }
+    }
+    if (!running) {
+      return;
+    }
+    if (config.enrichmentWorker && nowMs >= nextSynthesisCatchupAt) {
+      nextSynthesisCatchupAt = nowMs + synthesisCatchupIntervalMs;
+      try {
+        const result = await collectPendingSynthesisCandidates(config.client, {
+          limit: synthesisCatchupSampleLimit,
+          logger,
+          now: nowFn,
+          staleInProgressMs: synthesisInProgressStaleMs,
+        });
+        if (running) {
+          for (const candidate of result.candidates) {
+            queue.enqueue(candidate.candidate);
+          }
+        }
+        logger.info('[vh:news-daemon] pending synthesis catch-up attempted', {
+          holder_id: holderId,
+          next_catchup_at: nextSynthesisCatchupAt,
+          interval_ms: synthesisCatchupIntervalMs,
+          sample_limit: synthesisCatchupSampleLimit,
+          scanned: result.scanned,
+          enqueued: result.enqueued,
+          skipped: result.skipped,
+          stale_in_progress: result.staleInProgress,
+          in_progress_stale_ms: synthesisInProgressStaleMs,
+          enrichment_queue: queue.snapshot(),
+        });
+      } catch (error) {
+        logger.warn('[vh:news-daemon] pending synthesis catch-up failed', error);
+      }
+    }
+  };
+  const scheduleLeadershipMaintenance = (nowMs: number): void => {
+    if (!running || noWrite) {
+      return;
+    }
+    if (leadershipMaintenancePromise) {
+      logger.info('[vh:news-daemon] leadership maintenance already running; skipping this heartbeat', {
+        holder_id: holderId,
+        now_ms: nowMs,
+      });
+      return;
+    }
+    const inFlight = runLeadershipMaintenance(nowMs)
+      .catch((error) => {
+        logger.warn('[vh:news-daemon] leadership maintenance failed', error);
+      })
+      .finally(() => {
+        if (leadershipMaintenancePromise === inFlight) {
+          leadershipMaintenancePromise = null;
+        }
+      });
+    leadershipMaintenancePromise = inFlight;
+  };
   const leadershipTick = async (): Promise<void> => {
     if (!running) {
       return;
@@ -549,57 +635,8 @@ export function createNewsAggregatorDaemon(config: NewsAggregatorDaemonConfig): 
       lease_token_present: Boolean(lease.lease_token),
       expires_at: lease.expires_at,
     });
-    if (!acceptedSynthesisReplayAttempted && config.replayAcceptedSynthesis) {
-      acceptedSynthesisReplayAttempted = true;
-      try {
-        await config.replayAcceptedSynthesis(config.client);
-      } catch (error) {
-        logger.warn('[vh:news-daemon] accepted synthesis replay failed', error);
-      }
-    }
-    if (nowMs >= nextProductFeedReconciliationAt) {
-      nextProductFeedReconciliationAt = nowMs + productFeedReconcileIntervalMs;
-      try {
-        const result = await reconcileProductFeed(config.client);
-        logger.info('[vh:news-daemon] product feed reconciliation attempted', {
-          holder_id: holderId,
-          next_reconcile_at: nextProductFeedReconciliationAt,
-          interval_ms: productFeedReconcileIntervalMs,
-          result,
-        });
-      } catch (error) {
-        logger.warn('[vh:news-daemon] product feed reconciliation failed', error);
-      }
-    }
-    if (config.enrichmentWorker && nowMs >= nextSynthesisCatchupAt) {
-      nextSynthesisCatchupAt = nowMs + synthesisCatchupIntervalMs;
-      try {
-        const result = await collectPendingSynthesisCandidates(config.client, {
-          limit: synthesisCatchupSampleLimit,
-          logger,
-          now: nowFn,
-          staleInProgressMs: synthesisInProgressStaleMs,
-        });
-        for (const candidate of result.candidates) {
-          queue.enqueue(candidate.candidate);
-        }
-        logger.info('[vh:news-daemon] pending synthesis catch-up attempted', {
-          holder_id: holderId,
-          next_catchup_at: nextSynthesisCatchupAt,
-          interval_ms: synthesisCatchupIntervalMs,
-          sample_limit: synthesisCatchupSampleLimit,
-          scanned: result.scanned,
-          enqueued: result.enqueued,
-          skipped: result.skipped,
-          stale_in_progress: result.staleInProgress,
-          in_progress_stale_ms: synthesisInProgressStaleMs,
-          enrichment_queue: queue.snapshot(),
-        });
-      } catch (error) {
-        logger.warn('[vh:news-daemon] pending synthesis catch-up failed', error);
-      }
-    }
     startRuntimeIfNeeded();
+    scheduleLeadershipMaintenance(nowMs);
   };
   const runLeadershipTick = async (): Promise<void> => {
     if (leadershipTickPromise) {


### PR DESCRIPTION
## Summary

This PR fixes the abort observed during the #675 attended soak after relay hardening had already held: relays stayed healthy, but the publisher fail-closed on `news daemon lease expired` at 2026-06-22 23:12:09Z.

Root cause from the captured journal:
- Last successful heartbeat was 19:10:08 local, expiring at ~19:12:08.
- No 19:11 heartbeat occurred.
- The 10-minute product-feed reconciliation was due immediately after the 19:10 heartbeat, but no completion log appeared before lease expiry.
- `leadershipTickPromise` covered heartbeat plus accepted synthesis replay, product-feed reconciliation, and synthesis catch-up, so a slow/wedged maintenance pass could block later heartbeat ticks from issuing a fresh lease renewal.

## Changes

- Isolate the lease heartbeat path in `services/news-aggregator/src/daemon.ts`:
  - renew lease;
  - accept lease;
  - start runtime;
  - schedule post-leadership maintenance separately.
- Run accepted synthesis replay, product-feed reconciliation, and pending synthesis catch-up as non-overlapping background maintenance.
- If maintenance is still in flight at the next heartbeat, skip that maintenance cycle instead of blocking lease renewal.
- Keep no-write behavior unchanged.
- Update tests so maintenance is no longer expected to run before runtime start.
- Add regression tests proving lease renewal continues while product-feed reconciliation or synthesis catch-up remains in flight.
- Document the operational invariant in `docs/ops/news-aggregator-production-service.md`.

## Live Evidence

Captured and parked after abort:
- A6 authoritative publisher packet: `/tmp/phase5-soak-abort-20260622T231237Z-humble.tar.gz`
- Local copy: `.tmp/phase5-soak-aborts/phase5-soak-abort-20260622T231237Z-humble.tar.gz`
- Supplemental relay/admin packet: `.tmp/phase5-soak-aborts/phase5-soak-abort-20260622T231237Z.tar.gz`

Publisher was parked after capture:
- `ActiveState=failed`, `SubState=failed`, `ExecMainStatus=78`, `NRestarts=0`
- `UnitFileState=disabled`
- `VH_NEWS_DAEMON_START_APPROVED` unset from the humble user manager

Relay state at abort was healthy:
- no new critical route 500s
- no backpressure
- no watchdog trips
- no relay restarts
- queues drained
- p99 event-loop lag ~21ms
- RSS back down to ~365-436MB

## Verification

All commands run with Node 20 via `PATH=/opt/homebrew/opt/node@20/bin:$PATH` unless noted.

- `pnpm --filter @vh/news-aggregator exec vitest run src/daemon.test.ts src/daemon.coverage.test.ts --config ./vitest.config.ts`
  - 2 files passed, 33 tests passed
- `pnpm --filter @vh/news-aggregator exec vitest run src/daemon.test.ts src/daemon.storylines.test.ts src/daemonWriteLane.test.ts src/daemon.coverage.test.ts src/daemon.production.test.ts --config ./vitest.config.ts`
  - 5 files passed, 55 tests passed
- `pnpm --filter @vh/news-aggregator build`
  - pass
- `git diff --check`
  - pass
- `node tools/scripts/check-diff-coverage.mjs`
  - pass, no coverage-eligible source files changed
- `pnpm test:quick`
  - 319 files passed, 4,938 tests passed

## Boundaries

No live restart, publisher start, relay rebuild, StoryCluster reset, queue scrub, or mesh repair was performed after the abort. The next attended soak remains operator-owned after this PR is merged and deployed.
