### PR TITLE
Add LUMA account identity controls

### DIFF
--- a/apps/web-pwa/src/hooks/useIdentity.test.ts
+++ b/apps/web-pwa/src/hooks/useIdentity.test.ts
@@ -282,6 +282,7 @@ describe('useIdentity', () => {
     const { result } = renderHook(() => useIdentity());
     const { useXpLedger } = await import('../store/xpLedger');
     const { delegationStorageKey, useDelegationStore } = await import('../store/delegation');
+    const { useSentimentState } = await import('./useSentimentState');
     const { emitLumaEvent, lumaTelemetryStore } = await import('@vh/luma-sdk');
 
     await waitFor(() => expect(result.current.status).toBe('anonymous'));
@@ -308,8 +309,12 @@ describe('useIdentity', () => {
     expect(pairMock).toHaveBeenCalledTimes(1);
 
     useXpLedger.getState().addXp('civic', 4);
+    useSentimentState.setState({
+      signals: [{ topicId: 'topic-1', pointId: 'point-1', agreement: 1, ts: 1000 }] as any
+    });
     emitLumaEvent({ type: 'luma_session_created', tsMs: 1000 });
     expect(lumaTelemetryStore.getSnapshot()).toHaveLength(1);
+    expect((await vaultLoad() as any)?.session?.token).toEqual(`srv-token:${firstDeviceKey}`);
     localStorage.setItem(delegationStorageKey(firstNullifier!), '{"grants":[{"grantId":"g-1"}]}');
     useDelegationStore.getState().setActivePrincipal(firstNullifier!);
     const firstWalletBinding = await walletBinding.save({
@@ -326,8 +331,10 @@ describe('useIdentity', () => {
     await waitFor(() => expect(result.current.status).toBe('anonymous'));
     expect(useDelegationStore.getState().activePrincipal).toBeNull();
     expect(lumaTelemetryStore.getSnapshot()).toHaveLength(0);
+    expect(useSentimentState.getState().signals).toEqual([]);
     expect(localStorage.getItem(delegationStorageKey(firstNullifier!))).toBe('{"grants":[{"grantId":"g-1"}]}');
     expect(useXpLedger.getState().activeNullifier).toBeNull();
+    expect(await vaultLoad()).toBeNull();
     expect(await deviceCredential.loadOrCreate()).toEqual(firstDeviceCredential);
     expect(await delegationSigningKey.publicKey()).toEqual(firstDelegationPublicKey);
     expect(await walletBinding.load()).toEqual(firstWalletBinding);
@@ -360,6 +367,8 @@ describe('useIdentity', () => {
     const useIdentity = await loadHook();
     const { result } = renderHook(() => useIdentity());
     const { delegationStorageKey, useDelegationStore } = await import('../store/delegation');
+    const { useXpLedger } = await import('../store/xpLedger');
+    const { useSentimentState } = await import('./useSentimentState');
     const { emitLumaEvent, lumaTelemetryStore } = await import('@vh/luma-sdk');
 
     await waitFor(() => expect(result.current.status).toBe('anonymous'));
@@ -388,8 +397,12 @@ describe('useIdentity', () => {
       issuedAt: 1000,
       expiresAt: 2000
     });
+    useSentimentState.setState({
+      signals: [{ topicId: 'topic-2', pointId: 'point-2', agreement: -1, ts: 1000 }] as any
+    });
     emitLumaEvent({ type: 'luma_session_created', tsMs: 1000 });
     expect(lumaTelemetryStore.getSnapshot()).toHaveLength(1);
+    expect(useXpLedger.getState().activeNullifier).toBe(firstNullifier);
 
     await act(async () => {
       await result.current.resetIdentity();
@@ -399,6 +412,8 @@ describe('useIdentity', () => {
     expect(localStorage.getItem(delegationStorageKey(firstNullifier))).toBeNull();
     expect(useDelegationStore.getState().activePrincipal).toBeNull();
     expect(lumaTelemetryStore.getSnapshot()).toHaveLength(0);
+    expect(useSentimentState.getState().signals).toEqual([]);
+    expect(useXpLedger.getState().activeNullifier).toBeNull();
     expect(await vaultLoad()).toBeNull();
     expect(await walletBinding.load()).toBeNull();
     expect(await operatorAuthorizationToken.load()).toBeNull();

--- a/apps/web-pwa/src/routes/AccountIdentityPage.test.tsx
+++ b/apps/web-pwa/src/routes/AccountIdentityPage.test.tsx
@@ -1,0 +1,199 @@
+/* @vitest-environment jsdom */
+
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import type React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AccountIdentityPage } from './AccountIdentityPage';
+
+const identityMock = vi.hoisted(() => ({
+  state: {
+    identity: null as any,
+    status: 'anonymous' as any,
+    error: undefined as string | undefined,
+    createIdentity: vi.fn(),
+    signOut: vi.fn(),
+    resetIdentity: vi.fn(),
+  },
+}));
+
+const walletMock = vi.hoisted(() => ({
+  state: {
+    account: null as string | null,
+    walletBinding: null as any,
+    connect: vi.fn(),
+    loading: false,
+  },
+}));
+
+const telemetryMock = vi.hoisted(() => ({
+  state: {
+    events: [] as any[],
+  },
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ to, children, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { to: string }) => (
+    <a href={to} {...props}>{children}</a>
+  ),
+}));
+
+vi.mock('@vh/ui', () => ({
+  Button: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  ),
+}));
+
+vi.mock('../hooks/useIdentity', () => ({
+  useIdentity: () => identityMock.state,
+}));
+
+vi.mock('../hooks/useWallet', () => ({
+  useWallet: () => walletMock.state,
+}));
+
+vi.mock('../hooks/useTelemetry', () => ({
+  useTelemetry: () => telemetryMock.state,
+}));
+
+function readyIdentity(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'identity-record',
+    createdAt: Date.parse('2026-07-01T11:00:00Z'),
+    attestation: { platform: 'web', integrityToken: 'token', deviceKey: 'device', nonce: 'nonce' },
+    assuranceEnvelope: { verifierId: 'beta-local' },
+    session: {
+      token: 'secret-session-token',
+      trustScore: 0.5,
+      scaledTrustScore: 5000,
+      nullifier: 'secret-principal-nullifier',
+      createdAt: Date.parse('2026-07-01T11:00:00Z'),
+      expiresAt: Date.parse('2099-07-10T11:00:00Z'),
+    },
+    handle: 'alice',
+    ...overrides,
+  };
+}
+
+describe('AccountIdentityPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    identityMock.state.identity = readyIdentity();
+    identityMock.state.status = 'ready';
+    identityMock.state.error = undefined;
+    identityMock.state.createIdentity.mockResolvedValue(undefined);
+    identityMock.state.signOut.mockResolvedValue(undefined);
+    identityMock.state.resetIdentity.mockResolvedValue(undefined);
+    walletMock.state.account = null;
+    walletMock.state.walletBinding = null;
+    walletMock.state.loading = false;
+    telemetryMock.state.events = [
+      { type: 'luma_session_created', level: 'info', ts_ms: 1000, message: 'created' },
+      { type: 'luma_policy_blocked', level: 'warn', ts_ms: 2000, message: 'blocked' },
+    ];
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it('renders identity controls without exposing raw principal, token, or numeric trust score', () => {
+    render(<AccountIdentityPage />);
+
+    expect(screen.getByTestId('identity-panel')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Identity' })).toBeInTheDocument();
+    expect(screen.getByText('Beta-local identity on this device')).toBeInTheDocument();
+    expect(screen.getByText('Verifier')).toBeInTheDocument();
+    expect(screen.getByText('beta-local')).toBeInTheDocument();
+    expect(screen.getByTestId('identity-session-expiry')).toHaveTextContent('2099-07-10 11:00 UTC');
+    expect(screen.getByTestId('identity-telemetry-debug')).toHaveTextContent('luma_policy_blocked');
+
+    expect(screen.queryByText(/secret-principal-nullifier/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/secret-session-token/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/trust score/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/50\.0/)).not.toBeInTheDocument();
+  });
+
+  it('shows the near-expiry warning without blocking controls', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-03T11:00:00Z'));
+    identityMock.state.identity = readyIdentity({
+      session: {
+        ...readyIdentity().session,
+        expiresAt: Date.parse('2026-07-04T06:00:00Z'),
+      },
+    });
+
+    render(<AccountIdentityPage />);
+
+    expect(screen.getByText(/Your session expires soon/)).toBeInTheDocument();
+    expect(screen.getByTestId('identity-sign-out')).toBeEnabled();
+    expect(screen.getByTestId('identity-reset')).toBeEnabled();
+  });
+
+  it('confirms Sign Out and preserves the copy boundary', async () => {
+    render(<AccountIdentityPage />);
+
+    fireEvent.click(screen.getByTestId('identity-sign-out'));
+    const dialog = screen.getByRole('dialog', { name: 'Sign out of this device?' });
+
+    expect(dialog).toHaveTextContent('Signing out ends your current session.');
+    expect(dialog).toHaveTextContent('Your published posts and votes are unaffected.');
+    expect(dialog).not.toHaveTextContent(/removes your data/i);
+
+    fireEvent.click(within(dialog).getByTestId('identity-sign-out-confirm'));
+
+    await waitFor(() => expect(identityMock.state.signOut).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(screen.getAllByText(/Signed out/).length).toBeGreaterThanOrEqual(1));
+  });
+
+  it('requires the typed Reset confirmation before resetIdentity runs', async () => {
+    render(<AccountIdentityPage />);
+
+    fireEvent.click(screen.getByTestId('identity-reset'));
+    const dialog = screen.getByRole('dialog', { name: 'Reset your identity on this device?' });
+    const confirm = within(dialog).getByTestId('identity-reset-confirm');
+
+    expect(dialog).toHaveTextContent('Resetting creates a new pseudonym and stops using the current one.');
+    expect(dialog).toHaveTextContent('Resetting does not remove them and cannot make them yours again.');
+    expect(confirm).toBeDisabled();
+
+    fireEvent.change(within(dialog).getByLabelText('Type reset to confirm'), { target: { value: 'reset' } });
+    expect(confirm).toBeEnabled();
+    fireEvent.click(confirm);
+
+    await waitFor(() => expect(identityMock.state.resetIdentity).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(screen.getAllByText(/previous pseudonym's public history remains/).length).toBeGreaterThanOrEqual(1));
+  });
+
+  it('surfaces the wallet re-bind prompt for a binding on the previous identity', () => {
+    walletMock.state.account = '0x1111111111111111111111111111111111111111';
+    walletMock.state.walletBinding = {
+      boundPrincipalNullifier: 'previous-principal-nullifier',
+      address: walletMock.state.account,
+    };
+
+    render(<AccountIdentityPage />);
+
+    expect(screen.getByTestId('identity-wallet-rebind')).toHaveTextContent(
+      'This wallet was bound to your previous identity. Re-bind it to your current identity to continue.'
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Re-bind wallet' }));
+    expect(walletMock.state.connect).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the create-identity call to action for a device without an active session', () => {
+    identityMock.state.identity = null;
+    identityMock.state.status = 'anonymous';
+
+    render(<AccountIdentityPage />);
+
+    expect(screen.getByText('No active session on this device.')).toBeInTheDocument();
+    expect(screen.queryByTestId('identity-sign-out')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('identity-reset')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('identity-create'));
+    expect(identityMock.state.createIdentity).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web-pwa/src/routes/AccountIdentityPage.tsx
+++ b/apps/web-pwa/src/routes/AccountIdentityPage.tsx
@@ -1,0 +1,341 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { Link } from '@tanstack/react-router';
+import { Button } from '@vh/ui';
+import { useIdentity } from '../hooks/useIdentity';
+import { useTelemetry } from '../hooks/useTelemetry';
+import { useWallet } from '../hooks/useWallet';
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+type DialogMode = 'sign-out' | 'reset';
+
+function formatUtcTimestamp(value?: number): string {
+  if (!value) return 'Not scheduled';
+  return `${new Date(value).toISOString().slice(0, 16).replace('T', ' ')} UTC`;
+}
+
+function focusableElements(root: HTMLElement | null): HTMLElement[] {
+  if (!root) return [];
+  return Array.from(
+    root.querySelectorAll<HTMLElement>(
+      'a[href], button:not([disabled]), input:not([disabled]), textarea:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])'
+    )
+  ).filter((element) => !element.hasAttribute('aria-hidden'));
+}
+
+interface ConfirmationDialogProps {
+  readonly mode: DialogMode;
+  readonly busy: boolean;
+  readonly error?: string;
+  readonly resetInput: string;
+  readonly onResetInput: (value: string) => void;
+  readonly onCancel: () => void;
+  readonly onConfirm: () => void;
+}
+
+const ConfirmationDialog: React.FC<ConfirmationDialogProps> = ({
+  mode,
+  busy,
+  error,
+  resetInput,
+  onResetInput,
+  onCancel,
+  onConfirm
+}) => {
+  const dialogRef = useRef<HTMLDivElement | null>(null);
+  const titleId = mode === 'sign-out' ? 'identity-sign-out-title' : 'identity-reset-title';
+  const bodyId = mode === 'sign-out' ? 'identity-sign-out-body' : 'identity-reset-body';
+  const resetConfirmed = resetInput.trim().toLowerCase() === 'reset';
+
+  useEffect(() => {
+    const previous = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    const first = focusableElements(dialogRef.current)[0] ?? dialogRef.current;
+    first?.focus();
+    return () => {
+      previous?.focus();
+    };
+  }, []);
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      if (!busy) onCancel();
+      return;
+    }
+    if (event.key !== 'Tab') return;
+    const focusables = focusableElements(dialogRef.current);
+    if (!focusables.length) return;
+    const first = focusables[0]!;
+    const last = focusables[focusables.length - 1]!;
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/45 px-4 py-6">
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={bodyId}
+        tabIndex={-1}
+        onKeyDown={handleKeyDown}
+        className="w-full max-w-lg rounded-lg border border-slate-200 bg-white p-5 shadow-xl dark:border-slate-700 dark:bg-slate-950"
+      >
+        {mode === 'sign-out' ? (
+          <>
+            <h2 id={titleId} className="text-lg font-semibold text-slate-950 dark:text-slate-50">
+              Sign out of this device?
+            </h2>
+            <p id={bodyId} className="mt-3 text-sm leading-6 text-slate-700 dark:text-slate-200">
+              Signing out ends your current session. Your identity stays on this device: signing back in restores the same
+              pseudonym, wallet binding, and reputation. Your published posts and votes are unaffected.
+            </p>
+          </>
+        ) : (
+          <>
+            <h2 id={titleId} className="text-lg font-semibold text-slate-950 dark:text-slate-50">
+              Reset your identity on this device?
+            </h2>
+            <p id={bodyId} className="mt-3 text-sm leading-6 text-slate-700 dark:text-slate-200">
+              Resetting creates a new pseudonym and stops using the current one. Your previous posts, comments, and votes
+              remain public under your old pseudonym. Resetting does not remove them and cannot make them yours again.
+              Your wallet must be re-bound, and any operator authorization or delegations are cleared.
+            </p>
+            <label className="mt-4 block text-sm font-medium text-slate-800 dark:text-slate-100" htmlFor="identity-reset-input">
+              Type reset to confirm
+            </label>
+            <input
+              id="identity-reset-input"
+              className="mt-2 w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-950 outline-none focus:border-slate-500 focus:ring-2 focus:ring-slate-200 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-50"
+              value={resetInput}
+              onChange={(event) => onResetInput(event.target.value)}
+              disabled={busy}
+              autoComplete="off"
+            />
+          </>
+        )}
+
+        {error && (
+          <p className="mt-4 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-800" role="alert">
+            {error}
+          </p>
+        )}
+
+        <div className="mt-5 flex flex-wrap justify-end gap-2">
+          <Button type="button" variant="ghost" onClick={onCancel} disabled={busy}>
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            data-testid={mode === 'sign-out' ? 'identity-sign-out-confirm' : 'identity-reset-confirm'}
+            onClick={onConfirm}
+            disabled={busy || (mode === 'reset' && !resetConfirmed)}
+            aria-disabled={busy || (mode === 'reset' && !resetConfirmed)}
+            className={mode === 'reset' ? 'bg-red-600 text-white hover:bg-red-700 focus-visible:ring-red-500' : undefined}
+          >
+            {busy ? (mode === 'sign-out' ? 'Signing out...' : 'Resetting...') : mode === 'sign-out' ? 'Sign out' : 'Reset identity'}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const AccountIdentityPage: React.FC = () => {
+  const { identity, status, error, createIdentity, signOut, resetIdentity } = useIdentity();
+  const { events } = useTelemetry();
+  const { account, walletBinding, connect: connectWallet, loading: walletLoading } = useWallet();
+  const [dialog, setDialog] = useState<DialogMode | null>(null);
+  const [resetInput, setResetInput] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [actionError, setActionError] = useState<string | undefined>();
+  const [toast, setToast] = useState<string | undefined>();
+
+  const createdAt = identity?.session?.createdAt ?? identity?.createdAt;
+  const expiresAt = identity?.session?.expiresAt;
+  const now = Date.now();
+  const expiresSoon = Boolean(expiresAt && expiresAt > now && expiresAt - now <= ONE_DAY_MS);
+  const activePrincipal = identity?.session?.nullifier ?? null;
+  const walletNeedsRebind = Boolean(
+    activePrincipal
+    && account
+    && walletBinding?.boundPrincipalNullifier
+    && walletBinding.boundPrincipalNullifier !== activePrincipal
+  );
+
+  const recentEvents = useMemo(() => events.slice(-5).reverse(), [events]);
+
+  const closeDialog = () => {
+    if (busy) return;
+    setDialog(null);
+    setResetInput('');
+    setActionError(undefined);
+  };
+
+  const runAction = async (mode: DialogMode) => {
+    setBusy(true);
+    setActionError(undefined);
+    try {
+      if (mode === 'sign-out') {
+        await signOut();
+        setToast('Signed out. Your device identity remains available for re-attestation.');
+      } else {
+        await resetIdentity();
+        setToast("New identity created. Your previous pseudonym's public history remains on the network.");
+      }
+      setDialog(null);
+      setResetInput('');
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (status === 'hydrating') {
+    return (
+      <section className="rounded-lg border border-slate-200 bg-card p-5 shadow-sm dark:border-slate-700" data-testid="identity-panel">
+        <p className="text-sm text-slate-700 dark:text-slate-200">Loading identity...</p>
+      </section>
+    );
+  }
+
+  if (!identity || status === 'anonymous' || status === 'creating' || status === 'error') {
+    return (
+      <section className="space-y-4 rounded-lg border border-slate-200 bg-card p-5 shadow-sm dark:border-slate-700" data-testid="identity-panel">
+        <div>
+          <h1 className="text-xl font-semibold text-slate-950 dark:text-slate-50">Identity</h1>
+          <p className="mt-1 text-sm text-slate-600 dark:text-slate-300">No active session on this device.</p>
+        </div>
+        {error && <p className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-800">{error}</p>}
+        <Button type="button" onClick={() => void createIdentity()} disabled={status === 'creating'} data-testid="identity-create">
+          {status === 'creating' ? 'Creating...' : 'Create identity'}
+        </Button>
+      </section>
+    );
+  }
+
+  return (
+    <section className="space-y-5" data-testid="identity-panel">
+      <div className="rounded-lg border border-slate-200 bg-card p-5 shadow-sm dark:border-slate-700">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <h1 className="text-xl font-semibold text-slate-950 dark:text-slate-50">Identity</h1>
+            <p className="mt-1 text-sm text-slate-600 dark:text-slate-300">Beta-local identity on this device</p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Button type="button" variant="secondary" data-testid="identity-sign-out" onClick={() => setDialog('sign-out')} disabled={busy}>
+              Sign out
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              data-testid="identity-reset"
+              onClick={() => setDialog('reset')}
+              disabled={busy}
+              className="border border-red-200 text-red-700 hover:bg-red-50 focus-visible:ring-red-500"
+            >
+              Reset identity
+            </Button>
+          </div>
+        </div>
+
+        <dl className="mt-5 grid gap-3 sm:grid-cols-3">
+          <div className="rounded-md border border-slate-100 bg-card-muted px-3 py-2 dark:border-slate-700/70">
+            <dt className="text-xs uppercase tracking-wide text-slate-500">Created</dt>
+            <dd className="mt-1 text-sm font-semibold text-slate-900 dark:text-slate-100">{formatUtcTimestamp(createdAt)}</dd>
+          </div>
+          <div className="rounded-md border border-slate-100 bg-card-muted px-3 py-2 dark:border-slate-700/70" data-testid="identity-session-expiry">
+            <dt className="text-xs uppercase tracking-wide text-slate-500">Expires</dt>
+            <dd className="mt-1 text-sm font-semibold text-slate-900 dark:text-slate-100">{formatUtcTimestamp(expiresAt)}</dd>
+          </div>
+          <div className="rounded-md border border-slate-100 bg-card-muted px-3 py-2 dark:border-slate-700/70">
+            <dt className="text-xs uppercase tracking-wide text-slate-500">Verifier</dt>
+            <dd className="mt-1 text-sm font-semibold text-slate-900 dark:text-slate-100">beta-local</dd>
+          </div>
+        </dl>
+
+        {(expiresSoon || status === 'expired') && (
+          <p className="mt-4 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900">
+            Your session expires soon. Re-attest to continue posting and voting. Browsing is unaffected.
+          </p>
+        )}
+      </div>
+
+      {walletNeedsRebind && (
+        <div
+          className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-amber-950 shadow-sm"
+          data-testid="identity-wallet-rebind"
+        >
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <p className="text-sm">
+              This wallet was bound to your previous identity. Re-bind it to your current identity to continue.
+            </p>
+            <Button type="button" variant="secondary" onClick={() => void connectWallet()} disabled={walletLoading}>
+              Re-bind wallet
+            </Button>
+          </div>
+        </div>
+      )}
+
+      <div className="rounded-lg border border-slate-200 bg-card p-5 shadow-sm dark:border-slate-700">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h2 className="text-base font-semibold text-slate-950 dark:text-slate-50">Local telemetry</h2>
+            <p className="text-sm text-slate-600 dark:text-slate-300">
+              Recent local LUMA events are shown without tokens, keys, proof material, or mesh paths.
+            </p>
+          </div>
+          <span className="rounded-md border border-slate-200 px-2 py-1 text-xs font-semibold text-slate-600 dark:border-slate-700 dark:text-slate-300">
+            {events.length} events
+          </span>
+        </div>
+        <ul className="mt-4 space-y-2" data-testid="identity-telemetry-debug">
+          {recentEvents.length ? (
+            recentEvents.map((event, index) => (
+              <li key={`${event.type}-${index}`} className="rounded-md border border-slate-100 bg-card-muted px-3 py-2 text-sm dark:border-slate-700/70">
+                <span className="font-semibold text-slate-900 dark:text-slate-100">{event.type}</span>
+                <span className="ml-2 text-xs text-slate-500">{event.level}</span>
+              </li>
+            ))
+          ) : (
+            <li className="text-sm text-slate-600 dark:text-slate-300">No local LUMA events recorded.</li>
+          )}
+        </ul>
+      </div>
+
+      <div className="flex flex-wrap gap-3 text-sm text-slate-600 dark:text-slate-300">
+        <Link to="/support" className="underline underline-offset-4">Support</Link>
+        <Link to="/data-deletion" className="underline underline-offset-4">Data controls</Link>
+      </div>
+
+      <div aria-live="polite" className="sr-only">
+        {toast}
+      </div>
+      {toast && (
+        <p className="rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-900">
+          {toast}
+        </p>
+      )}
+
+      {dialog && (
+        <ConfirmationDialog
+          mode={dialog}
+          busy={busy}
+          error={actionError}
+          resetInput={resetInput}
+          onResetInput={setResetInput}
+          onCancel={closeDialog}
+          onConfirm={() => void runAction(dialog)}
+        />
+      )}
+    </section>
+  );
+};

--- a/apps/web-pwa/src/routes/dashboardContent.test.tsx
+++ b/apps/web-pwa/src/routes/dashboardContent.test.tsx
@@ -26,6 +26,12 @@ vi.mock('@vh/ui', () => ({
   )
 }));
 
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ to, children, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { to: string }) => (
+    <a href={to} {...props}>{children}</a>
+  )
+}));
+
 vi.mock('@vh/ai-engine', () => ({
   useAI: () => ({
     state: {
@@ -41,7 +47,7 @@ vi.mock('@vh/ai-engine', () => ({
 
 vi.mock('@vh/ai-engine/worker?worker', () => ({
   default: class MockWorker {}
-}), { virtual: true });
+}));
 
 vi.mock('../components/HandleEditor', () => ({
   HandleEditor: () => <div data-testid="handle-editor" />
@@ -100,6 +106,7 @@ describe('DashboardContent multi-device deferral', () => {
     expect(screen.getByTestId('link-device-deferred')).toHaveTextContent(
       'Multi-device identity linking is deferred to LUMA Phase 3+.'
     );
+    expect(screen.getByTestId('identity-controls-link')).toHaveAttribute('href', '/account/identity');
 
     expect(screen.queryByTestId('link-code')).not.toBeInTheDocument();
     expect(screen.queryByTestId('link-input')).not.toBeInTheDocument();

--- a/apps/web-pwa/src/routes/dashboardContent.tsx
+++ b/apps/web-pwa/src/routes/dashboardContent.tsx
@@ -1,4 +1,5 @@
 import React, { Suspense, lazy, useEffect, useState } from 'react';
+import { Link } from '@tanstack/react-router';
 import { Button } from '@vh/ui';
 import { TRUST_MINIMUM, TRUST_ELEVATED } from '@vh/data-model';
 import { useAI, type AnalysisResult } from '@vh/ai-engine';
@@ -184,9 +185,13 @@ export const DashboardContent: React.FC = () => {
 
           <div className="flex flex-wrap gap-3">
             <Button onClick={() => console.log('bootstrap mesh')}>Bootstrap Mesh</Button>
-            <Button variant="secondary" onClick={() => console.log('open settings')}>
-              Open Settings
-            </Button>
+            <Link
+              to="/account/identity"
+              className="inline-flex h-10 items-center justify-center gap-2 rounded-md bg-zinc-100 px-4 text-sm font-medium text-zinc-900 transition-colors hover:bg-zinc-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-400 focus-visible:ring-offset-2"
+              data-testid="identity-controls-link"
+            >
+              Identity controls
+            </Link>
             <Button
               variant="ghost"
               disabled

--- a/apps/web-pwa/src/routes/index.tsx
+++ b/apps/web-pwa/src/routes/index.tsx
@@ -12,6 +12,7 @@ import { ThreadView } from '../components/hermes/forum/ThreadView';
 import { IDChip } from '../components/hermes/IDChip';
 import { ScanContact } from '../components/hermes/ScanContact';
 import { DashboardPage } from './dashboardContent';
+import { AccountIdentityPage } from './AccountIdentityPage';
 import { DevColorPanel } from '../components/DevColorPanel';
 import { NewsReportAdminQueue } from '../components/admin/NewsReportAdminQueue';
 import {
@@ -100,6 +101,7 @@ const RootShell = ({ children }: { children: React.ReactNode }) => {
 const HomeComponent = () => <FeedList />;
 
 const DashboardComponent = DashboardPage;
+const AccountIdentityComponent = AccountIdentityPage;
 
 const AdminReportsComponent = () => <NewsReportAdminQueue />;
 
@@ -239,6 +241,11 @@ const dashboardRoute = createRoute({
   path: '/dashboard',
   component: DashboardComponent
 });
+const accountIdentityRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/account/identity',
+  component: AccountIdentityComponent
+});
 const adminReportsRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/admin/reports',
@@ -295,6 +302,7 @@ export const routeTree = rootRoute.addChildren([
   hermesRoute.addChildren([hermesIndexRoute, hermesMessagesRoute, hermesMessagesChannelRoute, hermesThreadRoute]),
   governanceRoute,
   dashboardRoute,
+  accountIdentityRoute,
   adminReportsRoute,
   complianceRoute,
   betaRoute,

--- a/docs/plans/LUMA_M1B_IDENTITY_CONTROLS_DESIGN_2026-07-02.md
+++ b/docs/plans/LUMA_M1B_IDENTITY_CONTROLS_DESIGN_2026-07-02.md
@@ -19,10 +19,10 @@ sequences how the UI lands them.
 | `useIdentity.signOut()` / `resetIdentity()` split | DONE | `apps/web-pwa/src/hooks/useIdentity.ts` (~315-336); `revokeSession()` is a deprecation shim |
 | Spec §13.2 state-graph behavior in the hooks | DONE (operator-token row completed after initial packet) | Sign Out preserves device credential / SEA pair / wallet binding / delegation key / operator token; Reset rotates or clears them; see §3 table |
 | `operatorAuthorizationToken` clearing on Reset | DONE | Implemented as an optional VaultV2 compartment; `resetIdentity()` explicitly clears it and tests prove Sign Out preserves it |
-| Unit tests for Sign Out / Reset semantics | PARTIAL | `useIdentity.test.ts` asserts the high-risk state rows including `operatorAuthorizationToken`; remaining rows listed in §6.1 |
-| `/account/identity` route | MISSING | No `/account/*` route in `apps/web-pwa/src/routes/index.tsx` |
-| Controls UI (panels, confirmation modals, session metadata) | MISSING | Dashboard has stub buttons only |
-| Wallet re-bind prompt after Reset | PARTIAL | `WalletPanel` handles the re-bind state; not wired into an identity-controls flow |
+| Unit tests for Sign Out / Reset semantics | DONE | `useIdentity.test.ts` asserts session clearing, runtime clearing, compartment preservation/rotation, wallet binding, delegation storage, operator token, XP active nullifier, sentiment signals, and telemetry reset |
+| `/account/identity` route | DONE | Route is registered in `apps/web-pwa/src/routes/index.tsx` |
+| Controls UI (panels, confirmation modals, session metadata) | DONE | `apps/web-pwa/src/routes/AccountIdentityPage.tsx` implements the panel, confirmation modals, session metadata, and telemetry debug surface |
+| Wallet re-bind prompt after Reset | DONE | `/account/identity` renders `identity-wallet-rebind` when the connected wallet is bound to a prior principal |
 | E2E flows (sign-out continuity / reset rotation) | MISSING | No e2e coverage of either journey |
 
 ## 2. UX copy pack (draft strings)
@@ -54,7 +54,7 @@ claim deletion, anonymity, or repudiation.
 
 - Button: `Reset identity` (destructive styling, separated placement)
 - Modal title: `Reset your identity on this device?`
-- Modal body: `Resetting creates a new pseudonym and abandons the current one.
+- Modal body: `Resetting creates a new pseudonym and stops using the current one.
   Your previous posts, comments, and votes remain public under your old
   pseudonym — resetting does not remove them and cannot make them yours again.
   Your wallet must be re-bound, and any operator authorization or delegations
@@ -132,12 +132,10 @@ action, not the controls.
 
 ### 6.1 Unit (state-graph completion)
 
-Extend `useIdentity.test.ts` so every row of the §3 table is asserted for
-both flows — the currently missing assertions are: `sessionToken`,
-`assuranceEnvelope`, `useSentimentState.signals`, `vaultMasterKey`
-preservation, and `xpLedger.activeNullifier` on Reset. The
-`operatorAuthorizationToken` row is now covered: Sign Out preserves the vault
-compartment and Reset Identity clears it explicitly.
+`useIdentity.test.ts` asserts every exposed row of the §3 table for both
+flows. Direct `vaultMasterKey` inspection remains intentionally unavailable;
+the test proves preservation through post-flow compartment load/create behavior
+for device credential, SEA pair, wallet binding, and delegation key material.
 
 ### 6.2 E2E (roadmap M1.B acceptance)
 


### PR DESCRIPTION
## Summary

Adds the M1.B `/account/identity` surface and keeps it inside the current public-beta/LUMA claim boundary.

- Registers `/account/identity` without changing the existing `user-link -> /dashboard` e2e contract.
- Adds the identity controls panel with beta-local session metadata, near-expiry warning, Sign Out and Reset Identity confirmation modals, wallet re-bind prompt, and local telemetry debug list.
- Keeps raw principal nullifier, session token, numeric trust score, keys, proof material, and mesh paths out of the rendered route.
- Adds a dashboard link to the new controls without touching mesh/public feed behavior.
- Extends `useIdentity.test.ts` coverage for Sign Out / Reset state graph rows: vault session clearing, XP active nullifier clearing, sentiment signal clearing, telemetry clearing, and existing compartment preservation/rotation checks.
- Updates the M1.B packet from draft/current-truth rows to match the implemented route and copy refinement.

## Validation

Passed:

- `corepack pnpm@9.7.1 exec vitest run apps/web-pwa/src/routes/AccountIdentityPage.test.tsx apps/web-pwa/src/routes/dashboardContent.test.tsx apps/web-pwa/src/hooks/useIdentity.test.ts --reporter=verbose` — 25/25
- `corepack pnpm@9.7.1 --filter @vh/web-pwa typecheck`
- `corepack pnpm@9.7.1 docs:check`
- `corepack pnpm@9.7.1 check:luma-forbidden-claims`
- `corepack pnpm@9.7.1 check:luma-production-profile`
- `corepack pnpm@9.7.1 check:luma-telemetry-redaction`
- `corepack pnpm@9.7.1 check:public-beta-launch-closeout`
- `PATH="/opt/homebrew/bin:$PATH" corepack pnpm@9.7.1 --filter @vh/web-pwa build`
- `git diff --check`

Caveats:

- `corepack pnpm@9.7.1 --filter @vh/web-pwa typecheck:test` remains red from existing repo-wide test typing debt; filtered output had no `AccountIdentityPage` or `dashboardContent.test` hits after this branch's local mock cleanup.
- `corepack pnpm@9.7.1 check:mvp-release-gates` is not a valid local signal in this shell because its nested bare `pnpm` resolves to the Codex runtime pnpm 11 / Node 24 and fails frozen install before branch code executes. The branch-specific gates above were rerun with the pinned toolchain after restoring `node_modules`.

## Non-goals

- No A6/operator action.
- No Scope A relay/publisher behavior change.
- No provider/profile promotion.
- No public schema epoch change.
- No `<TrustClaim>` runtime wrapper.
- No verifier deployment or Silver/production-attestation claims.
