### PR TITLE
Add early heap capture analyzer

### DIFF
--- a/docs/ops/news-aggregator-production-service.md
+++ b/docs/ops/news-aggregator-production-service.md
@@ -266,6 +266,41 @@ StoryCluster watch plus relay graph metrics as the Scope A health surface:
 - publisher diagnostics continue to show completed ticks with
   `nonfatal_prewrite_failure_count=0` outside attended maintenance overlap.
 
+Early heap capture intake is intentionally summary-only. Raw `.heapsnapshot`
+and `.heapprofile` artifacts remain host-private diagnostic files; do not copy
+or paste them into tickets, PRs, reports, or agent context. When one or more
+relay `*.heap-summary.json` files appear after the staggered early-capture
+thresholds, classify them with:
+
+```bash
+cd /home/humble/VHC
+node tools/scripts/analyze-early-heap-captures.mjs \
+  --diagnostic-dir /path/to/relay-diagnostics \
+  --soak-archive-dir "$HOME/.local/state/vhc/phase5-scope-a-soak" \
+  --relay vhc-relay-a
+```
+
+The analyzer emits `vh-early-heap-capture-analysis-v1` JSON and reads only
+`*.heap-summary.json` plus optional soak-archive `manifest.json`,
+`relay-liveness.json`, and `publisher-liveness.json` files. Its output includes
+capture basenames, memory component deltas, graph live-byte deltas, tick deltas,
+and one of these retainer classes:
+
+| Class | Meaning |
+| --- | --- |
+| `js_heap_non_graph` | JS heap growth dominates while graph live bytes are too small to explain the growth. |
+| `external_native` | external or native-non-heap growth dominates the summary/delta. |
+| `arraybuffers` | ArrayBuffer growth dominates the summary/delta. |
+| `graph_after_all` | graph live user bytes dominate the growth; revisit the graph-retention hypothesis. |
+| `inconclusive_need_diff` | the summaries do not name a retainer class; collect the named missing measurement instead of guessing. |
+
+The analyzer deliberately rejects `.heapsnapshot` input paths and does not emit
+absolute host paths or heap-snapshot paths from summary metadata. A
+`classified` result is evidence for the next bounded-memory PR design; it is
+not an authorization to run retention, compaction, eviction, publisher clear, or
+relay remediation. Those remain blocked until the retainer class is named and a
+separate fix is reviewed.
+
 Approved publisher start packet:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "check:public-feed:fresh-propagation": "pnpm --filter @vh/e2e test:live:daemon-feed:build && node ./packages/e2e/src/live/public-feed-fresh-propagation-gate.mjs",
     "check:public-feed:freshness-monitor": "pnpm --filter @vh/gun-client... build && node ./tools/scripts/public-feed-freshness-monitor.mjs",
     "check:public-feed:alert-watch": "node --test ./tools/scripts/public-feed-alert-watch.test.mjs",
+    "check:early-heap-captures": "node --test ./tools/scripts/analyze-early-heap-captures.test.mjs",
     "test:mesh:browser-canary": "VITE_GUN_PEERS='[\"http://127.0.0.1:7788/gun\",\"http://127.0.0.1:7789/gun\",\"http://127.0.0.1:7790/gun\"]' VITE_GUN_PEER_MINIMUM=3 VITE_GUN_PEER_QUORUM_REQUIRED=2 VITE_VH_ALLOW_LOCAL_MESH_PEERS=true VITE_VH_GUN_LOCAL_STORAGE=false VITE_VH_SHOW_HEALTH=true pnpm --filter @vh/web-pwa build && pnpm --filter @vh/e2e test:mesh:browser-canary",
     "test:mesh:signed-peer-config-canary": "node ./packages/e2e/src/mesh/signed-peer-config-canary.mjs",
     "test:mesh:deployed-wss-peer-config": "pnpm --filter @vh/e2e test:mesh:deployed-wss-peer-config",

