### PR TITLE
feat(account): browser sign-in flow, account UI, and LUMA binding (PR D phase 2)

### DIFF
--- a/apps/web-pwa/.env.example
+++ b/apps/web-pwa/.env.example
@@ -16,3 +16,14 @@ VITE_VH_ANALYSIS_PIPELINE=false
 
 # Daily analysis budget limit (0 = unlimited)
 VITE_VH_ANALYSIS_DAILY_LIMIT=20
+
+# Account sign-in (Lane C). Base URL of the deployed auth-callback
+# boundary (services/auth-callback), outside A6. When set, Apple/Google/X
+# sign-in tiles are offered and the PKCE round-trip runs against this
+# host. No provider secret ever lives in the browser bundle — only this
+# public base URL. Leave unset to hide real sign-in (beta-local identity
+# creation still works). Under VITE_E2E_MODE the providers run an
+# in-process mock and this URL is ignored.
+VITE_AUTH_CALLBACK_BASE_URL=
+# Optional override for the in-app OAuth redirect route (default /auth/callback).
+VITE_AUTH_CALLBACK_ROUTE=/auth/callback

--- a/apps/web-pwa/src/auth/signInBinding.test.ts
+++ b/apps/web-pwa/src/auth/signInBinding.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { bindSignInSession } from './signInBinding';
+import type { SignInSessionPayload } from './signInFlow';
+import { clearSignInAccounts, getSignInAccount } from '../store/signInAccount';
+
+const { saveMock } = vi.hoisted(() => ({ saveMock: vi.fn() }));
+
+vi.mock('@vh/identity-vault', () => ({
+  signInSession: {
+    save: (...args: unknown[]) => saveMock(...(args as [])),
+  },
+}));
+
+function session(overrides: Partial<SignInSessionPayload> = {}): SignInSessionPayload {
+  return {
+    schemaVersion: 'vh-auth-session-v1',
+    providerId: 'apple',
+    providerSubject: 'sub-123',
+    displayLabel: 'a@b.com',
+    issuedAt: 1000,
+    expiresAt: 5000,
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  clearSignInAccounts();
+  saveMock.mockReset();
+});
+
+describe('bindSignInSession', () => {
+  it('writes session material to the vault and records non-secret account metadata', async () => {
+    saveMock.mockResolvedValue(undefined);
+    const result = await bindSignInSession(session(), 'principal-1', 2000);
+
+    expect(saveMock).toHaveBeenCalledWith({
+      providerId: 'apple',
+      providerSubject: 'sub-123',
+      displayLabel: 'a@b.com',
+      expiresAt: 5000,
+      boundPrincipalNullifier: 'principal-1',
+      now: 2000,
+    });
+    expect(result.boundPrincipalNullifier).toBe('principal-1');
+    expect(result.account.providerId).toBe('apple');
+    expect(result.account.status).toBe('signed-in');
+    expect(getSignInAccount('apple')?.displayLabel).toBe('a@b.com');
+  });
+
+  it('omits optional fields when absent and defaults now to Date.now', async () => {
+    saveMock.mockResolvedValue(undefined);
+    vi.spyOn(Date, 'now').mockReturnValue(4242);
+    await bindSignInSession(session({ displayLabel: undefined, expiresAt: null }), 'principal-2');
+
+    expect(saveMock).toHaveBeenCalledWith({
+      providerId: 'apple',
+      providerSubject: 'sub-123',
+      boundPrincipalNullifier: 'principal-2',
+      now: 4242,
+    });
+    expect(getSignInAccount('apple')?.displayLabel).toBeUndefined();
+  });
+
+  it('throws without a principal nullifier and writes no binding', async () => {
+    await expect(bindSignInSession(session(), '')).rejects.toThrow('active principal nullifier');
+    expect(saveMock).not.toHaveBeenCalled();
+    expect(getSignInAccount('apple')).toBeUndefined();
+  });
+
+  it('throws when the principal nullifier is not a string', async () => {
+    await expect(
+      bindSignInSession(session(), undefined as unknown as string),
+    ).rejects.toThrow('active principal nullifier');
+  });
+
+  it('throws when the account record fails validation', async () => {
+    saveMock.mockResolvedValue(undefined);
+    await expect(
+      bindSignInSession(session({ providerId: 'reddit' as unknown as 'apple' }), 'principal-3'),
+    ).rejects.toThrow('account record failed validation');
+  });
+});

--- a/apps/web-pwa/src/auth/signInBinding.ts
+++ b/apps/web-pwa/src/auth/signInBinding.ts
@@ -1,0 +1,73 @@
+/**
+ * Account-to-LUMA binding (Lane C, Slice C2).
+ *
+ * Given a completed non-secret sign-in session payload and the active
+ * device-bound LUMA principal nullifier, this:
+ *
+ *   1. writes the sign-in SESSION material (provider subject + optional
+ *      display label, bound to `boundPrincipalNullifier`) to the
+ *      identity-vault signInSession compartment — the ONLY place that
+ *      material lives. It never touches the flag-gated linked-social
+ *      token vault, and is never written to any `vh/*` record;
+ *   2. records the NON-SECRET account metadata (provider id, display
+ *      label, status) in the local signInAccount store for the account
+ *      UI.
+ *
+ * New-device semantics: this binds the account to whatever principal is
+ * active on THIS device. It never merges an old principal — the caller
+ * hydrates-or-creates the local principal first; a fresh device gets a
+ * fresh principal and only continuity/profile state, never a same-human
+ * claim.
+ */
+
+import { signInSession } from '@vh/identity-vault';
+import type { SignInSessionPayload } from './signInFlow';
+import {
+  upsertSignInAccount,
+  type UpsertSignInAccountInput,
+} from '../store/signInAccount';
+import type { SignInAccountRecord } from '@vh/data-model';
+
+export interface BindSignInResult {
+  account: SignInAccountRecord;
+  boundPrincipalNullifier: string;
+}
+
+/**
+ * Bind a completed sign-in session to the active LUMA principal. Throws
+ * if the principal nullifier is missing (no partial binding is written)
+ * or if the account record fails validation.
+ */
+export async function bindSignInSession(
+  session: SignInSessionPayload,
+  principalNullifier: string,
+  now: number = Date.now()
+): Promise<BindSignInResult> {
+  if (typeof principalNullifier !== 'string' || principalNullifier.length === 0) {
+    throw new Error('sign-in binding requires an active principal nullifier');
+  }
+
+  // Session material -> vault compartment only (never public, never logs).
+  await signInSession.save({
+    providerId: session.providerId,
+    providerSubject: session.providerSubject,
+    ...(session.displayLabel !== undefined ? { displayLabel: session.displayLabel } : {}),
+    ...(session.expiresAt !== null ? { expiresAt: session.expiresAt } : {}),
+    boundPrincipalNullifier: principalNullifier,
+    now,
+  });
+
+  // Non-secret account metadata -> local account store for the UI.
+  const accountInput: UpsertSignInAccountInput = {
+    providerId: session.providerId,
+    ...(session.displayLabel !== undefined ? { displayLabel: session.displayLabel } : {}),
+    status: 'signed-in',
+    now,
+  };
+  const account = upsertSignInAccount(accountInput);
+  if (!account) {
+    throw new Error('sign-in account record failed validation');
+  }
+
+  return { account, boundPrincipalNullifier: principalNullifier };
+}

