### PR TITLE
Enforce rolling relay deploy verification

### DIFF
--- a/docs/ops/public-beta-image-deploy.md
+++ b/docs/ops/public-beta-image-deploy.md
@@ -363,23 +363,33 @@ their values.
 1. Install and verify the local `:3001` analysis backend.
 2. Run the direct on-disk relay snapshot precheck for every relay.
 3. Deploy one relay at a time with the existing host data bind mount preserved.
-4. After each relay restart, prove the running image tag/digest and verify the
+4. When the publisher is live, never batch relay recreates. A simultaneous
+   all-relay recreate creates the same brief `0/3` quorum window as a correlated
+   trip; a critical write in that window would fail-close the publisher. Use the
+   approved packet's rolling relay block as written: remove/run exactly one
+   relay, wait for `/readyz`, verify snapshot-backed latest-index reload,
+   confirm the per-relay early-capture thresholds and suppression config from
+   env/metrics, confirm graph-scan health when enabled, and confirm watchdog
+   trips remain `0` before touching the next relay. Prefer a gap between
+   publisher ticks when scheduling each relay; the rolling verifier is still the
+   hard gate.
+5. After each relay restart, prove the running image tag/digest and verify the
    three snapshot files still exist in the relay `GUN_FILE` directory. Confirm
    the relay env includes the watchdog/admission defaults and Docker shows
    `RestartPolicy.Name=on-failure` with `MaximumRetryCount=5`.
-5. After all relays prove the #638 image is running, run safe latest-index
+6. After all relays prove the #638 image is running, run safe latest-index
    behavior probes:
    - `persist=true` returns JSON 400.
    - `persist=false` leaves snapshot hash, mtime, and content unchanged.
-6. Deploy the origin image from the same `main` revision and repoint analysis to
+7. Deploy the origin image from the same `main` revision and repoint analysis to
    `http://127.0.0.1:3001`.
-7. Verify local and public `/api/analyze/health` and `/api/analyze/config`.
-8. Only after explicit operator approval, run the publisher installer with
+8. Verify local and public `/api/analyze/health` and `/api/analyze/config`.
+9. Only after explicit operator approval, run the publisher installer with
    `VH_NEWS_DAEMON_START_APPROVED=1`; the installer imports that approval into
    the user systemd manager before starting `vh-news-aggregator.service`.
-9. Prove latest content advances and synthesis lifecycle/publication evidence
+10. Prove latest content advances and synthesis lifecycle/publication evidence
    is fresh.
-10. Re-enable the relay liveness, publisher liveness, and public freshness
+11. Re-enable the relay liveness, publisher liveness, and public freshness
    monitors in that order, then begin soak/canary. The relay liveness timer is
    an active remediation timer once enabled: it can restart one unhealthy relay
    per run with cooldown, so leave it disabled during intentional relay

--- a/tools/scripts/emit-a6-public-beta-deploy-packet.sh
+++ b/tools/scripts/emit-a6-public-beta-deploy-packet.sh
@@ -149,6 +149,22 @@ function portFlags(container) {
   return flags;
 }
 
