### PR TITLE
Automate Scope A watch closure verdicts

### DIFF
--- a/docs/ops/news-aggregator-production-service.md
+++ b/docs/ops/news-aggregator-production-service.md
@@ -117,6 +117,8 @@ Templates:
 - `infra/systemd/user/vh-news-relay-liveness-watch.timer`
 - `infra/systemd/user/vh-phase5-scope-a-soak-archive.service`
 - `infra/systemd/user/vh-phase5-scope-a-soak-archive.timer`
+- `infra/systemd/user/vh-phase5-scope-a-watch-closure.service`
+- `infra/systemd/user/vh-phase5-scope-a-watch-closure.timer`
 - `infra/systemd/user/vh-public-feed-alert-watch.service`
 - `infra/systemd/user/vh-public-feed-alert-watch.timer`
 
@@ -249,6 +251,42 @@ missing, invalid, or reports non-`pass`, or when the public freshness monitor
 fails. It does not restart relays, start the publisher, mutate mesh state, or
 write public feed records. It exists to preserve time-window evidence even
 though the individual liveness watches overwrite their `latest.json` files.
+
+Phase 5 Scope A watch-closure packet timer:
+
+```bash
+mkdir -p ~/.config/vhc
+cat > ~/.config/vhc/phase5-scope-a-watch-closure.env <<'EOF'
+VH_PHASE5_SCOPE_A_WATCH_START_AT=2026-07-05T00:00:00.000Z
+VH_PHASE5_SCOPE_A_WATCH_CLEAN_START_AT=2026-07-05T00:00:00.000Z
+EOF
+chmod 0600 ~/.config/vhc/phase5-scope-a-watch-closure.env
+
+./tools/scripts/install-news-aggregator-production-service.sh
+systemctl --user start vh-phase5-scope-a-watch-closure.service
+jq '{status, severity, blockers, window, thresholds, relayMemory}' \
+  ~/.local/state/vhc/phase5-scope-a-watch-closure/verdict.json
+```
+
+Enable the timer only after the one-shot writes a fresh
+`vh-phase5-scope-a-watch-closure-verdict-v1` verdict for the intended clean
+window:
+
+```bash
+./tools/scripts/install-news-aggregator-production-service.sh --enable-watch-closure
+systemctl --user status vh-phase5-scope-a-watch-closure.timer --no-pager
+journalctl --user -u vh-phase5-scope-a-watch-closure.service -n 100 --no-pager
+```
+
+The service writes the full packet to
+`~/.local/state/vhc/phase5-scope-a-watch-closure/latest.json` and the compact
+alert-safe verdict to
+`~/.local/state/vhc/phase5-scope-a-watch-closure/verdict.json` every 30 minutes.
+Before 24h/48h elapsed, the verdict is `status: "in_progress"` with
+`window_short` blockers. If a threshold has elapsed and any abort criterion is
+present, the verdict is `status: "fail"` and the service exits nonzero so
+systemd records the failed run. The verdict preserves the threshold blockers and
+relay-memory projection provenance without absolute host paths.
 
 During the current post-#694 instrumented climb, treat the archive plus
 StoryCluster watch plus relay graph metrics as the Scope A health surface:

