### PR TITLE
Serve stale relay latest-index snapshots on empty reads

### DIFF
--- a/docs/ops/news-aggregator-production-service.md
+++ b/docs/ops/news-aggregator-production-service.md
@@ -611,6 +611,18 @@ publication is proving durability. Topic-synthesis backpressure or readback
 failure remains optional/non-fatal to the publisher under Scope A; relay-side
 bounding does not add it to the publisher fail-closed allow-list.
 
+Public latest-index serving is allowed to degrade stale-but-present. In
+production, `VH_RELAY_NEWS_INDEX_SERVE_STALE_SNAPSHOT_ON_EMPTY` defaults on: if
+the live latest-index read is empty and the relay has a non-empty persisted
+latest-index snapshot, the relay may serve that stale snapshot even when it is
+older than `VH_RELAY_NEWS_INDEX_SNAPSHOT_MAX_AGE_MS`. The response is annotated
+with `consistency.empty_read_cache.served_from="stale_latest_index_snapshot"`,
+`stale=true`, `cached_at`, `age_ms`, and `snapshot_max_age_ms`. This fallback is
+read-only; it does not refresh, rewrite, or prove a critical write, and it exists
+only to keep a launched feed stale-present instead of blank after relay restart
+or local graph hydration gaps. Critical write readbacks still use the live
+readback contract above.
+
 When the per-relay critical readback admission gate is saturated, the relay
 returns `503` with `error=relay-critical-readback-backpressure` (or
 `relay-critical-readback-queue-timeout`) and `Retry-After`. The gun client
@@ -653,9 +665,10 @@ or publish `.heapsnapshot` files without explicit secret-review approval.
 For the capped raw-only Scope A operating profile, run all three relays with
 `VH_RELAY_NEWS_INDEX_SNAPSHOT_VERIFY_STORY_BODIES=false` and
 `VH_RELAY_NEWS_INDEX_SNAPSHOT_REFRESH_STORY_STATES=false`. The relay still
-serves write-through latest-index snapshots and story bodies, but avoids the
-verify/refresh heap path that reads and retains full story bodies. The relay
-also bounds its latest-index snapshot entry cache and story-body cache; watch
+serves write-through latest-index snapshots, stale latest-index empty-read
+fallbacks, and snapshot-backed story bodies, but avoids the verify/refresh heap
+path that reads and retains full story bodies. The relay also bounds its
+latest-index snapshot entry cache and story-body cache; watch
 `vh_relay_news_latest_index_snapshot_cache_entries`,
 `vh_relay_news_latest_index_story_body_cache_entries`, and their eviction
 counters during sustained operation and any future verify/refresh re-enable

--- a/docs/ops/public-beta-image-deploy.md
+++ b/docs/ops/public-beta-image-deploy.md
@@ -29,11 +29,15 @@ re-enable monitors.
   `vh-news-latest-index-relay-snapshot-v1`, or has an empty/non-list `entries`
   array. Do not scrub or rewrite a valid latest-index snapshot solely because
   its preserved entry count differs from an older runbook example.
+- A non-empty latest-index snapshot is the public latest-index stale-serving
+  fallback after an empty live read. Do not delete a structurally valid snapshot
+  solely because it is older than the freshness SLO; deploy validation should
+  report the stale age, then let fresh publisher ticks move it forward.
 - Run relays with a UID/GID that can write the existing host data dirs.
   Snapshot persistence can otherwise fail without surfacing as a user-facing
   deploy error.
 - Set `NODE_ENV=production` on relays so snapshot-first latest-index serving
-  stays enabled by default.
+  and stale-on-empty latest-index serving stay enabled by default.
 - Run relays with bounded self-recovery: `--restart on-failure:5`,
   `--memory 2304m --memory-swap 2304m`,
   `VH_RELAY_RESOURCE_WATCHDOG_ENABLED=true`,

--- a/infra/relay/server.js
+++ b/infra/relay/server.js
@@ -3410,6 +3410,29 @@ function readPersistedNewsLatestIndexSnapshot(snapshotKey, cacheTtlMs) {
   }
 }
 
