### PR TITLE
Align docs with Phase 5 Scope A launch

### DIFF
--- a/docs/foundational/STATUS.md
+++ b/docs/foundational/STATUS.md
@@ -2,13 +2,13 @@
 
 > Status: Implementation Truth Ledger
 > Owner: VHC Core Engineering
-> Last Reviewed: 2026-05-11
+> Last Reviewed: 2026-06-24
 > Depends On: docs/foundational/System_Architecture.md, docs/CANON_MAP.md
 
 
-**Last Updated:** 2026-05-28
-**Version:** 0.9.2 (public feed analysis/frame reliability gate added)
-**Assessment:** Controlled beta candidate. The integrated VENN/HERMES/AGORA app is distributable in constrained Web PWA beta only when the release commit has a passing public-beta evidence packet. The Web PWA now has deterministic MVP release-gate evidence, public feed composition/freshness, latest-index/story-body/synthesis/frame reliability, lifecycle-accountability, pagination/refresh, and stance-aggregate/decay coverage, public-beta policy surfaces, a provisioned public support/contact path with minimum private escalation protocol, curated launch-content fallback, accepted synthesis correction, story-thread moderation, report-intake/admin-action coverage, minimum trusted beta operator authorization for current remediation writes, a public-beta launch closeout audit in `docs/ops/public-beta-launch-readiness-closeout.md`, a consolidated MVP closeout packet at `.tmp/mvp-closeout/latest/mvp-closeout-report.json`, service-backed five-user local engagement lane coverage, and a LUMA public-beta MVP readiness gate for the beta-local identity/signed-write layer. Live corroborated headlines remain beta-gated by production-readiness evidence; public feed composition/freshness and analysis/frame reliability, LUMA production-attestation/Silver, public WSS mesh `release_ready`, production app canary pass, full production app readiness, and test-group readiness remain separate downstream gates; legal/commercial approval remains outside repo automation.
+**Last Updated:** 2026-06-24
+**Version:** 0.9.3 (Phase 5 Scope A raw public-news launch recorded)
+**Assessment:** Controlled beta candidate with Phase 5 Scope A live. The A6 public-news publisher is running a capped raw-only Scope A profile: raw-fresh, v4-signed, product-visible news cards, relay REST 2-of-3 quorum, and raw pending lifecycle rows (`synthesis_pending` / `frame_table_pending`). The launch closeout is recorded in `docs/reports/phase5-scope-a-launch-closeout-2026-06-24.md`. This proves the raw public-news path and its operational monitors, not the broader public-beta umbrella. Accepted synthesis, frame tables, storyline overlays, topic synthesis enrichment, public WSS mesh `release_ready`, production app canary pass, full production app readiness, LUMA production-attestation/Silver, and legal/commercial approval remain separate downstream gates or post-launch tracks.
 
 > ⚠️ **This document reflects actual implementation status, not target architecture.**
 > For the full vision, see `System_Architecture.md` and whitepapers in `docs/`.
@@ -27,7 +27,7 @@
 | **HERMES Forum** | 🟢 Implemented + 240-char reply cap + article CTA | ⚠️ Partial |
 | **HERMES Docs** | 🟢 Foundation + CollabEditor wired into ArticleEditor (flag-gated) | ❌ No |
 | **HERMES Bridge (Civic Action Kit)** | 🟡 Full UI (5 components), trust/XP/budget enforcement, local receipt capture, and feed-card rendering support; unified feed publication remains partial | ❌ No |
-| **News Aggregator** | 🟡 Implemented with daemon-first StoryCluster production path, source-admission/health evidence, scout-backed source growth, and unified production-readiness; live public headline-soak density and broader overlap-ready source breadth remain active | ⚠️ Partial |
+| **News Aggregator** | 🟢 Phase 5 Scope A live: capped raw-only A6 publisher, StoryCluster-backed raw bundle publication, 2-of-3 relay REST quorum, pending lifecycle rows, host-local liveness/freshness monitors, and bounded relay heap/readback defenses. Accepted synthesis/storylines remain post-launch enrichment. | ⚠️ Scope A live; Scope B enrichment pending |
 | **Discovery Feed** | 🟢 Implemented with compact one-feed chrome, first-use orientation, fixture-backed integrity/semantic release gates, storyline-aware ranking/presentation, and deep-link focus state; public semantic soak remains smoke-only | ⚠️ Partial |
 | **Delegation Runtime** | 🟢 Store + hooks + control panel + 8/8 budget keys (all wired or deferred-with-rationale) | ⚠️ Partial |
 | **Linked-Social** | 🟡 Substrate + notification ingestion + feed cards | ⚠️ Partial |
