### PR TITLE
Gate optional storylines for raw-only Scope A soak

### DIFF
--- a/docs/ops/news-aggregator-production-service.md
+++ b/docs/ops/news-aggregator-production-service.md
@@ -394,20 +394,31 @@ Do not set it to `false` in production unless the incident commander has chosen
 an attended degraded-write experiment and the public-feed rollback plan is
 already active.
 
-For the next post-#679 launch soak after a clean StoryCluster reset, use:
+For the next capped raw-only Scope A launch soak after a clean StoryCluster reset,
+use:
 
 ```bash
 VH_BUNDLE_SYNTHESIS_ENABLED=0
+VH_ANALYSIS_EVAL_REPLAY_ON_START=0
+VH_NEWS_STORYLINES_ENABLED=0
 VH_NEWS_RUNTIME_RAW_BUNDLE_WRITE_CONCURRENCY=1
+VH_NEWS_RUNTIME_FIRST_TICK_MAX_PUBLISHED_BUNDLES=8
+VH_NEWS_RUNTIME_MAX_PUBLISHED_BUNDLES=8
 VH_NEWS_PRODUCT_FEED_REPAIR_SAMPLE_LIMIT=8
+VH_NEWS_PRODUCT_FEED_REPAIR_INTERVAL_MS=86400000
 ```
 
 `VH_NEWS_PRODUCT_FEED_REPAIR_SAMPLE_LIMIT=8` is a launch-soak value, not a
 permanent ceiling. Raise it deliberately only after paced repair has soaked
 cleanly. Scope A launch config keeps accepted synthesis disabled: the raw runtime
 may still enqueue local synthesis candidates and log an inactive local queue, but
-`VH_BUNDLE_SYNTHESIS_ENABLED=0` must not publish accepted/topic synthesis relay
-writes to `/vh/topics/synthesis-candidate` or `/vh/topics/synthesis`.
+`VH_BUNDLE_SYNTHESIS_ENABLED=0` and `VH_ANALYSIS_EVAL_REPLAY_ON_START=0` must not
+publish accepted/topic synthesis relay writes to `/vh/topics/synthesis-candidate`
+or `/vh/topics/synthesis`. `VH_NEWS_STORYLINES_ENABLED=0` omits the direct-Gun
+storyline overlay adapters for the raw-only soak; the runtime counts generated
+storylines as suppressed in tick summaries, and stale storyline cleanup remains
+parked until storyline overlays are deliberately re-enabled and soaked as
+post-launch enrichment.
 
 ## Env File Surface
 
@@ -435,6 +446,8 @@ VH_STORYCLUSTER_REMOTE_AUTH_TOKEN
 VH_STORYCLUSTER_REMOTE_HEALTH_URL
 OPENAI_API_KEY
 VH_BUNDLE_SYNTHESIS_ENABLED
+VH_ANALYSIS_EVAL_REPLAY_ON_START
+VH_NEWS_STORYLINES_ENABLED
 VH_NEWS_RELAY_REST_WRITE_FIRST
 VH_NEWS_RELAY_REST_WRITE_ORIGINS
 VH_NEWS_RELAY_REST_WRITE_TOKENS
@@ -464,6 +477,7 @@ VH_NEWS_PRODUCT_FEED_REPAIR_SAMPLE_LIMIT
 VH_NEWS_FEED_MAX_ITEMS_PER_SOURCE
 VH_NEWS_FEED_MAX_ITEMS_TOTAL
 VH_NEWS_RUNTIME_MAX_PUBLISHED_BUNDLES
+VH_NEWS_RUNTIME_FIRST_TICK_MAX_PUBLISHED_BUNDLES
 VH_NEWS_RUNTIME_RAW_BUNDLE_WRITE_CONCURRENCY
 VH_STORYCLUSTER_REMOTE_MAX_ITEMS_PER_REQUEST
 VH_NEWS_SYSTEM_WRITER_ID

--- a/docs/ops/news-aggregator.env.example
+++ b/docs/ops/news-aggregator.env.example
@@ -41,6 +41,10 @@ VH_NEWS_RELAY_REST_WRITE_REQUIRE_ALL=true
 VH_NEWS_RELAY_REST_WRITE_MIN_SUCCESS=2
 VH_NEWS_RELAY_REST_WRITE_TIMEOUT_MS=10000
 VH_BUNDLE_SYNTHESIS_ENABLED=true
+VH_ANALYSIS_EVAL_REPLAY_ON_START=0
+# Optional storyline overlays are enabled by default. Set to 0 only for raw-only
+# Scope A soaks or incident isolation; raw bundle publication is unaffected.
+VH_NEWS_STORYLINES_ENABLED=true
 VH_BUNDLE_SYNTHESIS_WRITE_RELAY_REST=true
 VH_BUNDLE_SYNTHESIS_RELAY_WRITE_ORIGINS='["https://gun-a.carboncaste.io","https://gun-b.carboncaste.io","https://gun-c.carboncaste.io"]'
 # Optional override for synthesis REST writes. If absent, synthesis uses

