### PR TITLE
Expand public feed alert coverage

### DIFF
--- a/docs/ops/public-feed-freshness-monitor.md
+++ b/docs/ops/public-feed-freshness-monitor.md
@@ -43,7 +43,9 @@ least one monitor failure path reaches the release owner outside the A6 host.
 
 `tools/scripts/public-feed-alert-watch.mjs` is the repo-side host alert path for
 the outage #2 silence gap. It composes the public freshness monitor with a
-read-only publisher unit check and sends a state-change-only alert when either:
+read-only publisher unit check, relay health readbacks, relay snapshot
+freshness, and the Scope A watch-closure verdict. It sends a state-change-only
+alert when either:
 
 - the public latest-index freshness monitor fails the 6-hour SLO or public
   health checks;
@@ -51,6 +53,11 @@ read-only publisher unit check and sends a state-change-only alert when either:
 - the publisher unit is in the #706 transport-total restart path with
   `ExecMainStatus=69`;
 - the publisher unit is parked with `ExecMainStatus=78`.
+- required relay-liveness, relay-snapshot, or watch-closure latest files are
+  missing or stale;
+- relay liveness or relay snapshot freshness reports fail;
+- the Scope A watch-closure verdict reports `status: "fail"` after an elapsed
+  threshold.
 
 Publisher exit classification is intentionally split:
 
@@ -87,6 +94,15 @@ The script supports two delivery channels configured by environment only:
 | `VH_PUBLIC_FEED_ALERT_HEARTBEAT_MS` | Optional resend interval for unchanged state. Default `0`, meaning no heartbeat. |
 | `VH_PUBLIC_FEED_ALERT_TEST_FIRE` | Set to `1` for a one-shot delivery test without changing the observed pass/fail result. |
 | `VH_PUBLIC_FEED_ALERT_STATE_DIR` | Default `~/.local/state/vhc/public-feed-alert`. |
+| `VH_PUBLIC_FEED_ALERT_REQUIRE_RELAY_LIVENESS` | Set by the shipped unit. Requires a fresh relay-liveness latest file. |
+| `VH_PUBLIC_FEED_ALERT_RELAY_LIVENESS_FILE` | Default `~/.local/state/vhc/relay-liveness/latest.json`. |
+| `VH_PUBLIC_FEED_ALERT_RELAY_LIVENESS_MAX_AGE_MS` | Default `900000` in the shipped unit. |
+| `VH_PUBLIC_FEED_ALERT_REQUIRE_RELAY_SNAPSHOT` | Set by the shipped unit. Requires a fresh relay snapshot watch latest file. |
+| `VH_PUBLIC_FEED_ALERT_RELAY_SNAPSHOT_FILE` | Default `~/.local/state/vhc/relay-snapshot-watch/latest.json`. |
+| `VH_PUBLIC_FEED_ALERT_RELAY_SNAPSHOT_MAX_AGE_MS` | Default `2700000` in the shipped unit. |
+| `VH_PUBLIC_FEED_ALERT_REQUIRE_WATCH_CLOSURE` | Set by the shipped unit. Requires a fresh Scope A watch-closure verdict. |
+| `VH_PUBLIC_FEED_ALERT_WATCH_CLOSURE_VERDICT_FILE` | Default `~/.local/state/vhc/phase5-scope-a-watch-closure/verdict.json`. |
+| `VH_PUBLIC_FEED_ALERT_WATCH_CLOSURE_MAX_AGE_MS` | Default `5400000` in the shipped unit. |
 
 State-change-only delivery means a repeated stale feed, repeated exit-69
 restart state, or repeated exit-78 publisher state does not spam every timer
@@ -124,6 +140,12 @@ $EDITOR ~/.config/vhc/public-feed-alert.env
 # and reachable from this host.
 grep -Eq '^(VH_PUBLIC_FEED_ALERT_WEBHOOK_URL|VH_PUBLIC_FEED_ALERT_EMAIL_TO)=' ~/.config/vhc/public-feed-alert.env
 
+# Fail closed before enabling: alert dependencies must already be producing
+# fresh latest files. If any command below fails, enable/fix that producer first.
+test -s ~/.local/state/vhc/relay-liveness/latest.json
+test -s ~/.local/state/vhc/relay-snapshot-watch/latest.json
+test -s ~/.local/state/vhc/phase5-scope-a-watch-closure/verdict.json
+
 mkdir -p ~/.config/systemd/user
 cp infra/systemd/user/vh-public-feed-alert-watch.service ~/.config/systemd/user/
 cp infra/systemd/user/vh-public-feed-alert-watch.timer ~/.config/systemd/user/