--- a/tools/scripts/analyze-early-heap-captures.mjs
+++ b/tools/scripts/analyze-early-heap-captures.mjs
@@ -1,0 +1,529 @@
+#!/usr/bin/env node
+
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const REPORT_SCHEMA_VERSION = 'vh-early-heap-capture-analysis-v1';
+const DOMINANT_SHARE = 0.6;
+const GRAPH_DOMINANT_SHARE = 0.6;
+const GRAPH_RULE_OUT_SHARE = 0.2;
+const DEFAULT_GRAPH_MATCH_WINDOW_MS = 2 * 60 * 60 * 1000;
+
+function usage() {
+  return [
+    'Usage: node tools/scripts/analyze-early-heap-captures.mjs --diagnostic-dir <dir> [--soak-archive-dir <dir>] [--relay <name>]',
+    '',
+    'Reads only *.heap-summary.json files and emits a secret-safe JSON summary.',
+    'Never pass .heapsnapshot or .heapsnapshot-error.json paths.',
+  ].join('\n');
+}
+
+function parseArgs(argv = process.argv.slice(2)) {
+  const args = {
+    diagnosticDir: null,
+    soakArchiveDir: null,
+    relay: null,
+    now: null,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    const readValue = () => {
+      const value = argv[index + 1];
+      if (!value || value.startsWith('--')) throw new Error(`missing value for ${token}`);
+      index += 1;
+      return value;
+    };
+    if (token === '--diagnostic-dir') {
+      args.diagnosticDir = readValue();
+    } else if (token === '--soak-archive-dir') {
+      args.soakArchiveDir = readValue();
+    } else if (token === '--relay') {
+      args.relay = readValue();
+    } else if (token === '--now') {
+      args.now = readValue();
+    } else if (token === '--help' || token === '-h') {
+      args.help = true;
+    } else {
+      throw new Error(`unknown argument: ${token}`);
+    }
+  }
+  return args;
+}
+
+function rejectSnapshotPath(inputPath) {
+  const segments = String(inputPath ?? '')
+    .split(/[\\/]+/)
+    .filter(Boolean);
+  const forbiddenSegment = segments.find((segment) => segment.includes('.heapsnapshot'));
+  if (forbiddenSegment) {
+    throw new Error(`refusing to read host-private heap snapshot path: ${forbiddenSegment}`);
+  }
+}
+
+function readJson(filePath) {
+  return JSON.parse(readFileSync(filePath, 'utf8'));
+}
+
+function finiteNumber(value) {
+  return Number.isFinite(value) ? value : null;
+}
+
+function bytes(value) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+}
+
+function isoMs(value) {
+  const parsed = Date.parse(String(value ?? ''));
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function safeFileId(filePath) {
+  return path.basename(filePath).replace(/\.heap-summary\.json$/, '');
+}
+
+function componentBreakdown(memoryBreakdown = {}) {
+  const jsHeapUsedBytes = bytes(memoryBreakdown.js_heap_used_bytes);
+  const externalBytes = bytes(memoryBreakdown.external_bytes);
+  const arrayBuffersBytes = bytes(memoryBreakdown.array_buffers_bytes);
+  const nativeNonHeapEstimateBytes = bytes(memoryBreakdown.native_non_heap_estimate_bytes);
+  const totalAccountedBytes = [
+    jsHeapUsedBytes,
+    externalBytes,
+    arrayBuffersBytes,
+    nativeNonHeapEstimateBytes,
+  ].reduce((sum, value) => sum + (value ?? 0), 0);
+  const share = (value) => totalAccountedBytes > 0 && value !== null
+    ? value / totalAccountedBytes
+    : null;
+  return {
+    rssBytes: bytes(memoryBreakdown.rss_bytes),
+    jsHeapTotalBytes: bytes(memoryBreakdown.js_heap_total_bytes),
+    jsHeapUsedBytes,
+    externalBytes,
+    arrayBuffersBytes,
+    nativeNonHeapEstimateBytes,
+    totalAccountedBytes,
+    shares: {
+      jsHeapUsed: share(jsHeapUsedBytes),
+      external: share(externalBytes),
+      arrayBuffers: share(arrayBuffersBytes),
+      nativeNonHeapEstimate: share(nativeNonHeapEstimateBytes),
+    },
+  };
+}
+
+function thresholdFromSummary(summary) {
+  return {
+    index: finiteNumber(summary.details?.threshold_index),
+    bytes: bytes(summary.details?.limit ?? summary.details?.observed ?? summary.details?.current),
+    configuredThresholds: Array.isArray(summary.details?.configured_thresholds)
+      ? summary.details.configured_thresholds.map(bytes).filter((value) => value !== null)
+      : [],
+  };
+}
+
+function summarizeHeapSpaceStatistics(spaces) {
+  if (!Array.isArray(spaces)) return [];
+  return spaces.map((space) => ({
+    name: String(space.space_name ?? space.name ?? 'unknown'),
+    usedBytes: bytes(space.space_used_size ?? space.usedBytes),
+    sizeBytes: bytes(space.space_size ?? space.sizeBytes),
+  })).sort((left, right) => left.name.localeCompare(right.name));
+}
+
+function captureFromSummary(filePath, summary) {
+  const generatedAtMs = isoMs(summary.generated_at ?? summary.generatedAt);
+  return {
+    id: safeFileId(filePath),
+    file: path.basename(filePath),
+    generatedAt: summary.generated_at ?? summary.generatedAt ?? null,
+    generatedAtMs,
+    relayId: summary.relay_id ?? null,
+    reason: summary.reason ?? null,
+    threshold: thresholdFromSummary(summary),
+    heapSnapshotStatus: summary.heap_snapshot_status ?? null,
+    heapSnapshotSizeBytes: bytes(summary.heap_snapshot_size_bytes),
+    memory: componentBreakdown(summary.memory_breakdown),
+    heapSpaces: summarizeHeapSpaceStatistics(summary.heap_space_statistics),
+  };
+}
+
+function readHeapCaptures(diagnosticDir) {
+  rejectSnapshotPath(diagnosticDir);
+  if (!diagnosticDir) throw new Error('--diagnostic-dir is required');
+  if (!existsSync(diagnosticDir)) {
+    throw new Error(`diagnostic dir does not exist: ${path.basename(diagnosticDir)}`);
+  }
+  if (!statSync(diagnosticDir).isDirectory()) {
+    throw new Error(`diagnostic path is not a directory: ${path.basename(diagnosticDir)}`);
+  }
+  const files = readdirSync(diagnosticDir)
+    .filter((file) => file.endsWith('.heap-summary.json'))
+    .sort();
+  const captures = files.map((file) => {
+    const filePath = path.join(diagnosticDir, file);
+    const summary = readJson(filePath);
+    if (summary.schema_version !== 'vh-relay-heap-summary-v1') {
+      throw new Error(`unsupported heap summary schema in ${file}: ${summary.schema_version ?? 'missing'}`);
+    }
+    return captureFromSummary(filePath, summary);
+  }).sort((left, right) => (left.generatedAtMs ?? 0) - (right.generatedAtMs ?? 0) || left.id.localeCompare(right.id));
+  if (captures.length === 0) {
+    throw new Error(`no *.heap-summary.json files found in ${path.basename(diagnosticDir)}`);
+  }
+  return captures;
+}
+
+function readOptionalJson(filePath) {
+  try {
+    return JSON.parse(readFileSync(filePath, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function sampleDirs(soakArchiveDir) {
+  if (!soakArchiveDir || !existsSync(soakArchiveDir) || !statSync(soakArchiveDir).isDirectory()) return [];
+  return readdirSync(soakArchiveDir)
+    .map((entry) => path.join(soakArchiveDir, entry))
+    .filter((entryPath) => {
+      try {
+        return statSync(entryPath).isDirectory();
+      } catch {
+        return false;
+      }
+    })
+    .sort();
+}
+
+function relayMatches(relay, requestedRelay, captureRelayId) {
+  const name = String(relay?.name ?? '');
+  if (requestedRelay) return name === requestedRelay;
+  if (captureRelayId) return name === captureRelayId;
+  return true;
+}
+
+function readSoakSamples({ soakArchiveDir, requestedRelay, captureRelayId }) {
+  rejectSnapshotPath(soakArchiveDir ?? '');
+  const samples = [];
+  for (const dir of sampleDirs(soakArchiveDir)) {
+    const manifest = readOptionalJson(path.join(dir, 'manifest.json'));
+    const relayLiveness = readOptionalJson(path.join(dir, 'relay-liveness.json'));
+    const publisherLiveness = readOptionalJson(path.join(dir, 'publisher-liveness.json'));
+    const generatedAt = relayLiveness?.generatedAt ?? manifest?.generatedAt ?? publisherLiveness?.generatedAt ?? null;
+    const generatedAtMs = isoMs(generatedAt);
+    if (generatedAtMs === null) continue;
+    const relay = (relayLiveness?.relays ?? []).find((entry) => relayMatches(entry, requestedRelay, captureRelayId));
+    samples.push({
+      id: path.basename(dir),
+      generatedAt,
+      generatedAtMs,
+      graphScan: relay?.metrics?.graphScan ?? null,
+      heapUsedBytes: bytes(relay?.metrics?.heapUsedBytes),
+      tickSequence: finiteNumber(publisherLiveness?.diagnostic?.latestTickSequence),
+    });
+  }
+  return samples.sort((left, right) => left.generatedAtMs - right.generatedAtMs);
+}
+
+function closestSample(samples, generatedAtMs, maxAgeMs = DEFAULT_GRAPH_MATCH_WINDOW_MS) {
+  if (!Number.isFinite(generatedAtMs)) return null;
+  let best = null;
+  for (const sample of samples) {
+    const ageMs = Math.abs(sample.generatedAtMs - generatedAtMs);
+    if (ageMs > maxAgeMs) continue;
+    if (!best || ageMs < best.ageMs) best = { sample, ageMs };
+  }
+  return best;
+}
+
+function attachCorrelation(captures, soakSamples) {
+  return captures.map((capture) => {
+    const closest = closestSample(soakSamples, capture.generatedAtMs);
+    return {
+      ...capture,
+      graph: closest?.sample?.graphScan
+        ? {
+            sampleId: closest.sample.id,
+            sampleAgeMs: closest.ageMs,
+            totalSouls: finiteNumber(closest.sample.graphScan.totalSouls),
+            liveUserValueBytes: bytes(closest.sample.graphScan.liveUserValueBytes),
+            tombstonedSouls: finiteNumber(closest.sample.graphScan.tombstonedSouls),
+            truncated: closest.sample.graphScan.truncated === true,
+            truncatedTotal: finiteNumber(closest.sample.graphScan.truncatedTotal),
+            namespaceLiveUserValueBytes: closest.sample.graphScan.namespaceLiveUserValueBytes ?? {},
+          }
+        : null,
+      tick: closest
+        ? {
+            sampleId: closest.sample.id,
+            sampleAgeMs: closest.ageMs,
+            latestTickSequence: closest.sample.tickSequence,
+          }
+        : null,
+    };
+  });
+}
+
+function positiveDelta(value) {
+  return Number.isFinite(value) && value > 0 ? value : 0;
+}
+
+function componentDeltas(first, second) {
+  const delta = {
+    jsHeapUsedBytes: (second.memory.jsHeapUsedBytes ?? 0) - (first.memory.jsHeapUsedBytes ?? 0),
+    externalBytes: (second.memory.externalBytes ?? 0) - (first.memory.externalBytes ?? 0),
+    arrayBuffersBytes: (second.memory.arrayBuffersBytes ?? 0) - (first.memory.arrayBuffersBytes ?? 0),
+    nativeNonHeapEstimateBytes:
+      (second.memory.nativeNonHeapEstimateBytes ?? 0) - (first.memory.nativeNonHeapEstimateBytes ?? 0),
+    rssBytes: (second.memory.rssBytes ?? 0) - (first.memory.rssBytes ?? 0),
+  };
+  const positiveTotalBytes = [
+    delta.jsHeapUsedBytes,
+    delta.externalBytes,
+    delta.arrayBuffersBytes,
+    delta.nativeNonHeapEstimateBytes,
+  ].reduce((sum, value) => sum + positiveDelta(value), 0);
+  const components = [
+    ['js_heap_used', delta.jsHeapUsedBytes],
+    ['external', delta.externalBytes],
+    ['arraybuffers', delta.arrayBuffersBytes],
+    ['native_non_heap_estimate', delta.nativeNonHeapEstimateBytes],
+  ].map(([name, bytesValue]) => ({
+    name,
+    bytes: bytesValue,
+    positiveShare: positiveTotalBytes > 0 ? positiveDelta(bytesValue) / positiveTotalBytes : null,
+  })).sort((left, right) => positiveDelta(right.bytes) - positiveDelta(left.bytes));
+  return {
+    ...delta,
+    positiveComponentGrowthBytes: positiveTotalBytes,
+    dominantComponent: components[0]?.name ?? null,
+    dominantComponentShare: components[0]?.positiveShare ?? null,
+    components,
+  };
+}
+
+function deltaBetween(first, second) {
+  const deltas = componentDeltas(first, second);
+  const graphLiveUserValueBytesDelta = first.graph?.liveUserValueBytes !== null
+    && first.graph?.liveUserValueBytes !== undefined
+    && second.graph?.liveUserValueBytes !== null
+    && second.graph?.liveUserValueBytes !== undefined
+      ? second.graph.liveUserValueBytes - first.graph.liveUserValueBytes
+      : null;
+  const tickDelta = first.tick?.latestTickSequence !== null
+    && first.tick?.latestTickSequence !== undefined
+    && second.tick?.latestTickSequence !== null
+    && second.tick?.latestTickSequence !== undefined
+      ? second.tick.latestTickSequence - first.tick.latestTickSequence
+      : null;
+  return {
+    fromCaptureId: first.id,
+    toCaptureId: second.id,
+    fromGeneratedAt: first.generatedAt,
+    toGeneratedAt: second.generatedAt,
+    elapsedMs: Number.isFinite(first.generatedAtMs) && Number.isFinite(second.generatedAtMs)
+      ? second.generatedAtMs - first.generatedAtMs
+      : null,
+    componentDeltas: deltas,
+    graphLiveUserValueBytesDelta,
+    graphShareOfPositiveGrowth: graphLiveUserValueBytesDelta !== null && deltas.positiveComponentGrowthBytes > 0
+      ? Math.max(0, graphLiveUserValueBytesDelta) / deltas.positiveComponentGrowthBytes
+      : null,
+    tickDelta,
+    bytesPerTickEstimate: tickDelta && tickDelta > 0
+      ? deltas.jsHeapUsedBytes / tickDelta
+      : null,
+  };
+}
+
+function summarizeDeltas(captures) {
+  const deltas = [];
+  for (let index = 1; index < captures.length; index += 1) {
+    deltas.push(deltaBetween(captures[index - 1], captures[index]));
+  }
+  return deltas;
+}
+
+function classifyFromDelta(delta) {
+  const basis = {
+    fromCaptureId: delta.fromCaptureId,
+    toCaptureId: delta.toCaptureId,
+    positiveComponentGrowthBytes: delta.componentDeltas.positiveComponentGrowthBytes,
+    dominantComponent: delta.componentDeltas.dominantComponent,
+    dominantComponentShare: delta.componentDeltas.dominantComponentShare,
+    graphLiveUserValueBytesDelta: delta.graphLiveUserValueBytesDelta,
+    graphShareOfPositiveGrowth: delta.graphShareOfPositiveGrowth,
+    tickDelta: delta.tickDelta,
+    bytesPerTickEstimate: delta.bytesPerTickEstimate,
+  };
+  if (delta.componentDeltas.positiveComponentGrowthBytes <= 0) {
+    return {
+      class: 'inconclusive_need_diff',
+      reason: 'no_positive_component_growth_between_captures',
+      basis,
+      missingMeasurement: 'later capture with positive growth',
+    };
+  }
+  if (delta.graphShareOfPositiveGrowth !== null && delta.graphShareOfPositiveGrowth >= GRAPH_DOMINANT_SHARE) {
+    return { class: 'graph_after_all', reason: 'graph_live_user_value_bytes_dominates_growth', basis };
+  }
+  const dominant = delta.componentDeltas.dominantComponent;
+  const share = delta.componentDeltas.dominantComponentShare ?? 0;
+  if (share < DOMINANT_SHARE) {
+    return {
+      class: 'inconclusive_need_diff',
+      reason: 'no_component_exceeds_dominance_threshold',
+      basis,
+      missingMeasurement: 'additional staggered capture or heap diff',
+    };
+  }
+  if (dominant === 'arraybuffers') {
+    return { class: 'arraybuffers', reason: 'arraybuffers_growth_dominates_component_delta', basis };
+  }
+  if (dominant === 'external' || dominant === 'native_non_heap_estimate') {
+    return { class: 'external_native', reason: `${dominant}_growth_dominates_component_delta`, basis };
+  }
+  if (dominant === 'js_heap_used') {
+    if (delta.graphShareOfPositiveGrowth === null) {
+      return {
+        class: 'inconclusive_need_diff',
+        reason: 'js_heap_growth_dominates_but_graph_measurement_missing',
+        basis,
+        missingMeasurement: 'matching graph liveUserValueBytes sample',
+      };
+    }
+    if (delta.graphShareOfPositiveGrowth <= GRAPH_RULE_OUT_SHARE) {
+      return { class: 'js_heap_non_graph', reason: 'js_heap_growth_dominates_and_graph_growth_is_small', basis };
+    }
+    return {
+      class: 'inconclusive_need_diff',
+      reason: 'js_heap_growth_dominates_but_graph_growth_not_ruled_out',
+      basis,
+      missingMeasurement: 'heap diff or tighter graph sample',
+    };
+  }
+  return {
+    class: 'inconclusive_need_diff',
+    reason: 'unknown_dominant_component',
+    basis,
+    missingMeasurement: 'additional component evidence',
+  };
+}
+
+function classifySingleCapture(capture) {
+  const shares = capture.memory.shares;
+  const shareEntries = [
+    ['js_heap_used', shares.jsHeapUsed],
+    ['external', shares.external],
+    ['arraybuffers', shares.arrayBuffers],
+    ['native_non_heap_estimate', shares.nativeNonHeapEstimate],
+  ].filter(([, share]) => Number.isFinite(share))
+    .sort((left, right) => right[1] - left[1]);
+  const [dominant, share] = shareEntries[0] ?? [null, null];
+  const basis = {
+    captureId: capture.id,
+    totalAccountedBytes: capture.memory.totalAccountedBytes,
+    dominantComponent: dominant,
+    dominantComponentShare: share,
+    graphLiveUserValueBytes: capture.graph?.liveUserValueBytes ?? null,
+  };
+  if (!dominant || share < DOMINANT_SHARE) {
+    return {
+      class: 'inconclusive_need_diff',
+      reason: 'single_capture_without_dominant_component',
+      basis,
+      missingMeasurement: 'second staggered heap summary',
+    };
+  }
+  if (dominant === 'arraybuffers') {
+    return { class: 'arraybuffers', reason: 'arraybuffers_dominates_single_capture', basis };
+  }
+  if (dominant === 'external' || dominant === 'native_non_heap_estimate') {
+    return { class: 'external_native', reason: `${dominant}_dominates_single_capture`, basis };
+  }
+  return {
+    class: 'inconclusive_need_diff',
+    reason: 'single_capture_js_heap_needs_growth_and_graph_delta',
+    basis,
+    missingMeasurement: 'second staggered heap summary plus graph sample',
+  };
+}
+
+function classify(captures, deltas) {
+  if (deltas.length > 0) {
+    return classifyFromDelta(deltas.at(-1));
+  }
+  return classifySingleCapture(captures[0]);
+}
+
+function buildReport({
+  diagnosticDir,
+  soakArchiveDir = null,
+  requestedRelay = null,
+  now = new Date(),
+}) {
+  rejectSnapshotPath(diagnosticDir);
+  rejectSnapshotPath(soakArchiveDir ?? '');
+  const rawCaptures = readHeapCaptures(diagnosticDir);
+  const captureRelayId = requestedRelay ?? rawCaptures.find((capture) => capture.relayId)?.relayId ?? null;
+  const soakSamples = readSoakSamples({ soakArchiveDir, requestedRelay, captureRelayId });
+  const captures = attachCorrelation(rawCaptures, soakSamples);
+  const deltas = summarizeDeltas(captures);
+  const retainerClassification = classify(captures, deltas);
+  return {
+    schemaVersion: REPORT_SCHEMA_VERSION,
+    generatedAt: now instanceof Date ? now.toISOString() : new Date(now).toISOString(),
+    status: retainerClassification.class === 'inconclusive_need_diff' ? 'inconclusive' : 'classified',
+    input: {
+      diagnosticDirName: path.basename(path.resolve(diagnosticDir)),
+      soakArchiveDirName: soakArchiveDir ? path.basename(path.resolve(soakArchiveDir)) : null,
+      requestedRelay,
+    },
+    captureCount: captures.length,
+    captures,
+    deltaCount: deltas.length,
+    deltas,
+    retainerClassification,
+  };
+}
+
+async function main() {
+  const args = parseArgs();
+  if (args.help) {
+    console.info(usage());
+    return;
+  }
+  if (!args.diagnosticDir) {
+    console.error(usage());
+    process.exit(2);
+  }
+  const report = buildReport({
+    diagnosticDir: args.diagnosticDir,
+    soakArchiveDir: args.soakArchiveDir,
+    requestedRelay: args.relay,
+    now: args.now ? new Date(args.now) : new Date(),
+  });
+  console.info(JSON.stringify(report, null, 2));
+}
+
+export const earlyHeapCaptureAnalysisInternal = {
+  REPORT_SCHEMA_VERSION,
+  buildReport,
+  classifyFromDelta,
+  classifySingleCapture,
+  componentBreakdown,
+  deltaBetween,
+  parseArgs,
+  rejectSnapshotPath,
+  readHeapCaptures,
+};
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(`[vh:early-heap-capture-analysis] ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(1);
+  });
+}

--- a/tools/scripts/analyze-early-heap-captures.test.mjs
+++ b/tools/scripts/analyze-early-heap-captures.test.mjs
@@ -1,0 +1,303 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { earlyHeapCaptureAnalysisInternal } from './analyze-early-heap-captures.mjs';
+
+function tempRoot() {
+  return mkdtempSync(path.join(os.tmpdir(), 'vh-early-heap-analysis-'));
+}
+
+function writeJson(filePath, value) {
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+function writeHeapSummary(dir, name, {
+  generatedAt,
+  relayId = 'vhc-relay-a',
+  thresholdBytes = 500_000_000,
+  thresholdIndex = 1,
+  memory,
+}) {
+  writeJson(path.join(dir, `${name}.heap-summary.json`), {
+    schema_version: 'vh-relay-heap-summary-v1',
+    generated_at: generatedAt,
+    relay_id: relayId,
+    reason: 'watchdog-early-heap-used-bytes',
+    details: {
+      reason: 'early_heap_used_bytes',
+      threshold_index: thresholdIndex,
+      limit: thresholdBytes,
+      configured_thresholds: [500_000_000, 700_000_000],
+    },
+    memory_breakdown: {
+      rss_bytes: memory.rssBytes ?? 1_000_000_000,
+      js_heap_total_bytes: memory.jsHeapTotalBytes ?? 600_000_000,
+      js_heap_used_bytes: memory.jsHeapUsedBytes,
+      external_bytes: memory.externalBytes,
+      array_buffers_bytes: memory.arrayBuffersBytes,
+      native_non_heap_estimate_bytes: memory.nativeNonHeapEstimateBytes,
+    },
+    heap_space_statistics: [
+      { space_name: 'old_space', space_used_size: memory.oldSpaceBytes ?? memory.jsHeapUsedBytes },
+    ],
+    heap_snapshot_status: 'success',
+    heap_snapshot_size_bytes: 123_456,
+    heap_snapshot_path: '/host/private/not-shareable.heapsnapshot',
+  });
+}
+
+function writeSoakSample(root, id, {
+  generatedAt,
+  relayName = 'vhc-relay-a',
+  graphLiveUserValueBytes,
+  graphTotalSouls = 100,
+  graphTombstonedSouls = 0,
+  tickSequence = null,
+}) {
+  const dir = path.join(root, id);
+  writeJson(path.join(dir, 'manifest.json'), {
+    schemaVersion: 'vh-phase5-scope-a-soak-archive-v1',
+    generatedAt,
+    status: 'pass',
+  });
+  writeJson(path.join(dir, 'relay-liveness.json'), {
+    schemaVersion: 'vh-news-relay-liveness-watch-v1',
+    generatedAt,
+    status: 'pass',
+    relays: [
+      {
+        name: relayName,
+        metrics: {
+          heapUsedBytes: 500_000_000,
+          graphScan: {
+            totalSouls: graphTotalSouls,
+            liveUserValueBytes: graphLiveUserValueBytes,
+            tombstonedSouls: graphTombstonedSouls,
+            truncated: false,
+            truncatedTotal: 0,
+            successes: 1,
+            namespaceLiveUserValueBytes: {
+              news_story: graphLiveUserValueBytes,
+            },
+          },
+        },
+      },
+    ],
+  });
+  writeJson(path.join(dir, 'publisher-liveness.json'), {
+    schemaVersion: 'vh-news-aggregator-publisher-liveness-watch-v1',
+    generatedAt,
+    status: 'pass',
+    diagnostic: {
+      latestTickSequence: tickSequence,
+    },
+  });
+}
+
+function baseMemory(overrides = {}) {
+  return {
+    jsHeapUsedBytes: 100,
+    externalBytes: 20,
+    arrayBuffersBytes: 10,
+    nativeNonHeapEstimateBytes: 20,
+    ...overrides,
+  };
+}
+
+test('classifies JS heap growth as non-graph when graph growth is small', () => {
+  const root = tempRoot();
+  try {
+    const diagnostics = path.join(root, 'diagnostics');
+    const soak = path.join(root, 'soak');
+    writeHeapSummary(diagnostics, 'first', {
+      generatedAt: '2026-07-05T22:00:00.000Z',
+      thresholdBytes: 500_000_000,
+      memory: baseMemory({ jsHeapUsedBytes: 100, externalBytes: 20 }),
+    });
+    writeHeapSummary(diagnostics, 'second', {
+      generatedAt: '2026-07-05T23:00:00.000Z',
+      thresholdBytes: 700_000_000,
+      thresholdIndex: 2,
+      memory: baseMemory({ jsHeapUsedBytes: 320, externalBytes: 30 }),
+    });
+    writeSoakSample(soak, 'sample1', {
+      generatedAt: '2026-07-05T22:00:00.000Z',
+      graphLiveUserValueBytes: 1_000,
+      tickSequence: 10,
+    });
+    writeSoakSample(soak, 'sample2', {
+      generatedAt: '2026-07-05T23:00:00.000Z',
+      graphLiveUserValueBytes: 1_020,
+      tickSequence: 15,
+    });
+
+    const report = earlyHeapCaptureAnalysisInternal.buildReport({
+      diagnosticDir: diagnostics,
+      soakArchiveDir: soak,
+      now: new Date('2026-07-05T23:05:00.000Z'),
+    });
+
+    assert.equal(report.status, 'classified');
+    assert.equal(report.retainerClassification.class, 'js_heap_non_graph');
+    assert.equal(report.retainerClassification.reason, 'js_heap_growth_dominates_and_graph_growth_is_small');
+    assert.equal(report.deltas[0].tickDelta, 5);
+    assert.equal(report.deltas[0].bytesPerTickEstimate, 44);
+    assert.equal(JSON.stringify(report).includes(root), false);
+    assert.equal(JSON.stringify(report).includes('not-shareable.heapsnapshot'), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('classifies external/native growth without graph evidence', () => {
+  const root = tempRoot();
+  try {
+    const diagnostics = path.join(root, 'diagnostics');
+    writeHeapSummary(diagnostics, 'first', {
+      generatedAt: '2026-07-05T22:00:00.000Z',
+      memory: baseMemory({ externalBytes: 20, nativeNonHeapEstimateBytes: 20 }),
+    });
+    writeHeapSummary(diagnostics, 'second', {
+      generatedAt: '2026-07-05T23:00:00.000Z',
+      memory: baseMemory({ externalBytes: 300, nativeNonHeapEstimateBytes: 25 }),
+    });
+
+    const report = earlyHeapCaptureAnalysisInternal.buildReport({
+      diagnosticDir: diagnostics,
+      now: new Date('2026-07-05T23:05:00.000Z'),
+    });
+
+    assert.equal(report.status, 'classified');
+    assert.equal(report.retainerClassification.class, 'external_native');
+    assert.equal(report.retainerClassification.reason, 'external_growth_dominates_component_delta');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('classifies array buffer growth', () => {
+  const root = tempRoot();
+  try {
+    const diagnostics = path.join(root, 'diagnostics');
+    writeHeapSummary(diagnostics, 'first', {
+      generatedAt: '2026-07-05T22:00:00.000Z',
+      memory: baseMemory({ arrayBuffersBytes: 10 }),
+    });
+    writeHeapSummary(diagnostics, 'second', {
+      generatedAt: '2026-07-05T23:00:00.000Z',
+      memory: baseMemory({ arrayBuffersBytes: 250 }),
+    });
+
+    const report = earlyHeapCaptureAnalysisInternal.buildReport({
+      diagnosticDir: diagnostics,
+      now: new Date('2026-07-05T23:05:00.000Z'),
+    });
+
+    assert.equal(report.status, 'classified');
+    assert.equal(report.retainerClassification.class, 'arraybuffers');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('classifies graph growth when graph bytes dominate component growth', () => {
+  const root = tempRoot();
+  try {
+    const diagnostics = path.join(root, 'diagnostics');
+    const soak = path.join(root, 'soak');
+    writeHeapSummary(diagnostics, 'first', {
+      generatedAt: '2026-07-05T22:00:00.000Z',
+      memory: baseMemory({ jsHeapUsedBytes: 100 }),
+    });
+    writeHeapSummary(diagnostics, 'second', {
+      generatedAt: '2026-07-05T23:00:00.000Z',
+      memory: baseMemory({ jsHeapUsedBytes: 300 }),
+    });
+    writeSoakSample(soak, 'sample1', {
+      generatedAt: '2026-07-05T22:00:00.000Z',
+      graphLiveUserValueBytes: 1_000,
+    });
+    writeSoakSample(soak, 'sample2', {
+      generatedAt: '2026-07-05T23:00:00.000Z',
+      graphLiveUserValueBytes: 1_200,
+    });
+
+    const report = earlyHeapCaptureAnalysisInternal.buildReport({
+      diagnosticDir: diagnostics,
+      soakArchiveDir: soak,
+      now: new Date('2026-07-05T23:05:00.000Z'),
+    });
+
+    assert.equal(report.status, 'classified');
+    assert.equal(report.retainerClassification.class, 'graph_after_all');
+    assert.equal(report.retainerClassification.reason, 'graph_live_user_value_bytes_dominates_growth');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('refuses to guess from a single JS-dominant capture', () => {
+  const root = tempRoot();
+  try {
+    const diagnostics = path.join(root, 'diagnostics');
+    writeHeapSummary(diagnostics, 'only', {
+      generatedAt: '2026-07-05T22:00:00.000Z',
+      memory: baseMemory({ jsHeapUsedBytes: 500, externalBytes: 20, arrayBuffersBytes: 5, nativeNonHeapEstimateBytes: 10 }),
+    });
+
+    const report = earlyHeapCaptureAnalysisInternal.buildReport({
+      diagnosticDir: diagnostics,
+      now: new Date('2026-07-05T23:05:00.000Z'),
+    });
+
+    assert.equal(report.status, 'inconclusive');
+    assert.equal(report.retainerClassification.class, 'inconclusive_need_diff');
+    assert.equal(report.retainerClassification.missingMeasurement, 'second staggered heap summary plus graph sample');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('allows a single external/native-dominant capture classification', () => {
+  const root = tempRoot();
+  try {
+    const diagnostics = path.join(root, 'diagnostics');
+    writeHeapSummary(diagnostics, 'only', {
+      generatedAt: '2026-07-05T22:00:00.000Z',
+      memory: baseMemory({ jsHeapUsedBytes: 50, externalBytes: 700, arrayBuffersBytes: 10, nativeNonHeapEstimateBytes: 10 }),
+    });
+
+    const report = earlyHeapCaptureAnalysisInternal.buildReport({
+      diagnosticDir: diagnostics,
+      now: new Date('2026-07-05T23:05:00.000Z'),
+    });
+
+    assert.equal(report.status, 'classified');
+    assert.equal(report.retainerClassification.class, 'external_native');
+    assert.equal(report.retainerClassification.reason, 'external_dominates_single_capture');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('rejects host-private heapsnapshot input paths', () => {
+  assert.throws(
+    () => earlyHeapCaptureAnalysisInternal.buildReport({
+      diagnosticDir: '/tmp/private-capture.heapsnapshot',
+      now: new Date('2026-07-05T23:05:00.000Z'),
+    }),
+    /refusing to read host-private heap snapshot path/,
+  );
+  assert.throws(
+    () => earlyHeapCaptureAnalysisInternal.buildReport({
+      diagnosticDir: '/tmp/private-capture.heapsnapshot.d/diagnostics',
+      now: new Date('2026-07-05T23:05:00.000Z'),
+    }),
+    /refusing to read host-private heap snapshot path/,
+  );
+});


### PR DESCRIPTION
## Summary
- add `tools/scripts/analyze-early-heap-captures.mjs`, a secret-safe analyzer for relay `*.heap-summary.json` early-capture artifacts
- correlate optional Scope A soak archive graph/tick samples without reading raw heap snapshots
- classify captures as `js_heap_non_graph`, `external_native`, `arraybuffers`, `graph_after_all`, or `inconclusive_need_diff`
- wire `pnpm check:early-heap-captures` and document the operator intake flow/no-remediation boundary

## Safety boundaries
- reads only `*.heap-summary.json` plus optional soak archive `manifest.json`, `relay-liveness.json`, and `publisher-liveness.json`
- rejects `.heapsnapshot` input paths
- does not emit absolute host paths or heap snapshot paths from summary metadata
- does not authorize retention, compaction, eviction, publisher clear, or relay remediation

## Validation
- `node --check tools/scripts/analyze-early-heap-captures.mjs`
- `corepack pnpm@9.7.1 exec node --test tools/scripts/analyze-early-heap-captures.test.mjs`
- `corepack pnpm@9.7.1 check:early-heap-captures`
- `corepack pnpm@9.7.1 docs:check`
- `git diff --check`

Note: local `pnpm` commands warn that this shell is Node v23.10.0 while the repo engine range is `>=20.0.0 <23.0.0`; the checks above passed.
