### PR TITLE
Make transport-total relay write failures retryable and restartable

### DIFF
--- a/docs/ops/news-aggregator-production-service.md
+++ b/docs/ops/news-aggregator-production-service.md
@@ -363,7 +363,50 @@ runtime write violation, and `vh-news-aggregator.service` uses
 `Restart=on-failure` plus `RestartPreventExitStatus=78` so that state stays down
 for operator inspection. The unit also sets `StartLimitIntervalSec=10min` and
 `StartLimitBurst=3` as a backstop for genuine process crashes or unexpected
-non-78 failures. Verify the installed unit before an attended start:
+non-78 failures.
+
+One fail-close cause is deliberately restartable: a **relay transport-total
+failure**, where a critical relay REST write got zero relay successes and every
+per-relay failure was network-level (the fetch itself threw — DNS resolution,
+connection refused, connection reset — with no HTTP response received from any
+relay). No relay **acknowledged** the write. That is not proof nothing was
+published (a response-leg reset can land after a relay applied the write), and
+the network-level cause can be relay-side (whole fleet down, TLS failure)
+rather than host-side — but retrying is safe regardless: the record is re-sent
+byte-identical and all relay news writes are id-keyed idempotent upserts, so a
+re-send cannot double-publish or diverge state. The write path first retries
+the fan-out in-process
+(`VH_NEWS_RELAY_REST_TRANSPORT_RETRY_COUNT`, default `2`, with
+`VH_NEWS_RELAY_REST_TRANSPORT_RETRY_BACKOFF_MS`, default `5000,15000`; only the
+zero-success all-transport case retries — any relay-returned response,
+including `503` backpressure, and any abort/timeout, including undici
+dispatcher header/body timeouts, keeps single-pass semantics). If retries
+exhaust, the daemon still fail-closes (writes blocked, teardown, halt) but
+exits `69` (`EX_UNAVAILABLE`) instead of `78`, so systemd restarts it after
+`RestartSec=30`, bounded by the same
+`StartLimitBurst=3`/`StartLimitIntervalSec=10min`. Exit `69` is emitted by no
+other publisher tooling — the wrapper's own refusal paths use `75` — so
+`ExecMainStatus=69` identifies this class unambiguously at the unit layer.
+
+Recovery timing: a blip short enough for the in-process retries clears in
+seconds and the tick completes normally. If the daemon exits `69`, recovery
+runs through the full wrapper preflights on restart, so expect minutes, not
+seconds. A persistent outage that fails again immediately at startup parks the
+unit after three attempts inside the 10-minute burst window; failures spaced
+at tick cadence (beyond the burst window) re-attempt indefinitely — each
+attempt is a clean unacknowledged-everywhere fail-close, so the publisher
+self-heals without operator action whenever the network returns. The publisher
+liveness watch classifies this state as `exit_69_transport_unavailable` (from
+`ExecMainStatus` only, never journal text, so a stale transport line cannot
+relabel a later genuine `78` park), and an `nrestarts_increased` blocker after
+a transport blip is the expected self-recovery signal. Investigate the network
+event — check the **relay fleet as well as host DNS/network**, since
+all-relays-unreachable classifies identically — but the publisher does not
+need a manual restart. Mixed outcomes (any relay acked, or any relay returned
+an HTTP error) never take this path: they keep the non-restarting exit `78`
+write-safety contract.
+
+Verify the installed unit before an attended start:
 
 ```bash
 systemctl --user show vh-news-aggregator.service \

--- a/docs/ops/news-aggregator.env.example
+++ b/docs/ops/news-aggregator.env.example
@@ -40,6 +40,14 @@ VH_NEWS_RELAY_REST_WRITE_TOKENS='{"https://gun-a.carboncaste.io":"<gun-a-relay-d
 VH_NEWS_RELAY_REST_WRITE_REQUIRE_ALL=true
 VH_NEWS_RELAY_REST_WRITE_MIN_SUCCESS=2
 VH_NEWS_RELAY_REST_WRITE_TIMEOUT_MS=10000
+# Transport-total retry: when a critical relay write gets ZERO successes and
+# every failure is network-level (fetch threw; no HTTP response from any
+# relay), the fan-out retries in-process before failing. Relay-returned errors
+# (500/503/4xx) and aborts/timeouts never retry. After exhaustion the daemon
+# exits 69 (EX_UNAVAILABLE, systemd-restartable, burst-bounded) instead of the
+# non-restarting write-safety exit 78. Negative count reads as 0 (disabled).
+VH_NEWS_RELAY_REST_TRANSPORT_RETRY_COUNT=2
+VH_NEWS_RELAY_REST_TRANSPORT_RETRY_BACKOFF_MS=5000,15000
 # Scope B enrichment is prepared but disabled for raw Scope A. Do not flip this
 # flag alone: it wires accepted synthesis, accepted replay/catch-up, product
 # latest/hot index refresh, and storyline overlays under one master switch.

--- a/packages/gun-client/src/newsAdapters.test.ts
+++ b/packages/gun-client/src/newsAdapters.test.ts
@@ -67,7 +67,9 @@ import {
   writeNewsIngestionLease,
   writeNewsLatestIndexEntry,
   writeNewsSynthesisLifecycleStatus,
-  writeNewsStory
+  writeNewsStory,
+  RelayRestTransportTotalFailureError,
+  isRelayRestTransportTotalFailureError,
 } from './newsAdapters';
 
 interface FakeMesh {
@@ -927,6 +929,262 @@ describe('newsAdapters', () => {
         'Relay REST news write failed for /vh/news/latest-index: 1/3 succeeded; required=2',
       );
       expect(mesh.writes).toEqual([]);
+    } finally {
+      vi.unstubAllGlobals();
+      restoreEnv();
+      restoreRuntimeConfig();
+    }
+  });
+
+  it('writeNewsLatestIndexEntry retries a transport-total relay failure and succeeds', async () => {
+    const restoreRuntimeConfig = withGunClientRuntimeConfig({
+      VH_NEWS_RELAY_REST_WRITE_FIRST: 'true',
+      VH_NEWS_RELAY_REST_WRITE_ORIGINS: '["https://gun-a.example.test","https://gun-b.example.test","https://gun-c.example.test"]',
+      VH_NEWS_RELAY_REST_WRITE_MIN_SUCCESS: '2',
+      VH_NEWS_RELAY_REST_TRANSPORT_RETRY_COUNT: '2',
+      VH_NEWS_RELAY_REST_TRANSPORT_RETRY_BACKOFF_MS: '0',
+    });
+    const restoreEnv = withProcessEnv({ VH_RELAY_DAEMON_TOKEN: 'relay-token-redacted' });
+    try {
+      const mesh = createFakeMesh();
+      const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+      const client = createClient(mesh, guard, {
+        peers: ['https://fallback-peer.example.test/gun'],
+      });
+      const okResponse = () => new Response(JSON.stringify({ ok: true, story_id: STORY.story_id }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+      const fetchMock = vi
+        .fn()
+        .mockRejectedValueOnce(new TypeError('fetch failed'))
+        .mockRejectedValueOnce(new TypeError('fetch failed'))
+        .mockRejectedValueOnce(new TypeError('fetch failed'))
+        .mockResolvedValueOnce(okResponse())
+        .mockResolvedValueOnce(okResponse())
+        .mockResolvedValueOnce(okResponse());
+      vi.stubGlobal('fetch', fetchMock);
+
+      await expect(
+        writeNewsLatestIndexEntry(client, STORY.story_id, STORY.cluster_window_end, STORY),
+      ).resolves.toBeUndefined();
+      expect(fetchMock).toHaveBeenCalledTimes(6);
+    } finally {
+      vi.unstubAllGlobals();
+      restoreEnv();
+      restoreRuntimeConfig();
+    }
+  });
+
+  it('writeNewsLatestIndexEntry throws the typed transport-total error after exhausting retries', async () => {
+    const restoreRuntimeConfig = withGunClientRuntimeConfig({
+      VH_NEWS_RELAY_REST_WRITE_FIRST: 'true',
+      VH_NEWS_RELAY_REST_WRITE_ORIGINS: '["https://gun-a.example.test","https://gun-b.example.test","https://gun-c.example.test"]',
+      VH_NEWS_RELAY_REST_WRITE_MIN_SUCCESS: '2',
+      VH_NEWS_RELAY_REST_TRANSPORT_RETRY_COUNT: '1',
+      VH_NEWS_RELAY_REST_TRANSPORT_RETRY_BACKOFF_MS: '0',
+    });
+    const restoreEnv = withProcessEnv({ VH_RELAY_DAEMON_TOKEN: 'relay-token-redacted' });
+    try {
+      const mesh = createFakeMesh();
+      const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+      const client = createClient(mesh, guard, {
+        peers: ['https://fallback-peer.example.test/gun'],
+      });
+      const fetchMock = vi.fn().mockRejectedValue(new TypeError('fetch failed'));
+      vi.stubGlobal('fetch', fetchMock);
+
+      const failure = await writeNewsLatestIndexEntry(
+        client,
+        STORY.story_id,
+        STORY.cluster_window_end,
+        STORY,
+      ).then(
+        () => null,
+        (error: unknown) => error,
+      );
+      expect(failure).toBeInstanceOf(Error);
+      expect(isRelayRestTransportTotalFailureError(failure)).toBe(true);
+      expect((failure as Error).message).toContain('0/3 succeeded');
+      expect((failure as Error).message).toContain('transport_unavailable_attempts=2');
+      expect((failure as RelayRestTransportTotalFailureError).attemptCount).toBe(2);
+      expect(fetchMock).toHaveBeenCalledTimes(6);
+      expect(mesh.writes).toEqual([]);
+    } finally {
+      vi.unstubAllGlobals();
+      restoreEnv();
+      restoreRuntimeConfig();
+    }
+  });
+
+  it('writeNewsLatestIndexEntry does not retry mixed transport and relay-returned failures', async () => {
+    const restoreRuntimeConfig = withGunClientRuntimeConfig({
+      VH_NEWS_RELAY_REST_WRITE_FIRST: 'true',
+      VH_NEWS_RELAY_REST_WRITE_ORIGINS: '["https://gun-a.example.test","https://gun-b.example.test","https://gun-c.example.test"]',
+      VH_NEWS_RELAY_REST_WRITE_MIN_SUCCESS: '2',
+      VH_NEWS_RELAY_REST_TRANSPORT_RETRY_COUNT: '2',
+      VH_NEWS_RELAY_REST_TRANSPORT_RETRY_BACKOFF_MS: '0',
+    });
+    const restoreEnv = withProcessEnv({ VH_RELAY_DAEMON_TOKEN: 'relay-token-redacted' });
+    try {
+      const mesh = createFakeMesh();
+      const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+      const client = createClient(mesh, guard, {
+        peers: ['https://fallback-peer.example.test/gun'],
+      });
+      const fetchMock = vi
+        .fn()
+        .mockRejectedValueOnce(new TypeError('fetch failed'))
+        .mockResolvedValueOnce(new Response('relay-backpressure', {
+          status: 503,
+          headers: { 'content-type': 'text/plain' },
+        }))
+        .mockRejectedValueOnce(new TypeError('fetch failed'));
+      vi.stubGlobal('fetch', fetchMock);
+
+      const failure = await writeNewsLatestIndexEntry(
+        client,
+        STORY.story_id,
+        STORY.cluster_window_end,
+        STORY,
+      ).then(
+        () => null,
+        (error: unknown) => error,
+      );
+      expect(failure).toBeInstanceOf(Error);
+      expect(isRelayRestTransportTotalFailureError(failure)).toBe(false);
+      expect((failure as Error).message).toContain('0/3 succeeded');
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+    } finally {
+      vi.unstubAllGlobals();
+      restoreEnv();
+      restoreRuntimeConfig();
+    }
+  });
+
+  it('writeNewsLatestIndexEntry does not retry abort/timeout failures', async () => {
+    const restoreRuntimeConfig = withGunClientRuntimeConfig({
+      VH_NEWS_RELAY_REST_WRITE_FIRST: 'true',
+      VH_NEWS_RELAY_REST_WRITE_ORIGINS: '["https://gun-a.example.test","https://gun-b.example.test","https://gun-c.example.test"]',
+      VH_NEWS_RELAY_REST_WRITE_MIN_SUCCESS: '2',
+      VH_NEWS_RELAY_REST_TRANSPORT_RETRY_COUNT: '2',
+      VH_NEWS_RELAY_REST_TRANSPORT_RETRY_BACKOFF_MS: '0',
+    });
+    const restoreEnv = withProcessEnv({ VH_RELAY_DAEMON_TOKEN: 'relay-token-redacted' });
+    try {
+      const mesh = createFakeMesh();
+      const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+      const client = createClient(mesh, guard, {
+        peers: ['https://fallback-peer.example.test/gun'],
+      });
+      const abortError = () => {
+        const error = new Error('This operation was aborted');
+        error.name = 'AbortError';
+        return error;
+      };
+      const fetchMock = vi
+        .fn()
+        .mockRejectedValueOnce(abortError())
+        .mockRejectedValueOnce(abortError())
+        .mockRejectedValueOnce(abortError());
+      vi.stubGlobal('fetch', fetchMock);
+
+      const failure = await writeNewsLatestIndexEntry(
+        client,
+        STORY.story_id,
+        STORY.cluster_window_end,
+        STORY,
+      ).then(
+        () => null,
+        (error: unknown) => error,
+      );
+      expect(failure).toBeInstanceOf(Error);
+      expect(isRelayRestTransportTotalFailureError(failure)).toBe(false);
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+    } finally {
+      vi.unstubAllGlobals();
+      restoreEnv();
+      restoreRuntimeConfig();
+    }
+  });
+
+  it('writeNewsLatestIndexEntry does not retry undici dispatcher timeouts wrapped as fetch failed', async () => {
+    const restoreRuntimeConfig = withGunClientRuntimeConfig({
+      VH_NEWS_RELAY_REST_WRITE_FIRST: 'true',
+      VH_NEWS_RELAY_REST_WRITE_ORIGINS: '["https://gun-a.example.test","https://gun-b.example.test","https://gun-c.example.test"]',
+      VH_NEWS_RELAY_REST_WRITE_MIN_SUCCESS: '2',
+      VH_NEWS_RELAY_REST_TRANSPORT_RETRY_COUNT: '2',
+      VH_NEWS_RELAY_REST_TRANSPORT_RETRY_BACKOFF_MS: '0',
+    });
+    const restoreEnv = withProcessEnv({ VH_RELAY_DAEMON_TOKEN: 'relay-token-redacted' });
+    try {
+      const mesh = createFakeMesh();
+      const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+      const client = createClient(mesh, guard, {
+        peers: ['https://fallback-peer.example.test/gun'],
+      });
+      // A headers timeout means the request WAS delivered and the relay is
+      // hanging — relay-side slowness, not transport-total.
+      const headersTimeout = () => {
+        const cause = new Error('Headers Timeout Error');
+        (cause as NodeJS.ErrnoException).code = 'UND_ERR_HEADERS_TIMEOUT';
+        return new TypeError('fetch failed', { cause });
+      };
+      const fetchMock = vi
+        .fn()
+        .mockRejectedValueOnce(headersTimeout())
+        .mockRejectedValueOnce(headersTimeout())
+        .mockRejectedValueOnce(headersTimeout());
+      vi.stubGlobal('fetch', fetchMock);
+
+      const failure = await writeNewsLatestIndexEntry(
+        client,
+        STORY.story_id,
+        STORY.cluster_window_end,
+        STORY,
+      ).then(
+        () => null,
+        (error: unknown) => error,
+      );
+      expect(failure).toBeInstanceOf(Error);
+      expect(isRelayRestTransportTotalFailureError(failure)).toBe(false);
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+    } finally {
+      vi.unstubAllGlobals();
+      restoreEnv();
+      restoreRuntimeConfig();
+    }
+  });
+
+  it('writeNewsLatestIndexEntry with retries disabled still throws the typed transport-total error', async () => {
+    const restoreRuntimeConfig = withGunClientRuntimeConfig({
+      VH_NEWS_RELAY_REST_WRITE_FIRST: 'true',
+      VH_NEWS_RELAY_REST_WRITE_ORIGINS: '["https://gun-a.example.test","https://gun-b.example.test","https://gun-c.example.test"]',
+      VH_NEWS_RELAY_REST_WRITE_MIN_SUCCESS: '2',
+      VH_NEWS_RELAY_REST_TRANSPORT_RETRY_COUNT: '0',
+    });
+    const restoreEnv = withProcessEnv({ VH_RELAY_DAEMON_TOKEN: 'relay-token-redacted' });
+    try {
+      const mesh = createFakeMesh();
+      const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+      const client = createClient(mesh, guard, {
+        peers: ['https://fallback-peer.example.test/gun'],
+      });
+      const fetchMock = vi.fn().mockRejectedValue(new TypeError('fetch failed'));
+      vi.stubGlobal('fetch', fetchMock);
+
+      const failure = await writeNewsLatestIndexEntry(
+        client,
+        STORY.story_id,
+        STORY.cluster_window_end,
+        STORY,
+      ).then(
+        () => null,
+        (error: unknown) => error,
+      );
+      expect(isRelayRestTransportTotalFailureError(failure)).toBe(true);
+      expect((failure as RelayRestTransportTotalFailureError).attemptCount).toBe(1);
+      expect(fetchMock).toHaveBeenCalledTimes(3);
     } finally {
       vi.unstubAllGlobals();
       restoreEnv();

--- a/packages/gun-client/src/newsAdapters.test.ts
+++ b/packages/gun-client/src/newsAdapters.test.ts
@@ -976,6 +976,130 @@ describe('newsAdapters', () => {
     }
   });
 
+  it('classifies only network-level thrown relay write failures as transport-class', () => {
+    expect(newsAdapterInternal.isTransportClassRelayWriteFailure('fetch failed')).toBe(false);
+    expect(newsAdapterInternal.isTransportClassRelayWriteFailure(new TypeError('fetch failed'))).toBe(true);
+    expect(newsAdapterInternal.isTransportClassRelayWriteFailure(new Error('ordinary application error'))).toBe(false);
+
+    const abortError = new Error('This operation was aborted');
+    abortError.name = 'AbortError';
+    expect(newsAdapterInternal.isTransportClassRelayWriteFailure(abortError)).toBe(false);
+    expect(newsAdapterInternal.isTransportClassRelayWriteFailure(new Error('request timeout'))).toBe(false);
+
+    expect(newsAdapterInternal.isTransportClassRelayWriteFailure(
+      new TypeError('fetch failed', { cause: 'getaddrinfo ENOTFOUND gun-a.example.test' }),
+    )).toBe(true);
+
+    expect(newsAdapterInternal.isTransportClassRelayWriteFailure(
+      new TypeError('fetch failed', { cause: new Error('socket hang up') }),
+    )).toBe(true);
+
+    const connectTimeoutCause = new Error('Connect Timeout Error');
+    (connectTimeoutCause as NodeJS.ErrnoException).code = 'UND_ERR_CONNECT_TIMEOUT';
+    expect(newsAdapterInternal.isTransportClassRelayWriteFailure(
+      new TypeError('fetch failed', { cause: connectTimeoutCause }),
+    )).toBe(true);
+
+    const bodyTimeoutCause = new Error('Body Timeout Error');
+    (bodyTimeoutCause as NodeJS.ErrnoException).code = 'UND_ERR_BODY_TIMEOUT';
+    expect(newsAdapterInternal.isTransportClassRelayWriteFailure(
+      new TypeError('fetch failed', { cause: bodyTimeoutCause }),
+    )).toBe(false);
+  });
+
+  it('resolves relay REST transport retry plan with defaults, clamps, and fallback parsing', () => {
+    const restoreInvalid = withGunClientRuntimeConfig({
+      VH_NEWS_RELAY_REST_TRANSPORT_RETRY_COUNT: 'not-a-number',
+      VH_NEWS_RELAY_REST_TRANSPORT_RETRY_BACKOFF_MS: 'bad also-bad',
+    });
+    try {
+      expect(newsAdapterInternal.resolveRelayRestTransportRetryPlan()).toEqual({
+        retries: 2,
+        backoffMs: [5000, 15000],
+      });
+    } finally {
+      restoreInvalid();
+    }
+
+    const restoreClamped = withGunClientRuntimeConfig({
+      VH_NEWS_RELAY_REST_TRANSPORT_RETRY_COUNT: '99',
+      VH_NEWS_RELAY_REST_TRANSPORT_RETRY_BACKOFF_MS: '1 -2 nope 999999',
+    });
+    try {
+      expect(newsAdapterInternal.resolveRelayRestTransportRetryPlan()).toEqual({
+        retries: 5,
+        backoffMs: [1, 60000],
+      });
+    } finally {
+      restoreClamped();
+    }
+
+    const restoreDisabled = withGunClientRuntimeConfig({
+      VH_NEWS_RELAY_REST_TRANSPORT_RETRY_COUNT: '-3',
+    });
+    try {
+      expect(newsAdapterInternal.resolveRelayRestTransportRetryPlan()).toMatchObject({
+        retries: 0,
+      });
+    } finally {
+      restoreDisabled();
+    }
+  });
+
+  it('writeNewsRecordViaRelayRest uses the configured transport retry backoff before succeeding', async () => {
+    const restoreRuntimeConfig = withGunClientRuntimeConfig({
+      VH_NEWS_RELAY_REST_WRITE_ORIGINS: '["https://gun-a.example.test","https://gun-b.example.test","https://gun-c.example.test"]',
+      VH_NEWS_RELAY_REST_WRITE_MIN_SUCCESS: '2',
+      VH_NEWS_RELAY_REST_TRANSPORT_RETRY_COUNT: '1',
+      VH_NEWS_RELAY_REST_TRANSPORT_RETRY_BACKOFF_MS: '1',
+    });
+    const restoreEnv = withProcessEnv({ VH_RELAY_DAEMON_TOKEN: 'relay-token-redacted' });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      const mesh = createFakeMesh();
+      const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+      const client = createClient(mesh, guard, {
+        peers: ['https://fallback-peer.example.test/gun'],
+      });
+      const okResponse = () => new Response(JSON.stringify({ ok: true, story_id: STORY.story_id }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+      const fetchMock = vi
+        .fn()
+        .mockRejectedValueOnce(new TypeError('fetch failed'))
+        .mockRejectedValueOnce(new TypeError('fetch failed'))
+        .mockRejectedValueOnce(new TypeError('fetch failed'))
+        .mockResolvedValueOnce(okResponse())
+        .mockResolvedValueOnce(okResponse())
+        .mockResolvedValueOnce(okResponse());
+      vi.stubGlobal('fetch', fetchMock);
+
+      await expect(newsAdapterInternal.writeNewsRecordViaRelayRest({
+        client,
+        path: '/vh/news/latest-index',
+        record: { story_id: STORY.story_id, ok: true },
+        writeClass: 'news-latest-index',
+        validate: (payload) => payload.ok === true,
+      })).resolves.toBeUndefined();
+
+      expect(fetchMock).toHaveBeenCalledTimes(6);
+      expect(warn).toHaveBeenCalledWith(
+        '[vh:news] relay REST write transport-unavailable; retrying',
+        expect.objectContaining({
+          attempt: 1,
+          max_attempts: 2,
+          retry_delay_ms: 1,
+        }),
+      );
+    } finally {
+      warn.mockRestore();
+      vi.unstubAllGlobals();
+      restoreEnv();
+      restoreRuntimeConfig();
+    }
+  });
+
   it('writeNewsLatestIndexEntry throws the typed transport-total error after exhausting retries', async () => {
     const restoreRuntimeConfig = withGunClientRuntimeConfig({
       VH_NEWS_RELAY_REST_WRITE_FIRST: 'true',

--- a/packages/gun-client/src/newsAdapters.ts
+++ b/packages/gun-client/src/newsAdapters.ts
@@ -2508,7 +2508,8 @@ async function writeNewsRecordViaRelayRest(input: {
     if (!isTransportTotalOutcome(outcome) || attempt >= maxAttempts) {
       break;
     }
-    const delayMs = retryPlan.backoffMs[Math.min(attempt - 1, retryPlan.backoffMs.length - 1)] ?? 0;
+    const backoffIndex = Math.min(attempt - 1, retryPlan.backoffMs.length - 1);
+    const delayMs = retryPlan.backoffMs[backoffIndex]!;
     lumaLog('warn', '[vh:news] relay REST write transport-unavailable; retrying', {
       write_class: input.writeClass,
       path: input.path,

--- a/packages/gun-client/src/newsAdapters.ts
+++ b/packages/gun-client/src/newsAdapters.ts
@@ -430,6 +430,110 @@ function relayRestNetworkClassification(error: unknown): string {
   return 'error';
 }
 
+/**
+ * Thrown when a relay REST news write fan-out gets ZERO relay successes and
+ * every per-relay failure is transport-class (the fetch itself threw — DNS
+ * resolution, connection refusal, connection reset — with no HTTP response
+ * received from any relay). No relay ACKNOWLEDGED the write. A response-leg
+ * reset can, in principle, occur after a relay applied the write, and the
+ * network-level cause may be relay-side (fleet down, TLS failure) rather
+ * than host-side — so this classification means "unacknowledged everywhere",
+ * not "provably unpublished" or "host network at fault". Retrying is safe
+ * regardless: the record is encoded once and re-sent byte-identical, and all
+ * relay news writes are id-keyed idempotent upserts (created_at is
+ * first-write-wins server-side), so a re-send cannot double-publish or
+ * diverge state.
+ */
+export class RelayRestTransportTotalFailureError extends Error {
+  readonly relayRestTransportTotalFailure = true;
+
+  readonly path: string;
+
+  readonly attemptCount: number;
+
+  constructor(message: string, options: { readonly path: string; readonly attemptCount: number }) {
+    super(message);
+    this.name = 'RelayRestTransportTotalFailureError';
+    this.path = options.path;
+    this.attemptCount = options.attemptCount;
+  }
+}
+
+/** Brand-based guard so duplicated package instances cannot break detection. */
+export function isRelayRestTransportTotalFailureError(
+  error: unknown,
+): error is RelayRestTransportTotalFailureError {
+  return error instanceof Error
+    && (error as { relayRestTransportTotalFailure?: unknown }).relayRestTransportTotalFailure === true;
+}
+
+/**
+ * Transport-class means the fetch threw with a network-level cause and no
+ * HTTP response was ever received. Aborts/timeouts are deliberately NOT
+ * transport-class: a hung relay may have received the request, and masking
+ * relay-side slowness with retries would hide capacity problems that the
+ * backpressure path (#675) exists to surface.
+ */
+function isTransportClassRelayWriteFailure(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  if (error.name === 'AbortError' || /abort|timeout/i.test(error.message)) return false;
+  const cause = (error as { cause?: unknown }).cause;
+  const causeText = cause instanceof Error
+    ? `${(cause as NodeJS.ErrnoException).code ?? ''} ${cause.name} ${cause.message}`
+    : cause === undefined || cause === null
+      ? ''
+      : String(cause);
+  // undici wraps dispatcher timeouts as TypeError('fetch failed') with the
+  // real cause underneath. A headers/body timeout means the request WAS
+  // delivered and the relay is hanging — that is relay-side slowness, not
+  // transport-total, so it must keep single-pass semantics like aborts.
+  // (UND_ERR_CONNECT_TIMEOUT stays transport-class: TCP never opened.)
+  if (/UND_ERR_HEADERS_TIMEOUT|UND_ERR_BODY_TIMEOUT|HeadersTimeoutError|BodyTimeoutError|headers timeout|body timeout/i.test(causeText)) {
+    return false;
+  }
+  const combined = `${error.message} ${causeText}`;
+  return /fetch failed|getaddrinfo|econnrefused|enotfound|eai_again|econnreset|ehostunreach|enetunreach|socket hang up|network/i.test(combined);
+}
+
+const RELAY_REST_TRANSPORT_RETRY_COUNT_ENV = [
+  'VITE_VH_NEWS_RELAY_REST_TRANSPORT_RETRY_COUNT',
+  'VH_NEWS_RELAY_REST_TRANSPORT_RETRY_COUNT',
+];
+const RELAY_REST_TRANSPORT_RETRY_BACKOFF_ENV = [
+  'VITE_VH_NEWS_RELAY_REST_TRANSPORT_RETRY_BACKOFF_MS',
+  'VH_NEWS_RELAY_REST_TRANSPORT_RETRY_BACKOFF_MS',
+];
+const RELAY_REST_TRANSPORT_RETRY_COUNT_DEFAULT = 2;
+const RELAY_REST_TRANSPORT_RETRY_COUNT_MAX = 5;
+const RELAY_REST_TRANSPORT_RETRY_BACKOFF_DEFAULT_MS = [5_000, 15_000] as const;
+const RELAY_REST_TRANSPORT_RETRY_BACKOFF_MAX_MS = 60_000;
+
+function resolveRelayRestTransportRetryPlan(): { retries: number; backoffMs: readonly number[] } {
+  const rawCount = readFirstRuntimeString(RELAY_REST_TRANSPORT_RETRY_COUNT_ENV);
+  const parsedCount = rawCount === undefined ? RELAY_REST_TRANSPORT_RETRY_COUNT_DEFAULT : Number.parseInt(rawCount, 10);
+  // Negative values read as "disable retries" (clamp to 0); non-numeric
+  // garbage falls back to the default rather than silently disabling.
+  const retries = Number.isFinite(parsedCount)
+    ? Math.min(Math.max(parsedCount, 0), RELAY_REST_TRANSPORT_RETRY_COUNT_MAX)
+    : RELAY_REST_TRANSPORT_RETRY_COUNT_DEFAULT;
+  const rawBackoff = readFirstRuntimeString(RELAY_REST_TRANSPORT_RETRY_BACKOFF_ENV);
+  const parsedBackoff = rawBackoff === undefined
+    ? [...RELAY_REST_TRANSPORT_RETRY_BACKOFF_DEFAULT_MS]
+    : rawBackoff
+        .split(/[,\s]+/)
+        .map((value) => Number.parseInt(value, 10))
+        .filter((value) => Number.isFinite(value) && value >= 0)
+        .map((value) => Math.min(value, RELAY_REST_TRANSPORT_RETRY_BACKOFF_MAX_MS));
+  const backoffMs = parsedBackoff.length > 0 ? parsedBackoff : [...RELAY_REST_TRANSPORT_RETRY_BACKOFF_DEFAULT_MS];
+  return { retries, backoffMs };
+}
+
+function sleepMs(delayMs: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, delayMs);
+  });
+}
+
 function createRelayRestReadDiagnostics(endpoints: readonly string[]): RelayRestReadDiagnostics {
   return {
     endpointsAttempted: [...endpoints],
@@ -2313,64 +2417,121 @@ async function writeNewsRecordViaRelayRest(input: {
     endpoint,
     headers: requireNewsRelayDaemonAuthHeaders(endpoint),
   }));
-  const failures: string[] = [];
-  const failedEndpointLabels: string[] = [];
-  let successCount = 0;
 
-  for (const { endpoint, headers } of relayTargets) {
-    const endpointLabel = relayRestEndpointLabel(endpoint);
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), RELAY_REST_WRITE_TIMEOUT_MS);
-    try {
-      const response = await fetch(endpoint, {
-        method: 'POST',
-        headers: {
-          'content-type': 'application/json',
-          ...headers,
-        },
-        body: JSON.stringify({ record: input.record }),
-        signal: controller.signal,
-      });
-      const body = await response.text().catch(() => '');
-      const payload = (() => {
-        try {
-          return body.trim() ? JSON.parse(body) as Record<string, unknown> : null;
-        } catch {
-          return null;
+  interface RelayRestWriteFanoutOutcome {
+    readonly successCount: number;
+    readonly failures: readonly string[];
+    readonly failedEndpointLabels: readonly string[];
+    readonly transportClassFailureCount: number;
+  }
+
+  const attemptFanout = async (): Promise<RelayRestWriteFanoutOutcome> => {
+    const failures: string[] = [];
+    const failedEndpointLabels: string[] = [];
+    let successCount = 0;
+    let transportClassFailureCount = 0;
+
+    for (const { endpoint, headers } of relayTargets) {
+      const endpointLabel = relayRestEndpointLabel(endpoint);
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), RELAY_REST_WRITE_TIMEOUT_MS);
+      try {
+        const response = await fetch(endpoint, {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            ...headers,
+          },
+          body: JSON.stringify({ record: input.record }),
+          signal: controller.signal,
+        });
+        const body = await response.text().catch(() => '');
+        const payload = (() => {
+          try {
+            return body.trim() ? JSON.parse(body) as Record<string, unknown> : null;
+          } catch {
+            return null;
+          }
+        })();
+        if (response.ok && payload && input.validate(payload)) {
+          successCount += 1;
+          continue;
         }
-      })();
-      if (response.ok && payload && input.validate(payload)) {
-        successCount += 1;
-        continue;
+        const classification = classifyRelayRestHttpFailure(response.status, body);
+        failedEndpointLabels.push(endpointLabel);
+        failures.push(`${endpointLabel}:${classification}`);
+      } catch (error) {
+        if (isTransportClassRelayWriteFailure(error)) {
+          transportClassFailureCount += 1;
+        }
+        failedEndpointLabels.push(endpointLabel);
+        failures.push(`${endpointLabel}:${error instanceof Error ? error.message : String(error)}`);
+      } finally {
+        clearTimeout(timeout);
       }
-      const classification = classifyRelayRestHttpFailure(response.status, body);
-      failedEndpointLabels.push(endpointLabel);
-      failures.push(`${endpointLabel}:${classification}`);
-    } catch (error) {
-      failedEndpointLabels.push(endpointLabel);
-      failures.push(`${endpointLabel}:${error instanceof Error ? error.message : String(error)}`);
-    } finally {
-      clearTimeout(timeout);
+    }
+
+    return { successCount, failures, failedEndpointLabels, transportClassFailureCount };
+  };
+
+  const isTransportTotalOutcome = (outcome: RelayRestWriteFanoutOutcome): boolean =>
+    outcome.successCount === 0 && outcome.transportClassFailureCount >= endpoints.length;
+
+  const retryPlan = resolveRelayRestTransportRetryPlan();
+  const maxAttempts = 1 + retryPlan.retries;
+  let outcome: RelayRestWriteFanoutOutcome | undefined;
+  let attemptsUsed = 0;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    attemptsUsed = attempt;
+    outcome = await attemptFanout();
+
+    if (outcome.successCount >= quorum.requiredSuccessCount) {
+      lumaLog('info', '[vh:news] relay REST write completed', {
+        write_class: input.writeClass,
+        path: input.path,
+        relay_success_count: outcome.successCount,
+        relay_target_count: endpoints.length,
+        relay_required_success_count: quorum.requiredSuccessCount,
+        relay_failed_endpoint_labels: outcome.failedEndpointLabels,
+        require_all: quorum.requireAll,
+        min_success_configured: quorum.minSuccessConfigured,
+        relay_write_attempt: attempt,
+      });
+      return;
+    }
+
+    // Retry ONLY the transport-total case: zero relays acked and every
+    // failure was network-level, so nothing was published anywhere and the
+    // id-keyed upsert is safe to re-send. Any relay-returned response (500,
+    // 503 backpressure, 4xx) or abort/timeout keeps single-pass semantics.
+    if (!isTransportTotalOutcome(outcome) || attempt >= maxAttempts) {
+      break;
+    }
+    const delayMs = retryPlan.backoffMs[Math.min(attempt - 1, retryPlan.backoffMs.length - 1)] ?? 0;
+    lumaLog('warn', '[vh:news] relay REST write transport-unavailable; retrying', {
+      write_class: input.writeClass,
+      path: input.path,
+      relay_target_count: endpoints.length,
+      relay_failed_endpoint_labels: outcome.failedEndpointLabels,
+      attempt,
+      max_attempts: maxAttempts,
+      retry_delay_ms: delayMs,
+    });
+    if (delayMs > 0) {
+      await sleepMs(delayMs);
     }
   }
 
-  if (successCount >= quorum.requiredSuccessCount) {
-    lumaLog('info', '[vh:news] relay REST write completed', {
-      write_class: input.writeClass,
-      path: input.path,
-      relay_success_count: successCount,
-      relay_target_count: endpoints.length,
-      relay_required_success_count: quorum.requiredSuccessCount,
-      relay_failed_endpoint_labels: failedEndpointLabels,
-      require_all: quorum.requireAll,
-      min_success_configured: quorum.minSuccessConfigured,
-    });
-    return;
+  const finalOutcome = outcome as RelayRestWriteFanoutOutcome;
+  const failureMessage = `Relay REST news write failed for ${input.path}: ${finalOutcome.successCount}/${endpoints.length} succeeded; required=${quorum.requiredSuccessCount}; failed=${finalOutcome.failures.join('; ')}`;
+  if (isTransportTotalOutcome(finalOutcome)) {
+    throw new RelayRestTransportTotalFailureError(
+      `${failureMessage}; transport_unavailable_attempts=${attemptsUsed}`,
+      { path: input.path, attemptCount: attemptsUsed },
+    );
   }
-
-  throw new Error(
-    `Relay REST news write failed for ${input.path}: ${successCount}/${endpoints.length} succeeded; required=${quorum.requiredSuccessCount}; failed=${failures.join('; ')}`,
-  );
+  throw new Error(failureMessage);
 }
 
 function resolveLatestIndexRelayRestRead(
@@ -3352,6 +3513,8 @@ export const newsAdapterInternal = {
   relayRestEndpointLabel,
   resolveRelayRestWriteEndpoints,
   resolveNewsRelayRestWriteQuorum,
+  resolveRelayRestTransportRetryPlan,
+  isTransportClassRelayWriteFailure,
   shouldRequireAllNewsRelayRestWrites,
   shouldWriteNewsViaRelayRestFirst,
   classifyRelayRestHttpFailure,

--- a/services/news-aggregator/src/daemon.coverage.test.ts
+++ b/services/news-aggregator/src/daemon.coverage.test.ts
@@ -81,6 +81,29 @@ describe('news daemon coverage guards', () => {
     expect(__internal.NEWS_DAEMON_FAIL_CLOSED_EXIT_CODE).toBe(78);
   });
 
+  it('pins the transport-unavailable exit code outside RestartPreventExitStatus and clear of wrapper exit codes', () => {
+    expect(__internal.NEWS_DAEMON_TRANSPORT_UNAVAILABLE_EXIT_CODE).toBe(69);
+    expect(__internal.NEWS_DAEMON_TRANSPORT_UNAVAILABLE_EXIT_CODE).not.toBe(
+      __internal.NEWS_DAEMON_FAIL_CLOSED_EXIT_CODE,
+    );
+    // 75 is reserved by the production wrapper (sibling-daemon refusal, reap
+    // failure); the transport class must stay unambiguous at the unit layer.
+    expect(__internal.NEWS_DAEMON_TRANSPORT_UNAVAILABLE_EXIT_CODE).not.toBe(75);
+  });
+
+  it('resolves EX_UNAVAILABLE only for branded transport-total relay failures', () => {
+    const transportTotal = Object.assign(new Error('Relay REST news write failed: 0/3 succeeded'), {
+      relayRestTransportTotalFailure: true,
+    });
+    expect(__internal.resolveFailClosedExitCode(transportTotal)).toBe(69);
+    expect(__internal.resolveFailClosedExitCode(new Error('Relay REST news write failed: 1/3 succeeded'))).toBe(78);
+    expect(__internal.resolveFailClosedExitCode(undefined)).toBe(78);
+    expect(__internal.resolveFailClosedExitCode('fetch failed')).toBe(78);
+    expect(
+      __internal.resolveFailClosedExitCode({ relayRestTransportTotalFailure: true }),
+    ).toBe(78);
+  });
+
   it('handles runtime not-started path and start/stop idempotence', async () => {
     const logger = makeLogger();
     const timers = makeTimerControls();

--- a/services/news-aggregator/src/daemon.ts
+++ b/services/news-aggregator/src/daemon.ts
@@ -61,7 +61,13 @@ import {
   isTruthyFlag,
   shouldEnableBundleSynthesisFromEnv,
 } from './bundleSynthesisDaemonConfig';
-import { NEWS_DAEMON_FAIL_CLOSED_EXIT_CODE, isDirectExecution, runFromCli } from './daemonCli';
+import {
+  NEWS_DAEMON_FAIL_CLOSED_EXIT_CODE,
+  NEWS_DAEMON_TRANSPORT_UNAVAILABLE_EXIT_CODE,
+  isDirectExecution,
+  resolveFailClosedExitCode,
+  runFromCli,
+} from './daemonCli';
 import {
   createDaemonWriteLaneRegistry,
   type DaemonWriteLaneRegistry,
@@ -1135,7 +1141,13 @@ export async function startNewsAggregatorDaemonFromEnv(): Promise<NewsAggregator
       failClosedOnRuntimeError,
       onFailClosedRuntimeError: (error) => {
         console.error('[vh:news-daemon] fail-closed runtime error shutting down process', error);
-        closeExitCode = NEWS_DAEMON_FAIL_CLOSED_EXIT_CODE;
+        closeExitCode = resolveFailClosedExitCode(error);
+        if (closeExitCode === NEWS_DAEMON_TRANSPORT_UNAVAILABLE_EXIT_CODE) {
+          console.error(
+            '[vh:news-daemon] fail-close cause is relay transport-total (no relay acknowledged the write); exiting EX_UNAVAILABLE for bounded systemd restart',
+            { exit_code: NEWS_DAEMON_TRANSPORT_UNAVAILABLE_EXIT_CODE },
+          );
+        }
         setTimeout(() => {
           void processHandle?.stop().catch((stopError) => {
             console.error('[vh:news-daemon] fail-closed process shutdown failed', stopError);
@@ -1225,6 +1237,8 @@ export const __internal = {
   resolveLeaseHolderId,
   runFromCli,
   NEWS_DAEMON_FAIL_CLOSED_EXIT_CODE,
+  NEWS_DAEMON_TRANSPORT_UNAVAILABLE_EXIT_CODE,
+  resolveFailClosedExitCode,
   startNewsAggregatorDaemonFromEnv,
   verifyStoryClusterHealth,
   isTruthyFlag,

--- a/services/news-aggregator/src/daemonCli.ts
+++ b/services/news-aggregator/src/daemonCli.ts
@@ -1,8 +1,38 @@
 import { pathToFileURL } from 'node:url';
+import { isRelayRestTransportTotalFailureError } from '@vh/gun-client';
 
 export type ProcessLifecycle = Pick<typeof process, 'once' | 'exit'>;
 export type CliLogger = Pick<Console, 'info' | 'error'>;
 export const NEWS_DAEMON_FAIL_CLOSED_EXIT_CODE = 78;
+
+/**
+ * EX_UNAVAILABLE: the fail-close cause was a relay transport-total failure —
+ * zero relays ACKNOWLEDGED the write (network-level fetch failure on every
+ * endpoint, no HTTP response received), so no write-safety invariant is in
+ * doubt and the writes are id-keyed idempotent upserts. systemd restarts this
+ * exit code (`Restart=on-failure`; only 78 is in `RestartPreventExitStatus`),
+ * bounded by `StartLimitBurst`/`StartLimitIntervalSec`, giving transient
+ * network blips a bounded self-recovery path while genuine write-safety halts
+ * stay parked on 78 for operator inspection.
+ *
+ * 69 is chosen deliberately: the production wrapper already uses exit 75 for
+ * sibling-daemon refusal and reap failures, so 75 would conflate a
+ * duplicate-daemon incident (needs operator action) with a transport blip
+ * (self-recovers). No other publisher tooling emits 69, so
+ * ExecMainStatus=69 identifies this class unambiguously at the unit layer.
+ */
+export const NEWS_DAEMON_TRANSPORT_UNAVAILABLE_EXIT_CODE = 69;
+
+/**
+ * Fail-close always halts the process; only the exit code differs. Transport-
+ * total relay failures exit EX_UNAVAILABLE(69) for bounded systemd restart;
+ * every other fail-close cause keeps the non-restarting write-safety code 78.
+ */
+export function resolveFailClosedExitCode(error: unknown): number {
+  return isRelayRestTransportTotalFailureError(error)
+    ? NEWS_DAEMON_TRANSPORT_UNAVAILABLE_EXIT_CODE
+    : NEWS_DAEMON_FAIL_CLOSED_EXIT_CODE;
+}
 
 export interface CliDaemonProcessHandle {
   stop(): Promise<void>;

--- a/services/news-aggregator/src/daemonWriteLane.test.ts
+++ b/services/news-aggregator/src/daemonWriteLane.test.ts
@@ -193,6 +193,62 @@ describe('daemonWriteLane', () => {
     );
   });
 
+  it('propagates the transport-total brand onto lane-stopped rejections so the fail-close exit code survives', async () => {
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    const lane = createDaemonWriteLaneRegistry({
+      logger,
+      defaultConcurrency: 1,
+      stopClassOnFailure: (writeClass) => writeClass === 'news_bundle',
+    });
+    const brandedTransportTotal = Object.assign(
+      new Error('Relay REST news write failed for /vh/news/hot-index: 0/3 succeeded; required=2'),
+      { relayRestTransportTotalFailure: true },
+    );
+
+    let releaseFailingWrite: (() => void) | null = null;
+    const failingWrite = lane.run('news_bundle', { story_id: 'story-a' }, () =>
+      new Promise<never>((_resolve, reject) => {
+        releaseFailingWrite = () => reject(brandedTransportTotal);
+      }));
+    // Queue a pending write behind the failing one (concurrency 1) so the
+    // stop path rejects it while it is still pending.
+    const pendingWrite = lane.run('news_bundle', { story_id: 'story-b' }, async () => 'unreachable');
+    while (!releaseFailingWrite) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+    releaseFailingWrite();
+
+    const failingError = await failingWrite.then(() => null, (error: unknown) => error);
+    const pendingError = await pendingWrite.then(() => null, (error: unknown) => error);
+    expect((failingError as { relayRestTransportTotalFailure?: unknown }).relayRestTransportTotalFailure).toBe(true);
+    expect(pendingError).toBeInstanceOf(Error);
+    expect((pendingError as Error).message).toContain('daemon write lane stopped after failure: news_bundle');
+    expect((pendingError as { relayRestTransportTotalFailure?: unknown }).relayRestTransportTotalFailure).toBe(true);
+
+    // Later writes on the stopped lane carry the brand too: a restart is the
+    // correct recovery for a lane stopped by a transport-total event.
+    const laterError = await lane
+      .run('news_bundle', { story_id: 'story-c' }, async () => 'unreachable')
+      .then(() => null, (error: unknown) => error);
+    expect((laterError as { relayRestTransportTotalFailure?: unknown }).relayRestTransportTotalFailure).toBe(true);
+
+    // A lane stopped by a NON-transport failure keeps plain rejections.
+    const plainLane = createDaemonWriteLaneRegistry({
+      logger,
+      defaultConcurrency: 1,
+      stopClassOnFailure: () => true,
+    });
+    await expect(
+      plainLane.run('news_bundle', { story_id: 'story-d' }, async () => {
+        throw new Error('relay returned 500');
+      }),
+    ).rejects.toThrow('relay returned 500');
+    const plainStopError = await plainLane
+      .run('news_bundle', { story_id: 'story-e' }, async () => 'unreachable')
+      .then(() => null, (error: unknown) => error);
+    expect((plainStopError as { relayRestTransportTotalFailure?: unknown }).relayRestTransportTotalFailure).toBeUndefined();
+  });
+
   it('paces product-feed repair writes with dedicated concurrency-one lanes', async () => {
     const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
     let releaseFirstRepair: (() => void) | null = null;

--- a/services/news-aggregator/src/daemonWriteLane.ts
+++ b/services/news-aggregator/src/daemonWriteLane.ts
@@ -34,6 +34,26 @@ interface LaneState {
   failedCount: number;
   durations: number[];
   stopped: boolean;
+  stoppedByTransportTotalFailure: boolean;
+}
+
+// Mirrors the RelayRestTransportTotalFailureError brand from @vh/gun-client.
+// Lane-stopped rejection errors must carry the brand of the error that stopped
+// the lane, or the daemon's fail-close exit-code classification sees a plain
+// Error and a transport-total event loses its bounded-restart exit code.
+const TRANSPORT_TOTAL_BRAND = 'relayRestTransportTotalFailure';
+
+function isTransportTotalBrandedError(error: unknown): boolean {
+  return error instanceof Error
+    && (error as { relayRestTransportTotalFailure?: unknown }).relayRestTransportTotalFailure === true;
+}
+
+function laneStoppedError(writeClass: string, transportTotal: boolean): Error {
+  const error = new Error(`daemon write lane stopped after failure: ${writeClass}`);
+  if (transportTotal) {
+    (error as { relayRestTransportTotalFailure?: boolean })[TRANSPORT_TOTAL_BRAND] = true;
+  }
+  return error;
 }
 
 export interface DaemonWriteLaneOptions {
@@ -83,6 +103,7 @@ export function createDaemonWriteLaneRegistry(
       failedCount: 0,
       durations: [],
       stopped: false,
+      stoppedByTransportTotalFailure: false,
     };
     lanes.set(writeClass, created);
     return created;
@@ -162,9 +183,10 @@ export function createDaemonWriteLaneRegistry(
           });
           if (shouldStopClassOnFailure(writeClass) && !state.stopped) {
             state.stopped = true;
+            state.stoppedByTransportTotalFailure = isTransportTotalBrandedError(error);
             const pending = state.pending.splice(0);
             for (const pendingItem of pending) {
-              pendingItem.reject(new Error(`daemon write lane stopped after failure: ${writeClass}`));
+              pendingItem.reject(laneStoppedError(writeClass, state.stoppedByTransportTotalFailure));
             }
             logger.error('[vh:news-daemon] write lane stopped after failure', {
               write_class: writeClass,
@@ -189,7 +211,7 @@ export function createDaemonWriteLaneRegistry(
       }
       const state = stateFor(writeClass);
       if (state.stopped) {
-        return Promise.reject(new Error(`daemon write lane stopped after failure: ${writeClass}`));
+        return Promise.reject(laneStoppedError(writeClass, state.stoppedByTransportTotalFailure));
       }
       return new Promise<T>((resolve, reject) => {
         state.pending.push({

--- a/tools/scripts/news-aggregator-publisher-liveness-watch.mjs
+++ b/tools/scripts/news-aggregator-publisher-liveness-watch.mjs
@@ -130,6 +130,14 @@ function readJournal(unit, lines, spawnSyncImpl = spawnSync) {
 
 function classifyJournal(journalText, properties) {
   const text = String(journalText ?? '');
+  // Classified by ExecMainStatus ONLY: exit 69 is emitted exclusively by the
+  // daemon's transport-total fail-close (the wrapper's own refusal paths use
+  // 75/78). Matching journal text here would let a stale transport-total line
+  // from an earlier recovered incident mislabel a current exit-78
+  // write-safety park still inside the journal window.
+  if (String(properties.ExecMainStatus ?? '').trim() === '69') {
+    return 'exit_69_transport_unavailable';
+  }
   if (/fail-closed runtime error|runtime error triggered fail-closed stop/i.test(text)) {
     return 'fail_closed_runtime_error';
   }

--- a/tools/scripts/news-aggregator-publisher-liveness-watch.test.mjs
+++ b/tools/scripts/news-aggregator-publisher-liveness-watch.test.mjs
@@ -214,6 +214,52 @@ test('publisher liveness classifies exit 78 fail-close and guard refusal separat
     });
     assert.equal(guardRefusal.status, 'fail');
     assert.equal(guardRefusal.failureClass, 'guard_refusal');
+
+    const transportUnavailable = await runNewsAggregatorPublisherLivenessWatch({
+      now: NOW,
+      env: baseEnv(paths),
+      systemctlShowText: failedSystemctl({ status: 69 }),
+      journalText: [
+        '[vh:news-daemon] fail-closed runtime error shutting down process',
+        '[vh:news-daemon] fail-close cause is relay transport-total (no relay acknowledged the write); exiting EX_UNAVAILABLE for bounded systemd restart',
+      ].join('\n'),
+    });
+    assert.equal(transportUnavailable.status, 'fail');
+    assert.equal(transportUnavailable.failureClass, 'exit_69_transport_unavailable');
+
+    const transportUnavailableByStatusOnly = await runNewsAggregatorPublisherLivenessWatch({
+      now: NOW,
+      env: baseEnv(paths),
+      systemctlShowText: failedSystemctl({ status: 69 }),
+      journalText: '',
+    });
+    assert.equal(transportUnavailableByStatusOnly.status, 'fail');
+    assert.equal(transportUnavailableByStatusOnly.failureClass, 'exit_69_transport_unavailable');
+
+    // Regression: a stale transport-total line from an earlier recovered
+    // incident must NOT relabel a current exit-78 write-safety park.
+    const staleTransportLineWithCurrent78Park = await runNewsAggregatorPublisherLivenessWatch({
+      now: NOW,
+      env: baseEnv(paths),
+      systemctlShowText: failedSystemctl({ status: 78 }),
+      journalText: [
+        '[vh:news-daemon] fail-close cause is relay transport-total (no relay acknowledged the write); exiting EX_UNAVAILABLE for bounded systemd restart',
+        '[vh:news-daemon] fail-closed runtime error shutting down process',
+      ].join('\n'),
+    });
+    assert.equal(staleTransportLineWithCurrent78Park.status, 'fail');
+    assert.equal(staleTransportLineWithCurrent78Park.failureClass, 'fail_closed_runtime_error');
+
+    // The wrapper's own exit-75 refusal paths (sibling daemon, reap failure)
+    // must never classify as transport-unavailable.
+    const wrapperSiblingRefusal = await runNewsAggregatorPublisherLivenessWatch({
+      now: NOW,
+      env: baseEnv(paths),
+      systemctlShowText: failedSystemctl({ status: 75 }),
+      journalText: '[vh:news-daemon:prod] refusing start: existing news daemon runtime process(es)',
+    });
+    assert.equal(wrapperSiblingRefusal.status, 'fail');
+    assert.notEqual(wrapperSiblingRefusal.failureClass, 'exit_69_transport_unavailable');
   } finally {
     rmSync(paths.root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Incident (outage #3)

`2026-07-04T17:19:46Z`, tick 158: a transient host DNS blip made all three relay REST hot-index writes fail at **fetch level** — `0/3 succeeded; failed=gun-a/b/c fetch failed`, no HTTP response from any relay, relays healthy throughout. The publisher classified this as a write-safety event and parked permanently (exit 78). Result: ~20h of silent feed staleness for a self-healing network condition in which **no relay had acknowledged anything**.

## Fix (two seams, no deploy in this PR)

1. **Bounded in-write transport retry** — `writeNewsRecordViaRelayRest` (the single fan-out shared by all four critical routes: story, latest-index, hot-index, synthesis-lifecycle). When an attempt yields **zero successes** and **every** failure is transport-class (fetch threw; aborts/timeouts and undici header/body dispatcher timeouts excluded), retry the full fan-out with bounded backoff (`VH_NEWS_RELAY_REST_TRANSPORT_RETRY_COUNT` default 2, cap 5; `VH_NEWS_RELAY_REST_TRANSPORT_RETRY_BACKOFF_MS` default `5000,15000`, cap 60s). On exhaustion, throw typed/branded `RelayRestTransportTotalFailureError`. **Any** relay-returned response (500/503/4xx), any ack, or any abort keeps byte-identical single-pass semantics — quorum math untouched, #675 backpressure semantics untouched. Retry safety rests on id-keyed idempotent upserts re-sent byte-identical.

2. **Restartable fail-close exit code** — `resolveFailClosedExitCode`: exit **69 (`EX_UNAVAILABLE`)** for the branded error, 78 for everything else. Fail-close behavior is otherwise identical (writes blocked, teardown, halt). systemd restarts 69 (`Restart=on-failure`; only 78 is in `RestartPreventExitStatus`), bounded by `StartLimitBurst=3/10min`. **69, deliberately not 75**: the production wrapper already exits 75 for sibling-daemon refusal and reap failures — 75 would label a duplicate-daemon incident as a self-recovering blip.

## Hardening from adversarial verification (4 refute lenses, findings all addressed)

- **Brand propagation in `daemonWriteLane`**: lane-stopped rejections (pending and subsequent) now carry the transport-total brand when the lane was stopped by a branded error — otherwise the plain "lane stopped" rejection wins the race to `onError` and silently degrades the restartable exit to a park.
- **Liveness classification from `ExecMainStatus` only** (`exit_69_transport_unavailable`), never journal text — a stale transport line inside the journal window can no longer relabel a later genuine exit-78 write-safety park, and the wrapper's exit-75 refusals stay distinct. Regression tests cover both.
- **Honest wording**: "no relay **acknowledged** the write" (not "provably unpublished" — a response-leg reset can land after a relay applied a write); relay-side causes (fleet down, TLS failure) classify identically and the runbook says to check the relay fleet too; recovery timing documented as seconds (in-process) vs minutes (unit restart through wrapper preflights); undici cause-level header/body timeouts excluded from transport-class (relay-side slowness must keep single-pass semantics).

## Behavior summary

| Condition | Before | After |
|---|---|---|
| Seconds-long network blip mid-write | exit 78, parked forever | absorbed in-write, tick completes |
| Minutes-long blip | exit 78, parked forever | exit 69 → systemd restart → self-heals |
| Persistent outage failing at startup | exit 78, parked | parks after 3 attempts/10min (burst) |
| Any relay acked / returned HTTP error / abort | exit 78, parked | **unchanged** (byte-identical message, exit 78) |

## Validation

- gun-client: 161/161 (6 new tests: retry-then-succeed, typed exhaustion, mixed-no-retry, abort-no-retry, undici-timeout-no-retry, retries-disabled)
- news-aggregator: 519/519 (new: exit-code pins incl. not-75, resolver negatives, lane brand propagation incl. plain-lane control)
- publisher liveness watch: 6/6 (new cases: 69 classification, stale-line-with-78-park regression, wrapper-75 non-conflation)
- `tsc --noEmit` clean (gun-client, news-aggregator); docs governance PASS; `git diff --check` clean

## Deploy note (operator)

No deploy/restart in this PR. Deploying requires the standard gun-client dist rebuild (daemonCli imports the new guard from `@vh/gun-client`; a stale dist fails loudly at module load). Independent infra hardening worth doing alongside: pin the three relay hostnames in A6 `/etc/hosts` (same box) to remove the DNS dependency from the local write path entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)