### PR TITLE
Align publisher preflight with synthesis disable flag

### DIFF
--- a/tools/scripts/news-aggregator-publisher-preflight.mjs
+++ b/tools/scripts/news-aggregator-publisher-preflight.mjs
@@ -355,8 +355,10 @@ export async function runNewsAggregatorPublisherPreflight({
     failures.push('relay_read_health_urls:missing');
   }
 
-  const synthesisEnabled = truthy(env.VH_BUNDLE_SYNTHESIS_ENABLED)
-    || Boolean(firstNonEmpty(env.VH_BUNDLE_SYNTHESIS_API_KEY, env.ANALYSIS_RELAY_API_KEY, env.OPENAI_API_KEY));
+  const synthesisEnabled = explicitlyFalse(env.VH_BUNDLE_SYNTHESIS_ENABLED)
+    ? false
+    : truthy(env.VH_BUNDLE_SYNTHESIS_ENABLED)
+      || Boolean(firstNonEmpty(env.VH_BUNDLE_SYNTHESIS_API_KEY, env.ANALYSIS_RELAY_API_KEY, env.OPENAI_API_KEY));
   const relayRestOrigins = parseDelimited(env.VH_BUNDLE_SYNTHESIS_RELAY_WRITE_ORIGINS);
   const relayRestWriteRequested = truthy(env.VH_BUNDLE_SYNTHESIS_WRITE_RELAY_REST)
     || relayRestOrigins.length > 0;

--- a/tools/scripts/news-aggregator-publisher-preflight.test.mjs
+++ b/tools/scripts/news-aggregator-publisher-preflight.test.mjs
@@ -56,6 +56,43 @@ test('publisher preflight fails closed when synthesis is enabled without relay R
   assert.match(result.failures.join('\n'), /relay_rest_synthesis_token:missing/);
 });
 
+test('publisher preflight honors explicit synthesis disable even when an API key is present', async () => {
+  const result = await runNewsAggregatorPublisherPreflight({
+    env: baseEnv({
+      VH_BUNDLE_SYNTHESIS_ENABLED: '0',
+      OPENAI_API_KEY: 'openai-key-redacted',
+      VH_BUNDLE_SYNTHESIS_WRITE_RELAY_REST: '',
+      VH_BUNDLE_SYNTHESIS_RELAY_WRITE_ORIGINS: '',
+      VH_RELAY_DAEMON_TOKEN: '',
+      VH_NEWS_RELAY_REST_WRITE_FIRST: 'true',
+      VH_NEWS_RELAY_REST_WRITE_ORIGINS: 'https://gun-a.example.test,https://gun-b.example.test',
+      VH_NEWS_RELAY_REST_WRITE_TOKENS: JSON.stringify({
+        'https://gun-a.example.test': 'relay-a-redacted',
+        'https://gun-b.example.test': 'relay-b-redacted',
+      }),
+    }),
+    fetchFn: async (input, init) => {
+      if (init.method === 'POST') {
+        return new Response(JSON.stringify({ ok: false, error: 'news-story-record-required' }), {
+          status: 400,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    },
+  });
+
+  assert.equal(result.status, 'pass');
+  assert.equal(result.synthesis_enabled, false);
+  assert.equal(result.relay_rest_synthesis.endpoint_count, 0);
+  assert.equal(result.relay_rest_synthesis.required_success_count, 0);
+  assert.equal(result.failures.some((failure) => failure.startsWith('relay_rest_synthesis')), false);
+  assert.equal(JSON.stringify(result).includes('openai-key-redacted'), false);
+});
+
 test('publisher preflight fails closed when news relay REST write-first lacks daemon token', async () => {
   const result = await runNewsAggregatorPublisherPreflight({
     env: baseEnv({


### PR DESCRIPTION
## Summary
- make `news-aggregator-publisher-preflight.mjs` honor `VH_BUNDLE_SYNTHESIS_ENABLED=0` before falling back to API-key auto-enable
- add a regression proving explicit synthesis disable wins even when `OPENAI_API_KEY` is present

## Why
The daemon already treats `VH_BUNDLE_SYNTHESIS_ENABLED=0` as authoritative. The launch-soak preflight should report the same state, otherwise raw-only preflight evidence is ambiguous when API keys are present.

## Verification (Node 22.23.0 via transient toolchain)
- `node --test tools/scripts/news-aggregator-publisher-preflight.test.mjs` -> 12 tests passed
- `node --test tools/scripts/start-news-aggregator-daemon-production.test.mjs tools/scripts/systemd-service-installers.test.mjs` -> 24 tests passed
- `git diff --check` -> passed

No live host start/restart was performed by this PR.
