### PR TITLE
Harden origin deploy and release evidence manifest

### DIFF
--- a/docs/ops/news-aggregator-production-service.md
+++ b/docs/ops/news-aggregator-production-service.md
@@ -1188,6 +1188,15 @@ These commands are read-only until the final restart/deploy line. Do not run any
 public latest-index HTTP probe before this packet proves the #638 relay image is
 running.
 
+For the generated A6 public-beta deploy packet
+(`tools/scripts/emit-a6-public-beta-deploy-packet.sh`), pass the intended release
+commit with `--expected-origin-revision` before printing recreate commands. The
+origin env rewrite intentionally drops `VH_PUBLIC_ORIGIN_BUILD_REVISION` and
+`VH_PUBLIC_ORIGIN_BUILD_CREATED` from the old container env capture so the new
+image-baked build stamp wins. The origin recreate block uses `set -euo
+pipefail`, checks the Docker revision label with exit `78` on mismatch, and
+polls `/healthz` for up to 60 seconds before asserting `build_revision`.
+
 Read-only precheck:
 
 ```bash
@@ -1300,6 +1309,20 @@ release-grade command is intentionally not the publisher restart preflight
 because a long publisher outage can otherwise create a deadlock: the feed cannot
 restart until it has recent release-evidence runs, but it cannot generate those
 runs while the publisher is stopped.
+
+For a release packet, regenerate the full MVP evidence manifest on the intended
+commit rather than reusing stale artifacts:
+
+```bash
+expected_commit="$(git rev-parse HEAD)"
+node tools/scripts/regenerate-mvp-release-evidence.mjs --check --commit "${expected_commit}"
+jq '{status, expected_commit, release_commit_verified, artifacts}' \
+  .tmp/release-evidence-pipeline/latest/release-evidence-pipeline-report.json
+```
+
+The manifest fails before running commands if the checkout does not match
+`--commit`, records every command identity without stdout/stderr, and includes a
+sha256 for each report consumed by `mvp-closeout`.
 
 ## Publisher Start Abort Criteria
 

--- a/tools/scripts/emit-a6-public-beta-deploy-packet.sh
+++ b/tools/scripts/emit-a6-public-beta-deploy-packet.sh
@@ -318,7 +318,7 @@ function envCaptureCommand(name, rewriteAnalysisTarget = false, relay = false) {
   }
   return [
     `sudo docker inspect ${name} --format '{{range .Config.Env}}{{println .}}{{end}}' > ${envPath}.current`,
-    `awk 'BEGIN{done=0} /^VH_PUBLIC_ORIGIN_STATIC_DIR=/{next} /^VH_PUBLIC_ORIGIN_PEER_CONFIG_PATH=/{next} /^VH_PUBLIC_ORIGIN_ANALYSIS_TARGET=/{print "VH_PUBLIC_ORIGIN_ANALYSIS_TARGET=${analysisTarget}"; done=1; next} {print} END{if(!done) print "VH_PUBLIC_ORIGIN_ANALYSIS_TARGET=${analysisTarget}"}' ${envPath}.current > ${envPath}`,
+    `awk 'BEGIN{done=0} /^VH_PUBLIC_ORIGIN_STATIC_DIR=/{next} /^VH_PUBLIC_ORIGIN_PEER_CONFIG_PATH=/{next} /^VH_PUBLIC_ORIGIN_BUILD_REVISION=/{next} /^VH_PUBLIC_ORIGIN_BUILD_CREATED=/{next} /^VH_PUBLIC_ORIGIN_ANALYSIS_TARGET=/{print "VH_PUBLIC_ORIGIN_ANALYSIS_TARGET=${analysisTarget}"; done=1; next} {print} END{if(!done) print "VH_PUBLIC_ORIGIN_ANALYSIS_TARGET=${analysisTarget}"}' ${envPath}.current > ${envPath}`,
     ...relayDefaults,
     `chmod 600 ${envPath}`,
     `rm -f ${envPath}.current`,
@@ -591,12 +591,29 @@ if (includeRecreate) {
   lines.push('Deploy origin only after all relays prove the #638 image and safe persist probes pass.');
   lines.push('');
   lines.push('```bash');
