### PR TITLE
Keep first tick caps until runtime recovery succeeds

### DIFF
--- a/docs/ops/news-aggregator-production-service.md
+++ b/docs/ops/news-aggregator-production-service.md
@@ -578,12 +578,20 @@ dozens of sequential remote StoryCluster requests or a large raw publication
 blast before the first successful write can be observed. The steady-state
 publication cap defaults to 96 bundles, while
 `VH_NEWS_RUNTIME_FIRST_TICK_MAX_PUBLISHED_BUNDLES` defaults to 8 and applies
-only to tick 1. `VH_NEWS_RUNTIME_FIRST_TICK_MAX_INGESTED_ITEMS_TOTAL` defaults
-to 24 and applies only to tick 1, capping the feed items sent into remote
-StoryCluster before the first post-reset raw write. These first-tick caps are
-intentionally narrow so the post-reset live start lands a small, inspectable
-batch before the daemon opens to the steady-state publication and ingest
-limits. `VH_NEWS_RUNTIME_PUBLICATION_FRESHNESS_MAX_AGE_MS`
+until the first runtime tick completes successfully.
+`VH_NEWS_RUNTIME_FIRST_TICK_MAX_INGESTED_ITEMS_TOTAL` defaults to 24 and also
+applies until that first successful completion, capping the feed
+items sent into remote StoryCluster before the first post-reset raw write. A
+pre-publication failure on tick 1 keeps the next retry bounded; the daemon opens
+to the steady-state publication and ingest limits only after one completed
+runtime tick. These first-tick caps are intentionally narrow so the post-reset
+live start lands a small, inspectable batch before steady state. Tick-1 content
+can understate corroboration or mixed-source composition because the capped
+freshness-priority sample may include a singleton before its corroborating pair
+enters the selected recovery batch. Treat tick-1 composition as a transient
+recovery read, not a release-quality composition verdict; verify the next
+steady-state tick before drawing content-mix conclusions.
+`VH_NEWS_RUNTIME_PUBLICATION_FRESHNESS_MAX_AGE_MS`
 defaults to 21600000, matching the 6-hour public freshness SLO: bundles inside
 that window are selected before stale high-corroboration bundles, while normal
 corroboration ordering still applies within the fresh set. Raw bundle writes

--- a/packages/ai-engine/src/newsRuntime.test.ts
+++ b/packages/ai-engine/src/newsRuntime.test.ts
@@ -410,9 +410,11 @@ describe('newsRuntime', () => {
     handle.stop();
   });
 
-  it('applies the first-tick ingest cap only to the first orchestrator run', async () => {
+  it('applies the first-tick ingest cap only until the first successful orchestrator run', async () => {
+    const writeStoryBundle = vi.fn().mockResolvedValue(undefined);
     const handle = startNewsRuntime({
       ...BASE_CONFIG,
+      writeStoryBundle,
       firstTickMaxIngestedItemsTotal: 24,
       pollIntervalMs: 1_000,
       runOnStart: true,
@@ -438,6 +440,84 @@ describe('newsRuntime', () => {
         maxIngestedItemsTotal: expect.any(Number),
       }),
     );
+
+    handle.stop();
+  });
+
+  it('keeps first-tick caps on the retry after a failed first orchestrator run', async () => {
+    orchestrateNewsPipelineMock
+      .mockRejectedValueOnce(new Error('remote cluster request timed out after 300000ms'))
+      .mockResolvedValue(batch([STORY_BUNDLE]));
+    const writeStoryBundle = vi.fn().mockResolvedValue(undefined);
+    const onTickSummary = vi.fn();
+
+    const handle = startNewsRuntime({
+      ...BASE_CONFIG,
+      writeStoryBundle,
+      maxPublishedBundles: 3,
+      firstTickMaxPublishedBundles: 1,
+      firstTickMaxIngestedItemsTotal: 24,
+      pollIntervalMs: 1_000,
+      runOnStart: true,
+      onTickSummary,
+    });
+
+    await flushTasks();
+
+    expect(orchestrateNewsPipelineMock).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        maxIngestedItemsTotal: 24,
+      }),
+    );
+    expect(onTickSummary).toHaveBeenLastCalledWith(expect.objectContaining({
+      status: 'failed',
+      tick_sequence: 1,
+      first_tick: true,
+      published_bundle_limit: 1,
+      ingested_item_limit: 24,
+    }));
+
+    orchestrateNewsPipelineMock.mockClear();
+    onTickSummary.mockClear();
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    await flushTasks();
+
+    expect(orchestrateNewsPipelineMock).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        maxIngestedItemsTotal: 24,
+      }),
+    );
+    expect(writeStoryBundle).toHaveBeenCalledTimes(1);
+    expect(onTickSummary).toHaveBeenLastCalledWith(expect.objectContaining({
+      status: 'completed',
+      tick_sequence: 2,
+      first_tick: true,
+      published_bundle_limit: 1,
+      ingested_item_limit: 24,
+    }));
+
+    orchestrateNewsPipelineMock.mockClear();
+    onTickSummary.mockClear();
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    await flushTasks();
+
+    expect(orchestrateNewsPipelineMock).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.not.objectContaining({
+        maxIngestedItemsTotal: expect.any(Number),
+      }),
+    );
+    expect(onTickSummary).toHaveBeenLastCalledWith(expect.objectContaining({
+      status: 'completed',
+      tick_sequence: 3,
+      first_tick: false,
+      published_bundle_limit: 3,
+      ingested_item_limit: null,
+    }));
 
     handle.stop();
   });

