### PR TITLE
Refine public feed alert severity provenance

### DIFF
--- a/docs/ops/news-aggregator-production-service.md
+++ b/docs/ops/news-aggregator-production-service.md
@@ -70,6 +70,11 @@ Current intended-live posture:
   and an operator confirms receipt from a `VH_PUBLIC_FEED_ALERT_TEST_FIRE=1`
   run. The 2026-07-05 test-fire observed publisher/freshness `pass` but failed
   closed with `alert_delivery_missing_channel` because no channel was configured.
+  Missing or invalid required watch inputs remain critical fail-closed
+  prechecks; relay liveness failure and publisher park classes are critical;
+  snapshot freshness failure, stale watch outputs, watch-closure regression,
+  restart churn, and default heap-limit provenance page as warnings through the
+  same deduped alert channel.
 - The hourly Scope A soak archive timer is intended to stay enabled during the
   post-#701 off-graph relay-memory diagnostic window so each hour preserves
   publisher liveness, relay liveness, relay snapshot freshness, public feed
@@ -148,8 +153,10 @@ PY
 ```
 
 Archive the JSON plus the relay name, image tag/digest, restart timestamp, and
-the two non-target relay `/readyz` readbacks. The artifact is operational
-evidence only; it is not approval to batch relay restarts.
+the two non-target relay `/readyz` readbacks. Only that captured bundle is
+sufficient to mark serve-stale as live-observed; image ancestry or an isolated
+latest-index response is not. The artifact is operational evidence only; it is
+not approval to batch relay restarts.
 
 ### 13:04Z Host-Event Evidence Bundle
 
@@ -344,6 +351,10 @@ systemctl --user start vh-phase5-scope-a-watch-closure.service
 jq '{status, severity, blockers, window, thresholds, relayMemory}' \
   ~/.local/state/vhc/phase5-scope-a-watch-closure/verdict.json
 ```
+
+The installer verifies generated user units with `systemd-analyze verify --user`
+when `systemd-analyze` is available; a verification failure exits `78` before
+daemon reload or timer enablement.
 
 Enable the timer only after the one-shot writes a fresh
 `vh-phase5-scope-a-watch-closure-verdict-v1` verdict for the intended clean

--- a/packages/ai-engine/src/newsRuntime.test.ts
+++ b/packages/ai-engine/src/newsRuntime.test.ts
@@ -474,6 +474,8 @@ describe('newsRuntime', () => {
       status: 'failed',
       tick_sequence: 1,
       first_tick: true,
+      skipped: true,
+      failed_stage: 'orchestrating',
       published_bundle_limit: 1,
       ingested_item_limit: 24,
     }));

--- a/tools/scripts/install-news-aggregator-production-service.sh
+++ b/tools/scripts/install-news-aggregator-production-service.sh
@@ -252,6 +252,36 @@ Unit=vh-phase5-scope-a-watch-closure.service
 WantedBy=timers.target
 EOF
 
+lint_user_units() {
+  if ! command -v systemd-analyze >/dev/null 2>&1; then
+    echo "systemd-analyze not available; skipping user unit verification"
+    return 0
+  fi
+
+  local units=(
+    "${UNIT_DIR}/vh-news-aggregator.service"
+    "${UNIT_DIR}/vh-relay-snapshot-freshness-watch.service"
+    "${UNIT_DIR}/vh-relay-snapshot-freshness-watch.timer"
+    "${UNIT_DIR}/vh-news-aggregator-liveness-watch.service"
+    "${UNIT_DIR}/vh-news-aggregator-liveness-watch.timer"
+    "${UNIT_DIR}/vh-news-relay-liveness-watch.service"
+    "${UNIT_DIR}/vh-news-relay-liveness-watch.timer"
+    "${UNIT_DIR}/vh-phase5-scope-a-soak-archive.service"
+    "${UNIT_DIR}/vh-phase5-scope-a-soak-archive.timer"
+    "${UNIT_DIR}/vh-phase5-scope-a-watch-closure.service"
+    "${UNIT_DIR}/vh-phase5-scope-a-watch-closure.timer"
+  )
+
+  if systemd-analyze verify --user "${units[@]}"; then
+    echo "Verified generated user units with systemd-analyze"
+    return 0
+  fi
+
+  echo "Generated user unit verification failed" >&2
+  exit 78
+}
+
+lint_user_units
 systemctl --user daemon-reload
 
 echo "Installed user units:"

