### PR TITLE
docs: add functioning MVP lane slice plan

### DIFF
--- a/docs/plans/FUNCTIONING_MVP_LANE_SLICE_PLAN_2026-07-06.md
+++ b/docs/plans/FUNCTIONING_MVP_LANE_SLICE_PLAN_2026-07-06.md
@@ -1,0 +1,1001 @@
+# Functioning MVP Lane Slice Plan - 2026-07-06
+
+> Status: Technical implementation and operating plan
+> Owner: VHC Core Engineering + VHC Launch Ops
+> Last Reviewed: 2026-07-06
+> Target: functioning Venn News Web PWA MVP
+> Depends On: `docs/foundational/STATUS.md`, `docs/plans/VENN_NEWS_MVP_ROADMAP_2026-04-20.md`, `docs/ops/public-beta-launch-readiness-closeout.md`, `docs/ops/news-aggregator-production-service.md`, `docs/ops/public-feed-freshness-monitor.md`, `docs/ops/vhc-incident-response.md`, `docs/reports/phase5-scope-a-post-slice0-current-state-2026-07-06.md`
+
+## Executive Decision
+
+The MVP target is the Web PWA news loop already defined in
+`docs/plans/VENN_NEWS_MVP_ROADMAP_2026-04-20.md`, not a native app, not the
+public WSS mesh, not production-attested LUMA/Silver, and not autonomous
+production execution.
+
+The functioning MVP is the smallest end-to-end product that can honestly be
+used and released as a public beta:
+
+1. A user opens a fresh usable news feed.
+2. The feed contains singleton stories and bundled stories.
+3. Topic preferences change feed ranking/filtering.
+4. A story opens into a durable detail surface.
+5. The detail surface shows accepted Venn analysis when the release claim says
+   analysis/frame/reframe is part of the MVP; otherwise it must clearly say
+   analysis is pending or unavailable.
+6. Users can take point-level stance on frame/reframe items, not on the story
+   as a whole.
+7. Stance persists, aggregates under the capped influence-falloff model, and is
+   visible after reload/cross-user readback.
+8. The story has a deterministic thread where beta users can reply, report, and
+   observe moderated state.
+9. Public-beta identity, support, policy, telemetry, and forbidden-claim gates
+   remain honest about beta-local proof semantics.
+10. A release evidence packet passes on the intended release commit.
+
+This plan intentionally puts Scope A reliability before enrichment. A stale or
+silent public feed cannot be rescued by a polished detail surface. The first
+MVP lane is therefore the already-live raw-feed/alert proof window, followed by
+accepted synthesis canary work only after the feed remains healthy or a clearly
+approved operator session widens the boundary.
+
+## Current State Of Play
+
+As of this plan:
+
+- Repo `main` is `76f3c77c` after PR #724 aligned the docs with the
+  post-Slice-0 recovery state.
+- Live A6 was updated to `main@47ba218d` after PR #723 fixed the
+  StoryCluster production timeout path. Treat any newer docs-only merge as repo
+  truth until an operator explicitly updates A6 again.
+- Slice 0 is complete: the host-private email alert path is configured, test
+  delivery reached the operator device, and both
+  `vh-public-feed-alert-watch.timer` and
+  `vh-phase5-scope-a-watch-closure.timer` are enabled and active.
+- The normal post-fix publisher tick completed at
+  `2026-07-06T22:44:08.567Z` with `ingested_item_count=24`,
+  `selected_bundle_count=8`, `raw_wrote_count=8`, and
+  `raw_write_failed_count=0`.
+- Public feed freshness, relay liveness, relay snapshot freshness,
+  watch-closure input, and alert watch passed after recovery.
+- The clean evidence window starts at `2026-07-06T22:44:08.567Z`.
+- The 48-hour proof target is `2026-07-08T22:44:08Z`.
+- The 14-day unattended target is `2026-07-20T22:44:08Z` if no operator touch
+  or anomaly resets the window.
+- No post-recovery 500 MB -> 700 MB early heap-summary pair exists yet.
+- The current driver remains `heap_driver_off_graph_likely`; no memory
+  remediation is authorized until secret-safe heap summaries name the retainer.
+- Codex live execution/autonomy is disabled. The executor stays dry-run.
+- The custom pager/PWA exists in repo after PR #722, but email remains the
+  active live alert path until a later pager deployment outside A6.
+
+## Hard Boundaries
+
+These boundaries are part of the plan, not footnotes:
+
+- Do not restart the publisher while feed freshness remains green.
+- Do not restart relays while relay liveness and snapshot freshness remain
+  green.
+- Do not enable Codex live execution or production autonomy.
+- Do not deploy/cut over the custom pager before the email path continues to
+  prove itself and the pager is deployed outside A6 with its own dead-man.
+- Do not run retention, relay compaction, publisher clear, eviction, pruning,
+  or memory remediation before the first post-recovery 500 MB -> 700 MB
+  analyzer summary classifies the retainer.
+- Do not promote raw-feed recovery into accepted-synthesis, mesh, native,
+  identity-assurance, or production-readiness claims.
+- Treat a new alert email as an incident, not setup noise.
+
+## MVP Dependency Graph
+
+```text
+Lane 0: Scope A raw feed + alert proof
+  -> Lane 1: heap evidence and memory-decision boundary
+  -> Lane 2: source supply and feed density
+  -> Lane 3: accepted synthesis/story detail canary
+  -> Lane 4: civic stance + discussion + beta identity
+  -> Lane 5: public beta shell/support/compliance
+  -> Lane 6: release evidence packet and go/no-go
+
+Lane 7: pager/incident hardening runs after email proof and outside A6
+Lane 8: deferred non-MVP tracks stay outside the MVP release claim
+```
+
+The dependency that matters most is Lane 0 before Lane 3. Accepted synthesis
+can increase product value, but it must not disturb the raw publication loop
+until the raw loop has either banked its proof window or a specific incident
+requires action.
+
+## Lane 0 - Scope A Reliability And Evidence Accrual
+
+### Goal
+
+Keep the recovered raw public feed fresh, observable, and untouched while the
+clean window accrues. This lane converts "we recovered" into evidence that the
+MVP feed foundation is actually stable enough to build on.
+
+### Grounded Surfaces
+
+- `docs/reports/phase5-scope-a-post-slice0-current-state-2026-07-06.md`
+- `docs/ops/news-aggregator-production-service.md`
+- `docs/ops/public-feed-freshness-monitor.md`
+- `tools/scripts/public-feed-alert-watch.mjs`
+- `tools/scripts/phase5-scope-a-watch-closure.mjs`
+- `tools/scripts/analyze-early-heap-captures.mjs`
+- `tools/scripts/install-news-aggregator-user-service.mjs`
+- `services/news-aggregator/src/index.ts`
+- `packages/ai-engine/src/newsRuntime.ts`
+
+### Slice 0.1 - No-Change Watch Window
+
+Implementation:
+
+- Leave `vh-news-aggregator.service`, `vh-storycluster-engine.service`, relay
+  services, alert timers, and watch-closure timers in their current healthy
+  state.
+- Record readbacks only when there is an operator-approved check-in or an
+  alert.
+- Preserve the current raw-only profile: accepted synthesis disabled,
+  replay disabled, storylines disabled, raw cap `8`, raw write concurrency `2`,
+  repair interval `86400000`, prune disabled, relay REST min-success `2`.
+
+Verification:
+
+- `vh-public-feed-alert-watch.timer` remains enabled/active.
+- `vh-phase5-scope-a-watch-closure.timer` remains enabled/active.
+- Alert watch reports delivery health and does not silently stall.
+- Watch closure remains `in_progress` only because the proof window is short,
+  not because freshness/liveness failed.
+
+Done when:
+
+- The 48-hour proof target passes without anomaly, or a new alert interrupts
+  the lane and opens an incident.
+
+### Slice 0.2 - Alert-First Incident Branch
+
+Trigger:
+
+- Any fresh email from the alert watch for freshness, relay liveness, relay
+  snapshot, watch-closure input, publisher park, or critical class.
+
+Implementation:
+
+- Stop planned MVP enrichment work.
+- Run read-only diagnosis first:
+  - publisher active state and latest tick summary;
+  - StoryCluster active state and timeout/error stage;
+  - raw write attempted/wrote/failed counts;
+  - relay REST auth/readiness/liveness;
+  - relay snapshot freshness;
+  - latest public index age;
+  - alert/watch-closure verdict files.
+- Decide the smallest operator action from the readback:
+  - publisher active but stale/no clean tick: restart publisher onto current
+    approved main only if the evidence says it is stuck/old;
+  - writes/readbacks fail: diagnose relay write path;
+  - writes pass but snapshots stale: repair snapshot/watch path;
+  - everything green: classify alert/watch issue before touching services.
+
+Verification:
+
+- Recovery email or pass readback arrives.
+- Latest normal production tick writes 2-of-3 or better.
+- Public freshness and relay snapshot return to pass.
+
+Done when:
+
+- Incident report captures cause, action, and recovery evidence, or the issue
+  remains open with a precise unresolved blocker.
+
+### Slice 0.3 - Heap Evidence Intake
+
+Trigger:
+
+- The first post-recovery early heap-capture summary pair appears for the
+  500 MB -> 700 MB climb.
+
+Implementation:
+
+- Run only the secret-safe analyzer summary path.
+- Do not move `.heapsnapshot` or `.heapprofile` artifacts through GitHub,
+  email, pager issues, or model prompts.
+- Classify the retainer before proposing remediation.
+- If classification points to off-graph runtime pressure, open a focused
+  memory-design PR/plan. If classification points to graph data, reconcile
+  against graph scan, soul count, tombstone, and userValueBytes evidence.
+
+Verification:
+
+- Analyzer output names the dominant retainer class or explicitly reports that
+  evidence remains insufficient.
+- No production state is mutated as part of analysis.
+
+Done when:
+
+- A memory-remediation decision packet exists, or the analyzer states why the
+  next capture threshold is required.
+
+### Slice 0.4 - Repeated `system-writer-validation-failed` Watch
+
+Trigger:
+
+- The warning repeats across normal ticks while raw writes/readbacks/freshness
+  still pass.
+
+Implementation:
+
+- Open a repo-side investigation scoped to system-writer validation only.
+- Inspect `packages/gun-client/src/analysisAdapters.ts`,
+  `tools/scripts/check-luma-topic-synthesis-system-v1.mjs`, and current
+  writer/readback fixtures before touching live services.
+- Treat one isolated warning as non-actionable while the live raw path is
+  passing.
+
+Done when:
+
+- Either the repeated warning is fixed by a repo PR with deterministic coverage,
+  or the investigation records why it is a benign diagnostic false positive.
+
+## Lane 1 - Source Supply And Feed Freshness
+
+### Goal
+
+Keep the MVP feed useful enough for public beta without weakening source
+readability and safety discipline. The feed should have fresh singleton and
+bundled stories, but only from sources that can satisfy the extraction and
+evidence boundary.
+
+### Grounded Surfaces
+
+- `docs/ops/NEWS_SOURCE_ADMISSION_RUNBOOK.md`
+- `services/news-aggregator/src/sourceHealthReport.ts`
+- `services/news-aggregator/src/sourceHealthPolicy.ts`
+- `services/news-aggregator/src/sourceScout.ts`
+- `services/news-aggregator/src/index.ts`
+- `services/storycluster-engine/src/benchmarkCorpusKnownEventOngoingFixtures.ts`
+- `services/storycluster-engine/src/benchmarkCorpusReplayKnownEventOngoingScenarios.ts`
+- `packages/e2e/src/live/daemon-first-feed-semantic-audit.live.spec.ts`
+- `packages/e2e/fixtures/launch-content/validated-snapshot.json`
+
+### Slice 1.1 - Source Health Packet Refresh
+
+Implementation:
+
+- Refresh source health evidence only from repo scripts and current artifacts.
+- Use the existing health/admission/scout tools rather than hand-curating
+  source changes.
+- Classify results as release-green, review-required, or blocked. Do not treat
+  `warn` as release-green.
+
+Commands:
+
+```bash
+corepack pnpm@9.7.1 check:news-sources:health
+corepack pnpm@9.7.1 report:news-sources:health
+corepack pnpm@9.7.1 check:storycluster:production-readiness
+```
+
+Done when:
+
+- The source-health artifact is fresh enough for the intended release claim.
+- Any non-green source class is either fixed or explicitly excluded from the
+  public beta claim.
+
+### Slice 1.2 - Candidate Admission
+
+Implementation:
+
+- If source breadth is insufficient, run scouting and admit candidates through
+  `docs/ops/NEWS_SOURCE_ADMISSION_RUNBOOK.md`.
+- Add one source set per PR so failures can be attributed.
+- Require extraction safety, recent-run coverage, headline correctness, and no
+  evidence-boundary overclaim before admission.
+
+Commands:
+
+```bash
+corepack pnpm@9.7.1 scout:news-sources:candidates
+corepack pnpm@9.7.1 report:news-sources:admission
+corepack pnpm@9.7.1 check:news-sources:liveness
+```
+
+Done when:
+
+- New sources improve feed density without increasing extraction failures or
+  leaking non-analyzed links into analysis evidence.
+
+### Slice 1.3 - Feed Composition And Propagation Gate
+
+Implementation:
+
+- Verify singleton/bundled composition from the public feed path.
+- Verify raw RSS-to-product-feed propagation.
+- Verify lifecycle accountability for pending/accepted/unavailable analysis
+  states.
+
+Commands:
+
+```bash
+corepack pnpm@9.7.1 check:public-feed:composition-freshness
+corepack pnpm@9.7.1 check:public-feed:fresh-propagation
+corepack pnpm@9.7.1 check:public-feed:lifecycle-accountability
+```
+
+Done when:
+
+- Public feed composition/freshness, propagation, and lifecycle gates pass on
+  the intended release commit or on the current evidence commit for pre-release
+  readiness.
+
+## Lane 2 - Accepted Synthesis And Story Detail
+
+### Goal
+
+Enable the Venn analysis/frame-reframe part of the MVP without regressing the
+raw publication loop. A functioning Venn News MVP cannot claim analysis,
+frames, reframes, or point-level stance over points unless accepted synthesis
+exists for the stories under that claim.
+
+### Explicit Synthesis Scope Decision
+
+There are two honest product envelopes:
+
+- **Raw-news beta envelope:** fresh feed, story cards, source/provenance,
+  discussion, support/compliance, and explicit `analysis pending/unavailable`
+  states. This can be useful, but it is not the full Venn News MVP loop.
+- **Functioning Venn News MVP envelope:** fresh feed plus accepted
+  `TopicSynthesisV2` detail, frame/reframe rows, stable point ids, point
+  stance, aggregates, and discussion. This is the target of this plan.
+
+The implementation path below therefore includes accepted synthesis, but it is
+sequenced after Lane 0 proof and bounded as a canary before broader rollout.
+
+### Grounded Surfaces
+
+- `services/news-aggregator/src/bundleSynthesisWorker.ts`
+- `services/news-aggregator/src/bundleSynthesisRelay.ts`
+- `services/news-aggregator/src/bundleSynthesisDaemonConfig.ts`
+- `services/news-aggregator/src/bundleSynthesisQueue.ts`
+- `packages/ai-engine/src/newsRuntime.ts`
+- `packages/gun-client/src/synthesisAdapters.ts`
+- `packages/gun-client/src/analysisAdapters.ts`
+- `packages/e2e/fixtures/launch-content/validated-snapshot.json`
+- `apps/web-pwa/src/components/feed/NewsCard.tsx`
+- `apps/web-pwa/src/components/feed/NewsCardBack.tsx`
+- `apps/web-pwa/src/hooks/useAnalysis.ts`
+- `docs/ops/news-aggregator.env.example`
+
+### Slice 2.1 - Local/Fixture Story Detail Proof
+
+Implementation:
+
+- Prove the full product loop locally before touching A6.
+- Use the deterministic analysis stub path to avoid live-model volatility.
+- Confirm detail renders accepted synthesis first and never silently launches a
+  blocking click-time analysis as the normal story-open path.
+- Confirm missing synthesis surfaces as pending/unavailable, not fake analysis.
+
+Commands:
+
+```bash
+corepack pnpm@9.7.1 live:stack:up:analysis-stub
+corepack pnpm@9.7.1 test:live:five-user-engagement
+corepack pnpm@9.7.1 check:launch-content-snapshot
+```
+
+Done when:
+
+- Five local beta users can open singleton and bundled stories, see accepted
+  synthesis detail, stance on frame/reframe points, reply in threads, reload,
+  and observe cross-user readback.
+
+### Slice 2.2 - Production Canary Preconditions
+
+Preconditions:
+
+- Lane 0 48-hour proof target is green, or an operator-approved incident
+  packet explicitly authorizes canary timing.
+- No active freshness, relay liveness, relay snapshot, or watch-closure alert.
+- Heap-capture analysis is not actively pointing at a synthesis-path blocker.
+- OpenAI/model auth is configured only in host-private env.
+- The release owner confirms the product claim requires accepted synthesis now.
+
+Implementation:
+
+- Keep storylines and topic synthesis enrichment disabled for the first canary.
+- Keep publish-time synthesis decoupled from raw write success. Raw publication
+  remains the first safety contract.
+- Use narrow caps and explicit relay REST quorum settings from
+  `docs/ops/news-aggregator.env.example`:
+  - `VH_BUNDLE_SYNTHESIS_ENABLED=true`
+  - `VH_BUNDLE_SYNTHESIS_WRITE_RELAY_REST=true`
+  - `VH_BUNDLE_SYNTHESIS_RELAY_WRITE_MIN_SUCCESS=2`
+  - `VH_BUNDLE_SYNTHESIS_TIMEOUT_MS=120000`
+  - `VH_BUNDLE_SYNTHESIS_RATE_PER_MIN=20` or lower for canary
+  - `VH_NEWS_RUNTIME_MAX_PUBLISHED_BUNDLES=96` only after canary expansion
+  - first-tick raw caps remain conservative
+- Do not enable storylines (`VH_NEWS_STORYLINES_ENABLED`) in the first accepted
+  synthesis canary unless the canary plan explicitly includes it.
+
+Done when:
+
+- The host-private canary plan names env deltas, rollback env deltas, readback
+  files, expected accepted-synthesis count, and exact stop conditions.
+
+### Slice 2.3 - Accepted Synthesis Canary
+
+Implementation:
+
+- Enable the smallest accepted synthesis canary that can prove the path.
+- Let the publisher complete a clean raw tick before expecting queued accepted
+  synthesis.
+- Read back accepted synthesis from relay/storage, not just local logs.
+- Confirm detail UI shows:
+  - generated timestamp;
+  - epoch;
+  - accepted `TopicSynthesisV2`;
+  - stable `frame_point_id` and `reframe_point_id`;
+  - source evidence limited to analysis-eligible sources;
+  - related links separated from analyzed evidence.
+
+Stop conditions:
+
+- Raw publication fails or parks.
+- Relay writes drop below 2-of-3.
+- Synthesis write/readback repeatedly fails.
+- Story detail displays unlabeled stale, placeholder, or source-unsafe
+  analysis.
+- Heap growth sharply changes before the first canary can be read back.
+
+Done when:
+
+- At least one canary story has accepted synthesis readback and Web PWA detail
+  renders it correctly, while raw feed freshness remains green.
+
+### Slice 2.4 - Expansion To MVP Coverage
+
+Implementation:
+
+- Increase accepted synthesis coverage only after the canary passes and raw feed
+  freshness remains green.
+- Add evidence for singleton and bundled story paths.
+- Preserve point identity across regenerations or record unmapped/orphaned
+  point counts before promotion.
+- Keep click-time analysis out of the normal detail path.
+
+Verification:
+
+```bash
+corepack pnpm@9.7.1 check:public-feed:lifecycle-accountability
+corepack pnpm@9.7.1 check:public-feed:stance-aggregate-decay
+corepack pnpm@9.7.1 check:mvp-release-gates
+```
+
+Done when:
+
+- The intended MVP release commit can pass accepted synthesis/frame reliability
+  gates for the release envelope.
+
+## Lane 3 - Civic Stance, Discussion, Moderation, And Beta Identity
+
+### Goal
+
+Make the product interactive in the exact MVP way: beta-local identity,
+point-level stance, deterministic story threads, report intake, and trusted
+operator moderation, without implying verified-human/Silver proof.
+
+### Grounded Surfaces
+
+- `packages/gun-client/src/sentimentAdapters.ts`
+- `packages/gun-client/src/topicEngagementAdapters.ts`
+- `packages/gun-client/src/forumAdapters.ts`
+- `packages/gun-client/src/newsReportAdapters.ts`
+- `apps/web-pwa/src/hooks/useSentimentState.ts`
+- `apps/web-pwa/src/components/feed/NewsCardBack.tsx`
+- `apps/web-pwa/src/components/forum/ForumThreadView.tsx`
+- `apps/web-pwa/src/lib/luma/actionPolicy.ts`
+- `tools/scripts/check-luma-topic-synthesis-system-v1.mjs`
+- `docs/specs/spec-civic-sentiment.md`
+- `docs/specs/spec-luma-service-v0.md`
+- `docs/ops/luma-verifier-current-state.md`
+
+### Slice 3.1 - LUMA Beta Identity Honesty
+
+Implementation:
+
+- Keep public beta copy on beta-local identity and signed-write semantics.
+- Do not claim production attestation, Silver, verified-human identity,
+  one-human-one-vote, cryptographic residency, Sybil resistance, or full
+  section 21.4 replay.
+- Confirm action policy covers directory/forum/news-report/aggregate/stance
+  write actions.
+
+Commands:
+
+```bash
+corepack pnpm@9.7.1 check:luma:mvp-production-readiness
+corepack pnpm@9.7.1 check:luma-forbidden-claims
+corepack pnpm@9.7.1 check:luma-production-profile
+corepack pnpm@9.7.1 check:luma-telemetry-redaction
+```
+
+Done when:
+
+- LUMA gates pass and release copy does not overstate identity guarantees.
+
+### Slice 3.2 - Point-Level Stance And Aggregate Readback
+
+Implementation:
+
+- Keep the canonical stance target:
+  `(topic_id, synthesis_id, epoch, point_id)`.
+- Ensure neutral stance clears or becomes non-counting in aggregates.
+- Ensure users cannot stance on a row without an accepted stable point id.
+- Verify aggregate falloff follows the Season 0 cap:
+  `E_new = E_current + 0.3 * (1.95 - E_current)`.
+
+Commands:
+
+```bash
+corepack pnpm@9.7.1 check:public-feed:stance-aggregate-decay
+corepack pnpm@9.7.1 test:live:five-user-engagement
+```
+
+Done when:
+
+- Stance writes persist, aggregate, survive reload, and remain public as
+  aggregate-only metadata.
+
+### Slice 3.3 - Story Threads, Reports, And Moderation
+
+Implementation:
+
+- Use the existing forum system. Do not create a second comment model.
+- Keep deterministic story thread ids in the `news-story:*` family.
+- Verify reply persistence, cross-user visibility, report intake, audited
+  hide/restore moderation, and trusted-operator authorization on current
+  remediation writes.
+
+Commands:
+
+```bash
+corepack pnpm@9.7.1 test:live:five-user-engagement
+corepack pnpm@9.7.1 check:mvp-release-gates
+```
+
+Done when:
+
+- The five-user lane proves comments, replies, report-to-action, and moderated
+  state without relying on non-MVP admin polish.
+
+## Lane 4 - Web PWA Shell, Launch Content, And Public Beta Support
+
+### Goal
+
+Ship the MVP as a Web PWA with honest public-beta surfaces and representative
+fallback content for demos/QA, while leaving native packaging and full app-store
+compliance out of the critical path.
+
+### Grounded Surfaces
+
+- `apps/web-pwa/`
+- `apps/web-pwa/src/components/layout/Footer.tsx`
+- `apps/web-pwa/src/pages/CompliancePage.tsx`
+- `apps/web-pwa/src/pages/BetaPage.tsx`
+- `apps/web-pwa/src/pages/PrivacyPage.tsx`
+- `apps/web-pwa/src/pages/TermsPage.tsx`
+- `apps/web-pwa/src/pages/ModerationPage.tsx`
+- `apps/web-pwa/src/pages/SupportPage.tsx`
+- `apps/web-pwa/src/pages/DataDeletionPage.tsx`
+- `apps/web-pwa/src/pages/TelemetryPage.tsx`
+- `apps/web-pwa/src/pages/CopyrightPage.tsx`
+- `.github/ISSUE_TEMPLATE/public-beta-support.yml`
+- `packages/e2e/fixtures/launch-content/validated-snapshot.json`
+- `docs/ops/public-beta-launch-readiness-closeout.md`
+
+### Slice 4.1 - Public Beta Route And Support Gate
+
+Implementation:
+
+- Confirm the footer links every required policy/support route.
+- Confirm `/support` points to the public beta GitHub Issue Form.
+- Confirm private escalation protocol remains documented without exposing
+  secrets or private contact paths in code.
+
+Command:
+
+```bash
+corepack pnpm@9.7.1 check:public-beta-compliance
+```
+
+Done when:
+
+- Compliance/support gate passes on the release commit.
+
+### Slice 4.2 - Launch Content Fallback
+
+Implementation:
+
+- Keep `packages/e2e/fixtures/launch-content/validated-snapshot.json`
+  representative enough to cover singleton, bundle, accepted synthesis,
+  correction, thread, moderation, and preference states.
+- Use this only for local demo/QA fallback; do not treat it as live ingestion
+  proof.
+
+Command:
+
+```bash
+corepack pnpm@9.7.1 check:launch-content-snapshot
+```
+
+Done when:
+
+- The snapshot gate passes and any release demo clearly distinguishes fixture
+  mode from live public-source freshness.
+
+### Slice 4.3 - Browser Smoke And PWA Usability
+
+Implementation:
+
+- Run the browser smoke against the intended public/local target.
+- Confirm feed opens, cards expand, detail content does not overlap on mobile,
+  support/policy routes are reachable, and pending/unavailable synthesis states
+  are visibly honest.
+
+Commands:
+
+```bash
+corepack pnpm@9.7.1 test:public-feed:browser-smoke
+corepack pnpm@9.7.1 check:public-beta-launch-closeout
+```
+
+Done when:
+
+- Browser smoke and launch closeout pass on the release candidate target.
+
+## Lane 5 - Pager And Incident Loop After Email Proof
+
+### Goal
+
+Replace silent failure with a durable incident loop, without putting custom
+pager deployment or Codex automation in front of the already-working email
+guardrail.
+
+### Grounded Surfaces
+
+- `services/vhc-pager/`
+- `tools/scripts/public-feed-alert-watch.mjs`
+- `tools/scripts/vhc-incident-codex-triage.mjs`
+- `tools/scripts/vhc-incident-reviewer-worker.mjs`
+- `tools/scripts/vhc-incident-executor.mjs`
+- `tools/scripts/vhc-incident-readback-verifier.mjs`
+- `tools/scripts/verify-vhc-incident-packet.mjs`
+- `.github/workflows/vhc-pager-deadman.yml`
+- `.github/ISSUE_TEMPLATE/a6-incident.yml`
+- `docs/ops/vhc-incident-response.md`
+- `docs/ops/vhc-pager-iphone-setup.md`
+- `docs/ops/vhc-codex-responder.md`
+- `docs/plans/AUTONOMOUS_INCIDENT_RESPONSE_SLICES_2026-07-06.md`
+
+### Slice 5.1 - Pager Deployment Outside A6
+
+Implementation:
+
+- Host the pager outside A6.
+- Configure secrets in the pager host only.
+- Keep the existing email alert channel enabled permanently.
+- Add the pager PWA to the operator iPhone Home Screen only after hosted
+  service health is verified.
+- Preserve platform honesty: iOS Web Push cannot override silent/Focus mode,
+  so email remains fallback.
+
+Done when:
+
+- Pager health endpoint passes and iPhone PWA enrollment succeeds without
+  changing A6 production behavior.
+
+### Slice 5.2 - Signed Webhook Cutover
+
+Implementation:
+
+- Configure A6 alert watch to send signed alerts to the pager endpoint.
+- The pager must durably persist before returning 2xx.
+- The pager creates/updates a public-safe GitHub incident issue.
+- The alert fans out to iPhone PWA and email.
+- Ack requires authenticated enrolled device token.
+
+Test-fire proof:
+
+- A6 emitted the alert.
+- Pager accepted and persisted it.
+- GitHub issue was created/updated.
+- iPhone/email received it.
+- Ack succeeded only with the device token.
+
+Done when:
+
+- A synthetic alert completes the full loop and the email fallback remains
+  active.
+
+### Slice 5.3 - Pager Dead-Man
+
+Implementation:
+
+- Enable the external dead-man after pager cutover.
+- Confirm deliberate pager outage opens a GitHub incident instead of silently
+  failing.
+- Keep weekly test-fire discipline until the 14-day proof target is banked.
+
+Done when:
+
+- Pager outage drill produces the expected dead-man incident and recovery note.
+
+### Slice 5.4 - Codex Responder Dry-Run Only
+
+Implementation:
+
+- Codex may investigate, write tests, draft PRs, and draft operator packets.
+- Reviewer/verifier can exercise signed packet paths.
+- A6 live executor stays dry-run and must refuse unapproved live execution.
+- Do not enable live A6 execution until the alert/pager loop has worked under
+  real operation for the required proof window and explicit drills pass.
+
+Command:
+
+```bash
+corepack pnpm@9.7.1 check:vhc-incident-response
+```
+
+Done when:
+
+- Incident-response checks pass and live execution remains disabled.
+
+## Lane 6 - Release Evidence And Go/No-Go Packet
+
+### Goal
+
+Make the release decision from evidence on the intended commit, not from a
+stale local memory of which lanes used to pass.
+
+### Grounded Surfaces
+
+- `tools/scripts/check-mvp-release-gates.mjs`
+- `tools/scripts/regenerate-mvp-release-evidence.mjs`
+- `tools/scripts/check-mvp-closeout.mjs`
+- `tools/scripts/check-public-beta-launch-closeout.mjs`
+- `.tmp/mvp-release-gates/latest/mvp-release-gates-report.json`
+- `.tmp/mvp-release-evidence/latest/`
+- `docs/ops/public-beta-launch-readiness-closeout.md`
+- `docs/foundational/STATUS.md`
+
+### Slice 6.1 - Release Commit Freeze
+
+Implementation:
+
+- Select a release candidate commit.
+- Confirm local `main`, `origin/main`, and any deployed Web PWA target are
+  actually at or intentionally derived from that commit.
+- Record any live A6 lag separately. A6 raw feed can be healthy at one commit
+  while docs or Web PWA release artifacts are at a newer commit.
+
+Done when:
+
+- The release packet names one commit and one deployment target set.
+
+### Slice 6.2 - Evidence Regeneration
+
+Commands:
+
+```bash
+corepack pnpm@9.7.1 check:mvp-release-evidence
+corepack pnpm@9.7.1 check:mvp-release-gates
+corepack pnpm@9.7.1 check:mvp-closeout
+corepack pnpm@9.7.1 check:public-beta-launch-closeout
+corepack pnpm@9.7.1 docs:check
+git diff --check
+```
+
+Implementation:
+
+- Treat `setup_scarcity` as a blocker unless the release envelope explicitly
+  excludes that lane.
+- Treat `skipped_not_in_scope` as acceptable only when the release copy makes
+  the same exclusion.
+- Preserve generated artifacts only when the runbook says they are meant to be
+  committed; otherwise record paths and hashes in the evidence packet.
+
+Done when:
+
+- All release-in-scope gates pass on the release candidate commit.
+
+### Slice 6.3 - Claim Review
+
+Implementation:
+
+- Compare the release copy to the gates that actually passed.
+- Explicitly reject claims for:
+  - native app/TestFlight/App Store availability;
+  - production-attested/Silver LUMA;
+  - verified one-human-one-vote;
+  - public WSS mesh `release_ready`;
+  - full production app canary;
+  - autonomous production execution;
+  - 14-day Scope A unattended stability before the target date passes.
+
+Done when:
+
+- The public beta claim is narrower than or equal to the verified evidence.
+
+### Slice 6.4 - Go/No-Go Packet
+
+Implementation:
+
+- Produce a final go/no-go report with:
+  - release commit;
+  - commands run;
+  - artifacts and hashes;
+  - live A6 state;
+  - Web PWA target state;
+  - known limitations;
+  - explicit non-goals;
+  - rollback path;
+  - operator contacts and support routing.
+
+Done when:
+
+- A reviewer can reproduce the evidence and approve or block without needing
+  unwritten tribal context.
+
+## Lane 7 - Deferred Non-MVP Tracks
+
+These are important, but they do not belong in the functioning MVP critical
+path unless the release claim expands:
+
+- Native iOS/TestFlight/App Store shell.
+- Public WSS mesh `release_ready`.
+- Production app canary as a full product-readiness claim.
+- LUMA production-attestation/Silver, verified-human identity,
+  Sybil-resistance, one-human-one-vote, and full section 21.4 recorded product
+  replay.
+- Scope B topic synthesis enrichment, storyline overlays, and broad storylines.
+- Retention/compaction/eviction/memory remediation before heap evidence names
+  the retainer.
+- Codex live production execution/autonomy.
+- Full trust-and-safety console, appeals workflow, SLA desk, and complete RBAC
+  membership management.
+- Commercial/legal approval beyond the already-implemented public-beta policy
+  route and support-surface minimums.
+
+## PR Sequencing
+
+### PR A - Plan And Alignment
+
+This document. It is plan-only and should not mutate production behavior.
+
+Validation:
+
+```bash
+corepack pnpm@9.7.1 docs:check
+git diff --check
+```
+
+### PR B - Scope A Evidence Update
+
+Open only after:
+
+- the 48-hour proof target passes;
+- a new alert triggers an incident; or
+- the first 500 MB -> 700 MB heap summary pair appears.
+
+Scope:
+
+- update current-state reports;
+- record analyzer summaries or incident evidence;
+- do not change live behavior unless the incident packet authorizes it.
+
+### PR C - Source Supply Refresh
+
+Open only if source-health/feed-density evidence says the MVP needs source
+changes.
+
+Scope:
+
+- source admission through the runbook;
+- source-health report updates;
+- feed composition/freshness evidence.
+
+### PR D - Accepted Synthesis Canary Plan/Guard
+
+Open after Lane 0 allows enrichment work.
+
+Scope:
+
+- canary env plan;
+- host-private operator session outline;
+- any missing guard tests for synthesis write/readback, lifecycle states, or
+  point-id preservation.
+
+### PR E - Civic Interaction Release Evidence
+
+Scope:
+
+- five-user engagement evidence;
+- LUMA beta identity checks;
+- stance aggregate decay checks;
+- report/moderation gate fixes if any fail.
+
+### PR F - Pager Deployment Packet
+
+Open after email proof remains reliable and before signed webhook cutover.
+
+Scope:
+
+- pager deployment outside A6;
+- full test-fire packet;
+- dead-man enablement;
+- Codex dry-run proof only.
+
+### PR G - MVP Release Packet
+
+Scope:
+
+- release evidence regeneration;
+- go/no-go report;
+- public beta claim review;
+- no unrelated refactors.
+
+## Validation Matrix
+
+| Lane | Main Commands | Live/Operator Readback |
+| --- | --- | --- |
+| Scope A reliability | `check:public-feed:alert-watch`, `check:scope-a-watch-closure`, heap analyzer when triggered | timer active states, latest tick, public freshness, relay liveness, relay snapshot |
+| Source supply | `check:news-sources:health`, `report:news-sources:health`, `check:storycluster:production-readiness` | no live mutation unless source admission PR requires deployment |
+| Feed composition | `check:public-feed:composition-freshness`, `check:public-feed:fresh-propagation`, `check:public-feed:lifecycle-accountability` | latest-index age, singleton/bundle mix, raw write/readback counts |
+| Accepted synthesis | `live:stack:up:analysis-stub`, `test:live:five-user-engagement`, `check:mvp-release-gates` | accepted synthesis readback, stable point ids, raw feed still fresh |
+| Civic interaction | `check:public-feed:stance-aggregate-decay`, `check:luma:mvp-production-readiness`, `test:live:five-user-engagement` | cross-user persistence, aggregate-only public metadata |
+| Public beta shell | `check:public-beta-compliance`, `check:launch-content-snapshot`, `test:public-feed:browser-smoke` | support route reachable, policy/footer links present |
+| Incident loop | `check:vhc-incident-response` | email fallback active, pager test-fire, GitHub issue, device ack, dead-man drill |
+| Release packet | `check:mvp-release-evidence`, `check:mvp-release-gates`, `check:mvp-closeout`, `docs:check`, `git diff --check` | release commit matches deployment targets and claim boundaries |
+
+## Functioning MVP Acceptance Criteria
+
+The MVP is functioning when all of the following are true on the intended
+release commit:
+
+- The public feed is fresh and observable through the active alert/watch
+  channel.
+- Singleton and bundled stories render in the Web PWA feed.
+- Topic preferences visibly affect feed ordering/filtering.
+- Story detail renders accepted synthesis for the release envelope, or the
+  release envelope explicitly excludes analysis and the UI honestly shows
+  pending/unavailable states.
+- Frame/reframe rows have stable point ids before stance controls are enabled.
+- Point stance persists, aggregates with falloff, survives reload, and exposes
+  aggregate-only public metadata.
+- Deterministic story threads support replies, reports, and audited moderation.
+- Public-beta LUMA identity gates pass without forbidden identity claims.
+- Public beta policy/support routes and GitHub support issue form are reachable.
+- Launch content fallback is valid for QA/demo and not confused with live
+  ingestion proof.
+- MVP release gates, closeout gates, docs check, and whitespace check pass.
+- A6 live state is either fresh/green or explicitly excluded from the release
+  action because the release is not touching A6.
+- Any remaining limitations are listed in the go/no-go packet and reflected in
+  public copy.
+
+## Failure Handling Rules
+
+- If a new alert arrives, pause enrichment work and run the read-only incident
+  branch first.
+- If the heap pair appears, run the analyzer first; do not remediate before the
+  retainer is named.
+- If source-health is `warn`, adjudicate it; do not call it release-green.
+- If accepted synthesis canary breaks raw publication, roll back synthesis
+  enablement and protect the raw feed first.
+- If five-user engagement fails, fix the failing interaction lane before
+  widening public beta.
+- If LUMA forbidden-claim gates fail, change copy or product surfaces; do not
+  weaken the gate.
+- If release gates fail, fix the lane or narrow the release envelope; do not
+  override the packet.

