### PR TITLE
Classify publisher exit 69 in public feed alert watch

### DIFF
--- a/docs/ops/public-feed-freshness-monitor.md
+++ b/docs/ops/public-feed-freshness-monitor.md
@@ -48,7 +48,20 @@ read-only publisher unit check and sends a state-change-only alert when either:
 - the public latest-index freshness monitor fails the 6-hour SLO or public
   health checks;
 - `vh-news-aggregator.service` is not `active/running`;
+- the publisher unit is in the #706 transport-total restart path with
+  `ExecMainStatus=69`;
 - the publisher unit is parked with `ExecMainStatus=78`.
+
+Publisher exit classification is intentionally split:
+
+- `exit_69_transport_unavailable` is warning-severity. It means the daemon saw a
+  branded all-relay transport-total REST failure and exited with `69`, which is
+  restartable by the managed systemd unit (`Restart=on-failure`;
+  `RestartPreventExitStatus=78`). The alert exists so the operator can confirm
+  self-recovery instead of discovering a stale feed later.
+- `exit_78_fail_closed` is critical-severity. It remains the non-restarting
+  write-safety park and requires operator inspection before publisher writes
+  resume.
 
 The alert output is secret-safe. It records statuses, blockers, counts, ages,
 and origin hashes only; it does not include tokens, raw feed payloads, story
@@ -66,15 +79,15 @@ The script supports two delivery channels configured by environment only:
 | `VH_PUBLIC_FEED_ALERT_TEST_FIRE` | Set to `1` for a one-shot delivery test without changing the observed pass/fail result. |
 | `VH_PUBLIC_FEED_ALERT_STATE_DIR` | Default `~/.local/state/vhc/public-feed-alert`. |
 
-State-change-only delivery means a repeated stale feed or repeated exit-78
-publisher state does not spam every timer tick. A transition into failure sends,
-a transition out of failure sends, and a heartbeat sends only when explicitly
-configured. The state fingerprint is based on failure class, publisher state,
-origin hashes, counts, and stale/fresh age state rather than the exact
-`newestAgeMs`, so an already-stale feed aging by another timer interval does not
-create a new alert by itself. A failed delivery is not treated as delivered; the
-next timer run retries the same observed failure until at least one configured
-channel succeeds.
+State-change-only delivery means a repeated stale feed, repeated exit-69
+restart state, or repeated exit-78 publisher state does not spam every timer
+tick. A transition into failure sends, a transition out of failure sends, and a
+heartbeat sends only when explicitly configured. The state fingerprint is based
+on failure class, publisher state, origin hashes, counts, and stale/fresh age
+state rather than the exact `newestAgeMs`, so an already-stale feed aging by
+another timer interval does not create a new alert by itself. A failed delivery
+is not treated as delivered; the next timer run retries the same observed
+failure until at least one configured channel succeeds.
 
 The repo ships user-systemd units but does not enable them:
 

--- a/tools/scripts/public-feed-alert-watch.mjs
+++ b/tools/scripts/public-feed-alert-watch.mjs
@@ -15,6 +15,8 @@ const STATE_SCHEMA_VERSION = 'vh-public-feed-alert-state-v1';
 const DEFAULT_UNIT = 'vh-news-aggregator.service';
 const DEFAULT_STATE_DIR = '.local/state/vhc/public-feed-alert';
 const DEFAULT_TIMEOUT_MS = 15_000;
