### PR TITLE
Add public feed alert watch

### DIFF
--- a/docs/ops/news-aggregator-production-service.md
+++ b/docs/ops/news-aggregator-production-service.md
@@ -94,6 +94,8 @@ Templates:
 - `infra/systemd/user/vh-news-relay-liveness-watch.timer`
 - `infra/systemd/user/vh-phase5-scope-a-soak-archive.service`
 - `infra/systemd/user/vh-phase5-scope-a-soak-archive.timer`
+- `infra/systemd/user/vh-public-feed-alert-watch.service`
+- `infra/systemd/user/vh-public-feed-alert-watch.timer`
 
 Installer:
 

--- a/docs/ops/public-feed-freshness-monitor.md
+++ b/docs/ops/public-feed-freshness-monitor.md
@@ -39,6 +39,77 @@ alerting channel by themselves. A fail-closed publisher can leave the feed stale
 until a human reads the host. Before any unattended long watch, confirm that at
 least one monitor failure path reaches the release owner outside the A6 host.
 
+## Host-Local Alert Watch
+
+`tools/scripts/public-feed-alert-watch.mjs` is the repo-side host alert path for
+the outage #2 silence gap. It composes the public freshness monitor with a
+read-only publisher unit check and sends a state-change-only alert when either:
+
+- the public latest-index freshness monitor fails the 6-hour SLO or public
+  health checks;
+- `vh-news-aggregator.service` is not `active/running`;
+- the publisher unit is parked with `ExecMainStatus=78`.
+
+The alert output is secret-safe. It records statuses, blockers, counts, ages,
+and origin hashes only; it does not include tokens, raw feed payloads, story
+bodies, URLs, pins, keys, or heap snapshot contents.
+
+The script supports two delivery channels configured by environment only:
+
+| Variable | Notes |
+| --- | --- |
+| `VH_PUBLIC_FEED_ALERT_WEBHOOK_URL` | HTTPS webhook target. Keep the value in the host env file, not the repo. |
+| `VH_PUBLIC_FEED_ALERT_EMAIL_TO` | Recipient for host-MTA delivery via `sendmail -t`. |
+| `VH_PUBLIC_FEED_ALERT_EMAIL_FROM` | Optional sender, default `vhc-public-feed-alert@localhost`. |
+| `VH_PUBLIC_FEED_ALERT_SENDMAIL` | Optional sendmail path, default `/usr/sbin/sendmail`. |
+| `VH_PUBLIC_FEED_ALERT_HEARTBEAT_MS` | Optional resend interval for unchanged state. Default `0`, meaning no heartbeat. |
+| `VH_PUBLIC_FEED_ALERT_TEST_FIRE` | Set to `1` for a one-shot delivery test without changing the observed pass/fail result. |
+| `VH_PUBLIC_FEED_ALERT_STATE_DIR` | Default `~/.local/state/vhc/public-feed-alert`. |
+
+State-change-only delivery means a repeated stale feed or repeated exit-78
+publisher state does not spam every timer tick. A transition into failure sends,
+a transition out of failure sends, and a heartbeat sends only when explicitly
+configured. The state fingerprint is based on failure class, publisher state,
+origin hashes, counts, and stale/fresh age state rather than the exact
+`newestAgeMs`, so an already-stale feed aging by another timer interval does not
+create a new alert by itself. A failed delivery is not treated as delivered; the
+next timer run retries the same observed failure until at least one configured
+channel succeeds.
+
+The repo ships user-systemd units but does not enable them:
+
+- `infra/systemd/user/vh-public-feed-alert-watch.service`
+- `infra/systemd/user/vh-public-feed-alert-watch.timer`
+
+Operator enablement, after explicit approval:
+
+```bash
+mkdir -p ~/.config/vhc
+install -m 0600 /dev/null ~/.config/vhc/public-feed-alert.env
+$EDITOR ~/.config/vhc/public-feed-alert.env
+
+mkdir -p ~/.config/systemd/user
+cp infra/systemd/user/vh-public-feed-alert-watch.service ~/.config/systemd/user/
+cp infra/systemd/user/vh-public-feed-alert-watch.timer ~/.config/systemd/user/
+systemctl --user daemon-reload
+
+VH_PUBLIC_FEED_ALERT_TEST_FIRE=1 systemctl --user start vh-public-feed-alert-watch.service
+cat ~/.local/state/vhc/public-feed-alert/latest.json
+
+systemctl --user enable --now vh-public-feed-alert-watch.timer
+systemctl --user status vh-public-feed-alert-watch.timer --no-pager
+```
+
+Rollback:
+
+```bash
+systemctl --user disable --now vh-public-feed-alert-watch.timer
+systemctl --user reset-failed vh-public-feed-alert-watch.service
+rm -f ~/.config/systemd/user/vh-public-feed-alert-watch.service
+rm -f ~/.config/systemd/user/vh-public-feed-alert-watch.timer
+systemctl --user daemon-reload
+```
+
 Host-local relay snapshot freshness is covered separately by
 `docs/ops/news-aggregator-production-service.md`. That watch reads
 `news-latest-index-snapshot.json` files directly and does not perform public
@@ -95,6 +166,9 @@ health, publisher liveness by itself, or broader release readiness.
 | `VH_PUBLIC_FEED_FRESHNESS_SCAN_LIMIT` | `120` | Relay scan limit for latest-index reads. |
 | `VH_PUBLIC_FEED_FRESHNESS_CHECK_OPENAI_PREFLIGHT` | `false` | When `true`, the monitor builds StoryCluster and fails on auth/quota/model preflight errors. |
 | `VH_PUBLIC_FEED_FRESHNESS_ARTIFACT_DIR` | `.tmp/public-feed-freshness/<timestamp>` | Override for deterministic local tests. |
+| `VH_PUBLIC_FEED_ALERT_WEBHOOK_URL` | unset | Host-local alert webhook URL; only read by `public-feed-alert-watch.mjs`. |
+| `VH_PUBLIC_FEED_ALERT_EMAIL_TO` | unset | Host-local alert email recipient; only read by `public-feed-alert-watch.mjs`. |
+| `VH_PUBLIC_FEED_ALERT_HEARTBEAT_MS` | `0` | Optional unchanged-state heartbeat interval for host-local alerting. |
 
 ## Failure Classes
 