@@ -159,6 +181,22 @@ console.log(JSON.stringify({
     execMainStatus: summary.publisher.execMainStatus,
   },
   freshnessStatus: summary.freshness?.status,
+  relayLiveness: summary.relayLiveness && {
+    status: summary.relayLiveness.status,
+    ageMs: summary.relayLiveness.ageMs,
+    blockers: summary.relayLiveness.blockers,
+  },
+  relaySnapshot: summary.relaySnapshot && {
+    status: summary.relaySnapshot.status,
+    ageMs: summary.relaySnapshot.ageMs,
+    blockers: summary.relaySnapshot.blockers,
+  },
+  watchClosure: summary.watchClosure && {
+    status: summary.watchClosure.status,
+    verdictStatus: summary.watchClosure.verdictStatus,
+    ageMs: summary.watchClosure.ageMs,
+    blockers: summary.watchClosure.blockers,
+  },
 }, null, 2));
 if (summary.delivery?.status !== 'sent') {
   process.exitCode = 1;

--- a/infra/systemd/user/vh-public-feed-alert-watch.service
+++ b/infra/systemd/user/vh-public-feed-alert-watch.service
@@ -9,6 +9,15 @@ Environment=VHC_REPO=/home/humble/VHC
 Environment=VH_PUBLIC_FEED_ALERT_STATE_DIR=%h/.local/state/vhc/public-feed-alert
 Environment=VH_PUBLIC_FEED_ALERT_OUTPUT_FILE=%h/.local/state/vhc/public-feed-alert/latest.json
 Environment=VH_PUBLIC_FEED_FRESHNESS_ARTIFACT_DIR=%h/.local/state/vhc/public-feed-alert/public-feed-freshness
+Environment=VH_PUBLIC_FEED_ALERT_REQUIRE_RELAY_LIVENESS=true
+Environment=VH_PUBLIC_FEED_ALERT_RELAY_LIVENESS_FILE=%h/.local/state/vhc/relay-liveness/latest.json
+Environment=VH_PUBLIC_FEED_ALERT_RELAY_LIVENESS_MAX_AGE_MS=900000
+Environment=VH_PUBLIC_FEED_ALERT_REQUIRE_RELAY_SNAPSHOT=true
+Environment=VH_PUBLIC_FEED_ALERT_RELAY_SNAPSHOT_FILE=%h/.local/state/vhc/relay-snapshot-watch/latest.json
+Environment=VH_PUBLIC_FEED_ALERT_RELAY_SNAPSHOT_MAX_AGE_MS=2700000
+Environment=VH_PUBLIC_FEED_ALERT_REQUIRE_WATCH_CLOSURE=true
+Environment=VH_PUBLIC_FEED_ALERT_WATCH_CLOSURE_VERDICT_FILE=%h/.local/state/vhc/phase5-scope-a-watch-closure/verdict.json
+Environment=VH_PUBLIC_FEED_ALERT_WATCH_CLOSURE_MAX_AGE_MS=5400000
 Environment=PATH=/home/humble/.local/bin:/home/humble/.hermes/node/bin:/usr/local/bin:/usr/bin:/bin
 WorkingDirectory=/home/humble/VHC
 ExecStart=/usr/bin/env bash -c 'if [ -f "%h/.config/vhc/public-feed-alert.env" ]; then set -a; source "%h/.config/vhc/public-feed-alert.env"; set +a; fi; exec node "/home/humble/VHC/tools/scripts/public-feed-alert-watch.mjs"'

--- a/tools/scripts/public-feed-alert-watch.mjs
+++ b/tools/scripts/public-feed-alert-watch.mjs
@@ -15,6 +15,9 @@ const STATE_SCHEMA_VERSION = 'vh-public-feed-alert-state-v1';
 const DEFAULT_UNIT = 'vh-news-aggregator.service';
 const DEFAULT_STATE_DIR = '.local/state/vhc/public-feed-alert';
 const DEFAULT_TIMEOUT_MS = 15_000;
+const DEFAULT_RELAY_LIVENESS_MAX_AGE_MS = 15 * 60 * 1000;
+const DEFAULT_RELAY_SNAPSHOT_MAX_AGE_MS = 45 * 60 * 1000;
+const DEFAULT_WATCH_CLOSURE_MAX_AGE_MS = 90 * 60 * 1000;
 const NEWS_DAEMON_TRANSPORT_UNAVAILABLE_EXIT_CODE = '69';
 const NEWS_DAEMON_WRAPPER_REFUSAL_EXIT_CODE = '75';
 const NEWS_DAEMON_FAIL_CLOSED_EXIT_CODE = '78';
@@ -117,6 +120,17 @@ function readJsonFile(filePath) {
   }
 }
 