+const NEWS_DAEMON_TRANSPORT_UNAVAILABLE_EXIT_CODE = '69';
+const NEWS_DAEMON_FAIL_CLOSED_EXIT_CODE = '78';
 const URL_IN_TEXT_PATTERN = /https?:\/\/[^\s"'<>)}\]]+?(?=:(?:[a-z][a-z0-9_-]*)(?::|$)|[\s"'<>)}\]]|$)/gi;
 
 function firstNonEmpty(...values) {
@@ -164,12 +166,37 @@ function inspectPublisherUnit({
   const result = properties.Result ?? null;
   const nRestarts = Number.parseInt(String(properties.NRestarts ?? ''), 10);
   const running = activeState === 'active' && subState === 'running';
-  const exit78 = String(execMainStatus ?? '').trim() === '78';
+  const normalizedExecMainStatus = String(execMainStatus ?? '').trim();
+  const exit69 = normalizedExecMainStatus === NEWS_DAEMON_TRANSPORT_UNAVAILABLE_EXIT_CODE;
+  const exit78 = normalizedExecMainStatus === NEWS_DAEMON_FAIL_CLOSED_EXIT_CODE;
+  const failureClass = exit69
+    ? 'exit_69_transport_unavailable'
+    : exit78
+      ? 'exit_78_fail_closed'
+      : !running
+        ? 'unit_not_running'
+        : 'none';
+  const severity = failureClass === 'none'
+    ? 'none'
+    : failureClass === 'exit_69_transport_unavailable'
+      ? 'warning'
+      : 'critical';
+  const recoveryHint = failureClass === 'exit_69_transport_unavailable'
+    ? 'systemd_restart_expected'
+    : failureClass === 'exit_78_fail_closed'
+      ? 'operator_required'
+      : !running
+        ? 'operator_inspection_required'
+        : 'none';
 
   if (!running && blockers.length === 0) {
-    blockers.push(exit78
-      ? `publisher_exit_78:${activeState ?? 'missing'}/${subState ?? 'missing'}`
-      : `publisher_not_running:${activeState ?? 'missing'}/${subState ?? 'missing'}`);
+    if (exit69) {
+      blockers.push(`publisher_exit_69_transport_unavailable:${activeState ?? 'missing'}/${subState ?? 'missing'}`);
+    } else if (exit78) {
+      blockers.push(`publisher_exit_78:${activeState ?? 'missing'}/${subState ?? 'missing'}`);
+    } else {
+      blockers.push(`publisher_not_running:${activeState ?? 'missing'}/${subState ?? 'missing'}`);
+    }
   }
 
   return {
@@ -181,7 +208,9 @@ function inspectPublisherUnit({
     execMainStatus,
     result,
     nRestarts: Number.isFinite(nRestarts) && nRestarts >= 0 ? nRestarts : null,
-    failureClass: exit78 ? 'exit_78_fail_closed' : !running ? 'unit_not_running' : 'none',
+    failureClass,
+    severity,
+    recoveryHint,
   };
 }
 

--- a/tools/scripts/public-feed-alert-watch.test.mjs
+++ b/tools/scripts/public-feed-alert-watch.test.mjs
@@ -33,6 +33,21 @@ function exit78Systemctl() {
   ].join('\n');
 }
 
+function exit69Systemctl({
+  activeState = 'activating',
+  subState = 'auto-restart',
+  nRestarts = 1,
+} = {}) {
+  return [
+    `ActiveState=${activeState}`,
+    `SubState=${subState}`,
+    `NRestarts=${nRestarts}`,
+    'ExecMainStatus=69',
+    'Result=exit-code',
+    '',
+  ].join('\n');
+}
+
 function freshnessSummary(overrides = {}) {
   const now = overrides.now ?? Date.parse('2026-07-02T18:00:00.000Z');
   return {
@@ -282,11 +297,88 @@ test('publisher exit 78 is a fail-close alert and can deliver through sendmail',
 
     assert.equal(summary.status, 'fail');
     assert.equal(summary.publisher.failureClass, 'exit_78_fail_closed');
+    assert.equal(summary.publisher.severity, 'critical');
+    assert.equal(summary.publisher.recoveryHint, 'operator_required');
     assert.match(summary.blockers.join('\n'), /publisher_exit_78/);
     assert.equal(summary.delivery.status, 'sent');
     assert.equal(mail.length, 1);
     assert.match(mail[0].input, /operator@example\.invalid/);
     assert.match(mail[0].input, /exit_78_fail_closed/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('publisher exit 69 is a warning transport alert distinct from exit 78', async () => {
+  const root = tempRoot();
+  const calls = [];
+  try {
+    const summary = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({
+      env: baseEnv(root, { VH_PUBLIC_FEED_ALERT_WEBHOOK_URL: 'https://hooks.example.invalid/token' }),
+      repoRoot: root,
+      now: Date.parse('2026-07-02T18:00:00.000Z'),
+      systemctlShowText: exit69Systemctl(),
+      freshnessMonitorImpl: async () => freshnessSummary(),
+      fetchImpl: async (url, init) => {
+        calls.push({ url, init });
+        return { ok: true, status: 204 };
+      },
+    });
+
+    assert.equal(summary.status, 'fail');
+    assert.equal(summary.publisher.failureClass, 'exit_69_transport_unavailable');
+    assert.equal(summary.publisher.severity, 'warning');
+    assert.equal(summary.publisher.recoveryHint, 'systemd_restart_expected');
+    assert.match(summary.blockers.join('\n'), /publisher_exit_69_transport_unavailable:activating\/auto-restart/);
+    assert.doesNotMatch(summary.blockers.join('\n'), /publisher_exit_78/);
+    assert.equal(summary.delivery.status, 'sent');
+    assert.equal(summary.delivery.reason, 'first_failure');
+    assert.equal(calls.length, 1);
+
+    const body = JSON.parse(calls[0].init.body);
+    assert.equal(body.publisher.failureClass, 'exit_69_transport_unavailable');
+    assert.equal(body.publisher.severity, 'warning');
+    assert.equal(body.publisher.recoveryHint, 'systemd_restart_expected');
+    assert.equal(JSON.stringify(body).includes('exit_78_fail_closed'), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('publisher recovery after exit 69 sends a state-changed pass alert', async () => {
+  const root = tempRoot();
+  const calls = [];
+  try {
+    const options = {
+      env: baseEnv(root, { VH_PUBLIC_FEED_ALERT_WEBHOOK_URL: 'https://hooks.example.invalid/token' }),
+      repoRoot: root,
+      freshnessMonitorImpl: async () => freshnessSummary(),
+      fetchImpl: async (url, init) => {
+        calls.push({ url, init });
+        return { ok: true, status: 204 };
+      },
+    };
+    const first = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({
+      ...options,
+      now: Date.parse('2026-07-02T18:00:00.000Z'),
+      systemctlShowText: exit69Systemctl({ activeState: 'failed', subState: 'failed', nRestarts: 3 }),
+    });
+    const second = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({
+      ...options,
+      now: Date.parse('2026-07-02T18:05:00.000Z'),
+      systemctlShowText: activeSystemctl(),
+    });
+
+    assert.equal(first.status, 'fail');
+    assert.equal(first.publisher.failureClass, 'exit_69_transport_unavailable');
+    assert.equal(second.status, 'pass');
+    assert.equal(second.observedStatus, 'pass');
+    assert.equal(second.publisher.failureClass, 'none');
+    assert.equal(second.publisher.severity, 'none');
+    assert.equal(second.publisher.recoveryHint, 'none');
+    assert.equal(second.delivery.status, 'sent');
+    assert.equal(second.delivery.reason, 'state_changed');
+    assert.equal(calls.length, 2);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- classify publisher ExecMainStatus=69 as exit_69_transport_unavailable in the public feed alert watcher
- add warning severity and systemd restart recovery hint while preserving exit_78_fail_closed as critical/operator-required
- document the exit-69 vs exit-78 alert semantics in the public feed freshness runbook

## Validation
- corepack pnpm@9.7.1 check:public-feed:alert-watch
- corepack pnpm@9.7.1 exec node --test tools/scripts/news-aggregator-publisher-liveness-watch.test.mjs tools/scripts/public-feed-alert-watch.test.mjs
- corepack pnpm@9.7.1 docs:check
- git diff --check

## Boundaries
- No live A6 actions taken.
- Did not alter relay quorum, critical readback semantics, test-fire delivery, or alert channel delivery plumbing.
- Left docs/plans/DISTRIBUTION_READINESS_GOAL_2026-07-05.md untracked and untouched.