### PR TITLE
Harden public feed alert classifications

### DIFF
--- a/docs/ops/news-aggregator-production-service.md
+++ b/docs/ops/news-aggregator-production-service.md
@@ -82,14 +82,15 @@ Current intended-live posture:
   the stagger while all three public-news relay votes remain co-located on A6.
 
 This launch state proves raw-fresh, v4-signed, product-visible cards with
-pending lifecycle rows, exit-69 restartability for the total relay transport
-class, and bounded first-tick recovery from a parked publisher. The post-#687
-bake still proves the known StoryCluster rerank truncation failure no longer
-interrupts the launched raw path. It does not prove alert delivery, unattended
-operation, current 48-hour sustained operation after outages #2/#3,
-retention/heap boundedness, accepted synthesis, frame tables, storyline overlays,
-topic synthesis, full public-beta readiness, mesh `release_ready`, production app
-canary readiness, or legal/commercial approval.
+pending lifecycle rows and bounded first-tick recovery from a parked publisher.
+Exit-69 restartability for the total relay transport class is configured and
+regression-tested, but it is not yet live-proven by an observed 69-to-restart
+cycle on A6. The post-#687 bake still proves the known StoryCluster rerank
+truncation failure no longer interrupts the launched raw path. It does not prove
+alert delivery, unattended operation, current 48-hour sustained operation after
+outages #2/#3, retention/heap boundedness, accepted synthesis, frame tables,
+storyline overlays, topic synthesis, full public-beta readiness, mesh
+`release_ready`, production app canary readiness, or legal/commercial approval.
 
 ## Hard Boundaries
 
@@ -417,16 +418,20 @@ seconds. A persistent outage that fails again immediately at startup parks the
 unit after three attempts inside the 10-minute burst window; failures spaced
 at tick cadence (beyond the burst window) re-attempt indefinitely — each
 attempt is a clean unacknowledged-everywhere fail-close, so the publisher
-self-heals without operator action whenever the network returns. The publisher
-liveness watch classifies this state as `exit_69_transport_unavailable` (from
+self-heals without operator action whenever the network returns before the
+start-limit window is exhausted. The publisher liveness watch classifies the
+bounded auto-restart state as `exit_69_transport_unavailable` (from
 `ExecMainStatus` only, never journal text, so a stale transport line cannot
-relabel a later genuine `78` park), and an `nrestarts_increased` blocker after
-a transport blip is the expected self-recovery signal. Investigate the network
-event — check the **relay fleet as well as host DNS/network**, since
-all-relays-unreachable classifies identically — but the publisher does not
-need a manual restart. Mixed outcomes (any relay acked, or any relay returned
-an HTTP error) never take this path: they keep the non-restarting exit `78`
-write-safety contract.
+relabel a later genuine `78` park). The public alert watch escalates a parked
+69 after start-limit exhaustion as `exit_69_start_limit_parked`, because that
+state is no longer self-recovering and requires operator restart after the
+network is healthy. An `nrestarts_increased` blocker after a transport blip is
+the expected self-recovery signal. Investigate the network event — check the
+**relay fleet as well as host DNS/network**, since all-relays-unreachable
+classifies identically — but the publisher does not need a manual restart while
+systemd remains in the bounded restart window. Mixed outcomes (any relay acked,
+or any relay returned an HTTP error) never take this path: they keep the
+non-restarting exit `78` write-safety contract.
 
 Verify the installed unit before an attended start:
 

--- a/docs/ops/public-feed-freshness-monitor.md
+++ b/docs/ops/public-feed-freshness-monitor.md
@@ -2,7 +2,7 @@
 
 > Status: Operational Monitor
 > Owner: VHC Launch Ops
-> Last Reviewed: 2026-07-03
+> Last Reviewed: 2026-07-05
 > Depends On: docs/ops/public-beta-launch-readiness-closeout.md, docs/reports/mesh-readiness-state-of-play-2026-06-12.md
 
 ## Purpose
@@ -57,8 +57,17 @@ Publisher exit classification is intentionally split:
 - `exit_69_transport_unavailable` is warning-severity. It means the daemon saw a
   branded all-relay transport-total REST failure and exited with `69`, which is
   restartable by the managed systemd unit (`Restart=on-failure`;
-  `RestartPreventExitStatus=78`). The alert exists so the operator can confirm
+  `RestartPreventExitStatus=78`) and systemd is still in the bounded
+  auto-restart window. The alert exists so the operator can confirm
   self-recovery instead of discovering a stale feed later.
