### PR TITLE
fix: telemetry-redaction gate false-positive on secret key-name detection

### DIFF
--- a/tools/scripts/check-luma-telemetry-redaction.mjs
+++ b/tools/scripts/check-luma-telemetry-redaction.mjs
@@ -53,6 +53,12 @@ const STRUCTURAL_GUARD_PATTERN = /\btypeof\b|\.length\s*(?:===|!==)/;
 // preserve-check comparing two in-memory field values, never logged). The
 // marker must carry a reason so every exemption is reviewable.
 const REDACTION_SAFE_MARKER = /\/\/\s*redaction-safe:/;
+// Quoted string contents (single/double/template). Used to tell a secret
+// *value* comparison (a bare `nullifier` identifier/property) apart from a
+// secret *key-name* comparison (`normalizedKey(k) === 'districthash'`), where
+// the token only ever appears inside a string literal — a detection idiom in
+// the privacy guards themselves, never a value leak.
+const QUOTED_STRING_PATTERN = /'[^']*'|"[^"]*"|`[^`]*`/g;
 const SOURCE_EXTENSIONS = new Set(['.ts', '.tsx']);
 
 export const SCAN_TARGETS = Object.freeze([
@@ -135,6 +141,12 @@ function scanLineForSecretEquality(relPath, lineText, lineNumber, violations) {
     return;
   }
   if (REDACTION_SAFE_MARKER.test(lineText)) {
+    return;
+  }
+  // If the secret token only appears inside a quoted string literal (a
+  // key-name detection like `normalizedKey(k) === 'districthash'`), it is not
+  // a secret-value comparison.
+  if (!SECRET_IDENTIFIER_PATTERN.test(lineText.replace(QUOTED_STRING_PATTERN, "''"))) {
     return;
   }
   violations.push({

--- a/tools/scripts/check-luma-telemetry-redaction.test.mjs
+++ b/tools/scripts/check-luma-telemetry-redaction.test.mjs
@@ -125,6 +125,24 @@ test('structural type/length guards on secret fields pass', () => {
   }
 });
 
+test('secret key-name detection (token only in a quoted literal) passes, value comparison still fails', () => {
+  const root = makeFixtureRepo({
+    'packages/gun-client/src/index.ts': [
+      "export const detect = keys.some((k) => normalizeKey(k) === 'districthash');",
+      "export const detect2 = normalizeKey(k) !== 'nullifier';",
+      'export const bad = record.nullifier === expectedNullifier;',
+    ].join('\n'),
+  });
+  try {
+    const { violations } = runTelemetryRedactionChecks(root);
+    assert.ok(!violations.some((v) => v.text.includes("'districthash'")));
+    assert.ok(!violations.some((v) => v.text.includes("'nullifier'")));
+    assert.ok(violations.some((v) => v.type === 'secret-equality' && v.text.includes('record.nullifier === expectedNullifier')));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test('redaction-safe marker exempts a vetted secret comparison but not others', () => {
   const root = makeFixtureRepo({
     'packages/identity-vault/src/vault.ts': [


### PR DESCRIPTION
## Summary

`check:luma-telemetry-redaction` went red on main after #732: the new `containsDistrictHashKey` guard does `normalizeKey(k) === 'districthash'` — a key-*name* detection where the secret token appears only inside a quoted string literal, not as a secret *value*. The rule flagged it as a secret-equality comparison.

## Fix

Exempt comparisons where the secret token survives only inside a quoted literal (single/double/template) after de-literalizing the line — this is the detection idiom used inside the privacy guards themselves. Bare-identifier/property value comparisons (`record.nullifier === expectedNullifier`) still fail.

New green/red self-test locks both directions; all 9 scanner self-tests pass; `check:luma-telemetry-redaction` PASS. Unblocks the release-gate chain (same class of cross-lane guard interaction as #731).

🤖 Generated with [Claude Code](https://claude.com/claude-code)