@@ -38,11 +38,15 @@
 ## Active Program — Production Hardening
 
 Current policy state:
-- Production rollout remains blocked until hard reliability gates pass.
+- Phase 5 Scope A raw public-news rollout is live on A6 under the capped raw-only
+  profile recorded in `docs/reports/phase5-scope-a-launch-closeout-2026-06-24.md`.
+- Broader production/beta claims remain blocked until the relevant downstream
+  gates pass; do not promote Scope A raw-feed proof into accepted synthesis,
+  full product, mesh release, native, or identity-assurance claims.
 - Transitional proof shims are dev/staging only and must be removed before ship.
 - Point-identity migration requires dual-write/backfill plus explicit sunset criteria.
 - Canary rollout requires quantitative SLO gates and validated rollback drills.
-- StoryCluster correctness is now gated primarily by the deterministic corpus/replay path plus the daemon-first semantic gate; the active blocker has moved to live public headline-soak recovery and overlap-ready source breadth.
+- StoryCluster correctness is now gated primarily by the deterministic corpus/replay path plus the daemon-first semantic gate; after the Phase 5 Scope A launch, remaining blockers are overlap-ready source breadth, accepted synthesis/storyline enrichment, and broader release evidence beyond the raw feed.
 - Blocking feed-release evidence now comes from fixture-backed daemon-first gates:
   - `pnpm test:storycluster:correctness`
   - `pnpm test:storycluster:gates`
@@ -70,6 +74,18 @@ Current policy state:
 - Production-grade feed claims now depend more on source-readability discipline than on additional StoryCluster corpus growth:
   - only onboarded readable, accessible, extraction-safe sources count toward the feed promise;
   - see `/Users/bldt/Desktop/VHC/VHC/docs/ops/NEWS_SOURCE_ADMISSION_RUNBOOK.md`.
+- Phase 5 Scope A launch evidence:
+  - closeout report: `/Users/bldt/Desktop/VHC/VHC/docs/reports/phase5-scope-a-launch-closeout-2026-06-24.md`;
+  - launched commit: `b3da27a09f683b7933f169bdd77c03f101681663`;
+  - relay image: `vhc-public-beta-relay:20260624-main-vb3da27a0-amd64`;
+  - launch profile: synthesis disabled, replay disabled, storylines disabled,
+    raw cap `8`, raw concurrency `1`, repair sample `8`, repair interval
+    `86400000`, prune disabled, relay min-success `2`;
+  - attended soak result: 8 tick summaries, 0 aborts, 0 fail-closes, 0
+    readback-500s, 0 relay backpressure-503s, 0 watchdog trips, and relay
+    restarts `0/0/0`;
+  - public feed state: `record_count=20`, all `pending_synthesis`, no accepted
+    synthesis available.
 - Web PWA public-beta support/compliance minimums are implemented and gated:
   - route surface: `/compliance`, `/beta`, `/privacy`, `/terms`, `/moderation`, `/support`, `/data-deletion`, `/telemetry`, `/copyright`;
   - support/contact path: VHC public beta GitHub Issue Form linked from `/support`;
@@ -154,7 +170,8 @@ Current policy state:
   - the scheduled headline-soak trend is still telemetry/review evidence, but the unified production-readiness rule now requires its latest trend artifact to remain fresh and pass over the recent run window.
 - Beta distribution posture is now explicit:
   - the integrated VENN/HERMES/AGORA application may be distributed in constrained beta on current `main`;
-  - live corroborated headlines remain beta-gated by `/Users/bldt/Desktop/VHC/VHC/.tmp/storycluster-production-readiness/latest/production-readiness-report.json`;
+  - live raw public-news headlines are live under the Phase 5 Scope A profile;
+  - live corroborated/accepted-synthesis headline claims remain beta-gated by `/Users/bldt/Desktop/VHC/VHC/.tmp/storycluster-production-readiness/latest/production-readiness-report.json`;
   - public-beta policy/support minimums are gated by `pnpm check:public-beta-compliance` and represented in the MVP gate report;
   - public-beta launch closeout is gated by `pnpm check:public-beta-launch-closeout` and recorded in `docs/ops/public-beta-launch-readiness-closeout.md`;
   - do not market the live headlines lane as production-grade until combined readiness resolves to `release_ready`.
@@ -164,6 +181,14 @@ Current policy state:
 
 Current truth for the news bundler and feed hardening lane:
 