--- a/docs/plans/FUNCTIONING_MVP_LANE_SLICE_PLAN_2026-07-06.md
+++ b/docs/plans/FUNCTIONING_MVP_LANE_SLICE_PLAN_2026-07-06.md
@@ -1,54 +1,74 @@
 # Functioning MVP Lane Slice Plan - 2026-07-06
 
-> Status: Technical implementation and operating plan
+> Status: Technical implementation and operating plan, v2 refined for initial release goals
 > Owner: VHC Core Engineering + VHC Launch Ops
 > Last Reviewed: 2026-07-06
-> Target: functioning Venn News Web PWA MVP
-> Depends On: `docs/foundational/STATUS.md`, `docs/plans/VENN_NEWS_MVP_ROADMAP_2026-04-20.md`, `docs/ops/public-beta-launch-readiness-closeout.md`, `docs/ops/news-aggregator-production-service.md`, `docs/ops/public-feed-freshness-monitor.md`, `docs/ops/vhc-incident-response.md`, `docs/reports/phase5-scope-a-post-slice0-current-state-2026-07-06.md`
+> Target: Venn News Web PWA initial release MVP
+> Depends On: `docs/foundational/STATUS.md`, `docs/plans/VENN_NEWS_MVP_ROADMAP_2026-04-20.md`, `docs/specs/topic-synthesis-v2.md`, `docs/specs/spec-civic-sentiment.md`, `docs/specs/spec-luma-service-v0.md`, `docs/specs/spec-identity-trust-constituency.md`, `docs/specs/spec-civic-action-kit-v0.md`, `docs/ops/BETA_SESSION_RUNSHEET.md`, `docs/ops/public-beta-launch-readiness-closeout.md`, `docs/ops/news-aggregator-production-service.md`, `docs/ops/public-feed-freshness-monitor.md`, `docs/ops/vhc-incident-response.md`, `docs/reports/phase5-scope-a-post-slice0-current-state-2026-07-06.md`
 
 ## Executive Decision
 