+- `exit_69_start_limit_parked` is critical-severity. It means the same
+  transport-total class repeated until systemd exhausted `StartLimitBurst`, so
+  the publisher is no longer self-recovering and needs operator action after the
+  host/network path is healthy again.
+- `exit_75_wrapper_refusal` is critical-severity. It means the production
+  wrapper refused to start before the daemon owned the process, such as a
+  sibling-service or approval/preflight refusal, and requires operator
+  inspection.
 - `exit_78_fail_closed` is critical-severity. It remains the non-restarting
   write-safety park and requires operator inspection before publisher writes
   resume.
@@ -98,9 +107,15 @@ The service unit includes `TimeoutStartSec=180`, which bounds a hung
 freshness/publisher probe without making normal 15-second HTTP timeouts race the
 systemd start deadline.
 
-Operator enablement, after explicit approval:
+Operator enablement, after explicit approval.
+
+Block A: configure, install, test-fire, and stop on any failed or stale
+readback. Set `TEST_FIRE_STARTED_AT` immediately before the test-fire so the
+readback can prove the output was produced by this block.
 
 ```bash
+TEST_FIRE_STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
 mkdir -p ~/.config/vhc
 install -m 0600 /dev/null ~/.config/vhc/public-feed-alert.env
 $EDITOR ~/.config/vhc/public-feed-alert.env
@@ -117,14 +132,18 @@ systemctl --user daemon-reload
 systemctl --user set-environment VH_PUBLIC_FEED_ALERT_TEST_FIRE=1
 systemctl --user start vh-public-feed-alert-watch.service || true
 systemctl --user unset-environment VH_PUBLIC_FEED_ALERT_TEST_FIRE
+! systemctl --user show-environment | grep -q '^VH_PUBLIC_FEED_ALERT_TEST_FIRE='
 
 node - <<'NODE'
 const fs = require('node:fs');
 const path = `${process.env.HOME}/.local/state/vhc/public-feed-alert/latest.json`;
 const summary = JSON.parse(fs.readFileSync(path, 'utf8'));
+const startedAt = Date.parse(process.env.TEST_FIRE_STARTED_AT || '');
 console.log(JSON.stringify({
   status: summary.status,
   observedStatus: summary.observedStatus,
+  severity: summary.severity,
+  generatedAt: summary.generatedAt,
   blockers: summary.blockers,
   delivery: summary.delivery && {
     status: summary.delivery.status,
@@ -143,13 +162,34 @@ console.log(JSON.stringify({
 }, null, 2));
 if (summary.delivery?.status !== 'sent') {
   process.exitCode = 1;
+} else if (!Number.isFinite(startedAt) || Date.parse(summary.generatedAt || '') < startedAt) {
+  process.exitCode = 1;
 }
 NODE
 
 systemctl --user reset-failed vh-public-feed-alert-watch.service
+```
 
-# Enable only after the node readback shows delivery.status="sent" and the
-# operator confirms receipt on a device outside the A6 host.
+Block B: run only after the node readback in Block A shows
+`delivery.status="sent"` from this test-fire and the operator confirms receipt
+on a device outside the A6 host.
+
+```bash
+node - <<'NODE'
+const fs = require('node:fs');
+const path = `${process.env.HOME}/.local/state/vhc/public-feed-alert/latest.json`;
+const summary = JSON.parse(fs.readFileSync(path, 'utf8'));
+if (summary.delivery?.status !== 'sent') {
+  throw new Error(`alert delivery is not sent: ${summary.delivery?.status || 'missing'}`);
+}
+if (summary.delivery?.reason !== 'test_fire') {
+  throw new Error(`latest alert output is not a test-fire: ${summary.delivery?.reason || 'missing'}`);
+}
+if (!summary.generatedAt || Date.now() - Date.parse(summary.generatedAt) > 10 * 60 * 1000) {
+  throw new Error(`latest alert output is stale: ${summary.generatedAt || 'missing'}`);
+}
+NODE
+
 systemctl --user enable --now vh-public-feed-alert-watch.timer
 systemctl --user status vh-public-feed-alert-watch.timer --no-pager
 ```