+- Phase 5 Scope A is live on A6 as of 2026-06-24:
+  - raw publication is capped at 8 bundles per tick with raw write concurrency 1;
+  - raw story, latest-index, hot-index, and pending lifecycle writes use relay
+    REST 2-of-3 quorum;
+  - accepted synthesis, topic synthesis, and storyline overlays are outside the
+    launched path and remain post-launch enrichment;
+  - publisher liveness, relay liveness, and relay snapshot freshness monitors
+    are operating monitors for the intended-live service.
 - StoryCluster is no longer treated as a generic topic clusterer; the active program is `EventCluster`-first and precision-biased.
 - Canonical bundle membership is limited to same-incident / same-developing-episode coverage.
 - Canonical source projection is publisher-normalized:
@@ -221,7 +246,8 @@ Current truth for the news bundler and feed hardening lane:
   - explicit promotion-readiness assessment with blocking reasons;
   - denser diagnostic artifacts for insufficient-bundle public runs.
 - The correctness-gate sufficiency lane is complete and in force on `main`.
-- The current active work is live public headline-soak recovery, source-surface density growth, and release-evidence accumulation:
+- The current active post-launch work is source-surface density growth, sustained
+  monitor operation, and release-evidence accumulation beyond raw Scope A:
   - treat the deterministic known-event fixture corpus plus replay corpus as the primary StoryCluster correctness proof;
   - require the daemon-first semantic gate as the served-stack confirmation of that proof;
   - keep public semantic runs smoke-only unless they independently earn promotion beyond telemetry;
@@ -243,6 +269,15 @@ Current truth for the news bundler and feed hardening lane:
 
 ### StoryCluster Next Steps (Active)
 
+0. Protect the live raw Scope A posture:
+   - keep raw publication, pending lifecycle, and relay REST quorum evidence
+     separate from accepted synthesis or storyline enrichment claims;
+   - treat monitor regressions, relay watchdog trips, readback 500s, fail-closed
+     publisher stops, and stale latest-index snapshots as live-operation
+     incidents, not launch-soak curiosities;
+   - do not re-enable accepted synthesis, topic synthesis, storyline writes,
+     verify/refresh, higher raw caps, or pruning without a separate attended
+     soak and an updated runbook entry.
 1. Keep the deterministic corpus/replay gate and daemon-first semantic gate explicit in release/readiness artifacts:
    - primary correctness proof must name the authoritative corpus, replay, and served semantic-gate inputs;
    - public semantic soak must remain labeled as secondary distribution telemetry.

--- a/docs/foundational/TRINITY_Season0_SoT.md
+++ b/docs/foundational/TRINITY_Season0_SoT.md
@@ -2,14 +2,14 @@
 
 > Status: Season Scope Contract
 > Owner: VHC Product + Architecture
-> Last Reviewed: 2026-04-16
+> Last Reviewed: 2026-06-24
 > Depends On: docs/foundational/trinity_project_brief.md, docs/foundational/System_Architecture.md
 
 
 **Purpose:** one **single tree** that gives **frontend + backend** devs the full picture (UX surfaces + contracts + privacy boundaries + gates).
 **Stance:** **Design & build for Synthesis V2**. Anything labeled V1 is **legacy/compat only**.
 **Legend:** ✅ Implemented · 🟡 Partial · 🔴 Stubbed · ⚪ Planned
-**Last updated:** 2026-04-16
+**Last updated:** 2026-06-24
 
 > Implementation-truth note: this document is season scope and target framing, not the current implementation ledger. For actual merged state and drift notes, use `/Users/bldt/Desktop/VHC/VHC/docs/foundational/STATUS.md`.
 
@@ -168,7 +168,7 @@
 
   - **Implementation reality check (what exists today vs target)** 🟡
     - **VENN analysis pipeline** 🟡 - end-to-end pipeline exists; current live profile defaults to API relay; local-first remains a target-state default pending capability thresholds
-    - **News Aggregator / StoryCluster** 🟡 - daemon-first bundling is real; fixture-backed browser gates are green; source-admission/health evidence, runtime keep/watch/remove enforcement, source-scouting, and source-health artifact autoload are in force; public semantic soak is still smoke-only; live public headline-soak density and broader overlap-ready source breadth remain the active blocker
+    - **News Aggregator / StoryCluster** 🟢/🟡 - daemon-first bundling is real and Phase 5 Scope A is live on A6 as a capped raw-only public-news feed with relay REST 2-of-3 quorum, pending lifecycle rows, and host-local liveness/freshness monitors; fixture-backed browser gates, source-admission/health evidence, runtime keep/watch/remove enforcement, source-scouting, and source-health artifact autoload are in force. Accepted synthesis, topic synthesis, storyline overlays, verify/refresh re-enable, higher caps, broader source-density claims, and full public-beta umbrella readiness remain post-launch tracks.
     - **Discovery feed / storyline UX** 🟡 - compact one-feed shell, first-use orientation, source-strip/story-media cards, storyline publication, ranking/diversification, focus state, archive presentation, and deep-link restoration are merged; browser/live evidence hardening remains active
     - **HERMES Messaging** 🟢 - E2EE working
     - **HERMES Forum** 🟢 - threads + votes working; unified topics fields landed (`topicId`, `sourceUrl`, `urlHash`, `isHeadline`)