+  lines.push('set -euo pipefail');
   lines.push(`sudo docker rm -f ${originName}`);
   lines.push(runCommandFor(originName, newOriginImage, false));
   lines.push(`sudo docker inspect ${originName} --format '{{.Config.Image}} {{.Image}} {{index .Config.Labels "org.opencontainers.image.revision"}}'`);
-  lines.push(`test "$(sudo docker inspect ${originName} --format '{{index .Config.Labels "org.opencontainers.image.revision"}}')" = ${shellSingleQuote(expectedOriginRevision)}`);
-  lines.push('curl -fsS http://127.0.0.1:8080/healthz > /tmp/vhc-public-beta-deploy/origin.healthz.json');
-  lines.push(`python3 - /tmp/vhc-public-beta-deploy/origin.healthz.json ${shellSingleQuote(expectedOriginRevision)} <<'PY'`);
+  lines.push(`origin_revision="$(sudo docker inspect ${originName} --format '{{index .Config.Labels "org.opencontainers.image.revision"}}')"`);
+  lines.push(`if [[ "\${origin_revision}" != ${shellSingleQuote(expectedOriginRevision)} ]]; then`);
+  lines.push(`  echo "${originName}: revision label \${origin_revision} did not match expected ${expectedOriginRevision}" >&2`);
+  lines.push('  exit 78');
+  lines.push('fi');
+  lines.push('origin_healthz=/tmp/vhc-public-beta-deploy/origin.healthz.json');
+  lines.push('origin_attempt=1');
+  lines.push('while [[ "${origin_attempt}" -le 60 ]]; do');
+  lines.push('  if curl -fsS http://127.0.0.1:8080/healthz > "${origin_healthz}"; then');
+  lines.push('    break');
+  lines.push('  fi');
+  lines.push('  if [[ "${origin_attempt}" -eq 60 ]]; then');
+  lines.push('    echo "origin /healthz did not pass after 60s" >&2');
+  lines.push('    exit 78');
+  lines.push('  fi');
+  lines.push('  sleep 1');
+  lines.push('  origin_attempt=$((origin_attempt + 1))');
+  lines.push('done');
+  lines.push(`python3 - "\${origin_healthz}" ${shellSingleQuote(expectedOriginRevision)} <<'PY'`);
   lines.push('import json, sys');
   lines.push('path, expected = sys.argv[1], sys.argv[2]');
   lines.push('with open(path, "r", encoding="utf-8") as handle: payload = json.load(handle)');