--- a/infra/systemd/user/vh-phase5-scope-a-watch-closure.service
+++ b/infra/systemd/user/vh-phase5-scope-a-watch-closure.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=VHC Phase 5 Scope A Watch Closure Packet
+Documentation=file:/home/humble/VHC/docs/ops/news-aggregator-production-service.md
+
+[Service]
+Type=oneshot
+Environment=VHC_REPO=/home/humble/VHC
+Environment=VH_PHASE5_SCOPE_A_WATCH_ARCHIVE_ROOT=%h/.local/state/vhc/phase5-scope-a-soak
+Environment=VH_PHASE5_SCOPE_A_WATCH_RUNTIME_DIAGNOSTICS_FILE=%h/.local/state/vhc/news-aggregator/artifacts/news-runtime-diagnostics.json
+Environment=VH_PHASE5_SCOPE_A_WATCH_STORYCLUSTER_FAILURE_DIR=%h/.local/state/vhc/storycluster-engine/openai-failures
+Environment=VH_PHASE5_SCOPE_A_WATCH_OUTPUT_FILE=%h/.local/state/vhc/phase5-scope-a-watch-closure/latest.json
+Environment=VH_PHASE5_SCOPE_A_WATCH_VERDICT_FILE=%h/.local/state/vhc/phase5-scope-a-watch-closure/verdict.json
+Environment=PATH=/home/humble/.local/bin:/home/humble/.hermes/node/bin:/usr/local/bin:/usr/bin:/bin
+WorkingDirectory=/home/humble/VHC
+ExecStart=/usr/bin/env bash -c 'if [ -f "%h/.config/vhc/phase5-scope-a-watch-closure.env" ]; then set -a; source "%h/.config/vhc/phase5-scope-a-watch-closure.env"; set +a; fi; exec node "/home/humble/VHC/tools/scripts/phase5-scope-a-watch-closure-packet.mjs"'

--- a/infra/systemd/user/vh-phase5-scope-a-watch-closure.timer
+++ b/infra/systemd/user/vh-phase5-scope-a-watch-closure.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Build VHC Phase 5 Scope A watch closure packet every 30 minutes
+
+[Timer]
+OnBootSec=12min
+OnUnitActiveSec=30min
+AccuracySec=2min
+Persistent=true
+Unit=vh-phase5-scope-a-watch-closure.service
+
+[Install]
+WantedBy=timers.target

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "check:public-feed:freshness-monitor": "pnpm --filter @vh/gun-client... build && node ./tools/scripts/public-feed-freshness-monitor.mjs",
     "check:public-feed:alert-watch": "node --test ./tools/scripts/public-feed-alert-watch.test.mjs",
     "check:early-heap-captures": "node --test ./tools/scripts/analyze-early-heap-captures.test.mjs",
+    "check:scope-a-watch-closure": "node --test ./tools/scripts/phase5-scope-a-watch-closure-packet.test.mjs",
     "test:mesh:browser-canary": "VITE_GUN_PEERS='[\"http://127.0.0.1:7788/gun\",\"http://127.0.0.1:7789/gun\",\"http://127.0.0.1:7790/gun\"]' VITE_GUN_PEER_MINIMUM=3 VITE_GUN_PEER_QUORUM_REQUIRED=2 VITE_VH_ALLOW_LOCAL_MESH_PEERS=true VITE_VH_GUN_LOCAL_STORAGE=false VITE_VH_SHOW_HEALTH=true pnpm --filter @vh/web-pwa build && pnpm --filter @vh/e2e test:mesh:browser-canary",
     "test:mesh:signed-peer-config-canary": "node ./packages/e2e/src/mesh/signed-peer-config-canary.mjs",
     "test:mesh:deployed-wss-peer-config": "pnpm --filter @vh/e2e test:mesh:deployed-wss-peer-config",

--- a/tools/scripts/install-news-aggregator-production-service.sh
+++ b/tools/scripts/install-news-aggregator-production-service.sh
@@ -9,6 +9,7 @@ ENABLE_WATCH=false
 ENABLE_PUBLISHER_LIVENESS_WATCH=false
 ENABLE_RELAY_LIVENESS_WATCH=false
 ENABLE_SOAK_ARCHIVE=false
+ENABLE_WATCH_CLOSURE=false
 START_PUBLISHER=false
 
 for arg in "$@"; do
@@ -24,6 +25,9 @@ for arg in "$@"; do
       ;;
     --enable-soak-archive)
       ENABLE_SOAK_ARCHIVE=true
+      ;;
+    --enable-watch-closure)
+      ENABLE_WATCH_CLOSURE=true
       ;;
     --start-publisher)
       START_PUBLISHER=true
@@ -215,6 +219,39 @@ Unit=vh-phase5-scope-a-soak-archive.service
 WantedBy=timers.target
 EOF
 