--- a/docs/reports/open-draft-pr-triage-2026-07-02.md
+++ b/docs/reports/open-draft-pr-triage-2026-07-02.md
@@ -1,0 +1,18 @@
+# Open Draft PR Triage - 2026-07-02
+
+> Status: Triage Only
+> Owner: VHC Launch Ops
+> Last Reviewed: 2026-07-02
+
+This note re-triages old open draft PRs without resuming their branches. It is
+repo-side bookkeeping only; it does not change live Scope A/A6 behavior.
+
+| PR | Branch | Disposition | Recommendation |
+| --- | --- | --- | --- |
+| #631 Stabilize public analysis frame pipeline | `coord/mvp-analysis-frame-pipeline-reliability-v1` | Superseded/conflicts with current claims posture. The branch predates outage #2 recovery, #691-#694 relay diagnostics/stagger, and the current Scope A raw-only/driver-evidence gate; it touches broad relay, feed, synthesis, and public-read surfaces. | Close or split after a fresh roadmap review. Do not refresh wholesale. |
+| #629 MVP public beta go/no-go approval hold | `coord/mvp-public-beta-go-no-go-v1` | Superseded. The launch-control packet predates the current Scope A outage ledger and LUMA forbidden-claims/profile gate posture. | Close; replace with a new approval packet only after current Scope A driver evidence and LUMA claim gates are incorporated. |
+| #544 Align docs after report intake admin merge | `coord/docs-alignment-after-report-intake` | Superseded by later docs-alignment work and current Scope A/LUMA docs. | Close unless a maintainer identifies a still-missing report-intake doc row; if so, cherry-pick that row into a new focused docs PR. |
+| #524 Wire bundle synthesis daemon spine | `coord/bundle-synthesis-spine` | Still conceptually valid as Scope B, but out of window. It introduces accepted/topic synthesis behavior and daemon publication surfaces while the current program explicitly holds Scope B and verifier/profile promotion work. | Keep parked or close-and-reopen later from current `main` under a Scope B authorization packet. Do not resume during the current Scope A/LUMA window. |
+
+Non-draft open PRs from the same era should be separately reviewed before any
+merge attempt; this note covers only old drafts.

--- a/docs/reports/phase5-scope-a-driver-verdict-2026-07-02.md
+++ b/docs/reports/phase5-scope-a-driver-verdict-2026-07-02.md
@@ -1,0 +1,68 @@
+# Phase 5 Scope A Driver Verdict - 2026-07-02
+
+> Status: Driver Unknown - Evidence Packet Missing
+> Owner: VHC Launch Ops
+> Last Reviewed: 2026-07-02
+> Depends On: docs/reports/phase5-scope-a-recovery-current-state-2026-07-02.md, docs/ops/news-aggregator-production-service.md
+
+## Scope
+
+This is the read-only Scope A heap-growth driver verdict for the post-outage #2
+program window. It does not change relay, publisher, A6, retention, compaction,
+watchdog, or deploy behavior.
+
+## Inputs Checked
+
+- The recovery report records that #691 graph metrics and #692 early heap
+  capture are enabled, and that the current gate is the 12-24 hour instrumented
+  climb from the post-deploy floor.
+- The repository contains the graph/heap ingestion code and the pre-outage
+  2026-06-28 closure evidence.
+- No post-#694 operator packet with the 12-24 hour graph-scan trend or
+  early-capture retainer summary is committed in the repo.
+- The documented local soak archive path,
+  `~/.local/state/vhc/phase5-scope-a-soak`, is absent on this workstation.
+
+## Verdict
+
+`heap_driver_unknown`.
+
+The required evidence for the four-way decision tree is not locally available:
+there is no complete post-#694 time series for relay heap/RSS against graph
+`userValueBytes`, tombstoned souls, link-only souls, and namespace live bytes,
+and there is no secret-safe early-capture retainer summary. The correct action
+is to hold all Scope A driver fixes.
+
+## Decision Tree Position
+
+| Candidate | Current evidence | Decision |
+| --- | --- | --- |
+| Live graph bytes track heap | Missing post-#694 graph/heap trend | Not selected |
+| Soul count or link/tombstone structure climbs while bytes stay flat | Missing post-#694 graph/heap trend | Not selected |
+| Graph bytes stay flat while heap climbs | Missing post-#694 graph/heap trend and early-capture retainer summary | Not selected |
+| Heap plateaus below staggered ceilings | Missing post-#694 heap/RSS trend across the staggered ceilings | Not selected |
+
+## Recommended Next Scope A PR
+
+No retention, publisher clearing, relay compaction, eviction, watchdog, or
+publisher/relay behavior PR is recommended from the current evidence. The next
+Scope A development PR should be selected only after the operator supplies a
+secret-safe packet containing:
+
+- hourly or finer relay heap/RSS samples;
+- graph scan success/truncation/error/age data;
+- graph `userValueBytes` by namespace and state;
+- total, live, tombstoned, and link-only soul counts;
+- the #692 early-capture aggregate retainer summary, with no raw heap snapshot
+  content.
+
+If those packet inputs remain unavailable, the next repo-side PR should be an
+offline packet validator/verdict generator for the existing soak archive shape,
+not a heap-driver fix.
+
+## Non-Goals
+
+- No retention or story clearing.
+- No relay-side compaction or Gun eviction.
+- No A6 service action, restart, env edit, monitor enable, or deploy.
+- No broad public-beta, Mesh `release_ready`, or production freshness claim.

