### PR TITLE
[codex] Fix StoryCluster rerank truncation handling

### DIFF
--- a/services/storycluster-engine/src/clusterLifecycle.test.ts
+++ b/services/storycluster-engine/src/clusterLifecycle.test.ts
@@ -1,10 +1,18 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { adjudicateCandidates, assignClusters, bundleClusters, rerankCandidates, retrieveCandidates } from './clusterLifecycle';
 import { deriveClusterRecord, toStoredSource } from './clusterRecords';
 import { coverageRoleForDocumentType } from './documentPolicy';
 import type { StoryClusterModelProvider } from './modelProvider';
+import { OpenAIStoryClusterProvider } from './openaiProvider';
 import type { PipelineState, StoredTopicState, WorkingDocument } from './stageState';
 import type { ClusterVectorBackend } from './vectorBackend';
+
+function jsonResponse(payload: unknown): Response {
+  return new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
 
 function makeWorkingDocument(
   docId: string,
@@ -70,6 +78,11 @@ function makeWorkingDocument(
 }
 
 describe('clusterLifecycle', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
   it('orders equal-score candidate matches deterministically by story id', async () => {
     const topicState: StoredTopicState = {
       schema_version: 'storycluster-state-v1',
@@ -418,6 +431,8 @@ describe('clusterLifecycle', () => {
     });
 
     expect(reranked.documents[0]?.candidate_matches[0]?.rerank_score).toBe(0.6);
+    expect(reranked.stage_metrics.cross_encoder_rerank?.rerank_results_applied).toBe(0);
+    expect(reranked.stage_metrics.cross_encoder_rerank?.rerank_results_missing).toBe(1);
 
     const lowConfidence = await adjudicateCandidates({
       topicId: 'topic-news',
@@ -433,6 +448,7 @@ describe('clusterLifecycle', () => {
           reason: 'below-threshold',
         }],
         rerank_score: 0.4,
+        adjudication: 'rejected',
       }],
       clusters: [],
       bundles: [],
@@ -462,6 +478,136 @@ describe('clusterLifecycle', () => {
 
     expect(lowConfidence.documents[0]?.adjudication).toBe('rejected');
     expect(lowConfidence.stage_metrics.llm_adjudication?.adjudicated_docs).toBe(0);
+  });
+
+  it('preserves prior rerank scores when an OpenAI rerank chunk truncates', async () => {
+    vi.stubEnv('VH_STORYCLUSTER_OPENAI_FAILURE_ARTIFACTS_ENABLED', '0');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const topicState: StoredTopicState = {
+      schema_version: 'storycluster-state-v1',
+      topic_id: 'topic-news',
+      next_cluster_seq: 1,
+      clusters: [],
+    };
+    const existing = makeWorkingDocument('doc-1', 'Port attack expands', 'port_attack', 'attack', [1, 0]);
+    topicState.clusters = [
+      deriveClusterRecord(topicState, 'topic-news', [toStoredSource(existing, existing.source_variants[0]!)], 'story-a'),
+    ];
+    const provider = new OpenAIStoryClusterProvider({
+      apiKey: 'key',
+      fetchFn: async () => jsonResponse({
+        choices: [{
+          finish_reason: 'length',
+          message: { content: '{"reranks":{"doc-9::story-a":0.' },
+        }],
+      }),
+    });
+
+    const next = await rerankCandidates({
+      topicId: 'topic-news',
+      referenceNowMs: 1000,
+      documents: [{
+        ...makeWorkingDocument('doc-9', 'Port attack update', 'port_attack', 'attack', [1, 0]),
+        candidate_matches: [{
+          story_id: 'story-a',
+          candidate_score: 0.6,
+          hybrid_score: 0.6,
+          rerank_score: 0.6,
+          adjudication: 'abstain',
+          reason: 'ambiguous-same-topic',
+        }],
+      }],
+      clusters: [],
+      bundles: [],
+      topic_state: topicState,
+      stage_metrics: {},
+    }, provider);
+
+    expect(next.documents[0]?.candidate_matches[0]?.rerank_score).toBe(0.6);
+    expect(next.stage_metrics.cross_encoder_rerank?.rerank_results_received).toBe(0);
+    expect(next.stage_metrics.cross_encoder_rerank?.rerank_results_missing).toBe(1);
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[vh:storycluster] cross_encoder_rerank output degraded to prior scores',
+      expect.objectContaining({
+        pairCount: 1,
+      }),
+    );
+  });
+
+  it('preserves prior rerank ordering when a nontrivial OpenAI rerank chunk is degenerate', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const topicState: StoredTopicState = {
+      schema_version: 'storycluster-state-v1',
+      topic_id: 'topic-news',
+      next_cluster_seq: 1,
+      clusters: [],
+    };
+    const existingA = makeWorkingDocument('doc-1', 'Port attack expands', 'port_attack', 'attack', [1, 0]);
+    const existingB = makeWorkingDocument('doc-2', 'Port security vote follows attack', 'port_attack', 'vote', [0.9, 0.1]);
+    topicState.clusters = [
+      deriveClusterRecord(topicState, 'topic-news', [toStoredSource(existingA, existingA.source_variants[0]!)], 'story-a'),
+      deriveClusterRecord(topicState, 'topic-news', [toStoredSource(existingB, existingB.source_variants[0]!)], 'story-b'),
+    ];
+    const provider = new OpenAIStoryClusterProvider({
+      apiKey: 'key',
+      fetchFn: async () => jsonResponse({
+        choices: [{
+          message: {
+            content: JSON.stringify({
+              reranks: {
+                'doc-9::story-a': 1,
+                'doc-9::story-b': 1,
+              },
+            }),
+          },
+        }],
+      }),
+    });
+
+    const next = await rerankCandidates({
+      topicId: 'topic-news',
+      referenceNowMs: 1000,
+      documents: [{
+        ...makeWorkingDocument('doc-9', 'Port attack update', 'port_attack', 'attack', [1, 0]),
+        candidate_matches: [
+          {
+            story_id: 'story-a',
+            candidate_score: 0.6,
+            hybrid_score: 0.6,
+            rerank_score: 0.6,
+            adjudication: 'abstain',
+            reason: 'ambiguous-same-topic',
+          },
+          {
+            story_id: 'story-b',
+            candidate_score: 0.55,
+            hybrid_score: 0.55,
+            rerank_score: 0.55,
+            adjudication: 'abstain',
+            reason: 'ambiguous-same-topic',
+          },
+        ],
+      }],
+      clusters: [],
+      bundles: [],
+      topic_state: topicState,
+      stage_metrics: {},
+    }, provider);
+
+    expect(next.documents[0]?.candidate_matches.map((match) => [match.story_id, match.rerank_score])).toEqual([
+      ['story-a', 0.6],
+      ['story-b', 0.55],
+    ]);
+    expect(next.stage_metrics.cross_encoder_rerank?.rerank_results_applied).toBe(0);
+    expect(next.stage_metrics.cross_encoder_rerank?.rerank_results_missing).toBe(2);
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[vh:storycluster] cross_encoder_rerank degenerate score chunk degraded',
+      expect.objectContaining({
+        pairCount: 2,
+        uniquePairCount: 2,
+        score: 1,
+      }),
+    );
   });
 
   it('requires a provider for rerank/bundling and fails when rerank references a missing cluster', async () => {
@@ -527,7 +673,7 @@ describe('clusterLifecycle', () => {
     }, undefined)).rejects.toThrow('storycluster model provider is required for summarize_publish_payloads');
   });
 
-  it('falls back to rejected when no adjudication result is returned for a low-confidence match', async () => {
+  it('preserves prior adjudication when no adjudication result is returned for a low-confidence match', async () => {
     const topicState: StoredTopicState = {
       schema_version: 'storycluster-state-v1',
       topic_id: 'topic-news',
@@ -553,6 +699,7 @@ describe('clusterLifecycle', () => {
           reason: 'ambiguous-same-topic',
         }],
         rerank_score: 0.6,
+        adjudication: 'abstain',
       }],
       clusters: [],
       bundles: [],
@@ -580,8 +727,10 @@ describe('clusterLifecycle', () => {
       },
     });
 
-    expect(next.documents[0]?.adjudication).toBe('rejected');
-    expect(next.stage_metrics.llm_adjudication?.adjudication_rejects).toBe(1);
+    expect(next.documents[0]?.adjudication).toBe('abstain');
+    expect(next.stage_metrics.llm_adjudication?.adjudication_results_applied).toBe(0);
+    expect(next.stage_metrics.llm_adjudication?.adjudication_results_missing).toBe(1);
+    expect(next.stage_metrics.llm_adjudication?.adjudication_abstains).toBe(1);
   });
 
   it('applies returned adjudication decisions to ambiguous candidates', async () => {

--- a/services/storycluster-engine/src/clusterLifecycle.ts
+++ b/services/storycluster-engine/src/clusterLifecycle.ts
@@ -1,5 +1,5 @@
 import type { ClusterBucket, PipelineState } from './stageState';
-import type { StoryClusterModelProvider, SummaryWorkItem } from './modelProvider';
+import type { PairJudgementWorkResult, PairRerankWorkResult, StoryClusterModelProvider, SummaryWorkItem } from './modelProvider';
 import type { ClusterVectorBackend } from './vectorBackend';
 import { MemoryVectorBackend } from './vectorBackend';
 import { canDocumentAttachToExistingCluster, canDocumentParticipateInCanonicalCluster } from './documentPolicy';
@@ -23,6 +23,47 @@ export function recordProviderFallbackOutcome(
     return { providerAssignedDocs: providerAssignedDocs + 1, providerRejectedDocs };
   }
   return { providerAssignedDocs, providerRejectedDocs: providerRejectedDocs + 1 };
+}
+
+function buildValidatedRerankMap(
+  requestedPairIds: ReadonlySet<string>,
+  reranks: readonly PairRerankWorkResult[],
+): { rerankById: Map<string, PairRerankWorkResult>; ignored: number } {
+  const rerankById = new Map<string, PairRerankWorkResult>();
+  let ignored = 0;
+  for (const item of reranks) {
+    if (
+      !requestedPairIds.has(item.pair_id) ||
+      rerankById.has(item.pair_id) ||
+      !Number.isFinite(item.score)
+    ) {
+      ignored += 1;
+      continue;
+    }
+    rerankById.set(item.pair_id, item);
+  }
+  return { rerankById, ignored };
+}
+
+function buildValidatedJudgementMap(
+  requestedPairIds: ReadonlySet<string>,
+  judgements: readonly PairJudgementWorkResult[],
+): { judgementById: Map<string, PairJudgementWorkResult>; ignored: number } {
+  const judgementById = new Map<string, PairJudgementWorkResult>();
+  let ignored = 0;
+  for (const item of judgements) {
+    if (
+      !requestedPairIds.has(item.pair_id) ||
+      judgementById.has(item.pair_id) ||
+      !Number.isFinite(item.score) ||
+      (item.decision !== 'accepted' && item.decision !== 'rejected' && item.decision !== 'abstain')
+    ) {
+      ignored += 1;
+      continue;
+    }
+    judgementById.set(item.pair_id, item);
+  }
+  return { judgementById, ignored };
 }
 
 export async function retrieveCandidates(state: PipelineState, vectorBackend: ClusterVectorBackend = new MemoryVectorBackend()): Promise<PipelineState> {
@@ -102,7 +143,8 @@ export async function rerankCandidates(state: PipelineState, provider: StoryClus
     }),
   );
   const reranks = await requireClusterProvider(provider, 'cross_encoder_rerank').rerankPairs(rerankItems);
-  const rerankById = new Map(reranks.map((item) => [item.pair_id, item]));
+  const requestedPairIds = new Set(rerankItems.map((item) => item.pair_id));
+  const { rerankById, ignored: ignoredRerankResults } = buildValidatedRerankMap(requestedPairIds, reranks);
   const documents = state.documents.map((document) => {
     const candidateMatches = applyPairReranks(document, document.candidate_matches, rerankById);
     return {
@@ -118,6 +160,10 @@ export async function rerankCandidates(state: PipelineState, provider: StoryClus
       ...state.stage_metrics,
       cross_encoder_rerank: {
         reranked_pairs: rerankItems.length,
+        rerank_results_received: reranks.length,
+        rerank_results_applied: rerankById.size,
+        rerank_results_ignored: ignoredRerankResults,
+        rerank_results_missing: Math.max(0, requestedPairIds.size - rerankById.size),
         accepted_after_rerank: documents.filter((document) => document.rerank_score >= clusterScoringConfig.acceptThreshold).length,
         rejected_after_rerank: documents.filter((document) => document.rerank_score < clusterScoringConfig.reviewThreshold).length,
       },
@@ -154,7 +200,8 @@ export async function adjudicateCandidates(
   const adjudications = adjudicationItems.length > 0
     ? await requireClusterProvider(provider, 'llm_adjudication').adjudicatePairs(adjudicationItems)
     : [];
-  const adjudicationById = new Map(adjudications.map((item) => [item.pair_id, item]));
+  const requestedPairIds = new Set(adjudicationItems.map((item) => item.pair_id));
+  const { judgementById: adjudicationById, ignored: ignoredAdjudications } = buildValidatedJudgementMap(requestedPairIds, adjudications);
   const documents = state.documents.map((document) => {
     const top = document.candidate_matches[0];
     if (!top) {
@@ -164,10 +211,7 @@ export async function adjudicateCandidates(
     if (adjudicated) {
       return { ...document, adjudication: adjudicated.decision };
     }
-    if (document.rerank_score >= clusterScoringConfig.acceptThreshold) {
-      return { ...document, adjudication: 'accepted' as const };
-    }
-    return { ...document, adjudication: 'rejected' as const };
+    return { ...document, adjudication: top.adjudication };
   });
   return {
     ...state,
@@ -177,6 +221,10 @@ export async function adjudicateCandidates(
       llm_adjudication: {
         ambiguity_rate: Number((documents.filter((document) => document.adjudication === 'abstain').length / Math.max(1, documents.length)).toFixed(6)),
         adjudicated_docs: adjudicationItems.length,
+        adjudication_results_received: adjudications.length,
+        adjudication_results_applied: adjudicationById.size,
+        adjudication_results_ignored: ignoredAdjudications,
+        adjudication_results_missing: Math.max(0, requestedPairIds.size - adjudicationById.size),
         adjudication_accepts: documents.filter((document) => document.adjudication === 'accepted').length,
         adjudication_rejects: documents.filter((document) => document.adjudication === 'rejected').length,
         adjudication_abstains: documents.filter((document) => document.adjudication === 'abstain').length,

--- a/services/storycluster-engine/src/openaiClient.test.ts
+++ b/services/storycluster-engine/src/openaiClient.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { OpenAIChatJsonParseError, OpenAIClient } from './openaiClient';
+import { OpenAIChatJsonParseError, OpenAIChatJsonTruncationError, OpenAIClient } from './openaiClient';
 
 function jsonResponse(payload: unknown, status = 200): Response {
   return new Response(JSON.stringify(payload), {
@@ -57,6 +57,48 @@ describe('OpenAIClient', () => {
       user: 'usr',
       maxTokens: 77,
     })).resolves.toEqual({ answer: 1 });
+  });
+
+  it('sends strict JSON schema response formats when provided', async () => {
+    let capturedBody: Record<string, unknown> | null = null;
+    const schema = {
+      type: 'object',
+      required: ['ok'],
+      additionalProperties: false,
+      properties: {
+        ok: { type: 'boolean' },
+      },
+    };
+    const fetchFn = vi.fn(async (_url: string, init?: RequestInit) => {
+      capturedBody = JSON.parse(String(init?.body));
+      return jsonResponse({
+        choices: [{ message: { content: '{"ok":true}' } }],
+      });
+    });
+
+    const client = new OpenAIClient({ apiKey: 'key', fetchFn });
+    await expect(client.chatJson<{ ok: boolean }>({
+      model: 'gpt-4o-mini',
+      system: 'sys',
+      user: 'usr',
+      responseFormat: {
+        type: 'json_schema',
+        json_schema: {
+          name: 'strict_test',
+          strict: true,
+          schema,
+        },
+      },
+    })).resolves.toEqual({ ok: true });
+
+    expect(capturedBody?.response_format).toEqual({
+      type: 'json_schema',
+      json_schema: {
+        name: 'strict_test',
+        strict: true,
+        schema,
+      },
+    });
   });
 
   it('uses max_tokens for non-gpt-5 chat models', async () => {
@@ -154,7 +196,7 @@ describe('OpenAIClient', () => {
     })).rejects.toBe('chat-string-error');
   });
 
-  it('attaches finish reason and bounded response details to chat JSON parse failures', async () => {
+  it('attaches finish reason and bounded response details to chat JSON truncation failures', async () => {
     const content = '{"reranks":[{"pair_id":"pair-1","score":0.9} {"pair_id":"pair-2","score":0.1}]}';
     const client = new OpenAIClient({
       apiKey: 'key',
@@ -174,13 +216,15 @@ describe('OpenAIClient', () => {
       });
       throw new Error('expected chatJson to fail');
     } catch (error) {
+      expect(error).toBeInstanceOf(OpenAIChatJsonTruncationError);
       expect(error).toBeInstanceOf(OpenAIChatJsonParseError);
-      const parseError = error as OpenAIChatJsonParseError;
-      expect(parseError.message).toContain('Expected');
+      const parseError = error as OpenAIChatJsonTruncationError;
+      expect(parseError.message).toContain('OpenAI chat response truncated');
       expect(parseError.details).toMatchObject({
         finishReason: 'length',
         responseContentLengthBytes: content.length,
         extractedJsonLengthBytes: content.length,
+        parseContext: 'finish_reason_length_invalid_json',
       });
       expect(parseError.details.responseContentSha256).toMatch(/^[a-f0-9]{64}$/);
       expect(parseError.details.responseContentPreview).toBe(content);

--- a/services/storycluster-engine/src/openaiClient.ts
+++ b/services/storycluster-engine/src/openaiClient.ts
@@ -1,11 +1,23 @@
 import { createHash } from 'node:crypto';
 
+export interface OpenAIChatJsonSchemaResponseFormat {
+  type: 'json_schema';
+  json_schema: {
+    name: string;
+    strict: true;
+    schema: Record<string, unknown>;
+  };
+}
+
+type OpenAIChatResponseFormat = { type: 'json_object' } | OpenAIChatJsonSchemaResponseFormat;
+
 interface ChatJsonOptions {
   model: string;
   system: string;
   user: string;
   temperature?: number;
   maxTokens?: number;
+  responseFormat?: OpenAIChatResponseFormat;
 }
 
 interface EmbeddingOptions {
@@ -35,6 +47,7 @@ export interface OpenAIChatJsonParseFailureDetails {
   readonly responseContentPreview: string;
   readonly extractedJsonLengthBytes: number | null;
   readonly parseError: string | null;
+  readonly parseContext: string;
 }
 
 export class OpenAIChatJsonParseError extends Error {
@@ -44,6 +57,13 @@ export class OpenAIChatJsonParseError extends Error {
     super(message);
     this.name = 'OpenAIChatJsonParseError';
     this.details = details;
+  }
+}
+
+export class OpenAIChatJsonTruncationError extends OpenAIChatJsonParseError {
+  constructor(message: string, details: OpenAIChatJsonParseFailureDetails) {
+    super(message, details);
+    this.name = 'OpenAIChatJsonTruncationError';
   }
 }
 
@@ -127,6 +147,7 @@ function parseFailureDetails(
   content: string,
   extractedJson: string | null,
   parseError: string | null,
+  parseContext: string,
 ): OpenAIChatJsonParseFailureDetails {
   const choice = (payload as { choices?: Array<{ finish_reason?: unknown }> })?.choices?.[0];
   const finishReason = typeof choice?.finish_reason === 'string' ? choice.finish_reason : null;
@@ -138,6 +159,7 @@ function parseFailureDetails(
     responseContentPreview: redactedContent.slice(0, OPENAI_CHAT_PARSE_PREVIEW_MAX_LENGTH),
     extractedJsonLengthBytes: extractedJson === null ? null : utf8Length(extractedJson),
     parseError,
+    parseContext,
   };
 }
 
@@ -147,11 +169,32 @@ function extractJsonContent(payload: unknown): unknown {
   if (typeof content !== 'string') {
     throw new Error('OpenAI chat response missing content');
   }
+  const finishReason = record?.choices?.[0]?.finish_reason;
+  if (finishReason === 'length') {
+    const match = content.match(/\{[\s\S]*\}/);
+    let parseError = 'finish_reason_length';
+    let parseContext = 'finish_reason_length';
+    if (!match) {
+      parseError = 'missing_json_object';
+      parseContext = 'finish_reason_length_missing_json_object';
+    } else {
+      try {
+        JSON.parse(match[0]);
+      } catch (error) {
+        parseError = error instanceof Error ? error.message : String(error);
+        parseContext = 'finish_reason_length_invalid_json';
+      }
+    }
+    throw new OpenAIChatJsonTruncationError(
+      `OpenAI chat response truncated before complete JSON: ${parseError}`,
+      parseFailureDetails(payload, content, match?.[0] ?? null, parseError, parseContext),
+    );
+  }
   const match = content.match(/\{[\s\S]*\}/);
   if (!match) {
     throw new OpenAIChatJsonParseError(
       `OpenAI chat response missing JSON object: ${redactSensitiveText(content).slice(0, 240)}`,
-      parseFailureDetails(payload, content, null, 'missing_json_object'),
+      parseFailureDetails(payload, content, null, 'missing_json_object', 'missing_json_object'),
     );
   }
   try {
@@ -160,7 +203,7 @@ function extractJsonContent(payload: unknown): unknown {
     const message = error instanceof Error ? error.message : String(error);
     throw new OpenAIChatJsonParseError(
       message,
-      parseFailureDetails(payload, content, match[0], message),
+      parseFailureDetails(payload, content, match[0], message, 'invalid_json_object'),
     );
   }
 }
@@ -199,7 +242,7 @@ export class OpenAIClient {
             ],
             temperature: options.temperature ?? 0,
             [tokenParam]: options.maxTokens ?? 2_000,
-            response_format: { type: 'json_object' },
+            response_format: options.responseFormat ?? { type: 'json_object' },
           }),
           signal: controller.signal,
         });

--- a/services/storycluster-engine/src/openaiProvider.test.ts
+++ b/services/storycluster-engine/src/openaiProvider.test.ts
@@ -288,11 +288,11 @@ describe('OpenAIStoryClusterProvider', () => {
           choices: [{
             message: {
               content: JSON.stringify({
-                reranks: [
-                  { pair_id: 'pair-accepted', score: 1.8 },
-                  { pair_id: 'pair-rejected', score: -4 },
-                  { pair_id: 'pair-fallback', score: null },
-                ],
+                reranks: {
+                  'pair-accepted': 1.8,
+                  'pair-rejected': -4,
+                  'pair-fallback': 0.51,
+                },
               }),
             },
           }],
@@ -347,7 +347,7 @@ describe('OpenAIStoryClusterProvider', () => {
     expect(reranks.slice(0, 3)).toEqual([
       { pair_id: 'pair-accepted', score: 1 },
       { pair_id: 'pair-rejected', score: 0 },
-      { pair_id: 'pair-fallback', score: 0 },
+      { pair_id: 'pair-fallback', score: 0.51 },
     ]);
 
     expect(await provider.adjudicatePairs([])).toEqual([]);
@@ -380,7 +380,188 @@ describe('OpenAIStoryClusterProvider', () => {
     expect(summaries).toHaveLength(7);
   });
 
-  it('completes missing provider outputs deterministically after retry exhaustion', async () => {
+  it('sends fixed-key strict rerank schemas for the requested pair ids', async () => {
+    let capturedBody: Record<string, unknown> | null = null;
+    const provider = new OpenAIStoryClusterProvider({
+      apiKey: 'key',
+      fetchFn: async (_url: string, init?: RequestInit) => {
+        capturedBody = JSON.parse(String(init?.body));
+        return jsonResponse({
+          choices: [{
+            message: {
+              content: JSON.stringify({
+                reranks: {
+                  'doc-1::story-a': 0.82,
+                  'doc-2::story-b': 0.27,
+                },
+              }),
+            },
+          }],
+        });
+      },
+    });
+
+    await expect(provider.rerankPairs([
+      {
+        pair_id: 'doc-1::story-a',
+        document_title: 'Doc 1',
+        document_text: 'Text 1',
+        document_entities: ['entity'],
+        document_trigger: 'attack',
+        cluster_headline: 'Headline A',
+        cluster_summary: 'Summary A',
+        cluster_entities: ['entity'],
+        cluster_triggers: ['attack'],
+      },
+      {
+        pair_id: 'doc-2::story-b',
+        document_title: 'Doc 2',
+        document_text: 'Text 2',
+        document_entities: ['entity'],
+        document_trigger: 'vote',
+        cluster_headline: 'Headline B',
+        cluster_summary: 'Summary B',
+        cluster_entities: ['entity'],
+        cluster_triggers: ['vote'],
+      },
+    ])).resolves.toEqual([
+      { pair_id: 'doc-1::story-a', score: 0.82 },
+      { pair_id: 'doc-2::story-b', score: 0.27 },
+    ]);
+
+    const responseFormat = capturedBody?.response_format as {
+      type: string;
+      json_schema: {
+        strict: boolean;
+        schema: {
+          required: string[];
+          additionalProperties: boolean;
+          properties: {
+            reranks: {
+              required: string[];
+              additionalProperties: boolean;
+              properties: Record<string, { type: string }>;
+            };
+          };
+        };
+      };
+    };
+    expect(responseFormat.type).toBe('json_schema');
+    expect(responseFormat.json_schema.strict).toBe(true);
+    expect(responseFormat.json_schema.schema.required).toEqual(['reranks']);
+    expect(responseFormat.json_schema.schema.additionalProperties).toBe(false);
+    expect(responseFormat.json_schema.schema.properties.reranks.required).toEqual([
+      'doc-1::story-a',
+      'doc-2::story-b',
+    ]);
+    expect(responseFormat.json_schema.schema.properties.reranks.additionalProperties).toBe(false);
+    expect(responseFormat.json_schema.schema.properties.reranks.properties).toEqual({
+      'doc-1::story-a': { type: 'number' },
+      'doc-2::story-b': { type: 'number' },
+    });
+    expect(JSON.stringify(responseFormat)).not.toContain('maxItems');
+  });
+
+  it('omits missing, unknown, and invalid fixed-key rerank outputs', async () => {
+    const provider = new OpenAIStoryClusterProvider({
+      apiKey: 'key',
+      fetchFn: async () => jsonResponse({
+        choices: [{
+          message: {
+            content: JSON.stringify({
+              reranks: {
+                'doc-1::story-a': 0.81,
+                'doc-3::story-c': 0.99,
+                'doc-2::story-b': null,
+              },
+            }),
+          },
+        }],
+      }),
+    });
+
+    await expect(provider.rerankPairs([
+      {
+        pair_id: 'doc-1::story-a',
+        document_title: 'Doc 1',
+        document_text: 'Text 1',
+        document_entities: ['entity'],
+        document_trigger: 'attack',
+        cluster_headline: 'Headline A',
+        cluster_summary: 'Summary A',
+        cluster_entities: ['entity'],
+        cluster_triggers: ['attack'],
+      },
+      {
+        pair_id: 'doc-2::story-b',
+        document_title: 'Doc 2',
+        document_text: 'Text 2',
+        document_entities: ['entity'],
+        document_trigger: 'vote',
+        cluster_headline: 'Headline B',
+        cluster_summary: 'Summary B',
+        cluster_entities: ['entity'],
+        cluster_triggers: ['vote'],
+      },
+    ])).resolves.toEqual([
+      { pair_id: 'doc-1::story-a', score: 0.81 },
+    ]);
+  });
+
+  it('degrades exactly identical nontrivial rerank chunks instead of applying low-quality scores', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const provider = new OpenAIStoryClusterProvider({
+      apiKey: 'key',
+      fetchFn: async () => jsonResponse({
+        choices: [{
+          message: {
+            content: JSON.stringify({
+              reranks: {
+                'doc-1::story-a': 1,
+                'doc-2::story-b': 1,
+              },
+            }),
+          },
+        }],
+      }),
+    });
+
+    await expect(provider.rerankPairs([
+      {
+        pair_id: 'doc-1::story-a',
+        document_title: 'Doc 1',
+        document_text: 'Text 1',
+        document_entities: ['entity'],
+        document_trigger: 'attack',
+        cluster_headline: 'Headline A',
+        cluster_summary: 'Summary A',
+        cluster_entities: ['entity'],
+        cluster_triggers: ['attack'],
+      },
+      {
+        pair_id: 'doc-2::story-b',
+        document_title: 'Doc 2',
+        document_text: 'Text 2',
+        document_entities: ['entity'],
+        document_trigger: 'attack',
+        cluster_headline: 'Headline B',
+        cluster_summary: 'Summary B',
+        cluster_entities: ['entity'],
+        cluster_triggers: ['attack'],
+      },
+    ])).resolves.toEqual([]);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[vh:storycluster] cross_encoder_rerank degenerate score chunk degraded',
+      expect.objectContaining({
+        pairCount: 2,
+        uniquePairCount: 2,
+        score: 1,
+      }),
+    );
+  });
+
+  it('keeps deterministic fallbacks while omitting missing gate-changing outputs after retry exhaustion', async () => {
     const provider = new OpenAIStoryClusterProvider({
       apiKey: 'key',
       fetchFn: async () => jsonResponse({
@@ -427,10 +608,7 @@ describe('OpenAIStoryClusterProvider', () => {
       cluster_summary: 'Summary',
       cluster_entities: ['entity'],
       cluster_triggers: ['attack'],
-    }])).resolves.toEqual([{
-      pair_id: 'pair-1',
-      score: 0,
-    }]);
+    }])).resolves.toEqual([]);
     await expect(provider.adjudicatePairs([{
       pair_id: 'pair-1',
       document_title: 'Doc',
@@ -441,11 +619,7 @@ describe('OpenAIStoryClusterProvider', () => {
       cluster_summary: 'Summary',
       cluster_entities: ['entity'],
       cluster_triggers: ['attack'],
-    }])).resolves.toEqual([{
-      pair_id: 'pair-1',
-      score: 0,
-      decision: 'abstain',
-    }]);
+    }])).resolves.toEqual([]);
     await expect(provider.summarize([{
       cluster_id: 'cluster-1',
       headline: 'Headline',
@@ -643,7 +817,7 @@ describe('OpenAIStoryClusterProvider', () => {
       cluster_summary: 'Summary',
       cluster_entities: ['entity'],
       cluster_triggers: ['attack'],
-    }])).rejects.toThrow('Expected');
+    }])).resolves.toEqual([]);
 
     const files = await readdir(artifactDir);
     expect(files).toHaveLength(1);
@@ -679,7 +853,7 @@ describe('OpenAIStoryClusterProvider', () => {
         content_preview: responseContent,
       },
       error: {
-        name: 'OpenAIChatJsonParseError',
+        name: 'OpenAIChatJsonTruncationError',
       },
     });
     expect(artifact.request.sha256).toMatch(/^[a-f0-9]{64}$/);
@@ -695,6 +869,13 @@ describe('OpenAIStoryClusterProvider', () => {
         chunkIndex: 0,
         pairCount: 1,
         finishReason: 'length',
+      }),
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[vh:storycluster] cross_encoder_rerank output degraded to prior scores',
+      expect.objectContaining({
+        chunkIndex: 0,
+        pairCount: 1,
       }),
     );
   });

--- a/services/storycluster-engine/src/openaiProvider.ts
+++ b/services/storycluster-engine/src/openaiProvider.ts
@@ -2,7 +2,7 @@ import { createHash } from 'node:crypto';
 import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { type DocumentAnalysisWorkItem, type DocumentAnalysisWorkResult, type EmbeddingWorkItem, type EmbeddingWorkResult, type PairJudgementWorkItem, type PairJudgementWorkResult, type PairRerankWorkResult, type StoryClusterModelProvider, type SummaryWorkItem, type SummaryWorkResult, type TranslationWorkItem, type TranslationWorkResult } from './modelProvider';
-import { OpenAIChatJsonParseError, OpenAIClient, type OpenAIClientOptions } from './openaiClient';
+import { OpenAIChatJsonParseError, OpenAIClient, type OpenAIChatJsonSchemaResponseFormat, type OpenAIClientOptions } from './openaiClient';
 import { normalizeDocumentType } from './contentSignals';
 import { ensureSentence, normalizeText } from './textSignals';
 export interface OpenAIStoryClusterProviderOptions extends OpenAIClientOptions {
@@ -256,7 +256,7 @@ async function collectWithRetry<TRequest, TResult>(
   request: (items: readonly TRequest[]) => Promise<TResult[]>,
   requestId: (item: TRequest) => string,
   resultId: (item: TResult) => string,
-  fallback: (item: TRequest) => TResult,
+  fallback: (item: TRequest) => TResult | null,
 ): Promise<TResult[]> {
   const firstPass = await request(chunk);
   const resultsById = new Map(firstPass.map((item) => [resultId(item), item]));
@@ -267,7 +267,14 @@ async function collectWithRetry<TRequest, TResult>(
       resultsById.set(resultId(item), item);
     });
   }
-  return chunk.map((item) => resultsById.get(requestId(item)) ?? fallback(item));
+  const results: TResult[] = [];
+  for (const item of chunk) {
+    const result = resultsById.get(requestId(item)) ?? fallback(item);
+    if (result !== null) {
+      results.push(result);
+    }
+  }
+  return results;
 }
 function defaultAnalysisResult(item: DocumentAnalysisWorkItem): DocumentAnalysisWorkResult {
   const entityHints = normalizeKeyList(item.entity_hints);
@@ -289,6 +296,84 @@ function defaultAnalysisResult(item: DocumentAnalysisWorkItem): DocumentAnalysis
     },
   };
 }
+
+function plainRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function modelOutputFailureCanDegrade(error: unknown): boolean {
+  return error instanceof OpenAIChatJsonParseError;
+}
+
+class RerankDegenerateScoresError extends Error {
+  constructor() {
+    super('cross_encoder_rerank returned identical scores for every requested pair');
+    this.name = 'RerankDegenerateScoresError';
+  }
+}
+
+function uniquePairIds(items: readonly PairJudgementWorkItem[]): string[] {
+  return [...new Set(items.map((item) => item.pair_id).filter(Boolean))];
+}
+
+function fixedKeyRerankResponseFormat(pairIds: readonly string[]): OpenAIChatJsonSchemaResponseFormat {
+  const scoreProperties = Object.fromEntries(pairIds.map((pairId) => [pairId, { type: 'number' }]));
+  return {
+    type: 'json_schema',
+    json_schema: {
+      name: 'storycluster_pair_rerank',
+      strict: true,
+      schema: {
+        type: 'object',
+        required: ['reranks'],
+        additionalProperties: false,
+        properties: {
+          reranks: {
+            type: 'object',
+            required: pairIds,
+            additionalProperties: false,
+            properties: scoreProperties,
+          },
+        },
+      },
+    },
+  };
+}
+
+function normalizeFixedKeyReranks(
+  value: unknown,
+  pairIds: readonly string[],
+): PairRerankWorkResult[] {
+  if (!plainRecord(value)) {
+    return [];
+  }
+  const requested = new Set(pairIds);
+  const seen = new Set<string>();
+  const results: PairRerankWorkResult[] = [];
+  for (const [pairId, rawScore] of Object.entries(value)) {
+    if (!requested.has(pairId) || seen.has(pairId) || typeof rawScore !== 'number' || !Number.isFinite(rawScore)) {
+      continue;
+    }
+    seen.add(pairId);
+    results.push({
+      pair_id: pairId,
+      score: clampScore(rawScore),
+    });
+  }
+  return results;
+}
+
+function hasDegenerateRerankScores(
+  results: readonly PairRerankWorkResult[],
+  requestedPairCount: number,
+): boolean {
+  if (requestedPairCount < 2 || results.length < requestedPairCount) {
+    return false;
+  }
+  const first = results[0]?.score;
+  return typeof first === 'number' && results.every((item) => item.score === first);
+}
+
 export class OpenAIStoryClusterProvider implements StoryClusterModelProvider {
   readonly providerId = OPENAI_STORYCLUSTER_PROVIDER_ID;
   private readonly client: OpenAIClient;
@@ -306,8 +391,9 @@ export class OpenAIStoryClusterProvider implements StoryClusterModelProvider {
       return [];
     }
     const chunks = chunkBySize(items, 8);
-    return collectChunksWithConcurrency(chunks, (chunk) =>
-      collectWithRetry(
+    return collectChunksWithConcurrency(chunks, async (chunk, chunkIndex) => {
+      try {
+        return await collectWithRetry(
         chunk,
         async (pending) => {
           const response = await this.client.chatJson<{ translations?: TranslationWorkResult[] }>({
@@ -328,8 +414,22 @@ export class OpenAIStoryClusterProvider implements StoryClusterModelProvider {
           doc_id: item.doc_id,
           translated_text: trimSummary(item.text),
         }),
-      ),
-    );
+        );
+      } catch (error) {
+        if (!modelOutputFailureCanDegrade(error)) {
+          throw error;
+        }
+        console.warn('[vh:storycluster] translation output degraded to source text', {
+          chunkIndex,
+          itemCount: chunk.length,
+          reason: redactOpenAIProviderMessage(error instanceof Error ? error.message : error),
+        });
+        return chunk.map((item) => ({
+          doc_id: item.doc_id,
+          translated_text: trimSummary(item.text),
+        }));
+      }
+    });
   }
   async embed(items: EmbeddingWorkItem[], dimensions: number): Promise<EmbeddingWorkResult[]> {
     if (items.length === 0) {
@@ -401,19 +501,22 @@ export class OpenAIStoryClusterProvider implements StoryClusterModelProvider {
       return [];
     }
     const chunks = chunkBySize(items, 8);
-    return collectChunksWithConcurrency(chunks, (chunk, chunkIndex) =>
-      collectWithRetry<PairJudgementWorkItem, PairRerankWorkResult>(
+    return collectChunksWithConcurrency(chunks, async (chunk, chunkIndex) => {
+      try {
+        return await collectWithRetry<PairJudgementWorkItem, PairRerankWorkResult>(
         chunk,
         async (pending) => {
           const user = JSON.stringify({ rerank_pairs: pending });
+          const pairIds = uniquePairIds(pending);
           let response;
           try {
-            response = await this.client.chatJson<{ reranks?: Array<{ pair_id: string; score: number }> }>({
+            response = await this.client.chatJson<{ reranks?: Record<string, number> }>({
               model: this.textModel,
-              system: ['You rerank document-to-cluster candidate pairs for same-event news clustering.', 'Return strict JSON: {"reranks":[{"pair_id":"...","score":0.0}]}.', 'score must be a calibrated 0..1 same-event similarity score.', 'Do not make final acceptance decisions here. Use the score only for ordering and margin comparison.'].join(' '),
+              system: ['You rerank document-to-cluster candidate pairs for same-event news clustering.', 'Return only the requested fixed-key JSON object: {"reranks":{"pair-id":0.0}}.', 'Each key must be one of the requested pair IDs and every requested pair ID must be present exactly once.', 'score must be a calibrated 0..1 same-event similarity score.', 'Do not make final acceptance decisions here. Use the score only for ordering and margin comparison.'].join(' '),
               user,
               temperature: 0,
               maxTokens: 4_000,
+              responseFormat: fixedKeyRerankResponseFormat(pairIds),
             });
           } catch (error) {
             await this.captureRerankParseFailure(error, {
@@ -423,19 +526,37 @@ export class OpenAIStoryClusterProvider implements StoryClusterModelProvider {
             });
             throw error;
           }
-          return (response.reranks ?? []).map((item) => ({
-            pair_id: item.pair_id,
-            score: clampScore(item.score),
-          }));
+          const reranks = normalizeFixedKeyReranks(response.reranks, pairIds);
+          if (hasDegenerateRerankScores(reranks, pairIds.length)) {
+            console.warn('[vh:storycluster] cross_encoder_rerank degenerate score chunk degraded', {
+              chunkIndex,
+              pairCount: pending.length,
+              uniquePairCount: pairIds.length,
+              score: reranks[0]?.score,
+            });
+            throw new RerankDegenerateScoresError();
+          }
+          return reranks;
         },
         (item) => item.pair_id,
         (item) => item.pair_id,
-        (item) => ({
-          pair_id: item.pair_id,
-          score: 0,
-        }),
-      ),
-    );
+        () => null,
+        );
+      } catch (error) {
+        if (error instanceof RerankDegenerateScoresError) {
+          return [];
+        }
+        if (!modelOutputFailureCanDegrade(error)) {
+          throw error;
+        }
+        console.warn('[vh:storycluster] cross_encoder_rerank output degraded to prior scores', {
+          chunkIndex,
+          pairCount: chunk.length,
+          reason: redactOpenAIProviderMessage(error instanceof Error ? error.message : error),
+        });
+        return [];
+      }
+    });
   }
 
   private async captureRerankParseFailure(
@@ -509,8 +630,9 @@ export class OpenAIStoryClusterProvider implements StoryClusterModelProvider {
       return [];
     }
     const chunks = chunkBySize(items, 8);
-    return collectChunksWithConcurrency(chunks, (chunk) =>
-      collectWithRetry<PairJudgementWorkItem, PairJudgementWorkResult>(
+    return collectChunksWithConcurrency(chunks, async (chunk, chunkIndex) => {
+      try {
+        return await collectWithRetry<PairJudgementWorkItem, PairJudgementWorkResult>(
         chunk,
         async (pending) => {
           const { sanitized, stats } = sanitizePairJudgementWorkItems(pending);
@@ -536,20 +658,27 @@ export class OpenAIStoryClusterProvider implements StoryClusterModelProvider {
             throw error;
           }
           return (response.judgements ?? []).map((item) => ({
-            pair_id: item.pair_id,
-            score: clampScore(item.score),
-            decision: judgementDecision(item.decision),
+          pair_id: item.pair_id,
+          score: clampScore(item.score),
+          decision: judgementDecision(item.decision),
           }));
         },
         (item) => item.pair_id,
         (item) => item.pair_id,
-        (item) => ({
-          pair_id: item.pair_id,
-          score: 0,
-          decision: 'abstain' as const,
-        }),
-      ),
-    );
+        () => null,
+        );
+      } catch (error) {
+        if (!modelOutputFailureCanDegrade(error)) {
+          throw error;
+        }
+        console.warn('[vh:storycluster] adjudication output degraded to prior gate state', {
+          chunkIndex,
+          pairCount: chunk.length,
+          reason: redactOpenAIProviderMessage(error instanceof Error ? error.message : error),
+        });
+        return [];
+      }
+    });
   }
   async summarize(items: SummaryWorkItem[]): Promise<SummaryWorkResult[]> {
     if (items.length === 0) {

--- a/services/storycluster-engine/src/remoteContract.ts
+++ b/services/storycluster-engine/src/remoteContract.ts
@@ -111,9 +111,20 @@ export interface StoryClusterRemoteResponse {
   telemetry: StoryClusterTelemetryEnvelope;
 }
 
+export class StoryClusterRemoteRequestValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'StoryClusterRemoteRequestValidationError';
+  }
+}
+
+function requestValidationError(message: string): StoryClusterRemoteRequestValidationError {
+  return new StoryClusterRemoteRequestValidationError(message);
+}
+
 function asRecord(value: unknown, message: string): Record<string, unknown> {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    throw new Error(message);
+    throw requestValidationError(message);
   }
   return value as Record<string, unknown>;
 }
@@ -121,7 +132,7 @@ function asRecord(value: unknown, message: string): Record<string, unknown> {
 function readRequiredString(record: Record<string, unknown>, key: string, path: string): string {
   const value = record[key];
   if (typeof value !== 'string' || !value.trim()) {
-    throw new Error(`${path}.${key} must be a non-empty string`);
+    throw requestValidationError(`${path}.${key} must be a non-empty string`);
   }
   return value.trim();
 }
@@ -137,7 +148,7 @@ function readOptionalNumber(record: Record<string, unknown>, key: string, path: 
     return undefined;
   }
   if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
-    throw new Error(`${path}.${key} must be a non-negative finite number when provided`);
+    throw requestValidationError(`${path}.${key} must be a non-negative finite number when provided`);
   }
   return Math.floor(value);
 }
@@ -145,11 +156,11 @@ function readOptionalNumber(record: Record<string, unknown>, key: string, path: 
 function readEntityKeys(record: Record<string, unknown>, path: string): string[] {
   const value = record.entity_keys;
   if (!Array.isArray(value)) {
-    throw new Error(`${path}.entity_keys must be an array`);
+    throw requestValidationError(`${path}.entity_keys must be an array`);
   }
   return value.map((entry, index) => {
     if (typeof entry !== 'string') {
-      throw new Error(`${path}.entity_keys[${index}] must be a string`);
+      throw requestValidationError(`${path}.entity_keys[${index}] must be a string`);
     }
     return entry.trim().toLowerCase();
   }).filter(Boolean);
@@ -166,7 +177,7 @@ function readCoverageRole(
   if (value === 'canonical' || value === 'related') {
     return value;
   }
-  throw new Error(`${path}.coverage_role must be canonical or related when provided`);
+  throw requestValidationError(`${path}.coverage_role must be canonical or related when provided`);
 }
 
 function normalizeRequest(payload: unknown, nowMs: number): StoryClusterRemoteRequest & { reference_now_ms: number } {
@@ -174,7 +185,7 @@ function normalizeRequest(payload: unknown, nowMs: number): StoryClusterRemoteRe
   const topicId = readRequiredString(record, 'topic_id', 'payload');
   const rawItems = record.items;
   if (!Array.isArray(rawItems)) {
-    throw new Error('payload.items must be an array');
+    throw requestValidationError('payload.items must be an array');
   }
 
   const items = rawItems.map((rawItem, index) => {

--- a/services/storycluster-engine/src/server.test.ts
+++ b/services/storycluster-engine/src/server.test.ts
@@ -370,6 +370,52 @@ describe('storycluster server', () => {
     expect(serverInternal.isAuthorized({ headers: {} } as never, {})).toBe(true);
   });
 
+  it('maps internal stage failures to 5xx while preserving malformed payload 400s', async () => {
+    const failingVectorBackend: ClusterVectorBackend = {
+      async queryTopic() {
+        return new Map();
+      },
+      async readiness() {
+        return { ok: true, detail: 'test-vector-ready' };
+      },
+      async replaceTopicClusters() {
+        throw new Error('synthetic vector stage failure');
+      },
+    };
+
+    await withServer({ vectorBackend: failingVectorBackend }, async (baseUrl) => {
+      const response = await fetch(`${baseUrl}/cluster`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          topic_id: 'topic-stage-failure',
+          items: [
+            {
+              sourceId: 'wire-a',
+              publisher: 'Wire A',
+              url: 'https://example.com/a',
+              canonicalUrl: 'https://example.com/a',
+              title: 'Breaking: Port attack triggers alerts',
+              publishedAt: 1_710_000_000_000,
+              summary: 'Authorities respond in the first hour',
+              url_hash: 'hash-a',
+              language: 'en',
+              translation_applied: false,
+              entity_keys: ['port', 'alerts'],
+            },
+          ],
+        }),
+      });
+
+      expect(response.status).toBe(503);
+      await expect(response.json()).resolves.toEqual({
+        error: 'storycluster stage qdrant_candidate_retrieval failed: synthetic vector stage failure',
+      });
+    });
+  });
+
   it('covers direct invalid-url/default-method/error-payload handling and start helper', async () => {
     const makeResponse = () => {
       const responseState: {

--- a/services/storycluster-engine/src/server.ts
+++ b/services/storycluster-engine/src/server.ts
@@ -2,7 +2,7 @@ import { createServer, type IncomingMessage, type ServerResponse } from 'node:ht
 import { StoryClusterStageError } from './contracts';
 import { getDefaultClusterStore, type ClusterStore } from './clusterStore';
 import { STORYCLUSTER_STAGE_SEQUENCE } from './contracts';
-import { runStoryClusterRemoteContract } from './remoteContract';
+import { StoryClusterRemoteRequestValidationError, runStoryClusterRemoteContract } from './remoteContract';
 import { type ClusterVectorBackend, resolveVectorBackend } from './vectorBackend';
 
 const DEFAULT_HOST = '127.0.0.1';
@@ -189,21 +189,37 @@ async function handleRequest(
     return;
   }
 
+  const store = options.store ?? getDefaultClusterStore();
+  const vectorBackend = resolveVectorBackend(options.vectorBackend);
+  const readiness = await runtimeReadiness(store, vectorBackend);
+  if (!readiness.ok) {
+    traceLog('cluster_request_rejected', {
+      request_id: requestId,
+      method,
+      path: parsed.pathname,
+      reason: readiness.detail,
+    });
+    sendJson(res, 503, { error: readiness.detail });
+    return;
+  }
+
+  let payload: unknown;
   try {
-    const store = options.store ?? getDefaultClusterStore();
-    const vectorBackend = resolveVectorBackend(options.vectorBackend);
-    const readiness = await runtimeReadiness(store, vectorBackend);
-    if (!readiness.ok) {
-      traceLog('cluster_request_rejected', {
-        request_id: requestId,
-        method,
-        path: parsed.pathname,
-        reason: readiness.detail,
-      });
-      sendJson(res, 503, { error: readiness.detail });
-      return;
-    }
-    const payload = await readJsonBody(req);
+    payload = await readJsonBody(req);
+  } catch (error) {
+    traceLog('cluster_request_rejected', {
+      request_id: requestId,
+      method,
+      path: parsed.pathname,
+      reason: error instanceof Error ? error.message : String(error),
+    });
+    sendJson(res, 400, {
+      error: error instanceof Error ? error.message : 'Invalid storycluster request payload',
+    });
+    return;
+  }
+
+  try {
     const topicId = typeof (payload as { topic_id?: unknown })?.topic_id === 'string'
       ? (payload as { topic_id: string }).topic_id
       : null;
@@ -243,7 +259,8 @@ async function handleRequest(
       error: error instanceof Error ? error.message : String(error),
       failed_stage: error instanceof StoryClusterStageError ? error.stageId : null,
     });
-    sendJson(res, 400, {
+    const statusCode = error instanceof StoryClusterRemoteRequestValidationError ? 400 : 503;
+    sendJson(res, statusCode, {
       error: error instanceof Error ? error.message : 'Invalid storycluster request payload',
     });
   }


### PR DESCRIPTION
## Summary
- Add strict `json_schema` support for OpenAI chat JSON calls and use a fixed-key rerank response shape: `{ "reranks": { "<pairId>": number } }`.
- Treat `finish_reason=length` as a typed truncation error with bounded response diagnostics.
- Degrade recoverable rerank/adjudication model-output failures to omit/no-op so prior deterministic gate state is preserved, while critical provider/config/HTTP failures still rethrow.
- Split malformed StoryCluster client payloads (`400`) from internal stage/model failures (`503`).

## Root Cause
`cross_encoder_rerank` could overproduce array rows until `finish_reason=length`, leaving malformed JSON. The old fallback path could also fabricate `score: 0` for missing reranks, which made a recoverable model-output failure feed gate-changing scores.

## Validation
- `CI=true corepack pnpm --filter @vh/storycluster-engine exec vitest run src/openaiClient.test.ts src/openaiProvider.test.ts src/clusterJudgement.test.ts src/clusterLifecycle.test.ts src/server.test.ts --config ./vitest.config.ts`
- `CI=true corepack pnpm --filter @vh/storycluster-engine exec vitest run src/vectorBackend.test.ts src/server.test.ts src/stageRunner.pipeline.test.ts src/coherenceAudit.test.ts src/storyclusterQualityGate.test.ts --config ./vitest.config.ts --reporter=verbose`
- `CI=true corepack pnpm --filter @vh/storycluster-engine build`
- `git diff --check`
- `node tools/scripts/check-diff-coverage.mjs`
- `CI=true corepack pnpm test:quick` (`319` files, `4,940` tests passed)

Note: the repo pins `pnpm@9.7.1`; the shell `pnpm` resolved to incompatible v11 in this environment, so validation used `corepack pnpm`.