+cat >"${UNIT_DIR}/vh-phase5-scope-a-watch-closure.service" <<EOF
+[Unit]
+Description=VHC Phase 5 Scope A Watch Closure Packet
+Documentation=file:${REPO_ROOT}/docs/ops/news-aggregator-production-service.md
+
+[Service]
+Type=oneshot
+Environment=VHC_REPO=${REPO_ROOT}
+Environment=VH_PHASE5_SCOPE_A_WATCH_ARCHIVE_ROOT=%h/.local/state/vhc/phase5-scope-a-soak
+Environment=VH_PHASE5_SCOPE_A_WATCH_RUNTIME_DIAGNOSTICS_FILE=%h/.local/state/vhc/news-aggregator/artifacts/news-runtime-diagnostics.json
+Environment=VH_PHASE5_SCOPE_A_WATCH_STORYCLUSTER_FAILURE_DIR=%h/.local/state/vhc/storycluster-engine/openai-failures
+Environment=VH_PHASE5_SCOPE_A_WATCH_OUTPUT_FILE=%h/.local/state/vhc/phase5-scope-a-watch-closure/latest.json
+Environment=VH_PHASE5_SCOPE_A_WATCH_VERDICT_FILE=%h/.local/state/vhc/phase5-scope-a-watch-closure/verdict.json
+Environment=PATH=${SERVICE_PATH}
+WorkingDirectory=${REPO_ROOT}
+ExecStart=/usr/bin/env bash -c 'if [ -f "%h/.config/vhc/phase5-scope-a-watch-closure.env" ]; then set -a; source "%h/.config/vhc/phase5-scope-a-watch-closure.env"; set +a; fi; exec node "${REPO_ROOT}/tools/scripts/phase5-scope-a-watch-closure-packet.mjs"'
+EOF
+
+cat >"${UNIT_DIR}/vh-phase5-scope-a-watch-closure.timer" <<'EOF'
+[Unit]
+Description=Build VHC Phase 5 Scope A watch closure packet every 30 minutes
+
+[Timer]
+OnBootSec=12min
+OnUnitActiveSec=30min
+AccuracySec=2min
+Persistent=true
+Unit=vh-phase5-scope-a-watch-closure.service
+
+[Install]
+WantedBy=timers.target
+EOF
+
 systemctl --user daemon-reload
 
 echo "Installed user units:"
@@ -227,6 +264,8 @@ echo "  ${UNIT_DIR}/vh-news-relay-liveness-watch.service"
 echo "  ${UNIT_DIR}/vh-news-relay-liveness-watch.timer"
 echo "  ${UNIT_DIR}/vh-phase5-scope-a-soak-archive.service"
 echo "  ${UNIT_DIR}/vh-phase5-scope-a-soak-archive.timer"
+echo "  ${UNIT_DIR}/vh-phase5-scope-a-watch-closure.service"
+echo "  ${UNIT_DIR}/vh-phase5-scope-a-watch-closure.timer"
 echo "Publisher env file expected at: ${ENV_FILE}"
 
 if [[ "${ENABLE_WATCH}" == "true" ]]; then
@@ -247,6 +286,11 @@ fi
 if [[ "${ENABLE_SOAK_ARCHIVE}" == "true" ]]; then
   systemctl --user enable --now vh-phase5-scope-a-soak-archive.timer
   echo "Enabled Phase 5 Scope A soak archive timer"
+fi
+
+if [[ "${ENABLE_WATCH_CLOSURE}" == "true" ]]; then
+  systemctl --user enable --now vh-phase5-scope-a-watch-closure.timer
+  echo "Enabled Phase 5 Scope A watch closure timer"
 fi
 
 if [[ "${START_PUBLISHER}" == "true" ]]; then

--- a/tools/scripts/phase5-scope-a-watch-closure-packet.mjs
+++ b/tools/scripts/phase5-scope-a-watch-closure-packet.mjs
@@ -8,6 +8,7 @@ import { pathToFileURL } from 'node:url';
 import { resolveRelayWatchdogLimits } from './relay-watchdog-thresholds.mjs';
 
 const SCHEMA_VERSION = 'vh-phase5-scope-a-watch-closure-v1';
