### PR TITLE
[codex] Add relay graph diagnostics metrics

### DIFF
--- a/docs/ops/public-beta-image-deploy.md
+++ b/docs/ops/public-beta-image-deploy.md
@@ -75,6 +75,21 @@ re-enable monitors.
   `VH_RELAY_RADATA_BYTES_SCAN_TIMEOUT_MS`. During soak, scrape the companion
   refresh age/error/truncation counters; a metrics scrape must not recursively
   walk the radata tree.
+- Treat Gun graph metrics as opt-in diagnostics, not release blockers.
+  `VH_RELAY_GUN_GRAPH_SCAN_ENABLED=false` by default. When enabled for an
+  attended memory soak, the relay scans `gun._.graph` only from a background
+  task and `/metrics` reads the cached result. Bound the scan with
+  `VH_RELAY_GUN_GRAPH_SCAN_INTERVAL_MS` (default 60s),
+  `VH_RELAY_GUN_GRAPH_SCAN_BATCH_SIZE` (default 1000),
+  `VH_RELAY_GUN_GRAPH_SCAN_MAX_SOULS` (default 250000), and
+  `VH_RELAY_GUN_GRAPH_SCAN_MAX_DURATION_MS` (default 5000). The shareable
+  metric families report namespace/state counts and byte totals only:
+  `vh_relay_gun_graph_souls_total`,
+  `vh_relay_gun_graph_user_fields_total`, and
+  `vh_relay_gun_graph_user_value_bytes`, plus scan age/duration/truncation and
+  success/error counters. They must not be used as hard rollout blockers until
+  a separate soak proves the signal. Missing or truncated graph scans mean the
+  heap driver remains unknown.
 - Leave relay `GUN_STATS` unset or explicitly `false`. The relay disables GUN's
   package-local stats writer by default; setting `GUN_STATS=true` makes GUN
   write `stats.<basename(GUN_FILE)>` beside `node_modules/gun`, which is not a

