### PR TITLE
Add LUMA forbidden-claims and profile gates with M1.B/M2.A design packets

### DIFF
--- a/docs/plans/LUMA_M1B_IDENTITY_CONTROLS_DESIGN_2026-07-02.md
+++ b/docs/plans/LUMA_M1B_IDENTITY_CONTROLS_DESIGN_2026-07-02.md
@@ -1,0 +1,169 @@
+# LUMA M1.B Identity Controls Design Packet
+
+> Status: Draft design packet (execution artifact; the spec wins on conflict)
+> Owner: VHC Spec Owners
+> Last Reviewed: 2026-07-02
+> Depends On: docs/specs/spec-luma-service-v0.md, docs/plans/LUMA_SERVICE_V0_ROADMAP_2026-05-02.md, apps/web-pwa/src/hooks/useIdentity.ts, packages/identity-vault/src/vault.ts, docs/foundational/STATUS.md
+
+Scope: UX copy, state model, preservation/rotation semantics, a11y criteria,
+and test expectations for the `/account/identity` identity-controls surface
+(roadmap M1.B). This packet is design-only: it changes no provider selection,
+no public schema, no vault layout, and no live Scope A behavior. Normative
+semantics live in `docs/specs/spec-luma-service-v0.md` §13; this packet
+sequences how the UI lands them.
+
+## 1. Current implementation truth (verified 2026-07-02)
+
+| M1.B deliverable | State | Evidence |
+| --- | --- | --- |
+| `useIdentity.signOut()` / `resetIdentity()` split | DONE | `apps/web-pwa/src/hooks/useIdentity.ts` (~315-336); `revokeSession()` is a deprecation shim |
+| Spec §13.2 state-graph behavior in the hooks | DONE (11 of 12 rows) | Sign Out preserves device credential / SEA pair / wallet binding / delegation key; Reset rotates or clears them; see §3 table |
+| `operatorAuthorizationToken` clearing on Reset | AUDIT ITEM | No explicit clear call in `resetIdentity()`; may be covered by `vaultClear()` zeroization — must be proven by a state-graph unit test, not assumed |
+| Unit tests for Sign Out / Reset semantics | PARTIAL | `useIdentity.test.ts` asserts ~6-7 of 12 rows per flow; missing rows listed in §6.1 |
+| `/account/identity` route | MISSING | No `/account/*` route in `apps/web-pwa/src/routes/index.tsx` |
+| Controls UI (panels, confirmation modals, session metadata) | MISSING | Dashboard has stub buttons only |
+| Wallet re-bind prompt after Reset | PARTIAL | `WalletPanel` handles the re-bind state; not wired into an identity-controls flow |
+| E2E flows (sign-out continuity / reset rotation) | MISSING | No e2e coverage of either journey |
+
+## 2. UX copy pack (draft strings)
+
+All strings below must stay inside the forbidden-claims registry
+(spec §20, enforced by `pnpm check:luma-forbidden-claims`). None of them may
+claim deletion, anonymity, or repudiation.
+
+### 2.1 Panel frame
+
+- Title: `Identity`
+- Assurance line: `Beta-local identity on this device` (tier language only;
+  never a numeric trust score, never the principal nullifier)
+- Session metadata rows: `Created`, `Expires` (with near-expiry warning within
+  24h per spec §12.3), `Verifier: beta-local`
+- Near-expiry warning: `Your session expires soon. Re-attest to continue
+  posting and voting. Browsing is unaffected.`
+
+### 2.2 Sign Out
+
+- Button: `Sign out`
+- Modal title: `Sign out of this device?`
+- Modal body: `Signing out ends your current session. Your identity stays on
+  this device: signing back in restores the same pseudonym, wallet binding,
+  and reputation. Your published posts and votes are unaffected.`
+- Confirm: `Sign out` / Cancel: `Cancel`
+
+### 2.3 Reset Identity
+
+- Button: `Reset identity` (destructive styling, separated placement)
+- Modal title: `Reset your identity on this device?`
+- Modal body: `Resetting creates a new pseudonym and abandons the current one.
+  Your previous posts, comments, and votes remain public under your old
+  pseudonym — resetting does not remove them and cannot make them yours again.
+  Your wallet must be re-bound, and any operator authorization or delegations
+  are cleared.`
+- Second-step confirmation (destructive tier): type-to-confirm the literal
+  word `reset`, then `Reset identity` / `Cancel`
+- Post-reset toast: `New identity created. Your previous pseudonym's public
+  history remains on the network.`
+
+Copy red-lines (from spec §13.3-§13.4 and §20): never render "delete", never
+imply prior history is removed, transferred, or disowned; never render the
+principal nullifier; never show a numeric trust score.
+
+### 2.4 Wallet re-bind prompt (post-Reset, on next claim)
+
+`This wallet was bound to your previous identity. Re-bind it to your current
+identity to continue.` Action: `Re-bind wallet`.
+
+### 2.5 Privacy links
+
+Panel footer links to `/support` and `/data-deletion` (spec §19.1); the
+data-deletion page copy already owns the honest-deletion stance.
+
+## 3. Preservation/rotation contract (spec §13.2 + implementation truth)
+
+| Asset | Sign Out | Reset Identity | Implementation anchor |
+| --- | --- | --- | --- |
+| `vaultMasterKey` | Preserved | Preserved | vault `keys` store; untouched by both flows |
+| `deviceCredential` | Preserved | Rotated | `deviceCredential.rotate()` in `resetIdentity()` |
+| `sessionToken` | Cleared | Cleared | `vaultClear()` |
+| `assuranceEnvelope` | Cleared | Cleared | `vaultClear()` |
+| `seaDevicePair` | Preserved | Rotated | `seaDevicePair.rotate(() => SEA.pair())` |
+| `walletBinding` | Preserved | Cleared (re-bind prompt) | `clearWalletBinding()` |
+| `delegationSigningKey` | Preserved | Rotated | `delegationSigningKey.rotateStored()` |
+| `operatorAuthorizationToken` | Preserved | Cleared | AUDIT: must be asserted by test (§6.1); add explicit clear if `vaultClear()` does not cover it |
+| `vh_delegation_v1:<principal>` localStorage | Preserved | Cleared | `clearDelegationStorageForPrincipal(oldPrincipal)` |
+| `xpLedger.activeNullifier` | Cleared, re-attached on re-attest | Cleared (new principal) | `clearActiveIdentityRuntime()` |
+| `useSentimentState.signals` | Cleared | Cleared | `clearActiveIdentityRuntime()` |
+| Public history (posts, votes, directory, on-chain) | Untouched | Untouched (historical artifact under old ids) | spec §13.3; UI copy must say so |
+
+## 4. State model
+
+Base identity states (existing `IdentityStatus`): `hydrating → anonymous →
+creating → ready → expired | error`.
+
+Controls-layer overlay states for `/account/identity`:
+
+```
+ready ──[Sign out clicked]──> confirmingSignOut ──[confirm]──> signingOut ──> anonymous
+ready ──[Reset clicked]────> confirmingReset ──[type-to-confirm]──> resetting ──> anonymous
+confirming* ──[cancel/esc/backdrop]──> ready (no state mutated)
+signingOut/resetting failure ──> ready + error banner (no partial mutation visible)
+expired ──> ready-with-reattest-prompt (Sign Out available; Reset available)
+```
+
+Rules: a cancelled confirmation must mutate nothing; the destructive path
+(Reset) requires the two-step confirm; both flows disable their trigger
+buttons while in-flight; `anonymous` state shows the create-identity call to
+action, not the controls.
+
+## 5. A11y expectations
+
+- Modals: focus trap, `role="dialog"`, `aria-labelledby` (title) +
+  `aria-describedby` (body), Escape cancels, focus returns to the trigger.
+- Destructive tier: Reset confirm button `aria-disabled` until the
+  type-to-confirm matches; the input has an explicit label.
+- Deferred affordances follow the existing dashboard pattern
+  (`aria-describedby` + `data-testid`, as in `link-device-deferred`).
+- Test ids: `identity-panel`, `identity-sign-out`, `identity-reset`,
+  `identity-sign-out-confirm`, `identity-reset-confirm`,
+  `identity-session-expiry`, `identity-wallet-rebind`.
+- Announcements: post-action toasts use a polite live region.
+
+## 6. Test expectations
+
+### 6.1 Unit (state-graph completion)
+
+Extend `useIdentity.test.ts` so every row of the §3 table is asserted for
+both flows — the currently missing assertions are: `sessionToken`,
+`assuranceEnvelope`, `operatorAuthorizationToken` (both flows),
+`useSentimentState.signals`, `vaultMasterKey` preservation, and
+`xpLedger.activeNullifier` on Reset. The `operatorAuthorizationToken` Reset
+row is the open audit item: the test must prove clearing, and if it fails,
+`resetIdentity()` gains an explicit clear call (hook change, separate PR).
+
+### 6.2 E2E (roadmap M1.B acceptance)
+
+- Continuity: create → publish → sign out → re-create asserts same
+  `principalNullifier`, same `forumAuthorId`, same operator authorization,
+  same wallet binding.
+- Rotation: create → publish → reset identity → re-create asserts different
+  `principalNullifier`, different `forumAuthorId`, no operator authorization,
+  no delegation grants, wallet re-bind prompt rendered.
+- Copy: both modals render; neither contains a forbidden-claims registry
+  phrase (rendered-copy assertion, complementing the build-time grep).
+
+### 6.3 Fixtures
+
+Vault fixtures for: populated v2 vault (session + wallet + delegations),
+post-sign-out vault (device-bound compartments intact), post-reset vault
+(rotated compartments). Reuse the compartment fakes from `useIdentity.test.ts`.
+
+## 7. Sequencing and non-goals
+
+Implementation PR order (each independently revertable): (1) route + panel +
+session metadata (read-only); (2) Sign Out flow + modal; (3) Reset flow +
+two-step confirm + wallet re-bind wiring; (4) state-graph unit-test completion
++ the `operatorAuthorizationToken` audit; (5) E2E flows.
+
+Non-goals for all of the above: no provider selection changes, no public
+schema/epoch changes, no vault layout changes, no delete-account affordance,
+no multi-device linking (stays fail-closed stub), no numeric trust display.