+const VERDICT_SCHEMA_VERSION = 'vh-phase5-scope-a-watch-closure-verdict-v1';
 const DEFAULT_MIN_TREND_HORIZON_HOURS = 7 * 24;
 const DEFAULT_HEAP_PLATEAU_MAX_ABS_SLOPE_BYTES_PER_HOUR = 5 * 1024 * 1024;
 const CLAIM_BOUNDARY = Object.freeze({
@@ -580,6 +581,96 @@ function thresholdVerdict(hoursObserved, thresholdHours, blockers, relayMemory) 
   };
 }
 
+function uniqueStrings(values) {
+  return [...new Set(values.filter((value) => typeof value === 'string' && value.length > 0))];
+}
+
+function buildWatchClosureVerdict(packet) {
+  const thresholdBlockers = uniqueStrings([
+    ...(packet.thresholds.twentyFourHour.blockers ?? []),
+    ...(packet.thresholds.fortyEightHour.blockers ?? []),
+  ]);
+  const hardFail = packet.thresholds.twentyFourHour.status === 'fail'
+    || packet.thresholds.fortyEightHour.status === 'fail';
+  const status = hardFail
+    ? 'fail'
+    : packet.thresholds.fortyEightHour.status === 'pass'
+      ? 'pass'
+      : 'in_progress';
+  return {
+    schemaVersion: VERDICT_SCHEMA_VERSION,
+    generatedAt: packet.generatedAt,
+    status,
+    severity: status === 'fail' ? 'critical' : status === 'pass' ? 'ok' : 'info',
+    blockers: thresholdBlockers,
+    window: packet.window,
+    thresholds: packet.thresholds,
+    archive: {
+      sampleCount: packet.archive.sampleCount,
+      firstSampleAt: packet.archive.firstSampleAt,
+      latestSampleAt: packet.archive.latestSampleAt,
+      passCount: packet.archive.passCount,
+      failCount: packet.archive.failCount,
+      latestPublisherStatus: packet.archive.latestPublisher?.status ?? null,
+      latestPublisherNRestarts: packet.archive.latestPublisher?.nRestarts ?? null,
+      latestRelayStatus: packet.archive.latestRelay?.status ?? null,
+      latestRelaySnapshotStatus: packet.archive.latestRelaySnapshot?.status ?? null,
+      latestPublicFreshnessStatus: packet.archive.latestPublicFreshness?.status ?? null,
+      latestPublicFreshnessGeneratedAt: packet.archive.latestPublicFreshness?.generatedAt ?? null,
+    },
+    runtime: {
+      journalSummary: packet.runtime.journalSummary,
+      diagnostics: packet.runtime.diagnostics,
+    },
+    storyCluster: {
+      failureArtifactCount: packet.storyCluster.failureArtifactCount,
+      failureArtifactCountSource: packet.storyCluster.failureArtifactCountSource,
+      degeneracyWarningCount: packet.storyCluster.degeneracyWarningCount,
+    },
+    relayMemory: {
+      status: packet.relayMemory.status,
+      heapPlateauVerdict: packet.relayMemory.heapPlateauVerdict,
+      heapLimitBytes: packet.relayMemory.heapLimitBytes,
+      heapLimitSource: packet.relayMemory.heapLimitSource,
+      rssLimitBytes: packet.relayMemory.rssLimitBytes,
+      rssLimitSource: packet.relayMemory.rssLimitSource,
+      minTrendHorizonHours: packet.relayMemory.minTrendHorizonHours,
+      heapPlateauMaxAbsSlopeBytesPerHour: packet.relayMemory.heapPlateauMaxAbsSlopeBytesPerHour,
+      relays: packet.relayMemory.relays.map((relay) => ({
+        name: relay.name,
+        sampleCount: relay.sampleCount,
+        trendStatus: relay.trendStatus,
+        heapPlateauVerdict: relay.heapPlateauVerdict,
+        heapPlateauReason: relay.heapPlateauReason,
+        heapPlateauProjectedLimitWindow: relay.heapPlateauProjectedLimitWindow,
+        heapLatestBytes: relay.heapLatestBytes,
+        heapSlopeBytesPerHour: relay.heapSlopeBytesPerHour,
+        heapLimitBytes: relay.heapLimitBytes,
+        heapLimitSource: relay.heapLimitSource,
+        heapHoursToLimit: relay.heapHoursToLimit,
+        rssLatestBytes: relay.rssLatestBytes,
+        rssSlopeBytesPerHour: relay.rssSlopeBytesPerHour,
+        rssLimitBytes: relay.rssLimitBytes,
+        rssLimitSource: relay.rssLimitSource,
+        rssHoursToLimit: relay.rssHoursToLimit,
+        shortestProjectedLimitHours: relay.shortestProjectedLimitHours,
+        restartCountMin: relay.restartCountMin,
+        restartCountMax: relay.restartCountMax,
+        watchdogTripsMin: relay.watchdogTripsMin,
+        watchdogTripsMax: relay.watchdogTripsMax,
+        graphSampleCount: relay.graphSampleCount,
+        graphMissingSampleCount: relay.graphMissingSampleCount,
+        graphTruncatedSampleCount: relay.graphTruncatedSampleCount,
+        graphLiveUserValueBytesLatest: relay.graphLiveUserValueBytesLatest,
+        graphLiveUserValueBytesSlopePerHour: relay.graphLiveUserValueBytesSlopePerHour,
+        earlyHeapSnapshotNextThresholdBytes: relay.earlyHeapSnapshotNextThresholdBytes,
+        earlyHeapSnapshotHoursToNextThreshold: relay.earlyHeapSnapshotHoursToNextThreshold,
+      })),
+    },
+    claimBoundary: packet.claimBoundary,
+  };
+}
+
 export function buildPhase5ScopeAWatchClosurePacket({
   env = process.env,
   now = new Date(),
@@ -643,20 +734,26 @@ async function main() {
     ? new Date(parseTimeMs(process.env.VH_PHASE5_SCOPE_A_WATCH_NOW))
     : new Date();
   const packet = buildPhase5ScopeAWatchClosurePacket({ env: process.env, now });
+  const verdict = buildWatchClosureVerdict(packet);
   const outputFile = firstNonEmpty(process.env.VH_PHASE5_SCOPE_A_WATCH_OUTPUT_FILE);
   if (outputFile) {
     await mkdir(path.dirname(outputFile), { recursive: true });
     writeFileSync(outputFile, `${JSON.stringify(packet, null, 2)}\n`, 'utf8');
   }
+  const verdictFile = firstNonEmpty(process.env.VH_PHASE5_SCOPE_A_WATCH_VERDICT_FILE);
+  if (verdictFile) {
+    await mkdir(path.dirname(verdictFile), { recursive: true });
+    writeFileSync(verdictFile, `${JSON.stringify(verdict, null, 2)}\n`, 'utf8');
+  }
   console.info(JSON.stringify(packet, null, 2));
-  const hardFail = packet.thresholds.twentyFourHour.status === 'fail'
-    || packet.thresholds.fortyEightHour.status === 'fail';
-  if (hardFail) {
+  if (verdict.status === 'fail') {
     process.exit(1);
   }
 }
 
 export const phase5ScopeAWatchClosureInternal = {
+  VERDICT_SCHEMA_VERSION,
+  buildWatchClosureVerdict,
   buildPhase5ScopeAWatchClosurePacket,
   countFilesSince,
   linearSlope,

--- a/tools/scripts/phase5-scope-a-watch-closure-packet.test.mjs
+++ b/tools/scripts/phase5-scope-a-watch-closure-packet.test.mjs
@@ -1,10 +1,15 @@
 import assert from 'node:assert/strict';
-import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
+import { fileURLToPath } from 'node:url';
 
 import { phase5ScopeAWatchClosureInternal } from './phase5-scope-a-watch-closure-packet.mjs';
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(SCRIPT_DIR, '../..');
 
 function tmpDir() {
   return mkdtempSync(path.join(os.tmpdir(), 'vh-phase5-watch-closure-'));
@@ -259,6 +264,72 @@ test('blocks the 48h threshold when relay heap trend projects below the safe hor
   assert.equal(packet.relayMemory.status, 'fail');
   assert.equal(packet.thresholds.fortyEightHour.status, 'fail');
   assert.deepEqual(packet.thresholds.fortyEightHour.blockers, ['relay_memory_trend_fail']);
+});
+
+test('builds a compact secret-safe verdict for watch automation and alert intake', () => {
+  const root = tmpDir();
+  const archiveRoot = path.join(root, 'archive');
+  makeSample(archiveRoot, '20260628T000000Z', '2026-06-28T00:00:00.000Z', [
+    relay('vhc-relay-a', 500_000_000, 400_000_000),
+  ]);
+  makeSample(archiveRoot, '20260629T000000Z', '2026-06-29T00:00:00.000Z', [
+    relay('vhc-relay-a', 1_000_000_000, 900_000_000),
+  ]);
+  makeSample(archiveRoot, '20260630T010000Z', '2026-06-30T01:00:00.000Z', [
+    relay('vhc-relay-a', 1_250_000_000, 1_200_000_000),
+  ]);
+
+  const packet = phase5ScopeAWatchClosureInternal.buildPhase5ScopeAWatchClosurePacket({
+    env: baseEnv(root),
+    now: new Date('2026-06-30T01:00:00.000Z'),
+  });
+  const verdict = phase5ScopeAWatchClosureInternal.buildWatchClosureVerdict(packet);
+  const serialized = JSON.stringify(verdict);
+
+  assert.equal(verdict.schemaVersion, phase5ScopeAWatchClosureInternal.VERDICT_SCHEMA_VERSION);
+  assert.equal(verdict.status, 'fail');
+  assert.equal(verdict.severity, 'critical');
+  assert.deepEqual(verdict.blockers, ['relay_memory_trend_fail']);
+  assert.equal(verdict.relayMemory.relays[0].name, 'vhc-relay-a');
+  assert.equal(verdict.relayMemory.relays[0].trendStatus, 'fail');
+  assert.equal(serialized.includes(root), false);
+  assert.equal(serialized.includes('failureArtifactDir'), false);
+});
+
+test('writes full packet and compact verdict files from the CLI', () => {
+  const root = tmpDir();
+  const archiveRoot = path.join(root, 'archive');
+  makeSample(archiveRoot, '20260628T000000Z', '2026-06-28T00:00:00.000Z', [
+    relay('vhc-relay-a', 420_000_000, 320_000_000),
+  ]);
+  makeSample(archiveRoot, '20260629T000000Z', '2026-06-29T00:00:00.000Z', [
+    relay('vhc-relay-a', 421_000_000, 321_000_000),
+  ]);
+  makeSample(archiveRoot, '20260630T010000Z', '2026-06-30T01:00:00.000Z', [
+    relay('vhc-relay-a', 422_000_000, 322_000_000),
+  ]);
+  const packetFile = path.join(root, 'watch-closure/latest.json');
+  const verdictFile = path.join(root, 'watch-closure/verdict.json');
+
+  execFileSync(process.execPath, ['tools/scripts/phase5-scope-a-watch-closure-packet.mjs'], {
+    cwd: REPO_ROOT,
+    env: {
+      ...process.env,
+      ...baseEnv(root),
+      VH_PHASE5_SCOPE_A_WATCH_NOW: '2026-06-30T01:00:00.000Z',
+      VH_PHASE5_SCOPE_A_WATCH_OUTPUT_FILE: packetFile,
+      VH_PHASE5_SCOPE_A_WATCH_VERDICT_FILE: verdictFile,
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  const packet = JSON.parse(readFileSync(packetFile, 'utf8'));
+  const verdict = JSON.parse(readFileSync(verdictFile, 'utf8'));
+
+  assert.equal(packet.schemaVersion, 'vh-phase5-scope-a-watch-closure-v1');
+  assert.equal(verdict.schemaVersion, phase5ScopeAWatchClosureInternal.VERDICT_SCHEMA_VERSION);
+  assert.equal(verdict.status, 'pass');
+  assert.equal(verdict.thresholds.fortyEightHour.status, 'pass');
 });
 
 test('projects relay heap trend against the public-beta per-relay watchdog ceiling by default', () => {

--- a/tools/scripts/systemd-service-installers.test.mjs
+++ b/tools/scripts/systemd-service-installers.test.mjs
@@ -148,6 +148,28 @@ test('news aggregator installer writes Phase 5 soak archive units without enabli
   assert.match(timer, /Unit=vh-phase5-scope-a-soak-archive\.service/);
 });
 
+test('news aggregator installer writes Phase 5 watch closure packet units without enabling them by default', () => {
+  const source = readScript('install-news-aggregator-production-service.sh');
+  const service = readInfraUnit('vh-phase5-scope-a-watch-closure.service');
+  const timer = readInfraUnit('vh-phase5-scope-a-watch-closure.timer');
+
+  assert.match(source, /vh-phase5-scope-a-watch-closure\.service/);
+  assert.match(source, /vh-phase5-scope-a-watch-closure\.timer/);
+  assert.match(source, /--enable-watch-closure/);
+  assert.match(source, /if \[\[ "\$\{ENABLE_WATCH_CLOSURE\}" == "true" \]\]/);
+  assert.match(source, /systemctl --user enable --now vh-phase5-scope-a-watch-closure\.timer/);
+
+  for (const unitSource of [source, service]) {
+    assert.match(unitSource, /phase5-scope-a-watch-closure-packet\.mjs/);
+    assert.match(unitSource, /VH_PHASE5_SCOPE_A_WATCH_ARCHIVE_ROOT=%h\/\.local\/state\/vhc\/phase5-scope-a-soak/);
+    assert.match(unitSource, /VH_PHASE5_SCOPE_A_WATCH_OUTPUT_FILE=%h\/\.local\/state\/vhc\/phase5-scope-a-watch-closure\/latest\.json/);
+    assert.match(unitSource, /VH_PHASE5_SCOPE_A_WATCH_VERDICT_FILE=%h\/\.local\/state\/vhc\/phase5-scope-a-watch-closure\/verdict\.json/);
+    assert.match(unitSource, /phase5-scope-a-watch-closure\.env/);
+  }
+  assert.match(timer, /OnUnitActiveSec=30min/);
+  assert.match(timer, /Unit=vh-phase5-scope-a-watch-closure\.service/);
+});
+
 test('public feed alert watch unit bounds host-local probe runtime', () => {
   const service = readInfraUnit('vh-public-feed-alert-watch.service');
 


### PR DESCRIPTION
## Summary
- add a compact `vh-phase5-scope-a-watch-closure-verdict-v1` alongside the full Scope A watch-closure packet
- write `latest.json` and alert-safe `verdict.json` from `phase5-scope-a-watch-closure-packet.mjs`
- add checked-in user-systemd watch-closure service/timer units and installer support via `--enable-watch-closure`
- document the one-shot readback and timer enablement flow for the 48h/14d evidence window

## Safety boundaries
- timer is installed but not enabled unless the operator runs `--enable-watch-closure`
- service only reads existing host-local liveness/archive/diagnostic artifacts and writes local state files
- service does not restart publisher/relays, mutate mesh state, deploy, retain, compact, or remediate memory
- compact verdict avoids absolute host paths so the alert slice can consume it safely

## Validation
- `node --check tools/scripts/phase5-scope-a-watch-closure-packet.mjs`
- `corepack pnpm@9.7.1 check:scope-a-watch-closure`
- `corepack pnpm@9.7.1 exec node --test tools/scripts/systemd-service-installers.test.mjs`
- `corepack pnpm@9.7.1 docs:check`
- `git diff --check`

Note: local `pnpm` commands warn that this shell is Node v23.10.0 while the repo engine range is `>=20.0.0 <23.0.0`; the checks above passed.