+function relayHostPort(container) {
+  const gunPort = envValue(container, 'GUN_PORT').trim() || '7777';
+  const bindings = container?.HostConfig?.PortBindings || {};
+  const candidates = [
+    ...(bindings[`${gunPort}/tcp`] || []),
+    ...(gunPort === '7777' ? [] : (bindings['7777/tcp'] || [])),
+  ];
+  const binding = candidates.find((entry) => entry?.HostPort);
+  return binding?.HostPort ? String(binding.HostPort).trim() : '';
+}
+
+function relayLocalOrigin(name) {
+  const port = relayHostPort(byName.get(name));
+  return port ? `http://127.0.0.1:${port}` : '';
+}
+
 function mountFlags(container) {
   const flags = [];
   for (const mount of container?.Mounts || []) {
@@ -240,6 +256,14 @@ function relayDefaultEarlyHeapThresholdList(name) {
   return '500000000,700000000';
 }
 
+function relayEarlyHeapThresholdParts(name) {
+  const parts = relayDefaultEarlyHeapThresholdList(name).split(',');
+  return {
+    first: parts[0],
+    second: parts[1] || '',
+  };
+}
+
 function envCaptureCommand(name, rewriteAnalysisTarget = false, relay = false) {
   const envPath = `/tmp/vhc-public-beta-deploy/${name}.env`;
   const relayDefaults = relay ? [
@@ -328,6 +352,78 @@ function runCommandFor(name, image, forceRelayUser = false) {
   return shellJoin(parts);
 }
 
+function rollingRelayVerifierFunction() {
+  return [
+    'verify_rolling_relay() {',
+    '  local name="$1"',
+    '  local origin="$2"',
+    '  local data_destination="$3"',
+    '  local first_threshold="$4"',
+    '  local second_threshold="$5"',
+    '  local metrics="/tmp/vhc-public-beta-deploy/${name}.metrics"',
+    '  local latest="/tmp/vhc-public-beta-deploy/${name}.latest-index.json"',
+    '  echo "[rolling-relay] waiting for ${name} readyz at ${origin}"',
+    '  local attempt=1',
+    '  while [[ "${attempt}" -le 60 ]]; do',
+    '    if curl -fsS "${origin}/readyz" > "/tmp/vhc-public-beta-deploy/${name}.readyz.json"; then',
+    '      break',
+    '    fi',
+    '    if [[ "${attempt}" -eq 60 ]]; then',
+    '      echo "${name}: /readyz did not pass after 60s; stop before touching the next relay" >&2',
+    '      exit 78',
+    '    fi',
+    '    sleep 1',
+    '    attempt=$((attempt + 1))',
+    '  done',
+    '  sudo docker exec "${name}" test -f "${data_destination}/news-latest-index-snapshot.json"',
+    '  sudo docker exec "${name}" test -f "${data_destination}/news-synthesis-lifecycle-snapshot.json"',
+    '  sudo docker exec "${name}" test -f "${data_destination}/topic-synthesis-latest-snapshot.json"',
+    '  curl -fsS "${origin}/vh/news/latest-index?limit=1&scan_limit=3&persist=false" > "${latest}"',
+    '  python3 - "${latest}" "${name}" <<\'PY\'',
+    'import json, sys',
+    'path, name = sys.argv[1], sys.argv[2]',
+    'with open(path, "r", encoding="utf-8") as handle:',
+    '    payload = json.load(handle)',
+    'if payload.get("ok") is not True:',
+    '    raise SystemExit(f"{name}: latest-index snapshot reload returned ok={payload.get(\'ok\')}")',
+    'record_count = payload.get("record_count")',
+    'records = payload.get("records")',
+    'if not isinstance(record_count, int) or record_count <= 0:',
+    '    raise SystemExit(f"{name}: latest-index snapshot reload record_count={record_count}")',
+    'if not isinstance(records, dict) or not records:',
+    '    raise SystemExit(f"{name}: latest-index snapshot reload records empty")',
+    'print(json.dumps({"relay": name, "latest_index_snapshot_reload": "pass", "record_count": record_count}, sort_keys=True))',
+    'PY',
+    '  test "$(sudo docker exec "${name}" printenv VH_RELAY_WATCHDOG_EARLY_HEAP_SNAPSHOT_HEAP_USED_BYTES_LIST)" = "${first_threshold},${second_threshold}"',
+    '  test "$(sudo docker exec "${name}" printenv VH_RELAY_WATCHDOG_POST_HEAP_SNAPSHOT_TRANSIENT_SUPPRESSION_INTERVALS)" = "2"',
+    '  local metrics_attempt=1',
+    '  while [[ "${metrics_attempt}" -le 60 ]]; do',
+    '    curl -fsS "${origin}/metrics" > "${metrics}"',
+    '    if grep -F "vh_relay_watchdog_early_heap_snapshot_threshold_bytes{threshold_index=\\"1\\",threshold_bytes=\\"${first_threshold}\\"} ${first_threshold}" "${metrics}" >/dev/null \\',
+    '      && grep -F "vh_relay_watchdog_early_heap_snapshot_threshold_bytes{threshold_index=\\"2\\",threshold_bytes=\\"${second_threshold}\\"} ${second_threshold}" "${metrics}" >/dev/null \\',
+    '      && grep -F "vh_relay_watchdog_transient_breach_suppression_samples_remaining" "${metrics}" >/dev/null \\',
+    '      && awk \'/^vh_relay_resource_watchdog_trips_total/ { if ($NF != 0) exit 1 }\' "${metrics}"; then',
+    '      if grep -q \'^vh_relay_gun_graph_scan_enabled 1$\' "${metrics}"; then',
+    '        if grep -E \'^vh_relay_gun_graph_scan_age_ms [0-9]+$\' "${metrics}" >/dev/null \\',
+    '          && grep -F \'vh_relay_gun_graph_scan_truncated 0\' "${metrics}" >/dev/null; then',
+    '          break',
+    '        fi',
+    '      else',
+    '        break',
+    '      fi',
+    '    fi',
+    '    if [[ "${metrics_attempt}" -eq 60 ]]; then',
+    '      echo "${name}: metrics did not advertise expected threshold/suppression/graph health within 60s" >&2',
+    '      exit 78',
+    '    fi',
+    '    sleep 1',
+    '    metrics_attempt=$((metrics_attempt + 1))',
+    '  done',
+    '  echo "[rolling-relay] ${name} verified; quorum-safe to proceed to the next relay"',
+    '}',
+  ].join('\n');
+}
+
 const blockers = [];
 for (const name of relayNames) {
   const container = byName.get(name);
@@ -339,6 +435,9 @@ for (const name of relayNames) {
     blockers.push(`${name}: ${destination} mount is ${mount.Type}, expected bind`);
   } else if (!mount.Source.includes(`/vhc-${name}/data`) && !mount.Source.endsWith(`/${name}/data`)) {
     blockers.push(`${name}: ${destination} source is unusual: ${mount.Source}`);
+  }
+  if (!relayLocalOrigin(name)) {
+    blockers.push(`${name}: missing host port binding for relay readyz/metrics verification`);
   }
 }
 
@@ -449,15 +548,22 @@ lines.push('');
 if (includeRecreate) {
   lines.push('## Relay Deploy');
   lines.push('');
-  lines.push('Run one relay at a time. Prove each relay before moving to the next. Do not run public latest-index HTTP probes until the #638 image is proven running.');
+  lines.push('Run one relay at a time while the publisher is live. The packet verifies `/readyz`, snapshot-backed latest-index reload, per-relay early-capture thresholds, suppression config, graph-scan health when enabled, and zero watchdog trips before executing the next relay removal. Stop immediately on any failure; do not batch the relay recreates.');
   lines.push('');
   lines.push('```bash');
+  lines.push('set -euo pipefail');
+  lines.push(rollingRelayVerifierFunction());
+  lines.push('');
   for (const name of relayNames) {
     const dataDestination = gunFileDestination(byName.get(name));
+    const origin = relayLocalOrigin(name);
+    const thresholds = relayEarlyHeapThresholdParts(name);
+    lines.push(`# Recreate ${name}; wait for this relay to verify before touching the next relay.`);
     lines.push(`sudo docker rm -f ${name}`);
     lines.push(runCommandFor(name, newRelayImage, true));
     lines.push(`sudo docker inspect ${name} --format '{{.Config.Image}} {{.Image}}'`);
-    lines.push(`sudo docker exec ${name} test -f ${dataDestination}/news-latest-index-snapshot.json`);
+    lines.push(`verify_rolling_relay ${shellSingleQuote(name)} ${shellSingleQuote(origin)} ${shellSingleQuote(dataDestination)} ${shellSingleQuote(thresholds.first)} ${shellSingleQuote(thresholds.second)}`);
+    lines.push('');
   }
   lines.push('```');
   lines.push('');

--- a/tools/scripts/public-beta-image-deploy.test.mjs
+++ b/tools/scripts/public-beta-image-deploy.test.mjs
@@ -413,7 +413,29 @@ test('deploy packet preserves relay bind mounts and rewrites origin env safely',
     assert.equal(result.status, 0, result.stderr);
     assert.match(result.stdout, /GUN_FILE destination: `\/data`/);
     assert.match(result.stdout, /\/home\/humble\/\.local\/share\/vhc\/vhc-relay-a\/data:\/data:rw/);
-    assert.match(result.stdout, /sudo docker exec vhc-relay-a test -f \/data\/news-latest-index-snapshot\.json/);
+    assert.match(result.stdout, /verify_rolling_relay\(\) \{/);
+    assert.match(result.stdout, /curl -fsS "\$\{origin\}\/readyz"/);
+    assert.match(result.stdout, /\/vh\/news\/latest-index\?limit=1&scan_limit=3&persist=false/);
+    assert.match(result.stdout, /latest_index_snapshot_reload": "pass"/);
+    assert.match(result.stdout, /vh_relay_watchdog_transient_breach_suppression_samples_remaining/);
+    assert.match(result.stdout, /vh_relay_gun_graph_scan_truncated 0/);
+    assert.match(result.stdout, /verify_rolling_relay 'vhc-relay-a' 'http:\/\/127\.0\.0\.1:8765' '\/data' '500000000' '700000000'/);
+    assert.match(result.stdout, /verify_rolling_relay 'vhc-relay-b' 'http:\/\/127\.0\.0\.1:8766' '\/data' '520000000' '720000000'/);
+    assert.match(result.stdout, /verify_rolling_relay 'vhc-relay-c' 'http:\/\/127\.0\.0\.1:8767' '\/data' '540000000' '740000000'/);
+    const relayDeploySection = result.stdout.slice(
+      result.stdout.indexOf('## Relay Deploy'),
+      result.stdout.indexOf('## Origin Deploy'),
+    );
+    assert.ok(relayDeploySection.includes('while the publisher is live'), relayDeploySection);
+    const removeA = relayDeploySection.indexOf('sudo docker rm -f vhc-relay-a');
+    const verifyA = relayDeploySection.indexOf("verify_rolling_relay 'vhc-relay-a'");
+    const removeB = relayDeploySection.indexOf('sudo docker rm -f vhc-relay-b');
+    const verifyB = relayDeploySection.indexOf("verify_rolling_relay 'vhc-relay-b'");
+    const removeC = relayDeploySection.indexOf('sudo docker rm -f vhc-relay-c');
+    const verifyC = relayDeploySection.indexOf("verify_rolling_relay 'vhc-relay-c'");
+    assert.ok(removeA > 0 && removeA < verifyA, relayDeploySection);
+    assert.ok(verifyA < removeB && removeB < verifyB, relayDeploySection);
+    assert.ok(verifyB < removeC && removeC < verifyC, relayDeploySection);
     assert.match(result.stdout, /grep -E 'vhc\\-public\\-origin\|vhc\\-relay\\-a\|vhc\\-relay\\-b\|vhc\\-relay\\-c'/);
     assert.match(result.stdout, /len\(entries\) == 0/);
     assert.match(result.stdout, /"entry_count": len\(entries\)/);
@@ -566,6 +588,7 @@ test('public beta compose bounds relay restart and memory self-defense', () => {
 });
 
 function makeRelay(name, dataDir) {
+  const hostPort = name.endsWith('-a') ? '8765' : name.endsWith('-b') ? '8766' : '8767';
   return makeContainer(name, 'vhc-public-beta-relay:old', [
     'NODE_ENV=production',
     'GUN_FILE=/data',
@@ -576,7 +599,7 @@ function makeRelay(name, dataDir) {
     Destination: '/data',
     Mode: 'rw',
     RW: true,
-  }], { '7777/tcp': [{ HostIp: '127.0.0.1', HostPort: '7777' }] });
+  }], { '7777/tcp': [{ HostIp: '127.0.0.1', HostPort: hostPort }] });
 }
 
 function makeContainer(name, image, env, mounts, portBindings) {


### PR DESCRIPTION
## Summary
- harden the A6 deploy packet so relay recreates are mechanically rolling while the publisher is live
- add a generated `verify_rolling_relay` gate between relay recreates: `/readyz`, snapshot-backed latest-index reload, per-relay early-capture threshold list, suppression env, metrics thresholds, graph scan health when enabled, and zero watchdog trips
- update the public-beta deploy runbook and tests so future packet changes cannot regress to a batch all-relay recreate

## Validation
- `bash -n tools/scripts/emit-a6-public-beta-deploy-packet.sh`
- `corepack pnpm@9.7.1 exec node --test tools/scripts/public-beta-image-deploy.test.mjs`
- generated Relay Deploy block extracted from an approved packet and passed `bash -n`
- `corepack pnpm@9.7.1 docs:check`
- `corepack pnpm@9.7.1 check:public-beta-launch-closeout`
- `git diff --check`

## Scope
Repo-side deploy-packet/runbook hardening only. No live A6 action, no relay/publisher behavior change, no retention/compaction.