### PR TITLE
Deburst product-feed repair startup

### DIFF
--- a/docs/ops/news-aggregator-production-service.md
+++ b/docs/ops/news-aggregator-production-service.md
@@ -2,7 +2,7 @@
 
 > Status: Operational Runbook
 > Owner: VHC Ops
-> Last Reviewed: 2026-06-15
+> Last Reviewed: 2026-06-23
 > Depends On: docs/ops/NEWS_SOURCE_ADMISSION_RUNBOOK.md, docs/ops/public-feed-freshness-monitor.md, docs/ops/analysis-backend-3001.md, docs/ops/storycluster-production-service.md, docs/ops/public-beta-launch-readiness-closeout.md
 
 ## Purpose
@@ -354,6 +354,25 @@ immediately after that completed summary. Set it to `false` only when first-tick
 caps, synthesis throughput, relay fanout, and the watchdog window have been
 recalibrated together.
 
+The first product-feed repair pass is also deferred until after the first
+completed raw runtime tick. This is production default behavior and does not
+depend on accepted synthesis being enabled or on the synthesis-defer flag. The
+daemon logs one safe `first_runtime_tick_pending` skip with the holder id while
+that first tick is still pending, leaves the repair timer eligible, and runs
+product-feed reconciliation on the next maintenance pass after a completed tick.
+This prevents startup product-feed repair from colliding with the first raw
+bundle plus raw pending lifecycle writes.
+
+Product-feed repair writes are paced separately from raw publication. Story-body,
+latest-index, hot-index, and repair lifecycle maintenance writes use dedicated
+`product_feed_repair_*` write lanes with concurrency 1. Those lanes preserve the
+configured relay REST quorum for each write, but their failures are maintenance
+telemetry: they are logged and counted by the repair result and must not call the
+fatal runtime `onError` path, stop raw publication, or set the daemon's
+runtime-write block. The startup deferral and the paced repair lanes solve
+different windows: deferral removes the startup write collision, while pacing
+protects steady-state repair runs from becoming a maintenance burst.
+
 Current Phase 5 Scope A is raw-fresh, v4-signed, product-visible news cards.
 Raw bundle publication and the publish-time pending lifecycle row
 (`synthesis_pending` / `frame_table_pending`) are critical and fail-closed
@@ -374,6 +393,21 @@ service stopped instead of allowing the write lane to drain more public stories.
 Do not set it to `false` in production unless the incident commander has chosen
 an attended degraded-write experiment and the public-feed rollback plan is
 already active.
+
+For the next post-#679 launch soak after a clean StoryCluster reset, use:
+
+```bash
+VH_BUNDLE_SYNTHESIS_ENABLED=0
+VH_NEWS_RUNTIME_RAW_BUNDLE_WRITE_CONCURRENCY=1
+VH_NEWS_PRODUCT_FEED_REPAIR_SAMPLE_LIMIT=8
+```
+
+`VH_NEWS_PRODUCT_FEED_REPAIR_SAMPLE_LIMIT=8` is a launch-soak value, not a
+permanent ceiling. Raise it deliberately only after paced repair has soaked
+cleanly. Scope A launch config keeps accepted synthesis disabled: the raw runtime
+may still enqueue local synthesis candidates and log an inactive local queue, but
+`VH_BUNDLE_SYNTHESIS_ENABLED=0` must not publish accepted/topic synthesis relay
+writes to `/vh/topics/synthesis-candidate` or `/vh/topics/synthesis`.
 
 ## Env File Surface
 
@@ -425,9 +459,12 @@ VH_NEWS_RUNTIME_DIAGNOSTIC_FILE
 VH_NEWS_RUNTIME_TICK_WATCHDOG_MS
 VH_NEWS_DAEMON_DEFER_SYNTHESIS_UNTIL_FIRST_TICK_COMPLETE
 VH_NEWS_DAEMON_FAIL_CLOSED_ON_RUNTIME_ERROR
+VH_NEWS_PRODUCT_FEED_REPAIR_INTERVAL_MS
+VH_NEWS_PRODUCT_FEED_REPAIR_SAMPLE_LIMIT
 VH_NEWS_FEED_MAX_ITEMS_PER_SOURCE
 VH_NEWS_FEED_MAX_ITEMS_TOTAL
 VH_NEWS_RUNTIME_MAX_PUBLISHED_BUNDLES
+VH_NEWS_RUNTIME_RAW_BUNDLE_WRITE_CONCURRENCY
 VH_STORYCLUSTER_REMOTE_MAX_ITEMS_PER_REQUEST
 VH_NEWS_SYSTEM_WRITER_ID
 VH_NEWS_SYSTEM_WRITER_PIN_JSON