--- a/docs/ops/news-aggregator-production-service.md
+++ b/docs/ops/news-aggregator-production-service.md
@@ -2,7 +2,7 @@
 
 > Status: Operational Runbook
 > Owner: VHC Ops
-> Last Reviewed: 2026-06-23
+> Last Reviewed: 2026-06-24
 > Depends On: docs/ops/NEWS_SOURCE_ADMISSION_RUNBOOK.md, docs/ops/public-feed-freshness-monitor.md, docs/ops/analysis-backend-3001.md, docs/ops/storycluster-production-service.md, docs/ops/public-beta-launch-readiness-closeout.md
 
 ## Purpose
@@ -16,13 +16,43 @@ an interval, keeps product-feed reconciliation and pending synthesis catch-up on
 their own intervals, and exits only when the process receives SIGINT/SIGTERM or
 startup fails closed.
 
+## Current Launch State
+
+Phase 5 Scope A is live on A6 as of 2026-06-24. The controlling closeout is
+`docs/reports/phase5-scope-a-launch-closeout-2026-06-24.md`.
+
+Current intended-live posture:
+
+- `vh-news-aggregator.service` is expected to be active/running, enabled, and at
+  `NRestarts=0`.
+- Relays run `vhc-public-beta-relay:20260624-main-vb3da27a0-amd64` with Docker
+  `on-failure:5`, 2304 MB memory ceilings, relay resource watchdogs, and bounded
+  latest-index/story-body caches.
+- Raw story, latest-index, hot-index, and pending synthesis-lifecycle writes use
+  relay REST quorum with required success count 2.
+- Accepted bundle synthesis, replay synthesis, topic synthesis, storyline writes,
+  and stale storyline cleanup are disabled for the launched raw Scope A profile.
+- Product-feed repair is deferred until after the first completed runtime tick
+  and then paced through dedicated non-fatal maintenance lanes.
+- Relay verify/refresh body maintenance is disabled for the launch profile;
+  re-enabling it requires a separate attended soak and updated evidence.
+- Publisher liveness, relay liveness, and relay snapshot freshness timers are
+  intended to stay enabled during live operation.
+
+This launch state proves raw-fresh, v4-signed, product-visible cards with
+pending lifecycle rows. It does not prove accepted synthesis, frame tables,
+storyline overlays, topic synthesis, full public-beta readiness, mesh
+`release_ready`, production app canary readiness, or legal/commercial approval.
+
 ## Hard Boundaries
 
 - Do not start production publisher writes without explicit operator approval.
-- Do not run public latest-index HTTP reads until the #638 relay code is proven
-  deployed on the host.
-- Keep public-feed monitors disabled until relay deploy proof, safe validation,
-  analysis health/config, publisher freshness, and canary/soak gates are green.
+- Public latest-index HTTP monitors must remain nonmutating (`persist=false` /
+  safe relay GET path). Do not add a monitor or browser smoke that can refresh or
+  rewrite relay snapshots as a side effect of reading.
+- Keep public-feed monitors enabled during intended-live operation. Disable them
+  only during an attended maintenance window or deliberate publisher stop, and
+  record that suppression in the incident/runbook notes.
 - Store secrets only in host env files outside git. Record env var names, host,
   port, and artifact paths only.
 
@@ -394,8 +424,7 @@ Do not set it to `false` in production unless the incident commander has chosen
 an attended degraded-write experiment and the public-feed rollback plan is
 already active.
 
-For the next capped raw-only Scope A launch soak after a clean StoryCluster reset,
-use:
+The launched capped raw-only Scope A operating profile is:
 
 ```bash
 VH_BUNDLE_SYNTHESIS_ENABLED=0
@@ -408,14 +437,14 @@ VH_NEWS_PRODUCT_FEED_REPAIR_SAMPLE_LIMIT=8
 VH_NEWS_PRODUCT_FEED_REPAIR_INTERVAL_MS=86400000
 ```
 
-`VH_NEWS_PRODUCT_FEED_REPAIR_SAMPLE_LIMIT=8` is a launch-soak value, not a
+`VH_NEWS_PRODUCT_FEED_REPAIR_SAMPLE_LIMIT=8` is a launch operating value, not a
 permanent ceiling. Raise it deliberately only after paced repair has soaked
