### PR TITLE
Add Scope A host closure runbooks

### DIFF
--- a/docs/ops/news-aggregator-production-service.md
+++ b/docs/ops/news-aggregator-production-service.md
@@ -92,6 +92,83 @@ outages #2/#3, retention/heap boundedness, accepted synthesis, frame tables,
 storyline overlays, topic synthesis, full public-beta readiness, mesh
 `release_ready`, production app canary readiness, or legal/commercial approval.
 
+## A6 Host Setup Closures
+
+### Host DNS Pin Standard
+
+Outage #3 proved that DNS failure across `gun-a.carboncaste.io`,
+`gun-b.carboncaste.io`, and `gun-c.carboncaste.io` can become a correlated
+total-transport event for publisher relay REST writes. On the single-host A6
+topology, the operator should pin those names in `/etc/hosts` to the
+operator-confirmed local A6 ingress address before enabling unattended Scope A
+operation:
+
+```bash
+getent hosts gun-a.carboncaste.io gun-b.carboncaste.io gun-c.carboncaste.io
+sudo cp /etc/hosts /etc/hosts.vhc-pre-scope-a-pin.$(date -u +%Y%m%dT%H%M%SZ)
+sudoedit /etc/hosts
+getent hosts gun-a.carboncaste.io gun-b.carboncaste.io gun-c.carboncaste.io
+```
+
+The pinned address is operator-owned; do not invent it in a deploy packet. The
+post-edit `getent hosts` readback must show the intended local A6 address for
+all three relay hostnames. Revisit and remove or update this pin before any
+failure-domain rebalance that moves relays off the A6 host.
+
+### Relay Serve-Stale Verification
+
+The current relay image contains the #686 serve-stale latest-index path by
+ancestry, but live A6 behavior still needs an operator-observed verification
+record. Do not mark serve-stale as observed in status docs until the operator
+captures it during an explicitly approved single-relay restart.
+
+Use only one relay at a time and keep the other two relays passing `/readyz` so
+the public feed retains 2-of-3 availability:
+
+```bash
+curl -fsS http://127.0.0.1:8766/readyz
+curl -fsS http://127.0.0.1:8767/readyz
+
+# After the approved restart of the target relay, before fresh cache rebuild:
+curl -fsS 'http://127.0.0.1:8765/vh/news/latest-index?limit=1&scan_limit=3&persist=false' \
+  >/tmp/vhc-serve-stale-gun-a-latest-index.json
+python3 - /tmp/vhc-serve-stale-gun-a-latest-index.json <<'PY'
+import json, sys
+with open(sys.argv[1], "r", encoding="utf-8") as handle:
+    payload = json.load(handle)
+served_from = (
+    payload.get("consistency", {})
+    .get("empty_read_cache", {})
+    .get("served_from")
+)
+if served_from != "stale_latest_index_snapshot":
+    raise SystemExit(f"serve-stale not observed: {served_from!r}")
+print({"serve_stale": "pass", "served_from": served_from})
+PY
+```
+
+Archive the JSON plus the relay name, image tag/digest, restart timestamp, and
+the two non-target relay `/readyz` readbacks. The artifact is operational
+evidence only; it is not approval to batch relay restarts.
+
+### 13:04Z Host-Event Evidence Bundle
+
+The unexplained all-relay restart around `2026-07-03T13:04Z` remains an
+operator-owned risk item. To collect a bounded, host-private packet without
+sharing raw logs, run:
+
+```bash
+tools/scripts/collect-host-event-window.sh \
+  --timestamp 2026-07-03T13:04:00Z \
+  --window-minutes 20 \
+  --output-dir /tmp/vhc-host-event-window-20260703T1304Z
+```
+
+Share only `summary.json` by default. The `raw/` subdirectory may contain
+host-private journal, Docker, and kernel log text and requires a separate
+secret-review approval before disclosure. Fold the summary verdict into the
+single-host residual-risk statement before any distribution claim.
+
 ## Hard Boundaries
 
 - Do not start production publisher writes without explicit operator approval.

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "check:public-feed:alert-watch": "node --test ./tools/scripts/public-feed-alert-watch.test.mjs",
     "check:early-heap-captures": "node --test ./tools/scripts/analyze-early-heap-captures.test.mjs",
     "check:scope-a-watch-closure": "node --test ./tools/scripts/phase5-scope-a-watch-closure-packet.test.mjs",
