### PR TITLE
guard: ban account-provider identity material before sign-in lands

### DIFF
--- a/packages/gun-client/src/topology.test.ts
+++ b/packages/gun-client/src/topology.test.ts
@@ -37,6 +37,32 @@ describe('TopologyGuard', () => {
     ).toThrow();
   });
 
+  it('blocks account-provider identity material in public paths', () => {
+    const guard = new TopologyGuard();
+    expect(() =>
+      guard.validateWrite('vh/forum/threads/thread-1', { title: 'ok', providerSubject: 'apple:000123.abc' })
+    ).toThrow(/PII in public path/);
+    expect(() =>
+      guard.validateWrite('vh/forum/threads/thread-1', { title: 'ok', displayLabel: 'Jane D.' })
+    ).toThrow(/PII in public path/);
+    expect(() =>
+      guard.validateWrite('vh/forum/threads/thread-1', { title: 'ok', access_token: 'raw-oauth-token' })
+    ).toThrow(/PII in public path/);
+    expect(() =>
+      guard.validateWrite('vh/forum/threads/thread-1', { title: 'ok', account_binding: { provider: 'x' } })
+    ).toThrow(/PII in public path/);
+  });
+
+  it('blocks raw region codes in public paths', () => {
+    const guard = new TopologyGuard();
+    expect(() =>
+      guard.validateWrite('vh/public/aggregates/topic', { ratio: 0.5, region_code: 'US-CA' })
+    ).toThrow(/PII in public path/);
+    expect(() =>
+      guard.validateWrite('vh/public/aggregates/topic', { ratio: 0.5, regionCode: 'US-CA' })
+    ).toThrow(/PII in public path/);
+  });
+
   it('allows hermes inbox writes when encrypted flag is present', () => {
     const guard = new TopologyGuard();
     expect(() =>

--- a/packages/gun-client/src/topology.ts
+++ b/packages/gun-client/src/topology.ts
@@ -63,12 +63,36 @@ const DEFAULT_RULES: TopologyRule[] = [
   { pathPrefix: 'vh/forum/indexes/', classification: 'public' }
 ];
 
+// Account-provider identity/token material (Apple/Google/X sign-in) plus raw
+// region codes. Vault/local-only per spec-data-topology-privacy-v0 §3 — never
+// allowed in public mesh records. Matched on the separator-stripped lowercase
+// key so camelCase and snake_case forms are both rejected.
+const FORBIDDEN_ACCOUNT_PROVIDER_KEYS = new Set([
+  'providersubject',
+  'provideraccountid',
+  'providerlabel',
+  'displaylabel',
+  'accesstoken',
+  'refreshtoken',
+  'idtoken',
+  'clientsecret',
+  'applesub',
+  'googlesub',
+  'xsub',
+  'accountbinding',
+  'regioncode',
+]);
+
 function containsPII(value: unknown): boolean {
   if (value === null || typeof value !== 'object') return false;
   const keys = Object.keys(value as Record<string, unknown>);
-  return keys.some((k) =>
-    ['nullifier', 'district_hash', 'email', 'wallet', 'address'].some((pii) => k.toLowerCase().includes(pii))
-  );
+  return keys.some((k) => {
+    const lower = k.toLowerCase();
+    if (['nullifier', 'district_hash', 'email', 'wallet', 'address'].some((pii) => lower.includes(pii))) {
+      return true;
+    }
+    return FORBIDDEN_ACCOUNT_PROVIDER_KEYS.has(lower.replace(/[-_]/g, ''));
+  });
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/luma-sdk/src/telemetry.test.ts
+++ b/packages/luma-sdk/src/telemetry.test.ts
@@ -79,6 +79,36 @@ describe('LUMA telemetry', () => {
     expect(() => assertLumaTelemetrySafe({ mesh: '/vh/news/story/demo' })).toThrow(/raw mesh path/);
   });
 
+  it('red test: rejects district hash fields in both naming forms', () => {
+    expect(() => assertLumaTelemetrySafe({ district_hash: 'd-123' })).toThrow(/forbidden field/);
+    expect(() => assertLumaTelemetrySafe({ districtHash: 'd-123' })).toThrow(/forbidden field/);
+  });
+
+  it('red test: rejects account-provider identity and token fields before they exist', () => {
+    const forbiddenProviderFields = [
+      'accessToken',
+      'access_token',
+      'refreshToken',
+      'refresh_token',
+      'idToken',
+      'id_token',
+      'providerSubject',
+      'provider_subject',
+      'providerLabel',
+      'provider_label',
+      'displayLabel',
+      'display_label',
+      'clientSecret',
+      'client_secret',
+      'oauthCode',
+      'oauth_code',
+    ];
+    for (const field of forbiddenProviderFields) {
+      expect(() => assertLumaTelemetrySafe({ [field]: 'leaked' }), field).toThrow(/forbidden field/);
+      expect(redactLumaTelemetryContext({ [field]: 'leaked' })).toEqual({ [field]: '[REDACTED:field]' });
+    }
+  });
+
   it('accepts primitives, arrays, repeated references, and malformed non-token URLs', () => {
     const repeated: Record<string, unknown> = { safe: true };
     repeated.self = repeated;

--- a/packages/luma-sdk/src/telemetry.ts
+++ b/packages/luma-sdk/src/telemetry.ts
@@ -78,6 +78,16 @@ const FORBIDDEN_FIELD_NAMES = Object.freeze([
   'vaultMasterKey',
   'privateKey',
   'secretKey',
+  // Account-provider identity/token material (Apple/Google/X sign-in).
+  // Normalization makes each entry cover camelCase and snake_case forms.
+  'accessToken',
+  'refreshToken',
+  'idToken',
+  'providerSubject',
+  'providerLabel',
+  'displayLabel',
+  'clientSecret',
+  'oauthCode',
 ] as const);
 const FORBIDDEN_FIELD_NAME_SET = new Set(FORBIDDEN_FIELD_NAMES.map(normalizeFieldName));
 const TOKEN_QUERY_KEYS = new Set([

--- a/tools/scripts/check-luma-telemetry-redaction.mjs
+++ b/tools/scripts/check-luma-telemetry-redaction.mjs
@@ -40,7 +40,7 @@ export const EXPECTED_LUMA_EVENT_TYPES = Object.freeze([
 ]);
 
 const DIRECT_CONSOLE_PATTERN = /\bconsole\.(?:log|info|warn|error|debug)\s*\(/;
-const SECRET_IDENTIFIER_PATTERN = /\b(?:nullifier|deviceCredential|sessionToken|rawSignatureBytes|rawEnvelopeJson|vaultMasterKey|privateKey|secretKey|districtHash|regionCode)\b/i;
+const SECRET_IDENTIFIER_PATTERN = /\b(?:nullifier|deviceCredential|sessionToken|rawSignatureBytes|rawEnvelopeJson|vaultMasterKey|privateKey|secretKey|districtHash|regionCode|access_?token|refresh_?token|id_?token|provider_?subject|provider_?label|display_?label|client_?secret|oauth_?code)\b/i;
 const SECRET_EQUALITY_PATTERN = /(?:===|!==)/;
 const NULLISH_PATTERN = /\b(?:null|undefined)\b/;
 const SOURCE_EXTENSIONS = new Set(['.ts', '.tsx']);

--- a/tools/scripts/check-public-namespace-leaks.mjs
+++ b/tools/scripts/check-public-namespace-leaks.mjs
@@ -79,6 +79,29 @@ function isPersonIdentifierKey(key) {
     'principalnullifier',
     'nullifier',
     'voterid',
+    'forumauthorid',
+    'identitydirectorykey',
+  ].includes(normalized);
+}
+
+// Account-provider identity/token material (Apple/Google/X sign-in).
+// Vault/local-only per spec-data-topology-privacy-v0 §3; never in vh/* public
+// records and never co-published with LUMA person-level identifiers.
+function isAccountProviderKey(key) {
+  const normalized = normalizedKey(key);
+  return [
+    'providersubject',
+    'provideraccountid',
+    'providerlabel',
+    'displaylabel',
+    'accesstoken',
+    'refreshtoken',
+    'idtoken',
+    'clientsecret',
+    'applesub',
+    'googlesub',
+    'xsub',
+    'accountbinding',
   ].includes(normalized);
 }
 
@@ -97,6 +120,7 @@ function isForbiddenSensitiveKey(key) {
     'privatekeyhex',
     'epriv',
     'priv',
+    'regioncode',
   ].includes(normalized);
 }
 
@@ -128,6 +152,18 @@ function validatePublicRecord(recordPath, record) {
   for (const [keyPath, key] of entries) {
     if (isForbiddenSensitiveKey(key)) {
       errors.push(`${recordPath}: forbidden sensitive key ${keyPath.join('.')}`);
+    }
+  }
+
+  const accountProviderEntries = entries.filter(([, key]) => isAccountProviderKey(key));
+  if (accountProviderEntries.length > 0) {
+    for (const [keyPath] of accountProviderEntries) {
+      errors.push(`${recordPath}: forbidden account-provider key ${keyPath.join('.')}`);
+    }
+    if (entries.some(([, key]) => isPersonIdentifierKey(key))) {
+      errors.push(
+        `${recordPath}: account-provider key is co-published with a person-level identifier (forbidden pairing)`,
+      );
     }
   }
 
@@ -276,6 +312,37 @@ const redFixtures = [
       emitted_at: 1,
     },
     match: /VoteIntentRecord fields/,
+  },
+  {
+    name: 'bare provider subject in public record',
+    path: 'vh/forum/threads/thread-1',
+    record: { schemaVersion: 'hermes-thread-v1', providerSubject: 'apple:000123.abc' },
+    match: /forbidden account-provider key providerSubject/,
+  },
+  {
+    name: 'provider label co-published with forum author id',
+    path: 'vh/forum/threads/thread-1',
+    record: {
+      schemaVersion: 'hermes-thread-v1',
+      forumAuthorId: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+      provider_label: 'Jane D.',
+    },
+    match: /account-provider key is co-published with a person-level identifier/,
+  },
+  {
+    name: 'nested provider token in public record',
+    path: 'vh/news/reports/report-1',
+    record: {
+      schemaVersion: 'hermes-news-report-v2',
+      accountBinding: { access_token: 'raw-oauth-token' },
+    },
+    match: /forbidden account-provider key accountBinding\.access_token/,
+  },
+  {
+    name: 'region code in public record',
+    path: 'vh/forum/threads/thread-1',
+    record: { schemaVersion: 'hermes-thread-v1', region_code: 'US-CA' },
+    match: /forbidden sensitive key region_code/,
   },
 ];
 


### PR DESCRIPTION
## Summary

Privacy-tripwire subset of PR E (Lane D, Slices D2/D3) of `docs/plans/FUNCTIONING_MVP_LANE_SLICE_PLAN_2026-07-06.md`. A follow-up PR adds the Apple/Google/X sign-in shell (provider subjects, display labels, OAuth tokens). These guards land FIRST so that material is rejected in public/telemetry surfaces before it exists — leaks fail closed by default.

## Changes

- **`packages/luma-sdk/src/telemetry.ts`**: `FORBIDDEN_FIELD_NAMES` gains `accessToken`, `refreshToken`, `idToken`, `providerSubject`, `providerLabel`, `displayLabel`, `clientSecret`, `oauthCode` (normalized matching covers camelCase/snake_case). Explicit `district_hash` red tests added (guard existed; coverage didn't).
- **`tools/scripts/check-luma-telemetry-redaction.mjs`**: `SECRET_IDENTIFIER_PATTERN` extended with underscore-optional forms of the same identifiers; word boundaries verified against `validToken`/`lease_token` false positives.
- **`tools/scripts/check-public-namespace-leaks.mjs`**: new account-provider key class — any occurrence in a `vh/*` record fails, and co-presence with a person-level identifier (`forumAuthorId`/`identityDirectoryKey`/`voterId`/`nullifier`) adds an explicit forbidden-pairing error per the plan's co-publication ban. `region_code` added to forbidden sensitive keys. Four new red fixtures, all existing green fixtures unchanged.
- **`packages/gun-client/src/topology.ts`**: runtime `containsPII` mirror via exact separator-stripped matching (deliberately not substring: `max_subscribers` contains `x_sub`, `valid_token` contains `id_token`). Legacy substring list byte-identical; `district_hash` rejection stays unconditional.

## Validation

- `@vh/luma-sdk`: 128 passed; `@vh/gun-client`: 601 passed (both suites grew, no regressions)
- `check:luma-telemetry-redaction`, `check:public-namespace-leaks` (incl. new red fixtures), `check:luma-signed-write-surface`, `check:luma-aggregate-voter-v1`, `check:public-beta-compliance`: PASS
- Collateral sweep: `displayLabel`/`providerLabel` exist only as local React props, never public payload keys; `identityDirectoryKey` stays legitimate on `vh/directory/*` (pairing-trigger only, no standalone ban)

🤖 Generated with [Claude Code](https://claude.com/claude-code)