-cleanly. Scope A launch config keeps accepted synthesis disabled: the raw runtime
+cleanly. Scope A live config keeps accepted synthesis disabled: the raw runtime
 may still enqueue local synthesis candidates and log an inactive local queue, but
 `VH_BUNDLE_SYNTHESIS_ENABLED=0` and `VH_ANALYSIS_EVAL_REPLAY_ON_START=0` must not
 publish accepted/topic synthesis relay writes to `/vh/topics/synthesis-candidate`
 or `/vh/topics/synthesis`. `VH_NEWS_STORYLINES_ENABLED=0` omits the direct-Gun
-storyline overlay adapters for the raw-only soak; the runtime counts generated
+storyline overlay adapters for the raw-only profile; the runtime counts generated
 storylines as suppressed in tick summaries, and stale storyline cleanup remains
 parked until storyline overlays are deliberately re-enabled and soaked as
 post-launch enrichment.
@@ -573,7 +602,7 @@ exhausting A6 memory across all three co-located relays. If
 heap snapshots are written as host-private `0600` artifacts only; do not attach
 or publish `.heapsnapshot` files without explicit secret-review approval.
 
-For the capped raw-only Scope A soak, run all three relays with
+For the capped raw-only Scope A operating profile, run all three relays with
 `VH_RELAY_NEWS_INDEX_SNAPSHOT_VERIFY_STORY_BODIES=false` and
 `VH_RELAY_NEWS_INDEX_SNAPSHOT_REFRESH_STORY_STATES=false`. The relay still
 serves write-through latest-index snapshots and story bodies, but avoids the
@@ -581,7 +610,8 @@ verify/refresh heap path that reads and retains full story bodies. The relay
 also bounds its latest-index snapshot entry cache and story-body cache; watch
 `vh_relay_news_latest_index_snapshot_cache_entries`,
 `vh_relay_news_latest_index_story_body_cache_entries`, and their eviction
-counters during the next soak.
+counters during sustained operation and any future verify/refresh re-enable
+soak.
 
 Operators should watch `/metrics` counters
 `vh_relay_critical_write_readbacks_started_total`,
@@ -863,8 +893,10 @@ Abort or stop the service if any of these occur:
 - latest content does not advance after approved start and expected ingest
   cadence.
 
-After an approved start, release evidence still requires
-`pnpm check:news-sources:health`, fresh content advance, pending lifecycle
-evidence, public canary, and soak. Accepted synthesis and storyline enrichment
-evidence remain post-launch quality checks, not Scope A raw-feed start gates. The
-service starting successfully is not a release-ready claim.
+After an approved start, Scope A live evidence requires fresh content advance,
+pending lifecycle evidence, public latest-index/story-body readability, an
+attended soak, and enabled liveness/freshness monitors. The 2026-06-24 closeout
+records the first completed proof for that raw Scope A launch. Accepted
+synthesis and storyline enrichment evidence remain post-launch quality checks,
+not Scope A raw-feed gates. The service starting successfully by itself is never
+a release-ready claim.

--- a/docs/ops/public-beta-launch-readiness-closeout.md
+++ b/docs/ops/public-beta-launch-readiness-closeout.md
@@ -2,13 +2,21 @@
 
 > Status: Engineering Closeout Audit
 > Owner: VHC Launch Ops
-> Last Reviewed: 2026-06-09
+> Last Reviewed: 2026-06-24
 > Depends On: docs/plans/VENN_NEWS_MVP_ROADMAP_2026-04-20.md, docs/ops/public-beta-compliance-minimums.md, docs/ops/BETA_SESSION_RUNSHEET.md
 
 Version: 0.9
 Document path: `docs/ops/public-beta-launch-readiness-closeout.md`
 Audit baseline: current public-beta closeout baseline plus the LUMA public-beta MVP readiness slice and consolidated MVP closeout packet.
 Scope: Web PWA public beta launch-readiness evidence, deterministic gate inventory, and remaining-work classification.
+
+2026-06-24 Scope A update: Phase 5 raw public-news Scope A is live under the
+controlled profile recorded in
+`docs/reports/phase5-scope-a-launch-closeout-2026-06-24.md`. That launch proves
+raw-fresh, signed, product-visible latest-index cards with pending lifecycle
+state and relay REST quorum. It does not satisfy the broader public-beta gates
+below for accepted synthesis, full app readiness, mesh `release_ready`, LUMA
+production assurance, or legal/commercial launch claims.
 
 ## 1. Closeout Verdict
 

--- a/docs/ops/public-feed-freshness-monitor.md
+++ b/docs/ops/public-feed-freshness-monitor.md
@@ -2,16 +2,22 @@
 
 > Status: Operational Monitor
 > Owner: VHC Launch Ops