@@ -612,6 +629,7 @@ if (includeRecreate) {
   lines.push('## Rollback');
   lines.push('');
   lines.push('```bash');
+  lines.push('set -euo pipefail');
   for (const name of relayNames) {
     const container = byName.get(name);
     lines.push(`sudo docker rm -f ${name}`);

--- a/tools/scripts/public-beta-image-deploy.test.mjs
+++ b/tools/scripts/public-beta-image-deploy.test.mjs
@@ -391,6 +391,8 @@ test('deploy packet preserves relay bind mounts and rewrites origin env safely',
       'VH_PUBLIC_ORIGIN_FAIL_IF_MISSING_STATIC=true',
       'VH_PUBLIC_ORIGIN_RELAY_TARGETS=http://127.0.0.1:8777,http://127.0.0.1:8778,http://127.0.0.1:8779',
       "VH_PUBLIC_ORIGIN_CSP_CONNECT_SRC='self' https://venn.carboncaste.io wss://gun-a.carboncaste.io",
+      'VH_PUBLIC_ORIGIN_BUILD_REVISION=old-image-revision',
+      'VH_PUBLIC_ORIGIN_BUILD_CREATED=2026-06-14T00:00:00.000Z',
       'SECRET_VALUE=do-not-print',
     ];
     const containers = [
@@ -444,6 +446,17 @@ test('deploy packet preserves relay bind mounts and rewrites origin env safely',
     assert.match(result.stdout, /origin\.healthz\.json/);
     assert.match(result.stdout, /build_revision.*expected/);
     assert.match(result.stdout, /"origin_healthz": "pass"/);
+    const originDeploySection = result.stdout.slice(
+      result.stdout.indexOf('## Origin Deploy'),
+      result.stdout.indexOf('## Rollback'),
+    );
+    assert.match(originDeploySection, /set -euo pipefail/);
+    assert.match(originDeploySection, /origin_revision="\$\(sudo docker inspect vhc-public-origin/);
+    assert.match(originDeploySection, /exit 78/);
+    assert.match(originDeploySection, /while \[\[ "\$\{origin_attempt\}" -le 60 \]\]; do/);
+    assert.match(originDeploySection, /origin \/healthz did not pass after 60s/);
+    const rollbackSection = result.stdout.slice(result.stdout.indexOf('## Rollback'));
+    assert.match(rollbackSection, /set -euo pipefail/);
     assert.match(result.stdout, /len\(entries\) == 0/);
     assert.match(result.stdout, /"entry_count": len\(entries\)/);
     assert.doesNotMatch(result.stdout, /entries != 15/);
@@ -524,6 +537,8 @@ test('deploy packet preserves relay bind mounts and rewrites origin env safely',
     assert.ok(originRewriteLine, result.stdout);
     assert.match(originRewriteLine, /\/\^VH_PUBLIC_ORIGIN_STATIC_DIR=\//);
     assert.match(originRewriteLine, /\/\^VH_PUBLIC_ORIGIN_PEER_CONFIG_PATH=\//);
+    assert.match(originRewriteLine, /\/\^VH_PUBLIC_ORIGIN_BUILD_REVISION=\//);
+    assert.match(originRewriteLine, /\/\^VH_PUBLIC_ORIGIN_BUILD_CREATED=\//);
     const originRewriteMatch = originRewriteLine.match(/^awk '([^']+)' \/tmp\/vhc-public-beta-deploy\/vhc-public-origin\.env\.current > \/tmp\/vhc-public-beta-deploy\/vhc-public-origin\.env$/);
     assert.ok(originRewriteMatch, originRewriteLine);
     const currentEnvPath = path.join(root, 'vhc-public-origin.env.current');
@@ -532,6 +547,8 @@ test('deploy packet preserves relay bind mounts and rewrites origin env safely',
     assert.equal(transformed.status, 0, transformed.stderr);
     assert.doesNotMatch(transformed.stdout, /^VH_PUBLIC_ORIGIN_STATIC_DIR=/m);
     assert.doesNotMatch(transformed.stdout, /^VH_PUBLIC_ORIGIN_PEER_CONFIG_PATH=/m);
+    assert.doesNotMatch(transformed.stdout, /^VH_PUBLIC_ORIGIN_BUILD_REVISION=/m);
+    assert.doesNotMatch(transformed.stdout, /^VH_PUBLIC_ORIGIN_BUILD_CREATED=/m);
     assert.match(transformed.stdout, /^VH_PUBLIC_ORIGIN_ANALYSIS_TARGET=http:\/\/127\.0\.0\.1:3001$/m);
     assert.match(transformed.stdout, /^HOST=127\.0\.0\.1$/m);
     assert.match(transformed.stdout, /^PORT=8080$/m);

--- a/tools/scripts/regenerate-mvp-release-evidence.mjs
+++ b/tools/scripts/regenerate-mvp-release-evidence.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { mkdir } from 'node:fs/promises';
 import path from 'node:path';
@@ -66,13 +67,14 @@ export const RELEASE_EVIDENCE_STEPS = Object.freeze([
 
 function usage() {
   return [
-    'Usage: node tools/scripts/regenerate-mvp-release-evidence.mjs [--check] [--allow-dirty]',
+    'Usage: node tools/scripts/regenerate-mvp-release-evidence.mjs [--check] [--allow-dirty] [--commit <sha>]',
     '',
     'Regenerates the reports consumed by pnpm check:mvp-closeout and writes a',
     'secret-safe pipeline report under .tmp/release-evidence-pipeline/latest.',
     '',
     'The report records command identity, exit status, artifact paths/statuses,',
-    'and closeout blockers. It does not store command stdout or stderr.',
+    'artifact sha256 values, and closeout blockers. It does not store command',
+    'stdout or stderr.',
   ].join('\n');
 }
 
@@ -80,12 +82,19 @@ function parseArgs(argv = process.argv.slice(2)) {
   const options = {
     check: false,
     allowDirty: false,
+    commit: null,
   };
-  for (const token of argv) {
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
     if (token === '--check') {
       options.check = true;
     } else if (token === '--allow-dirty') {
       options.allowDirty = true;
+    } else if (token === '--commit') {
+      const value = argv[index + 1];
+      if (!value) throw new Error('--commit requires a value');
+      options.commit = value;
+      index += 1;
     } else if (token === '--help' || token === '-h') {
       options.help = true;
     } else {
@@ -111,6 +120,17 @@ function commandText(command) {
 
 function relativePath(repoRoot, filePath) {
   return path.relative(repoRoot, filePath).split(path.sep).join('/');
+}
+
+function sha256File(filePath) {
+  return createHash('sha256').update(readFileSync(filePath)).digest('hex');
+}
+
+function commitMatches(actual, expected) {
+  if (!expected) return true;
+  const actualText = String(actual ?? '');
+  const expectedText = String(expected ?? '');
+  return actualText.length > 0 && expectedText.length > 0 && actualText.startsWith(expectedText);
 }
 
 function reportStatus(stepId, report) {
@@ -153,6 +173,7 @@ function readReportSummary(repoRoot, step) {
       path: step.reportPath,
       exists: false,
       status: null,
+      sha256: null,
     };
   }
   try {
@@ -160,6 +181,7 @@ function readReportSummary(repoRoot, step) {
     return {
       path: step.reportPath,
       exists: true,
+      sha256: sha256File(fullPath),
       ...reportStatus(step.id, report),
       repo_commit: report.repo?.commit ?? report.repo?.source_commit ?? report.source_commit ?? null,
       generated_at: report.generated_at ?? report.generatedAt ?? null,
@@ -168,6 +190,7 @@ function readReportSummary(repoRoot, step) {
     return {
       path: step.reportPath,
       exists: true,
+      sha256: sha256File(fullPath),
       status: 'unreadable',
       parse_error: error instanceof Error ? error.message : String(error),
     };
@@ -274,10 +297,21 @@ function pipelineBlockers({ initialRepo, finalRepo, steps, closeoutReport, allow
   return blockers;
 }
 
+function artifactManifest(commands) {
+  return commands.map((command) => ({
+    id: command.id,
+    path: command.report_path,
+    exists: command.report?.exists === true,
+    sha256: command.report?.sha256 ?? null,
+    status: command.report?.status ?? null,
+  }));
+}
+
 export async function runReleaseEvidencePipeline(options = {}, deps = {}) {
   const {
     allowDirty = false,
     check = false,
+    commit = null,
     env = process.env,
     repoRoot = defaultRepoRoot,
   } = options;
@@ -288,6 +322,30 @@ export async function runReleaseEvidencePipeline(options = {}, deps = {}) {
 
   const initialRepo = currentRepoStateImpl();
   const runId = buildRunId(initialRepo, nowMs);
+  const expectedCommit = commit;
+
+  if (expectedCommit && !commitMatches(initialRepo.commit, expectedCommit)) {
+    const report = {
+      schema_version: RELEASE_EVIDENCE_PIPELINE_SCHEMA_VERSION,
+      run_id: runId,
+      generated_at: nowIso(),
+      status: 'blocked',
+      check,
+      allow_dirty: allowDirty,
+      expected_commit: expectedCommit,
+      release_commit_verified: false,
+      repo: {
+        before: initialRepo,
+        after: initialRepo,
+      },
+      commands: [],
+      artifacts: [],
+      closeout: null,
+      blockers: [`repo_commit_mismatch:${initialRepo.commit ?? 'missing'}:${expectedCommit}`],
+    };
+    const paths = await writeReport(repoRoot, report);
+    return { report, ...paths };
+  }
 
   if (!allowDirty && initialRepo.dirty !== false) {
     const report = {
@@ -297,12 +355,14 @@ export async function runReleaseEvidencePipeline(options = {}, deps = {}) {
       status: 'blocked',
       check,
       allow_dirty: false,
+      expected_commit: expectedCommit,
       release_commit_verified: false,
       repo: {
         before: initialRepo,
         after: initialRepo,
       },
       commands: [],
+      artifacts: [],
       closeout: null,
       blockers: ['repo_dirty_before_release_evidence_regeneration'],
     };
@@ -318,18 +378,21 @@ export async function runReleaseEvidencePipeline(options = {}, deps = {}) {
   }));
   const closeoutReport = await runMvpCloseoutImpl({ check: false });
   const finalRepo = currentRepoStateImpl();
+  const closeoutReportPath = '.tmp/mvp-closeout/latest/mvp-closeout-report.json';
+  const closeoutReportFullPath = path.join(repoRoot, closeoutReportPath);
   const closeoutStep = {
     id: 'mvp_closeout',
     label: 'MVP consolidated closeout',
     command: 'pnpm check:mvp-closeout',
-    report_path: '.tmp/mvp-closeout/latest/mvp-closeout-report.json',
+    report_path: closeoutReportPath,
     exit_status: closeoutReport?.status === 'pass' ? 0 : 1,
     required_exit_zero: true,
     accepted_boundary_exit: false,
     pipeline_exit_ok: closeoutReport?.status === 'pass',
     report: {
-      path: '.tmp/mvp-closeout/latest/mvp-closeout-report.json',
-      exists: true,
+      path: closeoutReportPath,
+      exists: existsSync(closeoutReportFullPath),
+      sha256: existsSync(closeoutReportFullPath) ? sha256File(closeoutReportFullPath) : null,
       status: closeoutReport?.status ?? null,
       failure_count: Array.isArray(closeoutReport?.failures) ? closeoutReport.failures.length : null,
     },
@@ -349,16 +412,22 @@ export async function runReleaseEvidencePipeline(options = {}, deps = {}) {
     status: blockers.length === 0 ? 'pass' : 'blocked',
     check,
     allow_dirty: allowDirty,
-    release_commit_verified: !allowDirty && initialRepo.dirty === false && finalRepo.dirty === false && initialRepo.commit === finalRepo.commit,
+    expected_commit: expectedCommit,
+    release_commit_verified: !allowDirty
+      && initialRepo.dirty === false
+      && finalRepo.dirty === false
+      && initialRepo.commit === finalRepo.commit
+      && commitMatches(initialRepo.commit, expectedCommit),
     repo: {
       before: initialRepo,
       after: finalRepo,
     },
     commands: allCommands,
+    artifacts: artifactManifest(allCommands),
     closeout: {
       status: closeoutReport?.status ?? null,
       failures: Array.isArray(closeoutReport?.failures) ? closeoutReport.failures : [],
-      report_path: '.tmp/mvp-closeout/latest/mvp-closeout-report.json',
+      report_path: closeoutReportPath,
     },
     blockers,
   };

--- a/tools/scripts/regenerate-mvp-release-evidence.test.mjs
+++ b/tools/scripts/regenerate-mvp-release-evidence.test.mjs
@@ -106,7 +106,7 @@ test('release evidence pipeline regenerates closeout inputs and accepts boundary
   let tick = 1000;
   try {
     const result = await runReleaseEvidencePipeline(
-      { repoRoot: root, check: true, env: {} },
+      { repoRoot: root, check: true, env: {}, commit: 'abc1234567890' },
       {
         spawnSyncImpl: fakeSuccessfulSpawn(root, calls),
         currentRepoStateImpl: () => cleanRepoState(),
@@ -119,6 +119,7 @@ test('release evidence pipeline regenerates closeout inputs and accepts boundary
     );
 
     assert.equal(result.report.status, 'pass');
+    assert.equal(result.report.expected_commit, 'abc1234567890');
     assert.equal(result.report.release_commit_verified, true);
     assert.deepEqual(calls, [
       'pnpm check:news-sources:health',
@@ -136,10 +137,57 @@ test('release evidence pipeline regenerates closeout inputs and accepts boundary
     const persisted = readJson(result.latestReportPath);
     assert.equal(persisted.schema_version, 'vh-mvp-release-evidence-pipeline-v1');
     assert.equal(persisted.status, 'pass');
+    assert.equal(persisted.artifacts.length, 6);
+    assert.deepEqual(
+      persisted.artifacts.map((artifact) => artifact.id),
+      [
+        'source_health',
+        'luma_mvp',
+        'mesh',
+        'production_app_canary',
+        'mvp_release_gates',
+        'mvp_closeout',
+      ],
+    );
+    for (const artifact of persisted.artifacts) {
+      assert.equal(artifact.exists, true);
+      assert.match(artifact.sha256, /^[a-f0-9]{64}$/);
+    }
     for (const command of persisted.commands) {
       assert.equal(Object.hasOwn(command, 'stdout'), false);
       assert.equal(Object.hasOwn(command, 'stderr'), false);
+      assert.match(command.report.sha256, /^[a-f0-9]{64}$/);
     }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('release evidence pipeline refuses a mismatched named release commit before running commands', async () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), 'vh-release-evidence-commit-'));
+  const calls = [];
+  try {
+    const result = await runReleaseEvidencePipeline(
+      { repoRoot: root, check: true, env: {}, commit: 'expected-release-sha' },
+      {
+        spawnSyncImpl: (...args) => {
+          calls.push(args);
+          return { status: 0, signal: null };
+        },
+        currentRepoStateImpl: () => cleanRepoState('actual-release-sha'),
+        runMvpCloseoutImpl: fakeCloseout(root, 'pass'),
+        nowMs: () => 1500,
+      },
+    );
+
+    assert.equal(result.report.status, 'blocked');
+    assert.equal(result.report.expected_commit, 'expected-release-sha');
+    assert.deepEqual(result.report.commands, []);
+    assert.deepEqual(result.report.artifacts, []);
+    assert.deepEqual(result.report.blockers, [
+      'repo_commit_mismatch:actual-release-sha:expected-release-sha',
+    ]);
+    assert.deepEqual(calls, []);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- drop stale `VH_PUBLIC_ORIGIN_BUILD_REVISION` and `VH_PUBLIC_ORIGIN_BUILD_CREATED` from captured origin env files so image-baked build stamps win after recreate
- make the origin deploy block fail closed with `set -euo pipefail`, exit-78 revision-label mismatch, bounded `/healthz` retry, and rollback shell strict mode
- add `--commit` to the MVP release evidence regenerator and fail before running commands on checkout mismatch
- add per-artifact sha256 entries to the release evidence manifest consumed by `mvp-closeout`
- document the origin build-env behavior, origin assertions, and named-commit evidence command

## Safety
- no live A6 action
- packet still prints commands only; destructive recreate commands require `--include-recreate-commands`
- no command stdout/stderr is stored in the release evidence manifest
- origin healthz and label assertions fail closed before an operator could claim a release commit

## Validation
- node --check tools/scripts/regenerate-mvp-release-evidence.mjs
- bash -n tools/scripts/emit-a6-public-beta-deploy-packet.sh
- corepack pnpm@9.7.1 exec node --test tools/scripts/regenerate-mvp-release-evidence.test.mjs tools/scripts/public-beta-image-deploy.test.mjs
- corepack pnpm@9.7.1 docs:check
- git diff --check