--- a/docs/plans/LUMA_M2A_VERIFIER_SPEC_PACKET_2026-07-02.md
+++ b/docs/plans/LUMA_M2A_VERIFIER_SPEC_PACKET_2026-07-02.md
@@ -1,0 +1,180 @@
+# LUMA M2.A Verifier Spec Packet (Draft)
+
+> Status: Draft design packet — NOT a landed spec, NOT a deployment authorization
+> Owner: VHC Spec Owners
+> Last Reviewed: 2026-07-02
+> Depends On: docs/specs/spec-luma-service-v0.md, docs/ops/luma-verifier-current-state.md, docs/plans/LUMA_SERVICE_V0_ROADMAP_2026-05-02.md, docs/specs/spec-identity-trust-constituency.md, services/luma-verifier-dev/src/main.rs
+
+Scope: the design input for `spec-luma-verifier-v0.md` (roadmap M2.A). This
+packet consolidates the normative requirements the verifier spec must satisfy
+(service spec §10, §11.6, §14, §17, §18, §19, §21) against the recorded DEV
+current state, so the M2.A spec can be written from explicit drift instead of
+implicit assumptions. It deliberately does not land the spec: M2.A's
+acceptance requires decisions this packet can only name.
+
+## 0. Draft framing — unsatisfied dependencies
+
+This packet MUST NOT be treated as buildable until each is resolved:
+
+| Dependency | State | Consequence |
+| --- | --- | --- |
+| M1 complete (M1.A-M1.E) | NOT MET | Envelope wiring, identity controls, profile guard, forbidden-claims gate, telemetry are all inputs to verifier failure modes and client behavior |
+| Ops ownership (M2.A-4) | OPEN | No operating team named; cross-team review is an M2.A acceptance criterion |
+| Audit retention policy (M2.A-3) | OPEN | Retention numbers below are placeholders pending ops |
+| Custody architecture (M2.A-7) | DEFAULT PROPOSED | Cold root + online subkeys + 3-of-5 quorum is the roadmap default, unratified |
+| Env-name drift assertion (M1.C) | LANDED as `check:luma-production-profile` source/env guard | Bundle-level assertion still pending public-beta build wiring (`--dist`) |
+
+Hard non-goals in the current execution window: no verifier deployment, no
+`VITE_ATTESTATION_URL` promotion, no provider/profile promotion, no Silver or
+verified-human or one-human-one-vote or Sybil-resistance or cryptographic
+residency or mesh release-readiness claims, no public schema epoch change.
+
+## 1. Current-state drift the spec must consume
+
+From `docs/ops/luma-verifier-current-state.md` (M0.E record):
+
+- DEV stub serves only `GET /health` + `POST /verify`; truth-labeled
+  `environment: "DEV"`; length/prefix heuristics; no nonce freshness, no
+  replay detection, no signing, no audit. The heuristic is NOT the Silver
+  algorithm and MUST NOT be inherited.
+- Response drift: Rust returns `{token, trustScore, nullifier, environment,
+  disclaimer}`; canonical TS `SessionResponse` requires `{token, trustScore,
+  scaledTrustScore, nullifier, createdAt, expiresAt}`; a gun-client shim
+  bridges. M2.A owns the single shared schema (TS is the schema authority).
+- Nullifier derivation today: `sha256(NULLIFIER_SALT || device_key)` with an
+  unset-salt fallback. The spec requires constant-time
+  `HMAC-SHA-256(salt = NULLIFIER_SALT, message = deviceCredential)` (service
+  spec §3, §6.4, §11.3) and per-profile pinned salt (§17.2). Fallback salts
+  are forbidden in deployable profiles; the migration from sha256-concat to
+  HMAC MUST preserve continuity or be scheduled before any real enrollment.
+- Env-name drift (`ATTESTATION_URL` vs `VITE_ATTESTATION_URL`) is now locked
+  by the M1.C gate at source level; the verifier spec pins the URL contract
+  per profile.
+
+## 2. Endpoint contract (draft)
+
+| Endpoint | Purpose | Notes |
+| --- | --- | --- |
+| `GET /challenge` | Issue nonce challenge | Nonce: 128-bit random, single-use, bound to `audience`+`origin`+`profile`; default window 60s (M2.A-2); replay-cached until expiry |
+| `POST /verify` | Attestation → session | Consumes a live challenge; returns signed `SessionResponse` + `AssuranceEnvelope`; signature covers the full response plus bound `nonce`/`audience`/`origin`/`profile`; server-set `expiresAt` (7-day TTL per service spec §12.1) |
+| `GET /.well-known/jwks.json` | Online subkey set | Rotating subkeys; 7-day rotation grace (M2.A-6) |
+| `GET /.well-known/luma-verifier-manifest` | Transparency manifest | Shape per service spec §17; append-only, mirrored (GitHub Pages + Sigstore-rekor); client verifies JWKS matches manifest on every session creation; drift = hard reject |
+| `GET /.well-known/luma-verifier-revocations` | Session/key revocation list | Constant-time membership checks (§6.4) |
+| `GET /.well-known/luma-safety-bulletin` | Operational kill switch | Shape per §18; signed by the cold root key, never an online subkey (§18.2); 24h freshness window default |
+| `GET /health` | Liveness | No trust semantics |
+
+Single shared schema: TypeScript is the authority; the Rust (or other)
+implementation consumes generated/vendored types plus the frozen test vectors
+(§21.1). The DEV truth-label fields (`environment`, `disclaimer`) are not part
+of the production schema and MUST NOT leak into it by accident.
+
+## 3. Trust boundary and signing (draft)
+
+- Default suite `jcs-ed25519-sha512-v1` for verifier-issued envelopes; suite
+  set is closed and named per envelope (§6.2-6.3).
+- Client trust: JWKS plus build-pinned verifier identity
+  (`apps/web-pwa/src/luma/verifier-pin.json`, §17.1); the pin takes
+  precedence — a verifier whose live values mismatch the pin is untrusted
+  regardless of a valid JWKS chain.
+- Custody (M2.A-7 default, unratified): cold-storage root key; online
+  subkeys sign sessions/manifests; root signs safety bulletins and rotation
+  attestations; N=3-of-K=5 quorum for root operations.
+- Key rotation: 7-day grace overlap (M2.A-6); rotation is manifest-visible
+  (retiredKeys) and rekor-logged. Salt rotation is NOT key rotation — it is a
+  P0 identity-continuity incident (§17.2, current-state §5).
+- `AssuranceEnvelope` construction: `assuranceLevel='silver'`,
+  `claimVector.device_integrity='silver'`, `claimVector.liveness='silver'`,
+  all other claims `'beta_local'`/`'none'` (§4). The trust-score policy doc is
+  hashed into the manifest (`trustScorePolicyHash`); policy changes are
+  manifest-visible by construction.
+
+## 4. Rate limits and abuse posture (draft numbers, ops-unratified)
+
+- Per-IP: challenge 30/min burst 10; verify 10/min burst 5.
+- Per-devicePub: verify 5/min, 20/day.
+- Per-nullifier: re-attestation 10/day.
+- On limit: `rate_limited` with `Retry-After`; never a silent degrade to a
+  lower-assurance response.
+- `verifier_overload` (load-shed) is distinct from `rate_limited` (abuse).
+
+## 5. Failure-mode taxonomy (closed enums)
+
+Service-spec `PolicyReason` values apply unchanged. Verifier-specific
+additions (all typed, all closed): `bad_nonce`, `attestation_replayed`,
+`attestation_too_low`, `rate_limited`, `verifier_overload`, `salt_mismatch`,
+`manifest_drift`, `key_rotation_in_progress`. Failed attestation falls back
+to `view-only` — never silent anonymous, never a fake lower-assurance session
+(reads stay open per §10; identity gates only write/vote/claim).
+
+## 6. Audit events and retention (placeholder pending M2.A-3)
+
+- Append-only audit log; every event passes the §16.2 redaction list at emit
+  time (no raw nullifiers, tokens, signatures, evidence vectors, mesh paths;
+  `verifierIdHash` not `verifierId`).
+- Event classes: challenge issued/consumed, verify accepted/rejected (with
+  typed reason), key rotation, manifest publication, bulletin publication,
+  revocation-list change, rate-limit trip.
+- Retention: PLACEHOLDER 90 days hot / 365 days cold, digests-only after 30
+  days — numbers owned by ops (M2.A-3) and not committable here. Evidence
+  retention on the verifier side holds digests and timestamps, never raw
+  vectors (§11.6).
+
+## 7. SLOs (draft until ops review)
+
+Availability 99.5%; `POST /verify` p95 < 1.5s, p99 < 3s; challenge p99 <
+300ms; manifest/bulletin endpoints p99 < 300ms (static, mirrored). Bulletin
+freshness 24h. Client behavior on missing/stale bulletin in
+`production-attestation`: hard reject (§18.1).
+
+## 8. Deployment topology (draft)
+
+Standalone service (`services/luma-verifier`, M2.B), isolated from the
+public-news relay/publisher failure domain — a verifier outage MUST NOT be
+able to fail-close Scope A publication, and Scope A load MUST NOT contend
+with attestation latency. Static well-known artifacts served from mirrored
+storage. No shared host with the A6 relay stack in the production topology
+(the single-host A6 lesson from Phase 5 applies here as a design input).
+
+## 9. Continuity contract (§14, restated as verifier obligations)
+
+Same device + same `deviceCredential` → same `principalNullifier` under the
+pinned salt; the Silver envelope replaces the beta-local one with identical
+identity projection. The §21.3 continuity gate (byte-identical `PrincipalId`,
+`forumAuthorId`, XP, wallet binding, operator status across the upgrade on a
+recorded corpus) is the release gate for this obligation.
+
+## 10. Adversarial harness (gates the Silver claim, §21.2)
+
+The full §21.2 corpus (replayed video, synthetic feed, missing IMU,
+emulator/rooted, ± clock skew, nonce replay, origin/audience/profile
+crossover, salt mismatch, manifest drift, bulletin staleness, hostile
+verifier, suite mismatch, envelope downgrade, idempotency replay, a11y
+fallback to view-only) implemented under `services/luma-verifier/tests/
+adversarial/` and `apps/web-pwa/e2e/adversarial/`. No implementation may
+claim Silver before the corpus passes; the corpus result feeds
+`pnpm check:luma-production-profile`'s successor gate for the
+`production-attestation` profile.
+
+## 11. Key-compromise drill (runbook draft — graduates to docs/ops/luma-verifier-runbook.md at M2.A)
+
+1. Detect/suspect online-subkey compromise → publish root-signed safety
+   bulletin revoking the subkey id and its policy hash (§18); clients drop
+   affected sessions (`session_revoked_by_bulletin`).
+2. Rotate: new subkey in JWKS + manifest with `retiredKeys` entry naming the
+   reason; rekor entry; 7-day grace does NOT apply to compromised keys
+   (immediate cut).
+3. Root compromise: quorum (3-of-5) re-roots; new pin shipped in a client
+   build; old root's bulletins distrusted by pin update — this is a
+   full-population re-attestation event and a P0.
+4. Salt exposure: P0 identity-continuity incident per §17.2 — separate
+   migration plan, never handled inside key rotation.
+5. Rehearsal: quarterly, calendared at M2.A signoff (first date is an M2.A
+   acceptance criterion; deliberately not schedulable from this packet).
+
+## 12. Open decisions carried to M2.A signoff
+
+M2.A-2 nonce window (default 60s) · M2.A-3 audit retention (ops) · M2.A-4
+operating team (unblocks cross-team review) · M2.A-6 rotation grace (default
+7d) · M2.A-7 custody ratification (default cold-root 3-of-5) · Rust-vs-TS
+implementation language (M2.B-1) · sha256-concat → HMAC nullifier derivation
+migration timing (§1 above).