-The MVP target is the Web PWA news loop already defined in
-`docs/plans/VENN_NEWS_MVP_ROADMAP_2026-04-20.md`, not a native app, not the
-public WSS mesh, not production-attested LUMA/Silver, and not autonomous
-production execution.
+The initial release goal is narrower and sharper than "all MVP-adjacent VHC
+features." Users must be able to:
 
-The functioning MVP is the smallest end-to-end product that can honestly be
-used and released as a public beta:
+1. register or sign in through a familiar account shell;
+2. create or attach a beta-local LUMA identity to that account session;
+3. read accepted Venn summaries on story detail;
+4. see an accepted-current bias/framing table;
+5. vote on frame/reframe points only when stable `frame_point_id` and
+   `reframe_point_id` values exist;
+6. have one final stance per user per point persist and converge across
+   browsers;
+7. have Eye/Lightbulb engagement accounting follow the Season 0 model; and
+8. tie those civic sentiments to a beta-local constituency/representative
+   mapping through aggregate-only district/office surfaces.
 
-1. A user opens a fresh usable news feed.
-2. The feed contains singleton stories and bundled stories.
-3. Topic preferences change feed ranking/filtering.
-4. A story opens into a durable detail surface.
-5. The detail surface shows accepted Venn analysis when the release claim says
-   analysis/frame/reframe is part of the MVP; otherwise it must clearly say
-   analysis is pending or unavailable.
-6. Users can take point-level stance on frame/reframe items, not on the story
-   as a whole.
-7. Stance persists, aggregates under the capped influence-falloff model, and is
-   visible after reload/cross-user readback.
-8. The story has a deterministic thread where beta users can reply, report, and
-   observe moderated state.
-9. Public-beta identity, support, policy, telemetry, and forbidden-claim gates
-   remain honest about beta-local proof semantics.
-10. A release evidence packet passes on the intended release commit.
+This is still a Web PWA release. Native app packaging, public WSS mesh
+`release_ready`, LUMA Silver, verified-human proof, one-human-one-vote,
+cryptographic residency, cross-device per-human nullifier binding, and Codex
+live production execution are not part of the initial release claim.
 
-This plan intentionally puts Scope A reliability before enrichment. A stale or
-silent public feed cannot be rescued by a polished detail surface. The first
-MVP lane is therefore the already-live raw-feed/alert proof window, followed by
-accepted synthesis canary work only after the feed remains healthy or a clearly
-approved operator session widens the boundary.
+## Review Verdict On The Previous Plan
+
+The first plan had the right safety spine: keep Scope A raw-feed reliability in
+front of enrichment, preserve the email alert guardrail, keep Codex execution
+dry-run, and require release evidence on the intended commit. It was too broad
+for the product goal, and it under-specified three release-critical joins.
+
+Required refinements:
+
+- Accepted summaries and the framing table must be the first product lane, not
+  a generic "accepted synthesis later" note.
+- Vote controls must be tied to `accepted-current` lifecycle joins, not merely
+  the presence of a `TopicSynthesisV2`.
+- The account lane must exist explicitly. Current repo reality has beta-local
+  LUMA identity and linked-social storage primitives, but not a completed
+  Apple/Google/X sign-in release flow.
+- Social login must not be described as human uniqueness. It is account
+  continuity/profile recovery; LUMA beta-local identity supplies the current
+  release's device-bound `PrincipalId`/`Nullifier` semantics.
+- Constituency/representative mapping must be a first-class lane. The current
+  representative selector primitives exist, but `RepresentativeSelector` still
+  calls `findRepresentatives('')`, so it cannot satisfy local-office mapping
+  until the user's district hash is wired through.
+- The release rehearsal must exercise the product proof loop directly:
+  accepted summary/table, vote persistence, LUMA signed writes, account binding,
+  constituency mapping, and the manual 3-browser persistence check.
+
+This document is the refined plan that closes those gaps.
 
 ## Current State Of Play
 
 As of this plan:
 
-- Repo `main` is `76f3c77c` after PR #724 aligned the docs with the
-  post-Slice-0 recovery state.
-- Live A6 was updated to `main@47ba218d` after PR #723 fixed the
-  StoryCluster production timeout path. Treat any newer docs-only merge as repo
-  truth until an operator explicitly updates A6 again.
-- Slice 0 is complete: the host-private email alert path is configured, test
+- Repo `main` is `76f3c77c` after PR #724 aligned docs with the post-Slice-0
+  recovery state.
+- PR #725 carries this plan on
+  `coord/functioning-mvp-lane-plans-2026-07-06`.
+- Live A6 was updated to `main@47ba218d` after PR #723 fixed the StoryCluster
+  production timeout path. Treat newer docs-only commits as repo truth until an
+  operator explicitly updates A6 again.
+- Slice 0 is complete: host-private email alerting is configured, test
   delivery reached the operator device, and both
   `vh-public-feed-alert-watch.timer` and
   `vh-phase5-scope-a-watch-closure.timer` are enabled and active.
@@ -69,9 +89,93 @@ As of this plan:
 - The custom pager/PWA exists in repo after PR #722, but email remains the
   active live alert path until a later pager deployment outside A6.
 
-## Hard Boundaries
+## Non-Negotiable Release Semantics
 
-These boundaries are part of the plan, not footnotes:
+### Summary And Framing Table
+
+The release experience must use accepted `TopicSynthesisV2`, not provisional
+card-open analysis, as the votable release artifact.
+
+Per `docs/specs/topic-synthesis-v2.md`, story detail may enable vote controls
+only after joining the story lifecycle record and synthesis record:
+
+- lifecycle record status is `accepted_available`;
+- lifecycle `source_set_revision` matches the current `StoryBundle.provenance_hash`;
+- lifecycle `synthesis_id` and `epoch` match the `TopicSynthesisV2`;
+- `TopicSynthesisV2.inputs.story_bundle_ids` includes the current `story_id`;
+- `facts_summary` is non-empty;
+- frame/reframe rows are present; and
+- every votable row has stable `frame_point_id` and `reframe_point_id` values
+  that are not derived from mutable display text.
+
+If any of those joins fail, the UI may show summary/table status as loading,
+pending, retryable failure, terminal unavailable, or suppressed by correction,
+but it must not show active vote controls.
+
+### Vote And Engagement Semantics
+
+Per `docs/specs/spec-civic-sentiment.md`:
+
+- users vote on individual frame/reframe points, not whole stories;
+- one user has one final stance per
+  `(topic_id, synthesis_id, epoch, point_id)`;
+- `agreement = 0` is neutral and non-counting;
+- event-level signals with constituency proof are sensitive and must stay
+  local/encrypted;
+- public paths contain aggregate-only projections;
+- public aggregate voter nodes use topic/epoch-scoped `voterId`, never raw
+  nullifier; and
+- Eye and Lightbulb are capped by the Season 0 decay model, with
+  `E_cap = 1.95`.
+
+### Account And LUMA Semantics
+
+Initial release account language must say this clearly:
+
+- Apple/Google/X sign-in is account continuity and profile recovery.
+- Social login is not proof of human uniqueness.
+- In the current public-beta profile, LUMA provides beta-local identity:
+  `PrincipalId`, `principalNullifier`, `forumAuthorId`,
+  `identityDirectoryKey`, and topic/epoch-scoped `voterId`.
+- Current `principalNullifier` is device-bound. A user signing in on another
+  device does not automatically prove the same human and must not silently
+  inherit old votes as the same principal.
+- LUMA Silver, verified-human, one-human-one-vote, Sybil resistance,
+  cryptographic residency, and cross-device per-human binding remain deferred.
+
+Internally, the release may describe the beta-local LUMA `principalNullifier`
+as the current device-bound uniqueness identifier. User-facing copy must not
+call it a verified-human identifier.
+
+### Constituency And Representative Semantics
+
+Per `docs/specs/spec-identity-trust-constituency.md`:
+
+- `ConstituencyProof` shape is
+  `{ district_hash, nullifier, merkle_root }`;
+- `district_hash` and `nullifier` together are sensitive;
+- the pair must not appear in public mesh documents or on-chain storage;
+- district dashboards and representative-facing surfaces are aggregate-only;
+- `district_hash` may appear publicly only in allowed aggregate/dashboard
+  records that meet cohort thresholds; and
+- Season 0 proof acquisition is beta-local, not cryptographic residency proof.
+
+For initial release, "register opinion with local reps/offices" means:
+
+- capture a beta-local constituency proof at vote admission time;
+- verify the proof matches the active LUMA principal and configured district;
+- map the district hash to representative directory snapshots;
+- materialize aggregate district/office sentiment only when privacy thresholds
+  allow it; and
+- never expose raw address, raw region code, nullifier, proof material, OAuth
+  tokens, or per-user district rows in public records.
+
+Actual outbound delivery to a representative office is a separate Civic Action
+Kit send lane unless release copy explicitly includes and proves that behavior.
+
+## Hard Operational Boundaries
+
+These boundaries still apply while product lanes progress:
 
 - Do not restart the publisher while feed freshness remains green.
 - Do not restart relays while relay liveness and snapshot freshness remain
@@ -86,33 +190,34 @@ These boundaries are part of the plan, not footnotes:
   identity-assurance, or production-readiness claims.
 - Treat a new alert email as an incident, not setup noise.
 
-## MVP Dependency Graph
+## Parallel Lane Map
 
 ```text
-Lane 0: Scope A raw feed + alert proof
-  -> Lane 1: heap evidence and memory-decision boundary
-  -> Lane 2: source supply and feed density
-  -> Lane 3: accepted synthesis/story detail canary
-  -> Lane 4: civic stance + discussion + beta identity
-  -> Lane 5: public beta shell/support/compliance
-  -> Lane 6: release evidence packet and go/no-go
+Safety rail:
+  Scope A raw-feed freshness + email alert proof + heap evidence boundary
 
-Lane 7: pager/incident hardening runs after email proof and outside A6
-Lane 8: deferred non-MVP tracks stay outside the MVP release claim
+Initial release product lanes:
+  A. Accepted summary and framing table readiness
+  B. Stance/vote persistence and aggregate engagement
+  C. Account and sign-in shell
+  D. LUMA public-beta identity binding
+  E. Constituency and representative mapping
+  F. Release evidence rehearsal
+
+Post-initial-release rails:
+  Pager/PWA incident system, Codex dry-run responder, Scope B storylines,
+  Silver/production attestation, native app, public WSS mesh, live executor
 ```
 
-The dependency that matters most is Lane 0 before Lane 3. Accepted synthesis
-can increase product value, but it must not disturb the raw publication loop
-until the raw loop has either banked its proof window or a specific incident
-requires action.
+The product lanes can proceed in parallel in local/staging/repo work. A6 live
+mutation remains gated by the safety rail.
 
-## Lane 0 - Scope A Reliability And Evidence Accrual
+## Safety Rail - Scope A Reliability And Evidence Accrual
 
 ### Goal
 
 Keep the recovered raw public feed fresh, observable, and untouched while the
-clean window accrues. This lane converts "we recovered" into evidence that the
-MVP feed foundation is actually stable enough to build on.
+product lanes advance off-host. The MVP cannot ship on a stale or silent feed.
 
 ### Grounded Surfaces
 
@@ -122,259 +227,547 @@ MVP feed foundation is actually stable enough to build on.
 - `tools/scripts/public-feed-alert-watch.mjs`
 - `tools/scripts/phase5-scope-a-watch-closure.mjs`
 - `tools/scripts/analyze-early-heap-captures.mjs`
-- `tools/scripts/install-news-aggregator-user-service.mjs`
 - `services/news-aggregator/src/index.ts`
 - `packages/ai-engine/src/newsRuntime.ts`
 
-### Slice 0.1 - No-Change Watch Window
+### Slices
 
-Implementation:
+1. **No-change watch window.** Leave publisher, StoryCluster, relays, alert
+   timers, and watch-closure timers in their current healthy state. Record
+   readbacks only on scheduled review or alert.
+2. **Alert-first incident branch.** Any new alert pauses enrichment work.
+   Diagnose read-only first: latest tick, StoryCluster stage, raw write counts,
+   relay liveness, snapshot freshness, latest public index age, alert verdict.
+3. **Heap evidence intake.** When the post-recovery 500 MB -> 700 MB pair
+   appears, run only secret-safe analyzer summaries. Do not remediate until the
+   retainer is named.
+4. **`system-writer-validation-failed` watch.** One warning stays a watch item
+   while writes/readbacks/freshness pass. Repetition across normal ticks opens
+   a focused repo-side investigation.
 
-- Leave `vh-news-aggregator.service`, `vh-storycluster-engine.service`, relay
-  services, alert timers, and watch-closure timers in their current healthy
-  state.
-- Record readbacks only when there is an operator-approved check-in or an
-  alert.
-- Preserve the current raw-only profile: accepted synthesis disabled,
-  replay disabled, storylines disabled, raw cap `8`, raw write concurrency `2`,
-  repair interval `86400000`, prune disabled, relay REST min-success `2`.
+### Done
 
-Verification:
+- 48-hour proof target passes or a precise incident report exists.
+- Heap evidence is handled by analyzer summary only.
+- No live mutation happens merely because product lanes are ready.
 
-- `vh-public-feed-alert-watch.timer` remains enabled/active.
-- `vh-phase5-scope-a-watch-closure.timer` remains enabled/active.
-- Alert watch reports delivery health and does not silently stall.
-- Watch closure remains `in_progress` only because the proof window is short,
-  not because freshness/liveness failed.
-
-Done when:
-
-- The 48-hour proof target passes without anomaly, or a new alert interrupts
-  the lane and opens an incident.
-
-### Slice 0.2 - Alert-First Incident Branch
-
-Trigger:
-
-- Any fresh email from the alert watch for freshness, relay liveness, relay
-  snapshot, watch-closure input, publisher park, or critical class.
-
-Implementation:
-
-- Stop planned MVP enrichment work.
-- Run read-only diagnosis first:
-  - publisher active state and latest tick summary;
-  - StoryCluster active state and timeout/error stage;
-  - raw write attempted/wrote/failed counts;
-  - relay REST auth/readiness/liveness;
-  - relay snapshot freshness;
-  - latest public index age;
-  - alert/watch-closure verdict files.
-- Decide the smallest operator action from the readback:
-  - publisher active but stale/no clean tick: restart publisher onto current
-    approved main only if the evidence says it is stuck/old;
-  - writes/readbacks fail: diagnose relay write path;
-  - writes pass but snapshots stale: repair snapshot/watch path;
-  - everything green: classify alert/watch issue before touching services.
-
-Verification:
-
-- Recovery email or pass readback arrives.
-- Latest normal production tick writes 2-of-3 or better.
-- Public freshness and relay snapshot return to pass.
-
-Done when:
-
-- Incident report captures cause, action, and recovery evidence, or the issue
-  remains open with a precise unresolved blocker.
-
-### Slice 0.3 - Heap Evidence Intake
-
-Trigger:
-
-- The first post-recovery early heap-capture summary pair appears for the
-  500 MB -> 700 MB climb.
-
-Implementation:
-
-- Run only the secret-safe analyzer summary path.
-- Do not move `.heapsnapshot` or `.heapprofile` artifacts through GitHub,
-  email, pager issues, or model prompts.
-- Classify the retainer before proposing remediation.
-- If classification points to off-graph runtime pressure, open a focused
-  memory-design PR/plan. If classification points to graph data, reconcile
-  against graph scan, soul count, tombstone, and userValueBytes evidence.
-
-Verification:
-
-- Analyzer output names the dominant retainer class or explicitly reports that
-  evidence remains insufficient.
-- No production state is mutated as part of analysis.
-
-Done when:
-
-- A memory-remediation decision packet exists, or the analyzer states why the
-  next capture threshold is required.
-
-### Slice 0.4 - Repeated `system-writer-validation-failed` Watch
-
-Trigger:
-
-- The warning repeats across normal ticks while raw writes/readbacks/freshness
-  still pass.
-
-Implementation:
-
-- Open a repo-side investigation scoped to system-writer validation only.
-- Inspect `packages/gun-client/src/analysisAdapters.ts`,
-  `tools/scripts/check-luma-topic-synthesis-system-v1.mjs`, and current
-  writer/readback fixtures before touching live services.
-- Treat one isolated warning as non-actionable while the live raw path is
-  passing.
-
-Done when:
-
-- Either the repeated warning is fixed by a repo PR with deterministic coverage,
-  or the investigation records why it is a benign diagnostic false positive.
-
-## Lane 1 - Source Supply And Feed Freshness
+## Lane A - Accepted Summary And Framing Table Readiness
 
 ### Goal
 
-Keep the MVP feed useful enough for public beta without weakening source
-readability and safety discipline. The feed should have fresh singleton and
-bundled stories, but only from sources that can satisfy the extraction and
-evidence boundary.
+Make the release story-detail experience dependable: users open a story, read
+an accepted summary, see the accepted-current bias/framing table, and get vote
+controls only when the table is safe to vote on.
 
 ### Grounded Surfaces
 