-> Last Reviewed: 2026-06-12
+> Last Reviewed: 2026-06-24
 > Depends On: docs/ops/public-beta-launch-readiness-closeout.md, docs/reports/mesh-readiness-state-of-play-2026-06-12.md
 
 ## Purpose
 
 The MVP release gates are point-in-time evidence. This monitor is the continuous
 backstop for the deployed public feed after launch: it fails if the newest
-accepted story visible through the public latest-index is older than the
+product-visible row returned through the public latest-index is older than the
 configured freshness budget, or if the deployed origin/relay health surfaces
 stop responding.
+
+Phase 5 Scope A deliberately serves raw public-news cards whose synthesis state
+is `synthesis_pending` / `frame_table_pending`. This monitor therefore measures
+latest-index recency and public read-surface health, not accepted synthesis
+availability. Accepted synthesis freshness is a separate post-launch enrichment
+gate.
 
 ## Scheduled Alert Path
 
@@ -63,8 +69,8 @@ served snapshot as a side effect of monitoring.
 
 The stale publisher/feed incident remains separate from this monitor. A passing
 freshness monitor proves the public latest-index read surface is current enough
-at the sampled origins; it does not prove publisher recovery, source ingest
-health, or release readiness.
+at the sampled origins; it does not prove accepted synthesis, source ingest
+health, publisher liveness by itself, or broader release readiness.
 
 ## Configuration
 

--- a/docs/ops/public-news-mvp-release-decisions.md
+++ b/docs/ops/public-news-mvp-release-decisions.md
@@ -2,7 +2,7 @@
 
 > Status: Owner Decision Ledger
 > Owner: VHC Product + Launch Ops
-> Last Reviewed: 2026-06-20
+> Last Reviewed: 2026-06-24
 > Depends On: docs/ops/public-beta-launch-readiness-closeout.md, docs/reports/mesh-readiness-state-of-play-2026-06-12.md
 
 ## Status
@@ -11,14 +11,22 @@ These decisions are required before broad public-beta claims. This file records
 the current repo-side defaults and the remaining owner sign-off needed; it does
 not grant release approval by itself.
 
+Phase 5 Scope A launched on 2026-06-24 under the controlled raw-only operating
+profile recorded in `docs/reports/phase5-scope-a-launch-closeout-2026-06-24.md`.
+That launch accepts a constrained public-news claim: raw-fresh, signed,
+product-visible latest-index rows with pending lifecycle state and relay REST
+2-of-3 quorum on the current A6 topology. It does not expand the allowed claims
+to accepted synthesis, storyline overlays, full public beta, mesh
+`release_ready`, or production app readiness.
+
 ## Decisions
 
 | Decision | Current repo stance | Owner action needed |
 | --- | --- | --- |
-| Retention promise | No committed TTL/eviction promise for stories, syntheses, lifecycle rows, or aggregates. The freshness monitor only proves new accepted rows remain recent. | State the beta retention promise, for example `feed history retained at least N days`, `best-effort beta history`, or `indefinite beta retention`, and decide whether it becomes a gate or monitor. |
+| Retention promise | No committed TTL/eviction promise for stories, syntheses, lifecycle rows, or aggregates. Phase 5 Scope A keeps pruning disabled, while relay heap is bounded by snapshot/body cache caps and the public freshness monitor proves only that product-visible latest-index rows remain recent. | State the beta retention promise, for example `feed history retained at least N days`, `best-effort beta history`, or `indefinite beta retention`, and decide whether it becomes a gate or monitor. |
 | Live multi-source launch copy | `VH_PUBLIC_FEED_FRESH_PROPAGATION_REQUIRE_MULTI_SOURCE` is available and defaults to `false`. Current launch copy must not claim live breaking-news corroboration unless this flag is run against live RSS and passes. | Choose whether the beta pitch promises live cross-source corroboration. If yes, run fresh propagation with the flag enabled and capture a live multi-source event. |
 | Raw latest-root hygiene bar | User-visible readers filter invalid raw children, but the 2026-06-12 browser walkthrough still emitted raw latest-root `unknown-signer-id` warnings. Scrub tooling remains owner-gated because it writes production mesh state. | Decide whether zero invalid raw latest-root children blocks beta. If yes, approve dry-run evidence and then approve `--apply` scrub separately. |