@@ -568,10 +605,11 @@ waits for the next leadership tick. On shutdown it attempts to release its lease
 Lease renewal is intentionally isolated from post-leadership maintenance:
 accepted synthesis replay, product-feed reconciliation, and pending synthesis
 catch-up run as non-overlapping background work after the heartbeat and runtime
-start. A slow or wedged maintenance pass must be skipped on later heartbeats
-rather than blocking lease renewal. Treat `news daemon lease expired` during a
-healthy relay soak as a publisher bug in that isolation contract, not as relay
-quorum loss.
+start. Product-feed reconciliation additionally skips until the first completed
+runtime tick so startup maintenance cannot race the first raw publish tick. A
+slow or wedged maintenance pass must be skipped on later heartbeats rather than
+blocking lease renewal. Treat `news daemon lease expired` during a healthy relay
+soak as a publisher bug in that isolation contract, not as relay quorum loss.
 
 Recommended production holder:
 

--- a/packages/ai-engine/vitest.config.ts
+++ b/packages/ai-engine/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig, mergeConfig } from 'vitest/config';
+import rootConfig from '../../vitest.config';
+
+export default mergeConfig(rootConfig, defineConfig({
+  test: {
+    include: ['src/**/*.{test,spec}.{ts,tsx,js,jsx}'],
+    exclude: ['**/node_modules/**', '**/dist/**'],
+  },
+}));