+function readJsonReport(filePath) {
+  if (!filePath || !existsSync(filePath)) {
+    return { exists: false, parsed: null, error: null };
+  }
+  try {
+    return { exists: true, parsed: JSON.parse(readFileSync(filePath, 'utf8')), error: null };
+  } catch (error) {
+    return { exists: true, parsed: null, error };
+  }
+}
+
 async function writeJson(filePath, value) {
   await mkdir(path.dirname(filePath), { recursive: true });
   await writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
@@ -146,6 +160,325 @@ function summarizeFreshness(summary) {
     latestIndexReadbacks: Array.isArray(summary?.latestIndexReadbacks)
       ? summary.latestIndexReadbacks.map(summarizeFreshnessReadback)
       : [],
+  };
+}
+
+function reportGeneratedAgeMs(report, now) {
+  const generatedAtMs = Date.parse(String(report?.generatedAt ?? ''));
+  return Number.isFinite(generatedAtMs) ? Math.max(0, now - generatedAtMs) : null;
+}
+
+function reportInputEnabled(env, requireEnvName, fileEnvName) {
+  const requireValue = firstNonEmpty(env[requireEnvName]);
+  if (requireValue !== null) return boolEnv(requireValue, false);
+  return Boolean(firstNonEmpty(env[fileEnvName]));
+}
+
+function reportFreshnessBlockers({ label, report, maxAgeMs, now }) {
+  const blockers = [];
+  const ageMs = reportGeneratedAgeMs(report, now);
+  if (ageMs === null) {
+    blockers.push(`${label}_generated_at_missing`);
+  } else if (ageMs > maxAgeMs) {
+    blockers.push(`${label}_report_stale:${ageMs}/${maxAgeMs}`);
+  }
+  return {
+    ageMs,
+    blockers,
+  };
+}
+
+function reportStatusBlockers({ label, report, sanitizeBlocker = sanitizeAlertText }) {
+  if (report?.status === 'pass') return [];
+  const blockers = Array.isArray(report?.blockers) && report.blockers.length > 0
+    ? report.blockers.map((blocker) => `${label}:${sanitizeBlocker(blocker)}`)
+    : [`${label}_status:${sanitizeAlertText(report?.status ?? 'missing')}`];
+  return blockers;
+}
+
+function relayLivenessFile(env) {
+  return firstNonEmpty(env.VH_PUBLIC_FEED_ALERT_RELAY_LIVENESS_FILE)
+    ?? path.join(resolveHome(env), '.local/state/vhc/relay-liveness/latest.json');
+}
+
+function relaySnapshotFile(env) {
+  return firstNonEmpty(env.VH_PUBLIC_FEED_ALERT_RELAY_SNAPSHOT_FILE)
+    ?? path.join(resolveHome(env), '.local/state/vhc/relay-snapshot-watch/latest.json');
+}
+
+function watchClosureVerdictFile(env) {
+  return firstNonEmpty(env.VH_PUBLIC_FEED_ALERT_WATCH_CLOSURE_VERDICT_FILE)
+    ?? path.join(resolveHome(env), '.local/state/vhc/phase5-scope-a-watch-closure/verdict.json');
+}
+
+function summarizeRelayLivenessReport({ env, now }) {
+  const enabled = reportInputEnabled(
+    env,
+    'VH_PUBLIC_FEED_ALERT_REQUIRE_RELAY_LIVENESS',
+    'VH_PUBLIC_FEED_ALERT_RELAY_LIVENESS_FILE',
+  );
+  const filePath = relayLivenessFile(env);
+  const maxAgeMs = nonNegativeInt(env.VH_PUBLIC_FEED_ALERT_RELAY_LIVENESS_MAX_AGE_MS, DEFAULT_RELAY_LIVENESS_MAX_AGE_MS);
+  if (!enabled) {
+    return { status: 'skipped', severity: 'none', required: false, sourceFileHash: hashValue(filePath), blockers: [] };
+  }
+  const read = readJsonReport(filePath);
+  if (!read.exists) {
+    return {
+      status: 'fail',
+      severity: 'critical',
+      required: true,
+      sourceFileHash: hashValue(filePath),
+      generatedAt: null,
+      ageMs: null,
+      maxAgeMs,
+      blockers: ['relay_liveness_report_missing'],
+      relays: [],
+    };
+  }
+  if (!read.parsed) {
+    return {
+      status: 'fail',
+      severity: 'critical',
+      required: true,
+      sourceFileHash: hashValue(filePath),
+      generatedAt: null,
+      ageMs: null,
+      maxAgeMs,
+      blockers: [`relay_liveness_report_invalid:${sanitizeAlertError(read.error)}`],
+      relays: [],
+    };
+  }
+  const freshness = reportFreshnessBlockers({
+    label: 'relay_liveness',
+    report: read.parsed,
+    maxAgeMs,
+    now,
+  });
+  const blockers = [
+    ...freshness.blockers,
+    ...reportStatusBlockers({ label: 'relay_liveness', report: read.parsed }),
+  ];
+  return {
+    schemaVersion: read.parsed.schemaVersion ?? null,
+    status: blockers.length > 0 ? 'fail' : 'pass',
+    severity: blockers.length > 0 ? 'critical' : 'none',
+    required: true,
+    sourceFileHash: hashValue(filePath),
+    generatedAt: read.parsed.generatedAt ?? null,
+    ageMs: freshness.ageMs,
+    maxAgeMs,
+    blockers,
+    relays: Array.isArray(read.parsed.relays)
+      ? read.parsed.relays.map((relay) => ({
+          name: String(relay.name ?? ''),
+          status: relay.status ?? null,
+          blockerCount: Array.isArray(relay.blockers) ? relay.blockers.length : 0,
+          restartCount: Number.isFinite(relay.docker?.restartCount) ? relay.docker.restartCount : null,
+          rssBytes: Number.isFinite(relay.metrics?.rssBytes) ? relay.metrics.rssBytes : null,
+          heapUsedBytes: Number.isFinite(relay.metrics?.heapUsedBytes) ? relay.metrics.heapUsedBytes : null,
+          watchdogTrips: Number.isFinite(relay.metrics?.watchdogTrips) ? relay.metrics.watchdogTrips : null,
+          eventLoopLagP99Ms: Number.isFinite(relay.metrics?.eventLoopLagP99Ms) ? relay.metrics.eventLoopLagP99Ms : null,
+          criticalReadbacksQueued: Number.isFinite(relay.metrics?.criticalReadbacksQueued)
+            ? relay.metrics.criticalReadbacksQueued
+            : null,
+        }))
+      : [],
+  };
+}
+
+function relayNameFromSnapshotPath(filePath) {
+  return String(filePath ?? '').split(/[\\/]+/).find((segment) => segment.startsWith('vhc-relay-')) ?? null;
+}
+
+function sanitizeSnapshotBlocker(blocker) {
+  const text = String(blocker ?? '');
+  const separatorIndex = text.indexOf(':');
+  if (separatorIndex > 0 && text.slice(0, separatorIndex).includes('news-latest-index-snapshot.json')) {
+    return `snapshot_file_hash:${hashValue(text.slice(0, separatorIndex))}:${sanitizeAlertText(text.slice(separatorIndex + 1))}`;
+  }
+  return sanitizeAlertText(text);
+}
+
+function summarizeRelaySnapshotReport({ env, now }) {
+  const enabled = reportInputEnabled(
+    env,
+    'VH_PUBLIC_FEED_ALERT_REQUIRE_RELAY_SNAPSHOT',
+    'VH_PUBLIC_FEED_ALERT_RELAY_SNAPSHOT_FILE',
+  );
+  const filePath = relaySnapshotFile(env);
+  const maxAgeMs = nonNegativeInt(env.VH_PUBLIC_FEED_ALERT_RELAY_SNAPSHOT_MAX_AGE_MS, DEFAULT_RELAY_SNAPSHOT_MAX_AGE_MS);
+  if (!enabled) {
+    return { status: 'skipped', severity: 'none', required: false, sourceFileHash: hashValue(filePath), blockers: [] };
+  }
+  const read = readJsonReport(filePath);
+  if (!read.exists) {
+    return {
+      status: 'fail',
+      severity: 'critical',
+      required: true,
+      sourceFileHash: hashValue(filePath),
+      generatedAt: null,
+      ageMs: null,
+      maxAgeMs,
+      blockers: ['relay_snapshot_report_missing'],
+      snapshots: [],
+    };
+  }
+  if (!read.parsed) {
+    return {
+      status: 'fail',
+      severity: 'critical',
+      required: true,
+      sourceFileHash: hashValue(filePath),
+      generatedAt: null,
+      ageMs: null,
+      maxAgeMs,
+      blockers: [`relay_snapshot_report_invalid:${sanitizeAlertError(read.error)}`],
+      snapshots: [],
+    };
+  }
+  const freshness = reportFreshnessBlockers({
+    label: 'relay_snapshot',
+    report: read.parsed,
+    maxAgeMs,
+    now,
+  });
+  const blockers = [
+    ...freshness.blockers,
+    ...reportStatusBlockers({
+      label: 'relay_snapshot',
+      report: read.parsed,
+      sanitizeBlocker: sanitizeSnapshotBlocker,
+    }),
+  ];
+  return {
+    schemaVersion: read.parsed.schemaVersion ?? null,
+    status: blockers.length > 0 ? 'fail' : 'pass',
+    severity: blockers.length > 0 ? 'critical' : 'none',
+    required: true,
+    sourceFileHash: hashValue(filePath),
+    generatedAt: read.parsed.generatedAt ?? null,
+    ageMs: freshness.ageMs,
+    maxAgeMs,
+    blockers,
+    snapshots: Array.isArray(read.parsed.snapshots)
+      ? read.parsed.snapshots.map((snapshot) => ({
+          fileHash: hashValue(snapshot.file),
+          relay: relayNameFromSnapshotPath(snapshot.file),
+          status: snapshot.status ?? null,
+          entryCount: Number.isFinite(snapshot.entryCount) ? snapshot.entryCount : null,
+          cachedAgeMs: Number.isFinite(snapshot.cachedAgeMs) ? snapshot.cachedAgeMs : null,
+          newestEntryAgeMs: Number.isFinite(snapshot.newestEntryAgeMs) ? snapshot.newestEntryAgeMs : null,
+          failureCount: Array.isArray(snapshot.failures) ? snapshot.failures.length : 0,
+          freshnessFailureCount: Array.isArray(snapshot.freshnessFailures) ? snapshot.freshnessFailures.length : 0,
+        }))
+      : [],
+  };
+}
+
+function sanitizeWatchClosureBlocker(blocker) {
+  return sanitizeAlertText(blocker);
+}
+
+function summarizeWatchClosureVerdict({ env, now }) {
+  const enabled = reportInputEnabled(
+    env,
+    'VH_PUBLIC_FEED_ALERT_REQUIRE_WATCH_CLOSURE',
+    'VH_PUBLIC_FEED_ALERT_WATCH_CLOSURE_VERDICT_FILE',
+  );
+  const filePath = watchClosureVerdictFile(env);
+  const maxAgeMs = nonNegativeInt(env.VH_PUBLIC_FEED_ALERT_WATCH_CLOSURE_MAX_AGE_MS, DEFAULT_WATCH_CLOSURE_MAX_AGE_MS);
+  if (!enabled) {
+    return { status: 'skipped', severity: 'none', required: false, sourceFileHash: hashValue(filePath), blockers: [] };
+  }
+  const read = readJsonReport(filePath);
+  if (!read.exists) {
+    return {
+      status: 'fail',
+      severity: 'critical',
+      required: true,
+      sourceFileHash: hashValue(filePath),
+      generatedAt: null,
+      ageMs: null,
+      maxAgeMs,
+      blockers: ['watch_closure_verdict_missing'],
+      verdictStatus: null,
+    };
+  }
+  if (!read.parsed) {
+    return {
+      status: 'fail',
+      severity: 'critical',
+      required: true,
+      sourceFileHash: hashValue(filePath),
+      generatedAt: null,
+      ageMs: null,
+      maxAgeMs,
+      blockers: [`watch_closure_verdict_invalid:${sanitizeAlertError(read.error)}`],
+      verdictStatus: null,
+    };
+  }
+  const freshness = reportFreshnessBlockers({
+    label: 'watch_closure',
+    report: read.parsed,
+    maxAgeMs,
+    now,
+  });
+  const verdictFailed = read.parsed.status === 'fail';
+  const verdictBlockers = verdictFailed
+    ? Array.isArray(read.parsed.blockers) && read.parsed.blockers.length > 0
+      ? read.parsed.blockers.map((blocker) => `watch_closure:${sanitizeWatchClosureBlocker(blocker)}`)
+      : ['watch_closure_status:fail']
+    : [];
+  const blockers = [...freshness.blockers, ...verdictBlockers];
+  return {
+    schemaVersion: read.parsed.schemaVersion ?? null,
+    status: blockers.length > 0 ? 'fail' : 'pass',
+    severity: blockers.length > 0 ? 'critical' : 'none',
+    required: true,
+    sourceFileHash: hashValue(filePath),
+    generatedAt: read.parsed.generatedAt ?? null,
+    ageMs: freshness.ageMs,
+    maxAgeMs,
+    blockers,
+    verdictStatus: read.parsed.status ?? null,
+    verdictSeverity: read.parsed.severity ?? null,
+    window: read.parsed.window ?? null,
+    thresholds: {
+      twentyFourHour: read.parsed.thresholds?.twentyFourHour
+        ? {
+            status: read.parsed.thresholds.twentyFourHour.status ?? null,
+            blockers: Array.isArray(read.parsed.thresholds.twentyFourHour.blockers)
+              ? read.parsed.thresholds.twentyFourHour.blockers.map(sanitizeWatchClosureBlocker)
+              : [],
+          }
+        : null,
+      fortyEightHour: read.parsed.thresholds?.fortyEightHour
+        ? {
+            status: read.parsed.thresholds.fortyEightHour.status ?? null,
+            blockers: Array.isArray(read.parsed.thresholds.fortyEightHour.blockers)
+              ? read.parsed.thresholds.fortyEightHour.blockers.map(sanitizeWatchClosureBlocker)
+              : [],
+          }
+        : null,
+    },
+    relayMemory: read.parsed.relayMemory
+      ? {
+          status: read.parsed.relayMemory.status ?? null,
+          heapPlateauVerdict: read.parsed.relayMemory.heapPlateauVerdict ?? null,
+          relays: Array.isArray(read.parsed.relayMemory.relays)
+            ? read.parsed.relayMemory.relays.map((relay) => ({
+                name: relay.name ?? null,
+                trendStatus: relay.trendStatus ?? null,
+                heapPlateauVerdict: relay.heapPlateauVerdict ?? null,
+                shortestProjectedLimitHours: Number.isFinite(relay.shortestProjectedLimitHours)
+                  ? relay.shortestProjectedLimitHours
+                  : null,
+              }))
+            : [],
+        }
+      : null,
   };
 }
 