-- `docs/ops/NEWS_SOURCE_ADMISSION_RUNBOOK.md`
-- `services/news-aggregator/src/sourceHealthReport.ts`
-- `services/news-aggregator/src/sourceHealthPolicy.ts`
-- `services/news-aggregator/src/sourceScout.ts`
-- `services/news-aggregator/src/index.ts`
-- `services/storycluster-engine/src/benchmarkCorpusKnownEventOngoingFixtures.ts`
-- `services/storycluster-engine/src/benchmarkCorpusReplayKnownEventOngoingScenarios.ts`
-- `packages/e2e/src/live/daemon-first-feed-semantic-audit.live.spec.ts`
-- `packages/e2e/fixtures/launch-content/validated-snapshot.json`
-
-### Slice 1.1 - Source Health Packet Refresh
-
-Implementation:
-
-- Refresh source health evidence only from repo scripts and current artifacts.
-- Use the existing health/admission/scout tools rather than hand-curating
-  source changes.
-- Classify results as release-green, review-required, or blocked. Do not treat
-  `warn` as release-green.
-
-Commands:
-
-```bash
-corepack pnpm@9.7.1 check:news-sources:health
-corepack pnpm@9.7.1 report:news-sources:health
-corepack pnpm@9.7.1 check:storycluster:production-readiness
-```
-
-Done when:
-
-- The source-health artifact is fresh enough for the intended release claim.
-- Any non-green source class is either fixed or explicitly excluded from the
-  public beta claim.
-
-### Slice 1.2 - Candidate Admission
-
-Implementation:
-
-- If source breadth is insufficient, run scouting and admit candidates through
-  `docs/ops/NEWS_SOURCE_ADMISSION_RUNBOOK.md`.
-- Add one source set per PR so failures can be attributed.
-- Require extraction safety, recent-run coverage, headline correctness, and no
-  evidence-boundary overclaim before admission.
-
-Commands:
-
-```bash
-corepack pnpm@9.7.1 scout:news-sources:candidates
-corepack pnpm@9.7.1 report:news-sources:admission
-corepack pnpm@9.7.1 check:news-sources:liveness
-```
-
-Done when:
-
-- New sources improve feed density without increasing extraction failures or
-  leaking non-analyzed links into analysis evidence.
-
-### Slice 1.3 - Feed Composition And Propagation Gate
-
-Implementation:
-
-- Verify singleton/bundled composition from the public feed path.
-- Verify raw RSS-to-product-feed propagation.
-- Verify lifecycle accountability for pending/accepted/unavailable analysis
-  states.
-
-Commands:
-
-```bash
-corepack pnpm@9.7.1 check:public-feed:composition-freshness
-corepack pnpm@9.7.1 check:public-feed:fresh-propagation
-corepack pnpm@9.7.1 check:public-feed:lifecycle-accountability
-```
-
-Done when:
-
-- Public feed composition/freshness, propagation, and lifecycle gates pass on
-  the intended release commit or on the current evidence commit for pre-release
-  readiness.
-
-## Lane 2 - Accepted Synthesis And Story Detail
-
-### Goal
-
-Enable the Venn analysis/frame-reframe part of the MVP without regressing the
-raw publication loop. A functioning Venn News MVP cannot claim analysis,
-frames, reframes, or point-level stance over points unless accepted synthesis
-exists for the stories under that claim.
-
-### Explicit Synthesis Scope Decision
-
-There are two honest product envelopes:
-
-- **Raw-news beta envelope:** fresh feed, story cards, source/provenance,
-  discussion, support/compliance, and explicit `analysis pending/unavailable`
-  states. This can be useful, but it is not the full Venn News MVP loop.
-- **Functioning Venn News MVP envelope:** fresh feed plus accepted
-  `TopicSynthesisV2` detail, frame/reframe rows, stable point ids, point
-  stance, aggregates, and discussion. This is the target of this plan.
-
-The implementation path below therefore includes accepted synthesis, but it is
-sequenced after Lane 0 proof and bounded as a canary before broader rollout.
-
-### Grounded Surfaces
-
+- `docs/specs/topic-synthesis-v2.md`
 - `services/news-aggregator/src/bundleSynthesisWorker.ts`
 - `services/news-aggregator/src/bundleSynthesisRelay.ts`
 - `services/news-aggregator/src/bundleSynthesisDaemonConfig.ts`
 - `services/news-aggregator/src/bundleSynthesisQueue.ts`
-- `packages/ai-engine/src/newsRuntime.ts`
 - `packages/gun-client/src/synthesisAdapters.ts`
 - `packages/gun-client/src/analysisAdapters.ts`
-- `packages/e2e/fixtures/launch-content/validated-snapshot.json`
 - `apps/web-pwa/src/components/feed/NewsCard.tsx`
 - `apps/web-pwa/src/components/feed/NewsCardBack.tsx`
+- `apps/web-pwa/src/components/feed/CellVoteControls.tsx`
 - `apps/web-pwa/src/hooks/useAnalysis.ts`
 - `docs/ops/news-aggregator.env.example`
 
-### Slice 2.1 - Local/Fixture Story Detail Proof
+### Slice A1 - Accepted-Current Read Model
 
-Implementation:
+Implementation plan:
 
-- Prove the full product loop locally before touching A6.
-- Use the deterministic analysis stub path to avoid live-model volatility.
-- Confirm detail renders accepted synthesis first and never silently launches a
-  blocking click-time analysis as the normal story-open path.
-- Confirm missing synthesis surfaces as pending/unavailable, not fake analysis.
+- Make the story-detail read path explicitly join:
+  `StoryBundle`, `vh/news/stories/<storyId>/synthesis_lifecycle/latest`,
+  `vh/topics/<topicId>/epochs/<epoch>/synthesis`, and
+  `vh/topics/<topicId>/latest`.
+- Define one UI-ready object for story detail:
+  `acceptedCurrentSynthesis | pending | retryable_failure |
+  terminal_unavailable | suppressed_by_correction | invalid`.
+- Reject as votable when lifecycle source revision, synthesis id, epoch, story
+  id, or system-writer validation does not match.
+- Keep provisional/card-open analysis labeled non-votable if it remains
+  reachable in any dev path.
+
+Tests:
+
+- lifecycle/synthesis mismatch keeps vote controls disabled;
+- missing point ids keep vote controls disabled for that row;
+- corrected/suppressed synthesis is not votable;
+- invalid system-writer record fails closed with observable state.
+
+### Slice A2 - Summary And Table UX
+
+Implementation plan:
+
+- Story detail must show:
+  - summary/facts text;
+  - generated time and epoch;
+  - source evidence boundary;
+  - frame/reframe table;
+  - warning/divergence labels when present; and
+  - pending/unavailable reason class when accepted synthesis is absent.
+- Table rows must bind each visible frame cell to `frame_point_id` and each
+  reframe cell to `reframe_point_id`.
+- Vote buttons render only when the specific cell has a valid point id and
+  accepted-current context.
+
+Tests:
+
+- accepted synthesis renders summary and frame/reframe rows;
+- terminal unavailable renders honest non-votable state;
+- retryable failure remains visible but non-votable;
+- no public synthesis object contains nullifier, district hash, OAuth tokens,
+  or provider secrets.
+
+### Slice A3 - Production Canary Plan
+
+Implementation plan:
+
+- Do not start this on A6 until the safety rail allows enrichment.
+- Keep storylines/topic synthesis enrichment disabled for first canary unless a
+  separate packet explicitly includes them.
+- Keep raw publication first and accepted synthesis decoupled from raw write
+  success.
+- Canary env deltas must be explicit and reversible:
+  - `VH_BUNDLE_SYNTHESIS_ENABLED=true`
+  - `VH_BUNDLE_SYNTHESIS_WRITE_RELAY_REST=true`
+  - `VH_BUNDLE_SYNTHESIS_RELAY_WRITE_MIN_SUCCESS=2`
+  - bounded timeout/rate/cap values
+  - rollback to accepted synthesis disabled
+- Stop if raw publication fails, relay quorum falls below 2-of-3, accepted
+  synthesis readback fails repeatedly, or heap behavior changes materially.
+
+Done:
+
+- At least one singleton and one bundled story have accepted-current readback
+  and a safe votable table in Web PWA detail.
+
+## Lane B - Stance/Vote Persistence And Aggregate Engagement
+
+### Goal
+
+Harden the actual civic loop: one final stance per user per point, local or
+encrypted event-level signal, public aggregate-only counts, Eye/Lightbulb
+accounting, and 3-browser persistence proof.
+
+### Grounded Surfaces
+
+- `docs/specs/spec-civic-sentiment.md`
+- `apps/web-pwa/src/hooks/useSentimentState.ts`
+- `apps/web-pwa/src/hooks/voteAdmission.ts`
+- `apps/web-pwa/src/hooks/voteIntentQueue.ts`
+- `apps/web-pwa/src/hooks/voteIntentMaterializer.ts`
+- `apps/web-pwa/src/hooks/voteIntentProjection.ts`
+- `apps/web-pwa/src/hooks/lumaAggregateVoterRecords.ts`
+- `apps/web-pwa/src/components/feed/CellVoteControls.tsx`
+- `apps/web-pwa/src/components/feed/voteSemantics.ts`
+- `packages/gun-client/src/sentimentAdapters.ts`
+- `packages/gun-client/src/sentimentEventAdapters.ts`
+- `packages/gun-client/src/aggregateAdapters.ts`
+- `packages/gun-client/src/topicEngagementAdapters.ts`
+- `packages/data-model/src/schemas/hermes/sentiment.ts`
+
+### Slice B1 - Unified Vote Admission
+
+Implementation plan:
+
+- Feed and any analysis/detail surface must use identical admission rules:
+  valid active identity, valid beta-local constituency proof, valid
+  accepted-current synthesis context, valid point id, and budget/policy pass.
+- Admission success means a `VoteAdmissionReceipt` and durable local intent,
+  not guaranteed remote projection completion.
+- Denial reasons must be visible enough for support and telemetry:
+  missing identity, expired identity, missing proof, invalid proof, non-current
+  synthesis, missing point id, budget/policy denial, write queue failure.
+
+Tests:
+
+- no bypass write path exists for feed/detail voting;
+- stale or non-current synthesis denies voting;
+- mock/transitional proof is rejected in strict mode;
+- denial telemetry contains no nullifier or proof material.
+
+### Slice B2 - Intent, Projection, And Last-Write-Wins
+
+Implementation plan:
+
+- Preserve last-write-wins per `(voter_id, topic_id, synthesis_id, epoch,
+  point_id)`.
+- Keep `VoteIntentRecord` local durable queue state; never copy it to public
+  mesh paths.
+- Publish `aggregate-voter-node-v1` with `_writerKind: 'luma'`,
+  `_authorScheme: 'voter-v1'`, and `SignedWriteEnvelope.audience =
+  'vh-aggregate-voter'`.
+- Verify path `voterId`, payload `voter_id`, envelope `publicAuthor`, and
+  signed payload tuple all match before aggregate fan-in.
+
+Tests:
+
+- `+1`, `-1`, neutral reset, and vote mutation converge correctly;
+- public aggregate voter node uses topic/epoch-scoped `voterId`;
+- raw nullifier, district hash, merkle root, and address never appear in
+  public aggregate paths.
+
+### Slice B3 - Eye/Lightbulb And Aggregate Summary
+
+Implementation plan:
+
+- Eye increments on full read/expand events.
+- Lightbulb is driven only by active stance interactions, never by source count,
+  synthesis quorum, or other proxy values.
+- Use capped diminishing returns with `E_cap = 1.95`.
+- Public feed counters read topic engagement aggregate first, with documented
+  fallback to feed snapshot plus local persisted decayed weight.
+- Topic engagement summary writes remain system-writer records.
+
+Tests:
+
+```bash
+corepack pnpm@9.7.1 check:public-feed:stance-aggregate-decay
+corepack pnpm@9.7.1 check:luma-topic-engagement-summary-system-v1
+corepack pnpm@9.7.1 check:luma-aggregate-voter-v1
+```
+
+### Slice B4 - Three-Browser Persistence Proof
+
+Implementation plan:
+
+- Elevate the manual 3-browser check in
+  `docs/ops/BETA_SESSION_RUNSHEET.md` to a release rehearsal requirement.
+- Browser A, B, and C each get their own identity.
+- All three open the same accepted-current story.
+- A votes; B and C see aggregate.
+- B votes; A and C see aggregate.
+- C votes opposite; A and B see aggregate.
+- A changes vote; all clients converge.
+- All reload; analysis, vote cells, and aggregate state survive reload.
+
+Done:
+
+- Manual 3-browser check passes with no privacy leaks and no local-only
+  aggregate illusion.
+
+## Lane C - Account And Sign-In Shell
+
+### Goal
+
+Provide a user-facing registration/sign-in shell with Apple, Google, and X as
+account providers while preserving the LUMA boundary: account sign-in is
+continuity and recovery, not human uniqueness proof.
+
+### Grounded Surfaces
+
+- `apps/web-pwa/src/hooks/useIdentity.ts`
+- `apps/web-pwa/src/routes/AccountIdentityPage.tsx`
+- `apps/web-pwa/src/store/identityProvider.ts`
+- `apps/web-pwa/src/store/linkedSocial/accountStore.ts`
+- `apps/web-pwa/src/store/linkedSocial/tokenVault.ts`
+- `apps/web-pwa/src/store/identityProvider.browser.test.ts`
+- `apps/web-pwa/src/store/news/hydration.identity.test.ts`
+- `packages/identity-vault/src/vault.ts`
+- `packages/identity-vault/src/compartments/deviceCredential.ts`
+- `packages/identity-vault/src/compartments/delegationSigningKey.ts`
+- `docs/specs/secure-storage-policy.md`
+
+### Slice C1 - Account Provider Contract
+
+Implementation plan:
+
+- Define a closed provider enum for the release: `apple`, `google`, `x`.
+- Use OAuth/OIDC with PKCE through a backend/callback boundary where provider
+  client secrets never enter the browser bundle.
+- Store only non-secret display/account metadata in the account shell.
+- Store provider tokens, if retained at all, in the existing token/vault path;
+  never write them to public mesh, logs, support issues, telemetry, or release
+  evidence.
+- Normalize provider subject to a private account binding. Public projections
+  may use a provider/account display label only after sanitization.
+
+Tests:
+
+- provider tokens cannot appear in public projections;
+- account records validate against a closed schema;
+- unsupported provider ids are rejected;
+- sign-out clears session state without claiming network deletion.
+
+### Slice C2 - Account-To-LUMA Binding
+
+Implementation plan:
+
+- Sign-in flow:
+  1. user chooses Apple/Google/X;
+  2. account shell authenticates provider subject;
+  3. app hydrates or creates beta-local LUMA identity from the vault;
+  4. app binds account shell to the active device-bound `PrincipalId` /
+     `principalNullifier` locally;
+  5. stance/forum/report writes use LUMA signed-write envelopes, not raw social
+     account identity.
+- If a user signs in on a new device, the MVP must not silently merge the old
+  LUMA principal. It may show account continuity/profile state, but old votes
+  remain under the old device-bound principal unless a later multi-device link
+  feature is built and approved.
+- If a user resets identity, account binding must record that the old public
+  artifacts are not deleted or re-authored.
+
+Tests:
+
+- same browser sign-out/sign-in preserves the local LUMA identity unless Reset
+  Identity is invoked;
+- Reset Identity rotates the LUMA principal and leaves historical artifacts
+  under the prior pseudonyms;
+- another browser/device sign-in does not claim same-human continuity;
+- copy and telemetry avoid verified-human/one-human-one-vote language.
+
+### Slice C3 - Account UI And Recovery Copy
+
+Implementation plan:
+
+- Account page must show:
+  - sign-in provider status;
+  - LUMA beta-local identity status;
+  - session expiry/renewal state;
+  - sign-out action;
+  - reset identity action with irreversible-effects explanation;
+  - linked provider management;
+  - clear limitation copy for device-bound identity.
+- First vote attempt without account/identity should route user into sign-in
+  or beta-local identity creation, then back to the same story/point.
+- Sign-in failure must not strand the user with a partially admitted vote.
+
+Done:
+
+- A new user can register/sign in, create or attach beta-local LUMA identity,
+  return to the story, and vote without hidden identity claims.
+
+## Lane D - LUMA Public-Beta Identity Binding
+
+### Goal
+
+Use the current public-beta LUMA model for all write actions: beta-local
+`PrincipalId`/`Nullifier`, `SignedWriteEnvelope`, topic/epoch-scoped `voterId`,
+and action-policy enforcement. Keep the copy and topology honest.
+
+### Grounded Surfaces
+
+- `docs/specs/spec-luma-service-v0.md`
+- `docs/ops/luma-verifier-current-state.md`
+- `packages/luma-sdk/src/assurance.ts`
+- `packages/luma-sdk/src/signedWrites.ts`
+- `packages/luma-sdk/src/linkabilityDomains.ts`
+- `packages/luma-sdk/src/providers/index.ts`
+- `packages/types/src/identity.ts`
+- `packages/types/src/constituency-proof.ts`
+- `packages/types/src/constituency-verification.ts`
+- `apps/web-pwa/src/luma/mvpActionPolicy.ts`
+- `apps/web-pwa/src/hooks/useIdentity.ts`
+- `apps/web-pwa/src/hooks/useConstituencyProof.ts`
+- `apps/web-pwa/src/hooks/lumaAggregateVoterRecords.ts`
+- `apps/web-pwa/src/store/forum/lumaRecords.ts`
+- `apps/web-pwa/src/store/newsReportLumaRecords.ts`
+
+### Slice D1 - Public-Beta Profile Enforcement
+
+Implementation plan:
+
+- Build/deploy profile for initial release is `public-beta`.
+- Attestation provider is `BetaLocalAttestationProvider`.
+- Constituency provider is `BetaLocalConstituencyProvider`.
+- Lifecycle is enforced.
+- Dev fallback and mock providers are not available in release builds.
+- Direct trust-score comparisons outside policy helpers remain forbidden.
+
+Tests:
+
+```bash
+corepack pnpm@9.7.1 check:luma:mvp-production-readiness
+corepack pnpm@9.7.1 check:luma-provider-surface
+corepack pnpm@9.7.1 check:luma-identity-lifecycle
+corepack pnpm@9.7.1 check:luma-multidevice-stubs
+```
+
+### Slice D2 - Signed-Write Coverage
+
+Implementation plan:
+
+- Stance/vote writes use aggregate voter envelope.
+- Forum posts/comments use forum author envelope.
+- News reports use forum author reporter id envelope.
+- Account-provider state does not become a LUMA public author scheme.
+- Session references are hash/digest references; raw tokens are forbidden.
+
+Tests:
+
+```bash
+corepack pnpm@9.7.1 check:luma-signed-write-surface
+corepack pnpm@9.7.1 check:luma-aggregate-voter-v1
+corepack pnpm@9.7.1 check:luma-forum-author-v1
+corepack pnpm@9.7.1 check:luma-forum-post-v1
+corepack pnpm@9.7.1 check:luma-news-report-v1
+```
+
+### Slice D3 - Forbidden Claims And Telemetry Redaction
+
+Implementation plan:
+
+- User-facing copy must avoid forbidden claims including verified-human,
+  one-human-one-vote, Sybil-resistant, district-proof, cryptographic
+  residency, anonymous, and untraceable.
+- Telemetry/logging must redact raw nullifier, device credential,
+  district hash, region code, provider tokens, raw signed-write envelope, and
+  provider secrets.
+- Account/support flows must route sensitive account details out of public
+  GitHub issues.
+
+Tests:
+
+```bash
+corepack pnpm@9.7.1 check:luma-forbidden-claims
+corepack pnpm@9.7.1 check:luma-telemetry-redaction
+corepack pnpm@9.7.1 check:public-beta-compliance
+```
+
+Done:
+
+- Every release write path is LUMA-gated, every public author id is scoped to
+  the right linkability domain, and public copy stays within beta-local claims.
+
+## Lane E - Constituency And Representative Mapping
+
+### Goal
+
+Tie civic sentiment to local offices in the release-safe way: beta-local
+constituency proof at vote admission, representative-directory mapping by
+district hash, and aggregate-only district/office sentiment surfaces.
+
+### Grounded Surfaces
+
+- `docs/specs/spec-identity-trust-constituency.md`
+- `docs/specs/spec-civic-sentiment.md`
+- `docs/specs/spec-civic-action-kit-v0.md`
+- `apps/web-pwa/src/hooks/useRegion.ts`
+- `apps/web-pwa/src/hooks/useConstituencyProof.ts`
+- `apps/web-pwa/src/store/bridge/districtConfig.ts`
+- `apps/web-pwa/src/store/bridge/representativeDirectory.ts`
+- `apps/web-pwa/src/components/bridge/RepresentativeSelector.tsx`
+- `packages/luma-sdk/src/providers/index.ts`
+- `packages/types/src/constituency-verification.ts`
+- `packages/gun-client/src/civicRepresentativeAdapters.ts`
+- `packages/data-model/src/schemas/hermes/bridgeRepresentative.ts`
+
+### Slice E1 - District Acquisition And Proof Binding
+
+Implementation plan:
+
+- Initial release may use `VITE_DEFAULT_DISTRICT_HASH` or a user-selected
+  district profile, but it must label the proof as beta-local.
+- `useRegion()` derives proof from active LUMA nullifier plus configured
+  district.
+- `useConstituencyProof()` remains the write-path guard and rejects missing,
+  mock, malformed, or strict-mode transitional proofs.
+- Vote admission stores only proof reference/sensitive outbox material, never
+  raw proof in public paths.
+
+Tests:
+
+- missing identity blocks proof;
+- proof nullifier mismatch blocks vote admission;
+- configured district mismatch blocks representative action;
+- telemetry/support artifacts do not expose raw proof material.
+
+### Slice E2 - Representative Directory Lookup
+
+Implementation plan:
+
+- Fix representative lookup to use the current proof/configured district hash
+  instead of `findRepresentatives('')`.
+- Load representative directory snapshots through system-writer validated
+  records at `vh/civic/reps/<jurisdictionVersion>`.
+- Expose empty-state copy when no reps are loaded for a district without
+  leaking district proof material.
+- Keep directory snapshots as system records; do not migrate identity
+  directory or browser signing surfaces into those records.
+
+Tests:
+
+```bash
+corepack pnpm@9.7.1 check:luma-civic-reps-system-v1
+```
+
+Targeted component tests:
+
+- `RepresentativeSelector` passes current district hash to
+  `findRepresentatives`;
+- wrong district shows no matched offices;
+- system-writer validation failure refuses snapshot data.
+
+### Slice E3 - Aggregate District/Office Sentiment
+
+Implementation plan:
+
+- Build district/office aggregate read model from accepted vote tuples and
+  representative directory mapping.
+- Publish only aggregate/dashboard records that meet cohort thresholds.
+- Do not publish `{district_hash, nullifier}` pairs, raw address, raw region
+  code, provider account id, or per-user lines.
+- Office-level display should answer:
+  - which office/district the aggregate refers to;
+  - which topic/synthesis/epoch;
+  - aggregate agree/disagree by point;
+  - cohort size / threshold status;
+  - computed time and source snapshot version.
+- If cohort size is below threshold, show "not enough local signal yet" rather
+  than a small-cell count.
+
+Tests:
+
+- topology guard fails any public non-aggregate record containing
+  `district_hash`;
+- aggregate records require `cohortSize >= MIN_DISTRICT_COHORT_SIZE`;
+- representative dashboard payloads contain no nullifiers/proofs/tokens;
+- district/office aggregate is recomputable from aggregate-only source inputs.
+
+### Slice E4 - Opinion Registration Claim
+
+Implementation plan:
+
+- Product copy may say users can register their opinion in VHC's beta-local
+  civic sentiment aggregate for their configured/local office.
+- Product copy must not say the system has verified residence, verified human
+  uniqueness, or submitted an official message to an office unless those
+  separate flows are implemented and proven.
+
+Done:
+
+- A signed-in beta user can vote on a framing point and see that the opinion
+  participates in an aggregate district/office view without exposing sensitive
+  identity material.
+
+## Lane F - Release Evidence Rehearsal
+
+### Goal
+
+Prove the initial release loop independently of Scope A live stability work:
+accepted synthesis detail, stance persistence, account/LUMA binding,
+constituency mapping, support/compliance, and 3-browser convergence.
+
+### Grounded Surfaces
+
+- `docs/ops/BETA_SESSION_RUNSHEET.md`
+- `docs/ops/public-beta-launch-readiness-closeout.md`
+- `packages/e2e/src/live/bias-vote-convergence.live.spec.ts`
+- `packages/e2e/src/live/vote-mutation.live.spec.ts`
+- `packages/e2e/src/live/public-feed-lifecycle-accountability.mjs`
+- `packages/e2e/src/live/public-feed-composition-freshness-gate.mjs`
+- `packages/e2e/src/luma/mvp-production-readiness.mjs`
+- `packages/e2e/src/luma/account-identity-controls.spec.ts`
+- `packages/e2e/src/mvp-release-gates.mjs`
+- `tools/scripts/regenerate-mvp-release-evidence.mjs`
+- `tools/scripts/check-public-beta-compliance.mjs`
+- `tools/scripts/check-public-beta-launch-closeout.mjs`
+
+### Slice F1 - Local Product Proof
 
 Commands:
 
