### PR TITLE
fix: allow lumaLog import in discovery system-writer gate

### DIFF
--- a/tools/scripts/check-luma-discovery-index-system-v1.mjs
+++ b/tools/scripts/check-luma-discovery-index-system-v1.mjs
@@ -137,13 +137,36 @@ for (const token of [
 for (const token of [
   'createSignedWriteEnvelope',
   'verifySignedWriteEnvelope',
-  '@vh/luma-sdk',
   'canPerform(',
   'subtle.sign(',
   'createPrivateKey(',
   'crypto.sign(',
 ]) {
   forbidToken(adapterSource, token, 'discovery system writer adapter');
+}
+
+// Discovery is a system-writer surface: LUMA identity signing must stay out.
+// Redaction-safe logging via lumaLog is the sole permitted @vh/luma-sdk import
+// (same pattern as aggregateAdapters.ts).
+for (const importMatch of adapterSource.matchAll(
+  /import\s*(?:type\s*)?\{([^}]*)\}\s*from\s*'@vh\/luma-sdk'/g
+)) {
+  const importedNames = importMatch[1]
+    .split(',')
+    .map((entry) => entry.trim().replace(/^type\s+/, '').split(/\s+as\s+/)[0])
+    .filter(Boolean);
+  for (const name of importedNames) {
+    if (name !== 'lumaLog') {
+      failures.push(
+        `discovery system writer adapter imports forbidden @vh/luma-sdk symbol ${name} (only lumaLog is allowed)`
+      );
+    }
+  }
+}
+if (/from\s*'@vh\/luma-sdk\//.test(adapterSource)) {
+  failures.push(
+    'discovery system writer adapter imports a @vh/luma-sdk subpath (only the lumaLog named import is allowed)'
+  );
 }
 
 const writeDiscoveryItem = sliceExportedFunction(adapterSource, 'writeDiscoveryItem');


### PR DESCRIPTION
## Summary

`check:luma-discovery-index-system-v1` fails on current `main`: it blanket-forbids the `@vh/luma-sdk` token, which broke when #699 added redaction-safe `lumaLog` logging to `discoveryAdapters.ts` — the same pattern `aggregateAdapters.ts` uses (whose sibling check passes because it never blanket-banned the package). The failure blocks the `check:luma:mvp-production-readiness` release gate.

## Change

- Drop the blanket `@vh/luma-sdk` forbidden token.
- Add an import allow-list in its place: only the `lumaLog` named import may come from `@vh/luma-sdk`; any other symbol and any subpath import fails the gate.
- All existing signer-surface bans stay intact: `createSignedWriteEnvelope`, `verifySignedWriteEnvelope`, `canPerform(`, `subtle.sign(`, `createPrivateKey(`, `crypto.sign(`.

## Validation

- `check:luma-discovery-index-system-v1` passes.
- `check:luma:mvp-production-readiness` no longer reports the discovery blocker; its remaining blockers are the expected evidence-flow items (`repo_dirty` from the working tree, stale mesh coverage report pending regeneration at the release commit — Lane F rehearsal work per `docs/plans/FUNCTIONING_MVP_LANE_SLICE_PLAN_2026-07-06.md`).

Part of the Functioning MVP lane plan execution (unblocks the Lane D/PR E gate chain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)