--- a/infra/systemd/user/vh-public-feed-alert-watch.service
+++ b/infra/systemd/user/vh-public-feed-alert-watch.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=VHC Public Feed Alert Watch
+Documentation=file:/home/humble/VHC/docs/ops/public-feed-freshness-monitor.md
+
+[Service]
+Type=oneshot
+Environment=VHC_REPO=/home/humble/VHC
+Environment=VH_PUBLIC_FEED_ALERT_STATE_DIR=%h/.local/state/vhc/public-feed-alert
+Environment=VH_PUBLIC_FEED_ALERT_OUTPUT_FILE=%h/.local/state/vhc/public-feed-alert/latest.json
+Environment=VH_PUBLIC_FEED_FRESHNESS_ARTIFACT_DIR=%h/.local/state/vhc/public-feed-alert/public-feed-freshness
+Environment=PATH=/home/humble/.local/bin:/home/humble/.hermes/node/bin:/usr/local/bin:/usr/bin:/bin
+WorkingDirectory=/home/humble/VHC
+ExecStart=/usr/bin/env bash -c 'if [ -f "%h/.config/vhc/public-feed-alert.env" ]; then set -a; source "%h/.config/vhc/public-feed-alert.env"; set +a; fi; exec node "/home/humble/VHC/tools/scripts/public-feed-alert-watch.mjs"'

--- a/infra/systemd/user/vh-public-feed-alert-watch.timer
+++ b/infra/systemd/user/vh-public-feed-alert-watch.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Run VHC public feed alert watch every 15 minutes
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=15min
+AccuracySec=1min
+Persistent=true
+Unit=vh-public-feed-alert-watch.service
+
+[Install]
+WantedBy=timers.target

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "check:public-feed:lifecycle-accountability": "pnpm --filter @vh/gun-client build && node ./packages/e2e/src/live/public-feed-lifecycle-accountability.mjs",
     "check:public-feed:fresh-propagation": "pnpm --filter @vh/e2e test:live:daemon-feed:build && node ./packages/e2e/src/live/public-feed-fresh-propagation-gate.mjs",
     "check:public-feed:freshness-monitor": "pnpm --filter @vh/gun-client... build && node ./tools/scripts/public-feed-freshness-monitor.mjs",
+    "check:public-feed:alert-watch": "node --test ./tools/scripts/public-feed-alert-watch.test.mjs",
     "test:mesh:browser-canary": "VITE_GUN_PEERS='[\"http://127.0.0.1:7788/gun\",\"http://127.0.0.1:7789/gun\",\"http://127.0.0.1:7790/gun\"]' VITE_GUN_PEER_MINIMUM=3 VITE_GUN_PEER_QUORUM_REQUIRED=2 VITE_VH_ALLOW_LOCAL_MESH_PEERS=true VITE_VH_GUN_LOCAL_STORAGE=false VITE_VH_SHOW_HEALTH=true pnpm --filter @vh/web-pwa build && pnpm --filter @vh/e2e test:mesh:browser-canary",
     "test:mesh:signed-peer-config-canary": "node ./packages/e2e/src/mesh/signed-peer-config-canary.mjs",
     "test:mesh:deployed-wss-peer-config": "pnpm --filter @vh/e2e test:mesh:deployed-wss-peer-config",