@@ -384,406 +777,38 @@ corepack pnpm@9.7.1 test:live:five-user-engagement
 corepack pnpm@9.7.1 check:launch-content-snapshot
 ```
 
-Done when:
+Required proof:
 
-- Five local beta users can open singleton and bundled stories, see accepted
-  synthesis detail, stance on frame/reframe points, reply in threads, reload,
-  and observe cross-user readback.
+- accepted summaries and framing tables render;
+- vote controls appear only for accepted-current stable point ids;
+- stance persists and aggregates;
+- account/identity controls do not overclaim;
+- story threads/reporting remain non-regressed if they stay in release copy.
 
-### Slice 2.2 - Production Canary Preconditions
-
-Preconditions:
-
-- Lane 0 48-hour proof target is green, or an operator-approved incident
-  packet explicitly authorizes canary timing.
-- No active freshness, relay liveness, relay snapshot, or watch-closure alert.
-- Heap-capture analysis is not actively pointing at a synthesis-path blocker.
-- OpenAI/model auth is configured only in host-private env.
-- The release owner confirms the product claim requires accepted synthesis now.
-
-Implementation:
-
-- Keep storylines and topic synthesis enrichment disabled for the first canary.
-- Keep publish-time synthesis decoupled from raw write success. Raw publication
-  remains the first safety contract.
-- Use narrow caps and explicit relay REST quorum settings from
-  `docs/ops/news-aggregator.env.example`:
-  - `VH_BUNDLE_SYNTHESIS_ENABLED=true`
-  - `VH_BUNDLE_SYNTHESIS_WRITE_RELAY_REST=true`
-  - `VH_BUNDLE_SYNTHESIS_RELAY_WRITE_MIN_SUCCESS=2`
-  - `VH_BUNDLE_SYNTHESIS_TIMEOUT_MS=120000`
-  - `VH_BUNDLE_SYNTHESIS_RATE_PER_MIN=20` or lower for canary
-  - `VH_NEWS_RUNTIME_MAX_PUBLISHED_BUNDLES=96` only after canary expansion
-  - first-tick raw caps remain conservative
-- Do not enable storylines (`VH_NEWS_STORYLINES_ENABLED`) in the first accepted
-  synthesis canary unless the canary plan explicitly includes it.
-
-Done when:
-
-- The host-private canary plan names env deltas, rollback env deltas, readback
-  files, expected accepted-synthesis count, and exact stop conditions.
-
-### Slice 2.3 - Accepted Synthesis Canary
-
-Implementation:
-
-- Enable the smallest accepted synthesis canary that can prove the path.
-- Let the publisher complete a clean raw tick before expecting queued accepted
-  synthesis.
-- Read back accepted synthesis from relay/storage, not just local logs.
-- Confirm detail UI shows:
-  - generated timestamp;
-  - epoch;
-  - accepted `TopicSynthesisV2`;
-  - stable `frame_point_id` and `reframe_point_id`;
-  - source evidence limited to analysis-eligible sources;
-  - related links separated from analyzed evidence.
-
-Stop conditions:
-
-- Raw publication fails or parks.
-- Relay writes drop below 2-of-3.
-- Synthesis write/readback repeatedly fails.
-- Story detail displays unlabeled stale, placeholder, or source-unsafe
-  analysis.
-- Heap growth sharply changes before the first canary can be read back.
-
-Done when:
-
-- At least one canary story has accepted synthesis readback and Web PWA detail
-  renders it correctly, while raw feed freshness remains green.
-
-### Slice 2.4 - Expansion To MVP Coverage
-
-Implementation:
-
-- Increase accepted synthesis coverage only after the canary passes and raw feed
-  freshness remains green.
-- Add evidence for singleton and bundled story paths.
-- Preserve point identity across regenerations or record unmapped/orphaned
-  point counts before promotion.
-- Keep click-time analysis out of the normal detail path.
-
-Verification:
-
-```bash
-corepack pnpm@9.7.1 check:public-feed:lifecycle-accountability
-corepack pnpm@9.7.1 check:public-feed:stance-aggregate-decay
-corepack pnpm@9.7.1 check:mvp-release-gates
-```
-
-Done when:
-
-- The intended MVP release commit can pass accepted synthesis/frame reliability
-  gates for the release envelope.
-
-## Lane 3 - Civic Stance, Discussion, Moderation, And Beta Identity
-
-### Goal
-
-Make the product interactive in the exact MVP way: beta-local identity,
-point-level stance, deterministic story threads, report intake, and trusted
-operator moderation, without implying verified-human/Silver proof.
-
-### Grounded Surfaces
-
-- `packages/gun-client/src/sentimentAdapters.ts`
-- `packages/gun-client/src/topicEngagementAdapters.ts`
-- `packages/gun-client/src/forumAdapters.ts`
-- `packages/gun-client/src/newsReportAdapters.ts`
-- `apps/web-pwa/src/hooks/useSentimentState.ts`
-- `apps/web-pwa/src/components/feed/NewsCardBack.tsx`
-- `apps/web-pwa/src/components/forum/ForumThreadView.tsx`
-- `apps/web-pwa/src/lib/luma/actionPolicy.ts`
-- `tools/scripts/check-luma-topic-synthesis-system-v1.mjs`
-- `docs/specs/spec-civic-sentiment.md`
-- `docs/specs/spec-luma-service-v0.md`
-- `docs/ops/luma-verifier-current-state.md`
-
-### Slice 3.1 - LUMA Beta Identity Honesty
-
-Implementation:
-
-- Keep public beta copy on beta-local identity and signed-write semantics.
-- Do not claim production attestation, Silver, verified-human identity,
-  one-human-one-vote, cryptographic residency, Sybil resistance, or full
-  section 21.4 replay.
-- Confirm action policy covers directory/forum/news-report/aggregate/stance
-  write actions.
+### Slice F2 - Strict Matrix And 3-Browser Session
 
 Commands:
 
 ```bash
-corepack pnpm@9.7.1 check:luma:mvp-production-readiness
-corepack pnpm@9.7.1 check:luma-forbidden-claims
-corepack pnpm@9.7.1 check:luma-production-profile
-corepack pnpm@9.7.1 check:luma-telemetry-redaction
+VH_RUN_LIVE_MATRIX=true \
+VH_LIVE_MATRIX_REQUIRE_FULL=true \
+corepack pnpm@9.7.1 --filter @vh/e2e test:live:matrix:strict:stability
 ```
 
-Done when:
+Manual proof from `docs/ops/BETA_SESSION_RUNSHEET.md`:
 
-- LUMA gates pass and release copy does not overstate identity guarantees.
+- Browser A/B/C each get a distinct identity.
+- All three open the same vote-capable story.
+- All see the same accepted-current table from mesh.
+- Vote changes converge across all clients.
+- Reload preserves analysis, vote cells, and aggregate state.
 
-### Slice 3.2 - Point-Level Stance And Aggregate Readback
+Done:
 
-Implementation:
+- `strictStabilityAchieved: true`, `passCount: 3`, `scarcityCount: 0`, and
+  manual 3-browser PASS.
 
-- Keep the canonical stance target:
-  `(topic_id, synthesis_id, epoch, point_id)`.
-- Ensure neutral stance clears or becomes non-counting in aggregates.
-- Ensure users cannot stance on a row without an accepted stable point id.
-- Verify aggregate falloff follows the Season 0 cap:
-  `E_new = E_current + 0.3 * (1.95 - E_current)`.
-
-Commands:
-
-```bash
-corepack pnpm@9.7.1 check:public-feed:stance-aggregate-decay
-corepack pnpm@9.7.1 test:live:five-user-engagement
-```
-
-Done when:
-
-- Stance writes persist, aggregate, survive reload, and remain public as
-  aggregate-only metadata.
-
-### Slice 3.3 - Story Threads, Reports, And Moderation
-
-Implementation:
-
-- Use the existing forum system. Do not create a second comment model.
-- Keep deterministic story thread ids in the `news-story:*` family.
-- Verify reply persistence, cross-user visibility, report intake, audited
-  hide/restore moderation, and trusted-operator authorization on current
-  remediation writes.
-
-Commands:
-
-```bash
-corepack pnpm@9.7.1 test:live:five-user-engagement
-corepack pnpm@9.7.1 check:mvp-release-gates
-```
-
-Done when:
-
-- The five-user lane proves comments, replies, report-to-action, and moderated
-  state without relying on non-MVP admin polish.
-
-## Lane 4 - Web PWA Shell, Launch Content, And Public Beta Support
-
-### Goal
-
-Ship the MVP as a Web PWA with honest public-beta surfaces and representative
-fallback content for demos/QA, while leaving native packaging and full app-store
-compliance out of the critical path.
-
-### Grounded Surfaces
-
-- `apps/web-pwa/`
-- `apps/web-pwa/src/components/layout/Footer.tsx`
-- `apps/web-pwa/src/pages/CompliancePage.tsx`
-- `apps/web-pwa/src/pages/BetaPage.tsx`
-- `apps/web-pwa/src/pages/PrivacyPage.tsx`
-- `apps/web-pwa/src/pages/TermsPage.tsx`
-- `apps/web-pwa/src/pages/ModerationPage.tsx`
-- `apps/web-pwa/src/pages/SupportPage.tsx`
-- `apps/web-pwa/src/pages/DataDeletionPage.tsx`
-- `apps/web-pwa/src/pages/TelemetryPage.tsx`
-- `apps/web-pwa/src/pages/CopyrightPage.tsx`
-- `.github/ISSUE_TEMPLATE/public-beta-support.yml`
-- `packages/e2e/fixtures/launch-content/validated-snapshot.json`
-- `docs/ops/public-beta-launch-readiness-closeout.md`
-
-### Slice 4.1 - Public Beta Route And Support Gate
-
-Implementation:
-
-- Confirm the footer links every required policy/support route.
-- Confirm `/support` points to the public beta GitHub Issue Form.
-- Confirm private escalation protocol remains documented without exposing
-  secrets or private contact paths in code.
-
-Command:
-
-```bash
-corepack pnpm@9.7.1 check:public-beta-compliance
-```
-
-Done when:
-
-- Compliance/support gate passes on the release commit.
-
-### Slice 4.2 - Launch Content Fallback
-
-Implementation:
-
-- Keep `packages/e2e/fixtures/launch-content/validated-snapshot.json`
-  representative enough to cover singleton, bundle, accepted synthesis,
-  correction, thread, moderation, and preference states.
-- Use this only for local demo/QA fallback; do not treat it as live ingestion
-  proof.
-
-Command:
-
-```bash
-corepack pnpm@9.7.1 check:launch-content-snapshot
-```
-
-Done when:
-
-- The snapshot gate passes and any release demo clearly distinguishes fixture
-  mode from live public-source freshness.
-
-### Slice 4.3 - Browser Smoke And PWA Usability
-
-Implementation:
-
-- Run the browser smoke against the intended public/local target.
-- Confirm feed opens, cards expand, detail content does not overlap on mobile,
-  support/policy routes are reachable, and pending/unavailable synthesis states
-  are visibly honest.
-
-Commands:
-
-```bash
-corepack pnpm@9.7.1 test:public-feed:browser-smoke
-corepack pnpm@9.7.1 check:public-beta-launch-closeout
-```
-
-Done when:
-
-- Browser smoke and launch closeout pass on the release candidate target.
-
-## Lane 5 - Pager And Incident Loop After Email Proof
-
-### Goal
-
-Replace silent failure with a durable incident loop, without putting custom
-pager deployment or Codex automation in front of the already-working email
-guardrail.
-
-### Grounded Surfaces
-
-- `services/vhc-pager/`
-- `tools/scripts/public-feed-alert-watch.mjs`
-- `tools/scripts/vhc-incident-codex-triage.mjs`
-- `tools/scripts/vhc-incident-reviewer-worker.mjs`
-- `tools/scripts/vhc-incident-executor.mjs`
-- `tools/scripts/vhc-incident-readback-verifier.mjs`
-- `tools/scripts/verify-vhc-incident-packet.mjs`
-- `.github/workflows/vhc-pager-deadman.yml`
-- `.github/ISSUE_TEMPLATE/a6-incident.yml`
-- `docs/ops/vhc-incident-response.md`
-- `docs/ops/vhc-pager-iphone-setup.md`
-- `docs/ops/vhc-codex-responder.md`
-- `docs/plans/AUTONOMOUS_INCIDENT_RESPONSE_SLICES_2026-07-06.md`
-
-### Slice 5.1 - Pager Deployment Outside A6
-
-Implementation:
-
-- Host the pager outside A6.
-- Configure secrets in the pager host only.
-- Keep the existing email alert channel enabled permanently.
-- Add the pager PWA to the operator iPhone Home Screen only after hosted
-  service health is verified.
-- Preserve platform honesty: iOS Web Push cannot override silent/Focus mode,
-  so email remains fallback.
-
-Done when:
-
-- Pager health endpoint passes and iPhone PWA enrollment succeeds without
-  changing A6 production behavior.
-
-### Slice 5.2 - Signed Webhook Cutover
-
-Implementation:
-
-- Configure A6 alert watch to send signed alerts to the pager endpoint.
-- The pager must durably persist before returning 2xx.
-- The pager creates/updates a public-safe GitHub incident issue.
-- The alert fans out to iPhone PWA and email.
-- Ack requires authenticated enrolled device token.
-
-Test-fire proof:
-
-- A6 emitted the alert.
-- Pager accepted and persisted it.
-- GitHub issue was created/updated.
-- iPhone/email received it.
-- Ack succeeded only with the device token.
-
-Done when:
-
-- A synthetic alert completes the full loop and the email fallback remains
-  active.
-
-### Slice 5.3 - Pager Dead-Man
-
-Implementation:
-
-- Enable the external dead-man after pager cutover.
-- Confirm deliberate pager outage opens a GitHub incident instead of silently
-  failing.
-- Keep weekly test-fire discipline until the 14-day proof target is banked.
-
-Done when:
-
-- Pager outage drill produces the expected dead-man incident and recovery note.
-
-### Slice 5.4 - Codex Responder Dry-Run Only
-
-Implementation:
-
-- Codex may investigate, write tests, draft PRs, and draft operator packets.
-- Reviewer/verifier can exercise signed packet paths.
-- A6 live executor stays dry-run and must refuse unapproved live execution.
-- Do not enable live A6 execution until the alert/pager loop has worked under
-  real operation for the required proof window and explicit drills pass.
-
-Command:
-
-```bash
-corepack pnpm@9.7.1 check:vhc-incident-response
-```
-
-Done when:
-
-- Incident-response checks pass and live execution remains disabled.
-
-## Lane 6 - Release Evidence And Go/No-Go Packet
-
-### Goal
-
-Make the release decision from evidence on the intended commit, not from a
-stale local memory of which lanes used to pass.
-
-### Grounded Surfaces
-
-- `tools/scripts/check-mvp-release-gates.mjs`
-- `tools/scripts/regenerate-mvp-release-evidence.mjs`
-- `tools/scripts/check-mvp-closeout.mjs`
-- `tools/scripts/check-public-beta-launch-closeout.mjs`
-- `.tmp/mvp-release-gates/latest/mvp-release-gates-report.json`
-- `.tmp/mvp-release-evidence/latest/`
-- `docs/ops/public-beta-launch-readiness-closeout.md`
-- `docs/foundational/STATUS.md`
-
-### Slice 6.1 - Release Commit Freeze
-
-Implementation:
-
-- Select a release candidate commit.
-- Confirm local `main`, `origin/main`, and any deployed Web PWA target are
-  actually at or intentionally derived from that commit.
-- Record any live A6 lag separately. A6 raw feed can be healthy at one commit
-  while docs or Web PWA release artifacts are at a newer commit.
-
-Done when:
-
-- The release packet names one commit and one deployment target set.
-
-### Slice 6.2 - Evidence Regeneration
+### Slice F3 - Release Gate Packet
 
 Commands:
 
@@ -792,210 +817,196 @@ corepack pnpm@9.7.1 check:mvp-release-evidence
 corepack pnpm@9.7.1 check:mvp-release-gates
 corepack pnpm@9.7.1 check:mvp-closeout
 corepack pnpm@9.7.1 check:public-beta-launch-closeout
+corepack pnpm@9.7.1 check:public-beta-compliance
 corepack pnpm@9.7.1 docs:check
 git diff --check
 ```
 
-Implementation:
+Release packet must record:
 