+    "check:host-event-window": "node --test ./tools/scripts/collect-host-event-window.test.mjs",
     "test:mesh:browser-canary": "VITE_GUN_PEERS='[\"http://127.0.0.1:7788/gun\",\"http://127.0.0.1:7789/gun\",\"http://127.0.0.1:7790/gun\"]' VITE_GUN_PEER_MINIMUM=3 VITE_GUN_PEER_QUORUM_REQUIRED=2 VITE_VH_ALLOW_LOCAL_MESH_PEERS=true VITE_VH_GUN_LOCAL_STORAGE=false VITE_VH_SHOW_HEALTH=true pnpm --filter @vh/web-pwa build && pnpm --filter @vh/e2e test:mesh:browser-canary",
     "test:mesh:signed-peer-config-canary": "node ./packages/e2e/src/mesh/signed-peer-config-canary.mjs",
     "test:mesh:deployed-wss-peer-config": "pnpm --filter @vh/e2e test:mesh:deployed-wss-peer-config",

--- a/tools/scripts/collect-host-event-window.sh
+++ b/tools/scripts/collect-host-event-window.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TIMESTAMP=""
+WINDOW_MINUTES="15"
+OUTPUT_DIR=""
+
+usage() {
+  cat <<'EOF'
+Usage: tools/scripts/collect-host-event-window.sh --timestamp <iso> [options]
+
+Collect a host-private incident window bundle and a secret-safe summary.
+
+Required:
+  --timestamp <iso>       Center of the event window, for example 2026-07-03T13:04:00Z
+
+Options:
+  --window-minutes <n>    Total window width in minutes (default 15)
+  --output-dir <path>     Output directory (default /tmp/vhc-host-event-window-<timestamp>)
+  -h, --help              Show this help
+
+The raw bundle may contain host-private logs. Share summary.json only unless a
+separate secret-review approval authorizes raw log disclosure.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --timestamp)
+      TIMESTAMP="${2:-}"
+      shift 2
+      ;;
+    --window-minutes)
+      WINDOW_MINUTES="${2:-}"
+      shift 2
+      ;;
+    --output-dir)
+      OUTPUT_DIR="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 64
+      ;;
+  esac
+done
+
+if [[ -z "${TIMESTAMP}" ]]; then
+  echo "--timestamp is required" >&2
+  exit 64
+fi
+if ! [[ "${WINDOW_MINUTES}" =~ ^[0-9]+$ ]] || [[ "${WINDOW_MINUTES}" -le 0 ]]; then
+  echo "--window-minutes must be a positive integer" >&2
+  exit 64
+fi
+
+WINDOW_JSON="$(
+  TIMESTAMP="${TIMESTAMP}" WINDOW_MINUTES="${WINDOW_MINUTES}" node --input-type=module <<'NODE'
+const timestamp = process.env.TIMESTAMP;
+const minutes = Number.parseInt(process.env.WINDOW_MINUTES || '', 10);
+const centerMs = Date.parse(timestamp);
+if (!Number.isFinite(centerMs)) {
+  console.error(`invalid --timestamp: ${timestamp}`);
+  process.exit(65);
+}
+if (!Number.isFinite(minutes) || minutes <= 0) {
+  console.error(`invalid --window-minutes: ${process.env.WINDOW_MINUTES}`);
+  process.exit(65);
+}
+const halfMs = Math.floor(minutes * 60_000 / 2);
+const safeId = new Date(centerMs).toISOString().replace(/[:.]/g, '-');
+console.log(JSON.stringify({
+  center: new Date(centerMs).toISOString(),
+  start: new Date(centerMs - halfMs).toISOString(),
+  end: new Date(centerMs + halfMs).toISOString(),
+  safeId,
+}));
+NODE
+)"
+
+WINDOW_CENTER="$(printf '%s' "${WINDOW_JSON}" | node -e 'let data="";process.stdin.on("data",(c)=>data+=c);process.stdin.on("end",()=>process.stdout.write(JSON.parse(data).center));')"
+WINDOW_START="$(printf '%s' "${WINDOW_JSON}" | node -e 'let data="";process.stdin.on("data",(c)=>data+=c);process.stdin.on("end",()=>process.stdout.write(JSON.parse(data).start));')"
+WINDOW_END="$(printf '%s' "${WINDOW_JSON}" | node -e 'let data="";process.stdin.on("data",(c)=>data+=c);process.stdin.on("end",()=>process.stdout.write(JSON.parse(data).end));')"
+WINDOW_ID="$(printf '%s' "${WINDOW_JSON}" | node -e 'let data="";process.stdin.on("data",(c)=>data+=c);process.stdin.on("end",()=>process.stdout.write(JSON.parse(data).safeId));')"
+
+if [[ -z "${OUTPUT_DIR}" ]]; then
+  OUTPUT_DIR="/tmp/vhc-host-event-window-${WINDOW_ID}"
+fi
+
+RAW_DIR="${OUTPUT_DIR}/raw"
+SUMMARY_PATH="${OUTPUT_DIR}/summary.json"
+mkdir -p "${RAW_DIR}"
+chmod 700 "${OUTPUT_DIR}" "${RAW_DIR}"
+
+run_optional() {
+  local label="$1"
+  shift
+  local stdout_path="${RAW_DIR}/${label}.log"
+  local stderr_path="${RAW_DIR}/${label}.stderr"
+  if ! command -v "$1" >/dev/null 2>&1; then
+    printf 'command unavailable: %s\n' "$1" >"${stderr_path}"
+    : >"${stdout_path}"
+    return 0
+  fi
+  "$@" >"${stdout_path}" 2>"${stderr_path}" || true
+}
+
+run_optional journal-system journalctl --system --since "${WINDOW_START}" --until "${WINDOW_END}" -o json
+run_optional journal-user journalctl --user --since "${WINDOW_START}" --until "${WINDOW_END}" -o json
+run_optional dmesg dmesg --time-format iso
+run_optional docker-events docker events --since "${WINDOW_START}" --until "${WINDOW_END}" --format '{{json .}}'
+
+RAW_DIR="${RAW_DIR}" SUMMARY_PATH="${SUMMARY_PATH}" WINDOW_CENTER="${WINDOW_CENTER}" WINDOW_START="${WINDOW_START}" WINDOW_END="${WINDOW_END}" WINDOW_MINUTES="${WINDOW_MINUTES}" node --input-type=module <<'NODE'
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+const rawDir = process.env.RAW_DIR;
+const summaryPath = process.env.SUMMARY_PATH;
+
+function readLines(file) {
+  const filePath = path.join(rawDir, file);
+  if (!existsSync(filePath)) return [];
+  return readFileSync(filePath, 'utf8').split(/\r?\n/).filter(Boolean);
+}
+
+function increment(map, key) {
+  const safeKey = String(key || 'unknown');
+  map[safeKey] = (map[safeKey] || 0) + 1;
+}
+
+function sortedObject(map) {
+  return Object.fromEntries(Object.entries(map).sort(([left], [right]) => left.localeCompare(right)));
+}
+
+function parseJsonLines(lines) {
+  const rows = [];
+  let parseErrorCount = 0;
+  for (const line of lines) {
+    try {
+      rows.push(JSON.parse(line));
+    } catch {
+      parseErrorCount += 1;
+    }
+  }
+  return { rows, parseErrorCount };
+}
+
+function journalSummary(file) {
+  const { rows, parseErrorCount } = parseJsonLines(readLines(file));
+  const units = new Set();
+  const identifiers = new Set();
+  const priorities = {};
+  const exitCodes = {};
+  for (const row of rows) {
+    const unit = row._SYSTEMD_UNIT || row.UNIT || row.SYSTEMD_UNIT;
+    if (unit) units.add(String(unit));
+    const identifier = row.SYSLOG_IDENTIFIER || row._COMM;
+    if (identifier) identifiers.add(String(identifier));
+    increment(priorities, row.PRIORITY ?? 'unknown');
+    const message = String(row.MESSAGE || '');
+    const statusMatches = message.matchAll(/\bstatus=(\d+)(?:\/[A-Z_]+)?\b/g);
+    for (const match of statusMatches) increment(exitCodes, match[1]);
+    const exitMatches = message.matchAll(/\b(?:exit(?:ed)?|code)[ _-]?status[=: ]+(\d+)\b/gi);
+    for (const match of exitMatches) increment(exitCodes, match[1]);
+  }
+  return {
+    line_count: rows.length,
+    parse_error_count: parseErrorCount,
+    units: [...units].sort(),
+    identifiers: [...identifiers].sort(),
+    priorities: sortedObject(priorities),
+    exit_codes: sortedObject(exitCodes),
+  };
+}
+
+function dockerSummary() {
+  const { rows, parseErrorCount } = parseJsonLines(readLines('docker-events.log'));
+  const actions = {};
+  const statuses = {};
+  const containers = new Set();
+  const exitCodes = {};
+  for (const row of rows) {
+    increment(actions, row.Action || row.action || 'unknown');
+    increment(statuses, row.status || row.Status || 'unknown');
+    const attrs = row.Actor?.Attributes || row.actor?.attributes || {};
+    if (attrs.name) containers.add(String(attrs.name));
+    if (attrs.exitCode) increment(exitCodes, attrs.exitCode);
+  }
+  return {
+    line_count: rows.length,
+    parse_error_count: parseErrorCount,
+    actions: sortedObject(actions),
+    statuses: sortedObject(statuses),
+    containers: [...containers].sort(),
+    exit_codes: sortedObject(exitCodes),
+  };
+}
+
+function dmesgSummary() {
+  const lines = readLines('dmesg.log');
+  const lower = lines.map((line) => line.toLowerCase());
+  const count = (pattern) => lower.filter((line) => pattern.test(line)).length;
+  return {
+    line_count: lines.length,
+    oom_mentions: count(/\boom\b|out of memory|killed process/),
+    network_mentions: count(/\bnetwork\b|link is down|link down|dns|resolver/),
+    docker_mentions: count(/\bdocker\b|containerd|runc/),
+    systemd_mentions: count(/\bsystemd\b/),
+  };
+}
+
+const summary = {
+  schema_version: 'vh-host-event-window-summary-v1',
+  generated_at: new Date().toISOString(),
+  window: {
+    center: process.env.WINDOW_CENTER,
+    start: process.env.WINDOW_START,
+    end: process.env.WINDOW_END,
+    width_minutes: Number.parseInt(process.env.WINDOW_MINUTES || '0', 10),
+  },
+  raw_bundle_warning: 'raw/ may contain host-private log text; share summary.json only unless separately approved',
+  journal_system: journalSummary('journal-system.log'),
+  journal_user: journalSummary('journal-user.log'),
+  dmesg: dmesgSummary(),
+  docker_events: dockerSummary(),
+};
+
+writeFileSync(summaryPath, `${JSON.stringify(summary, null, 2)}\n`, { mode: 0o600 });
+NODE
+
+printf 'host_event_window_bundle=%s\n' "${OUTPUT_DIR}"
+printf 'secret_safe_summary=%s\n' "${SUMMARY_PATH}"