-| Quorum/host asymmetry | Current verified Phase 5 topology has all three public-news relay containers on A6, with `gun-c` locally redirected to relay C. A6 loss takes down origin plus all three relay votes; this is a known MVP single-host durability risk, not a current A6/Mac-mini split. | Explicitly accept this for controlled beta or schedule peer redistribution before broad beta. |
+| Quorum/host asymmetry | Current verified Phase 5 topology has all three public-news relay containers on A6, with `gun-c` locally redirected to relay C. A6 loss takes down origin plus all three relay votes; this is accepted only for the constrained 2026-06-24 Scope A launch and remains a known single-host durability risk, not a current A6/Mac-mini split. | Schedule peer redistribution before broad beta, production-grade durability claims, or higher-scope enrichment launch; otherwise explicitly re-accept the single-host risk in the release packet. |
 
 ## Claim Boundary
 

--- a/docs/reports/phase5-scope-a-launch-closeout-2026-06-24.md
+++ b/docs/reports/phase5-scope-a-launch-closeout-2026-06-24.md
@@ -1,0 +1,168 @@
+# Phase 5 Scope A Launch Closeout - 2026-06-24
+
+> Status: Launched
+> Owner: VHC Launch Ops
+> Commit: `b3da27a09f683b7933f169bdd77c03f101681663`
+> Depends On: `docs/ops/news-aggregator-production-service.md`, `docs/ops/public-beta-image-deploy.md`, `docs/ops/public-feed-freshness-monitor.md`
+
+## Verdict
+
+Phase 5 Scope A is live on A6 as a controlled raw-only public news feed.
+
+The launched scope is intentionally narrow:
+
+- raw-fresh, v4-signed, product-visible news cards;
+- relay REST write-first publication with 2-of-3 quorum;
+- raw pending synthesis lifecycle rows (`synthesis_pending`) on the same
+  critical quorum path;
+- accepted synthesis, frame tables, storyline overlays, and topic synthesis
+  enrichment disabled or treated as post-launch enrichment, not Scope A gates.
+
+This launch does not claim full public-beta product readiness, accepted
+synthesis readiness, Scope B enrichment readiness, LUMA Silver, verified-human
+assurance, public WSS mesh release readiness, native app readiness, or broad
+production-grade news operations.
+
+## Deployed State
+
+- Repo truth: local `main`, A6 `main`, and `origin/main` matched commit
+  `b3da27a09f683b7933f169bdd77c03f101681663`.
+- Relay image: `vhc-public-beta-relay:20260624-main-vb3da27a0-amd64`.
+- Publisher unit: `vh-news-aggregator.service` active/running, enabled,
+  `NRestarts=0`.
+- Monitor timers enabled after the successful attended soak:
+  - `vh-news-aggregator-liveness-watch.timer`;
+  - `vh-news-relay-liveness-watch.timer`;
+  - `vh-relay-snapshot-freshness-watch.timer`.
+
+Launch publisher configuration:
+
+```bash
+VH_BUNDLE_SYNTHESIS_ENABLED=0
+VH_ANALYSIS_EVAL_REPLAY_ON_START=0
+VH_NEWS_STORYLINES_ENABLED=0
+VH_NEWS_RUNTIME_FIRST_TICK_MAX_PUBLISHED_BUNDLES=8
+VH_NEWS_RUNTIME_MAX_PUBLISHED_BUNDLES=8
+VH_NEWS_RUNTIME_RAW_BUNDLE_WRITE_CONCURRENCY=1
+VH_NEWS_PRODUCT_FEED_REPAIR_SAMPLE_LIMIT=8
+VH_NEWS_PRODUCT_FEED_REPAIR_INTERVAL_MS=86400000
+VH_NEWS_RUNTIME_PRUNE_STALE_BUNDLES=0
+VH_NEWS_RELAY_REST_WRITE_MIN_SUCCESS=2
+VH_BUNDLE_SYNTHESIS_RELAY_WRITE_MIN_SUCCESS=2
+```
+
+Launch relay posture:
+
+- all three public-news relays remain on A6;
+- Docker restart policy is bounded (`on-failure:5`);
+- Docker memory ceiling is `2304m` with swap disabled;
+- relay resource watchdog is enabled;
+- latest-index snapshot and story-body caches are bounded;
+- snapshot story-body verification and story-state refresh are disabled for
+  Scope A raw-only operation;
+- heap snapshots are host-private diagnostic artifacts and must not be shared
+  without explicit secret review.
+
+## Launch Evidence
+
+Before publisher start:
+
+- StoryCluster reset completed with backup-first handling.
+- Qdrant collection `storycluster_coarse_vectors` was recreated and verified at
+  `0` points.
+- Raw publication readiness preflight passed with `synthesis_enabled:false`,
+  relay news min-success `2`, and synthesis required-success `0`.
+
+Attended soak:
+
+- First runtime tick completed cleanly.
+- A single attended soak passed beyond the 60-minute mark.
+- Final observed tick count: `8`.
+- Abort count: `0`.
+- Repeated tick summaries showed:
+  - `raw_wrote_count: 8`;
+  - `raw_write_failed_count: 0`;
+  - storyline writes suppressed;
+  - `storyline_wrote_count: 0`.
+- No fail-close.
+- No critical readback `500`.
+- No relay backpressure `503`.
+- No watchdog trips.
+- No relay OOM.
+- Relay Docker restarts stayed `0/0/0`.
+
+Public feed proof:
+
+- Public latest-index returned `ok:true`.
+- Public latest-index returned `record_count=20`.
+- Public composition was raw-only pending state:
+  - `pending_synthesis=20`;
+  - `accepted_synthesis_available=0`.
+- Relay snapshot freshness passed on all three relays after publication.
+- Publisher liveness watch passed.
+- Relay liveness watch passed.
+
+## What This Proves
+
+The launched path proves the Scope A contract:
+
+1. current RSS content can pass through source health, StoryCluster, raw bundle
+   publication, latest/hot indexes, and pending lifecycle rows;
+2. critical raw writes remain fail-closed and quorum-durable;
+3. optional enrichment is not allowed to poison raw publication;
+4. relay readback latency and relay heap growth are bounded enough for the
+   capped raw-only operating profile;
+5. host-local monitors are enabled after a successful attended run and can alert
+   on publisher liveness, relay liveness, and latest-index snapshot freshness.
+
+## What This Does Not Prove
+
+The launch deliberately does not prove:
+
+- accepted synthesis throughput;
+- accepted synthesis lane isolation;
+- topic synthesis publication under load;
+- storyline overlay durability;
+- snapshot verify/refresh under production load;
+- higher raw publication caps;
+- relay failure-domain independence;
+- full public-beta umbrella gate readiness;
+- native app or App Store readiness;
+- LUMA Silver / production attestation / Sybil-resistant identity.
+
+Those are post-launch or broader release tracks.
+
+## Operating Watch
+
+For the first 24-72 hours, the operational bar is:
+
+- `vh-news-aggregator.service` remains active/running;
+- publisher `NRestarts=0`;
+- publisher liveness watch passes;
+- relay liveness watch passes;
+- relay snapshot freshness watch passes;
+- relay Docker restarts remain stable;
+- relay watchdog trips stay `0`;
+- public latest-index newest-entry age remains under the 6-hour SLO;
+- public composition remains honest raw pending state until enrichment is
+  deliberately re-enabled.
+
+If a relay watchdog trips, collect the host-private diagnostic bundle and share
+only redacted summaries unless secret review explicitly approves raw heap
+artifacts.
+
+## Post-Launch Backlog
+
+1. Re-enable relay snapshot verify/refresh on A/B only under a separate
+   relay-memory soak, now that cache caps are in place.
+2. Split accepted/topic synthesis enrichment off the raw pending lifecycle fatal
+   lane, rate-limit it, and soak it separately before Scope B.
+3. Reintroduce storyline overlays only after their durability path is migrated
+   or separately bounded and soaked.
+4. Raise raw publication caps only after monitor data shows sustained relay
+   headroom.
+5. Decide the failure-domain rebalance for broader beta or production: all
+   three public-news relays currently share A6, so A6 loss still removes the
+   origin and all relay votes.
+6. Re-run broader public-beta release gates only when the launch claim expands
+   beyond controlled raw Scope A.