-- Treat `setup_scarcity` as a blocker unless the release envelope explicitly
-  excludes that lane.
-- Treat `skipped_not_in_scope` as acceptable only when the release copy makes
-  the same exclusion.
-- Preserve generated artifacts only when the runbook says they are meant to be
-  committed; otherwise record paths and hashes in the evidence packet.
+- release commit;
+- deployed Web PWA target;
+- live A6 state or explicit non-touch boundary;
+- accepted synthesis coverage;
+- vote persistence and 3-browser evidence;
+- account/LUMA binding evidence;
+- constituency/rep aggregate evidence;
+- support/compliance evidence;
+- known limitations and forbidden claims;
+- rollback path.
 
-Done when:
+## Pager And Codex Responder Follow-On
 
-- All release-in-scope gates pass on the release candidate commit.
+The custom pager, GitHub incident bridge, responder/reviewer/verifier, and
+pull-executor implementation are important but not the next product-release
+lane. Sequence:
 
-### Slice 6.3 - Claim Review
+1. keep email fallback active;
+2. deploy pager outside A6;
+3. run signed alert test-fire A6 -> pager -> GitHub issue -> iPhone/email ->
+   authenticated ack;
+4. enable pager dead-man;
+5. keep Codex responder dry-run only until the alert/incident loop proves
+   itself under real operation and explicit drills pass.
 
-Implementation:
+Validation:
 
-- Compare the release copy to the gates that actually passed.
-- Explicitly reject claims for:
-  - native app/TestFlight/App Store availability;
-  - production-attested/Silver LUMA;
-  - verified one-human-one-vote;
-  - public WSS mesh `release_ready`;
-  - full production app canary;
-  - autonomous production execution;
-  - 14-day Scope A unattended stability before the target date passes.
+```bash
+corepack pnpm@9.7.1 check:vhc-incident-response
+```
 
-Done when:
+## Deferred Non-Initial-Release Tracks
 
-- The public beta claim is narrower than or equal to the verified evidence.
+These stay outside the initial release claim unless a later release packet
+explicitly adds and proves them:
 
-### Slice 6.4 - Go/No-Go Packet
-
-Implementation:
-
-- Produce a final go/no-go report with:
-  - release commit;
-  - commands run;
-  - artifacts and hashes;
-  - live A6 state;
-  - Web PWA target state;
-  - known limitations;
-  - explicit non-goals;
-  - rollback path;
-  - operator contacts and support routing.
-
-Done when:
-
-- A reviewer can reproduce the evidence and approve or block without needing
-  unwritten tribal context.
-
-## Lane 7 - Deferred Non-MVP Tracks
-
-These are important, but they do not belong in the functioning MVP critical
-path unless the release claim expands:
-
-- Native iOS/TestFlight/App Store shell.
-- Public WSS mesh `release_ready`.
-- Production app canary as a full product-readiness claim.
-- LUMA production-attestation/Silver, verified-human identity,
-  Sybil-resistance, one-human-one-vote, and full section 21.4 recorded product
-  replay.
-- Scope B topic synthesis enrichment, storyline overlays, and broad storylines.
-- Retention/compaction/eviction/memory remediation before heap evidence names
-  the retainer.
-- Codex live production execution/autonomy.
-- Full trust-and-safety console, appeals workflow, SLA desk, and complete RBAC
-  membership management.
-- Commercial/legal approval beyond the already-implemented public-beta policy
-  route and support-surface minimums.
+- native iOS/TestFlight/App Store shell;
+- public WSS mesh `release_ready`;
+- full production app canary;
+- LUMA Silver or stronger assurance;
+- verified-human identity;
+- one-human-one-vote;
+- Sybil resistance;
+- cryptographic residency;
+- cross-device per-human nullifier binding;
+- official outbound delivery to representative offices;
+- Scope B storylines/topic synthesis enrichment;
+- memory remediation before heap evidence names the retainer;
+- Codex live production execution/autonomy;
+- full trust-and-safety console, appeals workflow, SLA desk, and complete RBAC
+  membership management;
+- commercial/legal approval beyond implemented public-beta policy/support
+  minimums.
 
 ## PR Sequencing
 
-### PR A - Plan And Alignment
+### PR A - Plan Refinement
 
-This document. It is plan-only and should not mutate production behavior.
+This document. It is plan-only and must not mutate production behavior.
 
 Validation:
 
 ```bash
 corepack pnpm@9.7.1 docs:check
 git diff --check
+corepack pnpm@9.7.1 check:luma-forbidden-claims
+corepack pnpm@9.7.1 check:vhc-incident-response
 ```
 
-### PR B - Scope A Evidence Update
-
-Open only after:
-
-- the 48-hour proof target passes;
-- a new alert triggers an incident; or
-- the first 500 MB -> 700 MB heap summary pair appears.
+### PR B - Accepted Summary/Table Readiness
 
 Scope:
 
-- update current-state reports;
-- record analyzer summaries or incident evidence;
-- do not change live behavior unless the incident packet authorizes it.
+- accepted-current read model;
+- lifecycle/synthesis join;
+- vote-control gating by stable point ids;
+- UI states for pending/retryable/terminal/suppressed;
+- tests for mismatch and non-votable states.
 
-### PR C - Source Supply Refresh
-
-Open only if source-health/feed-density evidence says the MVP needs source
-changes.
-
-Scope:
-
-- source admission through the runbook;
-- source-health report updates;
-- feed composition/freshness evidence.
-
-### PR D - Accepted Synthesis Canary Plan/Guard
-
-Open after Lane 0 allows enrichment work.
+### PR C - Vote Persistence And Aggregate Engagement
 
 Scope:
 
-- canary env plan;
-- host-private operator session outline;
-- any missing guard tests for synthesis write/readback, lifecycle states, or
-  point-id preservation.
+- unified vote admission;
+- local intent queue and projection hardening;
+- aggregate voter node validation;
+- Eye/Lightbulb counters;
+- three-browser persistence proof improvements.
 
-### PR E - Civic Interaction Release Evidence
-
-Scope:
-
-- five-user engagement evidence;
-- LUMA beta identity checks;
-- stance aggregate decay checks;
-- report/moderation gate fixes if any fail.
-
-### PR F - Pager Deployment Packet
-
-Open after email proof remains reliable and before signed webhook cutover.
+### PR D - Account And Sign-In Shell
 
 Scope:
 
-- pager deployment outside A6;
-- full test-fire packet;
-- dead-man enablement;
-- Codex dry-run proof only.
+- Apple/Google/X provider contract;
+- account-provider UI;
+- account-to-LUMA local binding;
+- token redaction/storage;
+- sign-out/reset identity copy and tests.
 
-### PR G - MVP Release Packet
+### PR E - LUMA Binding And Forbidden-Claim Hardening
 
 Scope:
 
-- release evidence regeneration;
-- go/no-go report;
-- public beta claim review;
-- no unrelated refactors.
+- public-beta profile enforcement;
+- signed-write coverage;
+- telemetry redaction;
+- forbidden-claim gates;
+- account/identity copy audit.
+
+### PR F - Constituency And Representative Mapping
+
+Scope:
+
+- district acquisition/review;
+- representative lookup wired to active district hash;
+- representative snapshot system-writer readback;
+- aggregate district/office sentiment read model;
+- privacy threshold/topology tests.
+
+### PR G - Release Rehearsal And Go/No-Go Packet
+
+Scope:
+
+- strict matrix;
+- manual 3-browser proof;
+- MVP release gates;
+- release evidence report;
+- claim review and launch decision.
 
 ## Validation Matrix
 
-| Lane | Main Commands | Live/Operator Readback |
+| Lane | Main Commands | Required Manual/Live Evidence |
 | --- | --- | --- |
-| Scope A reliability | `check:public-feed:alert-watch`, `check:scope-a-watch-closure`, heap analyzer when triggered | timer active states, latest tick, public freshness, relay liveness, relay snapshot |
-| Source supply | `check:news-sources:health`, `report:news-sources:health`, `check:storycluster:production-readiness` | no live mutation unless source admission PR requires deployment |
-| Feed composition | `check:public-feed:composition-freshness`, `check:public-feed:fresh-propagation`, `check:public-feed:lifecycle-accountability` | latest-index age, singleton/bundle mix, raw write/readback counts |
-| Accepted synthesis | `live:stack:up:analysis-stub`, `test:live:five-user-engagement`, `check:mvp-release-gates` | accepted synthesis readback, stable point ids, raw feed still fresh |
-| Civic interaction | `check:public-feed:stance-aggregate-decay`, `check:luma:mvp-production-readiness`, `test:live:five-user-engagement` | cross-user persistence, aggregate-only public metadata |
-| Public beta shell | `check:public-beta-compliance`, `check:launch-content-snapshot`, `test:public-feed:browser-smoke` | support route reachable, policy/footer links present |
-| Incident loop | `check:vhc-incident-response` | email fallback active, pager test-fire, GitHub issue, device ack, dead-man drill |
-| Release packet | `check:mvp-release-evidence`, `check:mvp-release-gates`, `check:mvp-closeout`, `docs:check`, `git diff --check` | release commit matches deployment targets and claim boundaries |
+| Safety rail | `check:public-feed:alert-watch`, `check:scope-a-watch-closure`, heap analyzer when triggered | timers active, latest tick, freshness, relay liveness, relay snapshot |
+| Accepted summary/table | `check:public-feed:lifecycle-accountability`, `check:luma-topic-synthesis-system-v1`, `check:mvp-release-gates` | story detail shows accepted-current summary/table; non-current table is non-votable |
+| Vote persistence | `check:public-feed:stance-aggregate-decay`, `check:luma-aggregate-voter-v1`, strict matrix | 3-browser vote convergence and reload persistence |
+| Account/sign-in | account identity tests, provider/token tests, `check:public-beta-compliance` | Apple/Google/X account flow binds to current-device LUMA identity without overclaim |
+| LUMA binding | `check:luma:mvp-production-readiness`, `check:luma-signed-write-surface`, `check:luma-forbidden-claims`, `check:luma-telemetry-redaction` | signed writes use correct public author schemes; no forbidden claims |
+| Constituency/reps | `check:luma-civic-reps-system-v1`, topology/privacy tests | active district hash maps to reps; aggregate-only district/office sentiment |
+| Release rehearsal | `check:mvp-release-evidence`, `check:mvp-release-gates`, `check:mvp-closeout`, `docs:check`, `git diff --check` | release packet names commit, artifacts, limitations, rollback |
+| Incident follow-on | `check:vhc-incident-response` | pager test-fire/dead-man later; Codex remains dry-run |
 
-## Functioning MVP Acceptance Criteria
+## Functioning Initial Release Acceptance Criteria
 
-The MVP is functioning when all of the following are true on the intended
+The initial release is functioning when all of these are true on the intended
 release commit:
 
-- The public feed is fresh and observable through the active alert/watch
-  channel.
-- Singleton and bundled stories render in the Web PWA feed.
-- Topic preferences visibly affect feed ordering/filtering.
-- Story detail renders accepted synthesis for the release envelope, or the
-  release envelope explicitly excludes analysis and the UI honestly shows
-  pending/unavailable states.
-- Frame/reframe rows have stable point ids before stance controls are enabled.
-- Point stance persists, aggregates with falloff, survives reload, and exposes
-  aggregate-only public metadata.
-- Deterministic story threads support replies, reports, and audited moderation.
-- Public-beta LUMA identity gates pass without forbidden identity claims.
-- Public beta policy/support routes and GitHub support issue form are reachable.
-- Launch content fallback is valid for QA/demo and not confused with live
-  ingestion proof.
-- MVP release gates, closeout gates, docs check, and whitespace check pass.
-- A6 live state is either fresh/green or explicitly excluded from the release
-  action because the release is not touching A6.
-- Any remaining limitations are listed in the go/no-go packet and reflected in
-  public copy.
+- Users can register/sign in with the approved provider shell.
+- Sign-in binds to or creates a beta-local LUMA identity on the current device.
+- Account copy does not claim verified-human, one-human-one-vote, Silver,
+  Sybil resistance, or residency proof.
+- Users can open a story and read an accepted summary.
+- The bias/framing table renders only from accepted-current `TopicSynthesisV2`
+  joined to the current story lifecycle.
+- Vote controls appear only for rows with stable accepted point ids.
+- One final stance per user per point persists and can be changed.
+- Public aggregate counts converge across at least three browser identities and
+  survive reload.
+- Eye/Lightbulb accounting follows the Season 0 cap and does not use proxy
+  signals.
+- LUMA signed-write envelopes cover stance/forum/report release writes.
+- Constituency proof is beta-local, validated at write admission, and kept out
+  of public paths.
+- Representative mapping uses the active district hash and system-writer
+  validated directory snapshots.
+- District/office sentiment surfaces are aggregate-only and thresholded.
+- Public beta support/compliance routes pass.
+- Scope A alerting remains active, and live A6 is not touched unless a separate
+  operator packet authorizes it.
+- Release gates, docs governance, and whitespace checks pass.
 
 ## Failure Handling Rules
 
-- If a new alert arrives, pause enrichment work and run the read-only incident
-  branch first.
+- If a new A6 alert arrives, pause product-lane work and run the read-only
+  incident branch first.
 - If the heap pair appears, run the analyzer first; do not remediate before the
   retainer is named.
-- If source-health is `warn`, adjudicate it; do not call it release-green.
-- If accepted synthesis canary breaks raw publication, roll back synthesis
-  enablement and protect the raw feed first.
-- If five-user engagement fails, fix the failing interaction lane before
-  widening public beta.
-- If LUMA forbidden-claim gates fail, change copy or product surfaces; do not
+- If accepted-current lifecycle joins fail, keep story detail non-votable.
+- If vote convergence fails, fix the vote/projection lane before widening beta.
+- If sign-in works but LUMA binding fails, do not admit votes.
+- If LUMA forbidden-claim gates fail, change copy/product surfaces; do not
   weaken the gate.
+- If representative mapping cannot prove active district lookup and aggregate
+  privacy thresholds, remove local-office sentiment claims from release copy.
 - If release gates fail, fix the lane or narrow the release envelope; do not
   override the packet.

--- a/docs/plans/FUNCTIONING_MVP_LANE_SLICE_PLAN_2026-07-06.md
+++ b/docs/plans/FUNCTIONING_MVP_LANE_SLICE_PLAN_2026-07-06.md
@@ -1,10 +1,10 @@
 # Functioning MVP Lane Slice Plan - 2026-07-06
 
-> Status: Technical implementation and operating plan, v2 refined for initial release goals
+> Status: Technical implementation and operating plan, v3 scrutinized and refined
 > Owner: VHC Core Engineering + VHC Launch Ops
 > Last Reviewed: 2026-07-06
 > Target: Venn News Web PWA initial release MVP
-> Depends On: `docs/foundational/STATUS.md`, `docs/plans/VENN_NEWS_MVP_ROADMAP_2026-04-20.md`, `docs/specs/topic-synthesis-v2.md`, `docs/specs/spec-civic-sentiment.md`, `docs/specs/spec-luma-service-v0.md`, `docs/specs/spec-identity-trust-constituency.md`, `docs/specs/spec-civic-action-kit-v0.md`, `docs/ops/BETA_SESSION_RUNSHEET.md`, `docs/ops/public-beta-launch-readiness-closeout.md`, `docs/ops/news-aggregator-production-service.md`, `docs/ops/public-feed-freshness-monitor.md`, `docs/ops/vhc-incident-response.md`, `docs/reports/phase5-scope-a-post-slice0-current-state-2026-07-06.md`
+> Depends On: `docs/foundational/STATUS.md`, `docs/plans/VENN_NEWS_MVP_ROADMAP_2026-04-20.md`, `docs/plans/AUTONOMOUS_INCIDENT_RESPONSE_SLICES_2026-07-06.md`, `docs/specs/topic-synthesis-v2.md`, `docs/specs/spec-civic-sentiment.md`, `docs/specs/spec-luma-service-v0.md`, `docs/specs/spec-identity-trust-constituency.md`, `docs/specs/spec-civic-action-kit-v0.md`, `docs/specs/spec-linked-socials-v0.md`, `docs/specs/spec-data-topology-privacy-v0.md`, `docs/ops/BETA_SESSION_RUNSHEET.md`, `docs/ops/public-beta-launch-readiness-closeout.md`, `docs/ops/news-aggregator-production-service.md`, `docs/ops/public-feed-freshness-monitor.md`, `docs/ops/vhc-incident-response.md`, `docs/reports/phase5-scope-a-post-slice0-current-state-2026-07-06.md`
 
 ## Executive Decision
 
@@ -23,39 +23,69 @@ features." Users must be able to:
 8. tie those civic sentiments to a beta-local constituency/representative
    mapping through aggregate-only district/office surfaces.
 
+Goal 1 requires new server-side work: no OAuth/PKCE flow, callback service, or
+provider registration exists in the repo today, so the account lane includes
+building and deploying that boundary, not just client wiring.
+
 This is still a Web PWA release. Native app packaging, public WSS mesh
 `release_ready`, LUMA Silver, verified-human proof, one-human-one-vote,
 cryptographic residency, cross-device per-human nullifier binding, and Codex
 live production execution are not part of the initial release claim.
 
-## Review Verdict On The Previous Plan
+## Review Verdict On Prior Versions
 
-The first plan had the right safety spine: keep Scope A raw-feed reliability in
-front of enrichment, preserve the email alert guardrail, keep Codex execution
-dry-run, and require release evidence on the intended commit. It was too broad
-for the product goal, and it under-specified three release-critical joins.
+The v1 plan had the right safety spine but was too broad for the product goal
+and under-specified the release-critical joins. v2 fixed that: it centered
+accepted summaries and the framing table, tied vote controls to
+accepted-current lifecycle joins, made the account lane explicit, separated
+social login from human uniqueness, and made constituency/representative
+mapping a first-class lane.
 
-Required refinements:
+A multi-lens adversarial review of v2 (goal coverage, topic-synthesis spec,
+civic-sentiment spec, LUMA/constituency spec, code reality, slicing, ops
+safety) confirmed the lane structure is sound and the current-state facts are
+accurate, but found and verified these gaps, all closed in this v3:
 