+function newsLatestIndexSnapshotAgeMs(snapshot) {
+  const cachedAt = Number(snapshot?.cached_at);
+  if (!Number.isFinite(cachedAt) || cachedAt <= 0) return null;
+  return Math.max(0, Date.now() - cachedAt);
+}
+
+function newsLatestIndexSnapshotHasEntries(snapshot) {
+  return Array.isArray(snapshot?.entries) && snapshot.entries.length > 0;
+}
+
+function newsLatestIndexSnapshotIsFresh(snapshot, maxAgeMs) {
+  if (!newsLatestIndexSnapshotHasEntries(snapshot)) return false;
+  if (maxAgeMs <= 0) return true;
+  const ageMs = newsLatestIndexSnapshotAgeMs(snapshot);
+  return Number.isFinite(ageMs) && ageMs <= maxAgeMs;
+}
+
+function newsLatestIndexSnapshotIsStale(snapshot, maxAgeMs) {
+  if (!newsLatestIndexSnapshotHasEntries(snapshot) || maxAgeMs <= 0) return false;
+  const ageMs = newsLatestIndexSnapshotAgeMs(snapshot);
+  return Number.isFinite(ageMs) && ageMs > maxAgeMs;
+}
+
 function emptyNewsLatestIndexSnapshot() {
   return {
     cached_at: 0,
@@ -3882,6 +3905,9 @@ function persistRefreshedLatestIndexSnapshotEntries(snapshot, options, refreshed
 }
 
 async function buildNewsLatestIndexResultFromSnapshot(gun, snapshot, options = {}, cacheInfo = {}) {
+  const allowSnapshotStoryFallback = cacheInfo.allow_snapshot_story_fallback === true;
+  const publicCacheInfo = { ...cacheInfo };
+  delete publicCacheInfo.allow_snapshot_story_fallback;
   const maxRecords = Math.min(
     numberEnv('VH_RELAY_NEWS_INDEX_REST_MAX_RECORDS', 80),
     positiveInteger(options.limit, numberEnv('VH_RELAY_NEWS_INDEX_REST_MAX_RECORDS', 80)),
@@ -3933,8 +3959,40 @@ async function buildNewsLatestIndexResultFromSnapshot(gun, snapshot, options = {
       });
     }
   }
-  const bodyReadbackResult = await verifySnapshotStoryBodies(gun, selectedEntries);
+  const selectedEntriesBeforeBodyReadback = [...selectedEntries];
+  let bodyReadbackResult = await verifySnapshotStoryBodies(gun, selectedEntries);
   selectedEntries = bodyReadbackResult.entries;
+  if (allowSnapshotStoryFallback) {
+    const selectedByStoryId = new Map(selectedEntries.map((entry) => [String(entry?.entry?.[0] ?? ''), entry]));
+    let fallbackCount = 0;
+    const restoredEntries = selectedEntriesBeforeBodyReadback
+      .map((entry) => {
+        const storyId = String(entry?.entry?.[0] ?? '').trim();
+        if (!storyId) return null;
+        const selected = selectedByStoryId.get(storyId);
+        if (selected) return selected;
+        const snapshotStory = parseStoryBundleEnvelope(JSON.stringify(entry?.story ?? null));
+        if (!snapshotStory || snapshotStory.story_id !== storyId) return null;
+        fallbackCount += 1;
+        return {
+          ...entry,
+          story: snapshotStory,
+        };
+      })
+      .filter(Boolean);
+    if (fallbackCount > 0) {
+      selectedEntries = restoredEntries;
+    }
+    bodyReadbackResult = {
+      ...bodyReadbackResult,
+      info: {
+        ...(bodyReadbackResult.info ?? {}),
+        snapshot_story_fallback_enabled: true,
+        snapshot_story_fallback_count: fallbackCount,
+        degraded_to_snapshot_stories: fallbackCount > 0,
+      },
+    };
+  }
   const refreshResult = await refreshSnapshotStoryStates(gun, selectedEntries);
   selectedEntries = refreshResult.entries;
   if (options.persistSnapshotOnRead === true) {
@@ -3966,7 +4024,7 @@ async function buildNewsLatestIndexResultFromSnapshot(gun, snapshot, options = {
     nextCursor: latestIndexPageNextCursor(chronologicalPageEntries, truncated),
     consistency: {
       ...(snapshot.consistency ?? {}),
-      empty_read_cache: cacheInfo,
+      empty_read_cache: publicCacheInfo,
       snapshot_story_body_readback: bodyReadbackResult.info,
       snapshot_story_state_refresh: refreshResult.info,
       excluded_count: excludedRecords.length,
@@ -4003,19 +4061,18 @@ async function readNewsLatestIndexRecordsWithEmptyRetry(gun, options = {}) {
   );
   const cacheKey = latestIndexRestCacheKey(options);
   const snapshotCacheKey = latestIndexSnapshotCacheKey(options);
+  const serveStaleSnapshotOnEmpty = boolEnv(
+    'VH_RELAY_NEWS_INDEX_SERVE_STALE_SNAPSHOT_ON_EMPTY',
+    process.env.NODE_ENV === 'production',
+  );
   if (boolEnv('VH_RELAY_NEWS_INDEX_REST_PREFER_SNAPSHOT', process.env.NODE_ENV === 'production')) {
     const snapshot = newsLatestIndexSnapshotCache.get(snapshotCacheKey)
       ?? readPersistedNewsLatestIndexSnapshot(snapshotCacheKey, snapshotMaxAgeMs);
-    if (
-      snapshot
-      && Array.isArray(snapshot.entries)
-      && snapshot.entries.length > 0
-      && (snapshotMaxAgeMs <= 0 || Date.now() - snapshot.cached_at <= snapshotMaxAgeMs)
-    ) {
+    if (newsLatestIndexSnapshotIsFresh(snapshot, snapshotMaxAgeMs)) {
       return buildNewsLatestIndexResultFromSnapshot(gun, snapshot, options, {
         served_from: 'preferred_latest_index_snapshot',
         cached_at: snapshot.cached_at,
-        age_ms: Date.now() - snapshot.cached_at,
+        age_ms: newsLatestIndexSnapshotAgeMs(snapshot),
         snapshot_max_age_ms: snapshotMaxAgeMs,
       });
     }
@@ -4067,13 +4124,27 @@ async function readNewsLatestIndexRecordsWithEmptyRetry(gun, options = {}) {
         }
         const snapshot = newsLatestIndexSnapshotCache.get(snapshotCacheKey)
           ?? readPersistedNewsLatestIndexSnapshot(snapshotCacheKey, snapshotMaxAgeMs);
-        if (snapshot && (snapshotMaxAgeMs <= 0 || Date.now() - snapshot.cached_at <= snapshotMaxAgeMs)) {
+        if (newsLatestIndexSnapshotIsFresh(snapshot, snapshotMaxAgeMs)) {
           return buildNewsLatestIndexResultFromSnapshot(gun, snapshot, options, {
             served_from: 'last_non_empty_latest_index_snapshot',
             cached_at: snapshot.cached_at,
-            age_ms: Date.now() - snapshot.cached_at,
+            age_ms: newsLatestIndexSnapshotAgeMs(snapshot),
             snapshot_max_age_ms: snapshotMaxAgeMs,
           });
+        }
+        if (serveStaleSnapshotOnEmpty) {
+          const staleSnapshot = newsLatestIndexSnapshotCache.get(snapshotCacheKey)
+            ?? readPersistedNewsLatestIndexSnapshot(snapshotCacheKey, 0);
+          if (newsLatestIndexSnapshotIsStale(staleSnapshot, snapshotMaxAgeMs)) {
+            return buildNewsLatestIndexResultFromSnapshot(gun, staleSnapshot, options, {
+              served_from: 'stale_latest_index_snapshot',
+              cached_at: staleSnapshot.cached_at,
+              age_ms: newsLatestIndexSnapshotAgeMs(staleSnapshot),
+              snapshot_max_age_ms: snapshotMaxAgeMs,
+              stale: true,
+              allow_snapshot_story_fallback: true,
+            });
+          }
         }
       }
       return result;

--- a/packages/e2e/src/live/relay-server.vitest.mjs
+++ b/packages/e2e/src/live/relay-server.vitest.mjs
@@ -305,32 +305,37 @@ function makeRelaySynthesisLifecycleRecord(story, {
   };
 }
 
-function writeLatestIndexSnapshotFile(snapshotFile, story) {
+function writeLatestIndexSnapshotFile(snapshotFile, story, overrides = {}) {
   const record = makeRelayLatestIndexRecord(story);
+  const now = Date.now();
+  const storyState = {
+    synthesis_state: 'synthesis_pending',
+    frame_table_state: 'frame_table_pending',
+    lifecycle_status: 'pending',
+    lifecycle_source_set_revision: story.provenance_hash,
+    lifecycle_updated_at: overrides.lifecycleUpdatedAt ?? now,
+    terminal_unavailable_reason: null,
+    retryable: false,
+    ...(overrides.storyState ?? {}),
+  };
+  const entries = overrides.entries ?? [{
+    story_id: story.story_id,
+    record,
+    story,
+    story_state: storyState,
+  }];
   writeFileSync(
     snapshotFile,
     `${JSON.stringify({
       schema_version: 'vh-news-latest-index-relay-snapshot-v1',
       snapshot_key: JSON.stringify({ consistencyFilter: true }),
-      cached_at: Date.now(),
-      source_key_count: 1,
-      scanned_key_count: 1,
+      cached_at: overrides.cachedAt ?? now,
+      source_key_count: overrides.sourceKeyCount ?? entries.length,
+      scanned_key_count: overrides.scannedKeyCount ?? entries.length,
       consistency: {},
       repaired_records: [],
-      entries: [{
-        story_id: story.story_id,
-        record,
-        story,
-        story_state: {
-          synthesis_state: 'synthesis_pending',
-          frame_table_state: 'frame_table_pending',
-          lifecycle_status: 'pending',
-          lifecycle_source_set_revision: story.provenance_hash,
-          lifecycle_updated_at: Date.now(),
-          terminal_unavailable_reason: null,
-          retryable: false,
-        },
-      }],
+      entries,
+      ...(overrides.snapshot ?? {}),
     })}\n`,
   );
 }
@@ -3585,6 +3590,85 @@ describe('infra relay server', () => {
           },
         }),
       });
+  }, 30_000);
+
+  it('serves a stale latest-index snapshot after restart when live latest-index state is empty', async () => {
+    const snapshotDir = mkdtempSync(path.join(os.tmpdir(), 'vh-relay-stale-latest-index-fallback-'));
+    tempDirs.add(snapshotDir);
+    const snapshotFile = path.join(snapshotDir, 'latest-index-snapshot.json');
+    const now = Date.now();
+    const cachedAt = now - 120_000;
+    const story = makeRelayNewsStory('story-stale-latest-index-fallback', now - 1_000, [
+      {
+        source_id: 'source-stale-latest-index-fallback',
+        publisher: 'Stale Latest Index Source',
+        url: 'https://example.com/stale-latest-index-fallback',
+        url_hash: 'hash-stale-latest-index-fallback',
+        published_at: now - 2_000,
+        title: 'Stale latest-index fallback story',
+      },
+    ]);
+    writeLatestIndexSnapshotFile(snapshotFile, story, {
+      cachedAt,
+      lifecycleUpdatedAt: now,
+    });
+    const snapshotBefore = readFileSync(snapshotFile, 'utf8');
+
+    const { port } = await startRelay(children, tempDirs, {
+      VH_RELAY_NEWS_INDEX_REST_MAX_RECORDS: '3',
+      VH_RELAY_NEWS_INDEX_REST_SCAN_RECORDS: '3',
+      VH_RELAY_NEWS_INDEX_STORY_REST_READ_TIMEOUT_MS: '100',
+      VH_RELAY_NEWS_STORY_REST_READ_TIMEOUT_MS: '100',
+      VH_RELAY_NEWS_INDEX_REST_EMPTY_RETRY_ATTEMPTS: '1',
+      VH_RELAY_NEWS_INDEX_REST_EMPTY_RETRY_DELAY_MS: '1',
+      VH_RELAY_NEWS_INDEX_SNAPSHOT_FILE: snapshotFile,
+      VH_RELAY_NEWS_INDEX_SNAPSHOT_MAX_AGE_MS: '1000',
+      VH_RELAY_NEWS_INDEX_REST_PREFER_SNAPSHOT: 'true',
+      VH_RELAY_NEWS_INDEX_SERVE_STALE_SNAPSHOT_ON_EMPTY: 'true',
+      VH_RELAY_NEWS_INDEX_SNAPSHOT_VERIFY_STORY_BODIES: 'true',
+      VH_RELAY_NEWS_INDEX_SNAPSHOT_REFRESH_STORY_STATES: 'false',
+    });
+    const latest = await requestJson(
+      `http://127.0.0.1:${port}/vh/news/latest-index?limit=3&scan_limit=3`,
+    );
+    expect(latest).toMatchObject({
+      statusCode: 200,
+      body: expect.objectContaining({
+        ok: true,
+        record_count: 1,
+        source_key_count: 1,
+        records: {
+          [story.story_id]: expect.objectContaining({
+            story_id: story.story_id,
+          }),
+        },
+        stories: {
+          [story.story_id]: expect.objectContaining({
+            story_id: story.story_id,
+            headline: story.headline,
+          }),
+        },
+        consistency: expect.objectContaining({
+          empty_read_cache: expect.objectContaining({
+            served_from: 'stale_latest_index_snapshot',
+            cached_at: cachedAt,
+            snapshot_max_age_ms: 1000,
+            stale: true,
+          }),
+          snapshot_story_body_readback: expect.objectContaining({
+            enabled: true,
+            selected_count: 1,
+            verified_count: 1,
+            dropped_count: 0,
+            snapshot_story_fallback_enabled: true,
+            snapshot_story_fallback_count: 0,
+            degraded_to_snapshot_stories: false,
+          }),
+        }),
+      }),
+    });
+    expect(latest.body.consistency.empty_read_cache.age_ms).toBeGreaterThan(1000);
+    expect(readFileSync(snapshotFile, 'utf8')).toBe(snapshotBefore);
   }, 30_000);
 
   it('serves scalar-only news story records without waiting for a missing parent node', async () => {


### PR DESCRIPTION
## Summary
- Serve a non-empty persisted latest-index snapshot as a stale public fallback only after the live latest-index read is empty and the snapshot is older than the configured max age.
- Annotate stale responses with `served_from=stale_latest_index_snapshot`, `stale`, `cached_at`, `age_ms`, and `snapshot_max_age_ms`, while keeping critical write readbacks live-only.
- Preserve snapshot-backed stories during stale fallback without mutating the snapshot file, and document the ops/deploy invariants.

## Tests
- `node --check infra/relay/server.js`
- `corepack pnpm --filter @vh/e2e exec vitest run src/live/relay-server.vitest.mjs --config ./vitest.config.ts -t "serves a stale latest-index snapshot after restart"`
- `corepack pnpm --filter @vh/e2e exec vitest run src/live/relay-server.vitest.mjs --config ./vitest.config.ts`
- `git diff --check`
- `node tools/scripts/check-diff-coverage.mjs`
- `corepack pnpm test:quick`

Note: the first full relay-suite attempt hit the existing raw-Gun pagination propagation test once; the focused rerun passed immediately, and the full relay suite passed on both subsequent full runs.