--- a/packages/ai-engine/src/newsRuntime.ts
+++ b/packages/ai-engine/src/newsRuntime.ts
@@ -634,6 +634,7 @@ export function startNewsRuntime(config: NewsRuntimeConfig): NewsRuntimeHandle {
   let inFlight = false;
   let lastRunAt: Date | null = null;
   let tickSequence = 0;
+  let firstTickCompleted = false;
   let publishedStoryIds = new Set<string>();
   let publishedStorylineIds = new Set<string>();
 
@@ -649,7 +650,7 @@ export function startNewsRuntime(config: NewsRuntimeConfig): NewsRuntimeHandle {
     inFlight = true;
     tickSequence += 1;
     const currentTickSequence = tickSequence;
-    const firstTick = currentTickSequence === 1;
+    const firstTick = !firstTickCompleted;
     const publishedBundleLimit = resolvePublishedBundleLimit(
       firstTick,
       maxPublishedBundles,
@@ -1086,6 +1087,7 @@ export function startNewsRuntime(config: NewsRuntimeConfig): NewsRuntimeHandle {
         first_selected_story_ids: bundlesToPublish.slice(0, 10).map((bundle) => bundle.story_id),
         last_stage: lastStage,
       }, config.onTickSummary);
+      firstTickCompleted = true;
     } catch (error) {
       const failedStage = lastStage;
       const prePublicationFailure = isPrePublicationFailureStage(failedStage);


### PR DESCRIPTION
## Summary
- key first-tick publication/ingest caps off first successful runtime completion instead of `tick_sequence === 1`
- add a regression test for the #708 caveat: failed tick 1 keeps tick 2 bounded, and only the following tick opens steady-state limits
- document tick-1 content/composition as transient recovery evidence rather than a release-quality composition verdict

## Safety
- does not change relay write quorum or critical readback semantics
- does not count write successes across attempts
- does not touch retention, compaction, eviction, or relay memory remediation

## Validation
- `corepack pnpm@9.7.1 --filter @vh/ai-engine exec vitest run src/newsRuntime.test.ts --config ./vitest.config.ts`
- `corepack pnpm@9.7.1 --filter @vh/ai-engine exec vitest run src/__tests__/newsIngest.test.ts src/__tests__/newsOrchestrator.storylines.test.ts src/newsRuntime.test.ts --config ./vitest.config.ts`
- `corepack pnpm@9.7.1 exec node --test tools/scripts/start-news-aggregator-daemon-production.test.mjs`
- `corepack pnpm@9.7.1 --filter @vh/ai-engine typecheck`
- `corepack pnpm@9.7.1 docs:check`
- `git diff --check`