-- Accepted summaries and the framing table must be the first product lane, not
-  a generic "accepted synthesis later" note.
-- Vote controls must be tied to `accepted-current` lifecycle joins, not merely
-  the presence of a `TopicSynthesisV2`.
-- The account lane must exist explicitly. Current repo reality has beta-local
-  LUMA identity and linked-social storage primitives, but not a completed
-  Apple/Google/X sign-in release flow.
-- Social login must not be described as human uniqueness. It is account
-  continuity/profile recovery; LUMA beta-local identity supplies the current
-  release's device-bound `PrincipalId`/`Nullifier` semantics.
-- Constituency/representative mapping must be a first-class lane. The current
-  representative selector primitives exist, but `RepresentativeSelector` still
-  calls `findRepresentatives('')`, so it cannot satisfy local-office mapping
-  until the user's district hash is wired through.
-- The release rehearsal must exercise the product proof loop directly:
-  accepted summary/table, vote persistence, LUMA signed writes, account binding,
-  constituency mapping, and the manual 3-browser persistence check.
-
-This document is the refined plan that closes those gaps.
+- **No slice delivered the OAuth backend.** Slice C1 mandated a
+  backend/callback boundary, but no lane, grounded surface, or PR built,
+  hosted, or validated it — and no such service exists in the repo. Lane C now
+  has Slice C0 owning the callback boundary, provider registration, and an
+  explicit outside-A6 deployment target, with rehearsal evidence in Lane F.
+- **Slice A3's canary gate was undefined.** "Until the safety rail allows
+  enrichment" had no defined condition, silently conflicted with STATUS.md's
+  attended-soak/runbook re-enablement rule, and would have voided the 14-day
+  unattended window. A3 is now gated on a dedicated operator canary packet and
+  the PR sequencing names that packet as an operator-owned step.
+- **The pager/Codex follow-on dropped the non-waivable PR #722 gate.** The
+  sequence now requires adversarial verification of the merged incident
+  response implementation against the incident-response v2 plan's Security
+  Architecture before any pager cutover or Codex-live decision, and the
+  test-fire step is bound to an operator maintenance session.
+- **The accepted-current join was missing the corrections record.**
+  `suppressed_by_correction` derives from
+  `vh/topics/<topicId>/synthesis_corrections/latest`, which Slice A1's join
+  list omitted; the union also lacked the spec's `loading` state.
+- **The sign-in provider enum collided with spec-linked-socials-v0.** The
+  linked-social `SocialProviderId` enum has no `apple`/`google`, its schemas
+  are strict, and its stores are flag-gated — so sign-in tokens must not
+  route through the linked-social token vault. Lane C now defines a new
+  sign-in provider schema with its own identity-vault compartment.
+- **Provider labels had no topology class.** Publishing sanitized
+  provider/account display labels joined to LUMA public ids would
+  de-pseudonymize them; Lane C/D/E now forbid co-publication outright and gate
+  any future public profile-label surface on a topology class plus a Protocol
+  RFC.
+- **Lanes C and E had no runnable gates.** Both now name runnable commands,
+  and PR D/PR F add named check scripts as deliverables.
+- Smaller verified fixes: Lightbulb accounting pinned to active non-neutral
+  stance count (anti-toggle-gaming), spec-required projection/write-outcome
+  telemetry added to Lane B's gates, Reset Identity account-binding semantics
+  defined, the stance-envelope acceptance criterion disambiguated from the
+  encrypted sentiment outbox, `RepresentativeSelector`'s direct trust-score
+  gate scheduled for policy-helper migration, three wrong grounded-surface
+  paths corrected, the B4/F2 3-browser proof deduplicated, and the deferred
+  list extended to cover Season-0 surfaces that ship in the same PWA without
+  being release claims.
 
 ## Current State Of Play
 
@@ -121,12 +151,17 @@ Per `docs/specs/spec-civic-sentiment.md`:
   `(topic_id, synthesis_id, epoch, point_id)`;
 - `agreement = 0` is neutral and non-counting;
 - event-level signals with constituency proof are sensitive and must stay
-  local/encrypted;
+  local/encrypted; encrypted sentiment outbox records must not carry
+  `_writerKind`, `_authorScheme`, or `SignedWriteEnvelope`
+  (`docs/specs/spec-data-topology-privacy-v0.md` §3); the public
+  aggregate voter node is the only stance artifact that carries a
+  signed-write envelope;
 - public paths contain aggregate-only projections;
 - public aggregate voter nodes use topic/epoch-scoped `voterId`, never raw
   nullifier; and
 - Eye and Lightbulb are capped by the Season 0 decay model, with
-  `E_cap = 1.95`.
+  `E_cap = 1.95`; Lightbulb impact uses the active non-neutral stance count
+  per `(topic_id, synthesis_id, epoch)`, not raw click/toggle count.
 
 ### Account And LUMA Semantics
 
@@ -140,6 +175,13 @@ Initial release account language must say this clearly:
 - Current `principalNullifier` is device-bound. A user signing in on another
   device does not automatically prove the same human and must not silently
   inherit old votes as the same principal.
+- Provider subjects and provider/account display labels are personal profile
+  data (`docs/specs/spec-data-topology-privacy-v0.md` §3: vault/local-only).
+  They are shown only in local account UI, are never written to `vh/*` public
+  records, and are never published joined with `forumAuthorId`,
+  `identityDirectoryKey`, `voterId`, or any envelope-bearing record. A future
+  public profile-label surface requires a topology classification plus a
+  Protocol RFC (`docs/specs/spec-luma-service-v0.md` §1.4).
 - LUMA Silver, verified-human, one-human-one-vote, Sybil resistance,
   cryptographic residency, and cross-device per-human binding remain deferred.
 
@@ -180,9 +222,21 @@ These boundaries still apply while product lanes progress:
 - Do not restart the publisher while feed freshness remains green.
 - Do not restart relays while relay liveness and snapshot freshness remain
   green.
-- Do not enable Codex live execution or production autonomy.
+- Do not change A6 publisher/synthesis environment (including any
+  `VH_BUNDLE_SYNTHESIS_*` switch) from any product lane; only a dedicated
+  operator canary packet may do so. A6 alert-env edits are governed by the
+  maintenance-session rule below.
+- Do not edit A6 host alert env, disable timers, or rerun test-fire while A6
+  is green outside an explicitly opened operator maintenance session
+  (`docs/ops/vhc-incident-response.md`).
+- Do not enable Codex live execution or production autonomy. Before any
+  Codex-live decision, the merged PR #722 implementation must pass adversarial
+  verification against
+  `docs/plans/AUTONOMOUS_INCIDENT_RESPONSE_SLICES_2026-07-06.md`
+  §Security Architecture (non-waivable).
 - Do not deploy/cut over the custom pager before the email path continues to
-  prove itself and the pager is deployed outside A6 with its own dead-man.
+  prove itself, the pager is deployed outside A6 with its own dead-man, and
+  the same non-waivable PR #722 adversarial verification has passed.
 - Do not run retention, relay compaction, publisher clear, eviction, pruning,
   or memory remediation before the first post-recovery 500 MB -> 700 MB
   analyzer summary classifies the retainer.
@@ -199,10 +253,13 @@ Safety rail:
 Initial release product lanes:
   A. Accepted summary and framing table readiness
   B. Stance/vote persistence and aggregate engagement
-  C. Account and sign-in shell
+  C. Account and sign-in shell (incl. OAuth callback boundary)
   D. LUMA public-beta identity binding
   E. Constituency and representative mapping
   F. Release evidence rehearsal
+
+Operator-owned step (not a repo PR):
+  Operator canary packet that executes Slice A3 on A6
 
 Post-initial-release rails:
   Pager/PWA incident system, Codex dry-run responder, Scope B storylines,
@@ -210,7 +267,7 @@ Post-initial-release rails:
 ```
 
 The product lanes can proceed in parallel in local/staging/repo work. A6 live
-mutation remains gated by the safety rail.
+mutation remains gated by the safety rail and the operator canary packet.
 
 ## Safety Rail - Scope A Reliability And Evidence Accrual
 
@@ -225,7 +282,7 @@ product lanes advance off-host. The MVP cannot ship on a stale or silent feed.
 - `docs/ops/news-aggregator-production-service.md`
 - `docs/ops/public-feed-freshness-monitor.md`
 - `tools/scripts/public-feed-alert-watch.mjs`
-- `tools/scripts/phase5-scope-a-watch-closure.mjs`
+- `tools/scripts/phase5-scope-a-watch-closure-packet.mjs`
 - `tools/scripts/analyze-early-heap-captures.mjs`
 - `services/news-aggregator/src/index.ts`
 - `packages/ai-engine/src/newsRuntime.ts`
@@ -250,6 +307,8 @@ product lanes advance off-host. The MVP cannot ship on a stale or silent feed.
 - 48-hour proof target passes or a precise incident report exists.
 - Heap evidence is handled by analyzer summary only.
 - No live mutation happens merely because product lanes are ready.
+- Completing this rail does not itself authorize A6 enrichment; Slice A3
+  requires its own operator canary packet.
 
 ## Lane A - Accepted Summary And Framing Table Readiness
 
@@ -265,13 +324,16 @@ controls only when the table is safe to vote on.
 - `services/news-aggregator/src/bundleSynthesisWorker.ts`
 - `services/news-aggregator/src/bundleSynthesisRelay.ts`
 - `services/news-aggregator/src/bundleSynthesisDaemonConfig.ts`
-- `services/news-aggregator/src/bundleSynthesisQueue.ts`
+- `services/news-aggregator/src/enrichmentQueue.ts`
+- `services/news-aggregator/src/pendingSynthesisCatchup.ts`
+- `services/news-aggregator/src/synthesisLifecycleLedger.ts`
+- `packages/gun-client/src/newsAdapters.ts`
 - `packages/gun-client/src/synthesisAdapters.ts`
 - `packages/gun-client/src/analysisAdapters.ts`
 - `apps/web-pwa/src/components/feed/NewsCard.tsx`
 - `apps/web-pwa/src/components/feed/NewsCardBack.tsx`
 - `apps/web-pwa/src/components/feed/CellVoteControls.tsx`
-- `apps/web-pwa/src/hooks/useAnalysis.ts`
+- `apps/web-pwa/src/components/feed/useAnalysis.ts`
 - `docs/ops/news-aggregator.env.example`
 
 ### Slice A1 - Accepted-Current Read Model
@@ -280,10 +342,15 @@ Implementation plan:
 
 - Make the story-detail read path explicitly join:
   `StoryBundle`, `vh/news/stories/<storyId>/synthesis_lifecycle/latest`,
-  `vh/topics/<topicId>/epochs/<epoch>/synthesis`, and
-  `vh/topics/<topicId>/latest`.
+  `vh/topics/<topicId>/epochs/<epoch>/synthesis`,
+  `vh/topics/<topicId>/latest`, and
+  `vh/topics/<topicId>/synthesis_corrections/latest`.
+- `suppressed_by_correction` is derived from the corrections record when its
+  status is `suppressed`; a non-suppressed correction maps to
+  `terminal_unavailable`, matching the existing derivation in
+  `apps/web-pwa/src/components/feed/NewsCardBack.tsx`.
 - Define one UI-ready object for story detail:
-  `acceptedCurrentSynthesis | pending | retryable_failure |
+  `loading | acceptedCurrentSynthesis | pending | retryable_failure |
   terminal_unavailable | suppressed_by_correction | invalid`.
 - Reject as votable when lifecycle source revision, synthesis id, epoch, story
   id, or system-writer validation does not match.
@@ -296,6 +363,13 @@ Tests:
 - missing point ids keep vote controls disabled for that row;
 - corrected/suppressed synthesis is not votable;
 - invalid system-writer record fails closed with observable state.
+
+Commands:
+
+```bash
+corepack pnpm@9.7.1 check:public-feed:lifecycle-accountability
+corepack pnpm@9.7.1 check:luma-topic-synthesis-system-v1
+```
 
 ### Slice A2 - Summary And Table UX
 
@@ -325,7 +399,19 @@ Tests:
 
 Implementation plan:
 
-- Do not start this on A6 until the safety rail allows enrichment.
+- Do not start this on A6 without a dedicated operator canary packet that
+  authorizes the A6 change. The safety rail defines no condition that
+  "allows" enrichment; passing the 48-hour proof target
+  (`2026-07-08T22:44:08Z`) is a necessary precondition for issuing that
+  packet, not itself an authorization.
+- Per `docs/foundational/STATUS.md`, re-enabling accepted synthesis requires a
+  separate attended soak and an updated runbook entry. The canary packet must
+  include both.
+- Starting the canary is an operator touch that ends the 14-day unattended
+  evidence window (target `2026-07-20T22:44:08Z`); the packet must schedule
+  the canary deliberately against that window.
+- No product-lane PR sets these env values on A6; the canary is executed as
+  an operator action (see Operator Canary Packet in PR Sequencing).
 - Keep storylines/topic synthesis enrichment disabled for first canary unless a
   separate packet explicitly includes them.
 - Keep raw publication first and accepted synthesis decoupled from raw write
@@ -342,7 +428,8 @@ Implementation plan:
 Done:
 
 - At least one singleton and one bundled story have accepted-current readback
-  and a safe votable table in Web PWA detail.
+  and a safe votable table in Web PWA detail, produced through the
+  operator-authorized canary packet.
 
 ## Lane B - Stance/Vote Persistence And Aggregate Engagement
 
@@ -363,6 +450,7 @@ accounting, and 3-browser persistence proof.
 - `apps/web-pwa/src/hooks/lumaAggregateVoterRecords.ts`
 - `apps/web-pwa/src/components/feed/CellVoteControls.tsx`
 - `apps/web-pwa/src/components/feed/voteSemantics.ts`
+- `apps/web-pwa/src/utils/sentimentTelemetry.ts`
 - `packages/gun-client/src/sentimentAdapters.ts`
 - `packages/gun-client/src/sentimentEventAdapters.ts`
 - `packages/gun-client/src/aggregateAdapters.ts`
@@ -408,21 +496,32 @@ Tests:
 - `+1`, `-1`, neutral reset, and vote mutation converge correctly;
 - public aggregate voter node uses topic/epoch-scoped `voterId`;
 - raw nullifier, district hash, merkle root, and address never appear in
-  public aggregate paths.
+  public aggregate paths;
+- projection retries/failures and terminal mesh-write outcomes
+  (success/failure/timeout) emit telemetry per
+  `docs/specs/spec-civic-sentiment.md` §9.5/§11.2; no silent-success path
+  exists.
 
 ### Slice B3 - Eye/Lightbulb And Aggregate Summary
 
 Implementation plan:
 
 - Eye increments on full read/expand events.
-- Lightbulb is driven only by active stance interactions, never by source count,
-  synthesis quorum, or other proxy values.
+- Lightbulb impact is driven by the count of active non-neutral stances per
+  `(topic_id, synthesis_id, epoch)` — not raw click/toggle count, and never by
+  source count, synthesis quorum, or other proxy values
+  (`docs/specs/spec-civic-sentiment.md` §5).
 - Use capped diminishing returns with `E_cap = 1.95`.
 - Public feed counters read topic engagement aggregate first, with documented
   fallback to feed snapshot plus local persisted decayed weight.
 - Topic engagement summary writes remain system-writer records.
 
 Tests:
+
+- repeated toggles on the same cell do not increase Lightbulb weight beyond
+  the active-count closed form.
+
+Commands:
 
 ```bash
 corepack pnpm@9.7.1 check:public-feed:stance-aggregate-decay
@@ -431,6 +530,9 @@ corepack pnpm@9.7.1 check:luma-aggregate-voter-v1
 ```
 
 ### Slice B4 - Three-Browser Persistence Proof
+
+This slice owns the definition of the manual 3-browser check; Slice F2
+executes it as the release rehearsal and produces the packet evidence.
 
 Implementation plan:
 
@@ -459,6 +561,8 @@ continuity and recovery, not human uniqueness proof.
 
 ### Grounded Surfaces
 
+- `docs/specs/spec-linked-socials-v0.md`
+- `docs/specs/spec-data-topology-privacy-v0.md`
 - `apps/web-pwa/src/hooks/useIdentity.ts`
 - `apps/web-pwa/src/routes/AccountIdentityPage.tsx`
 - `apps/web-pwa/src/store/identityProvider.ts`
@@ -469,25 +573,71 @@ continuity and recovery, not human uniqueness proof.
 - `packages/identity-vault/src/vault.ts`
 - `packages/identity-vault/src/compartments/deviceCredential.ts`
 - `packages/identity-vault/src/compartments/delegationSigningKey.ts`
+- `packages/e2e/src/luma/account-identity-controls.spec.ts`
 - `docs/specs/secure-storage-policy.md`
+
+### Slice C0 - OAuth Callback Boundary And Provider Registration
+
+No OAuth/PKCE flow, callback service, or provider app registration exists in
+the repo today; this slice builds the server component Slice C1 depends on.
+
+Implementation plan:
+
+- Decide and record the boundary approach: a new minimal auth-callback
+  service (new `services/` entry) or a serverless/hosted-auth function
+  co-located with the Web PWA hosting target. The decision, with its
+  trade-offs, is a named PR D deliverable.
+- Name the deployment target explicitly. It is deployed outside A6, mirroring
+  the pager's treatment: standing it up must not touch the publisher/relay
+  host during the watch window.
+- Register Apple, Google, and X developer applications; configure redirect
+  URIs per environment. Track registration lead time as an external
+  dependency with an owner — Apple in particular requires a server-held
+  signed client secret for code exchange.
+- Provider client secrets are provisioned host-private (env/secret store) and
+  never enter the repo, the browser bundle, logs, or release evidence.
+- The browser completes OAuth/OIDC with PKCE against this boundary only.
+
+Tests:
+
+- PKCE round-trip completes against the deployed boundary for each provider;
+- the built browser bundle contains no provider client secret (bundle scan);
+- callback errors surface as clean sign-in failures, not partial sessions.
 
 ### Slice C1 - Account Provider Contract
 
 Implementation plan:
 
 - Define a closed provider enum for the release: `apple`, `google`, `x`.
-- Use OAuth/OIDC with PKCE through a backend/callback boundary where provider
-  client secrets never enter the browser bundle.
+  This sign-in enum is a NEW schema, distinct from spec-linked-socials-v0's
+  `SocialProviderId` (`x/reddit/youtube/tiktok/instagram/other`), which has no
+  `apple`/`google` and is scoped to optional notification cards behind
+  `VITE_LINKED_SOCIAL_ENABLED`.
+- Use OAuth/OIDC with PKCE through the Slice C0 backend/callback boundary
+  where provider client secrets never enter the browser bundle.
 - Store only non-secret display/account metadata in the account shell.
-- Store provider tokens, if retained at all, in the existing token/vault path;
-  never write them to public mesh, logs, support issues, telemetry, or release
-  evidence.
-- Normalize provider subject to a private account binding. Public projections
-  may use a provider/account display label only after sanitization.
+- Sign-in tokens must NOT be written through
+  `apps/web-pwa/src/store/linkedSocial/tokenVault.ts` — its
+  `OAuthTokenRecordSchema` is strict to the linked-social enum and the store
+  is flag-gated. Define a dedicated identity-vault compartment for sign-in
+  session material (peer of
+  `packages/identity-vault/src/compartments/deviceCredential.ts`), following
+  the same vault-only/no-barrel-export rules; its contents are never written
+  to public mesh, logs, support issues, telemetry, or release evidence.
+- Normalize provider subject to a private account binding. Provider subjects
+  and account/provider display labels are vault/local-only personal profile
+  data: shown only in local account UI, never written to any `vh/*` public
+  record, and never published joined with `forumAuthorId`,
+  `identityDirectoryKey`, `voterId`, or any `SignedWriteEnvelope`-bearing
+  record. A future public profile-label surface requires a topology
+  classification plus a Protocol RFC.
 
 Tests:
 
 - provider tokens cannot appear in public projections;
+- no public record contains a provider subject or display label, and no
+  public record joins one with a LUMA public id
+  (`forumAuthorId` / `identityDirectoryKey` / `voterId`);
 - account records validate against a closed schema;
 - unsupported provider ids are rejected;
 - sign-out clears session state without claiming network deletion.
@@ -508,8 +658,11 @@ Implementation plan:
   LUMA principal. It may show account continuity/profile state, but old votes
   remain under the old device-bound principal unless a later multi-device link
   feature is built and approved.
-- If a user resets identity, account binding must record that the old public
-  artifacts are not deleted or re-authored.
+- On Reset Identity, the account-to-LUMA binding is cleared and
+  re-established against the new `principalNullifier` on next sign-in
+  (mirroring the `walletBinding` row in `docs/specs/spec-luma-service-v0.md`
+  §13.2). Account binding must record that the old public artifacts are not
+  deleted or re-authored.
 
 Tests:
 
@@ -517,6 +670,7 @@ Tests:
   Identity is invoked;
 - Reset Identity rotates the LUMA principal and leaves historical artifacts
   under the prior pseudonyms;
+- no binding record referencing the pre-reset nullifier survives reset;
 - another browser/device sign-in does not claim same-human continuity;
 - copy and telemetry avoid verified-human/one-human-one-vote language.
 
@@ -530,11 +684,25 @@ Implementation plan:
   - session expiry/renewal state;
   - sign-out action;
   - reset identity action with irreversible-effects explanation;
-  - linked provider management;
+  - sign-in provider management (distinct from the flag-gated linked-social
+    notification-account feature);
   - clear limitation copy for device-bound identity.
 - First vote attempt without account/identity should route user into sign-in
   or beta-local identity creation, then back to the same story/point.
 - Sign-in failure must not strand the user with a partially admitted vote.