--- a/packages/ai-engine/src/newsRuntime.storylines.test.ts
+++ b/packages/ai-engine/src/newsRuntime.storylines.test.ts
@@ -127,6 +127,36 @@ describe('newsRuntime storylines', () => {
     handle.stop();
   });
 
+  it('counts storylines as suppressed when adapters are intentionally omitted', async () => {
+    orchestrateNewsPipelineMock.mockResolvedValue(batch([STORY], [STORYLINE]));
+
+    const writeStoryBundle = vi.fn().mockResolvedValue(undefined);
+    const onTickSummary = vi.fn();
+
+    const handle = startNewsRuntime({
+      ...BASE_CONFIG,
+      writeStoryBundle,
+      onTickSummary,
+      runOnStart: true,
+      pollIntervalMs: 10,
+    });
+
+    await flushTasks();
+
+    expect(writeStoryBundle).toHaveBeenCalledWith(BASE_CONFIG.gunClient, STORY);
+    expect(onTickSummary).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'completed',
+      raw_write_attempted_count: 1,
+      raw_wrote_count: 1,
+      storyline_write_attempted_count: 0,
+      storyline_write_suppressed_count: 1,
+      storyline_wrote_count: 0,
+      storyline_write_failed_count: 0,
+    }));
+
+    handle.stop();
+  });
+
   it('does not let storyline write failures block bundle publication', async () => {
     const storylineError = new Error('storyline write failed');
     orchestrateNewsPipelineMock.mockResolvedValue(batch([STORY], [STORYLINE]));

--- a/packages/ai-engine/src/newsRuntime.ts
+++ b/packages/ai-engine/src/newsRuntime.ts
@@ -860,11 +860,13 @@ export function startNewsRuntime(config: NewsRuntimeConfig): NewsRuntimeHandle {
             }
           }
         }
-      } else if (noWrite) {
+      } else if (storylines.length > 0) {
         storylineWriteSuppressedCount = storylines.length;
-        for (const storyline of storylines) {
-          nextPublishedStorylineIds.add(storyline.storyline_id);
-          publishedStorylineIds.add(storyline.storyline_id);
+        if (noWrite) {
+          for (const storyline of storylines) {
+            nextPublishedStorylineIds.add(storyline.storyline_id);
+            publishedStorylineIds.add(storyline.storyline_id);
+          }
         }
       }
 

--- a/services/news-aggregator/src/daemon.production.test.ts
+++ b/services/news-aggregator/src/daemon.production.test.ts
@@ -360,6 +360,27 @@ describe('news daemon production wiring', () => {
     }
   });
 