@@ -275,7 +608,15 @@ function restartChurnBlocker({ publisher, previousState }) {
   return `publisher_restart_churn:${previousNRestarts}/${currentNRestarts}`;
 }
 
-function fingerprintFor({ status, blockers, publisher, freshness }) {
+function fingerprintFor({
+  status,
+  blockers,
+  publisher,
+  freshness,
+  relayLiveness,
+  relaySnapshot,
+  watchClosure,
+}) {
   return hashValue(JSON.stringify({
     status,
     blockers: [...blockers].map(stableFingerprintText).sort(),
@@ -296,6 +637,37 @@ function fingerprintFor({ status, blockers, publisher, freshness }) {
         recordCount: entry.recordCount,
         failureCount: entry.failureCount,
       })),
+    },
+    relayLiveness: {
+      status: relayLiveness.status,
+      blockers: relayLiveness.blockers.map(stableFingerprintText),
+      relays: (relayLiveness.relays ?? []).map((relay) => ({
+        name: relay.name,
+        status: relay.status,
+        blockerCount: relay.blockerCount,
+        restartCount: relay.restartCount,
+        watchdogTrips: relay.watchdogTrips,
+      })),
+    },
+    relaySnapshot: {
+      status: relaySnapshot.status,
+      blockers: relaySnapshot.blockers.map(stableFingerprintText),
+      snapshots: (relaySnapshot.snapshots ?? []).map((snapshot) => ({
+        fileHash: snapshot.fileHash,
+        relay: snapshot.relay,
+        status: snapshot.status,
+        entryCount: snapshot.entryCount,
+        failureCount: snapshot.failureCount,
+        freshnessFailureCount: snapshot.freshnessFailureCount,
+      })),
+    },
+    watchClosure: {
+      status: watchClosure.status,
+      blockers: watchClosure.blockers.map(stableFingerprintText),
+      verdictStatus: watchClosure.verdictStatus,
+      thresholds: watchClosure.thresholds,
+      relayMemoryStatus: watchClosure.relayMemory?.status ?? null,
+      relayMemoryVerdict: watchClosure.relayMemory?.heapPlateauVerdict ?? null,
     },
   }), 24);
 }
