### PR TITLE
feat(feed): accepted-current synthesis read model and votability gating (PR B)

### DIFF
--- a/apps/web-pwa/src/components/feed/BiasTable.test.tsx
+++ b/apps/web-pwa/src/components/feed/BiasTable.test.tsx
@@ -204,30 +204,10 @@ describe('BiasTable', () => {
     expect(screen.getByTestId('bias-table-source-count')).toHaveTextContent('0 sources analyzed');
   });
 
-  it('votingEnabled=true renders CellVoteControls in each cell using stable legacy display IDs', async () => {
-    const pointIds = await deriveExpectedPointIds();
-    render(
-      <BiasTable
-        analyses={[makeAnalysis()]}
-        frames={FRAMES}
-        topicId={TOPIC_ID}
-        analysisId={ANALYSIS_ID}
-        synthesisId={SYNTHESIS_ID}
-        epoch={EPOCH}
-        votingEnabled
-      />,
-    );
-
-    expect(await screen.findByTestId(`cell-vote-${pointIds.frame0}`)).toBeInTheDocument();
-    expect(await screen.findByTestId(`cell-vote-${pointIds.reframe0}`)).toBeInTheDocument();
-    expect(await screen.findByTestId(`cell-vote-${pointIds.frame1}`)).toBeInTheDocument();
-    expect(await screen.findByTestId(`cell-vote-${pointIds.reframe1}`)).toBeInTheDocument();
-  });
-
-  it('keeps legacy display point IDs stable even when synthesis point IDs exist', async () => {
+  it('legacy-compatible mode never renders vote controls, even with full voting context', async () => {
     const legacyPointIds = await deriveExpectedPointIds();
-    const synthesisPointIds = await deriveExpectedSynthesisPointIds(ANALYSIS_ID);
-    render(
+    const synthesisPointIds = await deriveExpectedSynthesisPointIds(SYNTHESIS_ID);
+    const { container } = render(
       <BiasTable
         analyses={[makeAnalysis()]}
         frames={FRAMES}
@@ -239,7 +219,10 @@ describe('BiasTable', () => {
       />,
     );
 
-    expect(await screen.findByTestId(`cell-vote-${legacyPointIds.frame0}`)).toBeInTheDocument();
+    // Text-derived point ids are forbidden voting targets; the rows still render.
+    expect(screen.getByText('Reuters: Urgency framing')).toBeInTheDocument();
+    expect(container.querySelector('[data-testid^="cell-vote-"]')).not.toBeInTheDocument();
+    expect(screen.queryByTestId(`cell-vote-${legacyPointIds.frame0}`)).not.toBeInTheDocument();
     expect(screen.queryByTestId(`cell-vote-${synthesisPointIds.frame0}`)).not.toBeInTheDocument();
   });
 
@@ -295,25 +278,27 @@ describe('BiasTable', () => {
     expect(screen.queryByTestId(`cell-vote-${legacyPointIds.frame0}`)).not.toBeInTheDocument();
   });
 
-  it('derives canonical vote ids from the explicit synthesis context when it exists', async () => {
-    const legacyPointIds = await deriveExpectedPointIds();
-    const stableSynthesisPointIds = await deriveExpectedSynthesisPointIds(SYNTHESIS_ID);
-    render(
+  it('accepted synthesis mode without an explicit synthesis context never renders vote controls', () => {
+    const { container } = render(
       <BiasTable
         analyses={[makeAnalysis()]}
-        frames={FRAMES}
+        frames={[
+          {
+            frame_point_id: 'persisted-frame-0',
+            frame: FRAMES[0]!.frame,
+            reframe_point_id: 'persisted-reframe-0',
+            reframe: FRAMES[0]!.reframe,
+          },
+        ]}
         topicId={TOPIC_ID}
         analysisId={ANALYSIS_ID}
-        synthesisId={SYNTHESIS_ID}
-        epoch={EPOCH}
         votingEnabled
+        votingPointIdMode="accepted-synthesis"
       />,
     );
 
-    expect(await screen.findByTestId(`cell-vote-agree-${legacyPointIds.frame0}`)).toHaveAttribute(
-      'data-canonical-point-id',
-      stableSynthesisPointIds.frame0,
-    );
+    // The analysisId fallback context must not become a voting context.
+    expect(container.querySelector('[data-testid^="cell-vote-"]')).not.toBeInTheDocument();
   });
 
   it('votingEnabled=false renders no vote controls', () => {
@@ -345,10 +330,9 @@ describe('BiasTable', () => {
     expect(container.querySelector('[data-testid^="cell-vote-"]')).not.toBeInTheDocument();
   });
 
-  it('renders vote controls when votingEnabled can fall back to analysis context', async () => {
+  it('does not render vote controls from the legacy analysis-fallback context', async () => {
     const legacyPointIds = await deriveExpectedPointIds();
-    const fallbackSynthesisPointIds = await deriveExpectedSynthesisPointIds(ANALYSIS_ID, 0);
-    render(
+    const { container } = render(
       <BiasTable
         analyses={[makeAnalysis()]}
         frames={FRAMES}
@@ -358,11 +342,9 @@ describe('BiasTable', () => {
       />,
     );
 
-    expect(await screen.findByTestId(`cell-vote-agree-${legacyPointIds.frame0}`)).toHaveAttribute(
-      'data-canonical-point-id',
-      fallbackSynthesisPointIds.frame0,
-    );
-    expect(await screen.findByTestId(`cell-vote-agree-${legacyPointIds.reframe0}`)).toBeInTheDocument();
+    expect(container.querySelector('[data-testid^="cell-vote-"]')).not.toBeInTheDocument();
+    expect(screen.queryByTestId(`cell-vote-agree-${legacyPointIds.frame0}`)).not.toBeInTheDocument();
+    expect(screen.queryByTestId(`cell-vote-agree-${legacyPointIds.reframe0}`)).not.toBeInTheDocument();
   });
 
   it('no vote controls when votingEnabled but missing both synthesis and analysis context', () => {
@@ -377,57 +359,71 @@ describe('BiasTable', () => {
     expect(container.querySelector('[data-testid^="cell-vote-"]')).not.toBeInTheDocument();
   });
 
-  it('point IDs stay stable across rerender even when synthesis context changes', async () => {
-    const legacyPointIds = await deriveExpectedPointIds();
+  it('persisted point IDs stay stable across rerender when the synthesis context changes', async () => {
+    const persistedFrames = [
+      {
+        frame_point_id: 'persisted-frame-0',
+        frame: FRAMES[0]!.frame,
+        reframe_point_id: 'persisted-reframe-0',
+        reframe: FRAMES[0]!.reframe,
+      },
+    ];
     const { rerender } = render(
       <BiasTable
         analyses={[makeAnalysis()]}
-        frames={FRAMES}
+        frames={persistedFrames}
         topicId={TOPIC_ID}
         analysisId={ANALYSIS_ID}
         synthesisId={SYNTHESIS_ID}
         epoch={EPOCH}
         votingEnabled
+        votingPointIdMode="accepted-synthesis"
       />,
     );
 
-    expect(await screen.findByTestId(`cell-vote-agree-${legacyPointIds.frame0}`)).toBeInTheDocument();
-    expect(await screen.findByTestId(`cell-vote-agree-${legacyPointIds.frame1}`)).toBeInTheDocument();
-    expect(await screen.findByTestId(`cell-vote-agree-${legacyPointIds.reframe0}`)).toBeInTheDocument();
-    expect(await screen.findByTestId(`cell-vote-agree-${legacyPointIds.reframe1}`)).toBeInTheDocument();
+    expect(await screen.findByTestId('cell-vote-persisted-frame-0')).toBeInTheDocument();
+    expect(await screen.findByTestId('cell-vote-persisted-reframe-0')).toBeInTheDocument();
 
     rerender(
       <BiasTable
         analyses={[makeAnalysis()]}
-        frames={FRAMES}
+        frames={persistedFrames}
         topicId={TOPIC_ID}
         analysisId={ANALYSIS_ID}
         synthesisId="synth-2"
         epoch={EPOCH + 1}
         votingEnabled
+        votingPointIdMode="accepted-synthesis"
       />,
     );
 
-    expect(await screen.findByTestId(`cell-vote-agree-${legacyPointIds.frame0}`)).toBeInTheDocument();
-    expect(await screen.findByTestId(`cell-vote-agree-${legacyPointIds.reframe0}`)).toBeInTheDocument();
+    expect(await screen.findByTestId('cell-vote-persisted-frame-0')).toBeInTheDocument();
+    expect(await screen.findByTestId('cell-vote-persisted-reframe-0')).toBeInTheDocument();
   });
 
   it('frame and reframe voting controls are independent', async () => {
-    const pointIds = await deriveExpectedPointIds();
     render(
       <BiasTable
         analyses={[makeAnalysis()]}
-        frames={FRAMES}
+        frames={[
+          {
+            frame_point_id: 'persisted-frame-0',
+            frame: FRAMES[0]!.frame,
+            reframe_point_id: 'persisted-reframe-0',
+            reframe: FRAMES[0]!.reframe,
+          },
+        ]}
         topicId={TOPIC_ID}
         analysisId={ANALYSIS_ID}
         synthesisId={SYNTHESIS_ID}
         epoch={EPOCH}
         votingEnabled
+        votingPointIdMode="accepted-synthesis"
       />,
     );
 
-    const frameVote = await screen.findByTestId(`cell-vote-${pointIds.frame0}`);
-    const reframeVote = await screen.findByTestId(`cell-vote-${pointIds.reframe0}`);
+    const frameVote = await screen.findByTestId('cell-vote-persisted-frame-0');
+    const reframeVote = await screen.findByTestId('cell-vote-persisted-reframe-0');
     expect(frameVote).not.toBe(reframeVote);
     expect(frameVote.closest('td')).not.toBe(reframeVote.closest('td'));
   });

--- a/apps/web-pwa/src/components/feed/BiasTable.tsx
+++ b/apps/web-pwa/src/components/feed/BiasTable.tsx
@@ -91,7 +91,15 @@ function ExpandableRow({
     (analysis?.biasClaimQuotes?.length ?? 0) > 0 ||
     (analysis?.justifyBiasClaims?.length ?? 0) > 0;
 
-  const showVoting = !!(votingEnabled && topicId && synthesisId && epoch !== undefined);
+  // Vote controls are restricted to accepted-synthesis point-id mode;
+  // text-derived legacy/analysis-fallback ids must never be votable.
+  const showVoting = !!(
+    votingEnabled
+    && votingPointIdMode === 'accepted-synthesis'
+    && topicId
+    && synthesisId
+    && epoch !== undefined
+  );
   const voteFramePointId = votingPointIdMode === 'accepted-synthesis'
     ? synthesisFramePointId
     : framePointId ?? synthesisFramePointId;
@@ -213,8 +221,14 @@ export const BiasTable: React.FC<BiasTableProps> = ({
     : analysisId;
   const effectiveSynthesisId = stableVotingContextId;
   const effectiveEpoch = epoch ?? 0;
+  // Vote controls require accepted-synthesis point-id mode and an explicit
+  // synthesis context; legacy-compatible and analysisId-fallback contexts
+  // derive point ids from mutable display text and must never be votable.
+  const votingAllowed = votingEnabled
+    && votingPointIdMode === 'accepted-synthesis'
+    && hasExplicitSynthesisContext;
   const hasVotingContext = Boolean(
-    votingEnabled &&
+    votingAllowed &&
       topicId &&
       effectiveSynthesisId &&
       Number.isFinite(effectiveEpoch),

--- a/apps/web-pwa/src/components/feed/DivergenceBadge.tsx
+++ b/apps/web-pwa/src/components/feed/DivergenceBadge.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+export const HIGH_DIVERGENCE_THRESHOLD = 0.5;
+
+interface DivergenceBadgeProps {
+  score: number | null | undefined;
+  label?: string;
+}
+
+export const DivergenceBadge: React.FC<DivergenceBadgeProps> = ({ score, label = 'High divergence' }) => {
+  if (typeof score !== 'number' || score <= HIGH_DIVERGENCE_THRESHOLD) {
+    return null;
+  }
+  return (
+    <span
+      className="inline-block rounded-full bg-amber-100 px-2 py-0.5 text-xs text-amber-700"
+      data-testid="synthesis-divergence"
+      title={`Disagreement: ${(score * 100).toFixed(0)}%`}
+    >
+      {label}
+    </span>
+  );
+};
+
+export default DivergenceBadge;

--- a/apps/web-pwa/src/components/feed/NewsCard.test.tsx
+++ b/apps/web-pwa/src/components/feed/NewsCard.test.tsx
@@ -557,6 +557,7 @@ describe('NewsCard', () => {
           } as Partial<TopicSynthesisV2>) as TopicSynthesisV2,
           correction: null,
           effectiveStatus: 'accepted_available',
+          invalid: false,
           hydrated: true,
           loading: false,
           error: null,
@@ -922,6 +923,211 @@ describe('NewsCard', () => {
     expect(readNewsSynthesisLifecycleStatusMock).toHaveBeenCalledWith(expect.anything(), 'story-news-1');
     refreshSpy.mockRestore();
     startHydrationSpy.mockRestore();
+  });
+
+  it.each([
+    ['synthesis_id', { synthesis_id: 'syn-other' }],
+    ['epoch', { epoch: 3 }],
+    ['source_set_revision', { source_set_revision: 'prov-other' }],
+  ] as const)(
+    'keeps the story non-votable when an accepted_available lifecycle %s mismatches the hydrated latest',
+    async (_field, lifecycleOverrides) => {
+      readNewsSynthesisLifecycleStatusMock.mockResolvedValue(makeAcceptedLifecycle(lifecycleOverrides));
+      useNewsStore.getState().setStories([makeStoryBundle()]);
+      useSynthesisStore.getState().setTopicSynthesis('news-1', makeSynthesis());
+
+      render(<NewsCard item={makeNewsItem()} />);
+      fireEvent.click(screen.getByTestId('news-card-headline-news-1'));
+
+      await waitFor(() => {
+        expect(readNewsSynthesisLifecycleStatusMock).toHaveBeenCalled();
+      });
+      await waitFor(() => {
+        expect(screen.getByTestId('news-card-summary-basis-news-1')).toHaveTextContent(
+          'Feed summary hint; synthesis pending',
+        );
+      });
+      expect(screen.queryByTestId('news-card-synthesis-provenance-news-1')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('news-card-stance-scope-news-1')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('bias-table')).not.toBeInTheDocument();
+      expect(screen.getByTestId('bias-table-empty')).toHaveTextContent(
+        'Accepted synthesis frame rows are pending for this story.',
+      );
+      expect(screen.queryByRole('button', { name: /Agree with /i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /Disagree with /i })).not.toBeInTheDocument();
+    },
+  );
+
+  it('does not treat a lifecycle record with missing epoch as accepted-current votable', async () => {
+    readNewsSynthesisLifecycleStatusMock.mockResolvedValue(
+      makeAcceptedLifecycle({ epoch: undefined as unknown as number }),
+    );
+    useNewsStore.getState().setStories([makeStoryBundle()]);
+    useSynthesisStore.getState().setTopicSynthesis('news-1', makeSynthesis());
+
+    render(<NewsCard item={makeNewsItem()} />);
+    fireEvent.click(screen.getByTestId('news-card-headline-news-1'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('news-card-summary-basis-news-1')).toHaveTextContent(
+        'Feed summary hint; synthesis pending',
+      );
+    });
+    expect(screen.queryByTestId('bias-table')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Agree with /i })).not.toBeInTheDocument();
+  });
+
+  it('recovers accepted-current synthesis from the epoch node when topics/latest lags', async () => {
+    const acceptedEpochRecord = makeSynthesis();
+    const staleLatest = makeSynthesis({ synthesis_id: 'syn-stale', epoch: 1 });
+    const client = makeReadableMockClient();
+    // Only vh/topics/<topicId>/epochs/<epoch>/synthesis terminates in a
+    // 'synthesis' key on this surface; route it to the epoch record.
+    const epochChain = {
+      ...client.mesh,
+      once: vi.fn((callback: (value: unknown) => void) => {
+        callback({ _: { '#': 'meta' }, ...acceptedEpochRecord });
+        return epochChain;
+      }),
+    };
+    const meshGet = client.mesh.get as unknown as {
+      mockImplementation: (impl: (key: string) => unknown) => void;
+    };
+    meshGet.mockImplementation((key) => (key === 'synthesis' ? epochChain : client.mesh));
+    setClientResolver(() => ({ ...client, config: {} }) as never);
+
+    useNewsStore.getState().setStories([makeStoryBundle()]);
+    useSynthesisStore.getState().setTopicSynthesis('news-1', staleLatest);
+
+    render(<NewsCard item={makeNewsItem()} />);
+    fireEvent.click(screen.getByTestId('news-card-headline-news-1'));
+
+    expect(await screen.findByTestId('news-card-summary-news-1')).toHaveTextContent(
+      'Council approved a phased transit expansion plan.',
+    );
+    expect(screen.getByTestId('news-card-summary-basis-news-1')).toHaveTextContent('Topic synthesis v2');
+    expect(await screen.findByTestId('cell-vote-agree-syn-1:0:frame')).toBeInTheDocument();
+  });
+
+  it('surfaces an invalid system-writer latest record as a non-votable invalid state', async () => {
+    readNewsSynthesisLifecycleStatusMock.mockResolvedValue(makeAcceptedLifecycle({
+      status: 'pending',
+      frame_table_state: 'frame_table_pending',
+      synthesis_id: null as unknown as string,
+      epoch: null as unknown as number,
+    }));
+    const invalidRecord = {
+      _writerKind: 'system',
+      _protocolVersion: 'luma-public-v1',
+      _systemWriterId: 'vh-system-writer-dev-v1',
+      _systemIssuedAt: NOW,
+      _systemSignature: 'tampered-signature',
+      __topic_synthesis_json: JSON.stringify(makeSynthesis()),
+      topic_id: 'news-1',
+      synthesis_id: 'syn-1',
+      epoch: 2,
+    };
+    const client = makeReadableMockClient();
+    client.mesh.once.mockImplementation((callback: (value: unknown) => void) => {
+      callback(invalidRecord);
+      return client.mesh;
+    });
+    setClientResolver(() => ({ ...client, config: {} }) as never);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      useNewsStore.getState().setStories([makeStoryBundle()]);
+
+      render(<NewsCard item={makeNewsItem()} />);
+      fireEvent.click(screen.getByTestId('news-card-headline-news-1'));
+
+      expect(await screen.findByTestId('news-card-synthesis-invalid-news-1')).toHaveTextContent(
+        'Accepted synthesis failed validation and is not shown.',
+      );
+      await waitFor(() => {
+        expect(screen.getByTestId('news-card-summary-basis-news-1')).toHaveTextContent(
+          'Publish-time synthesis failed validation',
+        );
+      });
+      // The empty-state message replaces skeleton rows once the refresh read settles.
+      await waitFor(() => {
+        expect(screen.getByTestId('bias-table-empty')).toHaveTextContent(
+          'Accepted synthesis failed validation and is not shown; stance controls remain unavailable until a valid record is published.',
+        );
+      });
+      expect(screen.queryByTestId('news-card-synthesis-unavailable-news-1')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('bias-table')).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /Agree with /i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /Disagree with /i })).not.toBeInTheDocument();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('renders retryable lifecycle state as visible but non-votable', async () => {
+    const startHydrationSpy = vi.spyOn(useSynthesisStore.getState(), 'startHydration').mockImplementation(() => undefined);
+    const refreshSpy = vi.spyOn(useSynthesisStore.getState(), 'refreshTopic').mockResolvedValue(undefined);
+    setClientResolver(() => makeReadableMockClient() as never);
+    readNewsSynthesisLifecycleStatusMock.mockResolvedValue({
+      schemaVersion: 'news-synthesis-lifecycle-v1',
+      story_id: 'story-news-1',
+      topic_id: CANONICAL_TOPIC_ID,
+      source_set_revision: 'prov-1',
+      status: 'retryable_failure',
+      frame_table_state: 'frame_table_pending',
+      retryable: true,
+      reason: 'provider_timeout',
+      synthesis_id: null,
+      epoch: null,
+      updated_at: NOW,
+    });
+    useNewsStore.getState().setStories([makeStoryBundle()]);
+
+    render(<NewsCard item={makeNewsItem()} />);
+    fireEvent.click(screen.getByTestId('news-card-headline-news-1'));
+
+    expect(await screen.findByTestId('news-card-synthesis-retryable-news-1')).toHaveTextContent(
+      'provider_timeout',
+    );
+    expect(screen.getByTestId('news-card-summary-basis-news-1')).toHaveTextContent(
+      'Publish-time synthesis retryable',
+    );
+    expect(screen.getByTestId('bias-table-empty')).toHaveTextContent(
+      'Accepted synthesis is retrying after a transient failure; stance controls remain unavailable until frame rows are ready.',
+    );
+    expect(screen.queryByRole('button', { name: /Agree with /i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Disagree with /i })).not.toBeInTheDocument();
+    refreshSpy.mockRestore();
+    startHydrationSpy.mockRestore();
+  });
+
+  it('shows a high-divergence label on story detail when disagreement exceeds the threshold', async () => {
+    useNewsStore.getState().setStories([makeStoryBundle()]);
+    useSynthesisStore.getState().setTopicSynthesis('news-1', makeSynthesis({
+      divergence_metrics: {
+        disagreement_score: 0.7,
+        source_dispersion: 0.2,
+        candidate_count: 3,
+      },
+    }));
+
+    render(<NewsCard item={makeNewsItem()} />);
+    fireEvent.click(screen.getByTestId('news-card-headline-news-1'));
+
+    expect(await screen.findByTestId('synthesis-divergence')).toHaveTextContent('High divergence');
+  });
+
+  it('hides the divergence label when disagreement stays at or below the threshold', async () => {
+    useNewsStore.getState().setStories([makeStoryBundle()]);
+    useSynthesisStore.getState().setTopicSynthesis('news-1', makeSynthesis());
+
+    render(<NewsCard item={makeNewsItem()} />);
+    fireEvent.click(screen.getByTestId('news-card-headline-news-1'));
+
+    expect(await screen.findByTestId('news-card-summary-news-1')).toHaveTextContent(
+      'Council approved a phased transit expansion plan.',
+    );
+    expect(screen.queryByTestId('synthesis-divergence')).not.toBeInTheDocument();
   });
 
   it('renders story-detail stance controls from accepted synthesis point IDs', async () => {

--- a/apps/web-pwa/src/components/feed/NewsCard.tsx
+++ b/apps/web-pwa/src/components/feed/NewsCard.tsx
@@ -1,8 +1,9 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useStore } from 'zustand';
-import type { FeedItem, StorylineGroup } from '@vh/data-model';
+import type { FeedItem, StorylineGroup, TopicSynthesisV2 } from '@vh/data-model';
 import {
   readNewsSynthesisLifecycleStatusWithRelayRestFallback,
+  readTopicEpochSynthesis,
   type NewsSynthesisLifecycleRecord,
 } from '@vh/gun-client';
 import { useNewsStore } from '../../store/news';
@@ -66,17 +67,17 @@ function acceptedSynthesisMatchesStoryRevision({
   if (!story?.provenance_hash?.trim()) {
     return false;
   }
+  // Lifecycle synthesis_id AND epoch must both name the TopicSynthesisV2;
+  // a lifecycle record missing its epoch never yields an accepted-current
+  // votable state (docs/specs/topic-synthesis-v2.md join semantics).
   return Boolean(
     lifecycle
     && lifecycle.status === 'accepted_available'
     && lifecycle.story_id === story.story_id
     && lifecycle.source_set_revision === story.provenance_hash
     && lifecycle.synthesis_id === synthesis?.synthesis_id
-    && (
-      lifecycle.epoch === undefined
-      || lifecycle.epoch === null
-      || lifecycle.epoch === synthesis?.epoch
-    ),
+    && typeof lifecycle.epoch === 'number'
+    && lifecycle.epoch === synthesis?.epoch,
   );
 }
 
@@ -159,30 +160,66 @@ export const NewsCard: React.FC<NewsCardProps> = ({ item }) => {
   const synthesisCorrection = synthesisTopicState?.correction ?? null;
   const synthesisLoading = synthesisTopicState?.loading ?? false;
   const synthesisError = synthesisTopicState?.error ?? null;
+  const synthesisInvalid = synthesisTopicState?.invalid ?? false;
   const [synthesisLifecycle, setSynthesisLifecycle] = useState<NewsSynthesisLifecycleRecord | null>(null);
   const [synthesisLifecycleLoading, setSynthesisLifecycleLoading] = useState(false);
+  const [epochScopedSynthesis, setEpochScopedSynthesis] = useState<TopicSynthesisV2 | null>(null);
   const lifecycleStatus = synthesisLifecycle?.status ?? null;
   const lifecycleReason = synthesisLifecycle?.reason ?? null;
   const storyId = normalizeStoryId(item.story_id) ?? story?.story_id ?? null;
   const storySourceSetRevision = story?.provenance_hash ?? null;
-  const acceptedSynthesisCurrent = acceptedSynthesisMatchesStoryRevision({
+  const lifecycleSynthesisId =
+    typeof synthesisLifecycle?.synthesis_id === 'string' && synthesisLifecycle.synthesis_id.trim()
+      ? synthesisLifecycle.synthesis_id
+      : null;
+  const lifecycleEpoch =
+    typeof synthesisLifecycle?.epoch === 'number' && Number.isFinite(synthesisLifecycle.epoch)
+      ? synthesisLifecycle.epoch
+      : null;
+  const latestMatchesLifecycle = acceptedSynthesisMatchesStoryRevision({
     synthesis,
     story,
     storyId,
     lifecycle: synthesisLifecycle,
   });
-  const correctionAppliesToLatestSynthesis = Boolean(
+  // A lagging topics/latest pointer must not hide an accepted-current record:
+  // when the lifecycle names a synthesis_id+epoch the hydrated latest does not
+  // match, verify against the epoch node before treating the story as pending.
+  const shouldReadEpochScopedSynthesis = Boolean(
+    synthesisLifecycle
+    && synthesisLifecycle.status === 'accepted_available'
+    && lifecycleSynthesisId
+    && lifecycleEpoch !== null
+    && story?.provenance_hash?.trim()
+    && synthesisLifecycle.story_id === story?.story_id
+    && synthesisLifecycle.source_set_revision === story?.provenance_hash
+    && !latestMatchesLifecycle
+  );
+  const epochScopedMatchesLifecycle = acceptedSynthesisMatchesStoryRevision({
+    synthesis: epochScopedSynthesis,
+    story,
+    storyId,
+    lifecycle: synthesisLifecycle,
+  });
+  const acceptedCurrentSynthesis = latestMatchesLifecycle
+    ? synthesis
+    : epochScopedMatchesLifecycle
+      ? epochScopedSynthesis
+      : null;
+  const acceptedSynthesisCurrent = acceptedCurrentSynthesis !== null;
+  const displayedSynthesis = acceptedCurrentSynthesis ?? synthesis;
+  const correctionAppliesToDisplayedSynthesis = Boolean(
     synthesisCorrection
-    && synthesis !== null
-    && synthesisCorrection.synthesis_id === synthesis.synthesis_id
-    && synthesisCorrection.epoch === synthesis.epoch
-    && synthesisCorrection.topic_id === synthesis.topic_id
+    && displayedSynthesis !== null
+    && synthesisCorrection.synthesis_id === displayedSynthesis.synthesis_id
+    && synthesisCorrection.epoch === displayedSynthesis.epoch
+    && synthesisCorrection.topic_id === displayedSynthesis.topic_id
   );
   const correctionBlocksSynthesis = Boolean(
-    correctionAppliesToLatestSynthesis
+    correctionAppliesToDisplayedSynthesis
     && (acceptedSynthesisCurrent || lifecycleStatus === 'suppressed')
   );
-  const effectiveSynthesis = correctionBlocksSynthesis || !acceptedSynthesisCurrent ? null : synthesis;
+  const effectiveSynthesis = correctionBlocksSynthesis || !acceptedSynthesisCurrent ? null : acceptedCurrentSynthesis;
   const latestActivity = formatIsoTimestamp(item.latest_activity_at);
   const createdAt = formatIsoTimestamp(item.created_at);
   const synthesisId = effectiveSynthesis?.synthesis_id ?? null;
@@ -216,6 +253,7 @@ export const NewsCard: React.FC<NewsCardProps> = ({ item }) => {
   const summaryBasisLabel = (() => {
     if (correctionBlocksSynthesis) return 'Operator correction';
     if (hasSynthesisSummary) return 'Topic synthesis v2';
+    if (synthesisInvalid) return 'Publish-time synthesis failed validation';
     if (synthesisLoading || synthesisLifecycleLoading || lifecycleStatus === 'in_progress') {
       return 'Publish-time synthesis loading';
     }
@@ -236,6 +274,7 @@ export const NewsCard: React.FC<NewsCardProps> = ({ item }) => {
     && !synthesisLifecycleLoading
     && !effectiveSynthesis
     && !synthesisError
+    && !synthesisInvalid
     && !correctionBlocksSynthesis
     && lifecycleStatus !== 'terminal_unavailable'
     && lifecycleStatus !== 'retryable_failure';
@@ -307,6 +346,42 @@ export const NewsCard: React.FC<NewsCardProps> = ({ item }) => {
   }, [isExpanded, storyId, storySourceSetRevision]);
 
   useEffect(() => {
+    if (!isExpanded || !shouldReadEpochScopedSynthesis || lifecycleEpoch === null || !lifecycleSynthesisId) {
+      return;
+    }
+
+    const client = resolveClientFromAppStore();
+    if (!client) {
+      return;
+    }
+
+    let cancelled = false;
+    // readTopicEpochSynthesis applies the same fail-closed system-writer
+    // validation as the latest read; a record that does not name the
+    // lifecycle synthesis_id+epoch is discarded so the story stays non-votable.
+    void readTopicEpochSynthesis(client, item.topic_id, lifecycleEpoch)
+      .then((record) => {
+        if (cancelled) {
+          return;
+        }
+        setEpochScopedSynthesis(
+          record && record.synthesis_id === lifecycleSynthesisId && record.epoch === lifecycleEpoch
+            ? record
+            : null,
+        );
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setEpochScopedSynthesis(null);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isExpanded, item.topic_id, lifecycleEpoch, lifecycleSynthesisId, shouldReadEpochScopedSynthesis]);
+
+  useEffect(() => {
     if (!isExpanded || effectiveSynthesis || synthesisCorrection || synthesisLoading || synthesisError) {
       return;
     }
@@ -364,6 +439,7 @@ export const NewsCard: React.FC<NewsCardProps> = ({ item }) => {
   useEffect(() => {
     setSynthesisLifecycle(null);
     setSynthesisLifecycleLoading(false);
+    setEpochScopedSynthesis(null);
   }, [storyId, storySourceSetRevision]);
 
   useEffect(() => {
@@ -481,11 +557,13 @@ export const NewsCard: React.FC<NewsCardProps> = ({ item }) => {
               analysisNeedsRegeneration={false}
               synthesisLoading={synthesisLoading}
               synthesisError={synthesisError}
+              synthesisInvalid={synthesisInvalid}
               synthesisUnavailable={synthesisUnavailable}
               synthesisReadinessTimedOut={synthesisReadinessTimedOut}
               synthesisLifecycleStatus={lifecycleStatus}
               synthesisLifecycleReason={lifecycleReason}
               synthesisCorrection={correctionBlocksSynthesis ? synthesisCorrection : null}
+              synthesisDisagreementScore={effectiveSynthesis?.divergence_metrics.disagreement_score ?? null}
               analysis={null}
               analysisId={null}
               synthesisId={synthesisId}

--- a/apps/web-pwa/src/components/feed/NewsCardBack.tsx
+++ b/apps/web-pwa/src/components/feed/NewsCardBack.tsx
@@ -6,9 +6,11 @@ import { useNewsReportStore } from '../../store/newsReports';
 import type { NewsCardAnalysisSynthesis } from './newsCardAnalysis';
 import { AnalysisLoadingState } from './AnalysisLoadingState';
 import { BiasTable, type BiasTableFrameRow } from './BiasTable';
+import { DivergenceBadge } from './DivergenceBadge';
 import { FeedDiscussionSection } from './FeedDiscussionSection';
 import { RemovalIndicator } from './RemovalIndicator';
 import { SourceViewerFrame } from './SourceViewerFrame';
+import { deriveAcceptedSynthesisReadState } from './useAcceptedSynthesis';
 
 export interface NewsCardMediaAsset {
   readonly sourceId: string;
@@ -65,11 +67,13 @@ export interface NewsCardBackProps {
   readonly analysisNeedsRegeneration?: boolean;
   readonly synthesisLoading: boolean;
   readonly synthesisError: string | null;
+  readonly synthesisInvalid?: boolean;
   readonly synthesisUnavailable?: boolean;
   readonly synthesisReadinessTimedOut?: boolean;
   readonly synthesisLifecycleStatus?: NewsSynthesisLifecycleStatus | null;
   readonly synthesisLifecycleReason?: string | null;
   readonly synthesisCorrection?: TopicSynthesisCorrection | null;
+  readonly synthesisDisagreementScore?: number | null;
   readonly analysis: NewsCardAnalysisSynthesis | null;
   readonly analysisId?: string | null;
   readonly synthesisId?: string | null;
@@ -117,11 +121,13 @@ export const NewsCardBack: React.FC<NewsCardBackProps> = ({
   analysisNeedsRegeneration = false,
   synthesisLoading,
   synthesisError,
+  synthesisInvalid = false,
   synthesisUnavailable = false,
   synthesisReadinessTimedOut = false,
   synthesisLifecycleStatus = null,
   synthesisLifecycleReason = null,
   synthesisCorrection = null,
+  synthesisDisagreementScore = null,
   analysis,
   analysisId,
   synthesisId,
@@ -142,26 +148,25 @@ export const NewsCardBack: React.FC<NewsCardBackProps> = ({
   const correctionStateLabel = synthesisCorrection?.status === 'suppressed'
     ? 'Accepted synthesis suppressed'
     : 'Accepted synthesis unavailable';
-  const acceptedSynthesisState = (() => {
-    if (synthesisCorrection) {
-      return synthesisCorrection.status === 'suppressed'
-        ? 'accepted_synthesis_suppressed_by_correction'
-        : 'accepted_synthesis_terminal_unavailable';
-    }
-    if (synthesisId) return 'accepted_synthesis_available';
-    if (synthesisLifecycleStatus === 'terminal_unavailable') return 'accepted_synthesis_terminal_unavailable';
-    if (synthesisLifecycleStatus === 'retryable_failure') return 'accepted_synthesis_retryable_failure';
-    if (synthesisLoading) return 'accepted_synthesis_loading';
-    return 'accepted_synthesis_pending';
-  })();
-  const frameEmptyMessage = acceptedSynthesisState === 'accepted_synthesis_loading'
+  const acceptedSynthesisState = deriveAcceptedSynthesisReadState({
+    loading: synthesisLoading,
+    invalid: synthesisInvalid,
+    hasAcceptedCurrentSynthesis: Boolean(synthesisId),
+    lifecycleStatus: synthesisLifecycleStatus,
+    correction: synthesisCorrection,
+  });
+  const frameEmptyMessage = acceptedSynthesisState === 'loading'
     ? 'Accepted synthesis frame rows are loading.'
-    : acceptedSynthesisState === 'accepted_synthesis_retryable_failure'
+    : acceptedSynthesisState === 'retryable_failure'
       ? 'Accepted synthesis is retrying after a transient failure; stance controls remain unavailable until frame rows are ready.'
-    : acceptedSynthesisState === 'accepted_synthesis_terminal_unavailable'
+    : acceptedSynthesisState === 'terminal_unavailable'
       ? 'Accepted synthesis is unavailable for this story.'
-      : acceptedSynthesisState === 'accepted_synthesis_suppressed_by_correction'
+      : acceptedSynthesisState === 'suppressed_by_correction'
         ? 'Accepted synthesis was suppressed; frame rows are hidden.'
+        : acceptedSynthesisState === 'invalid'
+          ? 'Accepted synthesis failed validation and is not shown; stance controls remain unavailable until a valid record is published.'
+        : acceptedSynthesisState === 'acceptedCurrentSynthesis'
+          ? 'Accepted synthesis has no votable frame rows for this story.'
         : synthesisReadinessTimedOut
           ? 'Accepted synthesis did not become available within the readiness window; stance controls remain unavailable until synthesis or a terminal reason is published.'
           : 'Accepted synthesis frame rows are pending for this story.';
@@ -258,6 +263,7 @@ export const NewsCardBack: React.FC<NewsCardBackProps> = ({
               ))}
             </div>
           )}
+          <DivergenceBadge score={synthesisDisagreementScore} />
           {synthesisCorrection && (
             <div
               className="space-y-1 rounded-lg border border-rose-200/80 bg-rose-50/80 px-3 py-2 text-xs leading-5 text-rose-800 dark:border-rose-900/70 dark:bg-rose-950/30 dark:text-rose-100"
@@ -491,6 +497,14 @@ export const NewsCardBack: React.FC<NewsCardBackProps> = ({
             data-testid={`news-card-synthesis-retryable-${topicId}`}
           >
             Accepted synthesis is retrying after a transient failure{synthesisLifecycleReason ? `: ${synthesisLifecycleReason}` : '.'}
+          </p>
+        )}
+        {acceptedSynthesisState === 'invalid' && !analysis && (
+          <p
+            className="mt-2 text-xs text-rose-700 dark:text-rose-100"
+            data-testid={`news-card-synthesis-invalid-${topicId}`}
+          >
+            Accepted synthesis failed validation and is not shown. Stance controls remain unavailable until a valid record is published.
           </p>
         )}
         {synthesisUnavailable && !analysis && !correctionBlocksSynthesis && (

--- a/apps/web-pwa/src/components/feed/SynthesisSummary.tsx
+++ b/apps/web-pwa/src/components/feed/SynthesisSummary.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import type { TopicSynthesisV2 } from '@vh/data-model';
+import { DivergenceBadge } from './DivergenceBadge';
 
 export interface SynthesisSummaryProps {
   /** Validated TopicSynthesisV2 payload. */
@@ -72,15 +73,7 @@ export const SynthesisSummary: React.FC<SynthesisSummaryProps> = ({ synthesis })
       )}
 
       {/* Divergence indicator */}
-      {synthesis.divergence_metrics.disagreement_score > 0.5 && (
-        <span
-          className="inline-block rounded-full bg-amber-100 px-2 py-0.5 text-xs text-amber-700"
-          data-testid="synthesis-divergence"
-          title={`Disagreement: ${(synthesis.divergence_metrics.disagreement_score * 100).toFixed(0)}%`}
-        >
-          ⚡ High divergence
-        </span>
-      )}
+      <DivergenceBadge score={synthesis.divergence_metrics.disagreement_score} label="⚡ High divergence" />
     </div>
   );
 };

--- a/apps/web-pwa/src/components/feed/TopicCard.test.tsx
+++ b/apps/web-pwa/src/components/feed/TopicCard.test.tsx
@@ -217,6 +217,21 @@ describe('TopicCard', () => {
     expect(screen.getByTestId('bias-table-row-1')).toHaveTextContent('Fiscal impact');
   });
 
+  it('keeps the topic frame table non-votable and explains why', () => {
+    const synthesis = makeSynthesis();
+    mockUseSynthesis.mockReturnValue(makeSynthesisResult({ synthesis, epoch: 3 }));
+    const { container } = render(<TopicCard item={makeTopicItem()} />);
+    expandTopicCard();
+
+    // Topic cards never join the story lifecycle/accepted-current record,
+    // so no vote controls may render even with persisted point ids present.
+    expect(screen.getByTestId('bias-table-row-0')).toBeInTheDocument();
+    expect(container.querySelector('[data-testid^="cell-vote-"]')).not.toBeInTheDocument();
+    expect(screen.getByTestId('topic-card-stance-unavailable-topic-42')).toHaveTextContent(
+      'not joined to an accepted-current story synthesis',
+    );
+  });
+
   it('shows divergence indicator when disagreement_score > 0.5', () => {
     const synthesis = makeSynthesis({
       divergence_metrics: { disagreement_score: 0.7, source_dispersion: 0.4, candidate_count: 5 },

--- a/apps/web-pwa/src/components/feed/TopicCard.tsx
+++ b/apps/web-pwa/src/components/feed/TopicCard.tsx
@@ -253,6 +253,15 @@ export const TopicCard: React.FC<TopicCardProps> = ({ item }) => {
             <h4 className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
               Frame / Reframe
             </h4>
+            {synthesis && (
+              <p
+                className="text-xs leading-5 text-slate-500 dark:text-slate-400"
+                data-testid={`topic-card-stance-unavailable-${item.topic_id}`}
+              >
+                Stance controls are unavailable here; this table is not joined to an
+                accepted-current story synthesis.
+              </p>
+            )}
             <BiasTable
               analyses={[]}
               frames={synthesis?.frames ?? []}
@@ -260,7 +269,7 @@ export const TopicCard: React.FC<TopicCardProps> = ({ item }) => {
               topicId={item.topic_id}
               synthesisId={synthesis?.synthesis_id}
               epoch={synthesis?.epoch}
-              votingEnabled={Boolean(synthesis)}
+              votingEnabled={false}
             />
           </section>
 

--- a/apps/web-pwa/src/components/feed/TopicSynthesisSections.tsx
+++ b/apps/web-pwa/src/components/feed/TopicSynthesisSections.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import type { TopicSynthesisV2 } from '@vh/data-model';
+import { DivergenceBadge } from './DivergenceBadge';
 
 export interface TopicSynthesisSectionProps {
   readonly synthesis: TopicSynthesisV2 | null;
@@ -75,14 +76,7 @@ export const SynthesisSection: React.FC<TopicSynthesisSectionProps> = ({
             ))}
           </div>
         )}
-        {synthesis.divergence_metrics.disagreement_score > 0.5 && (
-          <span
-            className="inline-block rounded-full bg-amber-100 px-2 py-0.5 text-xs text-amber-700"
-            data-testid="synthesis-divergence"
-          >
-            High divergence
-          </span>
-        )}
+        <DivergenceBadge score={synthesis.divergence_metrics.disagreement_score} />
       </div>
     );
   }

--- a/apps/web-pwa/src/components/feed/useAcceptedSynthesis.ts
+++ b/apps/web-pwa/src/components/feed/useAcceptedSynthesis.ts
@@ -1,0 +1,64 @@
+import type { NewsSynthesisLifecycleStatus } from '@vh/gun-client';
+import type { TopicSynthesisCorrection } from '@vh/data-model';
+
+/**
+ * Story-detail read model for the accepted Summary And Framing Table.
+ *
+ * Exactly one state is effective at a time; only `acceptedCurrentSynthesis`
+ * may ever render vote controls. All other states are fail-closed
+ * (visible, honest, non-votable).
+ *
+ * Spec: docs/specs/topic-synthesis-v2.md (accepted-current join semantics);
+ * plan: docs/plans/FUNCTIONING_MVP_LANE_SLICE_PLAN_2026-07-06.md Slice A1.
+ */
+export type AcceptedSynthesisReadState =
+  | 'loading'
+  | 'acceptedCurrentSynthesis'
+  | 'pending'
+  | 'retryable_failure'
+  | 'terminal_unavailable'
+  | 'suppressed_by_correction'
+  | 'invalid';
+
+export interface AcceptedSynthesisReadInput {
+  /** Synthesis or lifecycle reads are still in flight. */
+  readonly loading: boolean;
+  /** Latest topic record failed fail-closed system-writer validation. */
+  readonly invalid: boolean;
+  /**
+   * The full accepted-current join succeeded: lifecycle `accepted_available`
+   * with matching source_set_revision, synthesis_id, and epoch against a
+   * validated TopicSynthesisV2 whose inputs include the story.
+   */
+  readonly hasAcceptedCurrentSynthesis: boolean;
+  /** Story lifecycle status from `vh/news/stories/<storyId>/synthesis_lifecycle/latest`. */
+  readonly lifecycleStatus: NewsSynthesisLifecycleStatus | null;
+  /** Operator correction that blocks the displayed synthesis, if any. */
+  readonly correction: TopicSynthesisCorrection | null;
+}
+
+export function deriveAcceptedSynthesisReadState(
+  input: AcceptedSynthesisReadInput,
+): AcceptedSynthesisReadState {
+  if (input.correction) {
+    return input.correction.status === 'suppressed'
+      ? 'suppressed_by_correction'
+      : 'terminal_unavailable';
+  }
+  if (input.hasAcceptedCurrentSynthesis) {
+    return 'acceptedCurrentSynthesis';
+  }
+  if (input.invalid) {
+    return 'invalid';
+  }
+  if (input.lifecycleStatus === 'terminal_unavailable') {
+    return 'terminal_unavailable';
+  }
+  if (input.lifecycleStatus === 'retryable_failure') {
+    return 'retryable_failure';
+  }
+  if (input.loading) {
+    return 'loading';
+  }
+  return 'pending';
+}

--- a/apps/web-pwa/src/hooks/useSynthesis.ts
+++ b/apps/web-pwa/src/hooks/useSynthesis.ts
@@ -22,6 +22,9 @@ export interface UseSynthesisResult {
   /** Effective detail status after applying correction state. */
   readonly effectiveStatus: SynthesisTopicState['effectiveStatus'];
 
+  /** Whether the latest record failed system-writer validation (fail-closed). */
+  readonly invalid: boolean;
+
   /** Whether live hydration has been attached for the topic. */
   readonly hydrated: boolean;
 
@@ -41,6 +44,7 @@ const EMPTY_TOPIC_STATE: SynthesisTopicState = {
   synthesis: null,
   correction: null,
   effectiveStatus: 'synthesis_unavailable',
+  invalid: false,
   hydrated: false,
   loading: false,
   error: null
@@ -88,6 +92,7 @@ export function useSynthesis(topicId?: string | null): UseSynthesisResult {
     synthesis: topicState.synthesis,
     correction: topicState.correction,
     effectiveStatus: topicState.effectiveStatus,
+    invalid: topicState.invalid,
     hydrated: topicState.hydrated,
     loading: topicState.loading,
     error: topicState.error,

--- a/apps/web-pwa/src/store/synthesis/hydration.test.ts
+++ b/apps/web-pwa/src/store/synthesis/hydration.test.ts
@@ -5,18 +5,28 @@ import type { SynthesisState } from './types';
 const gunMocks = vi.hoisted(() => ({
   getTopicLatestSynthesisChain: vi.fn(),
   getTopicLatestSynthesisCorrectionChain: vi.fn(),
-  hasForbiddenSynthesisPayloadFields: vi.fn<(payload: unknown) => boolean>()
+  hasForbiddenSynthesisPayloadFields: vi.fn<(payload: unknown) => boolean>(),
+  // Defaults to the real parser (via the mock factory); a test may override
+  // it to exercise the defensive rejection path in ingestSynthesis.
+  parseTopicLatestSynthesisRecord: null as
+    | null
+    | ((...args: unknown[]) => Promise<unknown>)
 }));
 
-// The real parseTopicLatestSynthesisRecord stays in place so hydration
-// ingestion exercises the actual fail-closed system-writer validation.
+// The real parseTopicLatestSynthesisRecord stays in place by default so
+// hydration ingestion exercises the actual fail-closed system-writer
+// validation; a test can override gunMocks.parseTopicLatestSynthesisRecord.
 vi.mock('@vh/gun-client', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@vh/gun-client')>();
   return {
     ...actual,
     getTopicLatestSynthesisChain: gunMocks.getTopicLatestSynthesisChain,
     getTopicLatestSynthesisCorrectionChain: gunMocks.getTopicLatestSynthesisCorrectionChain,
-    hasForbiddenSynthesisPayloadFields: gunMocks.hasForbiddenSynthesisPayloadFields
+    hasForbiddenSynthesisPayloadFields: gunMocks.hasForbiddenSynthesisPayloadFields,
+    parseTopicLatestSynthesisRecord: (...args: unknown[]) =>
+      (gunMocks.parseTopicLatestSynthesisRecord ?? actual.parseTopicLatestSynthesisRecord)(
+        ...(args as Parameters<typeof actual.parseTopicLatestSynthesisRecord>)
+      )
   };
 });
 
@@ -174,6 +184,7 @@ describe('hydrateSynthesisStore', () => {
     gunMocks.hasForbiddenSynthesisPayloadFields.mockReset();
     gunMocks.getTopicLatestSynthesisCorrectionChain.mockReturnValue({ on: undefined });
     gunMocks.hasForbiddenSynthesisPayloadFields.mockReturnValue(false);
+    gunMocks.parseTopicLatestSynthesisRecord = null;
     vi.resetModules();
   });
 
@@ -515,6 +526,43 @@ describe('hydrateSynthesisStore', () => {
     );
     expect(state.setTopicHydrated).toHaveBeenCalledWith('topic-1', true);
     expect(state.setTopicError).toHaveBeenCalledWith('topic-1', null);
+  });
+
+  it('leaves state unchanged when synthesis validation rejects unexpectedly', async () => {
+    const synthesisChain = createSubscribableChain();
+    gunMocks.getTopicLatestSynthesisChain.mockReturnValue(synthesisChain.chain);
+    gunMocks.getTopicLatestSynthesisCorrectionChain.mockReturnValue({ on: undefined });
+    gunMocks.parseTopicLatestSynthesisRecord = () => Promise.reject(new Error('boom'));
+
+    const { hydrateSynthesisStore } = await import('./hydration');
+    const { store, state } = createStore();
+
+    hydrateSynthesisStore(() => ({}) as never, store, 'topic-1');
+    synthesisChain.emit({ _: { '#': 'meta' }, ...synthesis() });
+    await flushIngest();
+
+    expect(state.setTopicInvalid).not.toHaveBeenCalled();
+    expect(state.setTopicSynthesis).not.toHaveBeenCalled();
+    expect(state.setTopicHydrated).not.toHaveBeenCalled();
+  });
+
+  it('ignores correction envelopes whose scalar payload is non-string or unparseable', async () => {
+    const correctionChain = createSubscribableChain();
+    gunMocks.getTopicLatestSynthesisChain.mockReturnValue({ on: undefined });
+    gunMocks.getTopicLatestSynthesisCorrectionChain.mockReturnValue(correctionChain.chain);
+
+    const { hydrateSynthesisStore } = await import('./hydration');
+    const { store, state } = createStore();
+
+    hydrateSynthesisStore(() => ({}) as never, store, 'topic-1');
+
+    // Non-string scalar under the envelope key -> decode returns null.
+    correctionChain.emit({ __topic_synthesis_correction_json: 42 });
+    // Malformed JSON string -> JSON.parse throws -> decode returns null.
+    correctionChain.emit({ __topic_synthesis_correction_json: '{not valid json' });
+
+    expect(state.setTopicCorrection).not.toHaveBeenCalled();
+    expect(state.setTopicHydrated).not.toHaveBeenCalled();
   });
 
   it('ignores forbidden, invalid, and cross-topic correction payloads', async () => {

--- a/apps/web-pwa/src/store/synthesis/hydration.test.ts
+++ b/apps/web-pwa/src/store/synthesis/hydration.test.ts
@@ -8,11 +8,21 @@ const gunMocks = vi.hoisted(() => ({
   hasForbiddenSynthesisPayloadFields: vi.fn<(payload: unknown) => boolean>()
 }));
 
-vi.mock('@vh/gun-client', () => ({
-  getTopicLatestSynthesisChain: gunMocks.getTopicLatestSynthesisChain,
-  getTopicLatestSynthesisCorrectionChain: gunMocks.getTopicLatestSynthesisCorrectionChain,
-  hasForbiddenSynthesisPayloadFields: gunMocks.hasForbiddenSynthesisPayloadFields
-}));
+// The real parseTopicLatestSynthesisRecord stays in place so hydration
+// ingestion exercises the actual fail-closed system-writer validation.
+vi.mock('@vh/gun-client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@vh/gun-client')>();
+  return {
+    ...actual,
+    getTopicLatestSynthesisChain: gunMocks.getTopicLatestSynthesisChain,
+    getTopicLatestSynthesisCorrectionChain: gunMocks.getTopicLatestSynthesisCorrectionChain,
+    hasForbiddenSynthesisPayloadFields: gunMocks.hasForbiddenSynthesisPayloadFields
+  };
+});
+
+async function flushIngest(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
 
 function synthesis(overrides: Partial<TopicSynthesisV2> = {}): TopicSynthesisV2 {
   return {
@@ -140,6 +150,7 @@ function createStore() {
     getTopicState: vi.fn(),
     setTopicSynthesis: vi.fn(),
     setTopicCorrection: vi.fn(),
+    setTopicInvalid: vi.fn(),
     setTopicHydrated: vi.fn(),
     setTopicLoading: vi.fn(),
     setTopicError: vi.fn(),
@@ -224,6 +235,7 @@ describe('hydrateSynthesisStore', () => {
       epoch: 3
     });
     expect(hydrateSynthesisStore(() => ({}) as never, store, 'topic-1')).toBe(true);
+    await flushIngest();
 
     expect(chain.onSpy).toHaveBeenCalledTimes(1);
     expect(chain.onceSpy).toHaveBeenCalledTimes(2);
@@ -241,8 +253,7 @@ describe('hydrateSynthesisStore', () => {
     const { store, state } = createStore();
 
     expect(hydrateSynthesisStore(() => ({}) as never, store, 'topic-1')).toBe(true);
-    await Promise.resolve();
-    await Promise.resolve();
+    await flushIngest();
 
     expect(chain.getSpy).toHaveBeenCalledWith('__topic_synthesis_json');
     expect(state.setTopicSynthesis).toHaveBeenCalledWith('topic-1', expect.objectContaining({ synthesis_id: 'synth-scalar' }));
@@ -283,8 +294,7 @@ describe('hydrateSynthesisStore', () => {
     const { store, state } = createStore();
 
     expect(hydrateSynthesisStore(() => ({}) as never, store, 'topic-1')).toBe(true);
-    await Promise.resolve();
-    await Promise.resolve();
+    await flushIngest();
 
     expect(state.setTopicSynthesis).not.toHaveBeenCalled();
     expect(state.setTopicCorrection).not.toHaveBeenCalled();
@@ -350,6 +360,7 @@ describe('hydrateSynthesisStore', () => {
     expect(hydrateSynthesisStore(() => ({}) as never, store, 'topic-1')).toBe(true);
     releaseSynthesisHydration(store, 'topic-1');
     chain.emit(synthesis());
+    await flushIngest();
 
     expect(chain.offSpy).toHaveBeenCalledTimes(2);
     expect(chain.offSpy).toHaveBeenNthCalledWith(1, expect.any(Function));
@@ -373,6 +384,7 @@ describe('hydrateSynthesisStore', () => {
     releaseSynthesisHydration(store, 'topic-1');
     releaseSynthesisHydration(store, '   ');
     chain.emit(synthesis());
+    await flushIngest();
 
     expect(state.setTopicSynthesis).not.toHaveBeenCalled();
   });
@@ -425,6 +437,7 @@ describe('hydrateSynthesisStore', () => {
     hydrateSynthesisStore(() => ({}) as never, store, 'topic-1');
 
     chain.emit({ _: { '#': 'meta' }, ...synthesis() });
+    await flushIngest();
 
     expect(state.setTopicSynthesis).toHaveBeenCalledWith('topic-1', expect.objectContaining({ synthesis_id: 'synth-3' }));
     expect(state.setTopicHydrated).toHaveBeenCalledWith('topic-1', true);
@@ -448,6 +461,7 @@ describe('hydrateSynthesisStore', () => {
       synthesis_id: 'synth-3',
       epoch: 3
     });
+    await flushIngest();
 
     expect(state.setTopicSynthesis).toHaveBeenCalledWith('topic-1', expect.objectContaining({ synthesis_id: 'synth-3' }));
     expect(state.setTopicHydrated).toHaveBeenCalledWith('topic-1', true);
@@ -544,10 +558,45 @@ describe('hydrateSynthesisStore', () => {
     chain.emit(synthesis({ topic_id: 'topic-2' }));
     chain.emit({ __topic_synthesis_json: '{' });
     chain.emit({ __topic_synthesis_json: JSON.stringify({ ...synthesis(), token: 'forbidden' }) });
+    await flushIngest();
 
     expect(state.setTopicSynthesis).not.toHaveBeenCalled();
     expect(state.setTopicCorrection).not.toHaveBeenCalled();
+    expect(state.setTopicInvalid).not.toHaveBeenCalled();
     expect(state.setTopicHydrated).not.toHaveBeenCalled();
     expect(state.setTopicError).not.toHaveBeenCalled();
+  });
+
+  it('fails closed on invalid system-writer latest records and flags the topic invalid', async () => {
+    const chain = createSubscribableChain();
+    gunMocks.getTopicLatestSynthesisChain.mockReturnValue(chain.chain);
+    gunMocks.getTopicLatestSynthesisCorrectionChain.mockReturnValue({ on: undefined });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      const { hydrateSynthesisStore } = await import('./hydration');
+      const { store, state } = createStore();
+      const client = { config: {} };
+
+      hydrateSynthesisStore(() => client as never, store, 'topic-1');
+
+      chain.emit({
+        _writerKind: 'system',
+        _protocolVersion: 'luma-public-v1',
+        _systemWriterId: 'vh-system-writer-dev-v1',
+        _systemIssuedAt: 1_700_000_000_000,
+        _systemSignature: 'tampered-signature',
+        __topic_synthesis_json: JSON.stringify(synthesis()),
+        topic_id: 'topic-1',
+        synthesis_id: 'synth-3',
+        epoch: 3
+      });
+      await flushIngest();
+
+      expect(state.setTopicInvalid).toHaveBeenCalledWith('topic-1', true);
+      expect(state.setTopicSynthesis).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 });

--- a/apps/web-pwa/src/store/synthesis/hydration.ts
+++ b/apps/web-pwa/src/store/synthesis/hydration.ts
@@ -1,6 +1,5 @@
 import {
   TopicSynthesisCorrectionSchema,
-  TopicSynthesisV2Schema,
   type TopicSynthesisCorrection,
   type TopicSynthesisV2,
 } from '@vh/data-model';
@@ -8,6 +7,7 @@ import {
   getTopicLatestSynthesisChain,
   getTopicLatestSynthesisCorrectionChain,
   hasForbiddenSynthesisPayloadFields,
+  parseTopicLatestSynthesisRecord,
   type ChainWithGet,
   type VennClient
 } from '@vh/gun-client';
@@ -71,16 +71,6 @@ function decodeGunJsonEnvelope(payload: unknown, key: string): unknown {
   } catch {
     return null;
   }
-}
-
-function parseSynthesis(data: unknown): TopicSynthesisV2 | null {
-  const payload = decodeGunJsonEnvelope(stripGunMetadata(data), TOPIC_SYNTHESIS_JSON_KEY);
-  if (hasForbiddenSynthesisPayloadFields(payload)) {
-    return null;
-  }
-
-  const parsed = TopicSynthesisV2Schema.safeParse(payload);
-  return parsed.success ? parsed.data : null;
 }
 
 function parseCorrection(data: unknown): TopicSynthesisCorrection | null {
@@ -229,17 +219,32 @@ function bindSynthesisSubscription<T>(
   };
 }
 
-function ingestSynthesis(
+async function ingestSynthesis(
+  client: VennClient,
   store: StoreApi<SynthesisState>,
   topicId: string,
   data: unknown
-): void {
-  const synthesis = parseSynthesis(data);
-  if (!synthesis || synthesis.topic_id !== topicId) {
+): Promise<void> {
+  // Same fail-closed system-writer validation as the pull read path;
+  // blocked records surface as an observable invalid state instead of
+  // being silently ignored.
+  let result: Awaited<ReturnType<typeof parseTopicLatestSynthesisRecord>>;
+  try {
+    result = await parseTopicLatestSynthesisRecord(client, topicId, data);
+  } catch {
+    // Unexpected validation error: leave state unchanged (the callers are
+    // fire-and-forget subscription callbacks that cannot observe rejections).
+    return;
+  }
+  if (result.state === 'blocked') {
+    store.getState().setTopicInvalid(topicId, true);
+    return;
+  }
+  if (result.state !== 'valid') {
     return;
   }
 
-  store.getState().setTopicSynthesis(topicId, synthesis);
+  store.getState().setTopicSynthesis(topicId, result.synthesis);
   store.getState().setTopicHydrated(topicId, true);
   store.getState().setTopicError(topicId, null);
 }
@@ -260,15 +265,16 @@ function ingestCorrection(
 }
 
 function pullSynthesisSnapshot(
+  client: VennClient,
   store: StoreApi<SynthesisState>,
   topicId: string,
   latestChain: ChainWithGet<TopicSynthesisV2>,
   correctionChain: ChainWithGet<TopicSynthesisCorrection>
 ): void {
-  latestChain.once?.((data: unknown) => ingestSynthesis(store, topicId, data));
+  latestChain.once?.((data: unknown) => void ingestSynthesis(client, store, topicId, data));
   correctionChain.once?.((data: unknown) => ingestCorrection(store, topicId, data));
   readJsonScalarFromChain(latestChain, TOPIC_SYNTHESIS_JSON_KEY, (payload) => {
-    ingestSynthesis(store, topicId, { [TOPIC_SYNTHESIS_JSON_KEY]: JSON.stringify(payload) });
+    void ingestSynthesis(client, store, topicId, { [TOPIC_SYNTHESIS_JSON_KEY]: JSON.stringify(payload) });
   });
   readJsonScalarFromChain(correctionChain, TOPIC_SYNTHESIS_CORRECTION_JSON_KEY, (payload) => {
     ingestCorrection(store, topicId, { [TOPIC_SYNTHESIS_CORRECTION_JSON_KEY]: JSON.stringify(payload) });
@@ -304,7 +310,7 @@ export function hydrateSynthesisStore(
 
   if (hydratedTopics.has(normalizedTopicId)) {
     touchTopic(store, normalizedTopicId);
-    pullSynthesisSnapshot(store, normalizedTopicId, latestChain, correctionChain);
+    pullSynthesisSnapshot(client, store, normalizedTopicId, latestChain, correctionChain);
     return true;
   }
 
@@ -314,7 +320,7 @@ export function hydrateSynthesisStore(
 
   if (canSubscribe(latestChain)) {
     cleanups.push(bindSynthesisSubscription(latestChain, (data: unknown) =>
-      ingestSynthesis(store, normalizedTopicId, data)
+      void ingestSynthesis(client, store, normalizedTopicId, data)
     ));
   }
 
@@ -325,7 +331,7 @@ export function hydrateSynthesisStore(
   }
   getSubscriptionMap(store).set(normalizedTopicId, { cleanups });
 
-  pullSynthesisSnapshot(store, normalizedTopicId, latestChain, correctionChain);
+  pullSynthesisSnapshot(client, store, normalizedTopicId, latestChain, correctionChain);
 
   return true;
 }

--- a/apps/web-pwa/src/store/synthesis/index.test.ts
+++ b/apps/web-pwa/src/store/synthesis/index.test.ts
@@ -1,10 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { TopicSynthesisCorrection, TopicSynthesisV2 } from '@vh/data-model';
 
+type TopicSynthesisReadResult =
+  | { readonly state: 'valid'; readonly synthesis: TopicSynthesisV2 }
+  | { readonly state: 'legacy-invalid' }
+  | { readonly state: 'blocked' };
+
 const hydrateSynthesisStoreMock = vi.fn<(...args: unknown[]) => boolean>();
 const releaseSynthesisHydrationMock = vi.fn<(...args: unknown[]) => void>();
 const hasForbiddenSynthesisPayloadFieldsMock = vi.fn<(payload: unknown) => boolean>();
-const readTopicLatestSynthesisMock = vi.fn<(client: unknown, topicId: string) => Promise<TopicSynthesisV2 | null>>();
+const readTopicLatestSynthesisMock = vi.fn<
+  (client: unknown, topicId: string) => Promise<TopicSynthesisReadResult>
+>();
 const readTopicLatestSynthesisCorrectionMock = vi.fn<
   (client: unknown, topicId: string) => Promise<TopicSynthesisCorrection | null>
 >();
@@ -17,8 +24,12 @@ vi.mock('./hydration', () => ({
 vi.mock('@vh/gun-client', () => ({
   hasForbiddenSynthesisPayloadFields: hasForbiddenSynthesisPayloadFieldsMock,
   readTopicLatestSynthesisCorrection: readTopicLatestSynthesisCorrectionMock,
-  readTopicLatestSynthesisWithRelayRestFallback: readTopicLatestSynthesisMock
+  readTopicLatestSynthesisStatusWithRelayRestFallback: readTopicLatestSynthesisMock
 }));
+
+function validRead(payload: TopicSynthesisV2): TopicSynthesisReadResult {
+  return { state: 'valid', synthesis: payload };
+}
 
 function synthesis(overrides: Partial<TopicSynthesisV2> = {}): TopicSynthesisV2 {
   return {
@@ -99,7 +110,7 @@ describe('synthesis store', () => {
 
     hydrateSynthesisStoreMock.mockReturnValue(false);
     hasForbiddenSynthesisPayloadFieldsMock.mockReturnValue(false);
-    readTopicLatestSynthesisMock.mockResolvedValue(null);
+    readTopicLatestSynthesisMock.mockResolvedValue({ state: 'legacy-invalid' });
     readTopicLatestSynthesisCorrectionMock.mockResolvedValue(null);
 
     vi.resetModules();
@@ -123,6 +134,7 @@ describe('synthesis store', () => {
       synthesis: null,
       correction: null,
       effectiveStatus: 'synthesis_unavailable',
+      invalid: false,
       hydrated: false,
       loading: false,
       error: null
@@ -134,6 +146,7 @@ describe('synthesis store', () => {
       synthesis: null,
       correction: null,
       effectiveStatus: 'synthesis_unavailable',
+      invalid: false,
       hydrated: false,
       loading: false,
       error: null
@@ -255,6 +268,7 @@ describe('synthesis store', () => {
         synthesis: null,
         correction: null,
         effectiveStatus: 'synthesis_unavailable',
+        invalid: false,
         hydrated: true,
         loading: true,
         error: 'oops'
@@ -318,7 +332,7 @@ describe('synthesis store', () => {
     const client = { id: 'client' };
 
     readTopicLatestSynthesisMock.mockResolvedValue(
-      synthesis({ topic_id: 'topic-x', epoch: 8, synthesis_id: 'synth-8' })
+      validRead(synthesis({ topic_id: 'topic-x', epoch: 8, synthesis_id: 'synth-8' }))
     );
 
     const { createSynthesisStore } = await import('./index');
@@ -347,7 +361,7 @@ describe('synthesis store', () => {
       protocol: 'https:',
     });
     const meshClient = { id: 'mesh-client' };
-    readTopicLatestSynthesisMock.mockResolvedValue(synthesis());
+    readTopicLatestSynthesisMock.mockResolvedValue(validRead(synthesis()));
 
     const { createSynthesisStore } = await import('./index');
     const store = createSynthesisStore({ enabled: true, resolveClient: () => meshClient as never });
@@ -390,7 +404,7 @@ describe('synthesis store', () => {
   });
 
   it('refreshTopic hydrates correction state and exposes effective unavailable/suppressed state', async () => {
-    readTopicLatestSynthesisMock.mockResolvedValue(synthesis());
+    readTopicLatestSynthesisMock.mockResolvedValue(validRead(synthesis()));
     readTopicLatestSynthesisCorrectionMock.mockResolvedValue(correction({ status: 'unavailable' }));
 
     const { createSynthesisStore } = await import('./index');
@@ -406,7 +420,7 @@ describe('synthesis store', () => {
   it('refreshTopic exposes latest synthesis even when correction read stalls', async () => {
     vi.stubEnv('VITE_VH_SYNTHESIS_REFRESH_CORRECTION_TIMEOUT_MS', '5');
     vi.resetModules();
-    readTopicLatestSynthesisMock.mockResolvedValue(synthesis());
+    readTopicLatestSynthesisMock.mockResolvedValue(validRead(synthesis()));
     readTopicLatestSynthesisCorrectionMock.mockReturnValue(new Promise(() => undefined));
 
     const { createSynthesisStore } = await import('./index');
@@ -422,7 +436,7 @@ describe('synthesis store', () => {
   });
 
   it('refreshTopic handles null latest (no synthesis available)', async () => {
-    readTopicLatestSynthesisMock.mockResolvedValue(null);
+    readTopicLatestSynthesisMock.mockResolvedValue({ state: 'legacy-invalid' });
 
     const { createSynthesisStore } = await import('./index');
     const store = createSynthesisStore({ enabled: true, resolveClient: () => ({}) as never });
@@ -438,7 +452,7 @@ describe('synthesis store', () => {
   });
 
   it('refreshTopic preserves an accepted synthesis across transient null latest reads', async () => {
-    readTopicLatestSynthesisMock.mockResolvedValue(null);
+    readTopicLatestSynthesisMock.mockResolvedValue({ state: 'legacy-invalid' });
     readTopicLatestSynthesisCorrectionMock.mockResolvedValue(null);
 
     const { createSynthesisStore } = await import('./index');
@@ -456,7 +470,7 @@ describe('synthesis store', () => {
   });
 
   it('refreshTopic preserves durable corrections across transient null correction reads', async () => {
-    readTopicLatestSynthesisMock.mockResolvedValue(null);
+    readTopicLatestSynthesisMock.mockResolvedValue({ state: 'legacy-invalid' });
     readTopicLatestSynthesisCorrectionMock.mockResolvedValue(null);
 
     const { createSynthesisStore } = await import('./index');
@@ -475,7 +489,7 @@ describe('synthesis store', () => {
   });
 
   it('refreshTopic drops invalid latest payloads after defensive parse', async () => {
-    readTopicLatestSynthesisMock.mockResolvedValue({ invalid: true } as unknown as TopicSynthesisV2);
+    readTopicLatestSynthesisMock.mockResolvedValue(validRead({ invalid: true } as unknown as TopicSynthesisV2));
 
     const { createSynthesisStore } = await import('./index');
     const store = createSynthesisStore({ enabled: true, resolveClient: () => ({}) as never });
@@ -488,7 +502,7 @@ describe('synthesis store', () => {
   });
 
   it('refreshTopic drops cross-topic latest synthesis payloads', async () => {
-    readTopicLatestSynthesisMock.mockResolvedValue(synthesis({ topic_id: 'topic-2' }));
+    readTopicLatestSynthesisMock.mockResolvedValue(validRead(synthesis({ topic_id: 'topic-2' })));
     readTopicLatestSynthesisCorrectionMock.mockResolvedValue(correction());
 
     const { createSynthesisStore } = await import('./index');
@@ -501,6 +515,60 @@ describe('synthesis store', () => {
     expect(topic.epoch).toBeNull();
     expect(topic.correction?.correction_id).toBe('correction-1');
     expect(topic.effectiveStatus).toBe('synthesis_suppressed');
+  });
+
+  it('refreshTopic marks the topic invalid when the latest read is blocked and clears it on a valid read', async () => {
+    readTopicLatestSynthesisMock.mockResolvedValue({ state: 'blocked' });
+
+    const { createSynthesisStore } = await import('./index');
+    const store = createSynthesisStore({ enabled: true, resolveClient: () => ({}) as never });
+
+    await store.getState().refreshTopic('topic-1');
+
+    let topic = store.getState().getTopicState('topic-1');
+    expect(topic.synthesis).toBeNull();
+    expect(topic.invalid).toBe(true);
+    expect(topic.effectiveStatus).toBe('synthesis_unavailable');
+
+    readTopicLatestSynthesisMock.mockResolvedValue(validRead(synthesis()));
+    await store.getState().refreshTopic('topic-1');
+
+    topic = store.getState().getTopicState('topic-1');
+    expect(topic.synthesis?.synthesis_id).toBe('synth-1');
+    expect(topic.invalid).toBe(false);
+    expect(topic.effectiveStatus).toBe('accepted_available');
+  });
+
+  it('refreshTopic keeps the invalid flag across transient legacy-invalid reads', async () => {
+    readTopicLatestSynthesisMock.mockResolvedValue({ state: 'blocked' });
+
+    const { createSynthesisStore } = await import('./index');
+    const store = createSynthesisStore({ enabled: true, resolveClient: () => ({}) as never });
+
+    await store.getState().refreshTopic('topic-1');
+    expect(store.getState().getTopicState('topic-1').invalid).toBe(true);
+
+    readTopicLatestSynthesisMock.mockResolvedValue({ state: 'legacy-invalid' });
+    await store.getState().refreshTopic('topic-1');
+    expect(store.getState().getTopicState('topic-1').invalid).toBe(true);
+  });
+
+  it('setTopicInvalid marks and clears the invalid flag and ignores empty topic ids', async () => {
+    const { createSynthesisStore } = await import('./index');
+    const store = createSynthesisStore({ enabled: true, resolveClient: () => null });
+
+    store.getState().setTopicInvalid('topic-1', true);
+    expect(store.getState().getTopicState('topic-1').invalid).toBe(true);
+
+    store.getState().setTopicInvalid('topic-1', false);
+    expect(store.getState().getTopicState('topic-1').invalid).toBe(false);
+
+    store.getState().setTopicInvalid('   ', true);
+    expect(store.getState().topics['   ']).toBeUndefined();
+
+    store.getState().setTopicInvalid('topic-2', true);
+    store.getState().setTopicSynthesis('topic-2', synthesis({ topic_id: 'topic-2' }));
+    expect(store.getState().getTopicState('topic-2').invalid).toBe(false);
   });
 
   it('refreshTopic captures thrown errors', async () => {

--- a/apps/web-pwa/src/store/synthesis/index.ts
+++ b/apps/web-pwa/src/store/synthesis/index.ts
@@ -8,8 +8,9 @@ import {
 import {
   hasForbiddenSynthesisPayloadFields,
   readTopicLatestSynthesisCorrection,
-  readTopicLatestSynthesisWithRelayRestFallback,
+  readTopicLatestSynthesisStatusWithRelayRestFallback,
   type SystemWriterPin,
+  type TopicSynthesisReadResult,
   type VennClient
 } from '@vh/gun-client';
 import { resolveClientFromAppStore } from '../clientResolver';
@@ -26,7 +27,7 @@ type InternalDeps = SynthesisDeps & {
     topicId: string
   ) => boolean;
   releaseTopic: (store: StoreApi<SynthesisState>, topicId: string) => void;
-  readLatest: (client: VennClient, topicId: string) => Promise<TopicSynthesisV2 | null>;
+  readLatestStatus: (client: VennClient, topicId: string) => Promise<TopicSynthesisReadResult>;
   readLatestCorrection: (client: VennClient, topicId: string) => Promise<TopicSynthesisCorrection | null>;
 };
 
@@ -43,6 +44,7 @@ function createEmptyTopicState(topicId: string): SynthesisTopicState {
     synthesis: null,
     correction: null,
     effectiveStatus: 'synthesis_unavailable',
+    invalid: false,
     hydrated: false,
     loading: false,
     error: null
@@ -230,7 +232,7 @@ export function createSynthesisStore(overrides?: Partial<InternalDeps>): StoreAp
     enabled: true,
     hydrateTopic: hydrateSynthesisStore,
     releaseTopic: releaseSynthesisHydration,
-    readLatest: readTopicLatestSynthesisWithRelayRestFallback,
+    readLatestStatus: readTopicLatestSynthesisStatusWithRelayRestFallback,
     readLatestCorrection: readTopicLatestSynthesisCorrection
   };
 
@@ -270,6 +272,7 @@ export function createSynthesisStore(overrides?: Partial<InternalDeps>): StoreAp
           synthesis: validated,
           epoch: validated?.epoch ?? null,
           effectiveStatus: resolveEffectiveStatus(validated, current.correction),
+          invalid: validated ? false : current.invalid,
           error: null
         }))
       }));
@@ -292,6 +295,23 @@ export function createSynthesisStore(overrides?: Partial<InternalDeps>): StoreAp
           correction: validated,
           effectiveStatus: resolveEffectiveStatus(current.synthesis, validated),
           error: null
+        }))
+      }));
+    },
+
+    setTopicInvalid(topicId: string, invalid: boolean) {
+      const normalizedTopicId = normalizeTopicId(topicId);
+      if (!normalizedTopicId) {
+        return;
+      }
+      if ((get().topics[normalizedTopicId]?.invalid ?? false) === invalid) {
+        return;
+      }
+
+      set((state) => ({
+        topics: upsertTopicState(state.topics, normalizedTopicId, (current) => ({
+          ...current,
+          invalid
         }))
       }));
     },
@@ -357,16 +377,16 @@ export function createSynthesisStore(overrides?: Partial<InternalDeps>): StoreAp
       get().setTopicLoading(normalizedTopicId, true);
       get().setTopicError(normalizedTopicId, null);
 
-      let latest: TopicSynthesisV2 | null = null;
       let latestError: unknown = null;
       try {
-        latest = await withReadTimeout(
-          deps.readLatest(client, normalizedTopicId),
+        const latestResult = await withReadTimeout(
+          deps.readLatestStatus(client, normalizedTopicId),
           SYNTHESIS_REFRESH_READ_TIMEOUT_MS,
           'synthesis latest read',
         );
-        const validatedLatest = latest === null ? null : parseSynthesis(latest);
+        const validatedLatest = latestResult.state === 'valid' ? parseSynthesis(latestResult.synthesis) : null;
         const topicLatest = validatedLatest?.topic_id === normalizedTopicId ? validatedLatest : null;
+        const latestBlocked = latestResult.state === 'blocked';
 
         set((state) => ({
           topics: upsertTopicState(state.topics, normalizedTopicId, (current) => {
@@ -377,6 +397,7 @@ export function createSynthesisStore(overrides?: Partial<InternalDeps>): StoreAp
               epoch: nextSynthesis?.epoch ?? null,
               loading: false,
               effectiveStatus: resolveEffectiveStatus(nextSynthesis, current.correction),
+              invalid: topicLatest ? false : latestBlocked ? true : current.invalid,
               error: null
             };
           })
@@ -468,7 +489,7 @@ export function createMockSynthesisStore(seedSynthesis: TopicSynthesisV2[] = [])
     enabled: true,
     hydrateTopic: () => false,
     releaseTopic: () => {},
-    readLatest: async () => null,
+    readLatestStatus: async () => ({ state: 'legacy-invalid' as const }),
     readLatestCorrection: async () => null
   });
 

--- a/apps/web-pwa/src/store/synthesis/types.ts
+++ b/apps/web-pwa/src/store/synthesis/types.ts
@@ -21,6 +21,13 @@ export interface SynthesisTopicState {
   /** Effective story-detail state after applying correction records. */
   readonly effectiveStatus: SynthesisEffectiveStatus;
 
+  /**
+   * Whether the latest topic record failed fail-closed system-writer
+   * validation (`state: 'blocked'`). Distinguishes invalid records from
+   * merely absent/pending synthesis.
+   */
+  readonly invalid: boolean;
+
   /** Whether live hydration has been attached for this topic. */
   readonly hydrated: boolean;
 
@@ -41,6 +48,7 @@ export interface SynthesisState {
   getTopicState(topicId: string): SynthesisTopicState;
   setTopicSynthesis(topicId: string, synthesis: TopicSynthesisV2 | null): void;
   setTopicCorrection(topicId: string, correction: TopicSynthesisCorrection | null): void;
+  setTopicInvalid(topicId: string, invalid: boolean): void;
   setTopicHydrated(topicId: string, hydrated: boolean): void;
   setTopicLoading(topicId: string, loading: boolean): void;
   setTopicError(topicId: string, error: string | null): void;

--- a/packages/gun-client/src/newsAdapters.test.ts
+++ b/packages/gun-client/src/newsAdapters.test.ts
@@ -529,6 +529,8 @@ describe('newsAdapters', () => {
     expect(hasForbiddenNewsPayloadFields({ custom_token: 'x' })).toBe(true);
     expect(hasForbiddenNewsPayloadFields({ nested: { identity_session: 'x' } })).toBe(true);
     expect(hasForbiddenNewsPayloadFields({ list: [{ published: true }, { bearer: 'x' }] })).toBe(true);
+    expect(hasForbiddenNewsPayloadFields({ client_secret: 'x' })).toBe(true);
+    expect(hasForbiddenNewsPayloadFields({ nested: { provider_secret: 'x' } })).toBe(true);
 
     const cyclic: Record<string, unknown> = { safe: true };
     cyclic.self = cyclic;

--- a/packages/gun-client/src/newsAdapters.ts
+++ b/packages/gun-client/src/newsAdapters.ts
@@ -713,7 +713,12 @@ function isForbiddenNewsKey(key: string): boolean {
   if (normalized.endsWith('_token')) {
     return true;
   }
-  if (normalized.includes('oauth') || normalized.includes('bearer') || normalized.includes('nullifier')) {
+  if (
+    normalized.includes('oauth')
+    || normalized.includes('bearer')
+    || normalized.includes('nullifier')
+    || normalized.includes('secret')
+  ) {
     return true;
   }
   return false;

--- a/packages/gun-client/src/relayRestFallback.test.ts
+++ b/packages/gun-client/src/relayRestFallback.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createClient } from './index';
 import { resolveRelayRestEndpointFromPeer } from './relayRestFallback';
 import {
+  readTopicLatestSynthesisStatusWithRelayRestFallback,
   readTopicLatestSynthesisViaRelayRest,
   readTopicLatestSynthesisWithRelayRestFallback,
 } from './synthesisAdapters';
@@ -301,6 +302,102 @@ describe('readTopicLatestSynthesisViaRelayRest', () => {
     try {
       await expect(readTopicLatestSynthesisWithRelayRestFallback(client, 'topic-1'))
         .resolves.toBeNull();
+    } finally {
+      await client.shutdown();
+    }
+  }, 10_000);
+
+  it('status fallback keeps legacy-invalid when both direct and relay reads miss', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({ ok: false }), { status: 404 })));
+    const client = createClient({
+      peers: ['wss://gun-a.carboncaste.io/gun'],
+      requireSession: false,
+      gunLocalStorage: false,
+      gunRadisk: false,
+    });
+    client.markSessionReady();
+
+    try {
+      await expect(readTopicLatestSynthesisStatusWithRelayRestFallback(client, 'topic-1'))
+        .resolves.toEqual({ state: 'legacy-invalid' });
+    } finally {
+      await client.shutdown();
+    }
+  }, 10_000);
+
+  it('status fallback recovers a valid relay record when the direct read misses', async () => {
+    vi.stubGlobal('location', {
+      href: 'https://venn.carboncaste.io/',
+      origin: 'https://venn.carboncaste.io',
+      protocol: 'https:',
+    });
+    const synthesis = {
+      schemaVersion: 'topic-synthesis-v2',
+      topic_id: 'topic-1',
+      epoch: 2,
+      synthesis_id: 'synth-2',
+      inputs: { story_bundle_ids: ['story-1'] },
+      quorum: {
+        required: 1,
+        received: 1,
+        reached_at: 100,
+        timed_out: false,
+        selection_rule: 'deterministic',
+      },
+      facts_summary: 'Status fallback synthesis summary.',
+      frames: [
+        {
+          frame_point_id: 'frame-1',
+          frame: 'Frame',
+          reframe_point_id: 'reframe-1',
+          reframe: 'Reframe',
+        },
+      ],
+      warnings: [],
+      divergence_metrics: {
+        disagreement_score: 0,
+        source_dispersion: 0,
+        candidate_count: 1,
+      },
+      provenance: {
+        candidate_ids: ['candidate-1'],
+        provider_mix: [{ provider_id: 'provider-1', count: 1 }],
+      },
+      created_at: 200,
+    };
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+      ok: true,
+      record: {
+        __topic_synthesis_json: JSON.stringify(synthesis),
+        schemaVersion: synthesis.schemaVersion,
+        topic_id: synthesis.topic_id,
+        epoch: synthesis.epoch,
+        synthesis_id: synthesis.synthesis_id,
+        created_at: synthesis.created_at,
+      },
+    }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    })));
+
+    const client = createClient({
+      peers: ['wss://gun-a.carboncaste.io/gun'],
+      requireSession: false,
+      gunLocalStorage: false,
+      gunRadisk: false,
+    });
+    client.markSessionReady();
+
+    try {
+      await expect(readTopicLatestSynthesisStatusWithRelayRestFallback(client, 'topic-1'))
+        .resolves.toMatchObject({
+          state: 'valid',
+          synthesis: {
+            topic_id: 'topic-1',
+            synthesis_id: 'synth-2',
+            facts_summary: 'Status fallback synthesis summary.',
+          },
+        });
     } finally {
       await client.shutdown();
     }

--- a/packages/gun-client/src/synthesisAdapters.test.ts
+++ b/packages/gun-client/src/synthesisAdapters.test.ts
@@ -32,6 +32,7 @@ import {
   parseTopicLatestSynthesisRecord,
   readTopicEpochSynthesis,
   readTopicLatestSynthesisStatus,
+  readTopicLatestSynthesisStatusWithRelayRestFallback,
   readTopicLatestSynthesisCorrection,
   readTopicLatestSynthesis,
   readTopicSynthesisCorrection,
@@ -757,6 +758,19 @@ describe('synthesisAdapters', () => {
       state: 'valid',
       synthesis: SYNTHESIS,
     });
+  });
+
+  it('relay-rest status fallback returns a valid direct read without consulting the relay', async () => {
+    const { mesh, client, latestRecord } = await createSignedSynthesisFixture();
+    mesh.setRead('topics/topic-1/latest', latestRecord);
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+    await expect(
+      readTopicLatestSynthesisStatusWithRelayRestFallback(client, 'topic-1'),
+    ).resolves.toEqual({ state: 'valid', synthesis: SYNTHESIS });
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    fetchSpy.mockRestore();
   });
 
   it('parseTopicLatestSynthesisRecord validates live records with the pull-read fail-closed semantics', async () => {

--- a/packages/gun-client/src/synthesisAdapters.test.ts
+++ b/packages/gun-client/src/synthesisAdapters.test.ts
@@ -29,6 +29,7 @@ import {
   readTopicDigest,
   readTopicEpochCandidate,
   readTopicEpochCandidates,
+  parseTopicLatestSynthesisRecord,
   readTopicEpochSynthesis,
   readTopicLatestSynthesisStatus,
   readTopicLatestSynthesisCorrection,
@@ -507,6 +508,8 @@ describe('synthesisAdapters', () => {
     expect(hasForbiddenSynthesisPayloadFields({ custom_token: 'bad' })).toBe(true);
     expect(hasForbiddenSynthesisPayloadFields({ nested: { identity_session: 'bad' } })).toBe(true);
     expect(hasForbiddenSynthesisPayloadFields({ nested: [{ safe: true }, { bearer: 'bad' }] })).toBe(true);
+    expect(hasForbiddenSynthesisPayloadFields({ client_secret: 'bad' })).toBe(true);
+    expect(hasForbiddenSynthesisPayloadFields({ nested: { provider_secret: 'bad' } })).toBe(true);
 
     const cyclic: Record<string, unknown> = { ok: true };
     cyclic.self = cyclic;
@@ -754,6 +757,53 @@ describe('synthesisAdapters', () => {
       state: 'valid',
       synthesis: SYNTHESIS,
     });
+  });
+
+  it('parseTopicLatestSynthesisRecord validates live records with the pull-read fail-closed semantics', async () => {
+    const { client, latestRecord } = await createSignedSynthesisFixture();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      await expect(parseTopicLatestSynthesisRecord(client, 'topic-1', latestRecord)).resolves.toEqual({
+        state: 'valid',
+        synthesis: SYNTHESIS,
+      });
+
+      // Legacy (non-system-writer) envelope records remain readable.
+      await expect(
+        parseTopicLatestSynthesisRecord(client, 'topic-1', {
+          _: { '#': 'meta' },
+          [TOPIC_SYNTHESIS_JSON_KEY]: JSON.stringify(SYNTHESIS),
+          topic_id: SYNTHESIS.topic_id,
+          epoch: SYNTHESIS.epoch,
+          synthesis_id: SYNTHESIS.synthesis_id,
+        }),
+      ).resolves.toEqual({ state: 'valid', synthesis: SYNTHESIS });
+
+      // Tampered system-writer records fail closed as blocked.
+      await expect(
+        parseTopicLatestSynthesisRecord(client, 'topic-1', {
+          ...latestRecord,
+          [TOPIC_SYNTHESIS_JSON_KEY]: JSON.stringify({ ...SYNTHESIS, facts_summary: 'Tampered' }),
+        }),
+      ).resolves.toEqual({ state: 'blocked' });
+      await expect(
+        parseTopicLatestSynthesisRecord(client, 'topic-1', {
+          ...latestRecord,
+          _systemSignature: `${String(latestRecord._systemSignature)}tampered`,
+        }),
+      ).resolves.toEqual({ state: 'blocked' });
+
+      // Absent or malformed live payloads stay legacy-invalid, not blocked.
+      await expect(parseTopicLatestSynthesisRecord(client, 'topic-1', undefined)).resolves.toEqual({
+        state: 'legacy-invalid',
+      });
+      await expect(parseTopicLatestSynthesisRecord(client, 'topic-1', { invalid: true })).resolves.toEqual({
+        state: 'legacy-invalid',
+      });
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   it('rejects tampered or path-mismatched system writer synthesis records', async () => {

--- a/packages/gun-client/src/synthesisAdapters.ts
+++ b/packages/gun-client/src/synthesisAdapters.ts
@@ -134,7 +134,10 @@ function isForbiddenSynthesisKey(key: string): boolean {
   if (normalized.endsWith('_token')) {
     return true;
   }
-  return normalized.includes('oauth') || normalized.includes('bearer') || normalized.includes('nullifier');
+  return normalized.includes('oauth')
+    || normalized.includes('bearer')
+    || normalized.includes('nullifier')
+    || normalized.includes('secret');
 }
 
 /** Defensive privacy guard for public synthesis paths. */
@@ -924,6 +927,25 @@ export async function readTopicLatestSynthesis(client: VennClient, topicId: stri
   return result.state === 'valid' ? result.synthesis : null;
 }
 
+/**
+ * Fail-closed parser for latest-synthesis records delivered outside the pull
+ * read path (live Gun subscriptions/snapshots). Applies the same system-writer
+ * validation as `readTopicLatestSynthesisStatus`, so hydration consumers can
+ * distinguish invalid records (`blocked`) from absent/legacy noise.
+ */
+export async function parseTopicLatestSynthesisRecord(
+  client: VennClient,
+  topicId: string,
+  data: unknown,
+): Promise<TopicSynthesisReadResult> {
+  const normalizedTopicId = normalizeTopicId(topicId);
+  return parseSynthesisFromStoredRecord(client, {
+    path: topicLatestPath(normalizedTopicId),
+    topicId: normalizedTopicId,
+    data,
+  });
+}
+
 export async function readTopicLatestSynthesisViaRelayRest(
   client: VennClient,
   topicId: string,
@@ -985,6 +1007,33 @@ export async function readTopicLatestSynthesisWithRelayRestFallback(
       RELAY_REST_READ_TIMEOUT_MS + 1_000,
     ),
   ]);
+}
+
+/**
+ * Latest-synthesis read with relay REST fallback that preserves the
+ * fail-closed read state: a `blocked` direct read (invalid system-writer
+ * record) stays observable instead of collapsing into "not found".
+ */
+export async function readTopicLatestSynthesisStatusWithRelayRestFallback(
+  client: VennClient,
+  topicId: string,
+): Promise<TopicSynthesisReadResult> {
+  const normalizedTopicId = normalizeTopicId(topicId);
+  const relayRead = timeoutAsNull(
+    readTopicLatestSynthesisViaRelayRest(client, normalizedTopicId),
+    RELAY_REST_READ_TIMEOUT_MS + 1_000,
+  );
+  const direct = await readTopicLatestSynthesisStatus(client, normalizedTopicId);
+  if (direct.state !== 'legacy-invalid') {
+    // valid records win immediately; blocked records must stay observable
+    // rather than being masked by an unvalidated relay payload.
+    return direct;
+  }
+  const relay = await relayRead;
+  if (relay) {
+    return { state: 'valid', synthesis: relay };
+  }
+  return direct;
 }
 
 export async function writeTopicLatestSynthesis(client: VennClient, synthesis: unknown): Promise<TopicSynthesisV2> {


### PR DESCRIPTION
## Summary

Lane A (Slices A1 + A2) of `docs/plans/FUNCTIONING_MVP_LANE_SLICE_PLAN_2026-07-06.md`. Story detail now depends on the full accepted-current join before any vote control renders, fail-closed at every step. No A6 mutation — Slice A3 (production canary) stays operator-owned.

## What changed

- **Five-record join with the epoch node.** When an `accepted_available` lifecycle names a `synthesis_id`+`epoch` that a lagging `vh/topics/<id>/latest` pointer doesn't match, the card reads `vh/topics/<id>/epochs/<epoch>/synthesis` (full system-writer validation) and only accepts it if it matches the lifecycle exactly. A missing lifecycle `epoch` can never be accepted-current.
- **Seven-state read model** (`useAcceptedSynthesis.ts`, exported): `loading | acceptedCurrentSynthesis | pending | retryable_failure | terminal_unavailable | suppressed_by_correction | invalid`. `invalid` (system-writer validation failed) is now observable instead of collapsing to `pending`.
- **Hydration-path validation.** Live Gun subscription records go through the same fail-closed `parseTopicLatestSynthesisRecord` as pull reads; blocked → `invalid`.
- **No votable text-derived point ids.** `BiasTable` gates voting at table + row level to `accepted-synthesis` persisted-id mode; `TopicCard` renders non-votable. No legacy/analysis-fallback path can enable voting.
- **Divergence indicator** on story detail, extracted as a shared `DivergenceBadge` (previously duplicated in 3 components).
- **`secret`-shaped forbidden keys** added to synthesis + news payload guards.

## Review

Passed a high-effort multi-angle review (8 finders + verification). Applied fixes: shared `DivergenceBadge`, `acceptedCurrentSynthesis` empty-frames message, `useSynthesis` exposes `invalid`, `setTopicInvalid` dedupes no-op writes, `ingestSynthesis` guards validator rejection.

## Validation

- `@vh/web-pwa`: 2516 passed; `@vh/gun-client`: 602 passed
- `check:luma-topic-synthesis-system-v1`: ok; `@vh/web-pwa` + `@vh/gun-client` typecheck clean; `git diff --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)