@@ -164,11 +204,13 @@ timer until the channel returns a sent receipt and the operator receives it.
 Rollback:
 
 ```bash
+systemctl --user unset-environment VH_PUBLIC_FEED_ALERT_TEST_FIRE || true
 systemctl --user disable --now vh-public-feed-alert-watch.timer
 systemctl --user reset-failed vh-public-feed-alert-watch.service
 rm -f ~/.config/systemd/user/vh-public-feed-alert-watch.service
 rm -f ~/.config/systemd/user/vh-public-feed-alert-watch.timer
 systemctl --user daemon-reload
+! systemctl --user show-environment | grep -q '^VH_PUBLIC_FEED_ALERT_TEST_FIRE='
 ```
 
 Host-local relay snapshot freshness is covered separately by

--- a/tools/scripts/public-feed-alert-watch.mjs
+++ b/tools/scripts/public-feed-alert-watch.mjs
@@ -16,8 +16,14 @@ const DEFAULT_UNIT = 'vh-news-aggregator.service';
 const DEFAULT_STATE_DIR = '.local/state/vhc/public-feed-alert';
 const DEFAULT_TIMEOUT_MS = 15_000;
 const NEWS_DAEMON_TRANSPORT_UNAVAILABLE_EXIT_CODE = '69';
+const NEWS_DAEMON_WRAPPER_REFUSAL_EXIT_CODE = '75';
 const NEWS_DAEMON_FAIL_CLOSED_EXIT_CODE = '78';
 const URL_IN_TEXT_PATTERN = /https?:\/\/[^\s"'<>)}\]]+?(?=:(?:[a-z][a-z0-9_-]*)(?::|$)|[\s"'<>)}\]]|$)/gi;
+const SEVERITY_RANK = {
+  none: 0,
+  warning: 1,
+  critical: 2,
+};
 
 function firstNonEmpty(...values) {
   for (const value of values) {
@@ -67,8 +73,32 @@ function sanitizeAlertText(value) {
   return String(value ?? '').replace(URL_IN_TEXT_PATTERN, (url) => `url_hash:${hashValue(url)}`);
 }
 
+function sanitizeAlertError(error, redactions = []) {
+  let message = error instanceof Error ? error.message : String(error);
+  for (const raw of redactions) {
+    const value = String(raw ?? '');
+    if (value) {
+      message = message.split(value).join(`value_hash:${hashValue(value)}`);
+    }
+  }
+  return sanitizeAlertText(message);
+}
+
 function stableFingerprintText(value) {
-  return sanitizeAlertText(value).replace(/\b\d{4,}\b/g, '<n>');
+  return sanitizeAlertText(value)
+    .replace(/publisher_restart_churn:\d+\/\d+/g, 'publisher_restart_churn:<n>/<n>')
+    .replace(/\b\d{4,}\b/g, '<n>');
+}
+
+function maxSeverity(...values) {
+  let best = 'none';
+  for (const value of values) {
+    const severity = Object.hasOwn(SEVERITY_RANK, value) ? value : 'none';
+    if (SEVERITY_RANK[severity] > SEVERITY_RANK[best]) {
+      best = severity;
+    }
+  }
+  return best;
 }
 
 function freshnessAgeState(readback) {
@@ -157,7 +187,7 @@ function inspectPublisherUnit({
       systemctlShowText ?? readPublisherSystemctlShow(unit, spawnSyncImpl),
     );
   } catch (error) {
-    blockers.push(`publisher_systemctl_failed:${error instanceof Error ? error.message : String(error)}`);
+    blockers.push(`publisher_systemctl_failed:${sanitizeAlertError(error)}`);
   }
 
   const activeState = properties.ActiveState ?? null;
@@ -166,32 +196,49 @@ function inspectPublisherUnit({
   const result = properties.Result ?? null;
   const nRestarts = Number.parseInt(String(properties.NRestarts ?? ''), 10);
   const running = activeState === 'active' && subState === 'running';
+  const systemdRestarting = activeState === 'activating' || subState === 'auto-restart';
   const normalizedExecMainStatus = String(execMainStatus ?? '').trim();
   const exit69 = normalizedExecMainStatus === NEWS_DAEMON_TRANSPORT_UNAVAILABLE_EXIT_CODE;
+  const exit75 = normalizedExecMainStatus === NEWS_DAEMON_WRAPPER_REFUSAL_EXIT_CODE;
   const exit78 = normalizedExecMainStatus === NEWS_DAEMON_FAIL_CLOSED_EXIT_CODE;
-  const failureClass = exit69
-    ? 'exit_69_transport_unavailable'
-    : exit78
-      ? 'exit_78_fail_closed'
-      : !running
-        ? 'unit_not_running'
-        : 'none';
+  const startLimitHit = result === 'start-limit-hit';
+  const exit69Restarting = !running && exit69 && systemdRestarting && !startLimitHit;
+  const exit69Parked = !running && exit69 && (startLimitHit || !systemdRestarting);
+  const failureClass = running
+    ? 'none'
+    : exit69Restarting
+      ? 'exit_69_transport_unavailable'
+      : exit69Parked
+        ? 'exit_69_start_limit_parked'
+        : exit75
+          ? 'exit_75_wrapper_refusal'
+          : exit78
+            ? 'exit_78_fail_closed'
+            : 'unit_not_running';
   const severity = failureClass === 'none'
     ? 'none'
     : failureClass === 'exit_69_transport_unavailable'
       ? 'warning'
       : 'critical';
   const recoveryHint = failureClass === 'exit_69_transport_unavailable'
-    ? 'systemd_restart_expected'
+    ? 'bounded_systemd_restart_in_progress'
+    : failureClass === 'exit_69_start_limit_parked'
+      ? 'start_limit_exhausted_operator_restart_required'
     : failureClass === 'exit_78_fail_closed'
       ? 'operator_required'
+      : failureClass === 'exit_75_wrapper_refusal'
+        ? 'operator_required'
       : !running
         ? 'operator_inspection_required'
         : 'none';
 
   if (!running && blockers.length === 0) {
-    if (exit69) {
+    if (failureClass === 'exit_69_transport_unavailable') {
       blockers.push(`publisher_exit_69_transport_unavailable:${activeState ?? 'missing'}/${subState ?? 'missing'}`);
+    } else if (failureClass === 'exit_69_start_limit_parked') {
+      blockers.push(`publisher_exit_69_start_limit_parked:${activeState ?? 'missing'}/${subState ?? 'missing'}:${result ?? 'missing'}`);
+    } else if (failureClass === 'exit_75_wrapper_refusal') {
+      blockers.push(`publisher_exit_75_wrapper_refusal:${activeState ?? 'missing'}/${subState ?? 'missing'}:${result ?? 'missing'}`);
     } else if (exit78) {
       blockers.push(`publisher_exit_78:${activeState ?? 'missing'}/${subState ?? 'missing'}`);
     } else {
@@ -212,6 +259,20 @@ function inspectPublisherUnit({
     severity,
     recoveryHint,
   };
+}
+
+function previousPublisherRestartCount(previousState) {
+  const parsed = Number.parseInt(String(previousState?.lastPublisherNRestarts ?? ''), 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+}
+
+function restartChurnBlocker({ publisher, previousState }) {
+  const previousNRestarts = previousPublisherRestartCount(previousState);
+  const currentNRestarts = Number.isFinite(publisher?.nRestarts) ? publisher.nRestarts : null;
+  if (previousNRestarts === null || currentNRestarts === null || currentNRestarts <= previousNRestarts) {
+    return null;
+  }
+  return `publisher_restart_churn:${previousNRestarts}/${currentNRestarts}`;
 }
 
 function fingerprintFor({ status, blockers, publisher, freshness }) {
@@ -287,6 +348,7 @@ function alertPayload(summary, reason) {
     alertReason: reason,
     status: summary.status,
     observedStatus: summary.observedStatus,
+    severity: summary.severity,
     blockers: summary.blockers,
     fingerprint: summary.fingerprint,
     publisher: summary.publisher,
@@ -377,7 +439,7 @@ async function deliverAlert({
     try {
       channels.push(await deliverWebhook({ webhookUrl, payload, timeoutMs, fetchImpl }));
     } catch (error) {
-      errors.push(`webhook:${error instanceof Error ? error.message : String(error)}`);
+      errors.push(`webhook:${sanitizeAlertError(error, [webhookUrl])}`);
     }
   }
 
@@ -386,7 +448,7 @@ async function deliverAlert({
       const result = deliverEmail({ env, payload, spawnSyncImpl });
       if (result) channels.push(result);
     } catch (error) {
-      errors.push(`email:${error instanceof Error ? error.message : String(error)}`);
+      errors.push(`email:${sanitizeAlertError(error)}`);
     }
   }
 
@@ -421,6 +483,7 @@ async function persistState({
   nowIso,
   fingerprint,
   status,
+  publisher,
   delivery,
   previousState,
 }) {
@@ -441,6 +504,9 @@ async function persistState({
       : previousState?.lastDeliveredAt ?? null,
     lastDeliveryStatus: delivery.status,
     lastDeliveryReason: delivery.reason,
+    lastPublisherNRestarts: Number.isFinite(publisher?.nRestarts)
+      ? publisher.nRestarts
+      : previousState?.lastPublisherNRestarts ?? null,
   };
   await writeJson(stateFile, state);
   return state;
@@ -462,8 +528,10 @@ export async function runPublicFeedAlertWatch({
   const freshnessRaw = await freshnessMonitorImpl({ env, repoRoot, now });
   const freshness = summarizeFreshness(freshnessRaw);
   const publisher = inspectPublisherUnit({ env, systemctlShowText, spawnSyncImpl });
+  const restartChurn = restartChurnBlocker({ publisher, previousState });
   const observedBlockers = [
     ...publisher.blockers,
+    ...(restartChurn ? [restartChurn] : []),
     ...(freshness.status === 'pass'
       ? []
       : freshness.blockers.length > 0
@@ -471,6 +539,11 @@ export async function runPublicFeedAlertWatch({
         : [`public_feed_status:${freshness.status ?? 'missing'}`]),
   ];
   const observedStatus = observedBlockers.length === 0 ? 'pass' : 'fail';
+  const observedSeverity = maxSeverity(
+    publisher.severity,
+    restartChurn ? 'warning' : 'none',
+    freshness.status === 'pass' ? 'none' : 'critical',
+  );
   const fingerprint = fingerprintFor({
     status: observedStatus,
     blockers: observedBlockers,
@@ -490,6 +563,7 @@ export async function runPublicFeedAlertWatch({
     generatedAt,
     status: observedStatus,
     observedStatus,
+    severity: observedSeverity,
     blockers: observedBlockers,
     fingerprint,
     stateFile,
@@ -518,6 +592,7 @@ export async function runPublicFeedAlertWatch({
   };
   if (['failed', 'missing_channel'].includes(delivery.status)) {
     summary.status = 'fail';
+    summary.severity = maxSeverity(summary.severity, 'critical');
     summary.blockers.push(`alert_delivery_${delivery.status}`);
   }
 
@@ -526,6 +601,7 @@ export async function runPublicFeedAlertWatch({
     nowIso: generatedAt,
     fingerprint,
     status: observedStatus,
+    publisher,
     delivery,
     previousState,
   });
@@ -539,6 +615,7 @@ async function main() {
   console.info(JSON.stringify({
     status: summary.status,
     observedStatus: summary.observedStatus,
+    severity: summary.severity,
     blockers: summary.blockers,
     fingerprint: summary.fingerprint,
     delivery: summary.delivery,
@@ -555,6 +632,7 @@ export const publicFeedAlertWatchInternal = {
   boolEnv,
   fingerprintFor,
   inspectPublisherUnit,
+  maxSeverity,
   runPublicFeedAlertWatch,
   shouldDeliverAlert,
   summarizeFreshness,

--- a/tools/scripts/public-feed-alert-watch.test.mjs
+++ b/tools/scripts/public-feed-alert-watch.test.mjs
@@ -37,13 +37,30 @@ function exit69Systemctl({
   activeState = 'activating',
   subState = 'auto-restart',
   nRestarts = 1,
+  result = 'exit-code',
 } = {}) {
   return [
     `ActiveState=${activeState}`,
     `SubState=${subState}`,
     `NRestarts=${nRestarts}`,
     'ExecMainStatus=69',
-    'Result=exit-code',
+    `Result=${result}`,
+    '',
+  ].join('\n');
+}
+
+function exit75Systemctl({
+  activeState = 'failed',
+  subState = 'failed',
+  nRestarts = 0,
+  result = 'exit-code',
+} = {}) {
+  return [
+    `ActiveState=${activeState}`,
+    `SubState=${subState}`,
+    `NRestarts=${nRestarts}`,
+    'ExecMainStatus=75',
+    `Result=${result}`,
     '',
   ].join('\n');
 }
@@ -119,6 +136,7 @@ test('passing feed and active publisher do not require an alert channel', async 
 
     assert.equal(summary.status, 'pass');
     assert.equal(summary.observedStatus, 'pass');
+    assert.equal(summary.severity, 'none');
     assert.equal(summary.delivery.status, 'suppressed');
     assert.equal(summary.blockers.includes('alert_delivery_missing_channel'), false);
     assert.equal(summary.freshness.latestIndexReadbacks[0].storyIds, undefined);
@@ -149,6 +167,7 @@ test('stale feed sends a webhook on state change with secret-safe aggregate payl
     assert.equal(calls.length, 1);
     const body = JSON.parse(calls[0].init.body);
     assert.equal(body.alertReason, 'first_failure');
+    assert.equal(body.severity, 'critical');
     assert.equal(body.blockers.some((blocker) => blocker.includes('url_hash:')), true);
     assert.equal(body.freshness.latestIndexReadbacks[0].origin, undefined);
     assert.equal(body.freshness.latestIndexReadbacks[0].originHash.length, 16);
@@ -296,6 +315,7 @@ test('publisher exit 78 is a fail-close alert and can deliver through sendmail',
     });
 
     assert.equal(summary.status, 'fail');
+    assert.equal(summary.severity, 'critical');
     assert.equal(summary.publisher.failureClass, 'exit_78_fail_closed');
     assert.equal(summary.publisher.severity, 'critical');
     assert.equal(summary.publisher.recoveryHint, 'operator_required');
@@ -326,9 +346,10 @@ test('publisher exit 69 is a warning transport alert distinct from exit 78', asy
     });
 
     assert.equal(summary.status, 'fail');
+    assert.equal(summary.severity, 'warning');
     assert.equal(summary.publisher.failureClass, 'exit_69_transport_unavailable');
     assert.equal(summary.publisher.severity, 'warning');
-    assert.equal(summary.publisher.recoveryHint, 'systemd_restart_expected');
+    assert.equal(summary.publisher.recoveryHint, 'bounded_systemd_restart_in_progress');
     assert.match(summary.blockers.join('\n'), /publisher_exit_69_transport_unavailable:activating\/auto-restart/);
     assert.doesNotMatch(summary.blockers.join('\n'), /publisher_exit_78/);
     assert.equal(summary.delivery.status, 'sent');
@@ -337,15 +358,98 @@ test('publisher exit 69 is a warning transport alert distinct from exit 78', asy
 
     const body = JSON.parse(calls[0].init.body);
     assert.equal(body.publisher.failureClass, 'exit_69_transport_unavailable');
+    assert.equal(body.severity, 'warning');
     assert.equal(body.publisher.severity, 'warning');
-    assert.equal(body.publisher.recoveryHint, 'systemd_restart_expected');
+    assert.equal(body.publisher.recoveryHint, 'bounded_systemd_restart_in_progress');
     assert.equal(JSON.stringify(body).includes('exit_78_fail_closed'), false);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
 });
 
-test('publisher recovery after exit 69 sends a state-changed pass alert', async () => {
+test('publisher exit 69 parked by start limit is critical and not self-recovering', async () => {
+  const root = tempRoot();
+  const calls = [];
+  try {
+    const summary = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({
+      env: baseEnv(root, { VH_PUBLIC_FEED_ALERT_WEBHOOK_URL: 'https://hooks.example.invalid/token' }),
+      repoRoot: root,
+      now: Date.parse('2026-07-02T18:00:00.000Z'),
+      systemctlShowText: exit69Systemctl({
+        activeState: 'failed',
+        subState: 'failed',
+        nRestarts: 3,
+        result: 'start-limit-hit',
+      }),
+      freshnessMonitorImpl: async () => freshnessSummary(),
+      fetchImpl: async (url, init) => {
+        calls.push({ url, init });
+        return { ok: true, status: 204 };
+      },
+    });
+
+    assert.equal(summary.status, 'fail');
+    assert.equal(summary.severity, 'critical');
+    assert.equal(summary.publisher.failureClass, 'exit_69_start_limit_parked');
+    assert.equal(summary.publisher.severity, 'critical');
+    assert.equal(summary.publisher.recoveryHint, 'start_limit_exhausted_operator_restart_required');
+    assert.match(summary.blockers.join('\n'), /publisher_exit_69_start_limit_parked:failed\/failed:start-limit-hit/);
+    assert.doesNotMatch(summary.blockers.join('\n'), /publisher_exit_78/);
+    assert.equal(summary.delivery.status, 'sent');
+    assert.equal(calls.length, 1);
+
+    const body = JSON.parse(calls[0].init.body);
+    assert.equal(body.severity, 'critical');
+    assert.equal(body.publisher.failureClass, 'exit_69_start_limit_parked');
+    assert.equal(body.publisher.recoveryHint, 'start_limit_exhausted_operator_restart_required');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('publisher exit 69 with start-limit result is critical even if substate still says auto-restart', () => {
+  const publisher = publicFeedAlertWatchInternal.inspectPublisherUnit({
+    env: {},
+    systemctlShowText: exit69Systemctl({
+      activeState: 'activating',
+      subState: 'auto-restart',
+      nRestarts: 3,
+      result: 'start-limit-hit',
+    }),
+  });
+
+  assert.equal(publisher.status, 'fail');
+  assert.equal(publisher.failureClass, 'exit_69_start_limit_parked');
+  assert.equal(publisher.severity, 'critical');
+  assert.equal(publisher.recoveryHint, 'start_limit_exhausted_operator_restart_required');
+  assert.match(publisher.blockers.join('\n'), /publisher_exit_69_start_limit_parked/);
+});
+
+test('publisher exit 75 wrapper refusal is critical', async () => {
+  const root = tempRoot();
+  try {
+    const summary = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({
+      env: baseEnv(root, { VH_PUBLIC_FEED_ALERT_EMAIL_TO: 'operator@example.invalid' }),
+      repoRoot: root,
+      now: Date.parse('2026-07-02T18:00:00.000Z'),
+      systemctlShowText: exit75Systemctl(),
+      freshnessMonitorImpl: async () => freshnessSummary(),
+      spawnSyncImpl: () => ({ status: 0, stdout: '', stderr: '' }),
+    });
+
+    assert.equal(summary.status, 'fail');
+    assert.equal(summary.severity, 'critical');
+    assert.equal(summary.publisher.failureClass, 'exit_75_wrapper_refusal');
+    assert.equal(summary.publisher.severity, 'critical');
+    assert.equal(summary.publisher.recoveryHint, 'operator_required');
+    assert.match(summary.blockers.join('\n'), /publisher_exit_75_wrapper_refusal:failed\/failed:exit-code/);
+    assert.equal(summary.delivery.status, 'sent');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('publisher recovery after parked exit 69 sends a state-changed pass alert', async () => {
   const root = tempRoot();
   const calls = [];
   try {
@@ -370,7 +474,7 @@ test('publisher recovery after exit 69 sends a state-changed pass alert', async 
     });
 
     assert.equal(first.status, 'fail');
-    assert.equal(first.publisher.failureClass, 'exit_69_transport_unavailable');
+    assert.equal(first.publisher.failureClass, 'exit_69_start_limit_parked');
     assert.equal(second.status, 'pass');
     assert.equal(second.observedStatus, 'pass');
     assert.equal(second.publisher.failureClass, 'none');
@@ -379,6 +483,102 @@ test('publisher recovery after exit 69 sends a state-changed pass alert', async 
     assert.equal(second.delivery.status, 'sent');
     assert.equal(second.delivery.reason, 'state_changed');
     assert.equal(calls.length, 2);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('publisher restart churn is warning severity and dedupes by class', async () => {
+  const root = tempRoot();
+  const calls = [];
+  try {
+    const env = baseEnv(root, { VH_PUBLIC_FEED_ALERT_WEBHOOK_URL: 'https://hooks.example.invalid/token' });
+    const first = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({
+      env,
+      repoRoot: root,
+      now: Date.parse('2026-07-02T18:00:00.000Z'),
+      systemctlShowText: activeSystemctl(),
+      freshnessMonitorImpl: async () => freshnessSummary(),
+      fetchImpl: async () => ({ ok: true, status: 204 }),
+    });
+    assert.equal(first.status, 'pass');
+
+    const second = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({
+      env,
+      repoRoot: root,
+      now: Date.parse('2026-07-02T18:05:00.000Z'),
+      systemctlShowText: [
+        'ActiveState=active',
+        'SubState=running',
+        'NRestarts=1',
+        'ExecMainStatus=0',
+        'Result=success',
+        '',
+      ].join('\n'),
+      freshnessMonitorImpl: async () => freshnessSummary(),
+      fetchImpl: async (url, init) => {
+        calls.push({ url, init });
+        return { ok: true, status: 204 };
+      },
+    });
+    const third = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({
+      env,
+      repoRoot: root,
+      now: Date.parse('2026-07-02T18:10:00.000Z'),
+      systemctlShowText: [
+        'ActiveState=active',
+        'SubState=running',
+        'NRestarts=9',
+        'ExecMainStatus=0',
+        'Result=success',
+        '',
+      ].join('\n'),
+      freshnessMonitorImpl: async () => freshnessSummary(),
+      fetchImpl: async (url, init) => {
+        calls.push({ url, init });
+        return { ok: true, status: 204 };
+      },
+    });
+
+    assert.equal(second.status, 'fail');
+    assert.equal(second.observedStatus, 'fail');
+    assert.equal(second.severity, 'warning');
+    assert.deepEqual(second.blockers, ['publisher_restart_churn:0/1']);
+    assert.equal(second.delivery.status, 'sent');
+    assert.equal(second.delivery.reason, 'state_changed');
+    assert.equal(third.status, 'fail');
+    assert.equal(third.severity, 'warning');
+    assert.deepEqual(third.blockers, ['publisher_restart_churn:1/9']);
+    assert.equal(third.fingerprint, second.fingerprint);
+    assert.equal(third.delivery.status, 'suppressed');
+    assert.equal(calls.length, 1);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('webhook delivery errors redact configured webhook URL from output', async () => {
+  const root = tempRoot();
+  const webhookUrl = 'not-a-url-secret-token';
+  try {
+    const summary = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({
+      env: baseEnv(root, { VH_PUBLIC_FEED_ALERT_WEBHOOK_URL: webhookUrl }),
+      repoRoot: root,
+      now: Date.parse('2026-07-02T18:00:00.000Z'),
+      systemctlShowText: exit78Systemctl(),
+      freshnessMonitorImpl: async () => freshnessSummary(),
+      fetchImpl: async () => {
+        throw new TypeError(`Failed to parse URL from ${webhookUrl}`);
+      },
+    });
+
+    assert.equal(summary.status, 'fail');
+    assert.equal(summary.delivery.status, 'failed');
+    assert.match(summary.delivery.error, /value_hash:/);
+    assert.equal(summary.delivery.error.includes(webhookUrl), false);
+
+    const output = readFileSync(path.join(root, 'latest.json'), 'utf8');
+    assert.equal(output.includes(webhookUrl), false);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

- classify parked exit-69 start-limit exhaustion as `exit_69_start_limit_parked` with critical severity instead of self-recovery warning
- add `exit_75_wrapper_refusal`, top-level alert severity, and restart-churn visibility through persisted `NRestarts`
- sanitize webhook/email delivery errors before writing `latest.json` or stdout
- strengthen the alert enablement packet with a fresh test-fire readback gate and rollback test-fire cleanup
- correct the production-service claim: exit-69 restartability is configured/regression-tested, not live-proven on A6 yet

## Validation

- `corepack pnpm@9.7.1 check:public-feed:alert-watch`
- `corepack pnpm@9.7.1 exec node --test tools/scripts/news-aggregator-publisher-liveness-watch.test.mjs tools/scripts/public-feed-alert-watch.test.mjs`
- `corepack pnpm@9.7.1 docs:check`
- `git diff --check`

## Scope

Pre-enablement alert correctness only. No live A6 mutation, no timer enablement, no relay quorum changes, no retention/compaction/remediation, and no release-readiness claim.