@@ -353,6 +725,9 @@ function alertPayload(summary, reason) {
     fingerprint: summary.fingerprint,
     publisher: summary.publisher,
     freshness: summary.freshness,
+    relayLiveness: summary.relayLiveness,
+    relaySnapshot: summary.relaySnapshot,
+    watchClosure: summary.watchClosure,
   };
 }
 
@@ -528,6 +903,9 @@ export async function runPublicFeedAlertWatch({
   const freshnessRaw = await freshnessMonitorImpl({ env, repoRoot, now });
   const freshness = summarizeFreshness(freshnessRaw);
   const publisher = inspectPublisherUnit({ env, systemctlShowText, spawnSyncImpl });
+  const relayLiveness = summarizeRelayLivenessReport({ env, now });
+  const relaySnapshot = summarizeRelaySnapshotReport({ env, now });
+  const watchClosure = summarizeWatchClosureVerdict({ env, now });
   const restartChurn = restartChurnBlocker({ publisher, previousState });
   const observedBlockers = [
     ...publisher.blockers,
@@ -537,18 +915,27 @@ export async function runPublicFeedAlertWatch({
       : freshness.blockers.length > 0
         ? freshness.blockers.map((blocker) => `public_feed:${blocker}`)
         : [`public_feed_status:${freshness.status ?? 'missing'}`]),
+    ...relayLiveness.blockers,
+    ...relaySnapshot.blockers,
+    ...watchClosure.blockers,
   ];
   const observedStatus = observedBlockers.length === 0 ? 'pass' : 'fail';
   const observedSeverity = maxSeverity(
     publisher.severity,
     restartChurn ? 'warning' : 'none',
     freshness.status === 'pass' ? 'none' : 'critical',
+    relayLiveness.severity,
+    relaySnapshot.severity,
+    watchClosure.severity,
   );
   const fingerprint = fingerprintFor({
     status: observedStatus,
     blockers: observedBlockers,
     publisher,
     freshness,
+    relayLiveness,
+    relaySnapshot,
+    watchClosure,
   });
   const deliveryDecision = shouldDeliverAlert({
     env,
@@ -570,6 +957,9 @@ export async function runPublicFeedAlertWatch({
     outputFile,
     publisher,
     freshness,
+    relayLiveness,
+    relaySnapshot,
+    watchClosure,
     delivery: {
       status: 'pending',
       reason: deliveryDecision.reason,
@@ -636,6 +1026,9 @@ export const publicFeedAlertWatchInternal = {
   runPublicFeedAlertWatch,
   shouldDeliverAlert,
   summarizeFreshness,
+  summarizeRelayLivenessReport,
+  summarizeRelaySnapshotReport,
+  summarizeWatchClosureVerdict,
 };
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {

--- a/tools/scripts/public-feed-alert-watch.test.mjs
+++ b/tools/scripts/public-feed-alert-watch.test.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import assert from 'node:assert/strict';
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
@@ -123,6 +123,112 @@ function baseEnv(root, extra = {}) {
   };
 }
 
+function writeJson(filePath, value) {
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+function relayLivenessReport(overrides = {}) {
+  return {
+    schemaVersion: 'vh-news-relay-liveness-watch-v1',
+    generatedAt: '2026-07-02T17:58:00.000Z',
+    status: 'pass',
+    blockers: [],
+    relays: [
+      {
+        name: 'vhc-relay-a',
+        origin: 'http://127.0.0.1:8765',
+        status: 'pass',
+        blockers: [],
+        docker: { restartCount: 0 },
+        metrics: {
+          rssBytes: 420_000_000,
+          heapUsedBytes: 320_000_000,
+          watchdogTrips: 0,
+          eventLoopLagP99Ms: 20,
+          criticalReadbacksQueued: 0,
+        },
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function relaySnapshotReport(overrides = {}) {
+  const file = '/home/humble/.local/share/vhc/vhc-relay-a/data/news-latest-index-snapshot.json';
+  return {
+    schemaVersion: 'vh-relay-latest-index-snapshot-watch-v1',
+    generatedAt: '2026-07-02T17:58:00.000Z',
+    status: 'pass',
+    blockers: [],
+    snapshots: [
+      {
+        file,
+        status: 'pass',
+        failures: [],
+        entryCount: 80,
+        cachedAgeMs: 60_000,
+        newestEntryAgeMs: 120_000,
+        freshnessFailures: [],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function watchClosureVerdict(overrides = {}) {
+  return {
+    schemaVersion: 'vh-phase5-scope-a-watch-closure-verdict-v1',
+    generatedAt: '2026-07-02T17:58:00.000Z',
+    status: 'in_progress',
+    severity: 'info',
+    blockers: ['window_short:10.00/24'],
+    window: {
+      startAt: '2026-07-02T08:00:00.000Z',
+      cleanStartAt: '2026-07-02T08:00:00.000Z',
+      hoursObserved: 10,
+    },
+    thresholds: {
+      twentyFourHour: { thresholdHours: 24, status: 'not_ready', blockers: ['window_short:10.00/24'] },
+      fortyEightHour: { thresholdHours: 48, status: 'not_ready', blockers: ['window_short:10.00/48'] },
+    },
+    relayMemory: {
+      status: 'pass',
+      heapPlateauVerdict: 'heap_driver_unknown',
+      relays: [
+        {
+          name: 'vhc-relay-a',
+          trendStatus: 'pass',
+          heapPlateauVerdict: 'heap_driver_unknown',
+          shortestProjectedLimitHours: null,
+        },
+      ],
+    },
+    ...overrides,
+  };
+}
+
+function writeAuxReports(root, {
+  relay = relayLivenessReport(),
+  snapshot = relaySnapshotReport(),
+  closure = watchClosureVerdict(),
+} = {}) {
+  const relayFile = path.join(root, 'relay-liveness/latest.json');
+  const snapshotFile = path.join(root, 'relay-snapshot/latest.json');
+  const closureFile = path.join(root, 'watch-closure/verdict.json');
+  writeJson(relayFile, relay);
+  writeJson(snapshotFile, snapshot);
+  writeJson(closureFile, closure);
+  return {
+    VH_PUBLIC_FEED_ALERT_REQUIRE_RELAY_LIVENESS: '1',
+    VH_PUBLIC_FEED_ALERT_RELAY_LIVENESS_FILE: relayFile,
+    VH_PUBLIC_FEED_ALERT_REQUIRE_RELAY_SNAPSHOT: '1',
+    VH_PUBLIC_FEED_ALERT_RELAY_SNAPSHOT_FILE: snapshotFile,
+    VH_PUBLIC_FEED_ALERT_REQUIRE_WATCH_CLOSURE: '1',
+    VH_PUBLIC_FEED_ALERT_WATCH_CLOSURE_VERDICT_FILE: closureFile,
+  };
+}
+
 test('passing feed and active publisher do not require an alert channel', async () => {
   const root = tempRoot();
   try {
@@ -140,6 +246,246 @@ test('passing feed and active publisher do not require an alert channel', async 
     assert.equal(summary.delivery.status, 'suppressed');
     assert.equal(summary.blockers.includes('alert_delivery_missing_channel'), false);
     assert.equal(summary.freshness.latestIndexReadbacks[0].storyIds, undefined);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('required relay, snapshot, and watch-closure reports pass without an alert channel', async () => {
+  const root = tempRoot();
+  try {
+    const summary = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({
+      env: baseEnv(root, writeAuxReports(root)),
+      repoRoot: root,
+      now: Date.parse('2026-07-02T18:00:00.000Z'),
+      systemctlShowText: activeSystemctl(),
+      freshnessMonitorImpl: async () => freshnessSummary(),
+    });
+
+    assert.equal(summary.status, 'pass');
+    assert.equal(summary.severity, 'none');
+    assert.equal(summary.relayLiveness.status, 'pass');
+    assert.equal(summary.relaySnapshot.status, 'pass');
+    assert.equal(summary.watchClosure.status, 'pass');
+    assert.equal(summary.watchClosure.verdictStatus, 'in_progress');
+    assert.equal(summary.delivery.status, 'suppressed');
+    assert.equal(JSON.stringify(summary).includes('127.0.0.1'), false);
+    assert.equal(JSON.stringify(summary).includes('/home/humble'), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('relay liveness failures page through the existing alert delivery path', async () => {
+  const root = tempRoot();
+  const calls = [];
+  try {
+    const env = baseEnv(root, {
+      ...writeAuxReports(root, {
+        relay: relayLivenessReport({
+          status: 'fail',
+          blockers: ['vhc-relay-b:readyz_failed:fetch failed'],
+          relays: [
+            {
+              name: 'vhc-relay-b',
+              origin: 'http://127.0.0.1:8766/private',
+              status: 'fail',
+              blockers: ['readyz_failed:fetch failed'],
+              docker: { restartCount: 1 },
+              metrics: {
+                rssBytes: 1_200_000_000,
+                heapUsedBytes: 920_000_000,
+                watchdogTrips: 1,
+                eventLoopLagP99Ms: 30,
+                criticalReadbacksQueued: 0,
+              },
+            },
+          ],
+        }),
+      }),
+      VH_PUBLIC_FEED_ALERT_WEBHOOK_URL: 'https://hooks.example.invalid/token',
+    });
+    const summary = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({
+      env,
+      repoRoot: root,
+      now: Date.parse('2026-07-02T18:00:00.000Z'),
+      systemctlShowText: activeSystemctl(),
+      freshnessMonitorImpl: async () => freshnessSummary(),
+      fetchImpl: async (url, init) => {
+        calls.push({ url, init });
+        return { ok: true, status: 204 };
+      },
+    });
+
+    assert.equal(summary.status, 'fail');
+    assert.equal(summary.severity, 'critical');
+    assert.match(summary.blockers.join('\n'), /relay_liveness:vhc-relay-b:readyz_failed/);
+    assert.equal(summary.delivery.status, 'sent');
+    const body = JSON.parse(calls[0].init.body);
+    assert.equal(body.relayLiveness.status, 'fail');
+    assert.equal(body.relayLiveness.relays[0].name, 'vhc-relay-b');
+    assert.equal(body.relayLiveness.relays[0].origin, undefined);
+    assert.equal(JSON.stringify(body).includes('127.0.0.1'), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('relay snapshot failures redact absolute snapshot paths', async () => {
+  const root = tempRoot();
+  const calls = [];
+  const snapshotPath = '/home/humble/.local/share/vhc/vhc-relay-a/data/news-latest-index-snapshot.json';
+  try {
+    const env = baseEnv(root, {
+      ...writeAuxReports(root, {
+        snapshot: relaySnapshotReport({
+          status: 'fail',
+          blockers: [`${snapshotPath}:newest_entry_stale:30000000/21600000`],
+          snapshots: [
+            {
+              file: snapshotPath,
+              status: 'fail',
+              failures: ['newest_entry_stale:30000000/21600000'],
+              entryCount: 80,
+              cachedAgeMs: 60_000,
+              newestEntryAgeMs: 30_000_000,
+              freshnessFailures: ['newest_entry_stale:30000000/21600000'],
+            },
+          ],
+        }),
+      }),
+      VH_PUBLIC_FEED_ALERT_WEBHOOK_URL: 'https://hooks.example.invalid/token',
+    });
+    const summary = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({
+      env,
+      repoRoot: root,
+      now: Date.parse('2026-07-02T18:00:00.000Z'),
+      systemctlShowText: activeSystemctl(),
+      freshnessMonitorImpl: async () => freshnessSummary(),
+      fetchImpl: async (url, init) => {
+        calls.push({ url, init });
+        return { ok: true, status: 204 };
+      },
+    });
+
+    assert.equal(summary.status, 'fail');
+    assert.equal(summary.relaySnapshot.status, 'fail');
+    assert.match(summary.blockers.join('\n'), /snapshot_file_hash:/);
+    assert.equal(JSON.stringify(summary).includes(snapshotPath), false);
+    const body = JSON.parse(calls[0].init.body);
+    assert.equal(body.relaySnapshot.snapshots[0].fileHash.length, 16);
+    assert.equal(body.relaySnapshot.snapshots[0].relay, 'vhc-relay-a');
+    assert.equal(JSON.stringify(body).includes('/home/humble'), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('watch-closure fail verdict pages with threshold provenance', async () => {
+  const root = tempRoot();
+  const calls = [];
+  try {
+    const env = baseEnv(root, {
+      ...writeAuxReports(root, {
+        closure: watchClosureVerdict({
+          status: 'fail',
+          severity: 'critical',
+          blockers: ['relay_memory_trend_fail'],
+          thresholds: {
+            twentyFourHour: { thresholdHours: 24, status: 'pass', blockers: [] },
+            fortyEightHour: { thresholdHours: 48, status: 'fail', blockers: ['relay_memory_trend_fail'] },
+          },
+          relayMemory: {
+            status: 'fail',
+            heapPlateauVerdict: 'heap_still_linear',
+            relays: [
+              {
+                name: 'vhc-relay-c',
+                trendStatus: 'fail',
+                heapPlateauVerdict: 'heap_still_linear',
+                shortestProjectedLimitHours: 18,
+              },
+            ],
+          },
+        }),
+      }),
+      VH_PUBLIC_FEED_ALERT_WEBHOOK_URL: 'https://hooks.example.invalid/token',
+    });
+    const summary = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({
+      env,
+      repoRoot: root,
+      now: Date.parse('2026-07-02T18:00:00.000Z'),
+      systemctlShowText: activeSystemctl(),
+      freshnessMonitorImpl: async () => freshnessSummary(),
+      fetchImpl: async (url, init) => {
+        calls.push({ url, init });
+        return { ok: true, status: 204 };
+      },
+    });
+
+    assert.equal(summary.status, 'fail');
+    assert.equal(summary.watchClosure.status, 'fail');
+    assert.match(summary.blockers.join('\n'), /watch_closure:relay_memory_trend_fail/);
+    const body = JSON.parse(calls[0].init.body);
+    assert.equal(body.watchClosure.thresholds.fortyEightHour.status, 'fail');
+    assert.equal(body.watchClosure.relayMemory.heapPlateauVerdict, 'heap_still_linear');
+    assert.equal(body.watchClosure.relayMemory.relays[0].name, 'vhc-relay-c');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('missing required auxiliary reports fail closed before alert timer enablement', async () => {
+  const root = tempRoot();
+  try {
+    const summary = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({
+      env: baseEnv(root, {
+        VH_PUBLIC_FEED_ALERT_REQUIRE_RELAY_LIVENESS: '1',
+        VH_PUBLIC_FEED_ALERT_REQUIRE_RELAY_SNAPSHOT: '1',
+        VH_PUBLIC_FEED_ALERT_REQUIRE_WATCH_CLOSURE: '1',
+        VH_PUBLIC_FEED_ALERT_WEBHOOK_URL: 'https://hooks.example.invalid/token',
+      }),
+      repoRoot: root,
+      now: Date.parse('2026-07-02T18:00:00.000Z'),
+      systemctlShowText: activeSystemctl(),
+      freshnessMonitorImpl: async () => freshnessSummary(),
+      fetchImpl: async () => ({ ok: true, status: 204 }),
+    });
+
+    assert.equal(summary.status, 'fail');
+    assert.equal(summary.severity, 'critical');
+    assert.deepEqual(summary.blockers.filter((blocker) => blocker.endsWith('_missing')).sort(), [
+      'relay_liveness_report_missing',
+      'relay_snapshot_report_missing',
+      'watch_closure_verdict_missing',
+    ]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('explicit auxiliary require false overrides configured default file paths', async () => {
+  const root = tempRoot();
+  try {
+    const summary = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({
+      env: baseEnv(root, {
+        VH_PUBLIC_FEED_ALERT_REQUIRE_RELAY_LIVENESS: 'false',
+        VH_PUBLIC_FEED_ALERT_RELAY_LIVENESS_FILE: path.join(root, 'missing-relay.json'),
+        VH_PUBLIC_FEED_ALERT_REQUIRE_RELAY_SNAPSHOT: 'false',
+        VH_PUBLIC_FEED_ALERT_RELAY_SNAPSHOT_FILE: path.join(root, 'missing-snapshot.json'),
+        VH_PUBLIC_FEED_ALERT_REQUIRE_WATCH_CLOSURE: 'false',
+        VH_PUBLIC_FEED_ALERT_WATCH_CLOSURE_VERDICT_FILE: path.join(root, 'missing-verdict.json'),
+      }),
+      repoRoot: root,
+      now: Date.parse('2026-07-02T18:00:00.000Z'),
+      systemctlShowText: activeSystemctl(),
+      freshnessMonitorImpl: async () => freshnessSummary(),
+    });
+
+    assert.equal(summary.status, 'pass');
+    assert.equal(summary.relayLiveness.status, 'skipped');
+    assert.equal(summary.relaySnapshot.status, 'skipped');
+    assert.equal(summary.watchClosure.status, 'skipped');
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/tools/scripts/systemd-service-installers.test.mjs
+++ b/tools/scripts/systemd-service-installers.test.mjs
@@ -176,6 +176,15 @@ test('public feed alert watch unit bounds host-local probe runtime', () => {
   assert.match(service, /public-feed-alert-watch\.mjs/);
   assert.match(service, /TimeoutStartSec=180/);
   assert.match(service, /VH_PUBLIC_FEED_ALERT_STATE_DIR=%h\/\.local\/state\/vhc\/public-feed-alert/);
+  assert.match(service, /VH_PUBLIC_FEED_ALERT_REQUIRE_RELAY_LIVENESS=true/);
+  assert.match(service, /VH_PUBLIC_FEED_ALERT_RELAY_LIVENESS_FILE=%h\/\.local\/state\/vhc\/relay-liveness\/latest\.json/);
+  assert.match(service, /VH_PUBLIC_FEED_ALERT_RELAY_LIVENESS_MAX_AGE_MS=900000/);
+  assert.match(service, /VH_PUBLIC_FEED_ALERT_REQUIRE_RELAY_SNAPSHOT=true/);
+  assert.match(service, /VH_PUBLIC_FEED_ALERT_RELAY_SNAPSHOT_FILE=%h\/\.local\/state\/vhc\/relay-snapshot-watch\/latest\.json/);
+  assert.match(service, /VH_PUBLIC_FEED_ALERT_RELAY_SNAPSHOT_MAX_AGE_MS=2700000/);
+  assert.match(service, /VH_PUBLIC_FEED_ALERT_REQUIRE_WATCH_CLOSURE=true/);
+  assert.match(service, /VH_PUBLIC_FEED_ALERT_WATCH_CLOSURE_VERDICT_FILE=%h\/\.local\/state\/vhc\/phase5-scope-a-watch-closure\/verdict\.json/);
+  assert.match(service, /VH_PUBLIC_FEED_ALERT_WATCH_CLOSURE_MAX_AGE_MS=5400000/);
   assert.match(service, /source "%h\/\.config\/vhc\/public-feed-alert\.env"/);
 });
 


### PR DESCRIPTION
## Summary
- extend `public-feed-alert-watch.mjs` to monitor relay liveness, relay snapshot freshness, and the Scope A watch-closure verdict through the existing state-change dedup/delivery path
- add compact secret-safe summaries for the new alert inputs; relay origins and snapshot paths are omitted or hashed
- require those latest files in the shipped alert-watch unit with explicit max-age tolerances
- update the alert enablement runbook so test-fire fails closed unless delivery and all alert dependencies are fresh

## Safety boundaries
- alert watch remains read-only: no publisher/relay restarts, deploys, mesh writes, retention, compaction, or remediation
- delivery payloads include statuses, counts, ages, hashes, and blockers only
- explicit `VH_PUBLIC_FEED_ALERT_REQUIRE_*=false` can suppress an auxiliary input during an attended diagnostic run
- a `watchClosure.status="in_progress"` verdict does not page; missing/stale/fail verdicts do

## Validation
- `node --check tools/scripts/public-feed-alert-watch.mjs`
- `corepack pnpm@9.7.1 check:public-feed:alert-watch`
- `corepack pnpm@9.7.1 exec node --test tools/scripts/news-aggregator-publisher-liveness-watch.test.mjs tools/scripts/public-feed-alert-watch.test.mjs`
- `corepack pnpm@9.7.1 exec node --test tools/scripts/systemd-service-installers.test.mjs`
- `corepack pnpm@9.7.1 docs:check`
- `git diff --check`

Note: local `pnpm` commands warn that this shell is Node v23.10.0 while the repo engine range is `>=20.0.0 <23.0.0`; the checks above passed.