--- a/infra/relay/server.js
+++ b/infra/relay/server.js
@@ -206,6 +206,11 @@ const radataBytesRefreshIntervalMs = nonNegativeNumberEnv(
 const radataBytesScanMaxEntries = numberEnv('VH_RELAY_RADATA_BYTES_SCAN_MAX_ENTRIES', 50_000);
 const radataBytesScanMaxDepth = numberEnv('VH_RELAY_RADATA_BYTES_SCAN_MAX_DEPTH', 32);
 const radataBytesScanTimeoutMs = numberEnv('VH_RELAY_RADATA_BYTES_SCAN_TIMEOUT_MS', 5_000);
+const gunGraphScanEnabled = boolEnv('VH_RELAY_GUN_GRAPH_SCAN_ENABLED', false);
+const gunGraphScanIntervalMs = nonNegativeNumberEnv('VH_RELAY_GUN_GRAPH_SCAN_INTERVAL_MS', 60_000);
+const gunGraphScanBatchSize = numberEnv('VH_RELAY_GUN_GRAPH_SCAN_BATCH_SIZE', 1_000);
+const gunGraphScanMaxSouls = numberEnv('VH_RELAY_GUN_GRAPH_SCAN_MAX_SOULS', 250_000);
+const gunGraphScanMaxDurationMs = numberEnv('VH_RELAY_GUN_GRAPH_SCAN_MAX_DURATION_MS', 5_000);
 const relayPeerAuthModes = new Set(['none', 'private_network_allowlist', 'peer_bearer_token']);
 const relayPeerAuthMode = String(process.env.VH_RELAY_PEER_AUTH_MODE || 'none').trim() || 'none';
 if (!relayPeerAuthModes.has(relayPeerAuthMode)) {
@@ -248,6 +253,9 @@ const metrics = {
   radataBytesRefreshSuccesses: 0,
   radataBytesRefreshErrors: 0,
   radataBytesRefreshTruncated: 0,
+  gunGraphScanSuccesses: 0,
+  gunGraphScanErrors: 0,
+  gunGraphScanTruncated: 0,
 };
 const eventLoopDelay = monitorEventLoopDelay({ resolution: 20 });
 eventLoopDelay.enable();
@@ -408,6 +416,26 @@ const radataBytesCache = {
   scannedEntries: 0,
   truncated: false,
   lastError: '',
+};
+let gunGraphScanInFlight = false;
+const GUN_GRAPH_NAMESPACES = Object.freeze([
+  'news_story',
+  'news_latest_index',
+  'news_hot_index',
+  'news_lifecycle',
+  'topic_synthesis',
+  'aggregate',
+  'forum',
+  'other',
+]);
+const GUN_GRAPH_STATES = Object.freeze(['live', 'tombstoned', 'link_only', 'unknown']);
+const gunGraphScanCache = {
+  refreshedAt: 0,
+  durationMs: 0,
+  scannedSouls: 0,
+  truncated: false,
+  lastError: '',
+  buckets: new Map(),
 };
 
 function criticalWriteReadbacksAreActive() {
@@ -951,6 +979,193 @@ function startRadataBytesRefresh() {
   interval.unref?.();
 }
 
+function gunGraphNamespaceForSoul(soul) {
+  const normalized = typeof soul === 'string' ? soul.replace(/\/+$/, '') : '';
+  if (!normalized) return 'other';
+  if (normalized === 'vh/news/index/latest' || normalized.startsWith('vh/news/index/latest/')) {
+    return 'news_latest_index';
+  }
+  if (normalized === 'vh/news/index/hot' || normalized.startsWith('vh/news/index/hot/')) {
+    return 'news_hot_index';
+  }
+  if (normalized.includes('/synthesis_lifecycle')) {
+    return 'news_lifecycle';
+  }
+  if (normalized === 'vh/news/stories' || normalized.startsWith('vh/news/stories/')) {
+    return 'news_story';
+  }
+  if (normalized === 'vh/topics' || normalized.startsWith('vh/topics/')) {
+    return 'topic_synthesis';
+  }
+  if (normalized === 'vh/aggregates' || normalized.startsWith('vh/aggregates/')) {
+    return 'aggregate';
+  }
+  if (normalized === 'vh/forum' || normalized.startsWith('vh/forum/')) {
+    return 'forum';
+  }
+  return 'other';
+}
+
+function isGunLinkValue(value) {
+  if (!isPlainRecord(value)) return false;
+  const keys = Object.keys(value);
+  return keys.length === 1 && keys[0] === '#' && typeof value['#'] === 'string';
+}
+
+function emptyGunGraphBuckets() {
+  const buckets = new Map();
+  for (const namespace of GUN_GRAPH_NAMESPACES) {
+    for (const state of GUN_GRAPH_STATES) {
+      buckets.set(`${namespace}\t${state}`, {
+        namespace,
+        state,
+        souls: 0,
+        userFields: 0,
+        userValueBytes: 0,
+      });
+    }
+  }
+  return buckets;
+}
+
+function addGunGraphBucket(buckets, { namespace, state, userFields, userValueBytes }) {
+  const safeNamespace = GUN_GRAPH_NAMESPACES.includes(namespace) ? namespace : 'other';
+  const safeState = GUN_GRAPH_STATES.includes(state) ? state : 'unknown';
+  const key = `${safeNamespace}\t${safeState}`;
+  const bucket = buckets.get(key) ?? {
+    namespace: safeNamespace,
+    state: safeState,
+    souls: 0,
+    userFields: 0,
+    userValueBytes: 0,
+  };
+  bucket.souls += 1;
+  bucket.userFields += Math.max(0, userFields || 0);
+  bucket.userValueBytes += Math.max(0, userValueBytes || 0);
+  buckets.set(key, bucket);
+}
+
+function summarizeGunGraphNode(soul, node) {
+  const namespace = gunGraphNamespaceForSoul(soul);
+  if (!isPlainRecord(node)) {
+    return { namespace, state: 'unknown', userFields: 0, userValueBytes: 0 };
+  }
+
+  let linkFields = 0;
+  let userFields = 0;
+  let nonNullUserFields = 0;
+  let nullUserFields = 0;
+  let userValueBytes = 0;
+
+  for (const field in node) {
+    if (!Object.prototype.hasOwnProperty.call(node, field) || field === '_') continue;
+    const value = node[field];
+    if (isGunLinkValue(value)) {
+      linkFields += 1;
+      continue;
+    }
+    userFields += 1;
+    if (value === null) {
+      nullUserFields += 1;
+    } else {
+      nonNullUserFields += 1;
+      userValueBytes += approximateJsonBytes(value);
+    }
+  }
+
+  if (userFields > 0 && nonNullUserFields > 0) {
+    return { namespace, state: 'live', userFields, userValueBytes };
+  }
+  if (userFields > 0 && nullUserFields === userFields) {
+    return { namespace, state: 'tombstoned', userFields, userValueBytes };
+  }
+  if (userFields === 0 && linkFields > 0) {
+    return { namespace, state: 'link_only', userFields, userValueBytes };
+  }
+  return { namespace, state: 'unknown', userFields, userValueBytes };
+}
+
+async function scanGunGraph(gunInstance) {
+  const startedAt = Date.now();
+  const graph = gunInstance?._?.graph;
+  const buckets = emptyGunGraphBuckets();
+  if (!isPlainRecord(graph)) {
+    return { scanned_souls: 0, truncated: false, buckets };
+  }
+
+  let scannedSouls = 0;
+  let truncated = false;
+  for (const soul in graph) {
+    if (!Object.prototype.hasOwnProperty.call(graph, soul)) continue;
+    if (scannedSouls >= gunGraphScanMaxSouls) {
+      truncated = true;
+      break;
+    }
+    if (Date.now() - startedAt > gunGraphScanMaxDurationMs) {
+      truncated = true;
+      break;
+    }
+    scannedSouls += 1;
+    addGunGraphBucket(buckets, summarizeGunGraphNode(soul, graph[soul]));
+    if (scannedSouls % gunGraphScanBatchSize === 0) {
+      await yieldToEventLoop();
+      if (Date.now() - startedAt > gunGraphScanMaxDurationMs) {
+        truncated = true;
+        break;
+      }
+    }
+  }
+  return { scanned_souls: scannedSouls, truncated, buckets };
+}
+
+async function refreshGunGraphScanCache(gunInstance, reason = 'interval') {
+  if (!gunGraphScanEnabled || gunGraphScanInFlight) return;
+  gunGraphScanInFlight = true;
+  const startedAt = Date.now();
+  try {
+    const result = await scanGunGraph(gunInstance);
+    gunGraphScanCache.refreshedAt = Date.now();
+    gunGraphScanCache.durationMs = gunGraphScanCache.refreshedAt - startedAt;
+    gunGraphScanCache.scannedSouls = result.scanned_souls;
+    gunGraphScanCache.truncated = result.truncated;
+    gunGraphScanCache.lastError = '';
+    gunGraphScanCache.buckets = result.buckets;
+    metrics.gunGraphScanSuccesses += 1;
+    if (result.truncated) {
+      metrics.gunGraphScanTruncated += 1;
+      logEvent('warn', 'gun_graph_scan_truncated', {
+        relay_id: relayId,
+        reason,
+        scanned_souls: result.scanned_souls,
+        max_souls: gunGraphScanMaxSouls,
+        max_duration_ms: gunGraphScanMaxDurationMs,
+      });
+    }
+  } catch (error) {
+    metrics.gunGraphScanErrors += 1;
+    gunGraphScanCache.lastError = error instanceof Error ? error.message : String(error);
+    logEvent('warn', 'gun_graph_scan_failed', {
+      relay_id: relayId,
+      reason,
+      error: gunGraphScanCache.lastError,
+    });
+  } finally {
+    gunGraphScanInFlight = false;
+  }
+}
+
+function startGunGraphScan(gunInstance) {
+  if (!gunGraphScanEnabled) return;
+  setTimeout(() => {
+    void refreshGunGraphScanCache(gunInstance, 'startup');
+  }, 0).unref?.();
+  if (gunGraphScanIntervalMs <= 0) return;
+  const interval = setInterval(() => {
+    void refreshGunGraphScanCache(gunInstance, 'interval');
+  }, gunGraphScanIntervalMs);
+  interval.unref?.();
+}
+
 function openFileDescriptorCount() {
   for (const fdDir of ['/proc/self/fd', '/dev/fd']) {
     try {
@@ -997,6 +1212,22 @@ function metricsText() {
   add('vh_relay_radata_bytes_refresh_successes_total', metrics.radataBytesRefreshSuccesses);
   add('vh_relay_radata_bytes_refresh_errors_total', metrics.radataBytesRefreshErrors);
   add('vh_relay_radata_bytes_refresh_truncated_total', metrics.radataBytesRefreshTruncated);
+  add('vh_relay_gun_graph_scan_enabled', gunGraphScanEnabled ? 1 : 0);
+  add('vh_relay_gun_graph_scan_running', gunGraphScanInFlight ? 1 : 0);
+  add('vh_relay_gun_graph_scan_successes_total', metrics.gunGraphScanSuccesses);
+  add('vh_relay_gun_graph_scan_errors_total', metrics.gunGraphScanErrors);
+  add('vh_relay_gun_graph_scan_truncated', gunGraphScanCache.truncated ? 1 : 0);
+  add('vh_relay_gun_graph_scan_truncated_total', metrics.gunGraphScanTruncated);
+  add('vh_relay_gun_graph_scan_duration_ms', gunGraphScanCache.durationMs);
+  add('vh_relay_gun_graph_scan_age_ms', gunGraphScanCache.refreshedAt > 0 ? Date.now() - gunGraphScanCache.refreshedAt : -1);
+  add('vh_relay_gun_graph_scan_scanned_souls', gunGraphScanCache.scannedSouls);
+  for (const bucket of [...gunGraphScanCache.buckets.values()]
+    .sort((left, right) => `${left.namespace}\t${left.state}`.localeCompare(`${right.namespace}\t${right.state}`))) {
+    const labels = { namespace: bucket.namespace, state: bucket.state };
+    add('vh_relay_gun_graph_souls_total', bucket.souls, labels);
+    add('vh_relay_gun_graph_user_fields_total', bucket.userFields, labels);
+    add('vh_relay_gun_graph_user_value_bytes', bucket.userValueBytes, labels);
+  }
   const memory = process.memoryUsage();
   const openFds = openFileDescriptorCount();
   add('vh_relay_process_rss_bytes', memory.rss);
@@ -1157,6 +1388,11 @@ function relayDiagnosticSnapshot(reason, details = {}) {
       watchdog_max_heap_growth_bytes: relayWatchdogMaxHeapGrowthBytes,
       watchdog_heap_snapshot_enabled: relayWatchdogHeapSnapshotEnabled,
       diagnostic_dir: relayWatchdogDiagnosticDir,
+      gun_graph_scan_enabled: gunGraphScanEnabled,
+      gun_graph_scan_interval_ms: gunGraphScanIntervalMs,
+      gun_graph_scan_batch_size: gunGraphScanBatchSize,
+      gun_graph_scan_max_souls: gunGraphScanMaxSouls,
+      gun_graph_scan_max_duration_ms: gunGraphScanMaxDurationMs,
     },
   };
 }
@@ -6015,6 +6251,7 @@ server.prependListener('upgrade', (req, socket) => {
 installFatalCaptureHandlers();
 startRelayResourceWatchdog();
 startRadataBytesRefresh();
+startGunGraphScan(gun);
 
 function listen() {
   server.listen(port, host, () => {

--- a/packages/e2e/src/live/relay-server.vitest.mjs
+++ b/packages/e2e/src/live/relay-server.vitest.mjs
@@ -184,6 +184,19 @@ async function waitForOutput(child, pattern, timeoutMs = 10_000) {
   throw new Error(`timed out waiting for output ${pattern}`);
 }
 
+async function waitForMetrics(port, predicate, timeoutMs = 5_000) {
+  const start = Date.now();
+  let latest = null;
+  while (Date.now() - start < timeoutMs) {
+    latest = await fetchText(`http://127.0.0.1:${port}/metrics`);
+    if (latest.statusCode === 200 && predicate(latest.body)) {
+      return latest;
+    }
+    await delay(50);
+  }
+  throw new Error(`timed out waiting for metrics predicate. latest=${latest?.body ?? '<none>'}`);
+}
+
 async function waitForExit(child, timeoutMs = 10_000) {
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
@@ -477,6 +490,8 @@ describe('infra relay server', () => {
     expect(metrics.body).toContain('vh_relay_http_requests_total');
     expect(metrics.body).toContain('vh_relay_active_connections');
     expect(metrics.body).toContain('vh_relay_radata_bytes');
+    expect(metrics.body).toContain('vh_relay_gun_graph_scan_enabled 0');
+    expect(metrics.body).toContain('vh_relay_gun_graph_scan_successes_total 0');
     expect(metrics.body).toMatch(/vh_relay_process_open_fds \d+/);
   });
 
@@ -499,6 +514,43 @@ describe('infra relay server', () => {
     expect(metrics.body).toContain('vh_relay_radata_bytes 0');
     expect(metrics.body).toContain('vh_relay_radata_bytes_refresh_enabled 0');
     expect(metrics.body).toContain('vh_relay_radata_bytes_refresh_successes_total 0');
+  });
+
+  it('serves opt-in Gun graph metrics from a cached background scan without leaking values', async () => {
+    const { port } = await startRelay(children, tempDirs, {
+      GUN_RADISK: 'false',
+      VH_RELAY_GUN_GRAPH_SCAN_ENABLED: 'true',
+      VH_RELAY_GUN_GRAPH_SCAN_INTERVAL_MS: '50',
+      VH_RELAY_GUN_GRAPH_SCAN_BATCH_SIZE: '2',
+      VH_RELAY_GUN_GRAPH_SCAN_MAX_DURATION_MS: '5000',
+    });
+    const privateTitle = `graph metrics private title ${Date.now()}`;
+
+    await expect(requestJson(`http://127.0.0.1:${port}/vh/forum/thread`, {
+      method: 'POST',
+      body: {
+        thread: {
+          id: 'graph-metrics-thread',
+          title: privateTitle,
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        },
+      },
+    })).resolves.toMatchObject({
+      statusCode: 200,
+      body: expect.objectContaining({ ok: true, thread_id: 'graph-metrics-thread' }),
+    });
+
+    const metrics = await waitForMetrics(port, (body) =>
+      /vh_relay_gun_graph_scan_successes_total [1-9]\d*/.test(body)
+      && /vh_relay_gun_graph_souls_total\{namespace="forum",state="live"\} [1-9]\d*/.test(body)
+      && /vh_relay_gun_graph_user_value_bytes\{namespace="forum",state="live"\} [1-9]\d*/.test(body));
+
+    expect(metrics.body).toContain('vh_relay_gun_graph_scan_enabled 1');
+    expect(metrics.body).toContain('vh_relay_gun_graph_scan_truncated 0');
+    expect(metrics.body).toMatch(/vh_relay_gun_graph_scan_duration_ms \d+/);
+    expect(metrics.body).toMatch(/vh_relay_gun_graph_scan_age_ms -?\d+/);
+    expect(metrics.body).not.toContain(privateTitle);
   });
 
   it('keeps GUN package stats file writes disabled by default', async () => {

--- a/tools/scripts/news-relay-liveness-watch.mjs
+++ b/tools/scripts/news-relay-liveness-watch.mjs
@@ -150,6 +150,33 @@ function parseMetricValue(text, metricName, labels = null) {
   return rows;
 }
 
+function parseMetricLabels(labelText) {
+  const labels = {};
+  const trimmed = String(labelText ?? '').trim();
+  if (!trimmed) return labels;
+  const body = trimmed.startsWith('{') && trimmed.endsWith('}') ? trimmed.slice(1, -1) : trimmed;
+  const labelPattern = /([A-Za-z_][A-Za-z0-9_]*)="((?:\\.|[^"\\])*)"/g;
+  let match = labelPattern.exec(body);
+  while (match) {
+    labels[match[1]] = match[2].replace(/\\"/g, '"').replace(/\\\\/g, '\\');
+    match = labelPattern.exec(body);
+  }
+  return labels;
+}
+
+function parseMetricRows(text, metricName) {
+  const rows = [];
+  for (const line of String(text ?? '').split('\n')) {
+    if (!line || line.startsWith('#')) continue;
+    const match = line.match(/^([A-Za-z_:][A-Za-z0-9_:]*)(\{[^}]*\})?\s+(-?(?:\d+|\d*\.\d+)(?:e[+-]?\d+)?)$/i);
+    if (!match || match[1] !== metricName) continue;
+    const value = Number(match[3]);
+    if (!Number.isFinite(value)) continue;
+    rows.push({ labels: parseMetricLabels(match[2]), value });
+  }
+  return rows;
+}
+
 function metricNumber(text, metricName, fallback = null) {
   const rows = parseMetricValue(text, metricName);
   return rows.length > 0 && Number.isFinite(rows[0]) ? rows[0] : fallback;
@@ -157,6 +184,76 @@ function metricNumber(text, metricName, fallback = null) {
 
 function metricSum(text, metricName) {
   return parseMetricValue(text, metricName).reduce((sum, value) => sum + (Number.isFinite(value) ? value : 0), 0);
+}
+
+function parseGunGraphMetrics(text) {
+  const successes = metricNumber(text, 'vh_relay_gun_graph_scan_successes_total');
+  const enabled = metricNumber(text, 'vh_relay_gun_graph_scan_enabled');
+  if (successes === null && enabled === null) return null;
+
+  const buckets = new Map();
+  const ensureBucket = (namespace, state) => {
+    const key = `${namespace}\t${state}`;
+    const bucket = buckets.get(key) ?? {
+      namespace,
+      state,
+      souls: 0,
+      userFields: 0,
+      userValueBytes: 0,
+    };
+    buckets.set(key, bucket);
+    return bucket;
+  };
+
+  for (const row of parseMetricRows(text, 'vh_relay_gun_graph_souls_total')) {
+    const namespace = String(row.labels.namespace ?? '').trim();
+    const state = String(row.labels.state ?? '').trim();
+    if (!namespace || !state) continue;
+    ensureBucket(namespace, state).souls = row.value;
+  }
+  for (const row of parseMetricRows(text, 'vh_relay_gun_graph_user_fields_total')) {
+    const namespace = String(row.labels.namespace ?? '').trim();
+    const state = String(row.labels.state ?? '').trim();
+    if (!namespace || !state) continue;
+    ensureBucket(namespace, state).userFields = row.value;
+  }
+  for (const row of parseMetricRows(text, 'vh_relay_gun_graph_user_value_bytes')) {
+    const namespace = String(row.labels.namespace ?? '').trim();
+    const state = String(row.labels.state ?? '').trim();
+    if (!namespace || !state) continue;
+    ensureBucket(namespace, state).userValueBytes = row.value;
+  }
+
+  const bucketList = [...buckets.values()]
+    .sort((left, right) => `${left.namespace}\t${left.state}`.localeCompare(`${right.namespace}\t${right.state}`));
+  const namespaceLiveUserValueBytes = {};
+  for (const bucket of bucketList) {
+    if (bucket.state === 'live') {
+      namespaceLiveUserValueBytes[bucket.namespace] = (namespaceLiveUserValueBytes[bucket.namespace] ?? 0)
+        + bucket.userValueBytes;
+    }
+  }
+
+  return {
+    enabled: enabled === null ? null : enabled > 0,
+    running: metricNumber(text, 'vh_relay_gun_graph_scan_running', 0) > 0,
+    successes: successes ?? 0,
+    errors: metricNumber(text, 'vh_relay_gun_graph_scan_errors_total', 0),
+    truncated: metricNumber(text, 'vh_relay_gun_graph_scan_truncated') === 1,
+    truncatedTotal: metricNumber(text, 'vh_relay_gun_graph_scan_truncated_total', 0),
+    durationMs: metricNumber(text, 'vh_relay_gun_graph_scan_duration_ms'),
+    ageMs: metricNumber(text, 'vh_relay_gun_graph_scan_age_ms'),
+    scannedSouls: metricNumber(text, 'vh_relay_gun_graph_scan_scanned_souls'),
+    totalSouls: bucketList.reduce((sum, bucket) => sum + bucket.souls, 0),
+    liveUserValueBytes: bucketList
+      .filter((bucket) => bucket.state === 'live')
+      .reduce((sum, bucket) => sum + bucket.userValueBytes, 0),
+    tombstonedSouls: bucketList
+      .filter((bucket) => bucket.state === 'tombstoned')
+      .reduce((sum, bucket) => sum + bucket.souls, 0),
+    namespaceLiveUserValueBytes,
+    buckets: bucketList,
+  };
 }
 
 async function inspectRelay(target, {
@@ -213,6 +310,7 @@ async function inspectRelay(target, {
       criticalReadbacksActive: metricNumber(text, 'vh_relay_critical_write_readbacks_active', 0),
       criticalReadbacksQueued: metricNumber(text, 'vh_relay_critical_write_readbacks_queued', 0),
       watchdogTrips,
+      graphScan: parseGunGraphMetrics(text),
     };
     if (metrics.rssBytes !== null && metrics.rssBytes > limits.rssLimitBytes) blockers.push(`rss_hot:${metrics.rssBytes}/${limits.rssLimitBytes}`);
     if (metrics.heapUsedBytes !== null && metrics.heapUsedBytes > limits.heapLimitBytes) blockers.push(`heap_hot:${metrics.heapUsedBytes}/${limits.heapLimitBytes}`);
@@ -403,6 +501,7 @@ async function main() {
 export const newsRelayLivenessWatchInternal = {
   REPORT_SCHEMA_VERSION,
   STATE_SCHEMA_VERSION,
+  parseGunGraphMetrics,
   parseMetricValue,
   parseTargets,
   relayRestartEligibleBlockers,

--- a/tools/scripts/news-relay-liveness-watch.test.mjs
+++ b/tools/scripts/news-relay-liveness-watch.test.mjs
@@ -34,8 +34,10 @@ function metrics({
   lagP99 = 25,
   queued = 0,
   watchdogTrips = 0,
+  graph = false,
+  graphTruncated = 0,
 } = {}) {
-  return [
+  const rows = [
     `vh_relay_process_rss_bytes ${rss}`,
     `vh_relay_process_heap_used_bytes ${heap}`,
     `vh_relay_event_loop_lag_p99_ms ${lagP99}`,
@@ -43,8 +45,34 @@ function metrics({
     'vh_relay_critical_write_readbacks_active 0',
     `vh_relay_critical_write_readbacks_queued ${queued}`,
     `vh_relay_resource_watchdog_trips_total{reason="rss_bytes"} ${watchdogTrips}`,
-    '',
-  ].join('\n');
+  ];
+  if (graph) {
+    rows.push(
+      'vh_relay_gun_graph_scan_enabled 1',
+      'vh_relay_gun_graph_scan_running 0',
+      'vh_relay_gun_graph_scan_successes_total 3',
+      'vh_relay_gun_graph_scan_errors_total 0',
+      `vh_relay_gun_graph_scan_truncated ${graphTruncated}`,
+      `vh_relay_gun_graph_scan_truncated_total ${graphTruncated}`,
+      'vh_relay_gun_graph_scan_duration_ms 42',
+      'vh_relay_gun_graph_scan_age_ms 1000',
+      'vh_relay_gun_graph_scan_scanned_souls 19',
+      'vh_relay_gun_graph_souls_total{namespace="news_story",state="live"} 10',
+      'vh_relay_gun_graph_souls_total{namespace="news_story",state="tombstoned"} 2',
+      'vh_relay_gun_graph_user_fields_total{namespace="news_story",state="live"} 80',
+      'vh_relay_gun_graph_user_fields_total{namespace="news_story",state="tombstoned"} 14',
+      'vh_relay_gun_graph_user_value_bytes{namespace="news_story",state="live"} 12000',
+      'vh_relay_gun_graph_user_value_bytes{namespace="news_story",state="tombstoned"} 0',
+      'vh_relay_gun_graph_souls_total{namespace="news_latest_index",state="live"} 4',
+      'vh_relay_gun_graph_user_fields_total{namespace="news_latest_index",state="live"} 20',
+      'vh_relay_gun_graph_user_value_bytes{namespace="news_latest_index",state="live"} 3000',
+      'vh_relay_gun_graph_souls_total{namespace="other",state="link_only"} 3',
+      'vh_relay_gun_graph_user_fields_total{namespace="other",state="link_only"} 0',
+      'vh_relay_gun_graph_user_value_bytes{namespace="other",state="link_only"} 0',
+    );
+  }
+  rows.push('');
+  return rows.join('\n');
 }
 
 function makeFetch(responses) {
@@ -98,6 +126,36 @@ test('relay liveness passes for healthy readyz, metrics, and stable restart coun
 
     assert.equal(summary.status, 'pass');
     assert.equal(summary.relays.length, 2);
+  } finally {
+    rmSync(paths.root, { recursive: true, force: true });
+  }
+});
+
+test('relay liveness captures cached graph metrics without making them blockers', async () => {
+  const paths = makeTempState();
+  try {
+    const responses = new Map([
+      ['http://127.0.0.1:8765/readyz', JSON.stringify({ ok: true })],
+      ['http://127.0.0.1:8765/metrics', metrics({ graph: true, graphTruncated: 1 })],
+      ['http://127.0.0.1:8766/readyz', JSON.stringify({ ok: true })],
+      ['http://127.0.0.1:8766/metrics', metrics()],
+    ]);
+    const summary = await runNewsRelayLivenessWatch({
+      now: NOW,
+      env: baseEnv(paths),
+      fetchImpl: makeFetch(responses),
+      spawnSyncImpl: makeSpawn({ 'vhc-relay-a': 0, 'vhc-relay-b': 0 }),
+    });
+
+    assert.equal(summary.status, 'pass');
+    const graphScan = summary.relays[0].metrics.graphScan;
+    assert.equal(graphScan.enabled, true);
+    assert.equal(graphScan.truncated, true);
+    assert.equal(graphScan.totalSouls, 19);
+    assert.equal(graphScan.liveUserValueBytes, 15_000);
+    assert.equal(graphScan.tombstonedSouls, 2);
+    assert.equal(graphScan.namespaceLiveUserValueBytes.news_story, 12_000);
+    assert.equal(graphScan.namespaceLiveUserValueBytes.news_latest_index, 3_000);
   } finally {
     rmSync(paths.root, { recursive: true, force: true });
   }

--- a/tools/scripts/phase5-scope-a-watch-closure-packet.mjs
+++ b/tools/scripts/phase5-scope-a-watch-closure-packet.mjs
@@ -9,6 +9,7 @@ import { resolveRelayWatchdogLimits } from './relay-watchdog-thresholds.mjs';
 
 const SCHEMA_VERSION = 'vh-phase5-scope-a-watch-closure-v1';
 const DEFAULT_MIN_TREND_HORIZON_HOURS = 7 * 24;
+const DEFAULT_HEAP_PLATEAU_MAX_ABS_SLOPE_BYTES_PER_HOUR = 5 * 1024 * 1024;
 const CLAIM_BOUNDARY = Object.freeze({
   proves: [
     'raw Scope A publication health for the observed clean window',
@@ -215,6 +216,81 @@ function hoursUntilLimit(latestBytes, slopeBytesPerHour, limitBytes) {
   return (limitBytes - latestBytes) / slopeBytesPerHour;
 }
 
+function pointFirst(points) {
+  return points.length > 0 ? points[0].y : null;
+}
+
+function pointLatest(points) {
+  return points.length > 0 ? points.at(-1).y : null;
+}
+
+function summarizeNamespaceLiveBytes(namespacePoints) {
+  const summary = {};
+  for (const [namespace, points] of [...namespacePoints.entries()].sort()) {
+    summary[namespace] = {
+      firstBytes: pointFirst(points),
+      latestBytes: pointLatest(points),
+      slopeBytesPerHour: linearSlope(points),
+    };
+  }
+  return summary;
+}
+
+function relayHeapPlateauVerdict({
+  heapSlopeBytesPerHour,
+  rssSlopeBytesPerHour,
+  shortestProjectedLimitHours,
+  minTrendHorizonHours,
+  plateauMaxAbsSlopeBytesPerHour,
+  graphSampleCount,
+  graphMissingSampleCount,
+  graphTruncatedSampleCount,
+}) {
+  if (graphSampleCount <= 0 || graphMissingSampleCount > 0 || graphTruncatedSampleCount > 0) {
+    return {
+      verdict: 'heap_driver_unknown',
+      reason: graphTruncatedSampleCount > 0 ? 'graph_scan_truncated' : 'graph_scan_missing',
+      projectedLimitWindow: null,
+    };
+  }
+  const projectedLimitWindow = shortestProjectedLimitHours === null
+    ? null
+    : shortestProjectedLimitHours < 48
+      ? 'before_48h'
+      : shortestProjectedLimitHours < minTrendHorizonHours
+        ? `before_${minTrendHorizonHours}h`
+        : 'beyond_horizon';
+  const projectedHorizonSafe = shortestProjectedLimitHours === null
+    || shortestProjectedLimitHours >= minTrendHorizonHours;
+  const slopeNearZero = Math.abs(heapSlopeBytesPerHour) <= plateauMaxAbsSlopeBytesPerHour
+    && Math.abs(rssSlopeBytesPerHour) <= plateauMaxAbsSlopeBytesPerHour;
+  if (slopeNearZero && projectedHorizonSafe) {
+    return {
+      verdict: 'heap_plateau_observed',
+      reason: 'heap_and_rss_slopes_near_zero',
+      projectedLimitWindow,
+    };
+  }
+  return {
+    verdict: 'heap_still_linear',
+    reason: projectedLimitWindow && projectedLimitWindow !== 'beyond_horizon'
+      ? `projected_watchdog_crossing_${projectedLimitWindow}`
+      : 'heap_or_rss_slope_not_plateaued',
+    projectedLimitWindow,
+  };
+}
+
+function aggregateHeapPlateauVerdict(relays) {
+  if (relays.length <= 0) return 'heap_driver_unknown';
+  if (relays.some((relay) => relay.heapPlateauVerdict === 'heap_driver_unknown')) {
+    return 'heap_driver_unknown';
+  }
+  if (relays.some((relay) => relay.heapPlateauVerdict === 'heap_still_linear')) {
+    return 'heap_still_linear';
+  }
+  return 'heap_plateau_observed';
+}
+
 function summarizeRelayMemory(samples, windowStartMs, env) {
   const limits = resolveRelayWatchdogLimits(env, {
     heapOverrideEnvNames: ['VH_PHASE5_SCOPE_A_WATCH_HEAP_LIMIT_BYTES'],
@@ -223,6 +299,10 @@ function summarizeRelayMemory(samples, windowStartMs, env) {
   const minTrendHorizonHours = parsePositiveInt(
     env.VH_PHASE5_SCOPE_A_WATCH_MIN_TREND_HORIZON_HOURS,
     DEFAULT_MIN_TREND_HORIZON_HOURS,
+  );
+  const plateauMaxAbsSlopeBytesPerHour = parsePositiveInt(
+    env.VH_PHASE5_SCOPE_A_WATCH_HEAP_PLATEAU_MAX_ABS_SLOPE_BYTES_PER_HOUR,
+    DEFAULT_HEAP_PLATEAU_MAX_ABS_SLOPE_BYTES_PER_HOUR,
   );
   const byRelay = new Map();
   for (const sample of samples) {
@@ -234,12 +314,41 @@ function summarizeRelayMemory(samples, windowStartMs, env) {
         heap: [],
         restartCounts: [],
         watchdogTrips: [],
+        graphTotalSouls: [],
+        graphLiveUserValueBytes: [],
+        graphTombstonedSouls: [],
+        graphNamespaceLiveUserValueBytes: new Map(),
+        graphMissingSampleCount: 0,
+        graphTruncatedSampleCount: 0,
       };
       const x = (sample.generatedAtMs - windowStartMs) / 3_600_000;
       if (Number.isFinite(relay.metrics?.rssBytes)) current.rss.push({ x, y: relay.metrics.rssBytes });
       if (Number.isFinite(relay.metrics?.heapUsedBytes)) current.heap.push({ x, y: relay.metrics.heapUsedBytes });
       if (Number.isFinite(relay.docker?.restartCount)) current.restartCounts.push(relay.docker.restartCount);
       if (Number.isFinite(relay.metrics?.watchdogTrips)) current.watchdogTrips.push(relay.metrics.watchdogTrips);
+      const graphScan = relay.metrics?.graphScan;
+      const graphScanComplete = graphScan
+        && Number.isFinite(graphScan.totalSouls)
+        && Number.isFinite(graphScan.liveUserValueBytes)
+        && Number.isFinite(graphScan.tombstonedSouls)
+        && graphScan.truncated !== true
+        && Number(graphScan.truncatedTotal ?? 0) <= 0
+        && Number(graphScan.successes ?? 0) > 0;
+      if (graphScanComplete) {
+        current.graphTotalSouls.push({ x, y: graphScan.totalSouls });
+        current.graphLiveUserValueBytes.push({ x, y: graphScan.liveUserValueBytes });
+        current.graphTombstonedSouls.push({ x, y: graphScan.tombstonedSouls });
+        for (const [namespace, bytes] of Object.entries(graphScan.namespaceLiveUserValueBytes ?? {})) {
+          if (!Number.isFinite(bytes)) continue;
+          const points = current.graphNamespaceLiveUserValueBytes.get(namespace) ?? [];
+          points.push({ x, y: bytes });
+          current.graphNamespaceLiveUserValueBytes.set(namespace, points);
+        }
+      } else if (graphScan?.truncated === true || Number(graphScan?.truncatedTotal ?? 0) > 0) {
+        current.graphTruncatedSampleCount += 1;
+      } else {
+        current.graphMissingSampleCount += 1;
+      }
       byRelay.set(name, current);
     }
   }
@@ -254,6 +363,16 @@ function summarizeRelayMemory(samples, windowStartMs, env) {
     const rssHoursToLimit = hoursUntilLimit(latestRssBytes, rssSlopeBytesPerHour, limits.rssLimitBytes);
     const projectedHours = [heapHoursToLimit, rssHoursToLimit].filter((value) => value !== null);
     const shortestProjectedLimitHours = projectedHours.length > 0 ? Math.min(...projectedHours) : null;
+    const plateau = relayHeapPlateauVerdict({
+      heapSlopeBytesPerHour,
+      rssSlopeBytesPerHour,
+      shortestProjectedLimitHours,
+      minTrendHorizonHours,
+      plateauMaxAbsSlopeBytesPerHour,
+      graphSampleCount: values.graphTotalSouls.length,
+      graphMissingSampleCount: values.graphMissingSampleCount,
+      graphTruncatedSampleCount: values.graphTruncatedSampleCount,
+    });
     relays.push({
       name,
       sampleCount: values.heap.length,
@@ -270,6 +389,22 @@ function summarizeRelayMemory(samples, windowStartMs, env) {
       heapSlopeBytesPerHour,
       heapHoursToLimit,
       shortestProjectedLimitHours,
+      heapPlateauVerdict: plateau.verdict,
+      heapPlateauReason: plateau.reason,
+      heapPlateauProjectedLimitWindow: plateau.projectedLimitWindow,
+      graphSampleCount: values.graphTotalSouls.length,
+      graphMissingSampleCount: values.graphMissingSampleCount,
+      graphTruncatedSampleCount: values.graphTruncatedSampleCount,
+      graphTotalSoulsFirst: pointFirst(values.graphTotalSouls),
+      graphTotalSoulsLatest: pointLatest(values.graphTotalSouls),
+      graphTotalSoulsSlopePerHour: linearSlope(values.graphTotalSouls),
+      graphLiveUserValueBytesFirst: pointFirst(values.graphLiveUserValueBytes),
+      graphLiveUserValueBytesLatest: pointLatest(values.graphLiveUserValueBytes),
+      graphLiveUserValueBytesSlopePerHour: linearSlope(values.graphLiveUserValueBytes),
+      graphTombstonedSoulsFirst: pointFirst(values.graphTombstonedSouls),
+      graphTombstonedSoulsLatest: pointLatest(values.graphTombstonedSouls),
+      graphTombstonedSoulsSlopePerHour: linearSlope(values.graphTombstonedSouls),
+      graphNamespaceLiveUserValueBytes: summarizeNamespaceLiveBytes(values.graphNamespaceLiveUserValueBytes),
       trendStatus:
         shortestProjectedLimitHours === null || shortestProjectedLimitHours >= minTrendHorizonHours
           ? 'pass'
@@ -284,6 +419,8 @@ function summarizeRelayMemory(samples, windowStartMs, env) {
     rssLimitBytes: limits.rssLimitBytes,
     rssLimitSource: limits.rssLimitSource,
     minTrendHorizonHours,
+    heapPlateauMaxAbsSlopeBytesPerHour: plateauMaxAbsSlopeBytesPerHour,
+    heapPlateauVerdict: aggregateHeapPlateauVerdict(relays),
     relays,
     status: relays.some((relay) => relay.trendStatus === 'fail')
       ? 'fail'

--- a/tools/scripts/phase5-scope-a-watch-closure-packet.test.mjs
+++ b/tools/scripts/phase5-scope-a-watch-closure-packet.test.mjs
@@ -58,7 +58,31 @@ function makeSample(root, sampleId, generatedAt, relays) {
   });
 }
 
-function relay(name, rssBytes, heapUsedBytes) {
+function graphScan({
+  totalSouls = 100,
+  liveUserValueBytes = 10_000,
+  tombstonedSouls = 1,
+  namespaceLiveUserValueBytes = { news_story: liveUserValueBytes },
+  truncated = false,
+} = {}) {
+  return {
+    enabled: true,
+    running: false,
+    successes: 1,
+    errors: 0,
+    truncated,
+    durationMs: 20,
+    ageMs: 1000,
+    scannedSouls: totalSouls,
+    totalSouls,
+    liveUserValueBytes,
+    tombstonedSouls,
+    namespaceLiveUserValueBytes,
+    buckets: [],
+  };
+}
+
+function relay(name, rssBytes, heapUsedBytes, graph = null) {
   return {
     name,
     status: 'pass',
@@ -70,6 +94,7 @@ function relay(name, rssBytes, heapUsedBytes) {
       watchdogTrips: 0,
       eventLoopLagP99Ms: 20,
       criticalReadbacksQueued: 0,
+      ...(graph ? { graphScan: graph } : {}),
     },
   };
 }
@@ -136,11 +161,79 @@ test('passes the 48h threshold when archive, runtime, StoryCluster, and relay tr
   assert.equal(packet.thresholds.twentyFourHour.status, 'pass');
   assert.equal(packet.thresholds.fortyEightHour.status, 'pass');
   assert.equal(packet.status, 'pass');
+  assert.equal(packet.relayMemory.heapPlateauVerdict, 'heap_driver_unknown');
   assert.deepEqual(packet.claimBoundary.doesNotProve, [
     'single-host A6 topology resilience',
     'full weekly traffic cycle stability',
     'Scope B accepted/topic synthesis or storyline enrichment readiness',
   ]);
+});
+
+test('computes graph slopes and reports heap plateau when graph scans are complete', () => {
+  const root = tmpDir();
+  const archiveRoot = path.join(root, 'archive');
+  makeSample(archiveRoot, '20260628T000000Z', '2026-06-28T00:00:00.000Z', [
+    relay('vhc-relay-a', 420_000_000, 320_000_000, graphScan({
+      totalSouls: 100,
+      liveUserValueBytes: 10_000,
+      tombstonedSouls: 2,
+      namespaceLiveUserValueBytes: { news_story: 8_000, news_latest_index: 2_000 },
+    })),
+  ]);
+  makeSample(archiveRoot, '20260629T000000Z', '2026-06-29T00:00:00.000Z', [
+    relay('vhc-relay-a', 421_000_000, 321_000_000, graphScan({
+      totalSouls: 105,
+      liveUserValueBytes: 11_200,
+      tombstonedSouls: 3,
+      namespaceLiveUserValueBytes: { news_story: 9_000, news_latest_index: 2_200 },
+    })),
+  ]);
+  makeSample(archiveRoot, '20260630T000000Z', '2026-06-30T00:00:00.000Z', [
+    relay('vhc-relay-a', 422_000_000, 322_000_000, graphScan({
+      totalSouls: 110,
+      liveUserValueBytes: 12_400,
+      tombstonedSouls: 4,
+      namespaceLiveUserValueBytes: { news_story: 10_000, news_latest_index: 2_400 },
+    })),
+  ]);
+
+  const packet = phase5ScopeAWatchClosureInternal.buildPhase5ScopeAWatchClosurePacket({
+    env: baseEnv(root),
+    now: new Date('2026-06-30T00:00:00.000Z'),
+  });
+
+  const relayMemory = packet.relayMemory.relays[0];
+  assert.equal(packet.relayMemory.heapPlateauVerdict, 'heap_plateau_observed');
+  assert.equal(relayMemory.heapPlateauVerdict, 'heap_plateau_observed');
+  assert.equal(relayMemory.graphSampleCount, 3);
+  assert.equal(Math.round(relayMemory.graphTotalSoulsSlopePerHour * 1000), 208);
+  assert.equal(relayMemory.graphLiveUserValueBytesSlopePerHour, 50);
+  assert.equal(Math.round(relayMemory.graphTombstonedSoulsSlopePerHour * 1000), 42);
+  assert.equal(Math.round(relayMemory.graphNamespaceLiveUserValueBytes.news_story.slopeBytesPerHour), 42);
+});
+
+test('reports heap_still_linear when complete graph diagnostics accompany unsafe heap projection', () => {
+  const root = tmpDir();
+  const archiveRoot = path.join(root, 'archive');
+  makeSample(archiveRoot, '20260628T000000Z', '2026-06-28T00:00:00.000Z', [
+    relay('vhc-relay-a', 500_000_000, 500_000_000, graphScan()),
+  ]);
+  makeSample(archiveRoot, '20260629T000000Z', '2026-06-29T00:00:00.000Z', [
+    relay('vhc-relay-a', 740_000_000, 740_000_000, graphScan({ totalSouls: 102, liveUserValueBytes: 11_000 })),
+  ]);
+  makeSample(archiveRoot, '20260630T000000Z', '2026-06-30T00:00:00.000Z', [
+    relay('vhc-relay-a', 980_000_000, 980_000_000, graphScan({ totalSouls: 104, liveUserValueBytes: 12_000 })),
+  ]);
+
+  const packet = phase5ScopeAWatchClosureInternal.buildPhase5ScopeAWatchClosurePacket({
+    env: baseEnv(root),
+    now: new Date('2026-06-30T00:00:00.000Z'),
+  });
+
+  assert.equal(packet.relayMemory.heapPlateauVerdict, 'heap_still_linear');
+  assert.equal(packet.relayMemory.relays[0].heapPlateauVerdict, 'heap_still_linear');
+  assert.equal(packet.relayMemory.relays[0].heapPlateauProjectedLimitWindow, 'before_48h');
+  assert.equal(packet.relayMemory.status, 'fail');
 });
 
 test('blocks the 48h threshold when relay heap trend projects below the safe horizon', () => {


### PR DESCRIPTION
## Summary
- Add an opt-in cached Gun graph scanner for the relay with bounded async scans, namespace/state aggregate metrics, duration/age/truncation/error counters, and no raw value emission.
- Extend relay liveness watch output to ingest cached graph metrics when present, without making them blockers.
- Extend the Scope A watch closure packet with graph slopes and a diagnostic heap plateau verdict while preserving existing heap/RSS blocker behavior.
- Document the metrics as diagnostic-only, disabled by default, and safe for shareable aggregate reporting.

## Safety notes
- `VH_RELAY_GUN_GRAPH_SCAN_ENABLED=false` by default.
- `/metrics` reads cached scan results only; graph walking happens in the background scanner.
- Exported graph metrics are aggregate counts/bytes by namespace/state only, not story text, URLs, signatures, keys, or raw object values.
- Missing or truncated graph scans produce `heap_driver_unknown` in the closure packet, but graph metrics are not release blockers in this slice.

## Validation
- `node --check infra/relay/server.js`
- `node --check tools/scripts/news-relay-liveness-watch.mjs`
- `node --check tools/scripts/phase5-scope-a-watch-closure-packet.mjs`
- `node --test tools/scripts/news-relay-liveness-watch.test.mjs tools/scripts/phase5-scope-a-watch-closure-packet.test.mjs`
- `CI=true corepack pnpm@9.7.1 exec vitest run src/live/relay-server.vitest.mjs --config vitest.config.ts` from `packages/e2e`
- `git diff --check`