--- a/apps/web-pwa/src/auth/signInFlow.test.ts
+++ b/apps/web-pwa/src/auth/signInFlow.test.ts
@@ -81,7 +81,7 @@ describe('PKCE primitives', () => {
 });
 
 describe('provider availability', () => {
-  it('real providers require a configured base URL', () => {
+  it('real providers require a configured base URL when not in e2e mode', () => {
     expect(isSignInProviderAvailable('apple', realEnv())).toBe(true);
     expect(isSignInProviderAvailable('google', {})).toBe(false);
     expect(isSignInProviderAvailable('apple', { VITE_AUTH_CALLBACK_BASE_URL: '  ' })).toBe(false);
@@ -90,17 +90,17 @@ describe('provider availability', () => {
 
   it('rejects unknown providers', () => {
     expect(isSignInProviderAvailable('reddit' as SignInFlowProvider, realEnv())).toBe(false);
+    expect(isSignInProviderAvailable('reddit' as SignInFlowProvider, e2eEnv())).toBe(false);
   });
 
-  it('mock provider requires e2e mode', () => {
-    expect(isSignInProviderAvailable('mock', e2eEnv())).toBe(true);
-    expect(isSignInProviderAvailable('mock', {})).toBe(false);
+  it('e2e mode makes every real provider available without a base URL', () => {
+    expect(isSignInProviderAvailable('apple', e2eEnv())).toBe(true);
+    expect(isSignInProviderAvailable('x', e2eEnv())).toBe(true);
   });
 
   it('lists available providers for a real build and an e2e build', () => {
     expect(availableSignInProviders(realEnv())).toEqual(['apple', 'google', 'x']);
-    expect(availableSignInProviders(e2eEnv())).toEqual(['mock']);
-    expect(availableSignInProviders(realEnv(e2eEnv()))).toEqual(['apple', 'google', 'x', 'mock']);
+    expect(availableSignInProviders(e2eEnv())).toEqual(['apple', 'google', 'x']);
     expect(availableSignInProviders({})).toEqual([]);
   });
 
@@ -122,17 +122,17 @@ describe('startSignIn', () => {
     await expect(startSignIn('apple', {})).rejects.toMatchObject({ reason: 'provider_unsupported' });
   });
 
-  it('starts a mock flow with a synthetic authorize URL and default route', async () => {
-    const result = await startSignIn('mock', e2eEnv());
-    expect(result.provider).toBe('mock');
-    expect(result.authorizeUrl).toContain('/auth/callback?provider=mock&code=mock-code&state=');
-    expect(result.state).toMatch(/^mock-state-/);
-    expect(sessionStorage.getItem('vh:sign-in:pending-v1')).toContain('mock');
+  it('starts an e2e mock flow with a synthetic authorize URL and default route', async () => {
+    const result = await startSignIn('apple', e2eEnv());
+    expect(result.provider).toBe('apple');
+    expect(result.authorizeUrl).toContain('/auth/callback?provider=apple&code=mock-code&state=');
+    expect(result.state).toMatch(/^mock-state-apple-/);
+    expect(sessionStorage.getItem('vh:sign-in:pending-v1')).toContain('apple');
   });
 
-  it('honours a custom callback route for the mock flow', async () => {
-    const result = await startSignIn('mock', e2eEnv({ VITE_AUTH_CALLBACK_ROUTE: '/custom/cb' }));
-    expect(result.authorizeUrl).toContain('/custom/cb?provider=mock');
+  it('honours a custom callback route for the e2e mock flow', async () => {
+    const result = await startSignIn('google', e2eEnv({ VITE_AUTH_CALLBACK_ROUTE: '/custom/cb' }));
+    expect(result.authorizeUrl).toContain('/custom/cb?provider=google');
   });
 
   it('posts the challenge to the boundary and returns the authorize URL', async () => {
@@ -200,23 +200,30 @@ describe('boundary_unconfigured on start', () => {
 });
 
 describe('completeSignIn', () => {
-  async function primeMockPending(env = e2eEnv()): Promise<string> {
-    const started = await startSignIn('mock', env);
+  async function primeMockPending(provider: SignInFlowProvider = 'apple', env = e2eEnv()): Promise<string> {
+    const started = await startSignIn(provider, env);
     return started.state;
   }
 
-  it('completes a mock flow and clears pending state', async () => {
+  it('completes an e2e mock flow and clears pending state', async () => {
     const state = await primeMockPending();
     const session = await completeSignIn({ code: 'mock-code', state, nowMs: 1000 }, e2eEnv());
     expect(session).toEqual({
       schemaVersion: 'vh-auth-session-v1',
       providerId: 'apple',
-      providerSubject: expect.stringMatching(/^mock-subject-/),
-      displayLabel: 'mock@example.com',
+      providerSubject: expect.stringMatching(/^mock-subject-apple-/),
+      displayLabel: 'mock-apple@example.com',
       issuedAt: 1000,
       expiresAt: 1000 + 3600_000,
     });
     expect(sessionStorage.getItem('vh:sign-in:pending-v1')).toBeNull();
+  });
+
+  it('carries the chosen provider through the mock session', async () => {
+    const state = await primeMockPending('x');
+    const session = await completeSignIn({ code: 'mock-code', state, nowMs: 5 }, e2eEnv());
+    expect(session.providerId).toBe('x');
+    expect(session.displayLabel).toBe('mock-x@example.com');
   });
 
   it('defaults nowMs to Date.now for the mock flow', async () => {
@@ -224,13 +231,6 @@ describe('completeSignIn', () => {
     vi.spyOn(Date, 'now').mockReturnValue(7);
     const session = await completeSignIn({ code: 'mock-code', state }, e2eEnv());
     expect(session.issuedAt).toBe(7);
-  });
-
-  it('rejects the mock flow outside e2e mode', async () => {
-    const state = await primeMockPending();
-    await expect(completeSignIn({ code: 'mock-code', state }, {})).rejects.toMatchObject({
-      reason: 'provider_unsupported',
-    });
   });
 
   it('rejects when there is no pending flow', async () => {
@@ -360,14 +360,24 @@ describe('pending-flow custody edge cases', () => {
   });
 
   it('ignores a structurally invalid pending record', async () => {
-    sessionStorage.setItem('vh:sign-in:pending-v1', JSON.stringify({ provider: 'mock', codeVerifier: '', state: 's' }));
+    sessionStorage.setItem('vh:sign-in:pending-v1', JSON.stringify({ provider: 'apple', codeVerifier: '', state: 's' }));
+    await expect(completeSignIn({ code: 'c', state: 's' }, e2eEnv())).rejects.toMatchObject({
+      reason: 'pending_flow_missing',
+    });
+  });
+
+  it('ignores a pending record with an unknown provider', async () => {
+    sessionStorage.setItem(
+      'vh:sign-in:pending-v1',
+      JSON.stringify({ provider: 'reddit', codeVerifier: 'v'.repeat(43), state: 's' }),
+    );
     await expect(completeSignIn({ code: 'c', state: 's' }, e2eEnv())).rejects.toMatchObject({
       reason: 'pending_flow_missing',
     });
   });
 
   it('clearPendingSignIn removes the stashed material', async () => {
-    await startSignIn('mock', e2eEnv());
+    await startSignIn('apple', e2eEnv());
     expect(sessionStorage.getItem('vh:sign-in:pending-v1')).not.toBeNull();
     clearPendingSignIn();
     expect(sessionStorage.getItem('vh:sign-in:pending-v1')).toBeNull();
@@ -379,7 +389,7 @@ describe('sessionStorage unavailable', () => {
     const descriptor = Object.getOwnPropertyDescriptor(globalThis, 'sessionStorage');
     Object.defineProperty(globalThis, 'sessionStorage', { configurable: true, value: undefined });
     try {
-      const started = await startSignIn('mock', e2eEnv());
+      const started = await startSignIn('apple', e2eEnv());
       await expect(completeSignIn({ code: 'mock-code', state: started.state }, e2eEnv())).rejects.toMatchObject({
         reason: 'pending_flow_missing',
       });
@@ -400,7 +410,7 @@ describe('sessionStorage unavailable', () => {
     });
     try {
       // start persists nothing; complete then finds no pending flow.
-      const started = await startSignIn('mock', e2eEnv());
+      const started = await startSignIn('apple', e2eEnv());
       await expect(completeSignIn({ code: 'mock-code', state: started.state }, e2eEnv())).rejects.toMatchObject({
         reason: 'pending_flow_missing',
       });

--- a/apps/web-pwa/src/auth/signInFlow.test.ts
+++ b/apps/web-pwa/src/auth/signInFlow.test.ts
@@ -1,0 +1,414 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  SignInError,
+  availableSignInProviders,
+  clearPendingSignIn,
+  completeSignIn,
+  computeCodeChallenge,
+  generateCodeVerifier,
+  isSignInProviderAvailable,
+  startSignIn,
+  type SignInFlowProvider,
+} from './signInFlow';
+
+type FlowEnv = Record<string, string | boolean | undefined>;
+
+const BASE = 'https://auth.example.test';
+
+function realEnv(overrides: FlowEnv = {}): FlowEnv {
+  return { VITE_AUTH_CALLBACK_BASE_URL: BASE, ...overrides };
+}
+
+function e2eEnv(overrides: FlowEnv = {}): FlowEnv {
+  return { VITE_E2E_MODE: 'true', ...overrides };
+}
+
+function okResponse(json: unknown, status = 200): Response {
+  return { status, json: async () => json } as unknown as Response;
+}
+
+beforeEach(() => {
+  sessionStorage.clear();
+  delete (globalThis as { __VH_IMPORT_META_ENV__?: FlowEnv }).__VH_IMPORT_META_ENV__;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  sessionStorage.clear();
+});
+
+describe('SignInError', () => {
+  it('defaults its message to the reason code when none is given', () => {
+    const error = new SignInError('start_failed');
+    expect(error.reason).toBe('start_failed');
+    expect(error.message).toBe('start_failed');
+    expect(error.name).toBe('SignInError');
+  });
+});
+
+describe('PKCE primitives', () => {
+  it('generates a 43-char base64url verifier and a matching S256 challenge', async () => {
+    const verifier = generateCodeVerifier();
+    expect(verifier).toMatch(/^[A-Za-z0-9_-]{43}$/);
+    const challenge = await computeCodeChallenge(verifier);
+    expect(challenge).toMatch(/^[A-Za-z0-9_-]{43}$/);
+  });
+
+  it('throws crypto_unavailable when getRandomValues is missing', () => {
+    vi.spyOn(globalThis.crypto, 'getRandomValues').mockImplementation(() => {
+      throw new Error('unavailable');
+    });
+    // Force the guard by removing the method reference entirely.
+    const original = globalThis.crypto.getRandomValues;
+    Object.defineProperty(globalThis.crypto, 'getRandomValues', { value: undefined, configurable: true });
+    try {
+      expect(() => generateCodeVerifier()).toThrow(SignInError);
+    } finally {
+      Object.defineProperty(globalThis.crypto, 'getRandomValues', { value: original, configurable: true });
+    }
+  });
+
+  it('throws crypto_unavailable when subtle is missing', async () => {
+    const original = globalThis.crypto.subtle;
+    Object.defineProperty(globalThis.crypto, 'subtle', { value: undefined, configurable: true });
+    try {
+      await expect(computeCodeChallenge('verifier')).rejects.toMatchObject({ reason: 'crypto_unavailable' });
+    } finally {
+      Object.defineProperty(globalThis.crypto, 'subtle', { value: original, configurable: true });
+    }
+  });
+});
+
+describe('provider availability', () => {
+  it('real providers require a configured base URL', () => {
+    expect(isSignInProviderAvailable('apple', realEnv())).toBe(true);
+    expect(isSignInProviderAvailable('google', {})).toBe(false);
+    expect(isSignInProviderAvailable('apple', { VITE_AUTH_CALLBACK_BASE_URL: '  ' })).toBe(false);
+    expect(isSignInProviderAvailable('apple', { VITE_AUTH_CALLBACK_BASE_URL: 123 as unknown as string })).toBe(false);
+  });
+
+  it('rejects unknown providers', () => {
+    expect(isSignInProviderAvailable('reddit' as SignInFlowProvider, realEnv())).toBe(false);
+  });
+
+  it('mock provider requires e2e mode', () => {
+    expect(isSignInProviderAvailable('mock', e2eEnv())).toBe(true);
+    expect(isSignInProviderAvailable('mock', {})).toBe(false);
+  });
+
+  it('lists available providers for a real build and an e2e build', () => {
+    expect(availableSignInProviders(realEnv())).toEqual(['apple', 'google', 'x']);
+    expect(availableSignInProviders(e2eEnv())).toEqual(['mock']);
+    expect(availableSignInProviders(realEnv(e2eEnv()))).toEqual(['apple', 'google', 'x', 'mock']);
+    expect(availableSignInProviders({})).toEqual([]);
+  });
+
+  it('reads env from the global override when no arg is passed', () => {
+    (globalThis as { __VH_IMPORT_META_ENV__?: FlowEnv }).__VH_IMPORT_META_ENV__ = realEnv();
+    expect(isSignInProviderAvailable('apple')).toBe(true);
+    expect(availableSignInProviders()).toEqual(['apple', 'google', 'x']);
+  });
+
+  it('reads from import.meta.env when no override is set', () => {
+    // The vitest build env carries no VITE_AUTH_CALLBACK_BASE_URL, so no
+    // real provider is available and the mock is off without VITE_E2E_MODE.
+    expect(availableSignInProviders()).toEqual([]);
+  });
+});
+
+describe('startSignIn', () => {
+  it('rejects an unavailable provider', async () => {
+    await expect(startSignIn('apple', {})).rejects.toMatchObject({ reason: 'provider_unsupported' });
+  });
+
+  it('starts a mock flow with a synthetic authorize URL and default route', async () => {
+    const result = await startSignIn('mock', e2eEnv());
+    expect(result.provider).toBe('mock');
+    expect(result.authorizeUrl).toContain('/auth/callback?provider=mock&code=mock-code&state=');
+    expect(result.state).toMatch(/^mock-state-/);
+    expect(sessionStorage.getItem('vh:sign-in:pending-v1')).toContain('mock');
+  });
+
+  it('honours a custom callback route for the mock flow', async () => {
+    const result = await startSignIn('mock', e2eEnv({ VITE_AUTH_CALLBACK_ROUTE: '/custom/cb' }));
+    expect(result.authorizeUrl).toContain('/custom/cb?provider=mock');
+  });
+
+  it('posts the challenge to the boundary and returns the authorize URL', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      okResponse({ status: 'ok', authorizeUrl: `${BASE}/go`, parameters: { state: 'signed-state' } }),
+    );
+    const result = await startSignIn('google', realEnv());
+    expect(fetchMock).toHaveBeenCalledWith(`${BASE}/auth/google/start`, expect.objectContaining({ method: 'POST' }));
+    expect(result.authorizeUrl).toBe(`${BASE}/go`);
+    expect(result.state).toBe('signed-state');
+  });
+
+  it('rejects when the boundary base URL disappears after the availability check', async () => {
+    // isSignInProviderAvailable is true, but callbackBaseUrl trims to null:
+    // exercised by whitespace that passes typeof but not the length check is
+    // caught earlier; here we assert the boundary guard via a mock provider
+    // string that bypasses REAL_PROVIDERS is impossible — instead cover the
+    // real-provider boundary-missing branch by clearing after check.
+    const env = realEnv();
+    const fetchMock = vi.spyOn(globalThis, 'fetch');
+    // A non-200 start response maps to start_failed.
+    fetchMock.mockResolvedValue(okResponse({ status: 'rejected' }, 503));
+    await expect(startSignIn('apple', env)).rejects.toMatchObject({ reason: 'start_failed' });
+  });
+
+  it('maps a malformed start response to start_failed', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(okResponse({ status: 'ok', authorizeUrl: 42, parameters: {} }));
+    await expect(startSignIn('x', realEnv())).rejects.toMatchObject({ reason: 'start_failed' });
+  });
+
+  it('maps a network failure to network_error', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('offline'));
+    await expect(startSignIn('apple', realEnv())).rejects.toMatchObject({ reason: 'network_error' });
+  });
+
+  it('maps a non-JSON start response body to start_failed', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      status: 200,
+      json: async () => {
+        throw new Error('not json');
+      },
+    } as unknown as Response);
+    await expect(startSignIn('apple', realEnv())).rejects.toMatchObject({ reason: 'start_failed' });
+  });
+});
+
+describe('boundary_unconfigured on start', () => {
+  it('throws when a real provider passes availability but the base URL is gone', async () => {
+    // Directly stash a pending flow shape is not needed; force the branch by
+    // making isSignInProviderAvailable pass then base resolve to null. We do
+    // this by passing an env whose base URL is valid for the availability
+    // check but then mutated — simulate via a getter.
+    let calls = 0;
+    const env = new Proxy({} as FlowEnv, {
+      get(_target, prop) {
+        if (prop === 'VITE_AUTH_CALLBACK_BASE_URL') {
+          calls += 1;
+          return calls <= 1 ? BASE : '';
+        }
+        return undefined;
+      },
+    });
+    await expect(startSignIn('apple', env)).rejects.toMatchObject({ reason: 'boundary_unconfigured' });
+  });
+});
+
+describe('completeSignIn', () => {
+  async function primeMockPending(env = e2eEnv()): Promise<string> {
+    const started = await startSignIn('mock', env);
+    return started.state;
+  }
+
+  it('completes a mock flow and clears pending state', async () => {
+    const state = await primeMockPending();
+    const session = await completeSignIn({ code: 'mock-code', state, nowMs: 1000 }, e2eEnv());
+    expect(session).toEqual({
+      schemaVersion: 'vh-auth-session-v1',
+      providerId: 'apple',
+      providerSubject: expect.stringMatching(/^mock-subject-/),
+      displayLabel: 'mock@example.com',
+      issuedAt: 1000,
+      expiresAt: 1000 + 3600_000,
+    });
+    expect(sessionStorage.getItem('vh:sign-in:pending-v1')).toBeNull();
+  });
+
+  it('defaults nowMs to Date.now for the mock flow', async () => {
+    const state = await primeMockPending();
+    vi.spyOn(Date, 'now').mockReturnValue(7);
+    const session = await completeSignIn({ code: 'mock-code', state }, e2eEnv());
+    expect(session.issuedAt).toBe(7);
+  });
+
+  it('rejects the mock flow outside e2e mode', async () => {
+    const state = await primeMockPending();
+    await expect(completeSignIn({ code: 'mock-code', state }, {})).rejects.toMatchObject({
+      reason: 'provider_unsupported',
+    });
+  });
+
+  it('rejects when there is no pending flow', async () => {
+    await expect(completeSignIn({ code: 'c', state: 's' }, e2eEnv())).rejects.toMatchObject({
+      reason: 'pending_flow_missing',
+    });
+  });
+
+  it('rejects a mismatched state', async () => {
+    const state = await primeMockPending();
+    await expect(completeSignIn({ code: 'mock-code', state: `${state}x` }, e2eEnv())).rejects.toMatchObject({
+      reason: 'state_mismatch',
+    });
+  });
+
+  it('rejects a missing code', async () => {
+    const state = await primeMockPending();
+    await expect(completeSignIn({ code: '', state }, e2eEnv())).rejects.toMatchObject({
+      reason: 'callback_failed',
+    });
+  });
+
+  it('exchanges code + verifier at the boundary for a real provider', async () => {
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(okResponse({ status: 'ok', authorizeUrl: `${BASE}/go`, parameters: { state: 'st' } }))
+      .mockResolvedValueOnce(
+        okResponse({
+          status: 'ok',
+          session: {
+            schemaVersion: 'vh-auth-session-v1',
+            providerId: 'google',
+            providerSubject: 'sub-123',
+            displayLabel: 'p@e.com',
+            issuedAt: 5,
+            expiresAt: 9,
+          },
+        }),
+      );
+    await startSignIn('google', realEnv());
+    const session = await completeSignIn({ code: 'auth-code', state: 'st' }, realEnv());
+    expect(session.providerId).toBe('google');
+    expect(session.providerSubject).toBe('sub-123');
+    expect(session.expiresAt).toBe(9);
+  });
+
+  it('accepts a session with a null expiry and no display label', async () => {
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(okResponse({ status: 'ok', authorizeUrl: `${BASE}/go`, parameters: { state: 'st' } }))
+      .mockResolvedValueOnce(
+        okResponse({
+          status: 'ok',
+          session: {
+            schemaVersion: 'vh-auth-session-v1',
+            providerId: 'apple',
+            providerSubject: 'sub',
+            issuedAt: 1,
+            expiresAt: null,
+          },
+        }),
+      );
+    await startSignIn('apple', realEnv());
+    const session = await completeSignIn({ code: 'c', state: 'st' }, realEnv());
+    expect(session.expiresAt).toBeNull();
+    expect(session.displayLabel).toBeUndefined();
+  });
+
+  it('maps a non-200 callback to callback_failed', async () => {
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(okResponse({ status: 'ok', authorizeUrl: `${BASE}/go`, parameters: { state: 'st' } }))
+      .mockResolvedValueOnce(okResponse({ status: 'rejected', reason: 'code_verifier_mismatch' }, 401));
+    await startSignIn('apple', realEnv());
+    await expect(completeSignIn({ code: 'c', state: 'st' }, realEnv())).rejects.toMatchObject({
+      reason: 'callback_failed',
+    });
+  });
+
+  it('maps a non-ok callback body to callback_failed', async () => {
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(okResponse({ status: 'ok', authorizeUrl: `${BASE}/go`, parameters: { state: 'st' } }))
+      .mockResolvedValueOnce(okResponse({ status: 'rejected' }, 200));
+    await startSignIn('apple', realEnv());
+    await expect(completeSignIn({ code: 'c', state: 'st' }, realEnv())).rejects.toMatchObject({
+      reason: 'callback_failed',
+    });
+  });
+
+  it('maps a missing session object to session_invalid', async () => {
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(okResponse({ status: 'ok', authorizeUrl: `${BASE}/go`, parameters: { state: 'st' } }))
+      .mockResolvedValueOnce(okResponse({ status: 'ok', session: null }, 200));
+    await startSignIn('apple', realEnv());
+    await expect(completeSignIn({ code: 'c', state: 'st' }, realEnv())).rejects.toMatchObject({
+      reason: 'session_invalid',
+    });
+  });
+
+  it('maps a malformed session payload to session_invalid', async () => {
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(okResponse({ status: 'ok', authorizeUrl: `${BASE}/go`, parameters: { state: 'st' } }))
+      .mockResolvedValueOnce(
+        okResponse({ status: 'ok', session: { schemaVersion: 'vh-auth-session-v1', providerId: 'reddit', providerSubject: 'x', issuedAt: 1, expiresAt: 1 } }, 200),
+      );
+    await startSignIn('apple', realEnv());
+    await expect(completeSignIn({ code: 'c', state: 'st' }, realEnv())).rejects.toMatchObject({
+      reason: 'session_invalid',
+    });
+  });
+
+  it('throws boundary_unconfigured when the base URL vanishes before callback', async () => {
+    // Prime a real pending flow, then complete with an env missing the base URL.
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      okResponse({ status: 'ok', authorizeUrl: `${BASE}/go`, parameters: { state: 'st' } }),
+    );
+    await startSignIn('apple', realEnv());
+    await expect(completeSignIn({ code: 'c', state: 'st' }, {})).rejects.toMatchObject({
+      reason: 'boundary_unconfigured',
+    });
+  });
+});
+
+describe('pending-flow custody edge cases', () => {
+  it('ignores a corrupt pending record', async () => {
+    sessionStorage.setItem('vh:sign-in:pending-v1', '{not json');
+    await expect(completeSignIn({ code: 'c', state: 's' }, e2eEnv())).rejects.toMatchObject({
+      reason: 'pending_flow_missing',
+    });
+  });
+
+  it('ignores a structurally invalid pending record', async () => {
+    sessionStorage.setItem('vh:sign-in:pending-v1', JSON.stringify({ provider: 'mock', codeVerifier: '', state: 's' }));
+    await expect(completeSignIn({ code: 'c', state: 's' }, e2eEnv())).rejects.toMatchObject({
+      reason: 'pending_flow_missing',
+    });
+  });
+
+  it('clearPendingSignIn removes the stashed material', async () => {
+    await startSignIn('mock', e2eEnv());
+    expect(sessionStorage.getItem('vh:sign-in:pending-v1')).not.toBeNull();
+    clearPendingSignIn();
+    expect(sessionStorage.getItem('vh:sign-in:pending-v1')).toBeNull();
+  });
+});
+
+describe('sessionStorage unavailable', () => {
+  it('treats an absent sessionStorage as no pending flow', async () => {
+    const descriptor = Object.getOwnPropertyDescriptor(globalThis, 'sessionStorage');
+    Object.defineProperty(globalThis, 'sessionStorage', { configurable: true, value: undefined });
+    try {
+      const started = await startSignIn('mock', e2eEnv());
+      await expect(completeSignIn({ code: 'mock-code', state: started.state }, e2eEnv())).rejects.toMatchObject({
+        reason: 'pending_flow_missing',
+      });
+    } finally {
+      if (descriptor) {
+        Object.defineProperty(globalThis, 'sessionStorage', descriptor);
+      }
+    }
+  });
+
+  it('persist/read/clear degrade gracefully when sessionStorage throws', async () => {
+    const descriptor = Object.getOwnPropertyDescriptor(globalThis, 'sessionStorage');
+    Object.defineProperty(globalThis, 'sessionStorage', {
+      configurable: true,
+      get() {
+        throw new Error('blocked');
+      },
+    });
+    try {
+      // start persists nothing; complete then finds no pending flow.
+      const started = await startSignIn('mock', e2eEnv());
+      await expect(completeSignIn({ code: 'mock-code', state: started.state }, e2eEnv())).rejects.toMatchObject({
+        reason: 'pending_flow_missing',
+      });
+      expect(() => clearPendingSignIn()).not.toThrow();
+    } finally {
+      if (descriptor) {
+        Object.defineProperty(globalThis, 'sessionStorage', descriptor);
+      }
+    }
+  });
+});

--- a/apps/web-pwa/src/auth/signInFlow.ts
+++ b/apps/web-pwa/src/auth/signInFlow.ts
@@ -214,6 +214,9 @@ export function clearPendingSignIn(): void {
 async function postJson(url: string, body: unknown): Promise<{ status: number; json: unknown }> {
   let response: Response;
   try {
+    // No `credentials`: the boundary is authenticated by the signed state +
+    // PKCE verifier in the body, not cookies. Do NOT add credentials:'include'
+    // — it would widen the CSRF surface the state/PKCE binding closes.
     response = await fetch(url, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },

--- a/apps/web-pwa/src/auth/signInFlow.ts
+++ b/apps/web-pwa/src/auth/signInFlow.ts
@@ -16,10 +16,11 @@
  *      browser — that custody lives entirely in the boundary.
  *
  * Real providers are gated behind the deployment profile (a configured
- * `VITE_AUTH_CALLBACK_BASE_URL`). An E2E-only mock provider path
- * (`mock`), permitted just like PROVIDER_PROFILE_ALLOW_LIST entries in
- * dev/e2e, completes the same shaped round-trip against an in-process
- * stub with no network, so the whole flow is testable in CI.
+ * `VITE_AUTH_CALLBACK_BASE_URL`). Under `VITE_E2E_MODE` the same
+ * `apple`/`google`/`x` provider ids instead run an in-process mock
+ * exchange with no network (permitted just like the dev/e2e entries of
+ * PROVIDER_PROFILE_ALLOW_LIST), so the whole flow is testable in CI and
+ * the account record ids line up with the offered provider tiles.
  *
  * Transient PKCE material (the verifier + provider) is held in
  * `sessionStorage`, never the URL, browser history, or any `vh/*`
@@ -29,8 +30,8 @@
 
 import type { SignInProviderIdType } from '@vh/data-model';
 
-/** Providers a browser can begin sign-in with, incl. the e2e mock. */
-export type SignInFlowProvider = SignInProviderIdType | 'mock';
+/** Providers a browser can begin sign-in with. */
+export type SignInFlowProvider = SignInProviderIdType;
 
 /** Non-secret session payload the boundary returns (vh-auth-session-v1). */
 export interface SignInSessionPayload {
@@ -107,35 +108,22 @@ function callbackBaseUrl(env: SignInFlowEnv): string | null {
 
 /**
  * Whether a provider can begin a sign-in flow in the current build.
- * Real providers require a configured boundary base URL; the `mock`
- * provider is permitted only under VITE_E2E_MODE (mirroring the
- * PROVIDER_PROFILE_ALLOW_LIST dev/e2e gating).
+ * Under VITE_E2E_MODE every real provider id runs the in-process mock
+ * exchange; otherwise a provider requires a configured boundary base URL.
  */
 export function isSignInProviderAvailable(
   provider: SignInFlowProvider,
   env: SignInFlowEnv = readEnv()
 ): boolean {
-  if (provider === 'mock') {
-    return isE2eMode(env);
-  }
   if (!REAL_PROVIDERS.includes(provider)) {
     return false;
   }
-  return typeof callbackBaseUrl(env) === 'string';
+  return isE2eMode(env) || typeof callbackBaseUrl(env) === 'string';
 }
 
 /** The list of providers offered to the user in the current build. */
 export function availableSignInProviders(env: SignInFlowEnv = readEnv()): SignInFlowProvider[] {
-  const providers: SignInFlowProvider[] = [];
-  for (const provider of REAL_PROVIDERS) {
-    if (isSignInProviderAvailable(provider, env)) {
-      providers.push(provider);
-    }
-  }
-  if (isSignInProviderAvailable('mock', env)) {
-    providers.push('mock');
-  }
-  return providers;
+  return REAL_PROVIDERS.filter((provider) => isSignInProviderAvailable(provider, env));
 }
 
 function sessionStore(): Storage | null {
@@ -202,6 +190,7 @@ function readPendingFlow(): PendingFlow | null {
     const parsed = JSON.parse(raw) as Partial<PendingFlow>;
     if (
       typeof parsed?.provider !== 'string'
+      || !REAL_PROVIDERS.includes(parsed.provider as SignInProviderIdType)
       || typeof parsed.codeVerifier !== 'string'
       || parsed.codeVerifier.length === 0
       || typeof parsed.state !== 'string'
@@ -209,7 +198,7 @@ function readPendingFlow(): PendingFlow | null {
     ) {
       return null;
     }
-    return { provider: parsed.provider as SignInFlowProvider, codeVerifier: parsed.codeVerifier, state: parsed.state };
+    return { provider: parsed.provider, codeVerifier: parsed.codeVerifier, state: parsed.state };
   } catch {
     return null;
   }
@@ -254,12 +243,16 @@ function isOkObject(json: unknown): json is Record<string, unknown> {
  * vh-auth-session-v1 payload, so the client wiring is exercised end to
  * end without a network provider.
  */
-function mockSessionFor(state: string, nowMs: number): SignInSessionPayload {
+function mockSessionFor(
+  provider: SignInProviderIdType,
+  state: string,
+  nowMs: number
+): SignInSessionPayload {
   return {
     schemaVersion: 'vh-auth-session-v1',
-    providerId: 'apple',
-    providerSubject: `mock-subject-${state.slice(0, 8)}`,
-    displayLabel: 'mock@example.com',
+    providerId: provider,
+    providerSubject: `mock-subject-${provider}-${state.slice(0, 8)}`,
+    displayLabel: `mock-${provider}@example.com`,
     issuedAt: nowMs,
     expiresAt: nowMs + 3600_000,
   };
@@ -317,11 +310,11 @@ export async function startSignIn(
   const codeVerifier = generateCodeVerifier();
   const codeChallenge = await computeCodeChallenge(codeVerifier);
 
-  if (provider === 'mock') {
-    const state = `mock-state-${codeChallenge.slice(0, 16)}`;
+  if (isE2eMode(env)) {
+    const state = `mock-state-${provider}-${codeChallenge.slice(0, 16)}`;
     persistPendingFlow({ provider, codeVerifier, state });
     const callbackPath = env.VITE_AUTH_CALLBACK_ROUTE ?? '/auth/callback';
-    const authorizeUrl = `${callbackPath}?provider=mock&code=mock-code&state=${encodeURIComponent(state)}`;
+    const authorizeUrl = `${callbackPath}?provider=${provider}&code=mock-code&state=${encodeURIComponent(state)}`;
     return { provider, authorizeUrl, state };
   }
 
@@ -368,11 +361,8 @@ export async function completeSignIn(
       throw new SignInError('callback_failed', 'sign-in code missing');
     }
 
-    if (pending.provider === 'mock') {
-      if (!isE2eMode(env)) {
-        throw new SignInError('provider_unsupported', 'mock sign-in provider requires VITE_E2E_MODE');
-      }
-      return mockSessionFor(pending.state, params.nowMs ?? Date.now());
+    if (isE2eMode(env)) {
+      return mockSessionFor(pending.provider, pending.state, params.nowMs ?? Date.now());
     }
 
     const base = callbackBaseUrl(env);

--- a/apps/web-pwa/src/auth/signInFlow.ts
+++ b/apps/web-pwa/src/auth/signInFlow.ts
@@ -1,0 +1,395 @@
+/**
+ * Browser sign-in flow (Lane C, Slices C0/C1 client side).
+ *
+ * Drives the PKCE OAuth/OIDC round-trip against the deployed
+ * auth-callback boundary (services/auth-callback). The browser:
+ *
+ *   1. generates a PKCE `code_verifier` and its S256 `code_challenge`
+ *      with WebCrypto;
+ *   2. POSTs the challenge to `/auth/:provider/start` and receives an
+ *      HMAC-signed `state` plus the provider authorize URL;
+ *   3. is redirected back to the PWA with `code` + `state`;
+ *   4. POSTs `code` + `state` + `code_verifier` to
+ *      `/auth/:provider/callback` and receives the NON-SECRET
+ *      `vh-auth-session-v1` payload (provider id, subject, optional
+ *      display label, expiry). Raw provider tokens never reach the
+ *      browser — that custody lives entirely in the boundary.
+ *
+ * Real providers are gated behind the deployment profile (a configured
+ * `VITE_AUTH_CALLBACK_BASE_URL`). An E2E-only mock provider path
+ * (`mock`), permitted just like PROVIDER_PROFILE_ALLOW_LIST entries in
+ * dev/e2e, completes the same shaped round-trip against an in-process
+ * stub with no network, so the whole flow is testable in CI.
+ *
+ * Transient PKCE material (the verifier + provider) is held in
+ * `sessionStorage`, never the URL, browser history, or any `vh/*`
+ * record. Any failure surfaces as a clean SignInError with no partial
+ * session and no secret in state or history.
+ */
+
+import type { SignInProviderIdType } from '@vh/data-model';
+
+/** Providers a browser can begin sign-in with, incl. the e2e mock. */
+export type SignInFlowProvider = SignInProviderIdType | 'mock';
+
+/** Non-secret session payload the boundary returns (vh-auth-session-v1). */
+export interface SignInSessionPayload {
+  schemaVersion: 'vh-auth-session-v1';
+  providerId: SignInProviderIdType;
+  providerSubject: string;
+  displayLabel?: string;
+  issuedAt: number;
+  expiresAt: number | null;
+}
+
+/** Result of the /start leg: the URL to open + opaque bound state. */
+export interface SignInStartResult {
+  provider: SignInFlowProvider;
+  authorizeUrl: string;
+  state: string;
+}
+
+export type SignInErrorReason =
+  | 'provider_unsupported'
+  | 'boundary_unconfigured'
+  | 'crypto_unavailable'
+  | 'start_failed'
+  | 'callback_failed'
+  | 'session_invalid'
+  | 'pending_flow_missing'
+  | 'state_mismatch'
+  | 'network_error';
+
+/** A clean sign-in failure: stable reason code, no secret material. */
+export class SignInError extends Error {
+  readonly reason: SignInErrorReason;
+
+  constructor(reason: SignInErrorReason, message?: string) {
+    super(message ?? reason);
+    this.name = 'SignInError';
+    this.reason = reason;
+  }
+}
+
+const REAL_PROVIDERS: readonly SignInProviderIdType[] = ['apple', 'google', 'x'];
+const PENDING_STORAGE_KEY = 'vh:sign-in:pending-v1';
+
+interface PendingFlow {
+  provider: SignInFlowProvider;
+  codeVerifier: string;
+  state: string;
+}
+
+type SignInFlowEnv = Record<string, string | boolean | undefined>;
+
+function readEnv(): SignInFlowEnv {
+  const override = (globalThis as typeof globalThis & {
+    __VH_IMPORT_META_ENV__?: SignInFlowEnv;
+  }).__VH_IMPORT_META_ENV__;
+  // Vite statically inlines `import.meta.env` as a defined object, so no
+  // extra nullish fallback is needed here; the override exists purely for
+  // deterministic testing.
+  return override ?? (import.meta as unknown as { env: SignInFlowEnv }).env;
+}
+
+function isE2eMode(env: SignInFlowEnv): boolean {
+  return env.VITE_E2E_MODE === 'true';
+}
+
+function callbackBaseUrl(env: SignInFlowEnv): string | null {
+  const raw = env.VITE_AUTH_CALLBACK_BASE_URL;
+  if (typeof raw !== 'string') {
+    return null;
+  }
+  const trimmed = raw.trim().replace(/\/+$/u, '');
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+/**
+ * Whether a provider can begin a sign-in flow in the current build.
+ * Real providers require a configured boundary base URL; the `mock`
+ * provider is permitted only under VITE_E2E_MODE (mirroring the
+ * PROVIDER_PROFILE_ALLOW_LIST dev/e2e gating).
+ */
+export function isSignInProviderAvailable(
+  provider: SignInFlowProvider,
+  env: SignInFlowEnv = readEnv()
+): boolean {
+  if (provider === 'mock') {
+    return isE2eMode(env);
+  }
+  if (!REAL_PROVIDERS.includes(provider)) {
+    return false;
+  }
+  return typeof callbackBaseUrl(env) === 'string';
+}
+
+/** The list of providers offered to the user in the current build. */
+export function availableSignInProviders(env: SignInFlowEnv = readEnv()): SignInFlowProvider[] {
+  const providers: SignInFlowProvider[] = [];
+  for (const provider of REAL_PROVIDERS) {
+    if (isSignInProviderAvailable(provider, env)) {
+      providers.push(provider);
+    }
+  }
+  if (isSignInProviderAvailable('mock', env)) {
+    providers.push('mock');
+  }
+  return providers;
+}
+
+function sessionStore(): Storage | null {
+  try {
+    return globalThis.sessionStorage ?? null;
+  } catch {
+    return null;
+  }
+}
+
+// ── PKCE primitives (WebCrypto) ────────────────────────────────────
+
+function subtle(): SubtleCrypto {
+  const provided = globalThis.crypto?.subtle;
+  if (!provided) {
+    throw new SignInError('crypto_unavailable', 'WebCrypto subtle API is required');
+  }
+  return provided;
+}
+
+function bytesToBase64Url(bytes: Uint8Array): string {
+  let binary = '';
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary).replaceAll('+', '-').replaceAll('/', '_').replace(/=+$/u, '');
+}
+
+/** Generate a PKCE code_verifier (43-char base64url, matches the boundary regex). */
+export function generateCodeVerifier(): string {
+  const random = globalThis.crypto?.getRandomValues?.bind(globalThis.crypto);
+  if (!random) {
+    throw new SignInError('crypto_unavailable', 'crypto.getRandomValues is required');
+  }
+  return bytesToBase64Url(random(new Uint8Array(32)));
+}
+
+/** Compute the S256 code_challenge for a verifier. */
+export async function computeCodeChallenge(codeVerifier: string): Promise<string> {
+  const digest = await subtle().digest('SHA-256', new TextEncoder().encode(codeVerifier));
+  return bytesToBase64Url(new Uint8Array(digest));
+}
+
+// ── Pending-flow custody (sessionStorage, never the URL) ───────────
+
+function persistPendingFlow(flow: PendingFlow): void {
+  const store = sessionStore();
+  if (!store) {
+    return;
+  }
+  store.setItem(PENDING_STORAGE_KEY, JSON.stringify(flow));
+}
+
+function readPendingFlow(): PendingFlow | null {
+  const store = sessionStore();
+  if (!store) {
+    return null;
+  }
+  const raw = store.getItem(PENDING_STORAGE_KEY);
+  if (!raw) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(raw) as Partial<PendingFlow>;
+    if (
+      typeof parsed?.provider !== 'string'
+      || typeof parsed.codeVerifier !== 'string'
+      || parsed.codeVerifier.length === 0
+      || typeof parsed.state !== 'string'
+      || parsed.state.length === 0
+    ) {
+      return null;
+    }
+    return { provider: parsed.provider as SignInFlowProvider, codeVerifier: parsed.codeVerifier, state: parsed.state };
+  } catch {
+    return null;
+  }
+}
+
+/** Clear transient PKCE material after a completed or abandoned flow. */
+export function clearPendingSignIn(): void {
+  sessionStore()?.removeItem(PENDING_STORAGE_KEY);
+}
+
+// ── Network helpers ────────────────────────────────────────────────
+
+async function postJson(url: string, body: unknown): Promise<{ status: number; json: unknown }> {
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+  } catch {
+    throw new SignInError('network_error', 'sign-in boundary unreachable');
+  }
+  let json: unknown = null;
+  try {
+    json = await response.json();
+  } catch {
+    json = null;
+  }
+  return { status: response.status, json };
+}
+
+function isOkObject(json: unknown): json is Record<string, unknown> {
+  return typeof json === 'object' && json !== null && (json as { status?: unknown }).status === 'ok';
+}
+
+// ── Mock provider (E2E only, no network) ───────────────────────────
+
+/**
+ * In-process mock exchange used only under VITE_E2E_MODE. It produces a
+ * deterministic non-secret session shaped exactly like the boundary's
+ * vh-auth-session-v1 payload, so the client wiring is exercised end to
+ * end without a network provider.
+ */
+function mockSessionFor(state: string, nowMs: number): SignInSessionPayload {
+  return {
+    schemaVersion: 'vh-auth-session-v1',
+    providerId: 'apple',
+    providerSubject: `mock-subject-${state.slice(0, 8)}`,
+    displayLabel: 'mock@example.com',
+    issuedAt: nowMs,
+    expiresAt: nowMs + 3600_000,
+  };
+}
+
+// ── Session validation ─────────────────────────────────────────────
+
+function toSessionPayload(json: unknown): SignInSessionPayload {
+  if (!isOkObject(json)) {
+    throw new SignInError('callback_failed', 'sign-in callback rejected');
+  }
+  const session = (json as { session?: unknown }).session;
+  if (typeof session !== 'object' || session === null) {
+    throw new SignInError('session_invalid', 'sign-in session missing');
+  }
+  const record = session as Record<string, unknown>;
+  if (
+    record.schemaVersion !== 'vh-auth-session-v1'
+    || typeof record.providerId !== 'string'
+    || !REAL_PROVIDERS.includes(record.providerId as SignInProviderIdType)
+    || typeof record.providerSubject !== 'string'
+    || record.providerSubject.length === 0
+    || (record.displayLabel !== undefined && typeof record.displayLabel !== 'string')
+    || typeof record.issuedAt !== 'number'
+    || (record.expiresAt !== null && typeof record.expiresAt !== 'number')
+  ) {
+    throw new SignInError('session_invalid', 'sign-in session malformed');
+  }
+  return {
+    schemaVersion: 'vh-auth-session-v1',
+    providerId: record.providerId as SignInProviderIdType,
+    providerSubject: record.providerSubject,
+    ...(typeof record.displayLabel === 'string' ? { displayLabel: record.displayLabel } : {}),
+    issuedAt: record.issuedAt,
+    expiresAt: record.expiresAt as number | null,
+  };
+}
+
+// ── Public flow API ────────────────────────────────────────────────
+
+/**
+ * Begin a sign-in: generate PKCE material, ask the boundary for a bound
+ * `state` + authorize URL, and stash the verifier transiently. The
+ * caller opens `authorizeUrl`. For the `mock` provider the round-trip is
+ * local; a synthetic authorize URL routes straight to the PWA callback.
+ */
+export async function startSignIn(
+  provider: SignInFlowProvider,
+  env: SignInFlowEnv = readEnv()
+): Promise<SignInStartResult> {
+  if (!isSignInProviderAvailable(provider, env)) {
+    throw new SignInError('provider_unsupported', `sign-in provider ${provider} is not available`);
+  }
+
+  const codeVerifier = generateCodeVerifier();
+  const codeChallenge = await computeCodeChallenge(codeVerifier);
+
+  if (provider === 'mock') {
+    const state = `mock-state-${codeChallenge.slice(0, 16)}`;
+    persistPendingFlow({ provider, codeVerifier, state });
+    const callbackPath = env.VITE_AUTH_CALLBACK_ROUTE ?? '/auth/callback';
+    const authorizeUrl = `${callbackPath}?provider=mock&code=mock-code&state=${encodeURIComponent(state)}`;
+    return { provider, authorizeUrl, state };
+  }
+
+  const base = callbackBaseUrl(env);
+  if (!base) {
+    throw new SignInError('boundary_unconfigured', 'sign-in boundary base URL is not configured');
+  }
+
+  const { status, json } = await postJson(`${base}/auth/${provider}/start`, { codeChallenge });
+  if (status !== 200 || !isOkObject(json)) {
+    throw new SignInError('start_failed', 'sign-in start rejected');
+  }
+  const authorizeUrl = (json as { authorizeUrl?: unknown }).authorizeUrl;
+  const parameters = (json as { parameters?: { state?: unknown } }).parameters;
+  const state = parameters?.state;
+  if (typeof authorizeUrl !== 'string' || typeof state !== 'string' || state.length === 0) {
+    throw new SignInError('start_failed', 'sign-in start response malformed');
+  }
+
+  persistPendingFlow({ provider, codeVerifier, state });
+  return { provider, authorizeUrl, state };
+}
+
+/**
+ * Complete a sign-in after the provider redirect. Verifies the returned
+ * `state` matches the stashed pending flow, then exchanges
+ * code + verifier at the boundary and returns the non-secret session.
+ * Always clears the pending material — success or failure — so no
+ * partial session lingers.
+ */
+export async function completeSignIn(
+  params: { code: string; state: string; nowMs?: number },
+  env: SignInFlowEnv = readEnv()
+): Promise<SignInSessionPayload> {
+  const pending = readPendingFlow();
+  try {
+    if (!pending) {
+      throw new SignInError('pending_flow_missing', 'no pending sign-in flow');
+    }
+    if (typeof params.state !== 'string' || params.state !== pending.state) {
+      throw new SignInError('state_mismatch', 'sign-in state mismatch');
+    }
+    if (typeof params.code !== 'string' || params.code.length === 0) {
+      throw new SignInError('callback_failed', 'sign-in code missing');
+    }
+
+    if (pending.provider === 'mock') {
+      if (!isE2eMode(env)) {
+        throw new SignInError('provider_unsupported', 'mock sign-in provider requires VITE_E2E_MODE');
+      }
+      return mockSessionFor(pending.state, params.nowMs ?? Date.now());
+    }
+
+    const base = callbackBaseUrl(env);
+    if (!base) {
+      throw new SignInError('boundary_unconfigured', 'sign-in boundary base URL is not configured');
+    }
+
+    const { status, json } = await postJson(`${base}/auth/${pending.provider}/callback`, {
+      code: params.code,
+      state: params.state,
+      codeVerifier: pending.codeVerifier,
+    });
+    if (status !== 200) {
+      throw new SignInError('callback_failed', 'sign-in callback rejected');
+    }
+    return toSessionPayload(json);
+  } finally {
+    clearPendingSignIn();
+  }
+}

--- a/apps/web-pwa/src/auth/signInFlow.ts
+++ b/apps/web-pwa/src/auth/signInFlow.ts
@@ -296,7 +296,7 @@ function toSessionPayload(json: unknown): SignInSessionPayload {
 /**
  * Begin a sign-in: generate PKCE material, ask the boundary for a bound
  * `state` + authorize URL, and stash the verifier transiently. The
- * caller opens `authorizeUrl`. For the `mock` provider the round-trip is
+ * caller opens `authorizeUrl`. Under VITE_E2E_MODE the round-trip is
  * local; a synthetic authorize URL routes straight to the PWA callback.
  */
 export async function startSignIn(

--- a/apps/web-pwa/src/components/account/SignInProviderSection.tsx
+++ b/apps/web-pwa/src/components/account/SignInProviderSection.tsx
@@ -1,0 +1,129 @@
+import React, { useMemo } from 'react';
+import { Button } from '@vh/ui';
+import { useSignIn, type SignInIdentityBridge } from '../../hooks/useSignIn';
+import type { SignInFlowProvider } from '../../auth/signInFlow';
+import type { SignInAccountRecord } from '@vh/data-model';
+
+const PROVIDER_LABELS: Record<SignInFlowProvider, string> = {
+  apple: 'Apple',
+  google: 'Google',
+  x: 'X',
+  mock: 'Mock (test)',
+};
+
+function statusLabel(record: SignInAccountRecord | undefined): string {
+  if (!record) return 'Not connected';
+  if (record.status === 'signed-in') return 'Connected';
+  if (record.status === 'expired') return 'Session expired — reconnect';
+  return 'Signed out';
+}
+
+export interface SignInProviderSectionProps {
+  readonly identity: SignInIdentityBridge;
+}
+
+/**
+ * Account sign-in provider management (Slice C3). Distinct from the
+ * flag-gated linked-social notification-account feature: this drives
+ * account continuity/recovery only, never human-uniqueness. Copy stays
+ * inside the claim boundary — no verified-human / one-human-one-vote /
+ * anonymity language.
+ */
+export const SignInProviderSection: React.FC<SignInProviderSectionProps> = ({ identity }) => {
+  const { providers, accounts, phase, error, beginSignIn, signOutProvider } = useSignIn(identity);
+
+  const accountByProvider = useMemo(() => {
+    const map = new Map<string, SignInAccountRecord>();
+    for (const account of accounts) {
+      map.set(account.providerId, account);
+    }
+    return map;
+  }, [accounts]);
+
+  const connect = async (provider: SignInFlowProvider) => {
+    const authorizeUrl = await beginSignIn(provider);
+    if (!authorizeUrl) return;
+    // Same-origin mock authorize URLs and cross-origin provider authorize
+    // URLs are both handled by a full navigation: the app-side callback
+    // route completes the round-trip. No PKCE material rides the URL.
+    window.location.assign(authorizeUrl);
+  };
+
+  if (providers.length === 0) {
+    return (
+      <div className="rounded-lg border border-slate-200 bg-card p-5 shadow-sm dark:border-slate-700" data-testid="signin-providers">
+        <h2 className="text-base font-semibold text-slate-950 dark:text-slate-50">Sign-in accounts</h2>
+        <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">
+          Account sign-in is not configured in this build. You can still create a beta-local identity above.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border border-slate-200 bg-card p-5 shadow-sm dark:border-slate-700" data-testid="signin-providers">
+      <div>
+        <h2 className="text-base font-semibold text-slate-950 dark:text-slate-50">Sign-in accounts</h2>
+        <p className="mt-1 text-sm text-slate-600 dark:text-slate-300">
+          Connect Apple, Google, or X for account continuity and profile recovery. This is not a proof of a unique person,
+          and your votes always stay under your beta-local identity on this device.
+        </p>
+      </div>
+
+      {error && (
+        <p className="mt-3 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-800" role="alert" data-testid="signin-error">
+          Sign-in could not start ({error}).
+        </p>
+      )}
+
+      <ul className="mt-4 space-y-2">
+        {providers.map((provider) => {
+          const record = accountByProvider.get(provider);
+          const connected = record?.status === 'signed-in';
+          return (
+            <li
+              key={provider}
+              className="flex flex-wrap items-center justify-between gap-3 rounded-md border border-slate-100 bg-card-muted px-3 py-2 dark:border-slate-700/70"
+              data-testid={`signin-provider-${provider}`}
+            >
+              <div>
+                <p className="text-sm font-semibold text-slate-900 dark:text-slate-100">{PROVIDER_LABELS[provider]}</p>
+                <p className="text-xs text-slate-500" data-testid={`signin-status-${provider}`}>
+                  {statusLabel(record)}
+                  {record?.displayLabel ? ` · ${record.displayLabel}` : ''}
+                </p>
+              </div>
+              {connected && record ? (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  data-testid={`signin-disconnect-${provider}`}
+                  onClick={() => signOutProvider(record)}
+                >
+                  Disconnect
+                </Button>
+              ) : (
+                <Button
+                  type="button"
+                  variant="secondary"
+                  data-testid={`signin-connect-${provider}`}
+                  disabled={phase === 'starting'}
+                  onClick={() => void connect(provider)}
+                >
+                  {phase === 'starting' ? 'Starting...' : 'Connect'}
+                </Button>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+
+      <p className="mt-3 text-xs text-slate-500">
+        Disconnecting removes the account link on this device. It does not delete anything from the provider or the
+        network, and your beta-local identity and its history are unaffected.
+      </p>
+    </div>
+  );
+};
+
+export default SignInProviderSection;

--- a/apps/web-pwa/src/components/account/SignInProviderSection.tsx
+++ b/apps/web-pwa/src/components/account/SignInProviderSection.tsx
@@ -8,7 +8,6 @@ const PROVIDER_LABELS: Record<SignInFlowProvider, string> = {
   apple: 'Apple',
   google: 'Google',
   x: 'X',
-  mock: 'Mock (test)',
 };
 
 function statusLabel(record: SignInAccountRecord | undefined): string {
@@ -26,8 +25,8 @@ export interface SignInProviderSectionProps {
  * Account sign-in provider management (Slice C3). Distinct from the
  * flag-gated linked-social notification-account feature: this drives
  * account continuity/recovery only, never human-uniqueness. Copy stays
- * inside the claim boundary — no verified-human / one-human-one-vote /
- * anonymity language.
+ * inside the beta-local claim boundary — see the plan's "Account And
+ * LUMA Semantics" for the forbidden-claim registry this must respect.
  */
 export const SignInProviderSection: React.FC<SignInProviderSectionProps> = ({ identity }) => {
   const { providers, accounts, phase, error, beginSignIn, signOutProvider } = useSignIn(identity);

--- a/apps/web-pwa/src/components/feed/CellVoteControls.test.tsx
+++ b/apps/web-pwa/src/components/feed/CellVoteControls.test.tsx
@@ -225,6 +225,33 @@ describe('CellVoteControls', () => {
     );
   });
 
+  it('offers a sign-in link carrying return topic/point state when proof is missing', () => {
+    useConstituencyProofMock.mockReturnValue({
+      proof: null,
+      error: null,
+      assurance: 'none',
+      canClaimVerifiedHuman: false,
+      canClaimDistrictProof: false,
+      canClaimSybilResistance: false,
+    });
+
+    render(<CellVoteControls {...BASE_PROPS} synthesisPointId="canonical-xyz" pointLabel="  Frame headline  " />);
+
+    const link = screen.getByTestId('cell-vote-signin-point-abc');
+    expect(link).toHaveTextContent('Sign in to vote');
+    expect(link).toHaveAttribute(
+      'href',
+      '/account/identity?returnTopicId=topic-1&returnPointId=canonical-xyz',
+    );
+    // A trimmed non-empty label is used for the accessible vote target.
+    expect(screen.getByLabelText('Agree with Frame headline')).toBeInTheDocument();
+  });
+
+  it('does not show the sign-in link once a proof is present', () => {
+    render(<CellVoteControls {...BASE_PROPS} />);
+    expect(screen.queryByTestId('cell-vote-signin-point-abc')).not.toBeInTheDocument();
+  });
+
   it('denial with no reason clears visible denial message', () => {
     vi.spyOn(useSentimentState.getState(), 'setAgreement')
       .mockReturnValueOnce(deniedReceipt('Daily limit reached for sentiment_votes/day'))

--- a/apps/web-pwa/src/components/feed/CellVoteControls.tsx
+++ b/apps/web-pwa/src/components/feed/CellVoteControls.tsx
@@ -120,6 +120,14 @@ export const CellVoteControls: React.FC<CellVoteControlsProps> = ({
 
   const hasIdPartition = !!(legacyPointId && legacyPointId !== canonicalPointId);
   const accessibleTarget = pointLabel?.trim() || pointId;
+  // Route a signed-out user into sign-in / identity creation, carrying
+  // return state (topic + point) so they land back on this story/point.
+  // The vote is only ever admitted after a fully successful sign-in +
+  // binding — the return trip never carries a partially admitted vote.
+  const signInHref = `/account/identity?${new URLSearchParams({
+    returnTopicId: topicId,
+    returnPointId: canonicalPointId,
+  }).toString()}`;
 
   useEffect(() => {
     const payload = {
@@ -281,6 +289,15 @@ export const CellVoteControls: React.FC<CellVoteControlsProps> = ({
         >
           {proofError ?? 'Create or sign in to save your stance'}
         </span>
+      )}
+      {!hasProof && (
+        <a
+          className="text-[10px] font-semibold text-sky-700 underline underline-offset-2"
+          href={signInHref}
+          data-testid={`cell-vote-signin-${pointId}`}
+        >
+          Sign in to vote
+        </a>
       )}
       {denialText && (
         <span

--- a/apps/web-pwa/src/hooks/useIdentity.ts
+++ b/apps/web-pwa/src/hooks/useIdentity.ts
@@ -15,6 +15,7 @@ import { authenticateGunUser, publishDirectoryEntry, useAppStore } from '../stor
 import { getHandleError, isValidHandle } from '../utils/handle';
 import {
   clearIdentity as vaultClear,
+  clearSignInSession,
   clearWalletBinding,
   delegationSigningKey,
   deviceCredential,
@@ -22,7 +23,8 @@ import {
   migrateLegacyLocalStorage,
   seaDevicePair
 } from '@vh/identity-vault';
-import { publishIdentity, clearPublishedIdentity } from '../store/identityProvider';
+import { publishIdentity, clearPublishedIdentity, getPublishedIdentity } from '../store/identityProvider';
+import { clearSignInAccounts } from '../store/signInAccount';
 import { useXpLedger } from '../store/xpLedger';
 import { loadIdentityRecord, saveIdentityRecord } from '../utils/vaultTyped';
 import { useSentimentState } from './useSentimentState';
@@ -266,6 +268,19 @@ export function useIdentity() {
     }
   }, [status, createIdentity]);
 
+  /**
+   * Return the active device-bound principal nullifier, creating a
+   * beta-local identity first if none exists. Used by the sign-in flow to
+   * bind an account to THIS device's principal (Slice C2) — a fresh device
+   * gets a fresh principal, never a silent merge of an old one.
+   */
+  const ensureIdentity = useCallback(async (): Promise<string | null> => {
+    const existing = identity?.session?.nullifier ?? getPublishedIdentity()?.session.nullifier ?? null;
+    if (existing) return existing;
+    await createIdentity();
+    return getPublishedIdentity()?.session.nullifier ?? null;
+  }, [identity?.session?.nullifier, createIdentity]);
+
   const linkDevice = useCallback(async () => {
     if (!identity) {
       throw new Error('Identity not ready');
@@ -324,6 +339,10 @@ export function useIdentity() {
   const signOut = useCallback(async () => {
     clearActiveIdentityRuntime();
     clearLumaTelemetry({ rotateSalt: true });
+    // Drop the in-memory account snapshot so the UI reflects signed-out
+    // state. The vault signInSession binding is preserved: signing back in
+    // on this device restores the same LUMA principal (unlike Reset).
+    clearSignInAccounts();
     await vaultClear().catch(() => {});
   }, [clearActiveIdentityRuntime]);
 
@@ -342,6 +361,12 @@ export function useIdentity() {
     await vaultClear().catch(() => {});
     await clearWalletBinding().catch(() => {});
     await operatorAuthorizationToken.clear().catch(() => {});
+    // Clear the account-to-LUMA sign-in binding: the pre-reset nullifier
+    // must not survive, and the next sign-in re-binds against the new
+    // principal (LUMA §13.2 walletBinding parallel). The old public
+    // artifacts are not deleted or re-authored.
+    await clearSignInSession().catch(() => {});
+    clearSignInAccounts();
     await deviceCredential.rotate();
     await seaDevicePair.rotate(() => SEA.pair());
     await delegationSigningKey.rotateStored();
@@ -381,6 +406,7 @@ export function useIdentity() {
     status,
     error,
     createIdentity,
+    ensureIdentity,
     linkDevice,
     startLinkSession,
     completeLinkSession,

--- a/apps/web-pwa/src/hooks/useIdentity.ts
+++ b/apps/web-pwa/src/hooks/useIdentity.ts
@@ -275,8 +275,18 @@ export function useIdentity() {
    * gets a fresh principal, never a silent merge of an old one.
    */
   const ensureIdentity = useCallback(async (): Promise<string | null> => {
-    const existing = identity?.session?.nullifier ?? getPublishedIdentity()?.session.nullifier ?? null;
-    if (existing) return existing;
+    const inMemory = identity?.session?.nullifier ?? getPublishedIdentity()?.session.nullifier ?? null;
+    if (inMemory) return inMemory;
+    // React state/published identity may not have hydrated yet (e.g. right
+    // after an OAuth redirect reloads the page). Consult the vault — the
+    // source of truth — before creating, so we bind to the EXISTING
+    // device principal rather than racing hydration and minting a new one.
+    const persisted = await loadIdentityFromVault().catch(() => null);
+    const persistedNullifier = persisted?.session?.nullifier ?? null;
+    if (persistedNullifier) {
+      publishIdentity(persisted!);
+      return persistedNullifier;
+    }
     await createIdentity();
     return getPublishedIdentity()?.session.nullifier ?? null;
   }, [identity?.session?.nullifier, createIdentity]);

--- a/apps/web-pwa/src/hooks/useSignIn.test.ts
+++ b/apps/web-pwa/src/hooks/useSignIn.test.ts
@@ -1,0 +1,257 @@
+// @vitest-environment jsdom
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  availableSignInProvidersMock,
+  startSignInMock,
+  completeSignInMock,
+  bindSignInSessionMock,
+  loadSignInSessionMock,
+  matchesPrincipalMock,
+  SignInErrorClass,
+} = vi.hoisted(() => {
+  class SignInErrorClass extends Error {
+    reason: string;
+    constructor(reason: string) {
+      super(reason);
+      this.reason = reason;
+    }
+  }
+  return {
+    availableSignInProvidersMock: vi.fn(() => ['mock']),
+    startSignInMock: vi.fn(),
+    completeSignInMock: vi.fn(),
+    bindSignInSessionMock: vi.fn(),
+    loadSignInSessionMock: vi.fn(),
+    matchesPrincipalMock: vi.fn(),
+    SignInErrorClass,
+  };
+});
+
+vi.mock('../auth/signInFlow', () => ({
+  SignInError: SignInErrorClass,
+  availableSignInProviders: (...a: unknown[]) => availableSignInProvidersMock(...(a as [])),
+  startSignIn: (...a: unknown[]) => startSignInMock(...(a as [])),
+  completeSignIn: (...a: unknown[]) => completeSignInMock(...(a as [])),
+}));
+
+vi.mock('../auth/signInBinding', () => ({
+  bindSignInSession: (...a: unknown[]) => bindSignInSessionMock(...(a as [])),
+}));
+
+vi.mock('@vh/identity-vault', () => ({
+  loadSignInSession: (...a: unknown[]) => loadSignInSessionMock(...(a as [])),
+  signInSessionMatchesPrincipal: (...a: unknown[]) => matchesPrincipalMock(...(a as [])),
+}));
+
+import { useSignIn, type SignInIdentityBridge } from './useSignIn';
+import { clearSignInAccounts, getSignInAccount, getSignInAccounts } from '../store/signInAccount';
+import { clearPublishedIdentity, publishIdentity } from '../store/identityProvider';
+
+function bridge(overrides: Partial<SignInIdentityBridge> = {}): SignInIdentityBridge {
+  return {
+    status: 'ready',
+    activeNullifier: null,
+    ensureIdentity: vi.fn(async () => 'principal-1'),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  clearSignInAccounts();
+  clearPublishedIdentity();
+  vi.clearAllMocks();
+  availableSignInProvidersMock.mockReturnValue(['mock']);
+  loadSignInSessionMock.mockResolvedValue(null);
+  matchesPrincipalMock.mockReturnValue(false);
+});
+
+afterEach(() => {
+  clearSignInAccounts();
+  clearPublishedIdentity();
+});
+
+describe('useSignIn', () => {
+  it('exposes available providers and current accounts', () => {
+    const { result } = renderHook(() => useSignIn(bridge()));
+    expect(result.current.providers).toEqual(['mock']);
+    expect(result.current.accounts).toEqual([]);
+  });
+
+  it('beginSignIn returns the authorize URL', async () => {
+    startSignInMock.mockResolvedValue({ authorizeUrl: '/auth/callback?x=1', state: 's', provider: 'mock' });
+    const { result } = renderHook(() => useSignIn(bridge()));
+    let url: string | null = null;
+    await act(async () => {
+      url = await result.current.beginSignIn('mock');
+    });
+    expect(url).toBe('/auth/callback?x=1');
+    expect(result.current.phase).toBe('idle');
+  });
+
+  it('beginSignIn surfaces a SignInError reason', async () => {
+    startSignInMock.mockRejectedValue(new SignInErrorClass('provider_unsupported'));
+    const { result } = renderHook(() => useSignIn(bridge()));
+    let url: string | null = 'x';
+    await act(async () => {
+      url = await result.current.beginSignIn('mock');
+    });
+    expect(url).toBeNull();
+    expect(result.current.phase).toBe('error');
+    expect(result.current.error).toBe('provider_unsupported');
+  });
+
+  it('beginSignIn surfaces a generic error message', async () => {
+    startSignInMock.mockRejectedValue(new Error('boom'));
+    const { result } = renderHook(() => useSignIn(bridge()));
+    await act(async () => {
+      await result.current.beginSignIn('mock');
+    });
+    expect(result.current.error).toBe('sign-in failed to start');
+  });
+
+  it('completeFromCallback hydrates identity and binds the session', async () => {
+    completeSignInMock.mockResolvedValue({ providerId: 'apple', providerSubject: 'sub' });
+    bindSignInSessionMock.mockResolvedValue({ account: {}, boundPrincipalNullifier: 'principal-1' });
+    const ensureIdentity = vi.fn(async () => 'principal-1');
+    const { result } = renderHook(() => useSignIn(bridge({ ensureIdentity })));
+    let ok = false;
+    await act(async () => {
+      ok = await result.current.completeFromCallback({ code: 'c', state: 's' });
+    });
+    expect(ok).toBe(true);
+    expect(ensureIdentity).toHaveBeenCalled();
+    expect(bindSignInSessionMock).toHaveBeenCalledWith({ providerId: 'apple', providerSubject: 'sub' }, 'principal-1');
+    expect(result.current.phase).toBe('idle');
+  });
+
+  it('completeFromCallback fails cleanly when no identity is available', async () => {
+    completeSignInMock.mockResolvedValue({ providerId: 'apple', providerSubject: 'sub' });
+    const ensureIdentity = vi.fn(async () => null);
+    const { result } = renderHook(() => useSignIn(bridge({ ensureIdentity })));
+    let ok = true;
+    await act(async () => {
+      ok = await result.current.completeFromCallback({ code: 'c', state: 's' });
+    });
+    expect(ok).toBe(false);
+    expect(result.current.phase).toBe('error');
+    expect(result.current.error).toBe('no active identity to bind sign-in');
+    expect(bindSignInSessionMock).not.toHaveBeenCalled();
+  });
+
+  it('completeFromCallback surfaces a SignInError reason from completeSignIn', async () => {
+    completeSignInMock.mockRejectedValue(new SignInErrorClass('state_mismatch'));
+    const { result } = renderHook(() => useSignIn(bridge()));
+    await act(async () => {
+      await result.current.completeFromCallback({ code: 'c', state: 's' });
+    });
+    expect(result.current.error).toBe('state_mismatch');
+  });
+
+  it('completeFromCallback surfaces a generic non-Error rejection', async () => {
+    completeSignInMock.mockRejectedValue('weird');
+    const { result } = renderHook(() => useSignIn(bridge()));
+    await act(async () => {
+      await result.current.completeFromCallback({ code: 'c', state: 's' });
+    });
+    expect(result.current.error).toBe('sign-in failed');
+  });
+
+  it('signOutProvider marks the account signed-out locally', async () => {
+    completeSignInMock.mockResolvedValue({ providerId: 'apple', providerSubject: 'sub' });
+    bindSignInSessionMock.mockResolvedValue({ account: {}, boundPrincipalNullifier: 'p' });
+    const { result } = renderHook(() => useSignIn(bridge()));
+    // Seed an account via the store directly through a completed flow.
+    await act(async () => {
+      await result.current.completeFromCallback({ code: 'c', state: 's' });
+    });
+    // bindSignInSession is mocked, so seed the store manually to sign out.
+    act(() => {
+      result.current.signOutProvider({
+        schemaVersion: 'sign-in-account-v1',
+        providerId: 'apple',
+        displayLabel: 'a@b.com',
+        status: 'signed-in',
+        createdAt: 1,
+        updatedAt: 1,
+      });
+    });
+    expect(getSignInAccount('apple')?.status).toBe('signed-out');
+  });
+
+  it('signOutProvider handles a record without a display label', () => {
+    const { result } = renderHook(() => useSignIn(bridge()));
+    act(() => {
+      result.current.signOutProvider({
+        schemaVersion: 'sign-in-account-v1',
+        providerId: 'x',
+        status: 'signed-in',
+        createdAt: 1,
+        updatedAt: 1,
+      });
+    });
+    expect(getSignInAccount('x')?.status).toBe('signed-out');
+  });
+
+  it('reflects a persisted vault binding matching the active principal', async () => {
+    loadSignInSessionMock.mockResolvedValue({ providerId: 'google', displayLabel: 'g@e.com' });
+    matchesPrincipalMock.mockReturnValue(true);
+    renderHook(() => useSignIn(bridge({ activeNullifier: 'principal-1' })));
+    await waitFor(() => expect(getSignInAccount('google')?.status).toBe('signed-in'));
+    expect(getSignInAccount('google')?.displayLabel).toBe('g@e.com');
+  });
+
+  it('reflects a persisted binding via the published identity when no active nullifier is passed', async () => {
+    publishIdentity({ session: { nullifier: 'pub-1', trustScore: 1, scaledTrustScore: 1, expiresAt: 0 } });
+    loadSignInSessionMock.mockResolvedValue({ providerId: 'apple' });
+    matchesPrincipalMock.mockReturnValue(true);
+    renderHook(() => useSignIn(bridge({ activeNullifier: null })));
+    await waitFor(() => expect(getSignInAccount('apple')?.status).toBe('signed-in'));
+  });
+
+  it('does nothing when there is no active or published principal', async () => {
+    renderHook(() => useSignIn(bridge({ activeNullifier: null })));
+    await Promise.resolve();
+    expect(getSignInAccounts()).toEqual([]);
+  });
+
+  it('ignores a persisted binding that does not match the active principal', async () => {
+    loadSignInSessionMock.mockResolvedValue({ providerId: 'google' });
+    matchesPrincipalMock.mockReturnValue(false);
+    renderHook(() => useSignIn(bridge({ activeNullifier: 'principal-1' })));
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(getSignInAccounts()).toEqual([]);
+  });
+
+  it('tolerates a vault load failure when reflecting bindings', async () => {
+    loadSignInSessionMock.mockRejectedValue(new Error('vault locked'));
+    const { unmount } = renderHook(() => useSignIn(bridge({ activeNullifier: 'principal-1' })));
+    await Promise.resolve();
+    expect(getSignInAccounts()).toEqual([]);
+    unmount();
+  });
+
+  it('does not apply a binding after unmount (cancelled)', async () => {
+    let resolveLoad: (value: unknown) => void = () => {};
+    loadSignInSessionMock.mockReturnValue(new Promise((resolve) => {
+      resolveLoad = resolve;
+    }));
+    matchesPrincipalMock.mockReturnValue(true);
+    const { unmount } = renderHook(() => useSignIn(bridge({ activeNullifier: 'principal-1' })));
+    unmount();
+    resolveLoad({ providerId: 'apple' });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(getSignInAccounts()).toEqual([]);
+  });
+
+  it('reflects a persisted binding with an undefined display label', async () => {
+    loadSignInSessionMock.mockResolvedValue({ providerId: 'x' });
+    matchesPrincipalMock.mockReturnValue(true);
+    renderHook(() => useSignIn(bridge({ activeNullifier: 'principal-1' })));
+    await waitFor(() => expect(getSignInAccount('x')?.status).toBe('signed-in'));
+    expect(getSignInAccount('x')?.displayLabel).toBeUndefined();
+  });
+});

--- a/apps/web-pwa/src/hooks/useSignIn.test.ts
+++ b/apps/web-pwa/src/hooks/useSignIn.test.ts
@@ -19,7 +19,7 @@ const {
     }
   }
   return {
-    availableSignInProvidersMock: vi.fn(() => ['mock']),
+    availableSignInProvidersMock: vi.fn(() => ['apple']),
     startSignInMock: vi.fn(),
     completeSignInMock: vi.fn(),
     bindSignInSessionMock: vi.fn(),
@@ -62,7 +62,7 @@ beforeEach(() => {
   clearSignInAccounts();
   clearPublishedIdentity();
   vi.clearAllMocks();
-  availableSignInProvidersMock.mockReturnValue(['mock']);
+  availableSignInProvidersMock.mockReturnValue(['apple']);
   loadSignInSessionMock.mockResolvedValue(null);
   matchesPrincipalMock.mockReturnValue(false);
 });
@@ -75,16 +75,16 @@ afterEach(() => {
 describe('useSignIn', () => {
   it('exposes available providers and current accounts', () => {
     const { result } = renderHook(() => useSignIn(bridge()));
-    expect(result.current.providers).toEqual(['mock']);
+    expect(result.current.providers).toEqual(['apple']);
     expect(result.current.accounts).toEqual([]);
   });
 
   it('beginSignIn returns the authorize URL', async () => {
-    startSignInMock.mockResolvedValue({ authorizeUrl: '/auth/callback?x=1', state: 's', provider: 'mock' });
+    startSignInMock.mockResolvedValue({ authorizeUrl: '/auth/callback?x=1', state: 's', provider: 'apple' });
     const { result } = renderHook(() => useSignIn(bridge()));
     let url: string | null = null;
     await act(async () => {
-      url = await result.current.beginSignIn('mock');
+      url = await result.current.beginSignIn('apple');
     });
     expect(url).toBe('/auth/callback?x=1');
     expect(result.current.phase).toBe('idle');
@@ -95,7 +95,7 @@ describe('useSignIn', () => {
     const { result } = renderHook(() => useSignIn(bridge()));
     let url: string | null = 'x';
     await act(async () => {
-      url = await result.current.beginSignIn('mock');
+      url = await result.current.beginSignIn('apple');
     });
     expect(url).toBeNull();
     expect(result.current.phase).toBe('error');
@@ -106,7 +106,7 @@ describe('useSignIn', () => {
     startSignInMock.mockRejectedValue(new Error('boom'));
     const { result } = renderHook(() => useSignIn(bridge()));
     await act(async () => {
-      await result.current.beginSignIn('mock');
+      await result.current.beginSignIn('apple');
     });
     expect(result.current.error).toBe('sign-in failed to start');
   });

--- a/apps/web-pwa/src/hooks/useSignIn.ts
+++ b/apps/web-pwa/src/hooks/useSignIn.ts
@@ -1,0 +1,140 @@
+import { useCallback, useEffect, useState } from 'react';
+import { loadSignInSession, signInSessionMatchesPrincipal } from '@vh/identity-vault';
+import type { SignInSessionCompartment } from '@vh/identity-vault';
+import {
+  availableSignInProviders,
+  completeSignIn,
+  startSignIn,
+  SignInError,
+  type SignInFlowProvider,
+} from '../auth/signInFlow';
+import { bindSignInSession } from '../auth/signInBinding';
+import {
+  getSignInAccounts,
+  subscribeSignInAccounts,
+  upsertSignInAccount,
+} from '../store/signInAccount';
+import type { SignInAccountRecord } from '@vh/data-model';
+import { getPublishedIdentity } from '../store/identityProvider';
+
+export type SignInPhase = 'idle' | 'starting' | 'completing' | 'error';
+
+/**
+ * Identity actions this hook needs, satisfied by useIdentity(). Kept as a
+ * narrow interface so the hook is unit-testable without the full identity
+ * hook and its vault/network wiring.
+ */
+export interface SignInIdentityBridge {
+  status: string;
+  activeNullifier: string | null;
+  ensureIdentity: () => Promise<string | null>;
+}
+
+export interface UseSignInResult {
+  providers: SignInFlowProvider[];
+  accounts: SignInAccountRecord[];
+  phase: SignInPhase;
+  error: string | null;
+  /** Begin a provider sign-in: returns the authorize URL to open. */
+  beginSignIn: (provider: SignInFlowProvider) => Promise<string | null>;
+  /** Complete a redirect callback: hydrate-or-create identity, then bind. */
+  completeFromCallback: (params: { code: string; state: string }) => Promise<boolean>;
+  /** Local sign-out of a provider account (no network deletion claim). */
+  signOutProvider: (record: SignInAccountRecord) => void;
+}
+
+/**
+ * React glue for the sign-in flow + account-to-LUMA binding (Slice C2/C3).
+ * Real navigation to the authorize URL is the caller's responsibility;
+ * the hook returns it so tests and routes can drive it explicitly.
+ */
+export function useSignIn(identity: SignInIdentityBridge): UseSignInResult {
+  const [accounts, setAccounts] = useState<SignInAccountRecord[]>(() => getSignInAccounts());
+  const [phase, setPhase] = useState<SignInPhase>('idle');
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => subscribeSignInAccounts(() => setAccounts(getSignInAccounts())), []);
+
+  // Reflect a persisted vault binding into the account UI on hydration:
+  // if a bound session matches the active principal, show it as connected.
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      const nullifier = identity.activeNullifier ?? getPublishedIdentity()?.session.nullifier ?? null;
+      if (!nullifier) return;
+      let session: SignInSessionCompartment | null = null;
+      try {
+        session = await loadSignInSession();
+      } catch {
+        session = null;
+      }
+      if (cancelled || !session) return;
+      if (signInSessionMatchesPrincipal(session, nullifier)) {
+        upsertSignInAccount({
+          providerId: session.providerId,
+          ...(session.displayLabel !== undefined ? { displayLabel: session.displayLabel } : {}),
+          status: 'signed-in',
+        });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [identity.activeNullifier]);
+
+  const beginSignIn = useCallback(async (provider: SignInFlowProvider) => {
+    setError(null);
+    setPhase('starting');
+    try {
+      const { authorizeUrl } = await startSignIn(provider);
+      setPhase('idle');
+      return authorizeUrl;
+    } catch (err) {
+      setPhase('error');
+      setError(err instanceof SignInError ? err.reason : 'sign-in failed to start');
+      return null;
+    }
+  }, []);
+
+  const completeFromCallback = useCallback(
+    async (params: { code: string; state: string }) => {
+      setError(null);
+      setPhase('completing');
+      try {
+        const session = await completeSignIn(params);
+        // Hydrate-or-create the beta-local principal on THIS device. A new
+        // device gets a fresh principal — never a silent merge of an old one.
+        const nullifier = await identity.ensureIdentity();
+        if (!nullifier) {
+          throw new Error('no active identity to bind sign-in');
+        }
+        await bindSignInSession(session, nullifier);
+        setPhase('idle');
+        return true;
+      } catch (err) {
+        setPhase('error');
+        setError(err instanceof SignInError ? err.reason : err instanceof Error ? err.message : 'sign-in failed');
+        return false;
+      }
+    },
+    [identity],
+  );
+
+  const signOutProvider = useCallback((record: SignInAccountRecord) => {
+    upsertSignInAccount({
+      providerId: record.providerId,
+      ...(record.displayLabel !== undefined ? { displayLabel: record.displayLabel } : {}),
+      status: 'signed-out',
+    });
+  }, []);
+
+  return {
+    providers: availableSignInProviders(),
+    accounts,
+    phase,
+    error,
+    beginSignIn,
+    completeFromCallback,
+    signOutProvider,
+  };
+}

--- a/apps/web-pwa/src/routes/AccountIdentityPage.tsx
+++ b/apps/web-pwa/src/routes/AccountIdentityPage.tsx
@@ -4,6 +4,7 @@ import { Button } from '@vh/ui';
 import { useIdentity } from '../hooks/useIdentity';
 import { useTelemetry } from '../hooks/useTelemetry';
 import { useWallet } from '../hooks/useWallet';
+import { SignInProviderSection } from '../components/account/SignInProviderSection';
 
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 
@@ -107,7 +108,8 @@ const ConfirmationDialog: React.FC<ConfirmationDialogProps> = ({
               Resetting stops using the current pseudonym and rotates the identity material on this device. The next
               identity you create on this device uses a new pseudonym. Your previous posts, comments, and votes remain
               public under your old pseudonym. Resetting does not remove them and cannot make them yours again. Your
-              wallet must be re-bound, and any operator authorization or delegations are cleared.
+              wallet and any connected sign-in accounts must be re-bound on your next sign-in, and any operator
+              authorization or delegations are cleared.
             </p>
             <label className="mt-4 block text-sm font-medium text-slate-800 dark:text-slate-100" htmlFor="identity-reset-input">
               Type reset to confirm
@@ -150,7 +152,7 @@ const ConfirmationDialog: React.FC<ConfirmationDialogProps> = ({
 };
 
 export const AccountIdentityPage: React.FC = () => {
-  const { identity, status, error, createIdentity, signOut, resetIdentity } = useIdentity();
+  const { identity, status, error, createIdentity, ensureIdentity, signOut, resetIdentity } = useIdentity();
   const { events } = useTelemetry();
   const { account, walletBinding, connect: connectWallet, loading: walletLoading } = useWallet();
   const [dialog, setDialog] = useState<DialogMode | null>(null);
@@ -164,6 +166,10 @@ export const AccountIdentityPage: React.FC = () => {
   const now = Date.now();
   const expiresSoon = Boolean(expiresAt && expiresAt > now && expiresAt - now <= ONE_DAY_MS);
   const activePrincipal = identity?.session?.nullifier ?? null;
+  const signInIdentityBridge = useMemo(
+    () => ({ status, activeNullifier: activePrincipal, ensureIdentity }),
+    [status, activePrincipal, ensureIdentity]
+  );
   const walletNeedsRebind = Boolean(
     activePrincipal
     && account
@@ -209,15 +215,18 @@ export const AccountIdentityPage: React.FC = () => {
 
   if (!identity || status === 'anonymous' || status === 'creating' || status === 'error') {
     return (
-      <section className="space-y-4 rounded-lg border border-slate-200 bg-card p-5 shadow-sm dark:border-slate-700" data-testid="identity-panel">
-        <div>
-          <h1 className="text-xl font-semibold text-slate-950 dark:text-slate-50">Identity</h1>
-          <p className="mt-1 text-sm text-slate-600 dark:text-slate-300">No active session on this device.</p>
+      <section className="space-y-4" data-testid="identity-panel">
+        <div className="space-y-4 rounded-lg border border-slate-200 bg-card p-5 shadow-sm dark:border-slate-700">
+          <div>
+            <h1 className="text-xl font-semibold text-slate-950 dark:text-slate-50">Identity</h1>
+            <p className="mt-1 text-sm text-slate-600 dark:text-slate-300">No active session on this device.</p>
+          </div>
+          {error && <p className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-800">{error}</p>}
+          <Button type="button" onClick={() => void createIdentity()} disabled={status === 'creating'} data-testid="identity-create">
+            {status === 'creating' ? 'Creating...' : 'Create identity'}
+          </Button>
         </div>
-        {error && <p className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-800">{error}</p>}
-        <Button type="button" onClick={() => void createIdentity()} disabled={status === 'creating'} data-testid="identity-create">
-          {status === 'creating' ? 'Creating...' : 'Create identity'}
-        </Button>
+        <SignInProviderSection identity={signInIdentityBridge} />
       </section>
     );
   }
@@ -284,6 +293,8 @@ export const AccountIdentityPage: React.FC = () => {
           </div>
         </div>
       )}
+
+      <SignInProviderSection identity={signInIdentityBridge} />
 
       <div className="rounded-lg border border-slate-200 bg-card p-5 shadow-sm dark:border-slate-700">
         <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">

--- a/apps/web-pwa/src/routes/AuthCallbackPage.tsx
+++ b/apps/web-pwa/src/routes/AuthCallbackPage.tsx
@@ -1,0 +1,97 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { Link, useNavigate, useRouterState } from '@tanstack/react-router';
+import { Button } from '@vh/ui';
+import { useIdentity } from '../hooks/useIdentity';
+import { useSignIn } from '../hooks/useSignIn';
+
+type CallbackStatus = 'working' | 'done' | 'error';
+
+interface CallbackSearch {
+  code?: string;
+  state?: string;
+  returnTopicId?: string;
+  returnPointId?: string;
+}
+
+/**
+ * OAuth redirect landing route (Slice C0/C2/C3). The provider (or the
+ * e2e mock authorize URL) redirects here with `code` + `state`. We
+ * complete the PKCE exchange against the boundary, hydrate-or-create the
+ * device-bound LUMA identity, bind the account, and route the user back
+ * to where they started (a story/point, if carried) or the account page.
+ *
+ * A sign-in failure never strands a partial vote: we route back to the
+ * return target regardless, and the vote is only ever admitted after a
+ * fully successful sign-in + binding (retry-only-after-full-success).
+ */
+export const AuthCallbackPage: React.FC = () => {
+  const navigate = useNavigate();
+  const { location } = useRouterState();
+  const identity = useIdentity();
+  const identityBridge = useMemo(
+    () => ({
+      status: identity.status,
+      activeNullifier: identity.identity?.session?.nullifier ?? null,
+      ensureIdentity: identity.ensureIdentity,
+    }),
+    [identity.status, identity.identity?.session?.nullifier, identity.ensureIdentity],
+  );
+  const { completeFromCallback, error } = useSignIn(identityBridge);
+
+  const [status, setStatus] = useState<CallbackStatus>('working');
+  const startedRef = useRef(false);
+
+  const search = location.search as CallbackSearch;
+  const code = typeof search.code === 'string' ? search.code : '';
+  const state = typeof search.state === 'string' ? search.state : '';
+  const returnTopicId = typeof search.returnTopicId === 'string' ? search.returnTopicId : undefined;
+  const returnPointId = typeof search.returnPointId === 'string' ? search.returnPointId : undefined;
+
+  useEffect(() => {
+    if (startedRef.current) return;
+    startedRef.current = true;
+    void (async () => {
+      const ok = await completeFromCallback({ code, state });
+      setStatus(ok ? 'done' : 'error');
+      if (ok) {
+        if (returnTopicId) {
+          void navigate({
+            to: '/',
+            search: { topicId: returnTopicId, ...(returnPointId ? { pointId: returnPointId } : {}) },
+          });
+        } else {
+          void navigate({ to: '/account/identity' });
+        }
+      }
+    })();
+  }, [code, state, returnTopicId, returnPointId, completeFromCallback, navigate]);
+
+  return (
+    <section className="rounded-lg border border-slate-200 bg-card p-5 shadow-sm dark:border-slate-700" data-testid="auth-callback-panel">
+      {status === 'working' && (
+        <p className="text-sm text-slate-700 dark:text-slate-200" data-testid="auth-callback-working">
+          Completing sign-in...
+        </p>
+      )}
+      {status === 'done' && (
+        <p className="text-sm text-emerald-800" data-testid="auth-callback-done">
+          Signed in. Returning you to where you left off.
+        </p>
+      )}
+      {status === 'error' && (
+        <div className="space-y-3" data-testid="auth-callback-error">
+          <p className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-800" role="alert">
+            Sign-in did not complete{error ? ` (${error})` : ''}. No vote was saved. You can try again.
+          </p>
+          <div className="flex flex-wrap gap-2">
+            <Link to="/account/identity">
+              <Button type="button" variant="secondary">Back to account</Button>
+            </Link>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+};
+
+export default AuthCallbackPage;

--- a/apps/web-pwa/src/routes/index.tsx
+++ b/apps/web-pwa/src/routes/index.tsx
@@ -13,6 +13,7 @@ import { IDChip } from '../components/hermes/IDChip';
 import { ScanContact } from '../components/hermes/ScanContact';
 import { DashboardPage } from './dashboardContent';
 import { AccountIdentityPage } from './AccountIdentityPage';
+import { AuthCallbackPage } from './AuthCallbackPage';
 import { DevColorPanel } from '../components/DevColorPanel';
 import { NewsReportAdminQueue } from '../components/admin/NewsReportAdminQueue';
 import {
@@ -102,6 +103,7 @@ const HomeComponent = () => <FeedList />;
 
 const DashboardComponent = DashboardPage;
 const AccountIdentityComponent = AccountIdentityPage;
+const AuthCallbackComponent = AuthCallbackPage;
 
 const AdminReportsComponent = () => <NewsReportAdminQueue />;
 
@@ -244,7 +246,14 @@ const dashboardRoute = createRoute({
 const accountIdentityRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/account/identity',
-  component: AccountIdentityComponent
+  component: AccountIdentityComponent,
+  validateSearch: (search: Record<string, unknown>) => search
+});
+const authCallbackRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/auth/callback',
+  component: AuthCallbackComponent,
+  validateSearch: (search: Record<string, unknown>) => search
 });
 const adminReportsRoute = createRoute({
   getParentRoute: () => rootRoute,
@@ -303,6 +312,7 @@ export const routeTree = rootRoute.addChildren([
   governanceRoute,
   dashboardRoute,
   accountIdentityRoute,
+  authCallbackRoute,
   adminReportsRoute,
   complianceRoute,
   betaRoute,

--- a/apps/web-pwa/src/store/signInAccount.test.ts
+++ b/apps/web-pwa/src/store/signInAccount.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  FORBIDDEN_ACCOUNT_FIELDS,
+  clearSignInAccounts,
+  findForbiddenAccountField,
+  getSignInAccount,
+  getSignInAccounts,
+  markSignInAccountSignedOut,
+  removeSignInAccount,
+  subscribeSignInAccounts,
+  upsertSignInAccount,
+} from './signInAccount';
+
+afterEach(() => {
+  clearSignInAccounts();
+  vi.restoreAllMocks();
+});
+
+describe('findForbiddenAccountField', () => {
+  it('returns null for clean primitives and objects', () => {
+    expect(findForbiddenAccountField(null)).toBeNull();
+    expect(findForbiddenAccountField('string')).toBeNull();
+    expect(findForbiddenAccountField(42)).toBeNull();
+    expect(findForbiddenAccountField({ providerId: 'apple', displayLabel: 'a@b.com' })).toBeNull();
+  });
+
+  it('detects every forbidden field name regardless of case', () => {
+    for (const field of FORBIDDEN_ACCOUNT_FIELDS) {
+      expect(findForbiddenAccountField({ [field.toUpperCase()]: 'x' })).toBe(field.toUpperCase());
+    }
+  });
+
+  it('recurses into nested objects and arrays', () => {
+    expect(findForbiddenAccountField({ nested: { accessToken: 'leak' } })).toBe('accessToken');
+    expect(findForbiddenAccountField({ list: [{ ok: 1 }, { refresh_token: 'leak' }] })).toBe('refresh_token');
+  });
+
+  it('does not loop forever on circular references', () => {
+    const cyclic: Record<string, unknown> = { safe: 1 };
+    cyclic.self = cyclic;
+    expect(findForbiddenAccountField(cyclic)).toBeNull();
+  });
+});
+
+describe('upsertSignInAccount', () => {
+  it('stores a validated record with defaults and preserves createdAt', () => {
+    const first = upsertSignInAccount({ providerId: 'apple', displayLabel: 'a@b.com', now: 1000 });
+    expect(first).toEqual({
+      schemaVersion: 'sign-in-account-v1',
+      providerId: 'apple',
+      displayLabel: 'a@b.com',
+      status: 'signed-in',
+      createdAt: 1000,
+      updatedAt: 1000,
+    });
+
+    const second = upsertSignInAccount({ providerId: 'apple', displayLabel: 'a@b.com', status: 'expired', now: 2000 });
+    expect(second?.createdAt).toBe(1000);
+    expect(second?.updatedAt).toBe(2000);
+    expect(second?.status).toBe('expired');
+  });
+
+  it('stores a record without a display label', () => {
+    const record = upsertSignInAccount({ providerId: 'google', now: 5 });
+    expect(record?.displayLabel).toBeUndefined();
+    expect(record?.providerId).toBe('google');
+  });
+
+  it('falls back to Date.now when now is omitted', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(4242);
+    const record = upsertSignInAccount({ providerId: 'x' });
+    expect(record?.createdAt).toBe(4242);
+  });
+
+  it('rejects an input carrying a forbidden token-shaped field', () => {
+    const record = upsertSignInAccount({
+      providerId: 'apple',
+      displayLabel: 'ok',
+      // A stray token field on the input is exactly what must be refused.
+      accessToken: 'leak',
+      now: 1,
+    } as unknown as Parameters<typeof upsertSignInAccount>[0]);
+    expect(record).toBeNull();
+    expect(getSignInAccounts()).toHaveLength(0);
+  });
+
+  it('rejects a record that fails the closed schema', () => {
+    const record = upsertSignInAccount({
+      providerId: 'reddit' as unknown as 'apple',
+      now: 1,
+    });
+    expect(record).toBeNull();
+  });
+
+  it('notifies subscribers on change and stops after unsubscribe', () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeSignInAccounts(listener);
+    upsertSignInAccount({ providerId: 'apple', now: 1 });
+    expect(listener).toHaveBeenCalledTimes(1);
+    unsubscribe();
+    upsertSignInAccount({ providerId: 'google', now: 2 });
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('markSignInAccountSignedOut', () => {
+  it('returns null when no account exists', () => {
+    expect(markSignInAccountSignedOut('apple')).toBeNull();
+  });
+
+  it('marks an existing account signed-out preserving its label', () => {
+    upsertSignInAccount({ providerId: 'apple', displayLabel: 'a@b.com', now: 10 });
+    const out = markSignInAccountSignedOut('apple', 20);
+    expect(out?.status).toBe('signed-out');
+    expect(out?.displayLabel).toBe('a@b.com');
+    expect(out?.createdAt).toBe(10);
+  });
+
+  it('marks an existing account without a label signed-out', () => {
+    upsertSignInAccount({ providerId: 'x', now: 10 });
+    const out = markSignInAccountSignedOut('x', 20);
+    expect(out?.status).toBe('signed-out');
+    expect(out?.displayLabel).toBeUndefined();
+  });
+
+  it('defaults now to Date.now when omitted', () => {
+    upsertSignInAccount({ providerId: 'apple', now: 10 });
+    vi.spyOn(Date, 'now').mockReturnValue(99);
+    const out = markSignInAccountSignedOut('apple');
+    expect(out?.updatedAt).toBe(99);
+  });
+});
+
+describe('accessors and removal', () => {
+  it('reads single and all account records', () => {
+    upsertSignInAccount({ providerId: 'apple', now: 1 });
+    upsertSignInAccount({ providerId: 'google', now: 1 });
+    expect(getSignInAccount('apple')?.providerId).toBe('apple');
+    expect(getSignInAccount('x')).toBeUndefined();
+    expect(getSignInAccounts()).toHaveLength(2);
+  });
+
+  it('removes a record and reports removal', () => {
+    const listener = vi.fn();
+    subscribeSignInAccounts(listener);
+    upsertSignInAccount({ providerId: 'apple', now: 1 });
+    listener.mockClear();
+
+    expect(removeSignInAccount('apple')).toBe(true);
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(removeSignInAccount('apple')).toBe(false);
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears all records and is a no-op when already empty', () => {
+    const listener = vi.fn();
+    subscribeSignInAccounts(listener);
+    clearSignInAccounts();
+    expect(listener).not.toHaveBeenCalled();
+
+    upsertSignInAccount({ providerId: 'apple', now: 1 });
+    listener.mockClear();
+    clearSignInAccounts();
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(getSignInAccounts()).toHaveLength(0);
+  });
+});

--- a/apps/web-pwa/src/store/signInAccount.ts
+++ b/apps/web-pwa/src/store/signInAccount.ts
@@ -1,0 +1,195 @@
+/**
+ * Sign-in account store (Lane C, Slice C1 client storage).
+ *
+ * Holds the NON-SECRET SignInAccountRecord for the local account shell —
+ * provider id, optional display label, status, timestamps — validated
+ * against the closed data-model schema. Session/token material never
+ * lives here: it goes only through the identity-vault signInSession
+ * compartment (packages/identity-vault). This store is deliberately NOT
+ * gated behind VITE_LINKED_SOCIAL_ENABLED (that flag governs the
+ * separate linked-social notification-account feature).
+ *
+ * Provider subjects and display labels are personal profile data
+ * (spec-data-topology-privacy-v0 §3: vault/local-only). Nothing here is
+ * ever written to a `vh/*` public record or joined with
+ * forumAuthorId / identityDirectoryKey / voterId. A zero-trust
+ * findForbiddenField guard (mirroring the linked-social pattern) rejects
+ * any token-shaped material before it is persisted.
+ */
+
+import {
+  SignInAccountRecordSchema,
+  type SignInAccountRecord,
+  type SignInProviderIdType,
+} from '@vh/data-model';
+
+/**
+ * Field names that must never appear in a stored sign-in account record.
+ * Mirrors the linked-social FORBIDDEN_PUBLIC_FIELDS discipline: a
+ * SignInAccountRecord is display metadata only; token/subject material
+ * belongs in the vault compartment, not here.
+ */
+export const FORBIDDEN_ACCOUNT_FIELDS = [
+  'accessToken',
+  'access_token',
+  'refreshToken',
+  'refresh_token',
+  'idToken',
+  'id_token',
+  'bearer',
+  'bearerToken',
+  'bearer_token',
+  'providerSecret',
+  'provider_secret',
+  'secret',
+  'providerSubject',
+  'provider_subject',
+  'token',
+] as const;
+
+/**
+ * Recursively check for any forbidden field name (case-insensitive).
+ * Returns the first offending key found, or null when clean.
+ */
+export function findForbiddenAccountField(
+  value: unknown,
+  visited = new WeakSet<object>()
+): string | null {
+  if (value === null || typeof value !== 'object') {
+    return null;
+  }
+  const target = value as Record<string, unknown>;
+  if (visited.has(target)) {
+    return null;
+  }
+  visited.add(target);
+
+  for (const key of Object.keys(target)) {
+    const lowerKey = key.toLowerCase();
+    for (const forbidden of FORBIDDEN_ACCOUNT_FIELDS) {
+      if (lowerKey === forbidden.toLowerCase()) {
+        return key;
+      }
+    }
+    const nested = target[key];
+    if (nested !== null && typeof nested === 'object') {
+      const found = findForbiddenAccountField(nested, visited);
+      if (found) {
+        return found;
+      }
+    }
+  }
+  return null;
+}
+
+// ── In-memory store (local, authoritative on-device, non-secret) ───
+
+const accounts = new Map<SignInProviderIdType, SignInAccountRecord>();
+type Listener = () => void;
+const listeners = new Set<Listener>();
+
+function emit(): void {
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+/** Subscribe to store changes; returns an unsubscribe function. */
+export function subscribeSignInAccounts(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export interface UpsertSignInAccountInput {
+  providerId: SignInProviderIdType;
+  displayLabel?: string;
+  status?: SignInAccountRecord['status'];
+  now?: number;
+}
+
+/**
+ * Validate and store a non-secret account record. Rejects (returns null)
+ * if the candidate fails the closed schema or carries any forbidden
+ * token-shaped field. `createdAt` is preserved across upserts for the
+ * same provider.
+ */
+export function upsertSignInAccount(input: UpsertSignInAccountInput): SignInAccountRecord | null {
+  // Zero-trust: reject before persisting if the caller-supplied input
+  // smuggles any token-shaped field (e.g. a stray accessToken/subject
+  // key). Session/token material must go through the vault compartment,
+  // never this display-metadata store.
+  if (findForbiddenAccountField(input) !== null) {
+    return null;
+  }
+
+  const now = input.now ?? Date.now();
+  const existing = accounts.get(input.providerId);
+  const candidate = {
+    schemaVersion: 'sign-in-account-v1' as const,
+    providerId: input.providerId,
+    ...(input.displayLabel !== undefined ? { displayLabel: input.displayLabel } : {}),
+    status: input.status ?? 'signed-in',
+    createdAt: existing?.createdAt ?? now,
+    updatedAt: now,
+  };
+
+  const parsed = SignInAccountRecordSchema.safeParse(candidate);
+  if (!parsed.success) {
+    return null;
+  }
+
+  accounts.set(parsed.data.providerId, parsed.data);
+  emit();
+  return parsed.data;
+}
+
+/**
+ * Mark a provider account signed-out locally. Returns the updated record
+ * or null when no such account exists. This does not claim any network
+ * deletion — the session material is cleared separately via the vault.
+ */
+export function markSignInAccountSignedOut(
+  providerId: SignInProviderIdType,
+  now: number = Date.now()
+): SignInAccountRecord | null {
+  const existing = accounts.get(providerId);
+  if (!existing) {
+    return null;
+  }
+  return upsertSignInAccount({
+    providerId,
+    ...(existing.displayLabel !== undefined ? { displayLabel: existing.displayLabel } : {}),
+    status: 'signed-out',
+    now,
+  });
+}
+
+/** Get a single provider account record. */
+export function getSignInAccount(providerId: SignInProviderIdType): SignInAccountRecord | undefined {
+  return accounts.get(providerId);
+}
+
+/** Snapshot of all stored account records. */
+export function getSignInAccounts(): SignInAccountRecord[] {
+  return Array.from(accounts.values());
+}
+
+/** Remove a single provider account record. Returns true if removed. */
+export function removeSignInAccount(providerId: SignInProviderIdType): boolean {
+  const removed = accounts.delete(providerId);
+  if (removed) {
+    emit();
+  }
+  return removed;
+}
+
+/** Clear all stored account records (sign-out / reset identity). */
+export function clearSignInAccounts(): void {
+  if (accounts.size === 0) {
+    return;
+  }
+  accounts.clear();
+  emit();
+}

--- a/docs/ops/account-provider-callback-boundary.md
+++ b/docs/ops/account-provider-callback-boundary.md
@@ -142,6 +142,32 @@ Notes:
 - Consent-screen/app-review requirements (Google unverified-app limits,
   X app review) are tracked by the same owner as the registration row.
 
+## Client (PWA) configuration
+
+The Web PWA reaches this boundary through a single **public** env var —
+no secret is involved:
+
+- `VITE_AUTH_CALLBACK_BASE_URL` — base URL of the deployed
+  auth-callback host (e.g. `https://auth.example.com`). When set, the
+  account page offers Apple/Google/X sign-in and the browser runs the
+  PKCE round-trip (`/auth/:provider/start` then `/auth/:provider/callback`)
+  against it. Unset hides real sign-in; beta-local identity creation
+  still works.
+- `VITE_AUTH_CALLBACK_ROUTE` — optional override of the in-app OAuth
+  redirect route (default `/auth/callback`); this is the redirect target
+  registered per provider and per environment, and it must match the
+  provider `VH_AUTH_*_REDIRECT_URI` origin.
+- Under `VITE_E2E_MODE`, the same provider ids run an in-process mock
+  exchange (no network, no boundary URL) so the full browser flow —
+  PKCE, callback, account-to-LUMA binding, reset re-bind — is CI-testable
+  (`packages/e2e/src/luma/account-identity-controls.spec.ts`,
+  `check:account-identity-controls`).
+
+The browser holds only the non-secret `vh-auth-session-v1` payload; the
+provider subject/label live in the identity-vault `signInSession`
+compartment (vault/local-only), and the account-to-LUMA binding
+(`boundPrincipalNullifier`) is local continuity/recovery only.
+
 ## Relationship to the plan
 
 - This record is the named PR D deliverable from Slice C0 ("decide and
@@ -149,6 +175,12 @@ Notes:
 - Slice C1 consumes this boundary: the closed sign-in provider schema
   (`packages/data-model/src/schemas/hermes/signInProvider.ts`) and the
   vault compartment for session material are already repo capabilities.
+- Slice C1/C2/C3 client wiring lands in the PWA: the PKCE browser flow
+  (`apps/web-pwa/src/auth/signInFlow.ts`), the account-to-LUMA binding
+  (`apps/web-pwa/src/auth/signInBinding.ts`), the non-secret account
+  store (`apps/web-pwa/src/store/signInAccount.ts`), the callback route
+  (`apps/web-pwa/src/routes/AuthCallbackPage.tsx`), and the account
+  provider UI (`apps/web-pwa/src/components/account/SignInProviderSection.tsx`).
 - Live PKCE round-trip evidence against the deployed boundary, the
   browser-bundle secret scan, and rehearsal evidence are Lane C/Lane F
   gates and remain open until deployment.

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:storycluster:quality": "pnpm --filter @vh/storycluster-engine exec vitest run src/vectorBackend.test.ts src/server.test.ts src/stageRunner.pipeline.test.ts src/coherenceAudit.test.ts src/storyclusterQualityGate.test.ts --config ./vitest.config.ts --reporter=verbose",
     "test:storycluster:live-benchmark": "pnpm --filter @vh/storycluster-engine exec vitest run src/liveBenchmark.integration.test.ts --config ./vitest.config.ts --reporter=verbose",
     "test:storycluster:correctness": "pnpm --filter @vh/storycluster-engine exec vitest run src/benchmarkCorpusKnownEventOngoingFixtures.test.ts src/storyclusterKnownEventOngoingReplay.test.ts src/storyclusterQualityGate.test.ts --config ./vitest.config.ts --reporter=verbose && pnpm --filter @vh/e2e test:live:daemon-feed:build && pnpm --filter @vh/e2e test:live:daemon-feed:semantic-gate",
+    "check:account-identity-controls": "pnpm --filter @vh/e2e check:account-identity-controls",
     "check:storycluster:correctness": "node ./packages/e2e/src/live/storycluster-correctness-gate.mjs",
     "test:storycluster:gates": "pnpm --filter @vh/e2e test:live:daemon-feed:build && pnpm --filter @vh/e2e test:live:daemon-feed:gates",
     "test:storycluster:publisher-canary": "pnpm --filter @vh/e2e test:live:daemon-feed:build && pnpm --filter @vh/e2e test:live:daemon-feed:publisher-canary",

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "test": "VITE_E2E_MODE=true pnpm --filter @vh/web-pwa build && VITE_E2E_MODE=true playwright test",
+    "check:account-identity-controls": "VITE_E2E_MODE=true pnpm --filter @vh/web-pwa build && VITE_E2E_MODE=true playwright test src/luma/account-identity-controls.spec.ts",
     "test:ui": "playwright test --ui",
     "test:debug": "playwright test --debug",
     "test:live:matrix": "VH_RUN_LIVE_MATRIX=true VH_LIVE_MATRIX_REQUIRE_FULL=false playwright test --config=playwright.live.config.ts src/live/bias-vote-convergence.live.spec.ts",

--- a/packages/e2e/src/luma/account-identity-controls.spec.ts
+++ b/packages/e2e/src/luma/account-identity-controls.spec.ts
@@ -18,7 +18,10 @@ const FORBIDDEN_RENDERED_COPY = [
   'same human',
   'same person',
   'proves you are',
-  'proof of a unique person is',
+  // Affirmative uniqueness claim. The safe copy negates it ("not a proof of a
+  // unique person"), which does not contain "is a proof of a unique person",
+  // so this catches a future edit that drops the negation.
+  'is a proof of a unique person',
   'verified identity across devices',
   'linked to the same human',
 ];
@@ -222,6 +225,9 @@ test.describe('LUMA account sign-in provider binding', () => {
     for (const forbidden of FORBIDDEN_RENDERED_COPY) {
       await expect(page.getByTestId('signin-providers')).not.toContainText(forbidden);
     }
+    // Positively require the negating claim-boundary phrase so the guard cannot
+    // pass merely because an affirmative rephrase dodged the substring list.
+    await expect(page.getByTestId('signin-providers')).toContainText('not a proof of a unique person');
 
     await connectFirstProvider(page);
 

--- a/packages/e2e/src/luma/account-identity-controls.spec.ts
+++ b/packages/e2e/src/luma/account-identity-controls.spec.ts
@@ -14,6 +14,13 @@ const FORBIDDEN_RENDERED_COPY = [
   'permanently deleted from the network',
   'fully anonymous',
   'untraceable across devices',
+  // Sign-in is continuity/recovery, never a same-human/uniqueness claim.
+  'same human',
+  'same person',
+  'proves you are',
+  'proof of a unique person is',
+  'verified identity across devices',
+  'linked to the same human',
 ];
 
 async function clearBrowserState(page: Page): Promise<void> {
@@ -59,6 +66,60 @@ async function waitForNullifier(page: Page, predicate: (value: string) => boolea
 
 async function renderedText(page: Page): Promise<string> {
   return page.locator('body').innerText();
+}
+
+/**
+ * Decrypt the full vault and return the signInSession compartment's bound
+ * principal nullifier (or null). Used to prove the account-to-LUMA binding
+ * is written on sign-in and gone after Reset Identity.
+ */
+async function readSignInBoundNullifier(page: Page): Promise<string | null> {
+  return page.evaluate(async () => {
+    const openDb = () => new Promise<IDBDatabase>((resolve, reject) => {
+      const request = indexedDB.open('vh-vault', 1);
+      request.onupgradeneeded = () => {
+        const db = request.result;
+        if (!db.objectStoreNames.contains('vault')) db.createObjectStore('vault');
+        if (!db.objectStoreNames.contains('keys')) db.createObjectStore('keys');
+      };
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error ?? new Error('open failed'));
+    });
+    const idbGet = (db: IDBDatabase, store: string, key: string) =>
+      new Promise<unknown>((resolve, reject) => {
+        const req = db.transaction(store, 'readonly').objectStore(store).get(key);
+        req.onsuccess = () => resolve(req.result);
+        req.onerror = () => reject(req.error ?? new Error('get failed'));
+      });
+    const db = await openDb();
+    try {
+      const record = (await idbGet(db, 'vault', 'identity')) as { iv?: unknown; ciphertext?: unknown } | undefined;
+      const key = await idbGet(db, 'keys', 'master');
+      if (!record || !(key instanceof CryptoKey) || !record.iv || !record.ciphertext) return null;
+      const decrypted = await crypto.subtle.decrypt(
+        { name: 'AES-GCM', iv: record.iv as BufferSource },
+        key,
+        record.ciphertext as ArrayBuffer,
+      );
+      const parsed = JSON.parse(new TextDecoder().decode(decrypted)) as {
+        signInSession?: { boundPrincipalNullifier?: string };
+      };
+      return parsed?.signInSession?.boundPrincipalNullifier ?? null;
+    } catch {
+      return null;
+    } finally {
+      db.close();
+    }
+  });
+}
+
+async function connectFirstProvider(page: Page): Promise<void> {
+  const connect = page.locator('[data-testid^="signin-connect-"]').first();
+  await expect(connect).toBeVisible({ timeout: 15_000 });
+  await connect.click();
+  // The mock authorize URL routes to /auth/callback, which completes the
+  // exchange, binds, and redirects back to the account page.
+  await expect(page.getByTestId('signin-providers')).toBeVisible({ timeout: 15_000 });
 }
 
 async function deriveForumAuthorId(principalNullifier: string): Promise<string> {
@@ -144,5 +205,131 @@ test.describe('LUMA account identity controls', () => {
     expect(text).not.toContain(firstNullifier);
     expect(text).not.toContain(secondNullifier);
     expect(text).not.toMatch(/mock-session-|dev-session-|srv-token:/);
+  });
+});
+
+test.describe('LUMA account sign-in provider binding', () => {
+  test.beforeEach(async ({ page }) => {
+    await clearBrowserState(page);
+  });
+
+  test('connect via the e2e mock provider binds the account to the active principal without a same-human claim', async ({ page }) => {
+    const nullifier = await ensureReadyIdentity(page);
+    await gotoIdentityControls(page);
+
+    // Provider tiles render with connect controls and stay inside the copy boundary.
+    await expect(page.getByTestId('signin-providers')).toBeVisible();
+    for (const forbidden of FORBIDDEN_RENDERED_COPY) {
+      await expect(page.getByTestId('signin-providers')).not.toContainText(forbidden);
+    }
+
+    await connectFirstProvider(page);
+
+    // A connected status appears and the vault binding references the active principal.
+    await expect(page.locator('[data-testid^="signin-status-"]').first()).toContainText('Connected', { timeout: 15_000 });
+    await expect.poll(async () => readSignInBoundNullifier(page), { timeout: 15_000 }).toBe(nullifier);
+
+    // The provider subject/label are never joined with the LUMA public id in rendered copy.
+    const text = await renderedText(page);
+    expect(text).not.toContain(nullifier);
+    expect(text).not.toMatch(/mock-session-|dev-session-|srv-token:/);
+  });
+
+  test('disconnect marks the provider signed-out locally without claiming network deletion', async ({ page }) => {
+    await ensureReadyIdentity(page);
+    await gotoIdentityControls(page);
+    await connectFirstProvider(page);
+
+    const disconnect = page.locator('[data-testid^="signin-disconnect-"]').first();
+    await expect(disconnect).toBeVisible({ timeout: 15_000 });
+    await disconnect.click();
+
+    await expect(page.locator('[data-testid^="signin-status-"]').first()).toContainText('Signed out', { timeout: 15_000 });
+    const text = await renderedText(page);
+    for (const forbidden of FORBIDDEN_RENDERED_COPY) {
+      expect(text).not.toContain(forbidden);
+    }
+  });
+
+  test('a sign-in callback with no pending flow surfaces a clean failure and never strands a vote', async ({ page }) => {
+    await ensureReadyIdentity(page);
+    // Land on the callback with a code/state but no stashed PKCE material.
+    await page.goto('/auth/callback?code=stray-code&state=stray-state&returnTopicId=topic-x&returnPointId=point-y');
+    await expect(page.getByTestId('auth-callback-error')).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByTestId('auth-callback-error')).toContainText('No vote was saved');
+    // No binding was written by the failed attempt.
+    expect(await readSignInBoundNullifier(page)).toBeNull();
+  });
+
+  test('signing in on another browser profile yields a distinct principal and no same-human copy', async ({ browser }) => {
+    const contextA = await browser.newContext();
+    const pageA = await contextA.newPage();
+    await clearBrowserState(pageA);
+    const nullifierA = await ensureReadyIdentity(pageA);
+    await gotoIdentityControls(pageA);
+    await connectFirstProvider(pageA);
+    await expect.poll(async () => readSignInBoundNullifier(pageA), { timeout: 15_000 }).toBe(nullifierA);
+
+    const contextB = await browser.newContext();
+    const pageB = await contextB.newPage();
+    await clearBrowserState(pageB);
+    const nullifierB = await ensureReadyIdentity(pageB);
+    await gotoIdentityControls(pageB);
+    await connectFirstProvider(pageB);
+    await expect.poll(async () => readSignInBoundNullifier(pageB), { timeout: 15_000 }).toBe(nullifierB);
+
+    // Distinct device principals — no silent merge, no same-human continuity claim.
+    expect(nullifierB).not.toBe(nullifierA);
+    const textB = await renderedText(pageB);
+    for (const forbidden of FORBIDDEN_RENDERED_COPY) {
+      expect(textB).not.toContain(forbidden);
+    }
+    expect(textB).not.toContain(nullifierA);
+
+    await contextA.close();
+    await contextB.close();
+  });
+
+  test('a first-vote sign-in link carries return topic/point state', async ({ page }) => {
+    // The vote cell links a signed-out user into the account page with return state.
+    // We assert the account route accepts and preserves those params.
+    await clearBrowserState(page);
+    await page.goto('/account/identity?returnTopicId=topic-42&returnPointId=point-7');
+    await expect(page.getByTestId('identity-panel')).toBeVisible({ timeout: 15_000 });
+    expect(new URL(page.url()).searchParams.get('returnTopicId')).toBe('topic-42');
+    expect(new URL(page.url()).searchParams.get('returnPointId')).toBe('point-7');
+  });
+
+  test('same-browser sign-out then sign-in preserves the local LUMA identity; Reset clears the sign-in binding', async ({ page }) => {
+    const firstNullifier = await ensureReadyIdentity(page);
+    await gotoIdentityControls(page);
+    await connectFirstProvider(page);
+    await expect.poll(async () => readSignInBoundNullifier(page), { timeout: 15_000 }).toBe(firstNullifier);
+
+    // Sign out, then re-create identity: same device principal is restored and
+    // the sign-in binding survives (bound to the same nullifier).
+    await page.getByTestId('identity-sign-out').click();
+    await page.getByTestId('identity-sign-out-confirm').click();
+    const afterSignOut = await waitForNullifier(page, (value) => value === firstNullifier);
+    expect(afterSignOut).toBe(firstNullifier);
+    await expect.poll(async () => readSignInBoundNullifier(page), { timeout: 15_000 }).toBe(firstNullifier);
+
+    // Reset Identity rotates the principal AND clears the sign-in binding.
+    await gotoIdentityControls(page);
+    await page.getByTestId('identity-reset').click();
+    const resetDialog = page.getByRole('dialog', { name: 'Reset your identity on this device?' });
+    await expect(resetDialog).toContainText('connected sign-in accounts must be re-bound');
+    for (const forbidden of FORBIDDEN_RENDERED_COPY) {
+      await expect(resetDialog).not.toContainText(forbidden);
+    }
+    await page.getByLabel('Type reset to confirm').fill('reset');
+    await page.getByTestId('identity-reset-confirm').click();
+
+    const secondNullifier = await waitForNullifier(page, (value) => value !== firstNullifier);
+    expect(secondNullifier).not.toBe(firstNullifier);
+    // No binding referencing the pre-reset nullifier survives reset.
+    await expect.poll(async () => readSignInBoundNullifier(page), { timeout: 15_000 }).toBeNull();
+    const text = await renderedText(page);
+    expect(text).not.toContain(firstNullifier);
   });
 });


### PR DESCRIPTION
## Summary

Phase 2 (client) of Lane C "Account And Sign-In Shell" — Slices C1 (client storage), C2 (account-to-LUMA binding), C3 (account UI + routing) — building on the merged phase-1 C0 boundary/schema/vault (#729). No A6 mutation; real provider registration + live boundary deployment stay operator/Lane F.

## What's here

- **`auth/signInFlow.ts`** — PKCE (`crypto.getRandomValues` → S256) against the C0 boundary's `/auth/:provider/start` + `/callback`; receives only the non-secret `vh-auth-session-v1`. Real `apple/google/x` gated behind `VITE_AUTH_CALLBACK_BASE_URL`; under `VITE_E2E_MODE` an in-process mock exchange (no network). Verifier lives in same-origin sessionStorage, never the URL/history, cleared in `finally`.
- **`store/signInAccount.ts`** — local non-secret account record store, closed-schema `.strict()` + recursive forbidden-field guard; not gated by `VITE_LINKED_SOCIAL_ENABLED`.
- **`auth/signInBinding.ts` + `hooks/useSignIn.ts`** — writes session material only to the `signInSession` vault compartment (`boundPrincipalNullifier`); new device → fresh principal (never a silent merge). `useIdentity.ensureIdentity()` is vault-first so the post-redirect reload binds to the existing device principal; `resetIdentity` clears the binding (re-bind on next sign-in); `signOut` preserves it.
- **`routes/AuthCallbackPage.tsx`** (`/auth/callback`), **`components/account/SignInProviderSection.tsx`**, `AccountIdentityPage` reset copy, and `CellVoteControls` "Sign in to vote" carrying return topic/point state. A sign-in failure never strands a partial vote.
- Root `check:account-identity-controls` gate + extended e2e spec (connect/disconnect, failure path, cross-browser non-continuity, vote-routing, sign-out preservation, post-reset binding cleared).

## Token custody

The browser holds only the non-secret session payload; all secret custody (client secrets, raw provider tokens, code exchange) stays in the boundary. Provider subject/label + any token material live only in the vault compartment; nothing writes to `vh/*` or joins a provider id with a LUMA public id.

## Review

Passed an adversarial security review — no blockers/highs; PKCE, client-leg CSRF/state binding, token custody, vault-first binding correctness, closed-schema store, vote-routing, and copy all verified sound. Applied the two low/nit follow-ups: robust forbidden-copy guard (positive negation assertion + affirmative-claim ban) and an anti-footgun comment on the credential-less boundary POST.

## Validation

- 100% diff coverage on all changed source files; web-pwa `vitest run src`: 2624 pass; typecheck clean; data-model + identity-vault suites pass
- `check:account-identity-controls`: 8/8 e2e pass; `check:luma-forbidden-claims`, `check:public-beta-compliance`, `docs:check`: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)