### PR DESCRIPTION
## Summary
- Records the Phase 5 Scope A launch closeout with deployed commit, relay image, launch env, soak evidence, monitor posture, and post-launch backlog.
- Updates foundational status and Season 0 scope docs so raw Scope A is marked live without promoting accepted synthesis, storyline overlays, mesh release readiness, or broader public-beta claims.
- Aligns news-aggregator, freshness-monitor, release-decision, and public-beta closeout docs around the current raw-only operating profile and monitor responsibilities.

## Validation
- pnpm docs:check -> PASS, 130 markdown files checked
- git diff --check -> PASS
- node tools/scripts/check-diff-coverage.mjs -> PASS, no coverage-eligible source files changed
- pnpm test:quick -> PASS, 319 files and 4,939 tests

Note: local validation ran under Node v23.10.0, outside the repo engine range >=20 <23. pnpm emitted the existing unsupported-engine warning, but all checks passed.

## Boundaries
- Docs-only change; no live host action.
- Scope A launch proof remains limited to raw-fresh signed latest-index cards with pending lifecycle rows and 2-of-3 relay REST quorum.
- Accepted synthesis, topic synthesis, storyline overlays, verify-refresh re-enable, higher caps, pruning, failure-domain rebalance, and broader public-beta readiness remain downstream or post-launch tracks.