### PR TITLE
Add LUMA telemetry redaction gate

### DIFF
--- a/apps/web-pwa/src/hooks/useIdentity.test.ts
+++ b/apps/web-pwa/src/hooks/useIdentity.test.ts
@@ -282,6 +282,7 @@ describe('useIdentity', () => {
     const { result } = renderHook(() => useIdentity());
     const { useXpLedger } = await import('../store/xpLedger');
     const { delegationStorageKey, useDelegationStore } = await import('../store/delegation');
+    const { emitLumaEvent, lumaTelemetryStore } = await import('@vh/luma-sdk');
 
     await waitFor(() => expect(result.current.status).toBe('anonymous'));
 
@@ -307,6 +308,8 @@ describe('useIdentity', () => {
     expect(pairMock).toHaveBeenCalledTimes(1);
 
     useXpLedger.getState().addXp('civic', 4);
+    emitLumaEvent({ type: 'luma_session_created', tsMs: 1000 });
+    expect(lumaTelemetryStore.getSnapshot()).toHaveLength(1);
     localStorage.setItem(delegationStorageKey(firstNullifier!), '{"grants":[{"grantId":"g-1"}]}');
     useDelegationStore.getState().setActivePrincipal(firstNullifier!);
     const firstWalletBinding = await walletBinding.save({
@@ -322,6 +325,7 @@ describe('useIdentity', () => {
     });
     await waitFor(() => expect(result.current.status).toBe('anonymous'));
     expect(useDelegationStore.getState().activePrincipal).toBeNull();
+    expect(lumaTelemetryStore.getSnapshot()).toHaveLength(0);
     expect(localStorage.getItem(delegationStorageKey(firstNullifier!))).toBe('{"grants":[{"grantId":"g-1"}]}');
     expect(useXpLedger.getState().activeNullifier).toBeNull();
     expect(await deviceCredential.loadOrCreate()).toEqual(firstDeviceCredential);
@@ -356,6 +360,7 @@ describe('useIdentity', () => {
     const useIdentity = await loadHook();
     const { result } = renderHook(() => useIdentity());
     const { delegationStorageKey, useDelegationStore } = await import('../store/delegation');
+    const { emitLumaEvent, lumaTelemetryStore } = await import('@vh/luma-sdk');
 
     await waitFor(() => expect(result.current.status).toBe('anonymous'));
 
@@ -383,6 +388,8 @@ describe('useIdentity', () => {
       issuedAt: 1000,
       expiresAt: 2000
     });
+    emitLumaEvent({ type: 'luma_session_created', tsMs: 1000 });
+    expect(lumaTelemetryStore.getSnapshot()).toHaveLength(1);
 
     await act(async () => {
       await result.current.resetIdentity();
@@ -391,6 +398,7 @@ describe('useIdentity', () => {
 
     expect(localStorage.getItem(delegationStorageKey(firstNullifier))).toBeNull();
     expect(useDelegationStore.getState().activePrincipal).toBeNull();
+    expect(lumaTelemetryStore.getSnapshot()).toHaveLength(0);
     expect(await vaultLoad()).toBeNull();
     expect(await walletBinding.load()).toBeNull();
     expect(await operatorAuthorizationToken.load()).toBeNull();

--- a/apps/web-pwa/src/hooks/useIdentity.ts
+++ b/apps/web-pwa/src/hooks/useIdentity.ts
@@ -4,8 +4,10 @@ import { isSessionExpired, isSessionNearExpiry, migrateSessionFields, DEFAULT_SE
 import { TRUST_MINIMUM } from '@vh/data-model';
 import { SEA, createSession } from '@vh/gun-client';
 import {
+  clearLumaTelemetry,
   createBetaLocalAssuranceEnvelope,
   deriveBetaLocalNullifier,
+  lumaLog,
   type AssuranceEnvelope,
   type DeploymentProfile
 } from '@vh/luma-sdk';
@@ -196,7 +198,7 @@ export function useIdentity() {
           session = await Promise.race([verifierPromise, timeout]);
         } catch (verifierErr) {
           if (DEV_FALLBACK_ENABLED) {
-            console.warn('[vh:identity] Attestation verifier unavailable, using dev fallback');
+            lumaLog('warn', '[vh:identity] Attestation verifier unavailable, using dev fallback');
             session = {
               token: `dev-session-${randomToken()}`,
               trustScore: DEV_FALLBACK_TRUST_SCORE,
@@ -245,7 +247,7 @@ export function useIdentity() {
           await authenticateGunUser(client, record.devicePair);
           await publishDirectoryEntry(client, record);
         } catch (err) {
-          console.warn('[vh:identity] Directory publish failed:', err);
+          lumaLog('warn', '[vh:identity] Directory publish failed', { error: err });
         }
       }
       setIdentity(record);
@@ -321,6 +323,7 @@ export function useIdentity() {
    */
   const signOut = useCallback(async () => {
     clearActiveIdentityRuntime();
+    clearLumaTelemetry({ rotateSalt: true });
     await vaultClear().catch(() => {});
   }, [clearActiveIdentityRuntime]);
 
@@ -331,6 +334,7 @@ export function useIdentity() {
   const resetIdentity = useCallback(async () => {
     const oldPrincipal = identity?.session.nullifier ?? null;
     clearActiveIdentityRuntime();
+    clearLumaTelemetry({ rotateSalt: true });
     if (oldPrincipal) {
       clearDelegationStorageForPrincipal(oldPrincipal);
     }
@@ -348,7 +352,7 @@ export function useIdentity() {
    * hook surface while the app migrates call sites.
    */
   const revokeSession = useCallback(async () => {
-    console.warn('[vh:identity] useIdentity.revokeSession() is deprecated; use signOut() instead');
+    lumaLog('warn', '[vh:identity] useIdentity.revokeSession() is deprecated; use signOut() instead');
     await signOut();
   }, [signOut]);
 

--- a/apps/web-pwa/src/hooks/useTelemetry.test.ts
+++ b/apps/web-pwa/src/hooks/useTelemetry.test.ts
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { clearLumaTelemetry, lumaTelemetryStore } from '@vh/luma-sdk';
+import { useTelemetry } from './useTelemetry';
+
+describe('useTelemetry', () => {
+  afterEach(() => {
+    clearLumaTelemetry({ rotateSalt: false });
+  });
+
+  it('subscribes to the local ring buffer and exposes emit, clear, and redacted path hashing', async () => {
+    clearLumaTelemetry({ rotateSalt: false });
+    const { result } = renderHook(() => useTelemetry());
+
+    expect(result.current.events).toEqual([]);
+
+    act(() => {
+      result.current.emit({
+        type: 'luma_policy_blocked',
+        level: 'warn',
+        tsMs: 1000,
+        message: 'blocked',
+        context: { reason: 'test' },
+      });
+    });
+
+    await waitFor(() => expect(result.current.events).toHaveLength(1));
+    expect(result.current.events[0]).toMatchObject({
+      type: 'luma_policy_blocked',
+      level: 'warn',
+      ts_ms: 1000,
+      message: 'blocked',
+      context: { reason: 'test' },
+    });
+
+    const originalCrypto = globalThis.crypto;
+    vi.stubGlobal('crypto', {
+      getRandomValues(bytes: Uint8Array) {
+        bytes.fill(9);
+        return bytes;
+      },
+      subtle: {
+        digest: vi.fn(async () => new Uint8Array(32).fill(3).buffer),
+      },
+    });
+    try {
+      const hash = await result.current.redactedPathHash('/vh/news/story/test');
+      expect(hash).toBe(`sha256:${'03'.repeat(32)}`);
+      expect(hash).not.toContain('/vh/news/story/test');
+    } finally {
+      vi.stubGlobal('crypto', originalCrypto);
+    }
+
+    act(() => {
+      result.current.clear();
+    });
+
+    await waitFor(() => expect(result.current.events).toEqual([]));
+    expect(lumaTelemetryStore.getSnapshot()).toEqual([]);
+  });
+});

--- a/apps/web-pwa/src/hooks/useTelemetry.ts
+++ b/apps/web-pwa/src/hooks/useTelemetry.ts
@@ -1,0 +1,31 @@
+import { useSyncExternalStore } from 'react';
+import {
+  clearLumaTelemetry,
+  emitLumaEvent,
+  lumaTelemetryStore,
+  redactedPathHash,
+  type EmitLumaEventInput,
+  type LumaEvent,
+} from '@vh/luma-sdk';
+
+export interface UseTelemetryResult {
+  readonly events: readonly LumaEvent[];
+  readonly emit: (event: EmitLumaEventInput) => LumaEvent;
+  readonly clear: () => void;
+  readonly redactedPathHash: (rawPath: string) => Promise<string>;
+}
+
+export function useTelemetry(): UseTelemetryResult {
+  const events = useSyncExternalStore(
+    lumaTelemetryStore.subscribe,
+    lumaTelemetryStore.getSnapshot,
+    lumaTelemetryStore.getSnapshot,
+  );
+
+  return {
+    events,
+    emit: emitLumaEvent,
+    clear: () => clearLumaTelemetry({ rotateSalt: true }),
+    redactedPathHash,
+  };
+}

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "check:luma-provider-surface": "node ./tools/scripts/check-luma-provider-surface.mjs",
     "check:luma-forbidden-claims": "node ./tools/scripts/check-luma-forbidden-claims.mjs",
     "check:luma-production-profile": "node ./tools/scripts/check-luma-production-profile.mjs",
+    "check:luma-telemetry-redaction": "node ./tools/scripts/check-luma-telemetry-redaction.mjs && cd packages/luma-sdk && vitest run src/telemetry.test.ts --config ./vitest.config.ts",
     "check:luma-signed-write-surface": "node ./tools/scripts/check-luma-signed-write-surface.mjs",
     "check:luma-vault-compartments": "node ./tools/scripts/check-luma-vault-compartments.mjs",
     "check:luma-delegation-signer-surface": "node ./tools/scripts/check-luma-delegation-signer-surface.mjs",

--- a/packages/data-model/src/schemas/hermes/forum.test.ts
+++ b/packages/data-model/src/schemas/hermes/forum.test.ts
@@ -727,16 +727,15 @@ describe('topic derivation', () => {
     );
   });
 
-  it('sha256Hex hashes without a global Buffer fallback', async () => {
-    const originalBuffer = globalThis.Buffer;
-    vi.stubGlobal('Buffer', undefined);
-    try {
-      await expect(sha256Hex('abc')).resolves.toBe(
-        'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad'
-      );
-    } finally {
-      vi.stubGlobal('Buffer', originalBuffer);
-    }
+  it('sha256Hex hashes through WebCrypto without a Node Buffer dependency', async () => {
+    const digest = vi.spyOn(crypto.subtle, 'digest');
+
+    await expect(sha256Hex('abc')).resolves.toBe(
+      'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad'
+    );
+
+    expect(digest).toHaveBeenCalledWith('SHA-256', expect.any(Uint8Array));
+    digest.mockRestore();
   });
 
   it('sha256Hex is deterministic', async () => {

--- a/packages/data-model/src/schemas/hermes/forum.ts
+++ b/packages/data-model/src/schemas/hermes/forum.ts
@@ -418,14 +418,7 @@ export const REPLY_CONTENT_MAX = REPLY_CONTENT_LIMIT;
 
 export async function sha256Hex(input: string): Promise<string> {
   const data = new TextEncoder().encode(input);
-  const nodeBuffer = (globalThis as typeof globalThis & {
-    Buffer?: { from(bytes: Uint8Array): Uint8Array };
-  }).Buffer;
-  const digestInput = nodeBuffer ? nodeBuffer.from(data) : new ArrayBuffer(data.byteLength);
-  if (!nodeBuffer) {
-    new Uint8Array(digestInput).set(data);
-  }
-  const hashBuffer = await crypto.subtle.digest('SHA-256', digestInput);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
   const hashArray = new Uint8Array(hashBuffer);
   return Array.from(hashArray, (b) => b.toString(16).padStart(2, '0')).join('');
 }

--- a/packages/e2e/src/mvp-release-gates.mjs
+++ b/packages/e2e/src/mvp-release-gates.mjs
@@ -302,6 +302,17 @@ export const GATES = [
     ],
   },
   {
+    id: 'luma_telemetry_redaction',
+    label: 'LUMA telemetry §16 source discipline holds; §21.4 replay remains deferred before <TrustClaim>',
+    command: ['pnpm', ['check:luma-telemetry-redaction']],
+    artifactRefs: [
+      'tools/scripts/check-luma-telemetry-redaction.mjs',
+      'packages/luma-sdk/src/telemetry.ts',
+      'packages/luma-sdk/src/telemetry.test.ts',
+      'docs/specs/spec-luma-service-v0.md',
+    ],
+  },
+  {
     id: 'luma_mvp_production_readiness',
     label: 'LUMA public-beta MVP readiness has current signed-write and mesh evidence',
     command: ['pnpm', ['check:luma:mvp-production-readiness']],

--- a/packages/gun-client/src/aggregateAdapters.ts
+++ b/packages/gun-client/src/aggregateAdapters.ts
@@ -9,6 +9,7 @@ import {
   type PointAggregateSnapshotV1,
 } from '@vh/data-model';
 import {
+  lumaLog,
   verifySignedWriteEnvelope,
   type SignedWriteVerifyHook,
 } from '@vh/luma-sdk';
@@ -1061,7 +1062,7 @@ export async function writeVoterNode(
       node: sanitized,
     }, { allowLumaV1: true });
     if (relayed) {
-      console.info('[vh:aggregate:voter-write]', {
+      lumaLog('info', '[vh:aggregate:voter-write]', {
         topic_id: normalizedTopicId,
         synthesis_id: normalizedSynthesisId,
         epoch: Number(normalizedEpoch),
@@ -1103,7 +1104,7 @@ export async function writeVoterNode(
         sanitized,
       );
       if (recovered) {
-        console.info('[vh:aggregate:voter-write]', {
+        lumaLog('info', '[vh:aggregate:voter-write]', {
           topic_id: normalizedTopicId,
           synthesis_id: normalizedSynthesisId,
           epoch: Number(normalizedEpoch),
@@ -1126,7 +1127,7 @@ export async function writeVoterNode(
         node: sanitized,
       }, { allowLumaV1: true });
       if (relayed) {
-        console.info('[vh:aggregate:voter-write]', {
+        lumaLog('info', '[vh:aggregate:voter-write]', {
           topic_id: normalizedTopicId,
           synthesis_id: normalizedSynthesisId,
           epoch: Number(normalizedEpoch),
@@ -1142,7 +1143,7 @@ export async function writeVoterNode(
       }
     }
 
-    console.warn('[vh:aggregate:voter-write]', {
+    lumaLog('warn', '[vh:aggregate:voter-write]', {
       topic_id: normalizedTopicId,
       synthesis_id: normalizedSynthesisId,
       epoch: Number(normalizedEpoch),
@@ -1166,7 +1167,7 @@ export async function writeVoterNode(
     node: sanitized,
   }, { allowLumaV1: true });
 
-  console.info('[vh:aggregate:voter-write]', {
+  lumaLog('info', '[vh:aggregate:voter-write]', {
     topic_id: normalizedTopicId,
     synthesis_id: normalizedSynthesisId,
     epoch: Number(normalizedEpoch),
@@ -1203,7 +1204,7 @@ export async function writePointAggregateSnapshot(
   if (shouldWriteAggregateViaRelayRestFirst()) {
     const relayed = await writePointSnapshotViaRelayFallback(client, sanitized);
     if (relayed) {
-      console.info('[vh:aggregate:point-snapshot-write]', {
+      lumaLog('info', '[vh:aggregate:point-snapshot-write]', {
         topic_id: normalizedTopicId,
         synthesis_id: normalizedSynthesisId,
         epoch: Number(normalizedEpoch),
@@ -1236,7 +1237,7 @@ export async function writePointAggregateSnapshot(
         sanitized,
       );
       if (recovered) {
-        console.info('[vh:aggregate:point-snapshot-write]', {
+        lumaLog('info', '[vh:aggregate:point-snapshot-write]', {
           topic_id: normalizedTopicId,
           synthesis_id: normalizedSynthesisId,
           epoch: Number(normalizedEpoch),
@@ -1257,7 +1258,7 @@ export async function writePointAggregateSnapshot(
 
       const relayed = await writePointSnapshotViaRelayFallback(client, sanitized);
       if (relayed) {
-        console.info('[vh:aggregate:point-snapshot-write]', {
+        lumaLog('info', '[vh:aggregate:point-snapshot-write]', {
           topic_id: normalizedTopicId,
           synthesis_id: normalizedSynthesisId,
           epoch: Number(normalizedEpoch),
@@ -1277,7 +1278,7 @@ export async function writePointAggregateSnapshot(
       }
     }
 
-    console.warn('[vh:aggregate:point-snapshot-write]', {
+    lumaLog('warn', '[vh:aggregate:point-snapshot-write]', {
       topic_id: normalizedTopicId,
       synthesis_id: normalizedSynthesisId,
       epoch: Number(normalizedEpoch),
@@ -1294,7 +1295,7 @@ export async function writePointAggregateSnapshot(
 
   const relayMirrored = await writePointSnapshotViaRelayFallback(client, sanitized);
 
-  console.info('[vh:aggregate:point-snapshot-write]', {
+  lumaLog('info', '[vh:aggregate:point-snapshot-write]', {
     topic_id: normalizedTopicId,
     synthesis_id: normalizedSynthesisId,
     epoch: Number(normalizedEpoch),

--- a/packages/gun-client/src/analysisAdapters.test.ts
+++ b/packages/gun-client/src/analysisAdapters.test.ts
@@ -660,7 +660,7 @@ describe('analysisAdapters', () => {
         expect.objectContaining({
           event: SYSTEM_WRITER_VALIDATION_EVENT,
           reason: 'missing-pin',
-          path: 'vh/news/stories/story-1/analysis/analysis-1',
+          path: '[REDACTED:mesh-path]',
         }),
       );
     } finally {

--- a/packages/gun-client/src/analysisAdapters.ts
+++ b/packages/gun-client/src/analysisAdapters.ts
@@ -4,6 +4,7 @@ import {
   type StoryAnalysisArtifact,
   type StoryAnalysisLatestPointer,
 } from '@vh/data-model';
+import { lumaLog } from '@vh/luma-sdk';
 import { createGuardedChain, putWithAckTimeout, type ChainWithGet, type PutAckResult } from './chain';
 import { writeWithDurability } from './durableWrite';
 import { readGunTimeoutMs } from './runtimeConfig';
@@ -275,7 +276,7 @@ const WRITE_READBACK_RETRY_MS = 250;
 async function putWithAck<T>(chain: ChainWithGet<T>, value: T): Promise<PutAckResult> {
   return putWithAckTimeout(chain, value, {
     timeoutMs: PUT_ACK_TIMEOUT_MS,
-    onTimeout: () => console.warn('[vh:gun-client] analysis put ack timed out, requiring readback confirmation'),
+    onTimeout: () => lumaLog('warn', '[vh:gun-client] analysis put ack timed out, requiring readback confirmation'),
   });
 }
 
@@ -367,7 +368,7 @@ function carriesLumaProtocolFields(value: Record<string, unknown>): boolean {
 function emitSystemWriterValidationFailure(
   failure: SystemWriterValidationFailure,
 ): void {
-  console.warn(`[vh:analysis] ${SYSTEM_WRITER_VALIDATION_EVENT}`, failure);
+  lumaLog('warn', `[vh:analysis] ${SYSTEM_WRITER_VALIDATION_EVENT}`, failure);
   if (typeof globalThis.dispatchEvent === 'function' && typeof CustomEvent !== 'undefined') {
     globalThis.dispatchEvent(
       new CustomEvent(SYSTEM_WRITER_VALIDATION_EVENT, { detail: failure })
@@ -576,7 +577,7 @@ export async function writeAnalysis(
     writeClass: 'analysis-latest-pointer',
     timeoutMs: PUT_ACK_TIMEOUT_MS,
     timeoutError: 'analysis latest pointer write timed out and readback did not confirm persistence',
-    onAckTimeout: () => console.warn('[vh:gun-client] analysis latest pointer ack timed out, requiring readback confirmation'),
+    onAckTimeout: () => lumaLog('warn', '[vh:gun-client] analysis latest pointer ack timed out, requiring readback confirmation'),
     readback: async () => {
       const result = await parseLatestPointerFromStoredRecord(
         client,

--- a/packages/gun-client/src/chain.ts
+++ b/packages/gun-client/src/chain.ts
@@ -1,3 +1,4 @@
+import { lumaLog } from '@vh/luma-sdk';
 import type { HydrationBarrier } from './sync/barrier';
 import type { TopologyGuard } from './topology';
 import { readGunTimeoutMs } from './runtimeConfig';
@@ -61,7 +62,7 @@ function warnWaitForRemoteTimeout(): void {
       : '';
   suppressedWaitForRemoteWarns = 0;
   lastWaitForRemoteWarnAt = now;
-  console.warn(`[vh:gun-client] waitForRemote timed out, proceeding anyway${suffix}`);
+  lumaLog('warn', `[vh:gun-client] waitForRemote timed out, proceeding anyway${suffix}`);
 }
 
 export async function waitForRemote<T>(chain: ChainLike<T>, barrier: HydrationBarrier): Promise<void> {

--- a/packages/gun-client/src/civicRepresentativeAdapters.test.ts
+++ b/packages/gun-client/src/civicRepresentativeAdapters.test.ts
@@ -498,7 +498,7 @@ describe('civicRepresentativeAdapters', () => {
         expect.objectContaining({
           event: SYSTEM_WRITER_VALIDATION_EVENT,
           reason: 'missing-pin',
-          path: 'vh/civic/reps/jurisdiction-v1',
+          path: '[REDACTED:mesh-path]',
         }),
       );
       expect(dispatchSpy).toHaveBeenCalledWith(

--- a/packages/gun-client/src/civicRepresentativeAdapters.ts
+++ b/packages/gun-client/src/civicRepresentativeAdapters.ts
@@ -2,6 +2,7 @@ import {
   RepresentativeDirectorySchema,
   type RepresentativeDirectory,
 } from '@vh/data-model';
+import { lumaLog } from '@vh/luma-sdk';
 import { createGuardedChain, type ChainWithGet } from './chain';
 import { writeWithDurability, type DurableWriteResult } from './durableWrite';
 import { readGunTimeoutMs } from './runtimeConfig';
@@ -116,7 +117,7 @@ function carriesLumaProtocolFields(value: Record<string, unknown>): boolean {
 }
 
 function emitSystemWriterValidationFailure(failure: SystemWriterValidationFailure): void {
-  console.warn(`[vh:civic-reps] ${SYSTEM_WRITER_VALIDATION_EVENT}`, failure);
+  lumaLog('warn', `[vh:civic-reps] ${SYSTEM_WRITER_VALIDATION_EVENT}`, failure);
   if (typeof globalThis.dispatchEvent === 'function' && typeof CustomEvent !== 'undefined') {
     globalThis.dispatchEvent(
       new CustomEvent(SYSTEM_WRITER_VALIDATION_EVENT, { detail: failure }),
@@ -248,7 +249,7 @@ function putWithAck<T>(
     timeoutError: options.timeoutError,
     readback: options.readback,
     readbackPredicate: options.readbackPredicate,
-    onAckTimeout: () => console.warn('[vh:civic-reps] put ack timed out, requiring readback confirmation'),
+    onAckTimeout: () => lumaLog('warn', '[vh:civic-reps] put ack timed out, requiring readback confirmation'),
   });
 }
 

--- a/packages/gun-client/src/directoryAdapters.ts
+++ b/packages/gun-client/src/directoryAdapters.ts
@@ -10,6 +10,7 @@ import {
 } from '@vh/data-model';
 import {
   canonicalizeSignedWritePayload,
+  lumaLog,
   verifySignedWriteEnvelope
 } from '@vh/luma-sdk';
 import { createGuardedChain, type ChainWithGet } from './chain';
@@ -91,7 +92,7 @@ export async function publishToDirectory(client: VennClient, entry: DirectoryEnt
       writeClass: 'directory',
       timeoutMs: DIRECTORY_PUT_ACK_TIMEOUT_MS,
       timeoutError: 'directory publish timed out and readback did not confirm persistence',
-      onAckTimeout: () => console.warn('[vh:directory] publish ack timed out, requiring readback confirmation'),
+      onAckTimeout: () => lumaLog('warn', '[vh:directory] publish ack timed out, requiring readback confirmation'),
       readback: () => lookupByIdentityDirectoryKey(client, validatedEntry.identityDirectoryKey),
       readbackPredicate: (observed) => {
         const candidate = observed as DirectoryEntry | null;

--- a/packages/gun-client/src/discoveryAdapters.test.ts
+++ b/packages/gun-client/src/discoveryAdapters.test.ts
@@ -609,7 +609,7 @@ describe('discoveryAdapters', () => {
         expect.objectContaining({
           event: SYSTEM_WRITER_VALIDATION_EVENT,
           reason: 'missing-pin',
-          path: 'vh/discovery/items/topic-1',
+          path: '[REDACTED:mesh-path]',
         }),
       );
       expect(dispatchSpy).toHaveBeenCalledWith(

--- a/packages/gun-client/src/discoveryAdapters.ts
+++ b/packages/gun-client/src/discoveryAdapters.ts
@@ -8,6 +8,7 @@ import {
   type PublicDiscoveryItem,
   type PublicDiscoverySortMode,
 } from '@vh/data-model';
+import { lumaLog } from '@vh/luma-sdk';
 import { createGuardedChain, type ChainWithGet } from './chain';
 import { writeWithDurability, type DurableWriteResult } from './durableWrite';
 import { readGunTimeoutMs } from './runtimeConfig';
@@ -185,7 +186,7 @@ function assertNoForbiddenDiscoveryIdentityFields(value: unknown): void {
 }
 
 function emitSystemWriterValidationFailure(failure: SystemWriterValidationFailure): void {
-  console.warn(`[vh:discovery] ${SYSTEM_WRITER_VALIDATION_EVENT}`, failure);
+  lumaLog('warn', `[vh:discovery] ${SYSTEM_WRITER_VALIDATION_EVENT}`, failure);
   if (typeof globalThis.dispatchEvent === 'function' && typeof CustomEvent !== 'undefined') {
     globalThis.dispatchEvent(
       new CustomEvent(SYSTEM_WRITER_VALIDATION_EVENT, { detail: failure }),
@@ -427,7 +428,7 @@ function putWithAck<T>(
     timeoutError: options.timeoutError,
     readback: options.readback,
     readbackPredicate: options.readbackPredicate,
-    onAckTimeout: () => console.warn('[vh:discovery] put ack timed out, requiring readback confirmation'),
+    onAckTimeout: () => lumaLog('warn', '[vh:discovery] put ack timed out, requiring readback confirmation'),
   });
 }
 

--- a/packages/gun-client/src/durableWrite.ts
+++ b/packages/gun-client/src/durableWrite.ts
@@ -1,3 +1,4 @@
+import { lumaLog } from '@vh/luma-sdk';
 import { putWithAckTimeout, type ChainWithGet, type PutAckResult } from './chain';
 import { readGunTimeoutMs } from './runtimeConfig';
 
@@ -74,10 +75,10 @@ function emitDefaultDurableWriteEvent(event: DurableWriteEvent): void {
   };
   const label = '[vh:mesh:durable-write]';
   if (event.stage === 'failed' || event.stage === 'ack-error') {
-    console.warn(label, payload);
+    lumaLog('warn', label, payload);
     return;
   }
-  console.info(label, payload);
+  lumaLog('info', label, payload);
 }
 
 function emitEvent(options: DurableWriteOptions<unknown>, event: DurableWriteEvent): void {

--- a/packages/gun-client/src/forumAdapters.ts
+++ b/packages/gun-client/src/forumAdapters.ts
@@ -9,6 +9,7 @@ import {
   type TrustedOperatorAuthorization,
 } from '@vh/data-model';
 import {
+  lumaLog,
   verifySignedWriteEnvelope,
   type SignedWriteVerifyHook
 } from '@vh/luma-sdk';
@@ -283,7 +284,7 @@ export async function writeForumCommentModeration(
     writeClass: 'forum-comment-moderation',
     timeoutMs: 2_500,
     timeoutError: 'forum comment moderation write timed out and readback did not confirm persistence',
-    onAckTimeout: () => console.warn('[vh:forum] moderation put ack timed out, requiring readback confirmation'),
+    onAckTimeout: () => lumaLog('warn', '[vh:forum] moderation put ack timed out, requiring readback confirmation'),
     readback: () => readForumCommentModeration(client, threadId, moderationId),
     readbackPredicate: (observed) => {
       const candidate = observed as HermesCommentModeration | null;
@@ -302,7 +303,7 @@ export async function writeForumCommentModeration(
     writeClass: 'forum-latest-comment-moderation',
     timeoutMs: 2_500,
     timeoutError: 'forum latest comment moderation write timed out and readback did not confirm persistence',
-    onAckTimeout: () => console.warn('[vh:forum] latest moderation put ack timed out, requiring readback confirmation'),
+    onAckTimeout: () => lumaLog('warn', '[vh:forum] latest moderation put ack timed out, requiring readback confirmation'),
     readback: () => readForumLatestCommentModeration(client, threadId, commentId),
     readbackPredicate: (observed) => {
       const candidate = observed as HermesCommentModeration | null;

--- a/packages/gun-client/src/index.ts
+++ b/packages/gun-client/src/index.ts
@@ -1,6 +1,7 @@
 import Gun from 'gun';
 import 'gun/sea.js';
 import type { IGunInstance } from 'gun';
+import { lumaLog } from '@vh/luma-sdk';
 import { waitForRemote, type ChainAck, type ChainLike, type ChainWithGet } from './chain';
 import { createStorageAdapter } from './storage/adapter';
 import type { StorageAdapter, StorageRecord } from './storage/types';
@@ -137,7 +138,7 @@ export function createClient(config: VennClientConfig = {}): VennClient {
       }
     })
     .catch((error: unknown) => {
-      console.warn('[vh] storage hydration failed', error);
+      lumaLog('warn', '[vh] storage hydration failed', { error });
       if (typeof globalThis.dispatchEvent === 'function' && typeof CustomEvent !== 'undefined') {
         const message = error instanceof Error ? error.message : String(error);
         globalThis.dispatchEvent(

--- a/packages/gun-client/src/newsAdapters.test.ts
+++ b/packages/gun-client/src/newsAdapters.test.ts
@@ -785,7 +785,7 @@ describe('newsAdapters', () => {
       expect(mesh.writes).toEqual([]);
       expect(fetchMock).toHaveBeenCalledTimes(3);
       expect(info).toHaveBeenCalledWith('[vh:news] relay REST write completed', expect.objectContaining({
-        path: '/vh/news/latest-index',
+        path: '[REDACTED:mesh-path]',
         relay_success_count: 2,
         relay_target_count: 3,
         relay_required_success_count: 2,
@@ -3769,7 +3769,7 @@ describe('newsAdapters', () => {
         expect.objectContaining({
           event: 'system-writer-validation-failed',
           reason: 'missing-pin',
-          path: 'vh/news/stories/story-123',
+          path: '[REDACTED:mesh-path]',
         })
       );
     } finally {
@@ -4449,7 +4449,7 @@ describe('newsAdapters', () => {
         expect.objectContaining({
           event: 'system-writer-validation-failed',
           reason: 'missing-pin',
-          path: 'vh/news/index/latest/story-a',
+          path: '[REDACTED:mesh-path]',
         })
       );
       expect(warning).toHaveBeenCalledWith(
@@ -4457,7 +4457,7 @@ describe('newsAdapters', () => {
         expect.objectContaining({
           event: 'system-writer-validation-failed',
           reason: 'missing-pin',
-          path: 'vh/news/index/hot/story-a',
+          path: '[REDACTED:mesh-path]',
         })
       );
     } finally {

--- a/packages/gun-client/src/newsAdapters.ts
+++ b/packages/gun-client/src/newsAdapters.ts
@@ -4,6 +4,7 @@ import {
   StoryBundleSchema,
   type StoryBundle,
 } from '@vh/data-model';
+import { lumaLog } from '@vh/luma-sdk';
 import { createGuardedChain, type ChainWithGet } from './chain';
 import { writeWithDurability, type DurableWriteResult } from './durableWrite';
 import { readGunTimeoutMs } from './runtimeConfig';
@@ -942,7 +943,7 @@ function warnNewsAckTimeout(): void {
       : '';
   suppressedNewsAckWarns = 0;
   lastNewsAckWarnAt = now;
-  console.warn(`[vh:news] put ack timed out, requiring readback confirmation${suffix}`);
+  lumaLog('warn', `[vh:news] put ack timed out, requiring readback confirmation${suffix}`);
 }
 
 async function putWithAck<T>(
@@ -1518,7 +1519,7 @@ function blocksLegacyIndexFallback(value: unknown): boolean {
 function emitSystemWriterValidationFailure(
   failure: SystemWriterValidationFailure,
 ): void {
-  console.warn(`[vh:news] ${SYSTEM_WRITER_VALIDATION_EVENT}`, failure);
+  lumaLog('warn', `[vh:news] ${SYSTEM_WRITER_VALIDATION_EVENT}`, failure);
   if (typeof globalThis.dispatchEvent === 'function' && typeof CustomEvent !== 'undefined') {
     globalThis.dispatchEvent(
       new CustomEvent(SYSTEM_WRITER_VALIDATION_EVENT, { detail: failure })
@@ -2354,7 +2355,7 @@ async function writeNewsRecordViaRelayRest(input: {
   }
 
   if (successCount >= quorum.requiredSuccessCount) {
-    console.info('[vh:news] relay REST write completed', {
+    lumaLog('info', '[vh:news] relay REST write completed', {
       write_class: input.writeClass,
       path: input.path,
       relay_success_count: successCount,

--- a/packages/gun-client/src/newsReportAdapters.ts
+++ b/packages/gun-client/src/newsReportAdapters.ts
@@ -6,6 +6,7 @@ import {
   type HermesNewsReportStatus,
   type TrustedOperatorAuthorization,
 } from '@vh/data-model';
+import { lumaLog } from '@vh/luma-sdk';
 import { createGuardedChain, type ChainWithGet } from './chain';
 import { writeWithDurability } from './durableWrite';
 import type { VennClient } from './types';
@@ -178,7 +179,7 @@ export async function writeNewsReport(
     writeClass: 'news-report',
     timeoutMs: 2_500,
     timeoutError: 'news report write timed out and readback did not confirm persistence',
-    onAckTimeout: () => console.warn('[vh:news-report] report put ack timed out, requiring readback confirmation'),
+    onAckTimeout: () => lumaLog('warn', '[vh:news-report] report put ack timed out, requiring readback confirmation'),
     readback: () => readNewsReport(client, reportId),
     readbackPredicate: (observed) => {
       const candidate = observed as HermesNewsReport | null;
@@ -201,7 +202,7 @@ export async function writeNewsReport(
     writeClass: 'news-report-index',
     timeoutMs: 2_500,
     timeoutError: 'news report status-index write timed out and readback did not confirm persistence',
-    onAckTimeout: () => console.warn('[vh:news-report] status-index put ack timed out, requiring readback confirmation'),
+    onAckTimeout: () => lumaLog('warn', '[vh:news-report] status-index put ack timed out, requiring readback confirmation'),
     readback: () => readOnce(getNewsReportStatusIndexEntryChain(client, sanitized.status, reportId)),
     readbackPredicate: (observed) => parseQueuePointer(observed, reportId) === reportId,
   });

--- a/packages/gun-client/src/sentimentEventAdapters.ts
+++ b/packages/gun-client/src/sentimentEventAdapters.ts
@@ -4,6 +4,7 @@ import {
   deriveSentimentEventId,
   type SentimentEvent,
 } from '@vh/data-model';
+import { lumaLog } from '@vh/luma-sdk';
 import { createGuardedChain, type ChainWithGet, type PutAckResult } from './chain';
 import { writeWithDurability } from './durableWrite';
 import { readGunTimeoutMs } from './runtimeConfig';
@@ -158,7 +159,7 @@ async function putWithAck<T>(
     timeoutError: options.timeoutError,
     readback: options.readback,
     readbackPredicate: options.readbackPredicate,
-    onAckTimeout: () => console.warn('[vh:gun-client] sentiment outbox put ack timed out, requiring readback confirmation'),
+    onAckTimeout: () => lumaLog('warn', '[vh:gun-client] sentiment outbox put ack timed out, requiring readback confirmation'),
   });
   return result.ack;
 }

--- a/packages/gun-client/src/storylineAdapters.test.ts
+++ b/packages/gun-client/src/storylineAdapters.test.ts
@@ -400,7 +400,7 @@ describe('storylineAdapters', () => {
         expect.objectContaining({
           event: 'system-writer-validation-failed',
           reason: 'missing-pin',
-          path: 'vh/news/storylines/storyline-1',
+          path: '[REDACTED:mesh-path]',
         })
       );
       expect(dispatchEvent).toHaveBeenCalledWith(expect.objectContaining({

--- a/packages/gun-client/src/storylineAdapters.ts
+++ b/packages/gun-client/src/storylineAdapters.ts
@@ -1,4 +1,5 @@
 import { StorylineGroupSchema, type StorylineGroup } from '@vh/data-model';
+import { lumaLog } from '@vh/luma-sdk';
 import { createGuardedChain, type ChainWithGet } from './chain';
 import { writeWithDurability } from './durableWrite';
 import { readGunTimeoutMs } from './runtimeConfig';
@@ -82,7 +83,7 @@ async function putWithAck<T>(
     timeoutError: options.timeoutError,
     readback: options.readback,
     readbackPredicate: options.readbackPredicate,
-    onAckTimeout: () => console.warn('[vh:storylines] put ack timed out, requiring readback confirmation'),
+    onAckTimeout: () => lumaLog('warn', '[vh:storylines] put ack timed out, requiring readback confirmation'),
   });
 }
 
@@ -236,7 +237,7 @@ function carriesLumaProtocolFields(value: unknown): boolean {
 function emitSystemWriterValidationFailure(
   failure: SystemWriterValidationFailure,
 ): void {
-  console.warn(`[vh:storylines] ${SYSTEM_WRITER_VALIDATION_EVENT}`, failure);
+  lumaLog('warn', `[vh:storylines] ${SYSTEM_WRITER_VALIDATION_EVENT}`, failure);
   if (typeof globalThis.dispatchEvent === 'function' && typeof CustomEvent !== 'undefined') {
     globalThis.dispatchEvent(
       new CustomEvent(SYSTEM_WRITER_VALIDATION_EVENT, { detail: failure })

--- a/packages/gun-client/src/synthesisAdapters.test.ts
+++ b/packages/gun-client/src/synthesisAdapters.test.ts
@@ -809,7 +809,7 @@ describe('synthesisAdapters', () => {
         expect.objectContaining({
           event: SYSTEM_WRITER_VALIDATION_EVENT,
           reason: 'missing-pin',
-          path: 'vh/topics/topic-1/epochs/2/synthesis',
+          path: '[REDACTED:mesh-path]',
         }),
       );
       expect(dispatchSpy).toHaveBeenCalledWith(
@@ -1616,7 +1616,7 @@ describe('synthesisAdapters', () => {
         expect.objectContaining({
           event: SYSTEM_WRITER_VALIDATION_EVENT,
           reason: 'missing-pin',
-          path: 'vh/topics/topic-1/digests/digest-1',
+          path: '[REDACTED:mesh-path]',
         }),
       );
       expect(dispatchSpy).toHaveBeenCalledWith(

--- a/packages/gun-client/src/synthesisAdapters.ts
+++ b/packages/gun-client/src/synthesisAdapters.ts
@@ -10,6 +10,7 @@ import {
   type TopicSynthesisV2,
   type TrustedOperatorAuthorization
 } from '@vh/data-model';
+import { lumaLog } from '@vh/luma-sdk';
 import { createGuardedChain, putWithAckTimeout, type ChainWithGet } from './chain';
 import { writeWithDurability } from './durableWrite';
 import { resolveRelayRestEndpointFromPeer } from './relayRestFallback';
@@ -410,7 +411,7 @@ function carriesLumaProtocolFields(value: Record<string, unknown>): boolean {
 }
 
 function emitSystemWriterValidationFailure(failure: SystemWriterValidationFailure): void {
-  console.warn(`[vh:synthesis] ${SYSTEM_WRITER_VALIDATION_EVENT}`, failure);
+  lumaLog('warn', `[vh:synthesis] ${SYSTEM_WRITER_VALIDATION_EVENT}`, failure);
   if (typeof globalThis.dispatchEvent === 'function' && typeof CustomEvent !== 'undefined') {
     globalThis.dispatchEvent(
       new CustomEvent(SYSTEM_WRITER_VALIDATION_EVENT, { detail: failure })
@@ -704,7 +705,7 @@ async function putSystemWriterSynthesisWithDurability(
         && candidate.epoch === synthesis.epoch
       );
     },
-    onAckTimeout: () => console.warn('[vh:synthesis] put ack timed out, requiring signed readback confirmation'),
+    onAckTimeout: () => lumaLog('warn', '[vh:synthesis] put ack timed out, requiring signed readback confirmation'),
   });
 }
 

--- a/packages/gun-client/src/topicEngagementAdapters.test.ts
+++ b/packages/gun-client/src/topicEngagementAdapters.test.ts
@@ -579,7 +579,7 @@ describe('topicEngagementAdapters', () => {
         expect.objectContaining({
           event: SYSTEM_WRITER_VALIDATION_EVENT,
           reason: 'missing-pin',
-          path: 'vh/aggregates/topics/topic-1/engagement/summary',
+          path: '[REDACTED:mesh-path]',
         }),
       );
       expect(dispatchSpy).toHaveBeenCalledWith(

--- a/packages/gun-client/src/topicEngagementAdapters.ts
+++ b/packages/gun-client/src/topicEngagementAdapters.ts
@@ -6,6 +6,7 @@ import {
   type TopicEngagementActorNode,
   type TopicEngagementAggregateV1,
 } from '@vh/data-model';
+import { lumaLog } from '@vh/luma-sdk';
 import { createGuardedChain, type ChainWithGet } from './chain';
 import { writeWithDurability, type DurableWriteResult } from './durableWrite';
 import { readGunTimeoutMs } from './runtimeConfig';
@@ -153,7 +154,7 @@ function carriesLumaProtocolFields(value: Record<string, unknown>): boolean {
 }
 
 function emitSystemWriterValidationFailure(failure: SystemWriterValidationFailure): void {
-  console.warn(`[vh:topic-engagement] ${SYSTEM_WRITER_VALIDATION_EVENT}`, failure);
+  lumaLog('warn', `[vh:topic-engagement] ${SYSTEM_WRITER_VALIDATION_EVENT}`, failure);
   if (typeof globalThis.dispatchEvent === 'function' && typeof CustomEvent !== 'undefined') {
     globalThis.dispatchEvent(
       new CustomEvent(SYSTEM_WRITER_VALIDATION_EVENT, { detail: failure })
@@ -267,7 +268,7 @@ function putWithAck<T>(
     timeoutError: options.timeoutError,
     readback: options.readback,
     readbackPredicate: options.readbackPredicate,
-    onAckTimeout: () => console.warn('[vh:topic-engagement] put ack timed out, requiring readback confirmation'),
+    onAckTimeout: () => lumaLog('warn', '[vh:topic-engagement] put ack timed out, requiring readback confirmation'),
   });
 }
 

--- a/packages/luma-sdk/src/index.ts
+++ b/packages/luma-sdk/src/index.ts
@@ -98,3 +98,24 @@ export {
   type UnsignedSignedWriteEnvelope,
   type VerifySignedWriteEnvelopeInput
 } from './signedWrites';
+
+export {
+  assertLumaTelemetrySafe,
+  clearLumaTelemetry,
+  createLumaTelemetryStore,
+  emitLumaEvent,
+  lumaLog,
+  LUMA_TELEMETRY_EVENT_TYPES,
+  lumaTelemetryStore,
+  redactLumaTelemetryContext,
+  redactedPathHash,
+  type EmitLumaEventInput,
+  type LumaEvent,
+  type LumaRedactedLogValue,
+  type LumaTelemetryContext,
+  type LumaTelemetryEventType,
+  type LumaTelemetryLevel,
+  type LumaTelemetryPrimitive,
+  type LumaTelemetryStore,
+  type LumaTelemetryValue
+} from './telemetry';

--- a/packages/luma-sdk/src/telemetry.test.ts
+++ b/packages/luma-sdk/src/telemetry.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  assertLumaTelemetrySafe,
+  clearLumaTelemetry,
+  createLumaTelemetryStore,
+  emitLumaEvent,
+  lumaLog,
+  LUMA_TELEMETRY_EVENT_TYPES,
+  lumaTelemetryStore,
+  redactLumaTelemetryContext,
+  redactedPathHash,
+} from './telemetry';
+
+describe('LUMA telemetry', () => {
+  it('locks the spec §16 event registry', () => {
+    expect(LUMA_TELEMETRY_EVENT_TYPES).toEqual([
+      'luma_session_created',
+      'luma_session_expired',
+      'luma_session_re_attested',
+      'luma_session_revoked',
+      'luma_session_revoked_by_bulletin',
+      'luma_policy_blocked',
+      'luma_envelope_rejected',
+      'luma_tombstone_attempted',
+      'luma_evidence_capture_started',
+      'luma_evidence_capture_succeeded',
+      'luma_evidence_capture_failed',
+      'luma_forbidden_claim_rendered',
+      'luma_safety_bulletin_fetched',
+      'luma_vault_migrated_v1_to_v2',
+    ]);
+  });
+
+  it('emits bounded in-memory events and notifies subscribers', () => {
+    const store = createLumaTelemetryStore({ maxEvents: 2, saltBytes: new Uint8Array(16).fill(1) });
+    const listener = vi.fn();
+    const unsubscribe = store.subscribe(listener);
+
+    store.emit({ type: 'luma_session_created', tsMs: 1, context: { profile: 'dev' } });
+    store.emit({ type: 'luma_session_expired', tsMs: 2 });
+    store.emit({ type: 'luma_policy_blocked', level: 'warn', tsMs: 3, message: 'blocked' });
+
+    expect(store.getSnapshot()).toMatchObject([
+      { sequence: 2, type: 'luma_session_expired', ts_ms: 2 },
+      { sequence: 3, type: 'luma_policy_blocked', level: 'warn', ts_ms: 3, message: 'blocked' },
+    ]);
+    expect(listener).toHaveBeenCalledTimes(3);
+    unsubscribe();
+    store.clear({ rotateSalt: false });
+    expect(listener).toHaveBeenCalledTimes(3);
+  });
+
+  it('red test: rejects unknown event types at emit time', () => {
+    const store = createLumaTelemetryStore({ saltBytes: new Uint8Array(16).fill(1) });
+    expect(() => store.emit({ type: 'luma_unknown' as never })).toThrow(/Unknown LUMA telemetry event type/);
+  });
+
+  it('red test: rejects unsafe event message strings before storing telemetry', () => {
+    const store = createLumaTelemetryStore({ saltBytes: new Uint8Array(16).fill(1) });
+
+    expect(() => store.emit({
+      type: 'luma_policy_blocked',
+      message: 'blocked raw /vh/news/story/demo path',
+    })).toThrow(/raw mesh path/);
+    expect(() => store.emit({
+      type: 'luma_policy_blocked',
+      message: 'https://example.test/callback?token=secret',
+    })).toThrow(/token-bearing URL/);
+    expect(store.getSnapshot()).toEqual([]);
+  });
+
+  it('red test: rejects typed secrets, raw envelopes, token URLs, and raw mesh paths', () => {
+    expect(() => assertLumaTelemetrySafe({ principalNullifier: 'n-123' })).toThrow(/forbidden field/);
+    expect(() => assertLumaTelemetrySafe({ sessionToken: 's-123' })).toThrow(/forbidden field/);
+    expect(() => assertLumaTelemetrySafe({ deviceCredential: 'd-123' })).toThrow(/forbidden field/);
+    expect(() => assertLumaTelemetrySafe({ rawEnvelopeJson: '{"envelopeVersion":1,"signature":"abc"}' })).toThrow(/forbidden field/);
+    expect(() => assertLumaTelemetrySafe({ payload: '{"envelopeVersion":1,"signature":"abc"}' })).toThrow(/raw envelope JSON/);
+    expect(() => assertLumaTelemetrySafe({ href: 'https://example.test/verify?token=secret' })).toThrow(/token-bearing URL/);
+    expect(() => assertLumaTelemetrySafe({ mesh: '/vh/news/story/demo' })).toThrow(/raw mesh path/);
+  });
+
+  it('accepts primitives, arrays, repeated references, and malformed non-token URLs', () => {
+    const repeated: Record<string, unknown> = { safe: true };
+    repeated.self = repeated;
+
+    expect(() => assertLumaTelemetrySafe(null)).not.toThrow();
+    expect(() => assertLumaTelemetrySafe(42)).not.toThrow();
+    expect(() => assertLumaTelemetrySafe(['ok', { nested: repeated }])).not.toThrow();
+    expect(() => assertLumaTelemetrySafe({ malformed: 'https://%' })).not.toThrow();
+    expect(() => assertLumaTelemetrySafe({ safeUrl: 'https://example.test/path?view=feed' })).not.toThrow();
+  });
+
+  it('redacts logs while preserving safe context shape', () => {
+    const circular: Record<string, unknown> = { ok: true };
+    circular.self = circular;
+    expect(redactLumaTelemetryContext({
+      verifierId: 'beta-local',
+      values: ['plain', '{"envelopeVersion":1,"signature":"abc"}'],
+      nested: { url: 'https://example.test/callback?access_token=secret' },
+      error: new Error('bad /vh/news/story/demo path'),
+      circular,
+      symbol: Symbol('luma'),
+      missing: undefined,
+    })).toEqual({
+      verifierId: '[REDACTED:field]',
+      values: ['plain', '[REDACTED:envelope-json]'],
+      nested: { url: '[REDACTED:token-url]' },
+      error: { name: 'Error', message: '[REDACTED:mesh-path]' },
+      circular: { ok: true, self: '[REDACTED:circular]' },
+      symbol: 'Symbol(luma)',
+      missing: undefined,
+    });
+  });
+
+  it('lumaLog is the only console sink and emits redacted payloads', () => {
+    const info = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    try {
+      lumaLog('info', '[vh:test:info] /vh/news/story/demo');
+      lumaLog('warn', '[vh:test]', {
+        signature: 'secret-signature',
+        path: '/vh/news/story/demo',
+      });
+      lumaLog('error', 'https://example.test/callback?token=secret', { ok: true });
+      expect(info).toHaveBeenCalledWith('[REDACTED:mesh-path]');
+      expect(warn).toHaveBeenCalledWith('[vh:test]', {
+        signature: '[REDACTED:field]',
+        path: '[REDACTED:mesh-path]',
+      });
+      expect(error).toHaveBeenCalledWith('[REDACTED:token-url]', { ok: true });
+    } finally {
+      info.mockRestore();
+      warn.mockRestore();
+      error.mockRestore();
+    }
+  });
+
+  it('hashes raw paths without exposing them and rotates salt on clear', async () => {
+    const store = createLumaTelemetryStore({ saltBytes: new Uint8Array(16).fill(2) });
+    const first = await store.redactedPathHash('/vh/news/story/demo');
+    const sameSalt = await store.redactedPathHash('/vh/news/story/demo');
+    store.clear();
+    const rotated = await store.redactedPathHash('/vh/news/story/demo');
+
+    expect(first).toMatch(/^sha256:[0-9a-f]{64}$/);
+    expect(sameSalt).toBe(first);
+    expect(rotated).not.toBe(first);
+    expect(first).not.toContain('/vh/news/story/demo');
+  });
+
+  it('supports explicit salt rotation and rejects empty or unhasheable path inputs', async () => {
+    const store = createLumaTelemetryStore({ saltBytes: new Uint8Array(16).fill(4) });
+    const first = await store.redactedPathHash('/vh/news/story/demo');
+    store.rotateSalt();
+    const rotated = await store.redactedPathHash('/vh/news/story/demo');
+
+    expect(rotated).not.toBe(first);
+    await expect(store.redactedPathHash('')).rejects.toThrow(/non-empty raw path/);
+  });
+
+  it('uses fallback salt bytes when getRandomValues is unavailable', () => {
+    const originalCrypto = globalThis.crypto;
+    vi.stubGlobal('crypto', undefined);
+    try {
+      const store = createLumaTelemetryStore();
+      store.emit({ type: 'luma_session_created' });
+      expect(store.getSnapshot()).toHaveLength(1);
+    } finally {
+      vi.stubGlobal('crypto', originalCrypto);
+    }
+  });
+
+  it('fails closed when WebCrypto SHA-256 is unavailable', async () => {
+    const originalCrypto = globalThis.crypto;
+    vi.stubGlobal('crypto', {
+      getRandomValues(bytes: Uint8Array) {
+        bytes.fill(7);
+        return bytes;
+      },
+    });
+    try {
+      const store = createLumaTelemetryStore({ saltBytes: new Uint8Array(16).fill(5) });
+      await expect(store.redactedPathHash('/vh/news/story/demo')).rejects.toThrow(/WebCrypto SHA-256/);
+    } finally {
+      vi.stubGlobal('crypto', originalCrypto);
+    }
+  });
+
+  it('returns without throwing when no console sink is available', () => {
+    const originalConsole = globalThis.console;
+    vi.stubGlobal('console', undefined);
+    try {
+      expect(() => lumaLog('warn', '[vh:test]')).not.toThrow();
+    } finally {
+      vi.stubGlobal('console', originalConsole);
+    }
+  });
+
+  it('singleton helpers use the same in-memory ring buffer', async () => {
+    clearLumaTelemetry({ rotateSalt: false });
+    const event = emitLumaEvent({ type: 'luma_safety_bulletin_fetched', tsMs: 10 });
+    const hash = await redactedPathHash('/vh/news/index/latest');
+
+    expect(lumaTelemetryStore.getSnapshot()).toEqual([event]);
+    expect(hash).toMatch(/^sha256:/);
+    clearLumaTelemetry({ rotateSalt: false });
+  });
+});

--- a/packages/luma-sdk/src/telemetry.ts
+++ b/packages/luma-sdk/src/telemetry.ts
@@ -1,0 +1,360 @@
+export const LUMA_TELEMETRY_EVENT_TYPES = Object.freeze([
+  'luma_session_created',
+  'luma_session_expired',
+  'luma_session_re_attested',
+  'luma_session_revoked',
+  'luma_session_revoked_by_bulletin',
+  'luma_policy_blocked',
+  'luma_envelope_rejected',
+  'luma_tombstone_attempted',
+  'luma_evidence_capture_started',
+  'luma_evidence_capture_succeeded',
+  'luma_evidence_capture_failed',
+  'luma_forbidden_claim_rendered',
+  'luma_safety_bulletin_fetched',
+  'luma_vault_migrated_v1_to_v2',
+] as const);
+
+export type LumaTelemetryEventType = typeof LUMA_TELEMETRY_EVENT_TYPES[number];
+export type LumaTelemetryLevel = 'info' | 'warn' | 'error';
+export type LumaTelemetryPrimitive = string | number | boolean | null;
+export type LumaTelemetryValue =
+  | LumaTelemetryPrimitive
+  | readonly LumaTelemetryValue[]
+  | { readonly [key: string]: LumaTelemetryValue };
+export type LumaTelemetryContext = Record<string, LumaTelemetryValue>;
+export type LumaRedactedLogValue =
+  | LumaTelemetryPrimitive
+  | undefined
+  | readonly LumaRedactedLogValue[]
+  | { readonly [key: string]: LumaRedactedLogValue };
+
+export interface LumaEvent {
+  readonly sequence: number;
+  readonly type: LumaTelemetryEventType;
+  readonly level: LumaTelemetryLevel;
+  readonly ts_ms: number;
+  readonly message?: string;
+  readonly context?: LumaTelemetryContext;
+}
+
+export interface EmitLumaEventInput {
+  readonly type: LumaTelemetryEventType;
+  readonly level?: LumaTelemetryLevel;
+  readonly tsMs?: number;
+  readonly message?: string;
+  readonly context?: LumaTelemetryContext;
+}
+
+export interface LumaTelemetryStore {
+  readonly emit: (input: EmitLumaEventInput) => LumaEvent;
+  readonly getSnapshot: () => readonly LumaEvent[];
+  readonly subscribe: (listener: () => void) => () => void;
+  readonly clear: (options?: { readonly rotateSalt?: boolean }) => void;
+  readonly rotateSalt: () => void;
+  readonly redactedPathHash: (rawPath: string) => Promise<string>;
+}
+
+const LUMA_TELEMETRY_EVENT_TYPE_SET = new Set<string>(LUMA_TELEMETRY_EVENT_TYPES);
+const DEFAULT_MAX_EVENTS = 1000;
+const SALT_BYTES = 16;
+const TEXT_ENCODER = new TextEncoder();
+const FORBIDDEN_FIELD_NAMES = Object.freeze([
+  'nullifier',
+  'principalNullifier',
+  'activeNullifier',
+  'deviceCredential',
+  'sessionToken',
+  'rawSignatureBytes',
+  'rawEnvelopeJson',
+  'assuranceEnvelope',
+  'envelope',
+  'signature',
+  'verifierId',
+  'district_hash',
+  'districtHash',
+  'region_code',
+  'regionCode',
+  'vaultMasterKey',
+  'privateKey',
+  'secretKey',
+] as const);
+const FORBIDDEN_FIELD_NAME_SET = new Set(FORBIDDEN_FIELD_NAMES.map(normalizeFieldName));
+const TOKEN_QUERY_KEYS = new Set([
+  'token',
+  'access_token',
+  'refresh_token',
+  'session_token',
+  'auth_token',
+  'oauth_token',
+  'bearer_token',
+  'pin',
+  'key',
+  'secret',
+]);
+const RAW_MESH_PATH_PATTERN = /(?:^|[\s"'`])\/?vh\/[A-Za-z0-9._~:/?#\[\]@!$&'()*+,;=%-]+/;
+const RAW_ENVELOPE_JSON_PATTERN = /"envelopeVersion"\s*:\s*\d+[\s\S]*"signature"\s*:/;
+
+function normalizeFieldName(name: string): string {
+  return name.replace(/[^a-z0-9]/gi, '').toLowerCase();
+}
+
+function assertKnownEventType(type: string): asserts type is LumaTelemetryEventType {
+  if (!LUMA_TELEMETRY_EVENT_TYPE_SET.has(type)) {
+    throw new Error(`Unknown LUMA telemetry event type: ${type}`);
+  }
+}
+
+function fieldNameForbidden(fieldName: string): boolean {
+  return FORBIDDEN_FIELD_NAME_SET.has(normalizeFieldName(fieldName));
+}
+
+function looksLikeTokenUrl(value: string): boolean {
+  if (!/^https?:\/\//i.test(value)) {
+    return false;
+  }
+  try {
+    const parsed = new URL(value);
+    for (const key of parsed.searchParams.keys()) {
+      if (TOKEN_QUERY_KEYS.has(key.toLowerCase())) {
+        return true;
+      }
+    }
+  } catch {
+    return false;
+  }
+  return false;
+}
+
+function stringForbiddenReason(value: string): string | null {
+  if (RAW_MESH_PATH_PATTERN.test(value)) {
+    return 'raw mesh path';
+  }
+  if (looksLikeTokenUrl(value)) {
+    return 'token-bearing URL';
+  }
+  if (RAW_ENVELOPE_JSON_PATTERN.test(value)) {
+    return 'raw envelope JSON';
+  }
+  return null;
+}
+
+function assertTelemetryValueSafe(value: unknown, path: string, seen: WeakSet<object>): void {
+  if (typeof value === 'string') {
+    const reason = stringForbiddenReason(value);
+    if (reason) {
+      throw new Error(`LUMA telemetry context contains forbidden ${reason} at ${path}`);
+    }
+    return;
+  }
+  if (value === null || typeof value !== 'object') {
+    return;
+  }
+  if (seen.has(value)) {
+    return;
+  }
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => assertTelemetryValueSafe(item, `${path}[${index}]`, seen));
+    return;
+  }
+
+  for (const [key, nested] of Object.entries(value)) {
+    const nestedPath = `${path}.${key}`;
+    if (fieldNameForbidden(key)) {
+      throw new Error(`LUMA telemetry context contains forbidden field "${key}" at ${nestedPath}`);
+    }
+    assertTelemetryValueSafe(nested, nestedPath, seen);
+  }
+}
+
+export function assertLumaTelemetrySafe(value: unknown): void {
+  assertTelemetryValueSafe(value, '$', new WeakSet<object>());
+}
+
+function redactString(value: string): string {
+  if (RAW_MESH_PATH_PATTERN.test(value)) {
+    return '[REDACTED:mesh-path]';
+  }
+  if (looksLikeTokenUrl(value)) {
+    return '[REDACTED:token-url]';
+  }
+  if (RAW_ENVELOPE_JSON_PATTERN.test(value)) {
+    return '[REDACTED:envelope-json]';
+  }
+  return value;
+}
+
+function sanitizeForLog(value: unknown, seen: WeakSet<object>): LumaRedactedLogValue {
+  if (value instanceof Error) {
+    return {
+      name: redactString(value.name),
+      message: redactString(value.message),
+    };
+  }
+  if (typeof value === 'string') {
+    return redactString(value);
+  }
+  if (typeof value === 'number' || typeof value === 'boolean' || value === null || value === undefined) {
+    return value;
+  }
+  if (typeof value !== 'object') {
+    return String(value);
+  }
+  if (seen.has(value)) {
+    return '[REDACTED:circular]';
+  }
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeForLog(item, seen));
+  }
+
+  const redacted: Record<string, LumaRedactedLogValue> = {};
+  for (const [key, nested] of Object.entries(value)) {
+    redacted[key] = fieldNameForbidden(key)
+      ? '[REDACTED:field]'
+      : sanitizeForLog(nested, seen);
+  }
+  return redacted;
+}
+
+export function redactLumaTelemetryContext(context: unknown): LumaRedactedLogValue {
+  return sanitizeForLog(context, new WeakSet<object>());
+}
+
+function randomSaltBytes(): Uint8Array {
+  const salt = new Uint8Array(SALT_BYTES);
+  const cryptoApi = globalThis.crypto;
+  if (cryptoApi && typeof cryptoApi.getRandomValues === 'function') {
+    cryptoApi.getRandomValues(salt);
+    return salt;
+  }
+  for (let index = 0; index < salt.length; index += 1) {
+    salt[index] = Math.floor(Math.random() * 256);
+  }
+  return salt;
+}
+
+function concatBytes(left: Uint8Array, right: Uint8Array): Uint8Array {
+  const joined = new Uint8Array(left.length + right.length);
+  joined.set(left, 0);
+  joined.set(right, left.length);
+  return joined;
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return [...bytes].map((byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+async function sha256Hex(bytes: Uint8Array): Promise<string> {
+  const cryptoApi = globalThis.crypto;
+  if (!cryptoApi?.subtle) {
+    throw new Error('WebCrypto SHA-256 is required for LUMA redactedPathHash');
+  }
+  const digestInput = new Uint8Array(bytes).buffer as ArrayBuffer;
+  const digest = await cryptoApi.subtle.digest('SHA-256', digestInput);
+  return bytesToHex(new Uint8Array(digest));
+}
+
+export function createLumaTelemetryStore(options: {
+  readonly maxEvents?: number;
+  readonly saltBytes?: Uint8Array;
+} = {}): LumaTelemetryStore {
+  const maxEvents = Math.max(1, Math.floor(options.maxEvents ?? DEFAULT_MAX_EVENTS));
+  const listeners = new Set<() => void>();
+  let events: LumaEvent[] = [];
+  let sequence = 0;
+  let saltBytes = options.saltBytes ? new Uint8Array(options.saltBytes) : randomSaltBytes();
+
+  function notify(): void {
+    for (const listener of listeners) {
+      listener();
+    }
+  }
+
+  return {
+    emit(input: EmitLumaEventInput): LumaEvent {
+      assertKnownEventType(input.type);
+      if (input.message !== undefined) {
+        assertLumaTelemetrySafe(input.message);
+      }
+      if (input.context) {
+        assertLumaTelemetrySafe(input.context);
+      }
+      const event: LumaEvent = Object.freeze({
+        sequence: sequence += 1,
+        type: input.type,
+        level: input.level ?? 'info',
+        ts_ms: input.tsMs ?? Date.now(),
+        ...(input.message !== undefined ? { message: input.message } : {}),
+        ...(input.context ? { context: Object.freeze({ ...input.context }) } : {}),
+      });
+      events = [...events, event].slice(-maxEvents);
+      notify();
+      return event;
+    },
+    getSnapshot(): readonly LumaEvent[] {
+      return events;
+    },
+    subscribe(listener: () => void): () => void {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    clear(optionsForClear: { readonly rotateSalt?: boolean } = {}): void {
+      events = [];
+      if (optionsForClear.rotateSalt !== false) {
+        saltBytes = randomSaltBytes();
+      }
+      notify();
+    },
+    rotateSalt(): void {
+      saltBytes = randomSaltBytes();
+      notify();
+    },
+    async redactedPathHash(rawPath: string): Promise<string> {
+      const reason = stringForbiddenReason(rawPath);
+      if (!reason && !rawPath.trim()) {
+        throw new Error('redactedPathHash requires a non-empty raw path');
+      }
+      const digest = await sha256Hex(concatBytes(saltBytes, TEXT_ENCODER.encode(rawPath)));
+      return `sha256:${digest}`;
+    },
+  };
+}
+
+export const lumaTelemetryStore = createLumaTelemetryStore();
+
+export function emitLumaEvent(input: EmitLumaEventInput): LumaEvent {
+  return lumaTelemetryStore.emit(input);
+}
+
+export function clearLumaTelemetry(options?: { readonly rotateSalt?: boolean }): void {
+  lumaTelemetryStore.clear(options);
+}
+
+export async function redactedPathHash(rawPath: string): Promise<string> {
+  return lumaTelemetryStore.redactedPathHash(rawPath);
+}
+
+export function lumaLog(level: LumaTelemetryLevel, message: string, context?: unknown): void {
+  const consoleForRuntime = globalThis.console;
+  if (!consoleForRuntime) {
+    return;
+  }
+  const sink =
+    level === 'error'
+      ? consoleForRuntime.error
+      : level === 'warn'
+        ? consoleForRuntime.warn
+        : consoleForRuntime.info;
+  const redactedMessage = redactString(message);
+  if (context === undefined) {
+    sink.call(consoleForRuntime, redactedMessage);
+    return;
+  }
+  sink.call(consoleForRuntime, redactedMessage, redactLumaTelemetryContext(context));
+}

--- a/tools/scripts/check-luma-telemetry-redaction.mjs
+++ b/tools/scripts/check-luma-telemetry-redaction.mjs
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+/**
+ * check:luma-telemetry-redaction — M1.E telemetry guard.
+ *
+ * Locks source-discipline rules from spec §16:
+ *  1. The LUMA event registry mirrors spec §16.1.
+ *  2. Identity/vault/gun-client/LUMA SDK code does not call console.*
+ *     directly; logs go through lumaLog so redaction is centralized.
+ *  3. Typed secret-like values are not compared with === / !== in the
+ *     guarded namespaces. Null/undefined presence checks are allowed.
+ *
+ * Runtime redaction behavior is covered by packages/luma-sdk/src/telemetry.test.ts.
+ * The full spec §21.4 recorded engagement replay remains deferred as a
+ * pre-<TrustClaim> obligation.
+ */
+
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '../..');
+
+export const EXPECTED_LUMA_EVENT_TYPES = Object.freeze([
+  'luma_session_created',
+  'luma_session_expired',
+  'luma_session_re_attested',
+  'luma_session_revoked',
+  'luma_session_revoked_by_bulletin',
+  'luma_policy_blocked',
+  'luma_envelope_rejected',
+  'luma_tombstone_attempted',
+  'luma_evidence_capture_started',
+  'luma_evidence_capture_succeeded',
+  'luma_evidence_capture_failed',
+  'luma_forbidden_claim_rendered',
+  'luma_safety_bulletin_fetched',
+  'luma_vault_migrated_v1_to_v2',
+]);
+
+const DIRECT_CONSOLE_PATTERN = /\bconsole\.(?:log|info|warn|error|debug)\s*\(/;
+const SECRET_IDENTIFIER_PATTERN = /\b(?:nullifier|deviceCredential|sessionToken|rawSignatureBytes|rawEnvelopeJson|vaultMasterKey|privateKey|secretKey|districtHash|regionCode)\b/i;
+const SECRET_EQUALITY_PATTERN = /(?:===|!==)/;
+const NULLISH_PATTERN = /\b(?:null|undefined)\b/;
+const SOURCE_EXTENSIONS = new Set(['.ts', '.tsx']);
+
+export const SCAN_TARGETS = Object.freeze([
+  { kind: 'file', path: 'apps/web-pwa/src/hooks/useIdentity.ts' },
+  { kind: 'dir', path: 'apps/web-pwa/src/hooks/identity', optional: true },
+  { kind: 'dir', path: 'packages/identity-vault/src' },
+  { kind: 'dir', path: 'packages/gun-client/src' },
+  { kind: 'dir', path: 'packages/luma-sdk/src' },
+]);
+
+export const DIRECT_CONSOLE_ALLOWLIST = new Set([
+  'packages/luma-sdk/src/telemetry.ts',
+]);
+
+function walkSourceFiles(root, files = []) {
+  for (const entry of readdirSync(root)) {
+    const full = path.join(root, entry);
+    const stats = statSync(full);
+    if (stats.isDirectory()) {
+      if (entry === 'dist' || entry === 'node_modules') continue;
+      walkSourceFiles(full, files);
+    } else if (SOURCE_EXTENSIONS.has(path.extname(entry)) && !/\.(test|spec)\.tsx?$/.test(entry)) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+function resolveScanFiles(repoRoot, failures) {
+  const files = [];
+  for (const target of SCAN_TARGETS) {
+    const full = path.join(repoRoot, target.path);
+    if (!existsSync(full)) {
+      if (!target.optional) {
+        failures.push(`${target.path}: guarded telemetry target missing`);
+      }
+      continue;
+    }
+    if (target.kind === 'file') {
+      files.push(full);
+    } else {
+      walkSourceFiles(full, files);
+    }
+  }
+  return [...new Set(files)].sort();
+}
+
+function parseRegistryTypes(source) {
+  const match = source.match(/LUMA_TELEMETRY_EVENT_TYPES\s*=\s*Object\.freeze\(\[([\s\S]*?)\]\s*as const\)/);
+  if (!match) {
+    return null;
+  }
+  const body = match[1] ?? '';
+  return [...body.matchAll(/'([^']+)'/g)].map((entry) => entry[1]);
+}
+
+function scanLineForDirectConsole(relPath, lineText, lineNumber, violations) {
+  if (!DIRECT_CONSOLE_PATTERN.test(lineText)) {
+    return;
+  }
+  if (DIRECT_CONSOLE_ALLOWLIST.has(relPath)) {
+    return;
+  }
+  violations.push({
+    type: 'direct-console',
+    file: relPath,
+    line: lineNumber,
+    text: lineText.trim(),
+  });
+}
+
+function scanLineForSecretEquality(relPath, lineText, lineNumber, violations) {
+  if (!SECRET_EQUALITY_PATTERN.test(lineText) || !SECRET_IDENTIFIER_PATTERN.test(lineText)) {
+    return;
+  }
+  if (NULLISH_PATTERN.test(lineText)) {
+    return;
+  }
+  violations.push({
+    type: 'secret-equality',
+    file: relPath,
+    line: lineNumber,
+    text: lineText.trim(),
+  });
+}
+
+export function runTelemetryRedactionChecks(repoRoot = REPO_ROOT) {
+  const failures = [];
+  const violations = [];
+  const files = resolveScanFiles(repoRoot, failures);
+  const telemetryPath = path.join(repoRoot, 'packages/luma-sdk/src/telemetry.ts');
+  if (!existsSync(telemetryPath)) {
+    failures.push('packages/luma-sdk/src/telemetry.ts: telemetry core missing');
+  } else {
+    const registry = parseRegistryTypes(readFileSync(telemetryPath, 'utf8'));
+    if (!registry) {
+      failures.push('packages/luma-sdk/src/telemetry.ts: LUMA_TELEMETRY_EVENT_TYPES registry missing');
+    } else if (JSON.stringify(registry) !== JSON.stringify(EXPECTED_LUMA_EVENT_TYPES)) {
+      failures.push(
+        `packages/luma-sdk/src/telemetry.ts: event registry drifted from spec §16.1 (expected ${EXPECTED_LUMA_EVENT_TYPES.length}, found ${registry.length})`,
+      );
+    }
+  }
+
+  for (const file of files) {
+    const relPath = path.relative(repoRoot, file);
+    const lines = readFileSync(file, 'utf8').split('\n');
+    lines.forEach((lineText, index) => {
+      scanLineForDirectConsole(relPath, lineText, index + 1, violations);
+      scanLineForSecretEquality(relPath, lineText, index + 1, violations);
+    });
+  }
+
+  return { scannedFileCount: files.length, failures, violations };
+}
+
+function main() {
+  const { scannedFileCount, failures, violations } = runTelemetryRedactionChecks();
+  console.log(`luma-telemetry-redaction: scanned ${scannedFileCount} guarded source files`);
+  if (failures.length > 0 || violations.length > 0) {
+    console.error(`luma-telemetry-redaction: FAIL — ${failures.length + violations.length} issue(s):`);
+    for (const failure of failures) {
+      console.error(`  ${failure}`);
+    }
+    for (const violation of violations) {
+      console.error(`  [${violation.type}] ${violation.file}:${violation.line}: ${violation.text}`);
+    }
+    process.exit(1);
+  }
+  console.log('luma-telemetry-redaction: PASS');
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/tools/scripts/check-luma-telemetry-redaction.test.mjs
+++ b/tools/scripts/check-luma-telemetry-redaction.test.mjs
@@ -1,0 +1,132 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import {
+  EXPECTED_LUMA_EVENT_TYPES,
+  runTelemetryRedactionChecks,
+} from './check-luma-telemetry-redaction.mjs';
+
+const FAITHFUL_TELEMETRY = `
+export const LUMA_TELEMETRY_EVENT_TYPES = Object.freeze([
+${EXPECTED_LUMA_EVENT_TYPES.map((type) => `  '${type}',`).join('\n')}
+] as const);
+
+export function lumaLog(level, message, context) {
+  console.warn(level, message, context);
+}
+`;
+
+const FAITHFUL_USE_IDENTITY = `
+import { lumaLog } from '@vh/luma-sdk';
+export function warn() {
+  lumaLog('warn', '[vh:identity] safe');
+}
+`;
+
+const FAITHFUL_GUN_CLIENT = `
+import { lumaLog } from '@vh/luma-sdk';
+export function warn() {
+  lumaLog('warn', '[vh:gun-client] safe');
+}
+`;
+
+const FAITHFUL_VAULT = `
+export function comparePresence(operatorAuthorizationToken) {
+  return operatorAuthorizationToken !== undefined;
+}
+`;
+
+function makeFixtureRepo(overrides = {}) {
+  const root = mkdtempSync(path.join(tmpdir(), 'luma-telemetry-redaction-'));
+  const files = {
+    'packages/luma-sdk/src/telemetry.ts': FAITHFUL_TELEMETRY,
+    'apps/web-pwa/src/hooks/useIdentity.ts': FAITHFUL_USE_IDENTITY,
+    'packages/gun-client/src/index.ts': FAITHFUL_GUN_CLIENT,
+    'packages/identity-vault/src/vault.ts': FAITHFUL_VAULT,
+    ...overrides,
+  };
+  for (const [relPath, content] of Object.entries(files)) {
+    if (content === null) continue;
+    const full = path.join(root, relPath);
+    mkdirSync(path.dirname(full), { recursive: true });
+    writeFileSync(full, content);
+  }
+  return root;
+}
+
+test('faithful fixture passes', () => {
+  const root = makeFixtureRepo();
+  try {
+    const result = runTelemetryRedactionChecks(root);
+    assert.deepEqual(result.failures, []);
+    assert.deepEqual(result.violations, []);
+    assert.equal(result.scannedFileCount, 4);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('red: direct console outside telemetry.ts fails', () => {
+  const root = makeFixtureRepo({
+    'packages/gun-client/src/index.ts': 'export function bad() { console.warn("raw"); }\n',
+  });
+  try {
+    const { violations } = runTelemetryRedactionChecks(root);
+    assert.ok(violations.some((violation) => violation.type === 'direct-console' && /gun-client/.test(violation.file)));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('red: direct console in future identity hook subdirectory fails', () => {
+  const root = makeFixtureRepo({
+    'apps/web-pwa/src/hooks/identity/debug.ts': 'export const bad = () => console.info("raw");\n',
+  });
+  try {
+    const { violations } = runTelemetryRedactionChecks(root);
+    assert.ok(violations.some((violation) => violation.type === 'direct-console' && /identity\/debug\.ts$/.test(violation.file)));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('red: typed secret equality fails, but nullish presence checks pass', () => {
+  const root = makeFixtureRepo({
+    'packages/identity-vault/src/vault.ts': [
+      'export const ok = operatorAuthorizationToken !== undefined;',
+      'export const bad = sessionToken === otherToken;',
+    ].join('\n'),
+  });
+  try {
+    const { violations } = runTelemetryRedactionChecks(root);
+    assert.ok(violations.some((violation) => violation.type === 'secret-equality' && violation.text.includes('sessionToken')));
+    assert.ok(!violations.some((violation) => violation.text.includes('operatorAuthorizationToken')));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('red: telemetry registry drift fails', () => {
+  const root = makeFixtureRepo({
+    'packages/luma-sdk/src/telemetry.ts': FAITHFUL_TELEMETRY.replace("  'luma_session_expired',\n", ''),
+  });
+  try {
+    const { failures } = runTelemetryRedactionChecks(root);
+    assert.ok(failures.some((failure) => failure.includes('event registry drifted')));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('missing optional identity subdirectory does not fail', () => {
+  const root = makeFixtureRepo();
+  try {
+    const { failures } = runTelemetryRedactionChecks(root);
+    assert.deepEqual(failures, []);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Adds the LUMA M1.E telemetry/redaction foundation without building `<TrustClaim>` or any production verifier surface:

- adds `packages/luma-sdk/src/telemetry.ts` with the spec §16 event registry, local in-memory ring buffer, redacted path hashing with per-session salt rotation, runtime telemetry safety assertions, and `lumaLog` redaction
- adds `useTelemetry()` for the future `/account/identity` debug panel, and clears/rotates telemetry on both `signOut()` and `resetIdentity()`
- routes guarded `packages/gun-client` and identity-hook console output through `lumaLog`, with tests updated to assert redacted mesh paths in console output while preserving existing dispatch-event detail
- routes telemetry `message` strings through the same safety/redaction discipline as context: event messages fail closed before storage when unsafe, and log messages are redacted before console output
- adds `pnpm check:luma-telemetry-redaction` plus red tests for direct console calls, typed-secret equality, event-registry drift, unsafe messages, and event/log redaction
- wires the new gate into `mvp-release-gates`, relabeled as §16 source discipline; the full §21.4 recorded replay remains explicitly deferred before `<TrustClaim>`
- removes the `sha256Hex` runtime Node `Buffer` dependency in `packages/data-model` by passing WebCrypto a `Uint8Array` directly; this preserves hash outputs and avoids corrupting Vitest worker RPC when browser-fallback coverage runs under Node 24 CI

No live Scope A/A6 behavior, deploy config, retention, compaction, schema epoch, provider promotion, or public claim surface changes.

## Validation

- `PATH="$(dirname $(command -v corepack)):$PATH" CI=true corepack pnpm@9.7.1 exec node tools/scripts/check-diff-coverage.mjs`
- `corepack pnpm@9.7.1 check:luma-telemetry-redaction`
- `corepack pnpm@9.7.1 exec node --test tools/scripts/check-luma-telemetry-redaction.test.mjs`
- `corepack pnpm@9.7.1 --filter @vh/luma-sdk typecheck`
- `corepack pnpm@9.7.1 docs:check`
- `corepack pnpm@9.7.1 check:luma-forbidden-claims`
- `corepack pnpm@9.7.1 check:luma-production-profile`
- `corepack pnpm@9.7.1 check:public-beta-launch-closeout`
- `git diff --check`

Known residual from prior runs: `corepack pnpm@9.7.1 --filter @vh/web-pwa typecheck:test` still fails on existing broad test-fixture/type debt across unrelated files; touched `useIdentity`/`useTelemetry` suites pass directly.