--- a/tools/scripts/collect-host-event-window.test.mjs
+++ b/tools/scripts/collect-host-event-window.test.mjs
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict';
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(SCRIPT_DIR, '../..');
+const SCRIPT = path.join(REPO_ROOT, 'tools/scripts/collect-host-event-window.sh');
+
+function writeExecutable(filePath, body) {
+  writeFileSync(filePath, body, 'utf8');
+  chmodSync(filePath, 0o755);
+}
+
+test('host event collector writes raw logs but keeps summary secret-safe', () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), 'vh-host-event-window-'));
+  try {
+    const bin = path.join(root, 'bin');
+    const out = path.join(root, 'out');
+    mkdirSync(bin);
+    writeExecutable(path.join(bin, 'journalctl'), `#!/usr/bin/env bash
+set -euo pipefail
+if [[ " $* " == *" --user "* ]]; then
+  printf '%s\\n' '{"_SYSTEMD_UNIT":"user-watch.service","SYSLOG_IDENTIFIER":"watch","PRIORITY":"4","MESSAGE":"callback failed for https://secret.example/hook?token=do-not-print status=75"}'
+else
+  printf '%s\\n' '{"_SYSTEMD_UNIT":"vh-news-aggregator.service","SYSLOG_IDENTIFIER":"systemd","PRIORITY":"3","MESSAGE":"Main process exited, code=exited, status=69/UNAVAILABLE"}'
+fi
+`);
+    writeExecutable(path.join(bin, 'docker'), `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' '{"status":"die","Action":"die","Actor":{"Attributes":{"name":"vhc-relay-a","exitCode":"137"}}}'
+`);
+    writeExecutable(path.join(bin, 'dmesg'), `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' 'Out of memory: Killed process 1234 node'
+printf '%s\\n' 'docker0: link is down'
+`);
+
+    const result = spawnSync('bash', [
+      SCRIPT,
+      '--timestamp',
+      '2026-07-03T13:04:00Z',
+      '--window-minutes',
+      '10',
+      '--output-dir',
+      out,
+    ], {
+      cwd: REPO_ROOT,
+      env: {
+        ...process.env,
+        PATH: `${bin}:${process.env.PATH}`,
+      },
+      encoding: 'utf8',
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /secret_safe_summary=/);
+
+    const summaryText = readFileSync(path.join(out, 'summary.json'), 'utf8');
+    assert.doesNotMatch(summaryText, /secret\.example|do-not-print|callback failed/);
+    const summary = JSON.parse(summaryText);
+    assert.equal(summary.schema_version, 'vh-host-event-window-summary-v1');
+    assert.equal(summary.window.center, '2026-07-03T13:04:00.000Z');
+    assert.deepEqual(summary.journal_system.units, ['vh-news-aggregator.service']);
+    assert.equal(summary.journal_system.exit_codes['69'], 1);
+    assert.deepEqual(summary.journal_user.units, ['user-watch.service']);
+    assert.equal(summary.journal_user.exit_codes['75'], 1);
+    assert.deepEqual(summary.docker_events.containers, ['vhc-relay-a']);
+    assert.equal(summary.docker_events.exit_codes['137'], 1);
+    assert.equal(summary.dmesg.oom_mentions, 1);
+    assert.equal(summary.dmesg.network_mentions, 1);
+
+    const rawUserJournal = readFileSync(path.join(out, 'raw/journal-user.log'), 'utf8');
+    assert.match(rawUserJournal, /do-not-print/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- add the A6 `/etc/hosts` pin runbook for `gun-a/b/c.carboncaste.io`, including readback and rebalance caveats
- document serve-stale live verification without claiming it is observed yet
- add `tools/scripts/collect-host-event-window.sh` plus a focused secret-safety test for the 2026-07-03T13:04Z host-event evidence workflow
- add `pnpm check:host-event-window`

## Related Closure
- #525 was rebased onto current `main`, passed `docs:check` locally, passed CI, and was merged as additive-historical documentation: https://github.com/CarbonCasteInc/VHC/pull/525

## Safety
- no live A6 actions were performed
- raw host logs stay under the operator-owned output `raw/` directory; the script emits a summary JSON with counts, unit/container names, and exit-code buckets only
- serve-stale verification remains operator-approved and single-relay only; this PR does not mark it live-observed

## Validation
- `corepack pnpm@9.7.1 check:host-event-window`
- `bash -n tools/scripts/collect-host-event-window.sh`
- `corepack pnpm@9.7.1 docs:check`
- `git diff --check origin/main...HEAD`