--- a/package.json
+++ b/package.json
@@ -57,6 +57,8 @@
     "check:public-beta-launch-closeout": "node ./tools/scripts/check-public-beta-launch-closeout.mjs",
     "check:linkability-domain-registry": "node ./tools/scripts/check-linkability-domain-registry.mjs",
     "check:luma-provider-surface": "node ./tools/scripts/check-luma-provider-surface.mjs",
+    "check:luma-forbidden-claims": "node ./tools/scripts/check-luma-forbidden-claims.mjs",
+    "check:luma-production-profile": "node ./tools/scripts/check-luma-production-profile.mjs",
     "check:luma-signed-write-surface": "node ./tools/scripts/check-luma-signed-write-surface.mjs",
     "check:luma-vault-compartments": "node ./tools/scripts/check-luma-vault-compartments.mjs",
     "check:luma-delegation-signer-surface": "node ./tools/scripts/check-luma-delegation-signer-surface.mjs",

--- a/packages/e2e/src/mvp-release-gates.mjs
+++ b/packages/e2e/src/mvp-release-gates.mjs
@@ -283,6 +283,25 @@ export const GATES = [
     ],
   },
   {
+    id: 'luma_forbidden_claims',
+    label: 'LUMA forbidden-claims registry holds over app copy (spec §20)',
+    command: ['pnpm', ['check:luma-forbidden-claims']],
+    artifactRefs: [
+      'tools/scripts/check-luma-forbidden-claims.mjs',
+      'docs/specs/spec-luma-service-v0.md',
+    ],
+  },
+  {
+    id: 'luma_production_profile',
+    label: 'LUMA profile guards keep dev fallback, mocks, and DEV-stub URLs out of deployable profiles',
+    command: ['pnpm', ['check:luma-production-profile']],
+    artifactRefs: [
+      'tools/scripts/check-luma-production-profile.mjs',
+      'apps/web-pwa/src/hooks/useIdentity.ts',
+      'packages/luma-sdk/src/providers/index.ts',
+    ],
+  },
+  {
     id: 'luma_mvp_production_readiness',
     label: 'LUMA public-beta MVP readiness has current signed-write and mesh evidence',
     command: ['pnpm', ['check:luma:mvp-production-readiness']],

--- a/tools/scripts/check-luma-forbidden-claims.mjs
+++ b/tools/scripts/check-luma-forbidden-claims.mjs
@@ -1,0 +1,239 @@
+#!/usr/bin/env node
+/**
+ * check:luma-forbidden-claims — M1.D build-time forbidden-claims gate.
+ *
+ * Greps `apps/web-pwa/src/**\/*.{ts,tsx,md}` against the normative
+ * forbidden-claims registry in docs/specs/spec-luma-service-v0.md §20.
+ * The registry is Protocol-RFC-gated: adding or removing an entry here
+ * requires the matching spec §20 change in the same PR.
+ *
+ * A match fails the gate unless the line matches one of the entry's
+ * documented allow-contexts. Allow-contexts exist because the compliance
+ * surface intentionally renders NEGATIVE bounds ("this beta is not a
+ * verified-human system") and identity code uses `'anonymous'` as a
+ * status-enum literal. Each allow-context names its reason; an allowed
+ * hit is still counted and reported for reviewer visibility.
+ *
+ * This gate scans source strings. It cannot judge semantics ("close
+ * paraphrases" per spec §20 remain a review responsibility), and it is
+ * not the runtime `<TrustClaim>` defense (deferred with M1.E telemetry).
+ */
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '../..');
+
+export const SCAN_ROOT = 'apps/web-pwa/src';
+export const SCAN_EXTENSIONS = new Set(['.ts', '.tsx', '.md']);
+
+/**
+ * Registry source: docs/specs/spec-luma-service-v0.md §20 (13 entries).
+ * `pattern` is the detection regex (case-insensitive, hyphen/space
+ * tolerant). `allow` entries are line-level regexes with reasons; a line
+ * matching any allow regex for that entry is reported but not fatal.
+ */
+export const FORBIDDEN_CLAIMS = [
+  {
+    id: 'verified-human',
+    registryPhrase: 'verified human',
+    pattern: /verified[- ]human/i,
+    allow: [
+      {
+        line: /is not a[\s\S]*verified-human system|not\.toContain\(|must not be presented as/i,
+        reason: 'compliance surface renders the negative bound ("is not a verified-human system") and its test asserts the negation',
+      },
+      {
+        line: /not verified-human/i,
+        reason: 'doc comment stating the surface must NOT use verified-human language',
+      },
+    ],
+  },
+  {
+    id: 'one-human-one-vote',
+    registryPhrase: 'one-human-one-vote',
+    pattern: /one[- ]human[,]?[- ]one[- ]vote/i,
+    allow: [
+      {
+        line: /must not be presented as|not\.toContain\(/i,
+        reason: 'compliance surface negative bound and its negation test',
+      },
+    ],
+  },
+  {
+    id: 'sybil-resistant',
+    registryPhrase: 'Sybil-resistant',
+    pattern: /sybil[- ]?resist/i,
+    allow: [
+      {
+        line: /canClaimSybilResistance/,
+        reason: 'typed denial flag; the identity surface asserts canClaimSybilResistance: false',
+      },
+      {
+        line: /must not be presented as|not verified-human/i,
+        reason: 'compliance surface negative bound / doc comment negation',
+      },
+    ],
+  },
+  {
+    id: 'district-proof',
+    registryPhrase: 'district-proof',
+    pattern: /district[- ]proof/i,
+    allow: [
+      {
+        line: /not verified-human, district-proof/i,
+        reason: 'doc comment stating the surface must NOT use district-proof language',
+      },
+      {
+        line: /must not include/i,
+        reason: 'compliance surface negative bound forbidding district proof payloads in public aggregates',
+      },
+    ],
+  },
+  {
+    id: 'cryptographic-residency',
+    registryPhrase: 'cryptographic residency',
+    pattern: /cryptographic residency/i,
+    allow: [
+      {
+        line: /not cryptographic residency/i,
+        reason: 'test title asserting the beta-local label is NOT cryptographic residency proof',
+      },
+    ],
+  },
+  {
+    id: 'permanently-delete',
+    registryPhrase: 'permanently delete',
+    pattern: /permanently delete/i,
+    allow: [],
+  },
+  {
+    id: 'anonymous',
+    registryPhrase: 'anonymous',
+    pattern: /\banonymous\b/i,
+    allow: [
+      {
+        line: /['"`]anonymous['"`]/,
+        reason: "IdentityStatus enum literal ('anonymous' = signed-out state), not an anonymity claim",
+      },
+      {
+        line: /@anonymous/,
+        reason: 'IDChip placeholder handle for a user without a published handle, not an anonymity claim',
+      },
+      {
+        line: /displayName/,
+        reason: "collab-editor presence placeholder name ('Anonymous') for a user without a handle, not an anonymity claim",
+      },
+      {
+        line: /\b(?:to|in|resolves? to|transitions? to|state is|status|anonymous state|anonymous when|anonymous without)\b/i,
+        reason: 'comment/test prose describing the anonymous status state machine',
+      },
+    ],
+  },
+  {
+    id: 'untraceable',
+    registryPhrase: 'untraceable',
+    pattern: /\buntraceable\b/i,
+    allow: [],
+  },
+  {
+    id: 'reset-identity-deletes',
+    registryPhrase: 'Reset Identity deletes your activity',
+    pattern: /reset identity deletes/i,
+    allow: [],
+  },
+  {
+    id: 'sign-out-removes-data',
+    registryPhrase: 'Sign Out removes your data from the network',
+    pattern: /sign[- ]?out removes your data/i,
+    allow: [],
+  },
+  {
+    id: 'permanently-deleted-network',
+    registryPhrase: 'permanently deleted from the network',
+    pattern: /permanently deleted from the network/i,
+    allow: [],
+  },
+  {
+    id: 'fully-anonymous',
+    registryPhrase: 'fully anonymous',
+    pattern: /fully anonymous/i,
+    allow: [],
+  },
+  {
+    id: 'untraceable-across-devices',
+    registryPhrase: 'untraceable across devices',
+    pattern: /untraceable across devices/i,
+    allow: [],
+  },
+];
+
+function walk(dir, files = []) {
+  for (const entry of readdirSync(dir)) {
+    const full = path.join(dir, entry);
+    const stats = statSync(full);
+    if (stats.isDirectory()) {
+      walk(full, files);
+    } else if (SCAN_EXTENSIONS.has(path.extname(entry))) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+export function scanForbiddenClaims(repoRoot = REPO_ROOT) {
+  const scanDir = path.join(repoRoot, SCAN_ROOT);
+  const violations = [];
+  const allowedHits = [];
+  const files = walk(scanDir);
+  for (const file of files) {
+    const relPath = path.relative(repoRoot, file);
+    const lines = readFileSync(file, 'utf8').split('\n');
+    lines.forEach((lineText, index) => {
+      for (const claim of FORBIDDEN_CLAIMS) {
+        if (!claim.pattern.test(lineText)) continue;
+        const allowMatch = claim.allow.find((rule) => rule.line.test(lineText));
+        const hit = {
+          claim: claim.id,
+          registryPhrase: claim.registryPhrase,
+          file: relPath,
+          line: index + 1,
+          text: lineText.trim().slice(0, 200),
+        };
+        if (allowMatch) {
+          allowedHits.push({ ...hit, allowReason: allowMatch.reason });
+        } else {
+          violations.push(hit);
+        }
+      }
+    });
+  }
+  return { scannedFileCount: files.length, violations, allowedHits };
+}
+
+function main() {
+  const { scannedFileCount, violations, allowedHits } = scanForbiddenClaims();
+  console.log(`luma-forbidden-claims: scanned ${scannedFileCount} files under ${SCAN_ROOT}`);
+  console.log(`luma-forbidden-claims: registry entries ${FORBIDDEN_CLAIMS.length} (spec-luma-service-v0.md §20)`);
+  if (allowedHits.length > 0) {
+    console.log(`luma-forbidden-claims: ${allowedHits.length} allowed hit(s) via documented allow-contexts:`);
+    for (const hit of allowedHits) {
+      console.log(`  allowed [${hit.claim}] ${hit.file}:${hit.line} — ${hit.allowReason}`);
+    }
+  }
+  if (violations.length > 0) {
+    console.error(`luma-forbidden-claims: FAIL — ${violations.length} violation(s):`);
+    for (const violation of violations) {
+      console.error(`  [${violation.claim}] ${violation.file}:${violation.line}: ${violation.text}`);
+    }
+    console.error('Forbidden-claims registry is normative (spec §20). Remove the phrase, or if the line is a genuine negative bound, add a documented allow-context in the same PR as a reviewed change.');
+    process.exit(1);
+  }
+  console.log('luma-forbidden-claims: PASS');
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/tools/scripts/check-luma-forbidden-claims.test.mjs
+++ b/tools/scripts/check-luma-forbidden-claims.test.mjs
@@ -1,0 +1,127 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { scanForbiddenClaims, FORBIDDEN_CLAIMS, SCAN_ROOT } from './check-luma-forbidden-claims.mjs';
+
+function makeFixtureRepo(files) {
+  const root = mkdtempSync(path.join(tmpdir(), 'luma-forbidden-claims-'));
+  for (const [relPath, content] of Object.entries(files)) {
+    const full = path.join(root, SCAN_ROOT, relPath);
+    mkdirSync(path.dirname(full), { recursive: true });
+    writeFileSync(full, content);
+  }
+  return root;
+}
+
+test('registry mirrors spec §20 (13 entries, RFC-gated)', () => {
+  const expected = [
+    'verified-human',
+    'one-human-one-vote',
+    'sybil-resistant',
+    'district-proof',
+    'cryptographic-residency',
+    'permanently-delete',
+    'anonymous',
+    'untraceable',
+    'reset-identity-deletes',
+    'sign-out-removes-data',
+    'permanently-deleted-network',
+    'fully-anonymous',
+    'untraceable-across-devices',
+  ];
+  assert.deepEqual(FORBIDDEN_CLAIMS.map((claim) => claim.id), expected);
+});
+
+test('clean tree passes with zero violations', () => {
+  const root = makeFixtureRepo({
+    'components/Feed.tsx': 'export const Feed = () => <div>Latest stories</div>;\n',
+  });
+  try {
+    const { violations, scannedFileCount } = scanForbiddenClaims(root);
+    assert.equal(scannedFileCount, 1);
+    assert.deepEqual(violations, []);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('red: forbidden claim copy fails the gate', () => {
+  const root = makeFixtureRepo({
+    'components/Promo.tsx': "export const promo = 'Every account is a verified human.';\n",
+  });
+  try {
+    const { violations } = scanForbiddenClaims(root);
+    assert.equal(violations.length, 1);
+    assert.equal(violations[0].claim, 'verified-human');
+    assert.match(violations[0].file, /Promo\.tsx$/);
+    assert.equal(violations[0].line, 1);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('red: anonymity and deletion claims fail the gate', () => {
+  const root = makeFixtureRepo({
+    'components/Privacy.tsx': [
+      "const a = 'Your posts are fully anonymous.';",
+      "const b = 'Reset Identity deletes your activity.';",
+      "const c = 'Your history is untraceable across devices.';",
+    ].join('\n'),
+  });
+  try {
+    const { violations } = scanForbiddenClaims(root);
+    const claimIds = violations.map((violation) => violation.claim);
+    assert.ok(claimIds.includes('fully-anonymous'));
+    assert.ok(claimIds.includes('reset-identity-deletes'));
+    assert.ok(claimIds.includes('untraceable-across-devices'));
+    assert.ok(claimIds.includes('untraceable'));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('negative bounds and typed denial flags are allowed with reasons', () => {
+  const root = makeFixtureRepo({
+    'hooks/useProof.ts': 'export const proof = { canClaimSybilResistance: false };\n',
+    'routes/compliance.tsx': "const bound = 'Beta surfaces must not be presented as Sybil resistance or one-human-one-vote assurance.';\n",
+  });
+  try {
+    const { violations, allowedHits } = scanForbiddenClaims(root);
+    assert.deepEqual(violations, []);
+    assert.ok(allowedHits.length >= 3);
+    assert.ok(allowedHits.every((hit) => typeof hit.allowReason === 'string' && hit.allowReason.length > 0));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("status-enum 'anonymous' literal is allowed; anonymity claim is not", () => {
+  const root = makeFixtureRepo({
+    'hooks/useThing.ts': "const status = 'anonymous';\n",
+    'components/Claim.tsx': 'export const claim = <p>Browsing here keeps you anonymous forever</p>;\n',
+  });
+  try {
+    const { violations, allowedHits } = scanForbiddenClaims(root);
+    assert.equal(violations.length, 1);
+    assert.match(violations[0].file, /Claim\.tsx$/);
+    assert.ok(allowedHits.some((hit) => /useThing\.ts$/.test(hit.file)));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('markdown copy inside the app tree is scanned', () => {
+  const root = makeFixtureRepo({
+    'content/about.md': '# About\nOur network is Sybil-resistant by design.\n',
+  });
+  try {
+    const { violations } = scanForbiddenClaims(root);
+    assert.equal(violations.length, 1);
+    assert.equal(violations[0].claim, 'sybil-resistant');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/tools/scripts/check-luma-production-profile.mjs
+++ b/tools/scripts/check-luma-production-profile.mjs
@@ -1,0 +1,222 @@
+#!/usr/bin/env node
+/**
+ * check:luma-production-profile — M1.C deterministic profile-guard gate.
+ *
+ * Locks the source- and env-level invariants that keep DEV fallback, mock
+ * providers, `VITE_E2E_MODE`, and DEV-stub verifier URLs out of the
+ * `public-beta` and `production-attestation` profiles:
+ *
+ *  1. useIdentity dev-fallback stays triple-gated (dev mode AND not
+ *     public-beta AND explicit VITE_LUMA_DEV_FALLBACK=true).
+ *  2. useIdentity keeps the public-beta runtime assertion that rejects
+ *     E2E mode, dev-mode builds, dev fallback, and localhost verifiers.
+ *  3. apps/web-pwa/.env.production never enables E2E mode, dev fallback,
+ *     or a localhost attestation URL.
+ *  4. The public-beta image build pins VITE_LUMA_PROFILE=public-beta,
+ *     VITE_LUMA_DEV_FALLBACK=false, VITE_E2E_MODE=false, and an empty
+ *     VITE_ATTESTATION_URL.
+ *  5. The luma-sdk provider allow-list keeps Mock and RustDevStub
+ *     providers out of public-beta and production-attestation.
+ *  6. The `ATTESTATION_URL` (gun-client) and `VITE_ATTESTATION_URL`
+ *     (web-pwa) fallback literals stay identical, and both env names,
+ *     when set in the invoking environment, resolve to the same URL.
+ *  7. Optional `--dist <dir>`: scans built JS for mock-provider symbols
+ *     and DEV-stub verifier hosts (bundle-level tree-shake evidence).
+ *
+ * This is a source/env-level guard: without `--dist` it proves the
+ * invariants in source and build inputs, not the emitted bundle. Wire
+ * `--dist` in image builds for bundle-level assurance.
+ */
+
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '../..');
+
+const USE_IDENTITY = 'apps/web-pwa/src/hooks/useIdentity.ts';
+const ENV_PRODUCTION = 'apps/web-pwa/.env.production';
+const BUILD_SCRIPT = 'tools/scripts/build-public-beta-images.sh';
+const PROVIDERS = 'packages/luma-sdk/src/providers/index.ts';
+const GUN_AUTH = 'packages/gun-client/src/auth.ts';
+
+const FORBIDDEN_BUNDLE_SYMBOLS = [
+  'MockAttestationProvider',
+  'MockConstituencyProvider',
+  'RustDevStubAttestationProvider',
+  'localhost:3000/verify',
+  'x-mock-attestation',
+];
+
+function read(repoRoot, relPath, failures) {
+  const full = path.join(repoRoot, relPath);
+  if (!existsSync(full)) {
+    failures.push(`${relPath}: file missing (guard target moved? update this gate deliberately)`);
+    return null;
+  }
+  return readFileSync(full, 'utf8');
+}
+
+export function runChecks(repoRoot = REPO_ROOT, { distDir = null, env = process.env } = {}) {
+  const failures = [];
+  const notes = [];
+
+  // 1 + 2: useIdentity source invariants.
+  const useIdentity = read(repoRoot, USE_IDENTITY, failures);
+  if (useIdentity) {
+    const devFallbackGate = /const DEV_FALLBACK_ENABLED =\s*\n?\s*DEV_MODE\s*\n?\s*&&\s*!PUBLIC_BETA_PROFILE\s*\n?\s*&&\s*IDENTITY_ENV\.VITE_LUMA_DEV_FALLBACK === 'true'/;
+    if (!devFallbackGate.test(useIdentity)) {
+      failures.push(`${USE_IDENTITY}: DEV_FALLBACK_ENABLED must stay triple-gated (DEV_MODE && !PUBLIC_BETA_PROFILE && VITE_LUMA_DEV_FALLBACK === 'true')`);
+    }
+    const runtimeAssertions = [
+      ["public-beta identity creation requires VITE_E2E_MODE=false", /VITE_E2E_MODE=false/],
+      ['dev-mode build rejection', /not allowed from a dev-mode build/],
+      ['dev-fallback rejection', /forbids VITE_LUMA_DEV_FALLBACK/],
+      ['localhost verifier rejection', /must not use localhost verifier defaults/],
+    ];
+    for (const [label, pattern] of runtimeAssertions) {
+      if (!pattern.test(useIdentity)) {
+        failures.push(`${USE_IDENTITY}: assertRuntimeProfileSafeForIdentityCreation lost its "${label}" guard`);
+      }
+    }
+  }
+
+  // 3: .env.production must not enable dev/e2e surfaces.
+  const envProduction = read(repoRoot, ENV_PRODUCTION, failures);
+  if (envProduction) {
+    if (!/^VITE_E2E_MODE=false$/m.test(envProduction)) {
+      failures.push(`${ENV_PRODUCTION}: VITE_E2E_MODE=false must be pinned`);
+    }
+    if (/^VITE_LUMA_DEV_FALLBACK=true$/m.test(envProduction)) {
+      failures.push(`${ENV_PRODUCTION}: VITE_LUMA_DEV_FALLBACK=true is forbidden in production env`);
+    }
+    if (/^VITE_ATTESTATION_URL=.*(localhost|127\.0\.0\.1)/m.test(envProduction)) {
+      failures.push(`${ENV_PRODUCTION}: VITE_ATTESTATION_URL must not point at a local DEV-stub verifier`);
+    }
+  }
+
+  // 4: public-beta image build env pins.
+  const buildScript = read(repoRoot, BUILD_SCRIPT, failures);
+  if (buildScript) {
+    const requiredPins = [
+      'VITE_LUMA_PROFILE=public-beta',
+      'VITE_LUMA_DEV_FALLBACK=false',
+      'VITE_E2E_MODE=false',
+    ];
+    for (const pin of requiredPins) {
+      if (!buildScript.includes(pin)) {
+        failures.push(`${BUILD_SCRIPT}: missing required pin ${pin}`);
+      }
+    }
+    if (!/^VITE_ATTESTATION_URL=\s*$/m.test(buildScript)) {
+      failures.push(`${BUILD_SCRIPT}: VITE_ATTESTATION_URL must be pinned empty (no verifier URL in public-beta builds)`);
+    }
+  }
+
+  // 5: provider allow-list keeps mock/DEV-stub providers out of deployable profiles.
+  const providers = read(repoRoot, PROVIDERS, failures);
+  if (providers) {
+    const allowListMatch = providers.match(/PROVIDER_PROFILE_ALLOW_LIST = Object\.freeze\(\{([\s\S]*?)\}\s*as const/);
+    if (!allowListMatch) {
+      failures.push(`${PROVIDERS}: PROVIDER_PROFILE_ALLOW_LIST not found (guard target moved? update this gate deliberately)`);
+    } else {
+      const body = allowListMatch[1];
+      const entryPattern = /(\w+):\s*Object\.freeze\(\[([^\]]*)\]\)/g;
+      const restricted = ['MockConstituencyProvider', 'MockAttestationProvider', 'RustDevStubAttestationProvider'];
+      const seen = new Set();
+      let entry;
+      while ((entry = entryPattern.exec(body)) !== null) {
+        const [, name, profilesRaw] = entry;
+        seen.add(name);
+        if (restricted.includes(name)) {
+          for (const forbidden of ['public-beta', 'production-attestation']) {
+            if (profilesRaw.includes(forbidden)) {
+              failures.push(`${PROVIDERS}: ${name} allow-list must not include ${forbidden}`);
+            }
+          }
+        }
+        if (name === 'BetaLocalAttestationProvider' && !profilesRaw.includes('public-beta')) {
+          failures.push(`${PROVIDERS}: BetaLocalAttestationProvider must remain the public-beta attestation provider`);
+        }
+      }
+      for (const name of restricted) {
+        if (!seen.has(name)) {
+          failures.push(`${PROVIDERS}: allow-list entry for ${name} not found (renamed? update this gate deliberately)`);
+        }
+      }
+    }
+  }
+
+  // 6: verifier URL env-name drift.
+  const gunAuth = read(repoRoot, GUN_AUTH, failures);
+  if (gunAuth && useIdentity) {
+    const literalPattern = /'(http:\/\/localhost:3000\/verify)'/;
+    const authDefault = gunAuth.match(literalPattern)?.[1] ?? null;
+    const identityDefault = useIdentity.match(literalPattern)?.[1] ?? null;
+    if (authDefault !== identityDefault) {
+      failures.push(`env-name drift: ${GUN_AUTH} default (${authDefault}) != ${USE_IDENTITY} default (${identityDefault})`);
+    }
+    if (useIdentity && !/PUBLIC_BETA_PROFILE \? undefined/.test(useIdentity)) {
+      failures.push(`${USE_IDENTITY}: public-beta must not inherit the localhost verifier default (PUBLIC_BETA_PROFILE ? undefined guard missing)`);
+    }
+  }
+  const envVite = env.VITE_ATTESTATION_URL;
+  const envPlain = env.ATTESTATION_URL;
+  if (envVite !== undefined && envPlain !== undefined && envVite !== envPlain) {
+    failures.push(`env-name drift: ATTESTATION_URL (${envPlain}) != VITE_ATTESTATION_URL (${envVite}) in the invoking environment`);
+  } else if (envVite === undefined && envPlain === undefined) {
+    notes.push('env comparison: neither ATTESTATION_URL nor VITE_ATTESTATION_URL set in the invoking environment; static default-literal comparison applied');
+  }
+
+  // 7: optional built-bundle scan.
+  if (distDir) {
+    const distFull = path.isAbsolute(distDir) ? distDir : path.join(repoRoot, distDir);
+    if (!existsSync(distFull)) {
+      failures.push(`--dist ${distDir}: directory not found`);
+    } else {
+      const jsFiles = [];
+      (function walk(dir) {
+        for (const item of readdirSync(dir)) {
+          const full = path.join(dir, item);
+          if (statSync(full).isDirectory()) walk(full);
+          else if (full.endsWith('.js') || full.endsWith('.mjs')) jsFiles.push(full);
+        }
+      })(distFull);
+      for (const file of jsFiles) {
+        const content = readFileSync(file, 'utf8');
+        for (const symbol of FORBIDDEN_BUNDLE_SYMBOLS) {
+          if (content.includes(symbol)) {
+            failures.push(`bundle leak: ${path.relative(repoRoot, file)} contains forbidden symbol "${symbol}"`);
+          }
+        }
+      }
+      notes.push(`bundle scan: ${jsFiles.length} built JS files checked under ${distDir}`);
+    }
+  } else {
+    notes.push('bundle scan: skipped (pass --dist <dir> after a public-beta build for bundle-level tree-shake evidence)');
+  }
+
+  return { failures, notes };
+}
+
+function main() {
+  const distFlagIndex = process.argv.indexOf('--dist');
+  const distDir = distFlagIndex !== -1 ? process.argv[distFlagIndex + 1] : null;
+  const { failures, notes } = runChecks(REPO_ROOT, { distDir });
+  for (const note of notes) {
+    console.log(`luma-production-profile: ${note}`);
+  }
+  if (failures.length > 0) {
+    console.error(`luma-production-profile: FAIL — ${failures.length} violation(s):`);
+    for (const failure of failures) {
+      console.error(`  ${failure}`);
+    }
+    process.exit(1);
+  }
+  console.log('luma-production-profile: PASS');
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/tools/scripts/check-luma-production-profile.test.mjs
+++ b/tools/scripts/check-luma-production-profile.test.mjs
@@ -1,0 +1,188 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { runChecks } from './check-luma-production-profile.mjs';
+
+const FAITHFUL_USE_IDENTITY = `
+const DEV_FALLBACK_ENABLED =
+  DEV_MODE
+  && !PUBLIC_BETA_PROFILE
+  && IDENTITY_ENV.VITE_LUMA_DEV_FALLBACK === 'true';
+const ATTESTATION_URL =
+  (typeof CONFIGURED_ATTESTATION_URL === 'string' ? CONFIGURED_ATTESTATION_URL : undefined)
+  ?? (PUBLIC_BETA_PROFILE ? undefined : 'http://localhost:3000/verify');
+function assertRuntimeProfileSafeForIdentityCreation() {
+  if (E2E_MODE) throw new Error('public-beta identity creation requires VITE_E2E_MODE=false');
+  if (DEV_MODE) throw new Error('public-beta identity creation is not allowed from a dev-mode build');
+  if (IDENTITY_ENV.VITE_LUMA_DEV_FALLBACK === 'true') throw new Error('public-beta identity creation forbids VITE_LUMA_DEV_FALLBACK');
+  if (/localhost:3000\\/verify/.test(ATTESTATION_URL)) throw new Error('public-beta identity creation must not use localhost verifier defaults');
+}
+`;
+
+const FAITHFUL_ENV_PRODUCTION = 'VITE_E2E_MODE=false\n';
+
+const FAITHFUL_BUILD_SCRIPT = `
+VITE_LUMA_PROFILE=public-beta
+VITE_LUMA_DEV_FALLBACK=false
+VITE_ATTESTATION_URL=
+VITE_E2E_MODE=false
+`;
+
+const FAITHFUL_PROVIDERS = `
+export const PROVIDER_PROFILE_ALLOW_LIST = Object.freeze({
+  BetaLocalConstituencyProvider: Object.freeze(['dev', 'public-beta', 'production-attestation']),
+  MockConstituencyProvider: Object.freeze(['dev', 'e2e']),
+  BetaLocalAttestationProvider: Object.freeze(['dev', 'public-beta']),
+  MockAttestationProvider: Object.freeze(['dev', 'e2e']),
+  RustDevStubAttestationProvider: Object.freeze(['dev', 'e2e'])
+} as const satisfies Record<LumaProviderName, readonly DeploymentProfile[]>);
+`;
+
+const FAITHFUL_GUN_AUTH = `
+const DEFAULT_VERIFIER_URL =
+  (import.meta as any).env?.ATTESTATION_URL ?? 'http://localhost:3000/verify';
+`;
+
+function makeFixtureRepo(overrides = {}) {
+  const root = mkdtempSync(path.join(tmpdir(), 'luma-production-profile-'));
+  const files = {
+    'apps/web-pwa/src/hooks/useIdentity.ts': FAITHFUL_USE_IDENTITY,
+    'apps/web-pwa/.env.production': FAITHFUL_ENV_PRODUCTION,
+    'tools/scripts/build-public-beta-images.sh': FAITHFUL_BUILD_SCRIPT,
+    'packages/luma-sdk/src/providers/index.ts': FAITHFUL_PROVIDERS,
+    'packages/gun-client/src/auth.ts': FAITHFUL_GUN_AUTH,
+    ...overrides,
+  };
+  for (const [relPath, content] of Object.entries(files)) {
+    if (content === null) continue;
+    const full = path.join(root, relPath);
+    mkdirSync(path.dirname(full), { recursive: true });
+    writeFileSync(full, content);
+  }
+  return root;
+}
+
+test('faithful fixture passes', () => {
+  const root = makeFixtureRepo();
+  try {
+    const { failures } = runChecks(root, { env: {} });
+    assert.deepEqual(failures, []);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('red: loosened dev-fallback gate fails', () => {
+  const root = makeFixtureRepo({
+    'apps/web-pwa/src/hooks/useIdentity.ts': FAITHFUL_USE_IDENTITY.replace("&& !PUBLIC_BETA_PROFILE\n", ''),
+  });
+  try {
+    const { failures } = runChecks(root, { env: {} });
+    assert.ok(failures.some((failure) => failure.includes('DEV_FALLBACK_ENABLED')));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('red: production env enabling dev fallback fails', () => {
+  const root = makeFixtureRepo({
+    'apps/web-pwa/.env.production': 'VITE_E2E_MODE=false\nVITE_LUMA_DEV_FALLBACK=true\n',
+  });
+  try {
+    const { failures } = runChecks(root, { env: {} });
+    assert.ok(failures.some((failure) => failure.includes('VITE_LUMA_DEV_FALLBACK=true is forbidden')));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('red: production env pointing verifier at localhost fails', () => {
+  const root = makeFixtureRepo({
+    'apps/web-pwa/.env.production': 'VITE_E2E_MODE=false\nVITE_ATTESTATION_URL=http://localhost:3000/verify\n',
+  });
+  try {
+    const { failures } = runChecks(root, { env: {} });
+    assert.ok(failures.some((failure) => failure.includes('must not point at a local DEV-stub verifier')));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('red: unpinned public-beta build env fails', () => {
+  const root = makeFixtureRepo({
+    'tools/scripts/build-public-beta-images.sh': 'VITE_LUMA_PROFILE=public-beta\nVITE_E2E_MODE=false\nVITE_ATTESTATION_URL=\n',
+  });
+  try {
+    const { failures } = runChecks(root, { env: {} });
+    assert.ok(failures.some((failure) => failure.includes('VITE_LUMA_DEV_FALLBACK=false')));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('red: mock provider allowed into public-beta fails', () => {
+  const root = makeFixtureRepo({
+    'packages/luma-sdk/src/providers/index.ts': FAITHFUL_PROVIDERS.replace(
+      "MockAttestationProvider: Object.freeze(['dev', 'e2e'])",
+      "MockAttestationProvider: Object.freeze(['dev', 'e2e', 'public-beta'])",
+    ),
+  });
+  try {
+    const { failures } = runChecks(root, { env: {} });
+    assert.ok(failures.some((failure) => failure.includes('MockAttestationProvider allow-list must not include public-beta')));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('red: env-name drift in invoking environment fails', () => {
+  const root = makeFixtureRepo();
+  try {
+    const { failures } = runChecks(root, {
+      env: { ATTESTATION_URL: 'https://a.example/verify', VITE_ATTESTATION_URL: 'https://b.example/verify' },
+    });
+    assert.ok(failures.some((failure) => failure.includes('env-name drift: ATTESTATION_URL')));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('red: default-literal drift between gun-client and web-pwa fails', () => {
+  const root = makeFixtureRepo({
+    'packages/gun-client/src/auth.ts': FAITHFUL_GUN_AUTH.replace('localhost:3000', 'localhost:4000'),
+  });
+  try {
+    const { failures } = runChecks(root, { env: {} });
+    assert.ok(failures.some((failure) => failure.includes('env-name drift:')));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('red: dist bundle containing a mock provider symbol fails', () => {
+  const root = makeFixtureRepo({
+    'dist/assets/app.js': 'export const p = new MockAttestationProvider();',
+  });
+  try {
+    const { failures, notes } = runChecks(root, { env: {}, distDir: 'dist' });
+    assert.ok(failures.some((failure) => failure.includes('bundle leak') && failure.includes('MockAttestationProvider')));
+    assert.ok(notes.some((note) => note.includes('bundle scan: 1 built JS files')));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('clean dist bundle passes the bundle scan', () => {
+  const root = makeFixtureRepo({
+    'dist/assets/app.js': 'export const providers = { betaLocal: true };',
+  });
+  try {
+    const { failures } = runChecks(root, { env: {}, distDir: 'dist' });
+    assert.deepEqual(failures, []);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
LUMA execution-window slice while Scope A accumulates the instrumented relay graph/heap window. Strictly docs/spec/readiness + CI gates: no live Scope A publisher/relay behavior, A6 config, retention/compaction, watchdog thresholds, deploy paths, public schema epochs, or provider promotion. No Silver/production-attestation claims.

## Implemented (code, CI-gate-only)
- **M1.D** `pnpm check:luma-forbidden-claims`: greps `apps/web-pwa/src/**/*.{ts,tsx,md}` against the spec §20 registry (13 entries, RFC-gated). Per-entry documented allow-contexts cover the compliance surface's negative bounds ("is not a verified-human system"), the `canClaimSybilResistance: false` denial flag, and the `'anonymous'` status-enum literal — 56 allowed hits reported transparently; PASS on current main. Fixture-based red tests (7) prove forbidden copy fails. Wired into `mvp-release-gates` as `luma_forbidden_claims`.
- **M1.C** `pnpm check:luma-production-profile`: deterministic source/env-level guard locking the dev-fallback triple-gate, the four public-beta runtime assertions, `.env.production` pins, public-beta image-build env pins, the luma-sdk provider allow-list (mock/DEV-stub providers excluded from deployable profiles), and `ATTESTATION_URL`/`VITE_ATTESTATION_URL` drift (static literals + invoking-env comparison). Optional `--dist` mode scans built JS for mock-provider symbols and DEV-stub hosts. Red tests (10). Wired into `mvp-release-gates` as `luma_production_profile`.

## Design-only (docs/plans, non-authoritative)
- **M1.B** `LUMA_M1B_IDENTITY_CONTROLS_DESIGN_2026-07-02.md`: verified implementation truth (signOut/resetIdentity split exists and is tested; `/account/identity` route and all controls UI missing), full UX copy pack audited against §20, controls state model, the 12-row preservation/rotation table, a11y criteria, unit/E2E test expectations, and the `operatorAuthorizationToken` Reset-clearing audit item.
- **M2.A** `LUMA_M2A_VERIFIER_SPEC_PACKET_2026-07-02.md`: draft verifier-spec packet (endpoint contract incl. challenge/JWKS/manifest/revocations/bulletin, signing + custody default, rate limits, closed failure taxonomy, audit/retention placeholders, SLO drafts, topology isolated from the A6 failure domain, continuity obligations, §21.2 adversarial corpus, key-compromise drill draft) with explicit unsatisfied-dependency framing (M1 incomplete, M2.A-3 retention, M2.A-4 ops ownership).

## Deliberately not done (unsafe or out of sequence in this window)
- `<TrustClaim>` runtime wrapper (depends on M1.E telemetry registry; design + test plan captured in the M1.B/M1.D lane docs).
- `/account/identity` route/UI implementation (sequenced in the M1.B packet).
- Landing `spec-luma-verifier-v0.md` as a spec or any runbook under docs/ops (M2.A acceptance requires ops-ownership + retention decisions).
- Timeout-per-profile pinning and the `DEV_FALLBACK_TRUST_SCORE` constant extraction (app-code changes; follow-up PR).

## Validation
- `node tools/scripts/check-docs-governance.mjs` (= `pnpm docs:check`): PASS, 135 files.
- Both new gates: PASS on this branch's tree.
- `node --test` on both gate test files: 17/17 pass.
- `node --check` on all touched JS; `git diff --check` clean.
- No Scope A / relay / publisher / schema files touched (new files + package.json + mvp-release-gates.mjs only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)