+  it('omits storyline adapters for the raw-only Scope A launch config', async () => {
+    const tmpDir = mkdtempSync(path.join(os.tmpdir(), 'vh-news-daemon-storylines-disabled-'));
+    primeHealthyEnv();
+    vi.stubEnv('VH_NEWS_DAEMON_STATE_DIR', tmpDir);
+    vi.stubEnv('VH_NEWS_STORYLINES_ENABLED', '0');
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('ok', { status: 200 })));
+    let handle: { stop(): Promise<void> } | null = null;
+
+    try {
+      handle = await startNewsAggregatorDaemonFromEnv();
+      const runtimeConfig = mocks.startNewsRuntime.mock.calls[0]?.[0] as NewsRuntimeConfig;
+
+      expect(runtimeConfig.writeStorylineGroup).toBeUndefined();
+      expect(runtimeConfig.removeStorylineGroup).toBeUndefined();
+      expect(runtimeConfig.writeStoryBundle).toBeTypeOf('function');
+    } finally {
+      await handle?.stop();
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it('honors an explicit no-write diagnostic tick limit before self-stopping', async () => {
     const tmpDir = mkdtempSync(path.join(os.tmpdir(), 'vh-news-daemon-bounded-diagnostic-'));
     const runtimeHandle = {

--- a/services/news-aggregator/src/daemon.storylines.test.ts
+++ b/services/news-aggregator/src/daemon.storylines.test.ts
@@ -127,6 +127,60 @@ describe('news daemon storyline adapters', () => {
     await daemon.stop();
   });
 
+  it('omits storyline adapters when storyline writes are disabled', async () => {
+    const logger = makeLogger();
+    const timers = makeTimerControls();
+    const runtimeHandle = {
+      stop: vi.fn(),
+      isRunning: vi.fn(() => true),
+      lastRun: vi.fn(() => null),
+    };
+
+    const startRuntime = vi.fn(() => runtimeHandle);
+    const readLease = vi.fn().mockResolvedValueOnce(null).mockResolvedValue(makeLease());
+    const writeLease = vi.fn().mockResolvedValue(makeLease());
+    const writeBundle = vi.fn(async (_client: VennClient, bundle: unknown) => bundle);
+
+    const daemon = createNewsAggregatorDaemon({
+      client: { id: 'client-storyline-disabled' } as VennClient,
+      feedSources: [...FEED_SOURCES],
+      topicMapping: { ...TOPIC_MAPPING },
+      startRuntime,
+      readLease,
+      writeLease,
+      writeBundle,
+      logger,
+      setIntervalFn: timers.setIntervalFn,
+      clearIntervalFn: timers.clearIntervalFn,
+      leaseHolderId: 'vh-news-daemon:test',
+      now: () => 1_700_000_000_000,
+      random: () => 0.42,
+      storylineWritesEnabled: false,
+      failClosedOnRuntimeError: true,
+    });
+
+    await daemon.start();
+
+    const runtimeConfig = startRuntime.mock.calls[0]?.[0] as NewsRuntimeConfig;
+    expect(runtimeConfig.writeStorylineGroup).toBeUndefined();
+    expect(runtimeConfig.removeStorylineGroup).toBeUndefined();
+    await expect(
+      runtimeConfig.writeStoryBundle?.(
+        { id: 'client-storyline-disabled' },
+        { story_id: 'story-raw-after-storyline-disabled' } as any,
+      ),
+    ).resolves.toEqual({ story_id: 'story-raw-after-storyline-disabled' });
+
+    expect(gunMocks.writeNewsStoryline).not.toHaveBeenCalled();
+    expect(gunMocks.removeNewsStoryline).not.toHaveBeenCalled();
+    expect(writeBundle).toHaveBeenCalledWith(
+      { id: 'client-storyline-disabled' },
+      { story_id: 'story-raw-after-storyline-disabled' },
+    );
+
+    await daemon.stop();
+  });
+
   it('keeps fail-closed state open after runtime reports a storyline write failure as non-fatal', async () => {
     const logger = makeLogger();
     const timers = makeTimerControls();

--- a/services/news-aggregator/src/daemon.ts
+++ b/services/news-aggregator/src/daemon.ts
@@ -152,6 +152,7 @@ export interface NewsAggregatorDaemonConfig {
   onRuntimeTickLimitReached?: (summary: NewsRuntimeTickSummary) => void | Promise<void>;
   runtimeTickWatchdogMs?: number;
   deferEnrichmentUntilFirstTickComplete?: boolean;
+  storylineWritesEnabled?: boolean;
   failClosedOnRuntimeError?: boolean;
   onFailClosedRuntimeError?: (error: unknown) => void | Promise<void>;
   now?: () => number;
@@ -188,6 +189,7 @@ export function createNewsAggregatorDaemon(config: NewsAggregatorDaemonConfig): 
   const holderId = resolveLeaseHolderId(config.leaseHolderId);
   const noWrite = config.noWrite === true;
   const failClosedOnRuntimeError = config.failClosedOnRuntimeError ?? !noWrite;
+  const storylineWritesEnabled = config.storylineWritesEnabled ?? true;
   const writeLanes = config.writeLanes ?? createDaemonWriteLaneRegistry({
     logger,
     now: nowFn,
@@ -403,36 +405,40 @@ export function createNewsAggregatorDaemon(config: NewsAggregatorDaemonConfig): 
           return removeBundle(runtimeClient as VennClient, storyId);
         });
       },
-      writeStorylineGroup: async (runtimeClient: unknown, storyline: unknown) => {
-        const storylineId =
-          typeof storyline === 'object' && storyline !== null
-            ? (storyline as { storyline_id?: unknown }).storyline_id
-            : null;
-        if (noWrite) {
-          logger.info('[vh:news-daemon] no-write storyline write suppressed', {
-            storyline_id: storylineId ?? null,
-          });
-          return storyline;
-        }
-        assertRuntimeWritesAllowed();
-        await leaseGuard.assertHeld(nowFn());
-        return writeLanes.run('storyline', { storyline_id: storylineId ?? null }, async () => {
-          return writeNewsStoryline(runtimeClient as VennClient, storyline);
-        });
-      },
-      removeStorylineGroup: async (runtimeClient: unknown, storylineId: string) => {
-        if (noWrite) {
-          logger.info('[vh:news-daemon] no-write storyline remove suppressed', {
-            storyline_id: storylineId,
-          });
-          return undefined;
-        }
-        assertRuntimeWritesAllowed();
-        await leaseGuard.assertHeld(nowFn());
-        return writeLanes.run('storyline_remove', { storyline_id: storylineId }, async () => {
-          return removeNewsStoryline(runtimeClient as VennClient, storylineId);
-        });
-      },
+      ...(storylineWritesEnabled
+        ? {
+            writeStorylineGroup: async (runtimeClient: unknown, storyline: unknown) => {
+              const storylineId =
+                typeof storyline === 'object' && storyline !== null
+                  ? (storyline as { storyline_id?: unknown }).storyline_id
+                  : null;
+              if (noWrite) {
+                logger.info('[vh:news-daemon] no-write storyline write suppressed', {
+                  storyline_id: storylineId ?? null,
+                });
+                return storyline;
+              }
+              assertRuntimeWritesAllowed();
+              await leaseGuard.assertHeld(nowFn());
+              return writeLanes.run('storyline', { storyline_id: storylineId ?? null }, async () => {
+                return writeNewsStoryline(runtimeClient as VennClient, storyline);
+              });
+            },
+            removeStorylineGroup: async (runtimeClient: unknown, storylineId: string) => {
+              if (noWrite) {
+                logger.info('[vh:news-daemon] no-write storyline remove suppressed', {
+                  storyline_id: storylineId,
+                });
+                return undefined;
+              }
+              assertRuntimeWritesAllowed();
+              await leaseGuard.assertHeld(nowFn());
+              return writeLanes.run('storyline_remove', { storyline_id: storylineId }, async () => {
+                return removeNewsStoryline(runtimeClient as VennClient, storylineId);
+              });
+            },
+          }
+        : {}),
       onSynthesisCandidate(candidate) {
         if (noWrite) {
           logger.info('[vh:news-daemon] no-write synthesis candidate suppressed', {
@@ -1007,6 +1013,7 @@ export async function startNewsAggregatorDaemonFromEnv(): Promise<NewsAggregator
   const deferEnrichmentUntilFirstTickComplete = !isDisabledFlag(
     readEnvVar('VH_NEWS_DAEMON_DEFER_SYNTHESIS_UNTIL_FIRST_TICK_COMPLETE'),
   );
+  const storylineWritesEnabled = !isDisabledFlag(readEnvVar('VH_NEWS_STORYLINES_ENABLED'));
   const failClosedOnRuntimeError = noWrite
     ? false
     : !isDisabledFlag(readEnvVar('VH_NEWS_DAEMON_FAIL_CLOSED_ON_RUNTIME_ERROR'));
@@ -1108,6 +1115,7 @@ export async function startNewsAggregatorDaemonFromEnv(): Promise<NewsAggregator
       onRuntimeTickLimitReached: diagnosticMaxTicks ? requestDiagnosticStop : undefined,
       runtimeTickWatchdogMs,
       deferEnrichmentUntilFirstTickComplete: !noWrite && deferEnrichmentUntilFirstTickComplete,
+      storylineWritesEnabled,
       failClosedOnRuntimeError,
       onFailClosedRuntimeError: (error) => {
         console.error('[vh:news-daemon] fail-closed runtime error shutting down process', error);


### PR DESCRIPTION
## Summary
- add `VH_NEWS_STORYLINES_ENABLED` with default-on behavior, and omit daemon storyline write/remove adapters only when explicitly disabled
- keep raw bundle + raw pending lifecycle writes unchanged and fail-closed; storyline overlays become suppressed optional work for the raw-only Scope A soak
- make ai-engine tick summaries count generated storylines as suppressed when the storyline adapter is intentionally absent
- document the capped raw-only launch-soak env block, including synthesis/replay off, bundle caps, repair interval/sample limit, and storylines off

## Scope A safety notes
- raw publish and raw pending lifecycle stay on the existing quorum-durable fatal path
- `VH_NEWS_STORYLINES_ENABLED=0` removes only direct-Gun storyline overlay writes and stale storyline cleanup callbacks
- accepted/topic synthesis remains disabled by `VH_BUNDLE_SYNTHESIS_ENABLED=0` plus `VH_ANALYSIS_EVAL_REPLAY_ON_START=0` for the launch soak
- no relay quorum weakening, no live host writes, no publisher/relay starts, no StoryCluster reset in this PR

## Verification (Node 22.23.0 via transient toolchain)
- `pnpm --filter @vh/news-aggregator exec vitest run src/daemon.storylines.test.ts src/daemon.production.test.ts src/daemon.test.ts --config ./vitest.config.ts` -> 3 files, 43 tests passed
- `pnpm --filter @vh/ai-engine exec vitest run src/newsRuntime.storylines.test.ts src/newsRuntime.test.ts --config ./vitest.config.ts` -> 2 files, 52 tests passed
- `pnpm --filter @vh/news-aggregator build` -> passed
- `pnpm --filter @vh/ai-engine build` -> passed
- `git diff --check` -> passed
- `node tools/scripts/check-diff-coverage.mjs` -> passed
- `pnpm test:quick` -> 319 files, 4,939 tests passed