--- a/services/news-aggregator/src/daemon.production.test.ts
+++ b/services/news-aggregator/src/daemon.production.test.ts
@@ -2,7 +2,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import type { NewsRuntimeTickSummary } from '@vh/ai-engine';
+import type {
+  NewsRuntimeConfig,
+  NewsRuntimeSynthesisCandidate,
+  NewsRuntimeTickSummary,
+} from '@vh/ai-engine';
 
 const mocks = vi.hoisted(() => ({
   startNewsRuntime: vi.fn(),
@@ -94,6 +98,28 @@ function makeTickSummary(overrides: Partial<NewsRuntimeTickSummary> = {}): NewsR
     ...overrides,
   };
 }
+
+const SYNTHESIS_CANDIDATE: NewsRuntimeSynthesisCandidate = {
+  story_id: 'story-disabled-synthesis',
+  provider: {
+    provider_id: 'remote-analysis',
+    model_id: 'gpt-5-nano',
+    kind: 'remote',
+  },
+  request: {
+    prompt: 'Summary',
+    model: 'gpt-5-nano',
+    max_tokens: 2048,
+    temperature: 0.1,
+  },
+  work_items: [{
+    story_id: 'story-disabled-synthesis',
+    topic_id: 'topic-news',
+    work_type: 'full-analysis',
+    summary_hint: 'Summary',
+    requested_at: 1_700_000_000_000,
+  }],
+};
 
 function waitForScheduledStop(): Promise<void> {
   return new Promise((resolve) => {
@@ -301,6 +327,35 @@ describe('news daemon production wiring', () => {
       expect(runtimeHandle.stop).toHaveBeenCalledTimes(1);
       expect(shutdown).toHaveBeenCalledTimes(1);
     } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps accepted/topic synthesis relay writes disabled for Scope A launch config', async () => {
+    const tmpDir = mkdtempSync(path.join(os.tmpdir(), 'vh-news-daemon-synthesis-disabled-'));
+    const fetchMock = vi.fn(async () => new Response('ok', { status: 200 }));
+    primeHealthyEnv();
+    vi.stubEnv('VH_NEWS_DAEMON_STATE_DIR', tmpDir);
+    vi.stubEnv('VH_BUNDLE_SYNTHESIS_ENABLED', '0');
+    vi.stubEnv('VH_BUNDLE_SYNTHESIS_WRITE_RELAY_REST', 'true');
+    vi.stubEnv('VH_RELAY_DAEMON_TOKEN', 'relay-token');
+    vi.stubGlobal('fetch', fetchMock);
+    let handle: { stop(): Promise<void> } | null = null;
+
+    try {
+      handle = await startNewsAggregatorDaemonFromEnv();
+      const runtimeConfig = mocks.startNewsRuntime.mock.calls[0]?.[0] as NewsRuntimeConfig;
+
+      runtimeConfig.onSynthesisCandidate?.(SYNTHESIS_CANDIDATE);
+      await runtimeConfig.onTickSummary?.(makeTickSummary());
+      await waitForScheduledStop();
+
+      const fetchedUrls = fetchMock.mock.calls.map((call) => String(call[0]));
+      expect(fetchedUrls).toContain('https://storycluster.example.com/health');
+      expect(fetchedUrls.some((url) => url.includes('/vh/topics/synthesis-candidate'))).toBe(false);
+      expect(fetchedUrls.some((url) => url.includes('/vh/topics/synthesis'))).toBe(false);
+    } finally {
+      await handle?.stop();
       rmSync(tmpDir, { recursive: true, force: true });
     }
   });

--- a/services/news-aggregator/src/daemon.test.ts
+++ b/services/news-aggregator/src/daemon.test.ts
@@ -296,7 +296,7 @@ describe('news aggregator daemon', () => {
     await daemon.stop();
   });
 
-  it('reconciles raw stories into product feed indexes after acquiring leadership', async () => {
+  it('defers product feed reconciliation until after the first completed runtime tick', async () => {
     const logger = makeLogger();
     const runtimeHandle = makeRuntimeHandle();
     const timers = makeTimerControls();
@@ -323,19 +323,31 @@ describe('news aggregator daemon', () => {
     });
 
     await daemon.start();
+    await flushMicrotasks();
+
+    expect(reconcileProductFeed).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledWith(
+      '[vh:news-daemon] product feed reconciliation deferred until first runtime tick completes',
+      {
+        holder_id: 'vh-news-daemon:test',
+        reason: 'first_runtime_tick_pending',
+      },
+    );
+
+    const runtimeConfig = startRuntime.mock.calls[0]?.[0] as NewsRuntimeConfig;
+    await runtimeConfig.onTickSummary?.(makeTickSummary());
+
+    const heartbeatTick = timers.ticks[0];
+    heartbeatTick?.();
+    await vi.waitFor(() => {
+      expect(reconcileProductFeed).toHaveBeenCalledTimes(1);
+    });
 
     expect(reconcileProductFeed).toHaveBeenCalledTimes(1);
     expect(reconcileProductFeed).toHaveBeenCalledWith({ id: 'client-reconcile' });
     expect(reconcileProductFeed.mock.invocationCallOrder[0]).toBeGreaterThan(
       startRuntime.mock.invocationCallOrder[0],
     );
-
-    const heartbeatTick = timers.ticks[0];
-    heartbeatTick?.();
-    await Promise.resolve();
-    await Promise.resolve();
-
-    expect(reconcileProductFeed).toHaveBeenCalledTimes(1);
 
     await daemon.stop();
   });
@@ -369,15 +381,133 @@ describe('news aggregator daemon', () => {
     });
 
     await daemon.start();
-    expect(reconcileProductFeed).toHaveBeenCalledTimes(1);
+    await flushMicrotasks();
+    expect(reconcileProductFeed).not.toHaveBeenCalled();
+
+    const runtimeConfig = startRuntime.mock.calls[0]?.[0] as NewsRuntimeConfig;
+    await runtimeConfig.onTickSummary?.(makeTickSummary());
 
     const heartbeatTick = timers.ticks[0];
+    heartbeatTick?.();
+    await vi.waitFor(() => {
+      expect(reconcileProductFeed).toHaveBeenCalledTimes(1);
+    });
+
     nowMs += 1_001;
     heartbeatTick?.();
     await vi.waitFor(() => {
       expect(reconcileProductFeed).toHaveBeenCalledTimes(2);
     });
     expect(reconcileProductFeed).toHaveBeenLastCalledWith({ id: 'client-reconcile-periodic' });
+
+    await daemon.stop();
+  });
+
+  it('defers product feed reconciliation independently of the enrichment-defer flag', async () => {
+    const logger = makeLogger();
+    const runtimeHandle = makeRuntimeHandle();
+    const timers = makeTimerControls();
+    const reconcileProductFeed = vi.fn().mockResolvedValue({ repaired_latest_index: 1 });
+
+    const startRuntime = vi.fn(() => runtimeHandle);
+    const readLease = vi.fn().mockResolvedValue(null);
+    const writeLease = vi.fn(async (_client: VennClient, lease: unknown) => lease as NewsIngestionLease);
+
+    const daemon = createNewsAggregatorDaemon({
+      client: { id: 'client-reconcile-no-enrichment-defer' } as VennClient,
+      feedSources: [...FEED_SOURCES],
+      topicMapping: { ...TOPIC_MAPPING },
+      startRuntime,
+      readLease,
+      writeLease,
+      reconcileProductFeed,
+      deferEnrichmentUntilFirstTickComplete: false,
+      logger,
+      setIntervalFn: timers.setIntervalFn,
+      clearIntervalFn: timers.clearIntervalFn,
+      now: () => 1_700_000_000_000,
+      random: () => 0.12345,
+      leaseHolderId: 'vh-news-daemon:test',
+    });
+
+    await daemon.start();
+    await flushMicrotasks();
+
+    expect(reconcileProductFeed).not.toHaveBeenCalled();
+
+    const runtimeConfig = startRuntime.mock.calls[0]?.[0] as NewsRuntimeConfig;
+    await runtimeConfig.onTickSummary?.(makeTickSummary());
+    timers.ticks[0]?.();
+
+    await vi.waitFor(() => {
+      expect(reconcileProductFeed).toHaveBeenCalledTimes(1);
+    });
+    expect(reconcileProductFeed).toHaveBeenCalledWith({ id: 'client-reconcile-no-enrichment-defer' });
+
+    await daemon.stop();
+  });
+
+  it('keeps product feed repair failure non-fatal and leaves raw runtime writes enabled', async () => {
+    const logger = makeLogger();
+    const runtimeHandle = makeRuntimeHandle();
+    const timers = makeTimerControls();
+    const repairError = new Error('product-feed repair lifecycle readback failed');
+    const reconcileProductFeed = vi.fn().mockRejectedValue(repairError);
+    const onFailClosedRuntimeError = vi.fn();
+
+    const startRuntime = vi.fn(() => runtimeHandle);
+    const readLease = vi.fn().mockResolvedValue(null);
+    const writeLease = vi.fn(async (_client: VennClient, lease: unknown) => lease as NewsIngestionLease);
+    const writeBundle = vi.fn().mockResolvedValue({ story_id: 'story-after-repair-error' });
+
+    const daemon = createNewsAggregatorDaemon({
+      client: { id: 'client-repair-nonfatal' } as VennClient,
+      feedSources: [...FEED_SOURCES],
+      topicMapping: { ...TOPIC_MAPPING },
+      startRuntime,
+      readLease,
+      writeLease,
+      writeBundle,
+      reconcileProductFeed,
+      failClosedOnRuntimeError: true,
+      onFailClosedRuntimeError,
+      logger,
+      setIntervalFn: timers.setIntervalFn,
+      clearIntervalFn: timers.clearIntervalFn,
+      now: () => 1_700_000_000_000,
+      random: () => 0.12345,
+      leaseHolderId: 'vh-news-daemon:test',
+    });
+
+    await daemon.start();
+    await flushMicrotasks();
+
+    const runtimeConfig = startRuntime.mock.calls[0]?.[0] as NewsRuntimeConfig;
+    await runtimeConfig.onTickSummary?.(makeTickSummary());
+    timers.ticks[0]?.();
+
+    await vi.waitFor(() => {
+      expect(reconcileProductFeed).toHaveBeenCalledTimes(1);
+    });
+    expect(logger.warn).toHaveBeenCalledWith(
+      '[vh:news-daemon] product feed reconciliation failed',
+      {
+        holder_id: 'vh-news-daemon:test',
+        error: repairError,
+      },
+    );
+
+    await expect(
+      runtimeConfig.writeStoryBundle?.(
+        { id: 'client-repair-nonfatal' },
+        { story_id: 'story-after-repair-error' } as any,
+      ),
+    ).resolves.toEqual({ story_id: 'story-after-repair-error' });
+
+    expect(onFailClosedRuntimeError).not.toHaveBeenCalled();
+    expect(runtimeHandle.stop).not.toHaveBeenCalled();
+    expect(daemon.isRunning()).toBe(true);
+    expect(writeBundle).toHaveBeenCalledTimes(1);
 
     await daemon.stop();
   });
@@ -477,15 +607,23 @@ describe('news aggregator daemon', () => {
 
     await daemon.start();
     expect(writeLease).toHaveBeenCalledTimes(1);
-    expect(reconcileProductFeed).toHaveBeenCalledTimes(1);
+    expect(reconcileProductFeed).not.toHaveBeenCalled();
+
+    const runtimeConfig = startRuntime.mock.calls[0]?.[0] as NewsRuntimeConfig;
+    await runtimeConfig.onTickSummary?.(makeTickSummary());
+    timers.ticks[0]?.();
+    await vi.waitFor(() => {
+      expect(reconcileProductFeed).toHaveBeenCalledTimes(1);
+    });
+    expect(writeLease).toHaveBeenCalledTimes(2);
 
     nowMs += 60_000;
     timers.ticks[0]?.();
     await vi.waitFor(() => {
-      expect(writeLease).toHaveBeenCalledTimes(2);
+      expect(writeLease).toHaveBeenCalledTimes(3);
     });
 
-    expect(writeLease).toHaveBeenCalledTimes(2);
+    expect(writeLease).toHaveBeenCalledTimes(3);
     expect(reconcileProductFeed).toHaveBeenCalledTimes(1);
 
     deferredReconcile.resolve({ repaired_latest_index: 0 });

--- a/services/news-aggregator/src/daemon.ts
+++ b/services/news-aggregator/src/daemon.ts
@@ -70,7 +70,10 @@ import {
   replayAcceptedAnalysisEvalSyntheses,
   resolveAnalysisEvalReplayArtifactDirFromEnv,
 } from './analysisEvalReplay';
-import { reconcileProductFeedFromRawStories } from './productFeedReconciler';
+import {
+  PRODUCT_FEED_REPAIR_WRITE_LANE_CONCURRENCY,
+  reconcileProductFeedFromRawStories,
+} from './productFeedReconciler';
 import {
   DEFAULT_SYNTHESIS_IN_PROGRESS_STALE_MS,
   collectPendingSynthesisCatchupCandidates,
@@ -188,6 +191,7 @@ export function createNewsAggregatorDaemon(config: NewsAggregatorDaemonConfig): 
   const writeLanes = config.writeLanes ?? createDaemonWriteLaneRegistry({
     logger,
     now: nowFn,
+    classConcurrency: PRODUCT_FEED_REPAIR_WRITE_LANE_CONCURRENCY,
     stopClassOnFailure: failClosedOnRuntimeError && !noWrite
       ? shouldStopFailClosedRuntimeWriteClass
       : false,
@@ -212,6 +216,7 @@ export function createNewsAggregatorDaemon(config: NewsAggregatorDaemonConfig): 
   let runtimeTickLimitReached = false;
   let firstRuntimeTickCompleted = false;
   let enrichmentQueueDeferredLogged = false;
+  let productFeedReconciliationDeferredLogged = false;
   let running = false;
   let runtimeHandle: NewsRuntimeHandle | null = null;
   let leaseHeartbeatTimer: ReturnType<typeof setInterval> | null = null;
@@ -249,6 +254,7 @@ export function createNewsAggregatorDaemon(config: NewsAggregatorDaemonConfig): 
       ? reconcileProductFeedFromRawStories(client, {
           logger,
           now: nowFn,
+          runWrite: writeLanes.run,
           sampleLimit: parseOptionalPositiveInt(readEnvVar('VH_NEWS_PRODUCT_FEED_REPAIR_SAMPLE_LIMIT')),
         })
       : Promise.resolve({ skipped: 'mesh_unavailable' }));
@@ -318,20 +324,24 @@ export function createNewsAggregatorDaemon(config: NewsAggregatorDaemonConfig): 
             logger.warn('[vh:news-daemon] runtime tick limit stop callback failed', error);
           });
         }
-        if (
-          deferEnrichmentUntilFirstTickComplete
-          && !firstRuntimeTickCompleted
-          && summary.status === 'completed'
-        ) {
+        if (!firstRuntimeTickCompleted && summary.status === 'completed') {
           firstRuntimeTickCompleted = true;
-          queue.start();
-          logger.info('[vh:news-daemon] enrichment queue started after first runtime tick', {
+          logger.info('[vh:news-daemon] first runtime tick completed', {
             holder_id: holderId,
             tick_sequence: summary.tick_sequence,
             raw_wrote_count: summary.raw_wrote_count,
             selected_bundle_count: summary.selected_bundle_count,
-            enrichment_queue: queue.snapshot(),
           });
+          if (deferEnrichmentUntilFirstTickComplete) {
+            queue.start();
+            logger.info('[vh:news-daemon] enrichment queue started after first runtime tick', {
+              holder_id: holderId,
+              tick_sequence: summary.tick_sequence,
+              raw_wrote_count: summary.raw_wrote_count,
+              selected_bundle_count: summary.selected_bundle_count,
+              enrichment_queue: queue.snapshot(),
+            });
+          }
         }
       },
       writeStoryBundle: async (runtimeClient: unknown, bundle: unknown) => {
@@ -512,17 +522,30 @@ export function createNewsAggregatorDaemon(config: NewsAggregatorDaemonConfig): 
       return;
     }
     if (nowMs >= nextProductFeedReconciliationAt) {
-      nextProductFeedReconciliationAt = nowMs + productFeedReconcileIntervalMs;
-      try {
-        const result = await reconcileProductFeed(config.client);
-        logger.info('[vh:news-daemon] product feed reconciliation attempted', {
-          holder_id: holderId,
-          next_reconcile_at: nextProductFeedReconciliationAt,
-          interval_ms: productFeedReconcileIntervalMs,
-          result,
-        });
-      } catch (error) {
-        logger.warn('[vh:news-daemon] product feed reconciliation failed', error);
+      if (!firstRuntimeTickCompleted) {
+        if (!productFeedReconciliationDeferredLogged) {
+          productFeedReconciliationDeferredLogged = true;
+          logger.info('[vh:news-daemon] product feed reconciliation deferred until first runtime tick completes', {
+            holder_id: holderId,
+            reason: 'first_runtime_tick_pending',
+          });
+        }
+      } else {
+        nextProductFeedReconciliationAt = nowMs + productFeedReconcileIntervalMs;
+        try {
+          const result = await reconcileProductFeed(config.client);
+          logger.info('[vh:news-daemon] product feed reconciliation attempted', {
+            holder_id: holderId,
+            next_reconcile_at: nextProductFeedReconciliationAt,
+            interval_ms: productFeedReconcileIntervalMs,
+            result,
+          });
+        } catch (error) {
+          logger.warn('[vh:news-daemon] product feed reconciliation failed', {
+            holder_id: holderId,
+            error,
+          });
+        }
       }
     }
     if (!running) {
@@ -1007,6 +1030,7 @@ export async function startNewsAggregatorDaemonFromEnv(): Promise<NewsAggregator
   }
   const writeLanes = createDaemonWriteLaneRegistry({
     logger: console,
+    classConcurrency: PRODUCT_FEED_REPAIR_WRITE_LANE_CONCURRENCY,
     stopClassOnFailure: failClosedOnRuntimeError && !noWrite
       ? shouldStopFailClosedRuntimeWriteClass
       : false,

--- a/services/news-aggregator/src/daemonWriteLane.test.ts
+++ b/services/news-aggregator/src/daemonWriteLane.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { createDaemonWriteLaneRegistry } from './daemonWriteLane';
+import { PRODUCT_FEED_REPAIR_WRITE_LANE_CONCURRENCY } from './productFeedReconciler';
 
 function flushMicrotasks(): Promise<void> {
   return Promise.resolve().then(() => undefined);
@@ -162,6 +163,60 @@ describe('daemonWriteLane', () => {
           failed_count: 1,
         }),
       ]),
+    );
+  });
+
+  it('paces product-feed repair writes with dedicated concurrency-one lanes', async () => {
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    let releaseFirstRepair: (() => void) | null = null;
+    const lane = createDaemonWriteLaneRegistry({
+      logger,
+      defaultConcurrency: 10,
+      classConcurrency: PRODUCT_FEED_REPAIR_WRITE_LANE_CONCURRENCY,
+      stopClassOnFailure: (writeClass) => writeClass === 'news_synthesis_lifecycle',
+    });
+
+    const firstRepair = lane.run('product_feed_repair_lifecycle', { story_id: 'story-1' }, () =>
+      new Promise<string>((resolve) => {
+        releaseFirstRepair = () => resolve('first-repair');
+      }),
+    );
+    const secondRepairTask = vi.fn(async () => 'second-repair');
+    const secondRepair = lane.run('product_feed_repair_lifecycle', { story_id: 'story-2' }, secondRepairTask);
+    const rawPendingLifecycle = lane.run('news_synthesis_lifecycle', { story_id: 'raw-story' }, async () => 'raw');
+
+    await flushMicrotasks();
+
+    expect(secondRepairTask).not.toHaveBeenCalled();
+    await expect(rawPendingLifecycle).resolves.toBe('raw');
+    expect(lane.snapshot()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          write_class: 'product_feed_repair_lifecycle',
+          pending_depth: 1,
+          in_flight: 1,
+          stopped: false,
+        }),
+        expect.objectContaining({
+          write_class: 'news_synthesis_lifecycle',
+          stopped: false,
+        }),
+      ]),
+    );
+
+    releaseFirstRepair?.();
+    await expect(firstRepair).resolves.toBe('first-repair');
+    await flushMicrotasks();
+    await expect(secondRepair).resolves.toBe('second-repair');
+
+    expect(secondRepairTask).toHaveBeenCalledTimes(1);
+    expect(lane.snapshot()).toContainEqual(
+      expect.objectContaining({
+        write_class: 'product_feed_repair_lifecycle',
+        pending_depth: 0,
+        in_flight: 0,
+        completed_count: 2,
+      }),
     );
   });
 });