--- a/tools/scripts/public-feed-alert-watch.mjs
+++ b/tools/scripts/public-feed-alert-watch.mjs
@@ -11,7 +11,7 @@ import { runPublicFeedFreshnessMonitor } from './public-feed-freshness-monitor.m
 import { newsAggregatorPublisherLivenessWatchInternal } from './news-aggregator-publisher-liveness-watch.mjs';
 
 const REPORT_SCHEMA_VERSION = 'vh-public-feed-alert-watch-v1';
-const STATE_SCHEMA_VERSION = 'vh-public-feed-alert-state-v1';
+const STATE_SCHEMA_VERSION = 'vh-public-feed-alert-state-v2';
 const DEFAULT_UNIT = 'vh-news-aggregator.service';
 const DEFAULT_STATE_DIR = '.local/state/vhc/public-feed-alert';
 const DEFAULT_TIMEOUT_MS = 15_000;
@@ -180,7 +180,7 @@ function reportFreshnessBlockers({ label, report, maxAgeMs, now }) {
   if (ageMs === null) {
     blockers.push(`${label}_generated_at_missing`);
   } else if (ageMs > maxAgeMs) {
-    blockers.push(`${label}_report_stale:${ageMs}/${maxAgeMs}`);
+    blockers.push(`${label}_output_stale:${ageMs}/${maxAgeMs}`);
   }
   return {
     ageMs,
@@ -194,6 +194,10 @@ function reportStatusBlockers({ label, report, sanitizeBlocker = sanitizeAlertTe
     ? report.blockers.map((blocker) => `${label}:${sanitizeBlocker(blocker)}`)
     : [`${label}_status:${sanitizeAlertText(report?.status ?? 'missing')}`];
   return blockers;
+}
+
+function hasBlockers(value) {
+  return Array.isArray(value) && value.length > 0;
 }
 
 function relayLivenessFile(env) {
@@ -255,14 +259,19 @@ function summarizeRelayLivenessReport({ env, now }) {
     maxAgeMs,
     now,
   });
+  const statusBlockers = reportStatusBlockers({ label: 'relay_liveness', report: read.parsed });
   const blockers = [
     ...freshness.blockers,
-    ...reportStatusBlockers({ label: 'relay_liveness', report: read.parsed }),
+    ...statusBlockers,
   ];
   return {
     schemaVersion: read.parsed.schemaVersion ?? null,
     status: blockers.length > 0 ? 'fail' : 'pass',
-    severity: blockers.length > 0 ? 'critical' : 'none',
+    severity: hasBlockers(statusBlockers)
+      ? 'critical'
+      : hasBlockers(freshness.blockers)
+        ? 'warning'
+        : 'none',
     required: true,
     sourceFileHash: hashValue(filePath),
     generatedAt: read.parsed.generatedAt ?? null,
@@ -344,18 +353,19 @@ function summarizeRelaySnapshotReport({ env, now }) {
     maxAgeMs,
     now,
   });
+  const statusBlockers = reportStatusBlockers({
+    label: 'relay_snapshot',
+    report: read.parsed,
+    sanitizeBlocker: sanitizeSnapshotBlocker,
+  });
   const blockers = [
     ...freshness.blockers,
-    ...reportStatusBlockers({
-      label: 'relay_snapshot',
-      report: read.parsed,
-      sanitizeBlocker: sanitizeSnapshotBlocker,
-    }),
+    ...statusBlockers,
   ];
   return {
     schemaVersion: read.parsed.schemaVersion ?? null,
     status: blockers.length > 0 ? 'fail' : 'pass',
-    severity: blockers.length > 0 ? 'critical' : 'none',
+    severity: blockers.length > 0 ? 'warning' : 'none',
     required: true,
     sourceFileHash: hashValue(filePath),
     generatedAt: read.parsed.generatedAt ?? null,
@@ -379,6 +389,32 @@ function summarizeRelaySnapshotReport({ env, now }) {
 
 function sanitizeWatchClosureBlocker(blocker) {
   return sanitizeAlertText(blocker);
+}
+
+function defaultLimitSource(value) {
+  return String(value ?? '').startsWith('default:');
+}
+
+function watchClosureProvenanceBlockers(verdict) {
+  const relayMemory = verdict?.relayMemory;
+  if (!relayMemory) return [];
+  const blockers = [];
+  if (defaultLimitSource(relayMemory.heapLimitSource)) {
+    blockers.push([
+      'watch_closure_heap_limit_source_default',
+      'aggregate',
+      sanitizeWatchClosureBlocker(relayMemory.heapLimitSource),
+    ].join(':'));
+  }
+  if (Array.isArray(relayMemory.relays)) {
+    for (const relay of relayMemory.relays) {
+      if (!defaultLimitSource(relay?.heapLimitSource)) continue;
+      blockers.push(
+        `watch_closure_heap_limit_source_default:${sanitizeWatchClosureBlocker(relay?.name ?? 'unknown')}:${sanitizeWatchClosureBlocker(relay.heapLimitSource)}`,
+      );
+    }
+  }
+  return blockers;
 }
 
 function summarizeWatchClosureVerdict({ env, now }) {
@@ -431,11 +467,12 @@ function summarizeWatchClosureVerdict({ env, now }) {
       ? read.parsed.blockers.map((blocker) => `watch_closure:${sanitizeWatchClosureBlocker(blocker)}`)
       : ['watch_closure_status:fail']
     : [];
-  const blockers = [...freshness.blockers, ...verdictBlockers];
+  const provenanceBlockers = watchClosureProvenanceBlockers(read.parsed);
+  const blockers = [...freshness.blockers, ...verdictBlockers, ...provenanceBlockers];
   return {
     schemaVersion: read.parsed.schemaVersion ?? null,
     status: blockers.length > 0 ? 'fail' : 'pass',
-    severity: blockers.length > 0 ? 'critical' : 'none',
+    severity: blockers.length > 0 ? 'warning' : 'none',
     required: true,
     sourceFileHash: hashValue(filePath),
     generatedAt: read.parsed.generatedAt ?? null,
@@ -467,11 +504,14 @@ function summarizeWatchClosureVerdict({ env, now }) {
       ? {
           status: read.parsed.relayMemory.status ?? null,
           heapPlateauVerdict: read.parsed.relayMemory.heapPlateauVerdict ?? null,
+          heapLimitSource: read.parsed.relayMemory.heapLimitSource ?? null,
+          rssLimitSource: read.parsed.relayMemory.rssLimitSource ?? null,
           relays: Array.isArray(read.parsed.relayMemory.relays)
             ? read.parsed.relayMemory.relays.map((relay) => ({
                 name: relay.name ?? null,
                 trendStatus: relay.trendStatus ?? null,
                 heapPlateauVerdict: relay.heapPlateauVerdict ?? null,
+                heapLimitSource: relay.heapLimitSource ?? null,
                 shortestProjectedLimitHours: Number.isFinite(relay.shortestProjectedLimitHours)
                   ? relay.shortestProjectedLimitHours
                   : null,
@@ -685,6 +725,9 @@ function shouldDeliverAlert({
   const previousStatus = previousState?.lastObservedStatus ?? null;
   const previousDeliveredFingerprint = previousState?.lastDeliveredFingerprint ?? null;
   const lastDeliveredAtMs = Date.parse(String(previousState?.lastDeliveredAt ?? ''));
+  const previousStateSchemaVersion = previousState?.schemaVersion ?? null;
+  const stateSchemaMismatch = previousStateSchemaVersion !== null
+    && previousStateSchemaVersion !== STATE_SCHEMA_VERSION;
   const heartbeatDue = heartbeatMs > 0
     && (!Number.isFinite(lastDeliveredAtMs) || now - lastDeliveredAtMs >= heartbeatMs);
   const changed = previousFingerprint !== null && previousFingerprint !== fingerprint;
@@ -702,14 +745,37 @@ function shouldDeliverAlert({
     reason = 'retry_failed_delivery';
   } else if (failureOrRecoveryChanged) {
     reason = 'state_changed';
+  } else if (stateSchemaMismatch && status === 'fail') {
+    reason = 'state_changed';
   } else if (heartbeatDue) {
     reason = 'heartbeat_due';
   }
   return {
-    deliver: testFire || firstFailure || retryUndeliveredFailure || failureOrRecoveryChanged || heartbeatDue,
+    deliver: testFire
+      || firstFailure
+      || retryUndeliveredFailure
+      || failureOrRecoveryChanged
+      || (stateSchemaMismatch && status === 'fail')
+      || heartbeatDue,
     reason,
     heartbeatMs,
     status,
+  };
+}
+
+function sourceStatusesFor({
+  publisher,
+  freshness,
+  relayLiveness,
+  relaySnapshot,
+  watchClosure,
+}) {
+  return {
+    publisher: publisher?.status ?? null,
+    freshness: freshness?.status ?? null,
+    relayLiveness: relayLiveness?.status ?? null,
+    relaySnapshot: relaySnapshot?.status ?? null,
+    watchClosure: watchClosure?.status ?? null,
   };
 }
 
@@ -859,6 +925,7 @@ async function persistState({
   fingerprint,
   status,
   publisher,
+  sourceStatuses,
   delivery,
   previousState,
 }) {
@@ -882,6 +949,7 @@ async function persistState({
     lastPublisherNRestarts: Number.isFinite(publisher?.nRestarts)
       ? publisher.nRestarts
       : previousState?.lastPublisherNRestarts ?? null,
+    sourceStatuses,
   };
   await writeJson(stateFile, state);
   return state;
@@ -992,6 +1060,13 @@ export async function runPublicFeedAlertWatch({
     fingerprint,
     status: observedStatus,
     publisher,
+    sourceStatuses: sourceStatusesFor({
+      publisher,
+      freshness,
+      relayLiveness,
+      relaySnapshot,
+      watchClosure,
+    }),
     delivery,
     previousState,
   });
@@ -1029,6 +1104,7 @@ export const publicFeedAlertWatchInternal = {
   summarizeRelayLivenessReport,
   summarizeRelaySnapshotReport,
   summarizeWatchClosureVerdict,
+  watchClosureProvenanceBlockers,
 };
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {

--- a/tools/scripts/public-feed-alert-watch.test.mjs
+++ b/tools/scripts/public-feed-alert-watch.test.mjs
@@ -195,11 +195,14 @@ function watchClosureVerdict(overrides = {}) {
     relayMemory: {
       status: 'pass',
       heapPlateauVerdict: 'heap_driver_unknown',
+      heapLimitSource: 'VH_RELAY_WATCHDOG_MAX_HEAP_USED_BYTES',
+      rssLimitSource: 'VH_RELAY_WATCHDOG_MAX_RSS_BYTES',
       relays: [
         {
           name: 'vhc-relay-a',
           trendStatus: 'pass',
           heapPlateauVerdict: 'heap_driver_unknown',
+          heapLimitSource: 'VH_RELAY_WATCHDOG_MAX_HEAP_USED_BYTES',
           shortestProjectedLimitHours: null,
         },
       ],
@@ -369,7 +372,9 @@ test('relay snapshot failures redact absolute snapshot paths', async () => {
     });
 
     assert.equal(summary.status, 'fail');
+    assert.equal(summary.severity, 'warning');
     assert.equal(summary.relaySnapshot.status, 'fail');
+    assert.equal(summary.relaySnapshot.severity, 'warning');
     assert.match(summary.blockers.join('\n'), /snapshot_file_hash:/);
     assert.equal(JSON.stringify(summary).includes(snapshotPath), false);
     const body = JSON.parse(calls[0].init.body);
@@ -381,7 +386,49 @@ test('relay snapshot failures redact absolute snapshot paths', async () => {
   }
 });
 
-test('watch-closure fail verdict pages with threshold provenance', async () => {
+test('stale auxiliary report output is warning severity and dedupes across age drift', async () => {
+  const root = tempRoot();
+  const calls = [];
+  try {
+    const env = baseEnv(root, {
+      ...writeAuxReports(root, {
+        relay: relayLivenessReport({ generatedAt: '2026-07-02T17:20:00.000Z' }),
+      }),
+      VH_PUBLIC_FEED_ALERT_RELAY_LIVENESS_MAX_AGE_MS: '600000',
+      VH_PUBLIC_FEED_ALERT_WEBHOOK_URL: 'https://hooks.example.invalid/token',
+    });
+    const options = {
+      env,
+      repoRoot: root,
+      systemctlShowText: activeSystemctl(),
+      freshnessMonitorImpl: async () => freshnessSummary(),
+      fetchImpl: async (url, init) => {
+        calls.push({ url, init });
+        return { ok: true, status: 204 };
+      },
+    };
+    const first = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({
+      ...options,
+      now: Date.parse('2026-07-02T18:00:00.000Z'),
+    });
+    const second = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({
+      ...options,
+      now: Date.parse('2026-07-02T18:05:00.000Z'),
+    });
+
+    assert.equal(first.status, 'fail');
+    assert.equal(first.severity, 'warning');
+    assert.equal(first.relayLiveness.severity, 'warning');
+    assert.match(first.blockers.join('\n'), /relay_liveness_output_stale:/);
+    assert.equal(second.fingerprint, first.fingerprint);
+    assert.equal(second.delivery.status, 'suppressed');
+    assert.equal(calls.length, 1);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('watch-closure fail verdict pages as warning with threshold provenance', async () => {
   const root = tempRoot();
   const calls = [];
   try {
@@ -424,12 +471,112 @@ test('watch-closure fail verdict pages with threshold provenance', async () => {
     });
 
     assert.equal(summary.status, 'fail');
+    assert.equal(summary.severity, 'warning');
     assert.equal(summary.watchClosure.status, 'fail');
+    assert.equal(summary.watchClosure.severity, 'warning');
     assert.match(summary.blockers.join('\n'), /watch_closure:relay_memory_trend_fail/);
     const body = JSON.parse(calls[0].init.body);
+    assert.equal(body.severity, 'warning');
     assert.equal(body.watchClosure.thresholds.fortyEightHour.status, 'fail');
     assert.equal(body.watchClosure.relayMemory.heapPlateauVerdict, 'heap_still_linear');
     assert.equal(body.watchClosure.relayMemory.relays[0].name, 'vhc-relay-c');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('watch-closure default heap limit provenance pages as warning', async () => {
+  const root = tempRoot();
+  try {
+    const env = baseEnv(root, {
+      ...writeAuxReports(root, {
+        closure: watchClosureVerdict({
+          relayMemory: {
+            status: 'pass',
+            heapPlateauVerdict: 'heap_plateau_observed',
+            heapLimitSource: 'default:public-beta-compose',
+            rssLimitSource: 'VH_RELAY_WATCHDOG_MAX_RSS_BYTES',
+            relays: [
+              {
+                name: 'vhc-relay-a',
+                trendStatus: 'pass',
+                heapPlateauVerdict: 'heap_plateau_observed',
+                heapLimitSource: 'default:public-beta-compose:relay-a',
+                shortestProjectedLimitHours: 240,
+              },
+            ],
+          },
+        }),
+      }),
+      VH_PUBLIC_FEED_ALERT_WEBHOOK_URL: 'https://hooks.example.invalid/token',
+    });
+    const summary = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({
+      env,
+      repoRoot: root,
+      now: Date.parse('2026-07-02T18:00:00.000Z'),
+      systemctlShowText: activeSystemctl(),
+      freshnessMonitorImpl: async () => freshnessSummary(),
+      fetchImpl: async () => ({ ok: true, status: 204 }),
+    });
+
+    assert.equal(summary.status, 'fail');
+    assert.equal(summary.severity, 'warning');
+    assert.equal(summary.watchClosure.severity, 'warning');
+    assert.match(summary.blockers.join('\n'), /watch_closure_heap_limit_source_default:aggregate/);
+    assert.match(summary.blockers.join('\n'), /watch_closure_heap_limit_source_default:vhc-relay-a/);
+    assert.equal(summary.watchClosure.relayMemory.heapLimitSource, 'default:public-beta-compose');
+    assert.equal(summary.watchClosure.relayMemory.relays[0].heapLimitSource, 'default:public-beta-compose:relay-a');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('state schema migration redelivers an unchanged failure once', async () => {
+  const root = tempRoot();
+  const calls = [];
+  try {
+    const env = baseEnv(root, {
+      ...writeAuxReports(root, {
+        snapshot: relaySnapshotReport({
+          status: 'fail',
+          blockers: ['newest_entry_stale:30000000/21600000'],
+        }),
+      }),
+      VH_PUBLIC_FEED_ALERT_WEBHOOK_URL: 'https://hooks.example.invalid/token',
+    });
+    const options = {
+      env,
+      repoRoot: root,
+      now: Date.parse('2026-07-02T18:00:00.000Z'),
+      systemctlShowText: activeSystemctl(),
+      freshnessMonitorImpl: async () => freshnessSummary(),
+      fetchImpl: async (url, init) => {
+        calls.push({ url, init });
+        return { ok: true, status: 204 };
+      },
+    };
+
+    const first = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch(options);
+    const state = JSON.parse(readFileSync(path.join(root, 'state.json'), 'utf8'));
+    assert.equal(state.schemaVersion, 'vh-public-feed-alert-state-v2');
+    assert.deepEqual(state.sourceStatuses, {
+      publisher: 'pass',
+      freshness: 'pass',
+      relayLiveness: 'pass',
+      relaySnapshot: 'fail',
+      watchClosure: 'pass',
+    });
+    writeJson(path.join(root, 'state.json'), {
+      ...state,
+      schemaVersion: 'vh-public-feed-alert-state-v1',
+    });
+
+    const second = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch(options);
+
+    assert.equal(first.fingerprint, second.fingerprint);
+    assert.equal(second.delivery.status, 'sent');
+    assert.equal(second.delivery.reason, 'state_changed');
+    assert.equal(calls.length, 2);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- stratify auxiliary alert severity instead of flattening every relay/snapshot/watch-closure blocker to critical
- add warning blockers for stale auxiliary outputs and default watch-closure heap-limit provenance
- bump alert state schema to v2 with source statuses and one-time redelivery on old-state failure migration
- assert skipped first ticks keep first-tick caps, verify generated user units with systemd-analyze when available, and clarify serve-stale observed evidence

## Safety
- no live A6 action
- missing/invalid required reports still fail closed as critical
- relay liveness and publisher parked/fail-closed classes remain critical
- snapshot freshness, watch-closure regression, restart churn, stale outputs, and default heap-limit provenance page as warnings through the existing dedup channel

## Validation
- corepack pnpm@9.7.1 check:public-feed:alert-watch
- corepack pnpm@9.7.1 check:scope-a-watch-closure
- corepack pnpm@9.7.1 --filter @vh/ai-engine exec vitest run src/newsRuntime.test.ts --config ./vitest.config.ts
- bash -n tools/scripts/install-news-aggregator-production-service.sh
- corepack pnpm@9.7.1 docs:check
- git diff --check
- corepack pnpm@9.7.1 exec node --test tools/scripts/news-aggregator-publisher-liveness-watch.test.mjs tools/scripts/public-feed-alert-watch.test.mjs
