### PR TITLE
[coord] Close out next-owner diagnostics and LUMA gates

### DIFF
--- a/apps/web-pwa/src/routes/AccountIdentityPage.test.tsx
+++ b/apps/web-pwa/src/routes/AccountIdentityPage.test.tsx
@@ -155,7 +155,8 @@ describe('AccountIdentityPage', () => {
     const dialog = screen.getByRole('dialog', { name: 'Reset your identity on this device?' });
     const confirm = within(dialog).getByTestId('identity-reset-confirm');
 
-    expect(dialog).toHaveTextContent('Resetting creates a new pseudonym and stops using the current one.');
+    expect(dialog).toHaveTextContent('Resetting stops using the current pseudonym and rotates the identity material on this device.');
+    expect(dialog).toHaveTextContent('The next identity you create on this device uses a new pseudonym.');
     expect(dialog).toHaveTextContent('Resetting does not remove them and cannot make them yours again.');
     expect(confirm).toBeDisabled();
 
@@ -164,7 +165,7 @@ describe('AccountIdentityPage', () => {
     fireEvent.click(confirm);
 
     await waitFor(() => expect(identityMock.state.resetIdentity).toHaveBeenCalledTimes(1));
-    await waitFor(() => expect(screen.getAllByText(/previous pseudonym's public history remains/).length).toBeGreaterThanOrEqual(1));
+    await waitFor(() => expect(screen.getAllByText(/Identity reset/).length).toBeGreaterThanOrEqual(1));
   });
 
   it('surfaces the wallet re-bind prompt for a binding on the previous identity', () => {
@@ -176,11 +177,18 @@ describe('AccountIdentityPage', () => {
 
     render(<AccountIdentityPage />);
 
-    expect(screen.getByTestId('identity-wallet-rebind')).toHaveTextContent(
-      'This wallet was bound to your previous identity. Re-bind it to your current identity to continue.'
-    );
+    expect(screen.getByTestId('identity-wallet-rebind')).toHaveTextContent('This wallet is not bound to your current identity.');
     fireEvent.click(screen.getByRole('button', { name: 'Re-bind wallet' }));
     expect(walletMock.state.connect).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces the wallet re-bind prompt when a connected wallet has no current binding', () => {
+    walletMock.state.account = '0x1111111111111111111111111111111111111111';
+    walletMock.state.walletBinding = null;
+
+    render(<AccountIdentityPage />);
+
+    expect(screen.getByTestId('identity-wallet-rebind')).toHaveTextContent('This wallet is not bound to your current identity.');
   });
 
   it('renders the create-identity call to action for a device without an active session', () => {

--- a/apps/web-pwa/src/routes/AccountIdentityPage.tsx
+++ b/apps/web-pwa/src/routes/AccountIdentityPage.tsx
@@ -104,9 +104,10 @@ const ConfirmationDialog: React.FC<ConfirmationDialogProps> = ({
               Reset your identity on this device?
             </h2>
             <p id={bodyId} className="mt-3 text-sm leading-6 text-slate-700 dark:text-slate-200">
-              Resetting creates a new pseudonym and stops using the current one. Your previous posts, comments, and votes
-              remain public under your old pseudonym. Resetting does not remove them and cannot make them yours again.
-              Your wallet must be re-bound, and any operator authorization or delegations are cleared.
+              Resetting stops using the current pseudonym and rotates the identity material on this device. The next
+              identity you create on this device uses a new pseudonym. Your previous posts, comments, and votes remain
+              public under your old pseudonym. Resetting does not remove them and cannot make them yours again. Your
+              wallet must be re-bound, and any operator authorization or delegations are cleared.
             </p>
             <label className="mt-4 block text-sm font-medium text-slate-800 dark:text-slate-100" htmlFor="identity-reset-input">
               Type reset to confirm
@@ -166,8 +167,7 @@ export const AccountIdentityPage: React.FC = () => {
   const walletNeedsRebind = Boolean(
     activePrincipal
     && account
-    && walletBinding?.boundPrincipalNullifier
-    && walletBinding.boundPrincipalNullifier !== activePrincipal
+    && (!walletBinding?.boundPrincipalNullifier || walletBinding.boundPrincipalNullifier !== activePrincipal)
   );
 
   const recentEvents = useMemo(() => events.slice(-5).reverse(), [events]);
@@ -188,7 +188,7 @@ export const AccountIdentityPage: React.FC = () => {
         setToast('Signed out. Your device identity remains available for re-attestation.');
       } else {
         await resetIdentity();
-        setToast("New identity created. Your previous pseudonym's public history remains on the network.");
+        setToast("Identity reset. Your previous pseudonym's public history remains on the network.");
       }
       setDialog(null);
       setResetInput('');
@@ -276,7 +276,7 @@ export const AccountIdentityPage: React.FC = () => {
         >
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <p className="text-sm">
-              This wallet was bound to your previous identity. Re-bind it to your current identity to continue.
+              This wallet is not bound to your current identity. Re-bind it to continue.
             </p>
             <Button type="button" variant="secondary" onClick={() => void connectWallet()} disabled={walletLoading}>
               Re-bind wallet

--- a/docs/ops/public-feed-freshness-monitor.md
+++ b/docs/ops/public-feed-freshness-monitor.md
@@ -81,12 +81,20 @@ The repo ships user-systemd units but does not enable them:
 - `infra/systemd/user/vh-public-feed-alert-watch.service`
 - `infra/systemd/user/vh-public-feed-alert-watch.timer`
 
+The service unit includes `TimeoutStartSec=180`, which bounds a hung
+freshness/publisher probe without making normal 15-second HTTP timeouts race the
+systemd start deadline.
+
 Operator enablement, after explicit approval:
 
 ```bash
 mkdir -p ~/.config/vhc
 install -m 0600 /dev/null ~/.config/vhc/public-feed-alert.env
 $EDITOR ~/.config/vhc/public-feed-alert.env
+
+# Fail closed before enabling: at least one delivery channel must be configured
+# and reachable from this host.
+grep -Eq '^(VH_PUBLIC_FEED_ALERT_WEBHOOK_URL|VH_PUBLIC_FEED_ALERT_EMAIL_TO)=' ~/.config/vhc/public-feed-alert.env
 
 mkdir -p ~/.config/systemd/user
 cp infra/systemd/user/vh-public-feed-alert-watch.service ~/.config/systemd/user/

--- a/docs/plans/LUMA_M1B_IDENTITY_CONTROLS_DESIGN_2026-07-02.md
+++ b/docs/plans/LUMA_M1B_IDENTITY_CONTROLS_DESIGN_2026-07-02.md
@@ -22,8 +22,8 @@ sequences how the UI lands them.
 | Unit tests for Sign Out / Reset semantics | DONE | `useIdentity.test.ts` asserts session clearing, runtime clearing, compartment preservation/rotation, wallet binding, delegation storage, operator token, XP active nullifier, sentiment signals, and telemetry reset |
 | `/account/identity` route | DONE | Route is registered in `apps/web-pwa/src/routes/index.tsx` |
 | Controls UI (panels, confirmation modals, session metadata) | DONE | `apps/web-pwa/src/routes/AccountIdentityPage.tsx` implements the panel, confirmation modals, session metadata, and telemetry debug surface |
-| Wallet re-bind prompt after Reset | DONE | `/account/identity` renders `identity-wallet-rebind` when the connected wallet is bound to a prior principal |
-| E2E flows (sign-out continuity / reset rotation) | MISSING | No e2e coverage of either journey |
+| Wallet re-bind prompt after Reset | DONE | `/account/identity` renders `identity-wallet-rebind` when a connected wallet is missing a binding to the current principal or is bound to a prior principal |
+| E2E flows (sign-out continuity / reset rotation) | DONE | `packages/e2e/src/luma/account-identity-controls.spec.ts` covers Sign Out continuity, Reset rotation, wallet re-bind prompt, and rendered-copy forbidden-claim assertions |
 
 ## 2. UX copy pack (draft strings)
 
@@ -54,15 +54,16 @@ claim deletion, anonymity, or repudiation.
 
 - Button: `Reset identity` (destructive styling, separated placement)
 - Modal title: `Reset your identity on this device?`
-- Modal body: `Resetting creates a new pseudonym and stops using the current one.
-  Your previous posts, comments, and votes remain public under your old
-  pseudonym — resetting does not remove them and cannot make them yours again.
-  Your wallet must be re-bound, and any operator authorization or delegations
-  are cleared.`
+- Modal body: `Resetting stops using the current pseudonym and rotates the
+  identity material on this device. The next identity you create on this device
+  uses a new pseudonym. Your previous posts, comments, and votes remain public
+  under your old pseudonym — resetting does not remove them and cannot make
+  them yours again. Your wallet must be re-bound, and any operator
+  authorization or delegations are cleared.`
 - Second-step confirmation (destructive tier): type-to-confirm the literal
   word `reset`, then `Reset identity` / `Cancel`
-- Post-reset toast: `New identity created. Your previous pseudonym's public
-  history remains on the network.`
+- Post-reset toast: `Identity reset. Your previous pseudonym's public history
+  remains on the network.`
 
 Copy red-lines (from spec §13.3-§13.4 and §20): never render "delete", never
 imply prior history is removed, transferred, or disowned; never render the
@@ -70,8 +71,8 @@ principal nullifier; never show a numeric trust score.
 
 ### 2.4 Wallet re-bind prompt (post-Reset, on next claim)
 
-`This wallet was bound to your previous identity. Re-bind it to your current
-identity to continue.` Action: `Re-bind wallet`.
+`This wallet is not bound to your current identity. Re-bind it to continue.`
+Action: `Re-bind wallet`.
 
 ### 2.5 Privacy links
 
@@ -147,6 +148,13 @@ for device credential, SEA pair, wallet binding, and delegation key material.
   no delegation grants, wallet re-bind prompt rendered.
 - Copy: both modals render; neither contains a forbidden-claims registry
   phrase (rendered-copy assertion, complementing the build-time grep).
+
+Implemented coverage: the current Playwright slice asserts principal and
+`forumAuthorId` continuity/rotation, rendered-copy forbidden-claim absence,
+raw principal/session-token non-disclosure, and wallet re-bind prompt rendering.
+Operator-authorization and delegation-grant browser seeding remain covered at
+the hook state-graph layer because the public UI does not expose controls to
+mint those compartments.
 
 ### 6.3 Fixtures
 

--- a/docs/reports/phase5-scope-a-driver-verdict-2026-07-02.md
+++ b/docs/reports/phase5-scope-a-driver-verdict-2026-07-02.md
@@ -1,68 +1,130 @@
-# Phase 5 Scope A Driver Verdict - 2026-07-02
+# Phase 5 Scope A Driver Verdict - 2026-07-03
 
-> Status: Driver Unknown - Evidence Packet Missing
+> Status: Off-Graph Heap Driver Likely - Early Capture Missing
 > Owner: VHC Launch Ops
-> Last Reviewed: 2026-07-02
+> Last Reviewed: 2026-07-03
 > Depends On: docs/reports/phase5-scope-a-recovery-current-state-2026-07-02.md, docs/ops/news-aggregator-production-service.md
 
 ## Scope
 
 This is the read-only Scope A heap-growth driver verdict for the post-outage #2
-program window. It does not change relay, publisher, A6, retention, compaction,
+instrumented window. It changes no relay, publisher, A6, retention, compaction,
 watchdog, or deploy behavior.
 
 ## Inputs Checked
 
-- The recovery report records that #691 graph metrics and #692 early heap
-  capture are enabled, and that the current gate is the 12-24 hour instrumented
-  climb from the post-deploy floor.
-- The repository contains the graph/heap ingestion code and the pre-outage
-  2026-06-28 closure evidence.
-- No post-#694 operator packet with the 12-24 hour graph-scan trend or
-  early-capture retainer summary is committed in the repo.
-- The documented local soak archive path,
-  `~/.local/state/vhc/phase5-scope-a-soak`, is absent on this workstation.
+- A6 host-local soak archive:
+  `~/.local/state/vhc/phase5-scope-a-soak`.
+- Read-only sample range with graph metrics present:
+  `2026-07-02T10:59:59.943Z` to `2026-07-03T12:33:59.937Z`
+  (`25.57h`, 26 samples per relay).
+- Public feed freshness, publisher liveness, relay liveness, relay snapshot
+  watch, and relay graph/heap metrics from the archive.
+- The slope figures below use first-to-last deltas over that read-only sample
+  range. They are trend estimates for driver selection, not a regression model
+  or a ceiling-crossing forecast.
+- Relay diagnostic directories were checked only for aggregate-safe heap summary
+  files. Raw `.heapsnapshot` files remain host-private and were not copied or
+  inspected.
+
+## Live State At Read
+
+- Publisher: `active/running`, `ExecMainStatus=0`, `NRestarts=0`.
+- Relays: all pass, graph scans enabled, no graph truncation, graph errors `0`,
+  watchdog trips `0`.
+- Latest graph scan duration: `4-5ms`; latest graph age under one scan interval.
+- Early-capture artifact: no `.heap-summary.json` or
+  `.heapsnapshot-error.json` found under relay data diagnostics. Existing raw
+  `.heapsnapshot` files are only the older 0-byte trip-time failures from
+  2026-06-25, 2026-06-29, and 2026-06-30.
+- This absence is expected for this sample because the latest observed heap was
+  about `300 MiB`, below the `~800 MiB` early-capture trigger; it is not another
+  trip-time capture failure.
+- Staleness caveat: this document reflects the read-only archive/live read at
+  the timestamps above. Later relay restarts, slope changes, or early-capture
+  artifacts can supersede the operational threshold math without changing this
+  window's driver classification.
+
+## Evidence
+
+| Relay | Heap first -> latest | Heap slope | RSS slope | Graph live bytes first -> latest | Graph live-byte slope | Tombstoned souls |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| `vhc-relay-a` | `30.0 MiB -> 290.5 MiB` | `10.98 MiB/h` | `11.15 MiB/h` | `97,162 -> 282,006` | `0.0083 MiB/h` | `0 -> 0` |
+| `vhc-relay-b` | `42.9 MiB -> 299.8 MiB` | `10.99 MiB/h` | `11.09 MiB/h` | `97,162 -> 282,006` | `0.0083 MiB/h` | `0 -> 0` |
+| `vhc-relay-c` | `29.1 MiB -> 297.7 MiB` | `11.33 MiB/h` | `11.49 MiB/h` | `97,162 -> 282,006` | `0.0083 MiB/h` | `0 -> 0` |
+
+Latest graph shape is identical across relays:
+
+| Namespace | Latest live bytes | Slope |
+| --- | ---: | ---: |
+| `news_story` | `207,806` | `6,351 B/h` |
+| `news_lifecycle` | `25,780` | `824 B/h` |
+| `news_hot_index` | `25,200` | `769 B/h` |
+| `news_latest_index` | `23,220` | `742 B/h` |
+| `aggregate`, `forum`, `topic_synthesis`, `other` | `0` | `0 B/h` |
+
+Total graph souls rose from `46` to `326` at about `10.07 souls/h`. That is
+expected publication growth, but the retained live payload bytes are tiny
+relative to the heap slope. The graph live-byte slope is less than `0.1%` of
+the heap slope on every relay.
+
+The packet used for this verdict did not include a cached link-only soul-count
+time series. It did include total souls, live bytes, tombstoned souls, scan
+success, scan duration, truncation, and error state. Because tombstoned souls
+remained `0`, live bytes ended at only `282,006`, and total souls ended at only
+`326`, any unreported link-only remainder is too small to explain hundreds of
+MiB of heap growth in this window.
 
 ## Verdict
 
-`heap_driver_unknown`.
+`heap_driver_off_graph_likely`.
 
-The required evidence for the four-way decision tree is not locally available:
-there is no complete post-#694 time series for relay heap/RSS against graph
-`userValueBytes`, tombstoned souls, link-only souls, and namespace live bytes,
-and there is no secret-safe early-capture retainer summary. The correct action
-is to hold all Scope A driver fixes.
+The graph scan is present, complete, and non-truncated. It does not support
+publisher-visible retention, tombstone skeleton accumulation, or link-only
+graph structure as the primary heap driver for this window. Heap/RSS are still
+rising linearly while graph `userValueBytes` are effectively flat at heap scale.
+
+The missing early-capture heap summary prevents naming the exact off-graph
+retainer. The candidate set remains RADISK staging/reload behavior, Gun peer
+sync state, buffers, duplicate/HAM state, or other non-`root.graph` retainers.
 
 ## Decision Tree Position
 
 | Candidate | Current evidence | Decision |
 | --- | --- | --- |
-| Live graph bytes track heap | Missing post-#694 graph/heap trend | Not selected |
-| Soul count or link/tombstone structure climbs while bytes stay flat | Missing post-#694 graph/heap trend | Not selected |
-| Graph bytes stay flat while heap climbs | Missing post-#694 graph/heap trend and early-capture retainer summary | Not selected |
-| Heap plateaus below staggered ceilings | Missing post-#694 heap/RSS trend across the staggered ceilings | Not selected |
+| Live graph bytes track heap | Graph live bytes slope `~0.008 MiB/h`; heap slope `~11 MiB/h` | Rejected |
+| Soul count or link/tombstone structure climbs while bytes stay flat | Souls rise, tombstones stay `0`, link-only series not present, and total graph scale is too small to explain heap | Not primary |
+| Graph bytes stay flat while heap climbs | Observed across all three relays | Selected |
+| Heap plateaus below staggered ceilings | No staggered ceiling was reached in this sample; a plateau was not yet testable from this window | Not selected |
 
 ## Recommended Next Scope A PR
 
-No retention, publisher clearing, relay compaction, eviction, watchdog, or
-publisher/relay behavior PR is recommended from the current evidence. The next
-Scope A development PR should be selected only after the operator supplies a
-secret-safe packet containing:
+Do not build publisher retention or relay compaction from this evidence. The
+next Scope A development PR should target off-graph diagnosis:
 
-- hourly or finer relay heap/RSS samples;
-- graph scan success/truncation/error/age data;
-- graph `userValueBytes` by namespace and state;
-- total, live, tombstoned, and link-only soul counts;
-- the #692 early-capture aggregate retainer summary, with no raw heap snapshot
-  content.
+- make early heap capture operationally asserted in the relay environment
+  (`VH_RELAY_WATCHDOG_EARLY_HEAP_SNAPSHOT_ENABLED=true` plus the intended
+  heap threshold) and add a liveness/watch check that fails if early capture is
+  expected but no `.heap-summary.json` appears by threshold;
+- add a secret-safe heap-summary analyzer for early-capture artifacts if one is
+  not already present on the host;
+- keep graph metrics as a negative control during the next climb;
+- keep all retention/compaction/eviction work gated until a secret-safe
+  retainer summary names the off-graph owner.
 
-If those packet inputs remain unavailable, the next repo-side PR should be an
-offline packet validator/verdict generator for the existing soak archive shape,
-not a heap-driver fix.
+## Alerting Enablement Note
+
+A6 alert enablement was authorized but not completed during this read because
+the host has no `~/.config/vhc/public-feed-alert.env`, no existing
+webhook/email alert env to reuse, and no visible `sendmail`/`mail` binary.
+Enabling the timer without a delivery channel would recreate the silence gap
+under a different name. The repo unit/runbook now require an explicit delivery
+channel before enablement.
 
 ## Non-Goals
 
 - No retention or story clearing.
 - No relay-side compaction or Gun eviction.
-- No A6 service action, restart, env edit, monitor enable, or deploy.
+- No publisher/relay restart or recreate from this verdict.
+- No raw heap snapshot copying or inspection.
 - No broad public-beta, Mesh `release_ready`, or production freshness claim.

--- a/infra/systemd/user/vh-public-feed-alert-watch.service
+++ b/infra/systemd/user/vh-public-feed-alert-watch.service
@@ -4,6 +4,7 @@ Documentation=file:/home/humble/VHC/docs/ops/public-feed-freshness-monitor.md
 
 [Service]
 Type=oneshot
+TimeoutStartSec=180
 Environment=VHC_REPO=/home/humble/VHC
 Environment=VH_PUBLIC_FEED_ALERT_STATE_DIR=%h/.local/state/vhc/public-feed-alert
 Environment=VH_PUBLIC_FEED_ALERT_OUTPUT_FILE=%h/.local/state/vhc/public-feed-alert/latest.json

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "check:luma-provider-surface": "node ./tools/scripts/check-luma-provider-surface.mjs",
     "check:luma-forbidden-claims": "node ./tools/scripts/check-luma-forbidden-claims.mjs",
     "check:luma-production-profile": "node ./tools/scripts/check-luma-production-profile.mjs",
-    "check:luma-telemetry-redaction": "node ./tools/scripts/check-luma-telemetry-redaction.mjs && cd packages/luma-sdk && vitest run src/telemetry.test.ts --config ./vitest.config.ts",
+    "check:luma-telemetry-redaction": "node ./tools/scripts/check-luma-telemetry-redaction.mjs && cd packages/luma-sdk && vitest run src/telemetry.test.ts src/telemetryReplayFixture.test.ts --config ./vitest.config.ts",
     "check:luma-signed-write-surface": "node ./tools/scripts/check-luma-signed-write-surface.mjs",
     "check:luma-vault-compartments": "node ./tools/scripts/check-luma-vault-compartments.mjs",
     "check:luma-delegation-signer-surface": "node ./tools/scripts/check-luma-delegation-signer-surface.mjs",

--- a/packages/e2e/src/luma/account-identity-controls.spec.ts
+++ b/packages/e2e/src/luma/account-identity-controls.spec.ts
@@ -1,0 +1,148 @@
+import { test, expect, type Page } from '@playwright/test';
+import { readVaultIdentity, waitForVaultIdentityNullifier } from '../helpers/vault-identity';
+
+const FORBIDDEN_RENDERED_COPY = [
+  'verified human',
+  'one-human-one-vote',
+  'Sybil-resistant',
+  'cryptographic residency',
+  'permanently delete',
+  'anonymous',
+  'untraceable',
+  'Reset Identity deletes your activity',
+  'Sign Out removes your data from the network',
+  'permanently deleted from the network',
+  'fully anonymous',
+  'untraceable across devices',
+];
+
+async function clearBrowserState(page: Page): Promise<void> {
+  await page.goto('/');
+  await page.evaluate(async () => {
+    localStorage.clear();
+    sessionStorage.clear();
+    await new Promise<void>((resolve) => {
+      const request = indexedDB.deleteDatabase('vh-vault');
+      request.onsuccess = () => resolve();
+      request.onerror = () => resolve();
+      request.onblocked = () => resolve();
+    });
+  });
+}
+
+async function gotoIdentityControls(page: Page): Promise<void> {
+  await page.goto('/account/identity');
+  await expect(page.getByTestId('identity-panel')).toBeVisible({ timeout: 15_000 });
+}
+
+async function ensureReadyIdentity(page: Page): Promise<string> {
+  await gotoIdentityControls(page);
+  const createButton = page.getByTestId('identity-create');
+  if (
+    await createButton.isVisible().catch(() => false)
+    && await createButton.isEnabled().catch(() => false)
+  ) {
+    await createButton.click();
+  }
+  await expect(page.getByTestId('identity-sign-out')).toBeVisible({ timeout: 15_000 });
+  return waitForVaultIdentityNullifier(page);
+}
+
+async function waitForNullifier(page: Page, predicate: (value: string) => boolean): Promise<string> {
+  let latest = '';
+  await expect.poll(async () => {
+    latest = (await readVaultIdentity(page))?.session?.nullifier ?? '';
+    return latest && predicate(latest);
+  }, { timeout: 15_000 }).toBeTruthy();
+  return latest;
+}
+
+async function renderedText(page: Page): Promise<string> {
+  return page.locator('body').innerText();
+}
+
+async function deriveForumAuthorId(principalNullifier: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(principalNullifier),
+    'HKDF',
+    false,
+    ['deriveBits'],
+  );
+  const bits = await crypto.subtle.deriveBits(
+    {
+      name: 'HKDF',
+      hash: 'SHA-256',
+      salt: new Uint8Array(32),
+      info: new TextEncoder().encode('vh:forum-author:v1'),
+    },
+    key,
+    256,
+  );
+  return Array.from(new Uint8Array(bits), (byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+test.describe('LUMA account identity controls', () => {
+  test.beforeEach(async ({ page }) => {
+    await clearBrowserState(page);
+  });
+
+  test('Sign Out preserves the device principal and rendered copy stays inside the claim boundary', async ({ page }) => {
+    const firstNullifier = await ensureReadyIdentity(page);
+    const firstForumAuthorId = await deriveForumAuthorId(firstNullifier);
+
+    await page.getByTestId('identity-sign-out').click();
+    const dialog = page.getByRole('dialog', { name: 'Sign out of this device?' });
+    await expect(dialog).toContainText('Signing out ends your current session.');
+    await expect(dialog).toContainText('Your published posts and votes are unaffected.');
+
+    for (const forbidden of FORBIDDEN_RENDERED_COPY) {
+      await expect(dialog).not.toContainText(forbidden);
+    }
+
+    await page.getByTestId('identity-sign-out-confirm').click();
+    const secondNullifier = await waitForNullifier(page, (value) => value === firstNullifier);
+    const secondForumAuthorId = await deriveForumAuthorId(secondNullifier);
+
+    expect(secondNullifier).toBe(firstNullifier);
+    expect(secondForumAuthorId).toBe(firstForumAuthorId);
+
+    await gotoIdentityControls(page);
+    const text = await renderedText(page);
+    expect(text).not.toContain(firstNullifier);
+    expect(text).not.toMatch(/mock-session-|dev-session-|srv-token:/);
+  });
+
+  test('Reset Identity rotates the principal and prompts wallet re-bind without claiming deletion', async ({ page }) => {
+    const firstNullifier = await ensureReadyIdentity(page);
+    const firstForumAuthorId = await deriveForumAuthorId(firstNullifier);
+
+    await page.getByTestId('identity-reset').click();
+    const dialog = page.getByRole('dialog', { name: 'Reset your identity on this device?' });
+    await expect(dialog).toContainText('Resetting stops using the current pseudonym');
+    await expect(dialog).toContainText('The next identity you create on this device uses a new pseudonym.');
+    await expect(dialog).toContainText('Resetting does not remove them and cannot make them yours again.');
+
+    for (const forbidden of FORBIDDEN_RENDERED_COPY) {
+      await expect(dialog).not.toContainText(forbidden);
+    }
+
+    await page.getByLabel('Type reset to confirm').fill('reset');
+    await page.getByTestId('identity-reset-confirm').click();
+
+    const secondNullifier = await waitForNullifier(page, (value) => value !== firstNullifier);
+    const secondForumAuthorId = await deriveForumAuthorId(secondNullifier);
+
+    expect(secondNullifier).not.toBe(firstNullifier);
+    expect(secondForumAuthorId).not.toBe(firstForumAuthorId);
+
+    await gotoIdentityControls(page);
+    await expect(page.getByTestId('identity-wallet-rebind')).toContainText('This wallet is not bound to your current identity.');
+    await expect(page.getByRole('button', { name: 'Re-bind wallet' })).toBeVisible();
+
+    const text = await renderedText(page);
+    expect(text).not.toContain(firstNullifier);
+    expect(text).not.toContain(secondNullifier);
+    expect(text).not.toMatch(/mock-session-|dev-session-|srv-token:/);
+  });
+});

--- a/packages/e2e/src/mvp-release-gates.mjs
+++ b/packages/e2e/src/mvp-release-gates.mjs
@@ -303,12 +303,13 @@ export const GATES = [
   },
   {
     id: 'luma_telemetry_redaction',
-    label: 'LUMA telemetry §16 source discipline holds; §21.4 replay remains deferred before <TrustClaim>',
+    label: 'LUMA telemetry §16 source discipline holds; §21.4 product replay remains deferred before <TrustClaim>',
     command: ['pnpm', ['check:luma-telemetry-redaction']],
     artifactRefs: [
       'tools/scripts/check-luma-telemetry-redaction.mjs',
       'packages/luma-sdk/src/telemetry.ts',
       'packages/luma-sdk/src/telemetry.test.ts',
+      'packages/luma-sdk/src/telemetryReplayFixture.test.ts',
       'docs/specs/spec-luma-service-v0.md',
     ],
   },

--- a/packages/luma-sdk/src/telemetryReplayFixture.test.ts
+++ b/packages/luma-sdk/src/telemetryReplayFixture.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createLumaTelemetryStore,
+  type EmitLumaEventInput,
+  type LumaEvent,
+} from './telemetry';
+
+const PUBLIC_BETA_TELEMETRY_REPLAY_FIXTURE: readonly EmitLumaEventInput[] = Object.freeze([
+  {
+    type: 'luma_session_created',
+    tsMs: 1,
+    context: {
+      profileTag: 'public-beta',
+      assuranceLevel: 'beta_local',
+      verifierIdHash: 'sha256:8b13f4c0a0db7a9d8ff3f018d8c7f2d3e0b4b2b179cfb7fd1be1ce6c2b70605a',
+    },
+  },
+  {
+    type: 'luma_policy_blocked',
+    level: 'warn',
+    tsMs: 2,
+    message: 'write blocked by policy',
+    context: {
+      audience: 'vh-forum-thread',
+      reason: 'session_near_expiry',
+    },
+  },
+  {
+    type: 'luma_envelope_rejected',
+    level: 'warn',
+    tsMs: 3,
+    context: {
+      audience: 'vh-news-report',
+      reason: 'audience_mismatch',
+      trace_id: 'trace-public-beta-001',
+    },
+  },
+  {
+    type: 'luma_tombstone_attempted',
+    tsMs: 4,
+    context: {
+      domain: 'forum',
+      pathClass: 'forum-author-record',
+      redactedPathHash: 'sha256:5a5f6a41c5d1b4ecb0af6e89a6d682711a5083e41a33162d795fd7af36eafcab',
+      outcome: 'ok',
+    },
+  },
+  {
+    type: 'luma_evidence_capture_started',
+    tsMs: 5,
+    context: { profileTag: 'public-beta' },
+  },
+  {
+    type: 'luma_evidence_capture_succeeded',
+    tsMs: 6,
+    context: {
+      profileTag: 'public-beta',
+      run_id: 'luma-replay-fixture-001',
+    },
+  },
+  {
+    type: 'luma_safety_bulletin_fetched',
+    tsMs: 7,
+    context: {
+      bulletinId: 'bulletin-public-beta-001',
+      outcome: 'fresh',
+    },
+  },
+  {
+    type: 'luma_session_revoked',
+    tsMs: 8,
+    context: {
+      mode: 'sign-out',
+    },
+  },
+]);
+
+const FORBIDDEN_REPLAY_STRINGS = [
+  'principalNullifier',
+  'sessionToken',
+  'deviceCredential',
+  'rawSignatureBytes',
+  'rawEnvelopeJson',
+  'assuranceEnvelope',
+  'verifierId":"',
+  '/vh/',
+  'access_token=',
+  '"signature"',
+];
+
+function replay(events: readonly EmitLumaEventInput[]): readonly LumaEvent[] {
+  const store = createLumaTelemetryStore({ saltBytes: new Uint8Array(16).fill(9) });
+  for (const event of events) {
+    store.emit(event);
+  }
+  return store.getSnapshot();
+}
+
+describe('LUMA telemetry replay-fixture redaction', () => {
+  it('replays a representative public-beta fixture without forbidden telemetry material', () => {
+    const snapshot = replay(PUBLIC_BETA_TELEMETRY_REPLAY_FIXTURE);
+    const serialized = JSON.stringify(snapshot);
+
+    expect(snapshot).toHaveLength(PUBLIC_BETA_TELEMETRY_REPLAY_FIXTURE.length);
+    for (const forbidden of FORBIDDEN_REPLAY_STRINGS) {
+      expect(serialized).not.toContain(forbidden);
+    }
+  });
+
+  it('red test: fails closed when a replay-fixture event contains typed secrets or raw paths', () => {
+    expect(() => replay([
+      ...PUBLIC_BETA_TELEMETRY_REPLAY_FIXTURE,
+      {
+        type: 'luma_policy_blocked',
+        level: 'warn',
+        tsMs: 9,
+        message: 'bad raw /vh/news/story/secret path',
+        context: {
+          audience: 'vh-news-report',
+          principalNullifier: 'raw-principal',
+        },
+      } as unknown as EmitLumaEventInput,
+    ])).toThrow(/forbidden/);
+  });
+
+  it('red test: fails closed when a replay-fixture event contains a token-bearing URL', () => {
+    expect(() => replay([
+      {
+        type: 'luma_evidence_capture_failed',
+        level: 'error',
+        tsMs: 10,
+        context: {
+          profileTag: 'public-beta',
+          reason: 'https://verifier.example.test/callback?access_token=secret',
+        },
+      },
+    ])).toThrow(/token-bearing URL/);
+  });
+});

--- a/tools/scripts/check-luma-telemetry-redaction.mjs
+++ b/tools/scripts/check-luma-telemetry-redaction.mjs
@@ -10,8 +10,9 @@
  *     guarded namespaces. Null/undefined presence checks are allowed.
  *
  * Runtime redaction behavior is covered by packages/luma-sdk/src/telemetry.test.ts.
- * The full spec §21.4 recorded engagement replay remains deferred as a
- * pre-<TrustClaim> obligation.
+ * packages/luma-sdk/src/telemetryReplayFixture.test.ts adds a fixture replay
+ * harness and red tests. The full spec §21.4 recorded product replay remains
+ * deferred until product emit sites and a capture/regeneration path exist.
  */
 
 import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';

--- a/tools/scripts/systemd-service-installers.test.mjs
+++ b/tools/scripts/systemd-service-installers.test.mjs
@@ -148,6 +148,15 @@ test('news aggregator installer writes Phase 5 soak archive units without enabli
   assert.match(timer, /Unit=vh-phase5-scope-a-soak-archive\.service/);
 });
 
+test('public feed alert watch unit bounds host-local probe runtime', () => {
+  const service = readInfraUnit('vh-public-feed-alert-watch.service');
+
+  assert.match(service, /public-feed-alert-watch\.mjs/);
+  assert.match(service, /TimeoutStartSec=180/);
+  assert.match(service, /VH_PUBLIC_FEED_ALERT_STATE_DIR=%h\/\.local\/state\/vhc\/public-feed-alert/);
+  assert.match(service, /source "%h\/\.config\/vhc\/public-feed-alert\.env"/);
+});
+
 test('news aggregator user unit orders publisher after StoryCluster', () => {
   for (const source of [
     readScript('install-news-aggregator-production-service.sh'),


### PR DESCRIPTION
## Summary

- Records the read-only Scope A evidence verdict from the instrumented relay window: graph bytes are flat at heap scale while heap/RSS still climb, so the likely driver is off-graph and early heap capture is still missing.
- Tightens that verdict doc's evidence framing: first-to-last slope estimator, missing link-only series disclosure, threshold-not-reached plateau framing, and staleness caveat for later restarts/slope changes.
- Hardens the public-feed alert unit/runbook with `TimeoutStartSec=180` and a fail-closed delivery-channel precheck before any A6 enablement.
- Tightens `/account/identity` reset copy and wallet re-bind detection so the UI does not imply immediate creation or miss a connected wallet with no current binding.
- Adds LUMA M1.B browser E2E coverage for Sign Out continuity, Reset rotation, copy-claim boundaries, raw-value non-disclosure, and wallet re-bind prompt.
- Keeps the LUMA telemetry replay work honest: `check:luma-telemetry-redaction` now includes a fixture replay harness and red tests, while the full spec §21.4 recorded product replay remains deferred until product emit sites and a capture/regeneration path exist.

## Current operational readout

- A6 alert enablement remains intentionally blocked until an operator provides a real delivery channel (`VH_PUBLIC_FEED_ALERT_WEBHOOK_URL` or email/MTA path). Enabling a timer that only logs locally would preserve the outage-#2 silence failure mode.
- The Scope A verdict is diagnostic only. It recommends no retention, compaction, eviction, publisher restart, relay restart, or A6 config change.
- `check:mvp-release-gates` was run under pnpm 9.7.1 and fails on current release evidence outside this diff: source health, public accepted synthesis/frame coverage, synthesis lifecycle, fresh-propagation publisher OpenAI auth, and pre-existing LUMA MVP readiness blockers.

## Validation

- `corepack pnpm@9.7.1 exec vitest run apps/web-pwa/src/routes/AccountIdentityPage.test.tsx apps/web-pwa/src/hooks/useIdentity.test.ts --reporter=verbose`
- `corepack pnpm@9.7.1 exec node --test tools/scripts/systemd-service-installers.test.mjs tools/scripts/public-feed-alert-watch.test.mjs`
- `corepack pnpm@9.7.1 check:luma-telemetry-redaction`
- `corepack pnpm@9.7.1 --filter @vh/e2e typecheck`
- `VITE_E2E_MODE=true` PWA build with pnpm 9.7.1 shim
- `VITE_E2E_MODE=true` Playwright: `packages/e2e/src/luma/account-identity-controls.spec.ts` (2/2 passed, no retries)
- `corepack pnpm@9.7.1 docs:check`
- `corepack pnpm@9.7.1 check:luma-forbidden-claims`
- `corepack pnpm@9.7.1 check:luma-production-profile`
- `corepack pnpm@9.7.1 check:public-beta-launch-closeout`
- `corepack pnpm@9.7.1 exec node --test tools/scripts/check-luma-forbidden-claims.test.mjs tools/scripts/check-luma-production-profile.test.mjs`
- `corepack pnpm@9.7.1 --filter @vh/luma-sdk typecheck`
- Overclaim grep found no branch-owned `RECORDED_*`, recorded-engagement, or §21.4 coverage assertions outside explicit deferred-product-replay wording.
- `git diff --check`

## Known non-branch blockers observed

- `@vh/web-pwa typecheck` still fails on existing CRDT/Yjs, `ethers`, and Vite config type drift unrelated to this diff.
- `check:mvp-release-gates` fails on current live/release evidence as described above; branch-adjacent LUMA entries inside that gate pass.