--- a/services/news-aggregator/src/productFeedReconciler.test.ts
+++ b/services/news-aggregator/src/productFeedReconciler.test.ts
@@ -93,9 +93,13 @@ describe('product feed reconciler', () => {
   it('repairs missing latest/hot indexes and missing lifecycle for eligible raw stories', async () => {
     const story = makeStory();
     const dependencies = makeDependencies(story);
+    const runWrite = vi.fn(async <T,>(_writeClass: string, _attributes: Record<string, unknown>, task: () => Promise<T>) =>
+      task(),
+    );
 
     const result = await reconcileProductFeedFromRawStories({ id: 'client' } as VennClient, {
       dependencies,
+      runWrite,
       now: () => 1_000,
       logger: { info: vi.fn(), warn: vi.fn() },
     });
@@ -125,6 +129,11 @@ describe('product feed reconciler', () => {
         frame_table_state: 'frame_table_pending',
       }),
     );
+    expect(runWrite.mock.calls.map((call) => call[0])).toEqual([
+      'product_feed_repair_latest_index',
+      'product_feed_repair_hot_index',
+      'product_feed_repair_lifecycle',
+    ]);
   });
 
   it('preserves current lifecycle when the story source-set revision is unchanged', async () => {

--- a/services/news-aggregator/src/productFeedReconciler.ts
+++ b/services/news-aggregator/src/productFeedReconciler.ts
@@ -26,6 +26,18 @@ const INCOMPLETE_LIFECYCLE_STATUSES = new Set<NewsSynthesisLifecycleRecord['stat
   'pending',
   'retryable_failure',
 ]);
+export const PRODUCT_FEED_REPAIR_WRITE_LANE_CONCURRENCY = {
+  product_feed_repair_story: 1,
+  product_feed_repair_latest_index: 1,
+  product_feed_repair_hot_index: 1,
+  product_feed_repair_lifecycle: 1,
+} as const;
+export type ProductFeedRepairWriteClass = keyof typeof PRODUCT_FEED_REPAIR_WRITE_LANE_CONCURRENCY;
+export type ProductFeedRepairRunWrite = <T>(
+  writeClass: ProductFeedRepairWriteClass,
+  attributes: Record<string, unknown>,
+  task: () => Promise<T>,
+) => Promise<T>;
 
 export interface ProductFeedReconciliationFailure {
   readonly story_id: string;
@@ -66,6 +78,7 @@ export interface ProductFeedReconcilerOptions {
   readonly now?: () => number;
   readonly logger?: LoggerLike;
   readonly dependencies?: ProductFeedReconcilerDependencies;
+  readonly runWrite?: ProductFeedRepairRunWrite;
 }
 
 function normalizeSampleLimit(value: unknown): number {
@@ -155,6 +168,7 @@ export async function reconcileProductFeedFromRawStories(
   const writeHotIndex = dependencies.writeHotIndexEntry ?? writeNewsHotIndexEntry;
   const writeLifecycle = dependencies.writeLifecycle ?? writeNewsSynthesisLifecycleStatus;
   const computeHotness = dependencies.computeHotness ?? computeStoryHotness;
+  const runWrite: ProductFeedRepairRunWrite = options.runWrite ?? ((_writeClass, _attributes, task) => task());
   const now = options.now ?? Date.now;
   const logger = options.logger ?? console;
   const sampleLimit = normalizeSampleLimit(options.sampleLimit);
@@ -186,7 +200,11 @@ export async function reconcileProductFeedFromRawStories(
           skippedInvalidStory += 1;
           continue;
         }
-        const rewritten = await writeStory(client, repairCandidate);
+        const rewritten = await runWrite(
+          'product_feed_repair_story',
+          { story_id: storyId, operation: 'repair_story_body' },
+          () => writeStory(client, repairCandidate),
+        );
         story = isEligibleRawStory(rewritten) ? rewritten : repairCandidate;
         repairedStoryBody += 1;
       }
@@ -199,33 +217,49 @@ export async function reconcileProductFeedFromRawStories(
 
       const latestIndexRecord = await readLatestIndexEntry(client, story.story_id).catch(() => null);
       if (latestIndexNeedsRepair(latestIndexRecord, story)) {
-        await writeLatestIndex(client, story.story_id, story.cluster_window_end, story);
+        await runWrite(
+          'product_feed_repair_latest_index',
+          { story_id: story.story_id, topic_id: story.topic_id },
+          () => writeLatestIndex(client, story.story_id, story.cluster_window_end, story),
+        );
         repairedLatestIndex += 1;
       }
 
       // Refresh hot rows even when a legacy scalar exists so story-backed
       // product metadata stays in parity with the latest index.
-      await writeHotIndex(client, story.story_id, computeHotness(story, now()), story);
+      await runWrite(
+        'product_feed_repair_hot_index',
+        { story_id: story.story_id, topic_id: story.topic_id },
+        () => writeHotIndex(client, story.story_id, computeHotness(story, now()), story),
+      );
       repairedHotIndex += 1;
 
       const lifecycle = await readLifecycle(client, story.story_id).catch(() => null);
       if (lifecycleNeedsPendingRepair(lifecycle, story)) {
-        await writeLifecycle(client, buildNewsSynthesisLifecycleRecord({
-          story,
-          status: 'pending',
-          frameTableState: 'frame_table_pending',
-          updatedAt: now(),
-        }));
+        await runWrite(
+          'product_feed_repair_lifecycle',
+          { story_id: story.story_id, status: 'pending' },
+          () => writeLifecycle(client, buildNewsSynthesisLifecycleRecord({
+            story,
+            status: 'pending',
+            frameTableState: 'frame_table_pending',
+            updatedAt: now(),
+          })),
+        );
         repairedLifecycle += 1;
       } else if (lifecycle && lifecycleNeedsIncompleteRefresh(lifecycle, story, now(), incompleteLifecycleRefreshMs)) {
-        await writeLifecycle(client, buildNewsSynthesisLifecycleRecord({
-          story,
-          status: lifecycle.status,
-          frameTableState: lifecycle.frame_table_state,
-          retryable: lifecycle.retryable,
-          reason: lifecycle.reason ?? 'product_feed_reconciled_incomplete_lifecycle',
-          updatedAt: now(),
-        }));
+        await runWrite(
+          'product_feed_repair_lifecycle',
+          { story_id: story.story_id, status: lifecycle.status },
+          () => writeLifecycle(client, buildNewsSynthesisLifecycleRecord({
+            story,
+            status: lifecycle.status,
+            frameTableState: lifecycle.frame_table_state,
+            retryable: lifecycle.retryable,
+            reason: lifecycle.reason ?? 'product_feed_reconciled_incomplete_lifecycle',
+            updatedAt: now(),
+          })),
+        );
         refreshedIncompleteLifecycle += 1;
       } else {
         preservedLifecycle += 1;


### PR DESCRIPTION
## Summary
- Root cause: startup product-feed repair could begin immediately and collide with the first raw publish tick, creating overlapping raw bundle, raw pending lifecycle, hot-index/latest-index, and repair lifecycle writes.
- First product-feed repair now defers until after the first completed runtime tick, independent of accepted synthesis or enrichment-defer settings.
- Repair writes now run through dedicated paced `product_feed_repair_*` lanes with concurrency 1 and remain non-fatal maintenance telemetry.
- Raw bundle publication and raw pending synthesis lifecycle writes remain fatal, quorum-safe, and fail-closed.
- No relay quorum weakening.
- No live host actions were performed: no publisher start, relay restart, StoryCluster reset, monitor enable, queue scrub, or live mesh writes.

## Launch-soak config
```env
VH_BUNDLE_SYNTHESIS_ENABLED=0
VH_NEWS_RUNTIME_RAW_BUNDLE_WRITE_CONCURRENCY=1
VH_NEWS_PRODUCT_FEED_REPAIR_SAMPLE_LIMIT=8
```

## Verification
- PASS: `pnpm --filter @vh/news-aggregator exec vitest run src/daemon.test.ts src/daemon.coverage.test.ts src/daemon.production.test.ts src/daemonWriteLane.test.ts --config ./vitest.config.ts` -> 4 files, 55 tests.
- PASS: `pnpm --filter @vh/ai-engine exec vitest run src/newsRuntime.test.ts src/newsRuntime.storylines.test.ts --config ./vitest.config.ts` -> 2 files, 51 tests. This branch adds the package-level Vitest config needed for the exact filtered command to resolve from `@vh/ai-engine`.
- PASS: `pnpm --filter @vh/news-aggregator build`.
- PASS: `git diff --check`.
- PASS: `node tools/scripts/check-diff-coverage.mjs` -> `Diff Coverage: PASS - no coverage-eligible source files changed.`
- PASS: `pnpm test:quick` -> 319 files, 4938 tests, duration 33.08s.

## Notes
- `VH_BUNDLE_SYNTHESIS_ENABLED=0` can still produce local queue-only enqueue logs with `active:false`; accepted/topic synthesis relay writes remain disabled.
- Tests assert no `/vh/topics/synthesis-candidate` or `/vh/topics/synthesis` relay writes when accepted synthesis is disabled.
- Deferral removes the startup collision window; pacing protects steady-state repair runs.