### PR TITLE
Fix StoryCluster production timeout path

### DIFF
--- a/services/storycluster-engine/src/clusterLifecycle.test.ts
+++ b/services/storycluster-engine/src/clusterLifecycle.test.ts
@@ -228,7 +228,24 @@ describe('clusterLifecycle', () => {
     ];
 
     const incoming = makeWorkingDocument('doc-9', 'Port attack expands further', 'port_attack', 'attack', [1, 0]);
-    incoming.candidate_matches = [];
+    incoming.candidate_matches = [
+      {
+        story_id: 'story-b',
+        candidate_score: 0.4,
+        hybrid_score: 0.4,
+        rerank_score: 0.4,
+        adjudication: 'rejected',
+        reason: 'pre-retrieved-candidate',
+      },
+      {
+        story_id: 'story-a',
+        candidate_score: 0.4,
+        hybrid_score: 0.4,
+        rerank_score: 0.4,
+        adjudication: 'rejected',
+        reason: 'pre-retrieved-candidate',
+      },
+    ];
     const next = await assignClusters({
       topicId: 'topic-news',
       referenceNowMs: 1000,
@@ -240,6 +257,55 @@ describe('clusterLifecycle', () => {
     }, undefined);
 
     expect(next.documents[0]?.assigned_story_id).toBe('story-a');
+    expect(next.stage_metrics.dynamic_cluster_assignment?.bounded_fallback_candidate_pool_max).toBe(2);
+  });
+
+  it('does not sweep historical clusters when no bounded retrieval candidates were returned', async () => {
+    const topicState: StoredTopicState = {
+      schema_version: 'storycluster-state-v1',
+      topic_id: 'topic-news',
+      next_cluster_seq: 1,
+      clusters: [],
+    };
+    const existing = makeWorkingDocument('doc-1', 'Port attack expands', 'port_attack', 'attack', [1, 0]);
+    topicState.clusters = [
+      deriveClusterRecord(topicState, 'topic-news', [toStoredSource(existing, existing.source_variants[0]!)], 'story-historical'),
+    ];
+    const incoming = makeWorkingDocument('doc-9', 'Port attack expands further', 'port_attack', 'attack', [1, 0]);
+    incoming.candidate_matches = [];
+
+    const next = await assignClusters({
+      topicId: 'topic-news',
+      referenceNowMs: 1000,
+      documents: [incoming],
+      clusters: [],
+      bundles: [],
+      topic_state: topicState,
+      stage_metrics: {},
+    }, {
+      providerId: 'unused-provider',
+      async translate() {
+        return [];
+      },
+      async embed() {
+        return [];
+      },
+      async analyzeDocuments() {
+        return [];
+      },
+      async rerankPairs() {
+        return [];
+      },
+      async adjudicatePairs() {
+        throw new Error('historical clusters should not be sent for fallback adjudication');
+      },
+      async summarize() {
+        return [];
+      },
+    });
+
+    expect(next.stage_metrics.dynamic_cluster_assignment?.bounded_fallback_candidate_pool_max).toBe(0);
+    expect(next.stage_metrics.dynamic_cluster_assignment?.bounded_fallback_candidate_pool_total).toBe(0);
   });
 
   it('uses provider adjudication to attach same-batch documents to newly created clusters', async () => {

--- a/services/storycluster-engine/src/clusterLifecycle.ts
+++ b/services/storycluster-engine/src/clusterLifecycle.ts
@@ -1,4 +1,4 @@
-import type { ClusterBucket, PipelineState } from './stageState';
+import type { ClusterBucket, PipelineState, StoredClusterRecord, WorkingDocument } from './stageState';
 import type { PairJudgementWorkResult, PairRerankWorkResult, StoryClusterModelProvider, SummaryWorkItem } from './modelProvider';
 import type { ClusterVectorBackend } from './vectorBackend';
 import { MemoryVectorBackend } from './vectorBackend';
@@ -245,6 +245,17 @@ export async function assignClusters(
   let providerRejectedDocs = 0;
   let relatedDocsDeferred = 0;
   let exactSourceReuses = 0;
+  let boundedFallbackCandidatePoolMax = 0;
+  let boundedFallbackCandidatePoolTotal = 0;
+  const candidateClustersForDocument = (document: WorkingDocument): StoredClusterRecord[] => {
+    const storyIds = new Set([
+      ...document.candidate_matches.map((match) => match.story_id),
+      ...changedStoryIds,
+    ]);
+    return [...storyIds]
+      .map((storyId) => clusters.get(storyId))
+      .filter((cluster): cluster is StoredClusterRecord => Boolean(cluster));
+  };
   for (const document of state.documents) {
     const sourceDocuments = document.source_variants.map((variant) => toStoredSource(document, variant));
     const exactSourceCluster = findExactSourceCluster(clusters.values(), document);
@@ -263,7 +274,10 @@ export async function assignClusters(
     }
     let accepted = document.candidate_matches.find((match) => match.adjudication === 'accepted');
     if (!accepted) {
-      const candidateMatches = [...clusters.values()]
+      const candidatePool = candidateClustersForDocument(document);
+      boundedFallbackCandidatePoolMax = Math.max(boundedFallbackCandidatePoolMax, candidatePool.length);
+      boundedFallbackCandidatePoolTotal += candidatePool.length;
+      const candidateMatches = candidatePool
         .filter((cluster) => candidateEligible(document, cluster))
         .map((cluster) => buildCandidateMatch(document, cluster))
         .sort((left, right) => right.rerank_score - left.rerank_score || left.story_id.localeCompare(right.story_id))
@@ -340,6 +354,8 @@ export async function assignClusters(
         provider_rejected_docs: providerRejectedDocs,
         related_docs_deferred: relatedDocsDeferred,
         exact_source_reuses: exactSourceReuses,
+        bounded_fallback_candidate_pool_max: boundedFallbackCandidatePoolMax,
+        bounded_fallback_candidate_pool_total: boundedFallbackCandidatePoolTotal,
       },
     },
   };

--- a/services/storycluster-engine/src/clusterTopology.test.ts
+++ b/services/storycluster-engine/src/clusterTopology.test.ts
@@ -166,6 +166,48 @@ describe('clusterTopology', () => {
     ]);
   });
 
+  it('limits hot-path reconciliation to changed clusters', () => {
+    const topicState = makeTopicState('topic-bounded-hot-path');
+    const stalePrimary = makeDocument('doc-stale-primary', 'Port attack expands');
+    const staleSecondary = makeDocument('doc-stale-secondary', 'Metro blackout spreads', {
+      source_id: 'wire-blackout',
+      url_hash: 'hash-blackout',
+      entities: ['metro_blackout'],
+      linked_entities: ['metro_blackout'],
+      trigger: 'blackout',
+      coarse_vector: [0, 1],
+      full_vector: [0, 1, 0],
+    });
+    const archivedParent = deriveClusterRecord(topicState, topicState.topic_id, [
+      toStoredSource(stalePrimary, stalePrimary.source_variants[0]!),
+      toStoredSource(staleSecondary, staleSecondary.source_variants[0]!),
+    ], 'story-archived-parent');
+    const touchedDoc = makeDocument('doc-touched', 'Court ruling expands', {
+      entities: ['court_ruling'],
+      linked_entities: ['court_ruling'],
+      trigger: 'ruling',
+      coarse_vector: [0.2, 0.8],
+      full_vector: [0.2, 0.8, 0],
+    });
+    const touched = deriveClusterRecord(
+      topicState,
+      topicState.topic_id,
+      [toStoredSource(touchedDoc, touchedDoc.source_variants[0]!)],
+      'story-touched',
+    );
+
+    const clusters = new Map<string, StoredClusterRecord>([
+      [archivedParent.story_id, archivedParent],
+      [touched.story_id, touched],
+    ]);
+    const changed = new Set<string>(['story-touched']);
+
+    reconcileClusterTopology(topicState, topicState.topic_id, clusters, changed);
+
+    expect(clusters.get('story-archived-parent')?.source_documents).toHaveLength(2);
+    expect([...clusters.values()].filter((cluster) => cluster.lineage.split_from === 'story-archived-parent')).toHaveLength(0);
+  });
+
   it('splits a same-tournament singleton out of a persisted bundle without deleting it', () => {
     const topicState = makeTopicState('topic-pga-singleton');
     const raiGuardian = makeDocument('doc-rai-guardian', 'Aaron Rai keeps celebrations low-key after PGA Championship win', {

--- a/services/storycluster-engine/src/clusterTopology.ts
+++ b/services/storycluster-engine/src/clusterTopology.ts
@@ -3,8 +3,29 @@ import { clustersShareExactSourceKey } from './clusterSourceIdentity';
 import { shouldMergeClusters, shouldSplitPair } from './clusterScoring';
 import type { StoredClusterRecord, StoredTopicState } from './stageState';
 
+function compareClusterOrder(left: StoredClusterRecord, right: StoredClusterRecord): number {
+  return left.created_at - right.created_at || left.story_id.localeCompare(right.story_id);
+}
+
 function isDirectSplitPair(left: StoredClusterRecord, right: StoredClusterRecord): boolean {
   return left.story_id === right.lineage.split_from || right.story_id === left.lineage.split_from;
+}
+
+function shouldReconcilePair(left: StoredClusterRecord, right: StoredClusterRecord): boolean {
+  return !isDirectSplitPair(left, right) &&
+    (clustersShareExactSourceKey(left, right) || shouldMergeClusters(left, right));
+}
+
+function mergeClusterPair(
+  left: StoredClusterRecord,
+  right: StoredClusterRecord,
+): StoredClusterRecord {
+  const [survivor, absorbed] = compareClusterOrder(left, right) <= 0
+    ? [left, right]
+    : [right, left];
+  const next = upsertClusterRecord(survivor, absorbed.source_documents);
+  next.lineage = { merged_from: [...new Set([...next.lineage.merged_from, absorbed.story_id])].sort() };
+  return next;
 }
 
 function reconcileSecondaryComponent(
@@ -37,27 +58,62 @@ export function reconcileClusterTopology(
   clusters: Map<string, StoredClusterRecord>,
   changedStoryIds: Set<string>,
 ): void {
+  const fullReconcile = changedStoryIds.size === 0;
   const ordered = [...clusters.values()].sort((left, right) => left.created_at - right.created_at || left.story_id.localeCompare(right.story_id));
-  for (let index = 0; index < ordered.length; index += 1) {
-    for (let otherIndex = index + 1; otherIndex < ordered.length; otherIndex += 1) {
-      const left = ordered[index]!;
-      const right = ordered[otherIndex]!;
-      if (
-        !clusters.has(left.story_id) ||
-        !clusters.has(right.story_id) ||
-        isDirectSplitPair(left, right) ||
-        (!clustersShareExactSourceKey(left, right) && !shouldMergeClusters(left, right))
-      ) {
+  if (fullReconcile) {
+    for (let index = 0; index < ordered.length; index += 1) {
+      for (let otherIndex = index + 1; otherIndex < ordered.length; otherIndex += 1) {
+        const left = ordered[index]!;
+        const right = ordered[otherIndex]!;
+        if (
+          !clusters.has(left.story_id) ||
+          !clusters.has(right.story_id) ||
+          !shouldReconcilePair(left, right)
+        ) {
+          continue;
+        }
+        const next = mergeClusterPair(left, right);
+        clusters.set(next.story_id, next);
+        clusters.delete(next.story_id === left.story_id ? right.story_id : left.story_id);
+        changedStoryIds.add(next.story_id);
+      }
+    }
+  } else {
+    const queue = [...changedStoryIds];
+    const visited = new Set<string>();
+    while (queue.length > 0) {
+      const storyId = queue.shift()!;
+      if (visited.has(storyId)) {
         continue;
       }
-      const next = upsertClusterRecord(left, right.source_documents);
-      next.lineage = { merged_from: [...new Set([...next.lineage.merged_from, right.story_id])].sort() };
-      clusters.set(next.story_id, next);
-      clusters.delete(right.story_id);
-      changedStoryIds.add(next.story_id);
+      visited.add(storyId);
+      const changed = clusters.get(storyId);
+      if (!changed) {
+        continue;
+      }
+      for (const candidate of [...clusters.values()].sort(compareClusterOrder)) {
+        const current = clusters.get(changed.story_id);
+        if (!current || candidate.story_id === current.story_id || !clusters.has(candidate.story_id)) {
+          continue;
+        }
+        if (!shouldReconcilePair(current, candidate)) {
+          continue;
+        }
+        const next = mergeClusterPair(current, candidate);
+        clusters.set(next.story_id, next);
+        clusters.delete(next.story_id === current.story_id ? candidate.story_id : current.story_id);
+        changedStoryIds.add(next.story_id);
+        if (!queue.includes(next.story_id)) {
+          visited.delete(next.story_id);
+          queue.push(next.story_id);
+        }
+      }
     }
   }
-  for (const cluster of [...clusters.values()]) {
+  const clustersToSplit = fullReconcile
+    ? [...clusters.values()]
+    : [...changedStoryIds].map((storyId) => clusters.get(storyId)).filter((cluster): cluster is StoredClusterRecord => Boolean(cluster));
+  for (const cluster of clustersToSplit) {
     const components = connectedComponents(cluster.source_documents, shouldSplitPair);
     if (components.length <= 1) {
       continue;


### PR DESCRIPTION
## Summary
- Bound dynamic assignment fallback to retrieved candidates plus same-batch changed clusters instead of sweeping every historical topic cluster.
- Make topology reconciliation incremental for hot-path changed clusters while preserving full maintenance behavior when no changed clusters are supplied.
- Add regression coverage for bounded fallback and hot-path topology scope.

## Incident Context
Slice 0 alerting is working, but A6 publishing remains stale. Readback showed A6 on `main@da1c95e4`, publisher active/current, relay auth/readiness passing, and each tick failing before raw writes with `remote cluster request timed out after 300000ms`. The failure occurs in StoryCluster `/cluster`, not relay writes or snapshot export.

## Validation
- `corepack pnpm@9.7.1 --filter @vh/storycluster-engine exec vitest run src/clusterLifecycle.test.ts src/clusterTopology.test.ts --config ./vitest.config.ts --reporter=verbose`
- `corepack pnpm@9.7.1 --filter @vh/storycluster-engine typecheck`
- `corepack pnpm@9.7.1 --filter @vh/storycluster-engine exec vitest run src/vectorBackend.test.ts src/server.test.ts src/stageRunner.pipeline.test.ts src/coherenceAudit.test.ts src/storyclusterQualityGate.test.ts --config ./vitest.config.ts --reporter=verbose`
- `corepack pnpm@9.7.1 --filter @vh/storycluster-engine build`
- `git diff --check`

Note: root `corepack pnpm@9.7.1 test:storycluster:quality` was not used for final validation because its nested `pnpm` invocation picked up pnpm 11 from the desktop runtime and attempted a non-TTY install. The equivalent direct vitest command above passed.

No Codex autonomy/executor was enabled. A6 was not patched with this unreviewed branch.