--- a/tools/scripts/public-feed-alert-watch.mjs
+++ b/tools/scripts/public-feed-alert-watch.mjs
@@ -1,0 +1,539 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync } from 'node:fs';
+import { mkdir, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { runPublicFeedFreshnessMonitor } from './public-feed-freshness-monitor.mjs';
+import { newsAggregatorPublisherLivenessWatchInternal } from './news-aggregator-publisher-liveness-watch.mjs';
+
+const REPORT_SCHEMA_VERSION = 'vh-public-feed-alert-watch-v1';
+const STATE_SCHEMA_VERSION = 'vh-public-feed-alert-state-v1';
+const DEFAULT_UNIT = 'vh-news-aggregator.service';
+const DEFAULT_STATE_DIR = '.local/state/vhc/public-feed-alert';
+const DEFAULT_TIMEOUT_MS = 15_000;
+const URL_IN_TEXT_PATTERN = /https?:\/\/[^\s"'<>)}\]]+?(?=:(?:[a-z][a-z0-9_-]*)(?::|$)|[\s"'<>)}\]]|$)/gi;
+
+function firstNonEmpty(...values) {
+  for (const value of values) {
+    const trimmed = typeof value === 'string' ? value.trim() : '';
+    if (trimmed) return trimmed;
+  }
+  return null;
+}
+
+function boolEnv(value, fallback = false) {
+  const normalized = String(value ?? '').trim().toLowerCase();
+  if (!normalized) return fallback;
+  if (['1', 'true', 'yes', 'y', 'on'].includes(normalized)) return true;
+  if (['0', 'false', 'no', 'n', 'off'].includes(normalized)) return false;
+  return fallback;
+}
+
+function nonNegativeInt(value, fallback) {
+  const parsed = Number.parseInt(String(value ?? ''), 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+function resolveHome(env) {
+  return firstNonEmpty(env.HOME, process.env.HOME) ?? os.homedir();
+}
+
+function resolveStateDir(env) {
+  return firstNonEmpty(env.VH_PUBLIC_FEED_ALERT_STATE_DIR)
+    ?? path.join(resolveHome(env), DEFAULT_STATE_DIR);
+}
+
+function resolveStateFile(env) {
+  return firstNonEmpty(env.VH_PUBLIC_FEED_ALERT_STATE_FILE)
+    ?? path.join(resolveStateDir(env), 'state.json');
+}
+
+function resolveOutputFile(env) {
+  return firstNonEmpty(env.VH_PUBLIC_FEED_ALERT_OUTPUT_FILE)
+    ?? path.join(resolveStateDir(env), 'latest.json');
+}
+
+function hashValue(value, length = 16) {
+  return createHash('sha256').update(String(value ?? '')).digest('hex').slice(0, length);
+}
+
+function sanitizeAlertText(value) {
+  return String(value ?? '').replace(URL_IN_TEXT_PATTERN, (url) => `url_hash:${hashValue(url)}`);
+}
+
+function stableFingerprintText(value) {
+  return sanitizeAlertText(value).replace(/\b\d{4,}\b/g, '<n>');
+}
+
+function freshnessAgeState(readback) {
+  const newestAgeMs = Number.isFinite(readback?.newestAgeMs) ? readback.newestAgeMs : null;
+  const maxAgeMs = Number.isFinite(readback?.maxAgeMs) ? readback.maxAgeMs : null;
+  if (newestAgeMs === null || maxAgeMs === null) return 'unknown';
+  return newestAgeMs > maxAgeMs ? 'stale' : 'fresh';
+}
+
+function readJsonFile(filePath) {
+  if (!filePath || !existsSync(filePath)) return null;
+  try {
+    return JSON.parse(readFileSync(filePath, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+async function writeJson(filePath, value) {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+function summarizeFreshnessReadback(readback) {
+  return {
+    originHash: hashValue(readback?.origin),
+    status: readback?.status ?? null,
+    recordCount: Number.isFinite(readback?.recordCount) ? readback.recordCount : null,
+    newestAgeMs: Number.isFinite(readback?.newestAgeMs) ? readback.newestAgeMs : null,
+    maxAgeMs: Number.isFinite(readback?.maxAgeMs) ? readback.maxAgeMs : null,
+    failureCount: Array.isArray(readback?.failures) ? readback.failures.length : 0,
+  };
+}
+
+function summarizeFreshness(summary) {
+  return {
+    schemaVersion: summary?.schemaVersion ?? null,
+    generatedAt: summary?.generatedAt ?? null,
+    status: summary?.status ?? null,
+    blockers: Array.isArray(summary?.blockers) ? summary.blockers.map(sanitizeAlertText) : [],
+    maxAgeMs: Number.isFinite(summary?.config?.maxAgeMs) ? summary.config.maxAgeMs : null,
+    originHashes: Array.isArray(summary?.config?.origins)
+      ? summary.config.origins.map((origin) => hashValue(origin))
+      : [],
+    latestIndexReadbacks: Array.isArray(summary?.latestIndexReadbacks)
+      ? summary.latestIndexReadbacks.map(summarizeFreshnessReadback)
+      : [],
+  };
+}
+
+function readPublisherSystemctlShow(unit, spawnSyncImpl = spawnSync) {
+  const result = spawnSyncImpl('systemctl', [
+    '--user',
+    'show',
+    unit,
+    '-p',
+    'ActiveState',
+    '-p',
+    'SubState',
+    '-p',
+    'NRestarts',
+    '-p',
+    'ExecMainStatus',
+    '-p',
+    'Result',
+    '--no-pager',
+  ], {
+    encoding: 'utf8',
+  });
+  if (result.status !== 0) {
+    throw new Error(String(result.stderr ?? result.stdout ?? '').trim() || `systemctl_show_failed:${unit}`);
+  }
+  return String(result.stdout ?? '');
+}
+
+function inspectPublisherUnit({
+  env,
+  systemctlShowText = null,
+  spawnSyncImpl = spawnSync,
+} = {}) {
+  const unit = firstNonEmpty(env.VH_PUBLIC_FEED_ALERT_PUBLISHER_UNIT, DEFAULT_UNIT);
+  const blockers = [];
+  let properties = {};
+  try {
+    properties = newsAggregatorPublisherLivenessWatchInternal.parseSystemctlShow(
+      systemctlShowText ?? readPublisherSystemctlShow(unit, spawnSyncImpl),
+    );
+  } catch (error) {
+    blockers.push(`publisher_systemctl_failed:${error instanceof Error ? error.message : String(error)}`);
+  }
+
+  const activeState = properties.ActiveState ?? null;
+  const subState = properties.SubState ?? null;
+  const execMainStatus = properties.ExecMainStatus ?? null;
+  const result = properties.Result ?? null;
+  const nRestarts = Number.parseInt(String(properties.NRestarts ?? ''), 10);
+  const running = activeState === 'active' && subState === 'running';
+  const exit78 = String(execMainStatus ?? '').trim() === '78';
+
+  if (!running && blockers.length === 0) {
+    blockers.push(exit78
+      ? `publisher_exit_78:${activeState ?? 'missing'}/${subState ?? 'missing'}`
+      : `publisher_not_running:${activeState ?? 'missing'}/${subState ?? 'missing'}`);
+  }
+
+  return {
+    unit,
+    status: blockers.length === 0 ? 'pass' : 'fail',
+    blockers,
+    activeState,
+    subState,
+    execMainStatus,
+    result,
+    nRestarts: Number.isFinite(nRestarts) && nRestarts >= 0 ? nRestarts : null,
+    failureClass: exit78 ? 'exit_78_fail_closed' : !running ? 'unit_not_running' : 'none',
+  };
+}
+
+function fingerprintFor({ status, blockers, publisher, freshness }) {
+  return hashValue(JSON.stringify({
+    status,
+    blockers: [...blockers].map(stableFingerprintText).sort(),
+    publisher: {
+      status: publisher.status,
+      activeState: publisher.activeState,
+      subState: publisher.subState,
+      execMainStatus: publisher.execMainStatus,
+      failureClass: publisher.failureClass,
+    },
+    freshness: {
+      status: freshness.status,
+      blockers: freshness.blockers.map(stableFingerprintText),
+      latestIndexReadbacks: freshness.latestIndexReadbacks.map((entry) => ({
+        originHash: entry.originHash,
+        status: entry.status,
+        ageState: freshnessAgeState(entry),
+        recordCount: entry.recordCount,
+        failureCount: entry.failureCount,
+      })),
+    },
+  }), 24);
+}
+
+function shouldDeliverAlert({
+  env,
+  now,
+  status,
+  fingerprint,
+  previousState,
+}) {
+  const heartbeatMs = nonNegativeInt(env.VH_PUBLIC_FEED_ALERT_HEARTBEAT_MS, 0);
+  const testFire = boolEnv(env.VH_PUBLIC_FEED_ALERT_TEST_FIRE, false);
+  const previousFingerprint = previousState?.lastObservedFingerprint ?? null;
+  const previousStatus = previousState?.lastObservedStatus ?? null;
+  const previousDeliveredFingerprint = previousState?.lastDeliveredFingerprint ?? null;
+  const lastDeliveredAtMs = Date.parse(String(previousState?.lastDeliveredAt ?? ''));
+  const heartbeatDue = heartbeatMs > 0
+    && (!Number.isFinite(lastDeliveredAtMs) || now - lastDeliveredAtMs >= heartbeatMs);
+  const changed = previousFingerprint !== null && previousFingerprint !== fingerprint;
+  const firstFailure = previousFingerprint === null && status === 'fail';
+  const retryUndeliveredFailure = previousFingerprint === fingerprint
+    && status === 'fail'
+    && previousDeliveredFingerprint !== fingerprint;
+  const failureOrRecoveryChanged = changed && (status === 'fail' || previousStatus === 'fail');
+  let reason = 'unchanged_suppressed';
+  if (testFire) {
+    reason = 'test_fire';
+  } else if (firstFailure) {
+    reason = 'first_failure';
+  } else if (retryUndeliveredFailure) {
+    reason = 'retry_failed_delivery';
+  } else if (failureOrRecoveryChanged) {
+    reason = 'state_changed';
+  } else if (heartbeatDue) {
+    reason = 'heartbeat_due';
+  }
+  return {
+    deliver: testFire || firstFailure || retryUndeliveredFailure || failureOrRecoveryChanged || heartbeatDue,
+    reason,
+    heartbeatMs,
+    status,
+  };
+}
+
+function alertPayload(summary, reason) {
+  return {
+    schemaVersion: REPORT_SCHEMA_VERSION,
+    generatedAt: summary.generatedAt,
+    alertReason: reason,
+    status: summary.status,
+    observedStatus: summary.observedStatus,
+    blockers: summary.blockers,
+    fingerprint: summary.fingerprint,
+    publisher: summary.publisher,
+    freshness: summary.freshness,
+  };
+}
+
+async function deliverWebhook({
+  webhookUrl,
+  payload,
+  timeoutMs,
+  fetchImpl = fetch,
+}) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetchImpl(webhookUrl, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      throw new Error(`webhook_http_${response.status}`);
+    }
+    return { status: 'sent', channel: 'webhook' };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function formatEmail({ to, from, subject, payload }) {
+  return [
+    `To: ${to}`,
+    `From: ${from}`,
+    `Subject: ${subject}`,
+    'Content-Type: application/json; charset=utf-8',
+    '',
+    JSON.stringify(payload, null, 2),
+    '',
+  ].join('\n');
+}
+
+function deliverEmail({
+  env,
+  payload,
+  spawnSyncImpl = spawnSync,
+}) {
+  const to = firstNonEmpty(env.VH_PUBLIC_FEED_ALERT_EMAIL_TO);
+  if (!to) return null;
+  const from = firstNonEmpty(env.VH_PUBLIC_FEED_ALERT_EMAIL_FROM, 'vhc-public-feed-alert@localhost');
+  const sendmail = firstNonEmpty(env.VH_PUBLIC_FEED_ALERT_SENDMAIL, '/usr/sbin/sendmail');
+  const subject = `[VHC] public feed alert ${payload.status} ${payload.fingerprint}`;
+  const result = spawnSyncImpl(sendmail, ['-t'], {
+    input: formatEmail({ to, from, subject, payload }),
+    encoding: 'utf8',
+  });
+  if (result.status !== 0) {
+    throw new Error(`sendmail_exit_${result.status ?? 'signal'}:${String(result.stderr ?? '').trim()}`);
+  }
+  return { status: 'sent', channel: 'email' };
+}
+
+async function deliverAlert({
+  env,
+  summary,
+  deliveryDecision,
+  fetchImpl = fetch,
+  spawnSyncImpl = spawnSync,
+}) {
+  if (!deliveryDecision.deliver) {
+    return {
+      status: 'suppressed',
+      reason: deliveryDecision.reason,
+      channels: [],
+      error: null,
+    };
+  }
+
+  const payload = alertPayload(summary, deliveryDecision.reason);
+  const channels = [];
+  const errors = [];
+  const timeoutMs = nonNegativeInt(env.VH_PUBLIC_FEED_ALERT_TIMEOUT_MS, DEFAULT_TIMEOUT_MS);
+  const webhookUrl = firstNonEmpty(env.VH_PUBLIC_FEED_ALERT_WEBHOOK_URL);
+  const hasEmail = Boolean(firstNonEmpty(env.VH_PUBLIC_FEED_ALERT_EMAIL_TO));
+
+  if (webhookUrl) {
+    try {
+      channels.push(await deliverWebhook({ webhookUrl, payload, timeoutMs, fetchImpl }));
+    } catch (error) {
+      errors.push(`webhook:${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  if (hasEmail) {
+    try {
+      const result = deliverEmail({ env, payload, spawnSyncImpl });
+      if (result) channels.push(result);
+    } catch (error) {
+      errors.push(`email:${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  if (!webhookUrl && !hasEmail) {
+    return {
+      status: 'missing_channel',
+      reason: deliveryDecision.reason,
+      channels: [],
+      error: 'no webhook or email channel configured',
+    };
+  }
+
+  if (errors.length > 0 || channels.length === 0) {
+    return {
+      status: 'failed',
+      reason: deliveryDecision.reason,
+      channels,
+      error: errors.join('; ') || 'no channel delivered',
+    };
+  }
+
+  return {
+    status: 'sent',
+    reason: deliveryDecision.reason,
+    channels,
+    error: null,
+  };
+}
+
+async function persistState({
+  stateFile,
+  nowIso,
+  fingerprint,
+  status,
+  delivery,
+  previousState,
+}) {
+  const delivered = delivery.status === 'sent';
+  const state = {
+    schemaVersion: STATE_SCHEMA_VERSION,
+    generatedAt: nowIso,
+    lastObservedFingerprint: fingerprint,
+    lastObservedStatus: status,
+    lastDeliveredFingerprint: delivered
+      ? fingerprint
+      : previousState?.lastDeliveredFingerprint ?? null,
+    lastDeliveredStatus: delivered
+      ? status
+      : previousState?.lastDeliveredStatus ?? null,
+    lastDeliveredAt: delivered
+      ? nowIso
+      : previousState?.lastDeliveredAt ?? null,
+    lastDeliveryStatus: delivery.status,
+    lastDeliveryReason: delivery.reason,
+  };
+  await writeJson(stateFile, state);
+  return state;
+}
+
+export async function runPublicFeedAlertWatch({
+  env = process.env,
+  repoRoot = process.cwd(),
+  now = Date.now(),
+  freshnessMonitorImpl = runPublicFeedFreshnessMonitor,
+  systemctlShowText = null,
+  fetchImpl = fetch,
+  spawnSyncImpl = spawnSync,
+} = {}) {
+  const generatedAt = new Date(now).toISOString();
+  const stateFile = resolveStateFile(env);
+  const outputFile = resolveOutputFile(env);
+  const previousState = readJsonFile(stateFile);
+  const freshnessRaw = await freshnessMonitorImpl({ env, repoRoot, now });
+  const freshness = summarizeFreshness(freshnessRaw);
+  const publisher = inspectPublisherUnit({ env, systemctlShowText, spawnSyncImpl });
+  const observedBlockers = [
+    ...publisher.blockers,
+    ...(freshness.status === 'pass'
+      ? []
+      : freshness.blockers.length > 0
+        ? freshness.blockers.map((blocker) => `public_feed:${blocker}`)
+        : [`public_feed_status:${freshness.status ?? 'missing'}`]),
+  ];
+  const observedStatus = observedBlockers.length === 0 ? 'pass' : 'fail';
+  const fingerprint = fingerprintFor({
+    status: observedStatus,
+    blockers: observedBlockers,
+    publisher,
+    freshness,
+  });
+  const deliveryDecision = shouldDeliverAlert({
+    env,
+    now,
+    status: observedStatus,
+    fingerprint,
+    previousState,
+  });
+
+  const summary = {
+    schemaVersion: REPORT_SCHEMA_VERSION,
+    generatedAt,
+    status: observedStatus,
+    observedStatus,
+    blockers: observedBlockers,
+    fingerprint,
+    stateFile,
+    outputFile,
+    publisher,
+    freshness,
+    delivery: {
+      status: 'pending',
+      reason: deliveryDecision.reason,
+      heartbeatMs: deliveryDecision.heartbeatMs,
+      channels: [],
+      error: null,
+    },
+  };
+
+  const delivery = await deliverAlert({
+    env,
+    summary,
+    deliveryDecision,
+    fetchImpl,
+    spawnSyncImpl,
+  });
+  summary.delivery = {
+    ...summary.delivery,
+    ...delivery,
+  };
+  if (['failed', 'missing_channel'].includes(delivery.status)) {
+    summary.status = 'fail';
+    summary.blockers.push(`alert_delivery_${delivery.status}`);
+  }
+
+  summary.state = await persistState({
+    stateFile,
+    nowIso: generatedAt,
+    fingerprint,
+    status: observedStatus,
+    delivery,
+    previousState,
+  });
+
+  await writeJson(outputFile, summary);
+  return summary;
+}
+
+async function main() {
+  const summary = await runPublicFeedAlertWatch();
+  console.info(JSON.stringify({
+    status: summary.status,
+    observedStatus: summary.observedStatus,
+    blockers: summary.blockers,
+    fingerprint: summary.fingerprint,
+    delivery: summary.delivery,
+    outputFile: summary.outputFile,
+  }, null, 2));
+  if (summary.status !== 'pass') {
+    process.exit(1);
+  }
+}
+
+export const publicFeedAlertWatchInternal = {
+  REPORT_SCHEMA_VERSION,
+  STATE_SCHEMA_VERSION,
+  boolEnv,
+  fingerprintFor,
+  inspectPublisherUnit,
+  runPublicFeedAlertWatch,
+  shouldDeliverAlert,
+  summarizeFreshness,
+};
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error('[vh:public-feed-alert-watch] failed', error);
+    process.exit(1);
+  });
+}

--- a/tools/scripts/public-feed-alert-watch.test.mjs
+++ b/tools/scripts/public-feed-alert-watch.test.mjs
@@ -1,0 +1,348 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { publicFeedAlertWatchInternal } from './public-feed-alert-watch.mjs';
+
+function tempRoot() {
+  return mkdtempSync(path.join(os.tmpdir(), 'vh-public-feed-alert-'));
+}
+
+function activeSystemctl() {
+  return [
+    'ActiveState=active',
+    'SubState=running',
+    'NRestarts=0',
+    'ExecMainStatus=0',
+    'Result=success',
+    '',
+  ].join('\n');
+}
+
+function exit78Systemctl() {
+  return [
+    'ActiveState=failed',
+    'SubState=failed',
+    'NRestarts=0',
+    'ExecMainStatus=78',
+    'Result=exit-code',
+    '',
+  ].join('\n');
+}
+
+function freshnessSummary(overrides = {}) {
+  const now = overrides.now ?? Date.parse('2026-07-02T18:00:00.000Z');
+  return {
+    schemaVersion: 'public-feed-freshness-monitor-v1',
+    generatedAt: new Date(now).toISOString(),
+    status: 'pass',
+    blockers: [],
+    config: {
+      origins: ['https://venn.carboncaste.io/', 'https://gun-a.carboncaste.io/'],
+      maxAgeMs: 21_600_000,
+    },
+    latestIndexReadbacks: [
+      {
+        origin: 'https://venn.carboncaste.io/',
+        status: 'pass',
+        recordCount: 80,
+        newestAgeMs: 120_000,
+        maxAgeMs: 21_600_000,
+        failures: [],
+        storyIds: ['story-body-not-copied'],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function staleFreshnessSummary({
+  now = Date.parse('2026-07-02T18:00:00.000Z'),
+  newestAgeMs = 30_000_000,
+  origin = 'https://venn.carboncaste.io/secret-path',
+} = {}) {
+  return freshnessSummary({
+    now,
+    status: 'fail',
+    blockers: [`latest_index_not_fresh:${origin}:latest_index_stale:${newestAgeMs}/21600000`],
+    latestIndexReadbacks: [
+      {
+        origin,
+        status: 'fail',
+        recordCount: 80,
+        newestAgeMs,
+        maxAgeMs: 21_600_000,
+        failures: [`latest_index_stale:${newestAgeMs}/21600000`],
+        storyIds: ['story-body-not-copied'],
+      },
+    ],
+  });
+}
+
+function baseEnv(root, extra = {}) {
+  return {
+    HOME: root,
+    VH_PUBLIC_FEED_ALERT_STATE_FILE: path.join(root, 'state.json'),
+    VH_PUBLIC_FEED_ALERT_OUTPUT_FILE: path.join(root, 'latest.json'),
+    ...extra,
+  };
+}
+
+test('passing feed and active publisher do not require an alert channel', async () => {
+  const root = tempRoot();
+  try {
+    const summary = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({
+      env: baseEnv(root),
+      repoRoot: root,
+      now: Date.parse('2026-07-02T18:00:00.000Z'),
+      systemctlShowText: activeSystemctl(),
+      freshnessMonitorImpl: async () => freshnessSummary(),
+    });
+
+    assert.equal(summary.status, 'pass');
+    assert.equal(summary.observedStatus, 'pass');
+    assert.equal(summary.delivery.status, 'suppressed');
+    assert.equal(summary.blockers.includes('alert_delivery_missing_channel'), false);
+    assert.equal(summary.freshness.latestIndexReadbacks[0].storyIds, undefined);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('stale feed sends a webhook on state change with secret-safe aggregate payload', async () => {
+  const root = tempRoot();
+  const calls = [];
+  try {
+    const summary = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({
+      env: baseEnv(root, { VH_PUBLIC_FEED_ALERT_WEBHOOK_URL: 'https://hooks.example.invalid/token' }),
+      repoRoot: root,
+      now: Date.parse('2026-07-02T18:00:00.000Z'),
+      systemctlShowText: activeSystemctl(),
+      freshnessMonitorImpl: async () => staleFreshnessSummary(),
+      fetchImpl: async (url, init) => {
+        calls.push({ url, init });
+        return { ok: true, status: 204 };
+      },
+    });
+
+    assert.equal(summary.status, 'fail');
+    assert.equal(summary.delivery.status, 'sent');
+    assert.equal(summary.delivery.reason, 'first_failure');
+    assert.equal(calls.length, 1);
+    const body = JSON.parse(calls[0].init.body);
+    assert.equal(body.alertReason, 'first_failure');
+    assert.equal(body.blockers.some((blocker) => blocker.includes('url_hash:')), true);
+    assert.equal(body.freshness.latestIndexReadbacks[0].origin, undefined);
+    assert.equal(body.freshness.latestIndexReadbacks[0].originHash.length, 16);
+    assert.equal(JSON.stringify(body).includes('story-body-not-copied'), false);
+    assert.equal(JSON.stringify(body).includes('venn.carboncaste.io'), false);
+    assert.equal(JSON.stringify(body).includes('secret-path'), false);
+    assert.equal(JSON.stringify(body).includes('hooks.example.invalid'), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('same stale-feed class suppresses repeat delivery even as monitor ages advance', async () => {
+  const root = tempRoot();
+  const calls = [];
+  try {
+    let run = 0;
+    const options = {
+      env: baseEnv(root, { VH_PUBLIC_FEED_ALERT_WEBHOOK_URL: 'https://hooks.example.invalid/token' }),
+      repoRoot: root,
+      systemctlShowText: activeSystemctl(),
+      freshnessMonitorImpl: async () => {
+        run += 1;
+        return staleFreshnessSummary({
+          now: Date.parse('2026-07-02T18:00:00.000Z') + (run - 1) * 300_000,
+          newestAgeMs: 30_000_000 + (run - 1) * 300_000,
+        });
+      },
+      fetchImpl: async (url, init) => {
+        calls.push({ url, init });
+        return { ok: true, status: 204 };
+      },
+    };
+    const first = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({
+      ...options,
+      now: Date.parse('2026-07-02T18:00:00.000Z'),
+    });
+    const second = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({
+      ...options,
+      now: Date.parse('2026-07-02T18:05:00.000Z'),
+    });
+
+    assert.equal(first.delivery.status, 'sent');
+    assert.equal(second.delivery.status, 'suppressed');
+    assert.equal(second.delivery.reason, 'unchanged_suppressed');
+    assert.equal(second.fingerprint, first.fingerprint);
+    assert.equal(calls.length, 1);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('failed delivery is retried for the same observed failure until one channel succeeds', async () => {
+  const root = tempRoot();
+  const calls = [];
+  try {
+    const options = {
+      env: baseEnv(root, { VH_PUBLIC_FEED_ALERT_WEBHOOK_URL: 'https://hooks.example.invalid/token' }),
+      repoRoot: root,
+      systemctlShowText: activeSystemctl(),
+      freshnessMonitorImpl: async () => staleFreshnessSummary(),
+      fetchImpl: async (url, init) => {
+        calls.push({ url, init });
+        return calls.length === 1
+          ? { ok: false, status: 503 }
+          : { ok: true, status: 204 };
+      },
+    };
+
+    const first = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({
+      ...options,
+      now: Date.parse('2026-07-02T18:00:00.000Z'),
+    });
+    const second = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({
+      ...options,
+      now: Date.parse('2026-07-02T18:05:00.000Z'),
+    });
+
+    assert.equal(first.delivery.status, 'failed');
+    assert.equal(first.status, 'fail');
+    assert.equal(second.delivery.status, 'sent');
+    assert.equal(second.delivery.reason, 'retry_failed_delivery');
+    assert.equal(second.fingerprint, first.fingerprint);
+    assert.equal(calls.length, 2);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('heartbeat interval can resend an unchanged state', async () => {
+  const root = tempRoot();
+  const calls = [];
+  const stale = freshnessSummary({
+    status: 'fail',
+    blockers: ['latest_index_not_fresh:origin:latest_index_stale:30000000/21600000'],
+  });
+  try {
+    const options = {
+      env: baseEnv(root, {
+        VH_PUBLIC_FEED_ALERT_WEBHOOK_URL: 'https://hooks.example.invalid/token',
+        VH_PUBLIC_FEED_ALERT_HEARTBEAT_MS: '600000',
+      }),
+      repoRoot: root,
+      systemctlShowText: activeSystemctl(),
+      freshnessMonitorImpl: async () => stale,
+      fetchImpl: async (url, init) => {
+        calls.push({ url, init });
+        return { ok: true, status: 204 };
+      },
+    };
+    await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({
+      ...options,
+      now: Date.parse('2026-07-02T18:00:00.000Z'),
+    });
+    const second = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({
+      ...options,
+      now: Date.parse('2026-07-02T18:11:00.000Z'),
+    });
+
+    assert.equal(second.delivery.status, 'sent');
+    assert.equal(second.delivery.reason, 'heartbeat_due');
+    assert.equal(calls.length, 2);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('publisher exit 78 is a fail-close alert and can deliver through sendmail', async () => {
+  const root = tempRoot();
+  const mail = [];
+  try {
+    const summary = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({
+      env: baseEnv(root, {
+        VH_PUBLIC_FEED_ALERT_EMAIL_TO: 'operator@example.invalid',
+        VH_PUBLIC_FEED_ALERT_SENDMAIL: '/usr/sbin/sendmail',
+      }),
+      repoRoot: root,
+      now: Date.parse('2026-07-02T18:00:00.000Z'),
+      systemctlShowText: exit78Systemctl(),
+      freshnessMonitorImpl: async () => freshnessSummary(),
+      spawnSyncImpl: (command, args, options) => {
+        mail.push({ command, args, input: options.input });
+        return { status: 0, stdout: '', stderr: '' };
+      },
+    });
+
+    assert.equal(summary.status, 'fail');
+    assert.equal(summary.publisher.failureClass, 'exit_78_fail_closed');
+    assert.match(summary.blockers.join('\n'), /publisher_exit_78/);
+    assert.equal(summary.delivery.status, 'sent');
+    assert.equal(mail.length, 1);
+    assert.match(mail[0].input, /operator@example\.invalid/);
+    assert.match(mail[0].input, /exit_78_fail_closed/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('test-fire sends a pass heartbeat without changing observed status', async () => {
+  const root = tempRoot();
+  const calls = [];
+  try {
+    const summary = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({
+      env: baseEnv(root, {
+        VH_PUBLIC_FEED_ALERT_WEBHOOK_URL: 'https://hooks.example.invalid/token',
+        VH_PUBLIC_FEED_ALERT_TEST_FIRE: '1',
+      }),
+      repoRoot: root,
+      now: Date.parse('2026-07-02T18:00:00.000Z'),
+      systemctlShowText: activeSystemctl(),
+      freshnessMonitorImpl: async () => freshnessSummary(),
+      fetchImpl: async (url, init) => {
+        calls.push({ url, init });
+        return { ok: true, status: 204 };
+      },
+    });
+
+    assert.equal(summary.observedStatus, 'pass');
+    assert.equal(summary.status, 'pass');
+    assert.equal(summary.delivery.status, 'sent');
+    assert.equal(summary.delivery.reason, 'test_fire');
+    assert.equal(calls.length, 1);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('alert output and state files are persisted for operator inspection', async () => {
+  const root = tempRoot();
+  try {
+    const env = baseEnv(root, { VH_PUBLIC_FEED_ALERT_WEBHOOK_URL: 'https://hooks.example.invalid/token' });
+    const summary = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({
+      env: {
+        ...env,
+        VH_PUBLIC_FEED_ALERT_TEST_FIRE: '1',
+      },
+      repoRoot: root,
+      now: Date.parse('2026-07-02T18:00:00.000Z'),
+      systemctlShowText: activeSystemctl(),
+      freshnessMonitorImpl: async () => freshnessSummary(),
+      fetchImpl: async () => ({ ok: true, status: 204 }),
+    });
+
+    const output = JSON.parse(readFileSync(env.VH_PUBLIC_FEED_ALERT_OUTPUT_FILE, 'utf8'));
+    const state = JSON.parse(readFileSync(env.VH_PUBLIC_FEED_ALERT_STATE_FILE, 'utf8'));
+    assert.equal(output.fingerprint, summary.fingerprint);
+    assert.equal(state.lastObservedFingerprint, summary.fingerprint);
+    assert.equal(state.lastDeliveredFingerprint, summary.fingerprint);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Adds the repo-side public feed alert watch and Scope A evidence packet without enabling anything on A6:

- adds `tools/scripts/public-feed-alert-watch.mjs`, composing public freshness with a read-only publisher unit check
- ships user-systemd service/timer templates and operator enable/rollback docs; nothing is enabled by this PR
- records the current Scope A driver verdict as `heap_driver_unknown` pending operator graph-scan/early-capture evidence
- adds old draft PR triage
- makes `pnpm check:public-feed:alert-watch` fixture-only, not a live host check

Adversarial review fixes now included:

- stale-feed fingerprints ignore volatile exact `newestAgeMs` drift and use failure class/stale-state/count/origin-hash shape, so an already-stale feed does not alert every tick
- failed alert delivery is not marked delivered; the next timer run retries the same observed failure until one channel succeeds
- alert payload blockers sanitize URL-like values to hashes; webhook URLs, raw origins, raw paths, story IDs, and feed payloads are not delivered
- tests use two-run monitor outputs with advancing stale ages and a failed-then-successful delivery path, instead of frozen pre-sanitized fixtures

No live Scope A/A6 behavior, deploy config, publisher/relay restart, retention, compaction, or watchdog threshold changes.

## Validation

- `corepack pnpm@9.7.1 check:public-feed:alert-watch`
- `node --check tools/scripts/public-feed-alert-watch.mjs`
- `corepack pnpm@9.7.1 docs:check`
- `corepack pnpm@9.7.1 check:public-beta-launch-closeout`
- `corepack pnpm@9.7.1 check:luma-forbidden-claims`
- `corepack pnpm@9.7.1 check:luma-production-profile`
- `git diff --check`