+
+Commands:
+
+```bash
+corepack pnpm@9.7.1 --filter @vh/web-pwa exec vitest run \
+  src/store/identityProvider.browser.test.ts \
+  src/store/news/hydration.identity.test.ts
+corepack pnpm@9.7.1 --filter @vh/e2e test src/luma/account-identity-controls.spec.ts
+```
+
+PR D additionally delivers a named root script
+(`check:account-identity-controls`) wrapping the e2e spec so the gate is
+addressable from the release packet.
 
 Done:
 
@@ -591,10 +759,16 @@ corepack pnpm@9.7.1 check:luma-multidevice-stubs
 
 Implementation plan:
 
-- Stance/vote writes use aggregate voter envelope.
+- Stance actions are LUMA policy-gated under the `vh-stance-vote` /
+  `vh-stance-clear` audiences; the public aggregate voter node is the only
+  stance artifact carrying a `SignedWriteEnvelope` (audience
+  `vh-aggregate-voter`). Event-level stance records stay in the encrypted
+  sentiment outbox and must not carry envelopes
+  (`docs/specs/spec-data-topology-privacy-v0.md` §3).
 - Forum posts/comments use forum author envelope.
 - News reports use forum author reporter id envelope.
-- Account-provider state does not become a LUMA public author scheme.
+- Account-provider state does not become a LUMA public author scheme and is
+  never co-published with LUMA public ids.
 - Session references are hash/digest references; raw tokens are forbidden.
 
 Tests:
@@ -654,6 +828,7 @@ district hash, and aggregate-only district/office sentiment surfaces.
 - `packages/luma-sdk/src/providers/index.ts`
 - `packages/types/src/constituency-verification.ts`
 - `packages/gun-client/src/civicRepresentativeAdapters.ts`
+- `packages/gun-client/src/topology.ts`
 - `packages/data-model/src/schemas/hermes/bridgeRepresentative.ts`
 
 ### Slice E1 - District Acquisition And Proof Binding
@@ -682,6 +857,12 @@ Implementation plan:
 
 - Fix representative lookup to use the current proof/configured district hash
   instead of `findRepresentatives('')`.
+- Migrate `RepresentativeSelector`'s direct `trustScore < TRUST_MINIMUM` gate
+  to the policy-helper path (`canPerform`/`scoreFromEnvelope`) or document it
+  as an accepted read-surface exception explicitly reconciled with Slice D1's
+  no-direct-comparison rule. Note: the existing direct-trust gate script
+  scans write-boundary files only and does not cover bridge components, so
+  this violation is invisible to the current gates.
 - Load representative directory snapshots through system-writer validated
   records at `vh/civic/reps/<jurisdictionVersion>`.
 - Expose empty-state copy when no reps are loaded for a district without
@@ -708,7 +889,10 @@ Implementation plan:
 
 - Build district/office aggregate read model from accepted vote tuples and
   representative directory mapping.
-- Publish only aggregate/dashboard records that meet cohort thresholds.
+- Publish only aggregate/dashboard records that meet cohort thresholds
+  (`MIN_DISTRICT_COHORT_SIZE = 100`, `docs/specs/spec-luma-service-v0.md`
+  §9.4; the topology lint rejects any public non-aggregate record carrying
+  `district_hash`, fail-closed).
 - Do not publish `{district_hash, nullifier}` pairs, raw address, raw region
   code, provider account id, or per-user lines.
 - Office-level display should answer:
@@ -723,10 +907,18 @@ Implementation plan:
 Tests:
 
 - topology guard fails any public non-aggregate record containing
-  `district_hash`;
+  `district_hash` (existing coverage:
+  `packages/gun-client/src/topology.test.ts`, run via
+  `corepack pnpm@9.7.1 --filter @vh/gun-client test`);
+- topology guard fails any public record containing a provider
+  subject/display label;
 - aggregate records require `cohortSize >= MIN_DISTRICT_COHORT_SIZE`;
 - representative dashboard payloads contain no nullifiers/proofs/tokens;
 - district/office aggregate is recomputable from aggregate-only source inputs.
+
+PR F additionally delivers a named check
+(`check:district-aggregate-thresholds`) covering the cohort-threshold and
+aggregate-only assertions for the new read model.
 
 ### Slice E4 - Opinion Registration Claim
 
@@ -783,6 +975,10 @@ Required proof:
 - vote controls appear only for accepted-current stable point ids;
 - stance persists and aggregates;
 - account/identity controls do not overclaim;
+- one real Apple, one real Google, and one real X sign-in complete against
+  the deployed Slice C0 callback boundary (this item runs against the
+  deployed boundary, not the local stack), with redirect-URI and
+  secret-custody evidence recorded for the release packet;
 - story threads/reporting remain non-regressed if they stay in release copy.
 
 ### Slice F2 - Strict Matrix And 3-Browser Session
@@ -795,10 +991,11 @@ VH_LIVE_MATRIX_REQUIRE_FULL=true \
 corepack pnpm@9.7.1 --filter @vh/e2e test:live:matrix:strict:stability
 ```
 
-Manual proof from `docs/ops/BETA_SESSION_RUNSHEET.md`:
+Manual proof: execute the Slice B4 procedure (which owns the definition) per
+`docs/ops/BETA_SESSION_RUNSHEET.md`:
 
 - Browser A/B/C each get a distinct identity.
-- All three open the same vote-capable story.
+- All three open the same accepted-current story.
 - All see the same accepted-current table from mesh.
 - Vote changes converge across all clients.
 - Reload preserves analysis, vote cells, and aggregate state.
@@ -806,7 +1003,7 @@ Manual proof from `docs/ops/BETA_SESSION_RUNSHEET.md`:
 Done:
 
 - `strictStabilityAchieved: true`, `passCount: 3`, `scarcityCount: 0`, and
-  manual 3-browser PASS.
+  manual 3-browser PASS recorded as the release-packet evidence.
 
 ### Slice F3 - Release Gate Packet
 
@@ -826,6 +1023,7 @@ Release packet must record:
 
 - release commit;
 - deployed Web PWA target;
+- deployed account-provider callback target (outside A6);
 - live A6 state or explicit non-touch boundary;
 - accepted synthesis coverage;
 - vote persistence and 3-browser evidence;
@@ -842,12 +1040,26 @@ pull-executor implementation are important but not the next product-release
 lane. Sequence:
 
 1. keep email fallback active;
-2. deploy pager outside A6;
-3. run signed alert test-fire A6 -> pager -> GitHub issue -> iPhone/email ->
-   authenticated ack;
-4. enable pager dead-man;
-5. keep Codex responder dry-run only until the alert/incident loop proves
-   itself under real operation and explicit drills pass.
+2. NON-WAIVABLE GATE: adversarially verify the merged PR #722
+   incident-response implementation against
+   `docs/plans/AUTONOMOUS_INCIDENT_RESPONSE_SLICES_2026-07-06.md`
+   §Security Architecture (identity gating, signed artifact chain, pull-model
+   executor, untrusted-content quarantine, reviewer independence).
+   `check:vhc-incident-response` is the repo-side gate only and does not
+   satisfy this step. This gate blocks all later steps in this sequence,
+   including any pager cutover and any Codex-live decision;
+3. deploy pager outside A6;
+4. run signed alert test-fire A6 -> pager -> GitHub issue -> iPhone/email ->
+   authenticated ack, only inside an explicitly opened operator maintenance
+   session — it requires setting `VH_PUBLIC_FEED_ALERT_WEBHOOK_URL` /
+   `VH_PUBLIC_FEED_ALERT_WEBHOOK_HMAC_SECRET` on A6 and rerunning test-fire,
+   which is forbidden while A6 is green outside a maintenance session
+   (`docs/ops/vhc-incident-response.md`), and this operator touch resets the
+   14-day unattended window (target `2026-07-20T22:44:08Z`);
+5. enable pager dead-man;
+6. keep Codex responder dry-run only until the alert/incident loop proves
+   itself under real operation, explicit drills pass, AND the step-2
+   adversarial verification gate has passed.
 
 Validation:
 
@@ -873,10 +1085,20 @@ explicitly adds and proves them:
 - Scope B storylines/topic synthesis enrichment;
 - memory remediation before heap evidence names the retainer;
 - Codex live production execution/autonomy;
+- the elevation/nomination loop (Season 0 hero path C);
+- Daily Boost/XP/GWC recognition surfaces;
+- linked-social notification cards (flag-gated);
+- docs/articles surfaces;
+- the LUMA §21.4 recorded product replay;
 - full trust-and-safety console, appeals workflow, SLA desk, and complete RBAC
   membership management;
 - commercial/legal approval beyond implemented public-beta policy/support
   minimums.
+
+Ships-but-unclaimed rule: any surface that remains reachable in the release
+build without being an initial-release claim (story threads, reporting,
+flag-gated Season-0 loops) must be non-regressed, and its copy must not
+overclaim — the same rule the plan applies to threads/reporting in Lane F.
 
 ## PR Sequencing
 
@@ -897,11 +1119,20 @@ corepack pnpm@9.7.1 check:vhc-incident-response
 
 Scope:
 
-- accepted-current read model;
+- accepted-current read model (five-record join incl. corrections);
 - lifecycle/synthesis join;
 - vote-control gating by stable point ids;
-- UI states for pending/retryable/terminal/suppressed;
+- UI states for loading/pending/retryable/terminal/suppressed;
 - tests for mismatch and non-votable states.
+
+### Operator Canary Packet (not a repo PR)
+
+Executes Slice A3 on A6. Operator-owned. Preconditions: 48-hour proof target
+passed, attended soak scheduled, runbook entry updated, and the operator has
+explicitly accepted that this touch ends the 14-day unattended evidence
+window. No product-lane PR performs this step. If this packet is not issued
+before release, Slice A3's Done is unmet and the release envelope must be
+narrowed rather than the gate bypassed.
 
 ### PR C - Vote Persistence And Aggregate Engagement
 
@@ -909,19 +1140,26 @@ Scope:
 
 - unified vote admission;
 - local intent queue and projection hardening;
+- projection/write-outcome telemetry per spec-civic-sentiment §9.5/§11.2;
 - aggregate voter node validation;
-- Eye/Lightbulb counters;
+- Eye/Lightbulb counters on the active-count basis;
 - three-browser persistence proof improvements.
 
 ### PR D - Account And Sign-In Shell
 
 Scope:
 
-- Apple/Google/X provider contract;
+- OAuth callback/token-exchange boundary (new service or hosted-auth
+  decision recorded), deployed outside A6, with provider registration and
+  redirect-URI/secrets handling (Slice C0);
+- Apple/Google/X provider contract (new sign-in schema, distinct from
+  linked-social `SocialProviderId`);
+- dedicated identity-vault compartment for sign-in session material;
 - account-provider UI;
-- account-to-LUMA local binding;
+- account-to-LUMA local binding incl. Reset Identity re-bind semantics;
 - token redaction/storage;
-- sign-out/reset identity copy and tests.
+- sign-out/reset identity copy and tests;
+- named root script `check:account-identity-controls`.
 
 ### PR E - LUMA Binding And Forbidden-Claim Hardening
 
@@ -939,16 +1177,19 @@ Scope:
 
 - district acquisition/review;
 - representative lookup wired to active district hash;
+- `RepresentativeSelector` trust-gate migration to policy helpers;
 - representative snapshot system-writer readback;
 - aggregate district/office sentiment read model;
-- privacy threshold/topology tests.
+- privacy threshold/topology tests;
+- named check `check:district-aggregate-thresholds`.
 
 ### PR G - Release Rehearsal And Go/No-Go Packet
 
 Scope:
 
 - strict matrix;
-- manual 3-browser proof;
+- manual 3-browser proof (executing the Slice B4 definition);
+- live provider sign-in rehearsal evidence;
 - MVP release gates;
 - release evidence report;
 - claim review and launch decision.
@@ -959,37 +1200,46 @@ Scope:
 | --- | --- | --- |
 | Safety rail | `check:public-feed:alert-watch`, `check:scope-a-watch-closure`, heap analyzer when triggered | timers active, latest tick, freshness, relay liveness, relay snapshot |
 | Accepted summary/table | `check:public-feed:lifecycle-accountability`, `check:luma-topic-synthesis-system-v1`, `check:mvp-release-gates` | story detail shows accepted-current summary/table; non-current table is non-votable |
-| Vote persistence | `check:public-feed:stance-aggregate-decay`, `check:luma-aggregate-voter-v1`, strict matrix | 3-browser vote convergence and reload persistence |
-| Account/sign-in | account identity tests, provider/token tests, `check:public-beta-compliance` | Apple/Google/X account flow binds to current-device LUMA identity without overclaim |
+| Vote persistence | `check:public-feed:stance-aggregate-decay`, `check:luma-topic-engagement-summary-system-v1`, `check:luma-aggregate-voter-v1`, strict matrix | 3-browser vote convergence and reload persistence; projection retry/terminal write-outcome telemetry per spec-civic-sentiment §9.5/§11.2 (Slice B2 tests) |
+| Account/sign-in | `--filter @vh/web-pwa exec vitest run src/store/identityProvider.browser.test.ts src/store/news/hydration.identity.test.ts`, `--filter @vh/e2e test src/luma/account-identity-controls.spec.ts`, `check:account-identity-controls` (PR D), `check:public-beta-compliance` | live Apple/Google/X sign-in against the deployed callback boundary binds to current-device LUMA identity without overclaim; no secrets in browser bundle |
 | LUMA binding | `check:luma:mvp-production-readiness`, `check:luma-signed-write-surface`, `check:luma-forbidden-claims`, `check:luma-telemetry-redaction` | signed writes use correct public author schemes; no forbidden claims |
-| Constituency/reps | `check:luma-civic-reps-system-v1`, topology/privacy tests | active district hash maps to reps; aggregate-only district/office sentiment |
+| Constituency/reps | `check:luma-civic-reps-system-v1`, `--filter @vh/gun-client test` (topology), `check:district-aggregate-thresholds` (PR F) | active district hash maps to reps; aggregate-only district/office sentiment |
 | Release rehearsal | `check:mvp-release-evidence`, `check:mvp-release-gates`, `check:mvp-closeout`, `docs:check`, `git diff --check` | release packet names commit, artifacts, limitations, rollback |
-| Incident follow-on | `check:vhc-incident-response` | pager test-fire/dead-man later; Codex remains dry-run |
+| Incident follow-on | `check:vhc-incident-response` | PR #722 adversarial verification vs incident-response v2 §Security Architecture BEFORE pager cutover; pager test-fire/dead-man later; Codex remains dry-run |
 
 ## Functioning Initial Release Acceptance Criteria
 
 The initial release is functioning when all of these are true on the intended
 release commit:
 
-- Users can register/sign in with the approved provider shell.
+- Users can register/sign in with the approved provider shell, against a
+  callback boundary deployed outside A6 that holds all provider secrets
+  server-side.
 - Sign-in binds to or creates a beta-local LUMA identity on the current device.
 - Account copy does not claim verified-human, one-human-one-vote, Silver,
   Sybil resistance, or residency proof.
-- Users can open a story and read an accepted summary.
+- Users can open a story and read an accepted summary; the accepted-current
+  evidence on A6 comes from the operator-authorized canary packet, or the
+  release envelope is narrowed.
 - The bias/framing table renders only from accepted-current `TopicSynthesisV2`
   joined to the current story lifecycle.
 - Vote controls appear only for rows with stable accepted point ids.
 - One final stance per user per point persists and can be changed.
 - Public aggregate counts converge across at least three browser identities and
   survive reload.
-- Eye/Lightbulb accounting follows the Season 0 cap and does not use proxy
-  signals.
-- LUMA signed-write envelopes cover stance/forum/report release writes.
+- Eye/Lightbulb accounting follows the Season 0 cap on the active non-neutral
+  stance-count basis and does not use proxy signals.
+- Stance actions are LUMA policy-gated; the public aggregate voter node is the
+  only stance artifact carrying a `SignedWriteEnvelope`; forum/report release
+  writes carry their own LUMA envelopes; encrypted sentiment outbox records
+  carry none.
 - Constituency proof is beta-local, validated at write admission, and kept out
   of public paths.
 - Representative mapping uses the active district hash and system-writer
   validated directory snapshots.
 - District/office sentiment surfaces are aggregate-only and thresholded.
+- No public record contains a provider subject/display label or joins one to
+  a LUMA public id.
 - Public beta support/compliance routes pass.
 - Scope A alerting remains active, and live A6 is not touched unless a separate
   operator packet authorizes it.
@@ -1002,7 +1252,12 @@ release commit:
 - If the heap pair appears, run the analyzer first; do not remediate before the
   retainer is named.
 - If accepted-current lifecycle joins fail, keep story detail non-votable.
+- If the operator canary packet is not issued, narrow the release envelope;
+  do not run Slice A3 from a product lane.
 - If vote convergence fails, fix the vote/projection lane before widening beta.
+- If provider registration or the callback boundary cannot be deployed in
+  time, narrow the sign-in claim to beta-local identity creation; do not ship
+  a browser-held-secret flow.
 - If sign-in works but LUMA binding fails, do not admit votes.
 - If LUMA forbidden-claim gates fail, change copy/product surfaces; do not
   weaken the gate.


### PR DESCRIPTION
## Summary
- Refines `docs/plans/FUNCTIONING_MVP_LANE_SLICE_PLAN_2026-07-06.md` into the v2 initial-release lane plan.
- Centers the release goal on accepted summaries, accepted-current bias/framing tables, stable point-id vote controls, stance persistence, registered account shell, beta-local LUMA binding, and aggregate constituency/representative mapping.
- Separates Apple/Google/X account continuity from LUMA identity semantics: social login is not human uniqueness; current release binding is beta-local and device-bound.
- Adds explicit critique of the prior plan, including the missing account lane and the representative lookup gap (`RepresentativeSelector` currently using `findRepresentatives('')`).
- Preserves Scope A wait/watch guardrails, email alerting, no live A6 mutation while green, no pager cutover, and no Codex live execution.

## Validation
Passed:
- `corepack pnpm@9.7.1 docs:check`
- `git diff --check`
- `corepack pnpm@9.7.1 check:luma-forbidden-claims`
- `corepack pnpm@9.7.1 check:luma-aggregate-voter-v1`
- `corepack pnpm@9.7.1 check:luma-civic-reps-system-v1`
- `corepack pnpm@9.7.1 check:public-beta-compliance`
- `corepack pnpm@9.7.1 check:luma-signed-write-surface`
- `corepack pnpm@9.7.1 check:vhc-incident-response`
- `corepack pnpm@9.7.1 exec vitest run apps/web-pwa/src/routes/AccountIdentityPage.test.tsx apps/web-pwa/src/store/linkedSocial/accountStore.test.ts apps/web-pwa/src/hooks/useConstituencyProof.test.ts apps/web-pwa/src/components/bridge/RepresentativeSelector.test.tsx`
- `corepack pnpm@9.7.1 exec vitest run apps/web-pwa/src/hooks/lumaAggregateVoterRecords.test.ts apps/web-pwa/src/hooks/voteIntentQueue.test.ts apps/web-pwa/src/hooks/voteIntentMaterializer.test.ts apps/web-pwa/src/components/feed/CellVoteControls.test.tsx apps/web-pwa/src/components/feed/voteSemantics.test.ts`

Attempted but not counted as pass in this local session:
- `corepack pnpm@9.7.1 check:luma:mvp-production-readiness` failed because its child commands invoke plain `pnpm`, which resolves here to bundled pnpm 11/Node 24 and hits frozen-lockfile override mismatch; it also reports stale mesh readiness evidence for this new docs commit.
- `corepack pnpm@9.7.1 check:public-feed:lifecycle-accountability` failed for the same inner plain-pnpm 11 toolchain path before reaching the live lifecycle check.

Notes:
- Node still prints the existing engine warning: local `v23.10.0`, repo wants `>=20 <23`.
- The two distribution readiness docs remain untracked and preserved.