### PR TITLE
chore(luma): scan account/sign-in shell for telemetry redaction (PR E)

### DIFF
--- a/tools/scripts/check-luma-telemetry-redaction.mjs
+++ b/tools/scripts/check-luma-telemetry-redaction.mjs
@@ -64,6 +64,12 @@ const SOURCE_EXTENSIONS = new Set(['.ts', '.tsx']);
 export const SCAN_TARGETS = Object.freeze([
   { kind: 'file', path: 'apps/web-pwa/src/hooks/useIdentity.ts' },
   { kind: 'dir', path: 'apps/web-pwa/src/hooks/identity', optional: true },
+  // Account/sign-in shell (Lane C): provider subjects, display labels, and
+  // session material must stay redaction-disciplined here too.
+  { kind: 'file', path: 'apps/web-pwa/src/hooks/useSignIn.ts', optional: true },
+  { kind: 'dir', path: 'apps/web-pwa/src/auth', optional: true },
+  { kind: 'file', path: 'apps/web-pwa/src/store/signInAccount.ts', optional: true },
+  { kind: 'dir', path: 'apps/web-pwa/src/components/account', optional: true },
   { kind: 'dir', path: 'packages/identity-vault/src' },
   { kind: 'dir', path: 'packages/gun-client/src' },
   { kind: 'dir', path: 'packages/luma-sdk/src' },


### PR DESCRIPTION
## Summary

Lane D residual (Slice D3) of `docs/plans/FUNCTIONING_MVP_LANE_SLICE_PLAN_2026-07-06.md`. The core Lane D gates (forbidden-claims, telemetry key-name pattern, co-publication ban, signed-write, aggregate-voter) already landed via #726/#727/#731/#733. This closes the remaining item: extend the telemetry-redaction scan to the account/sign-in surfaces merged in PR D (#729/#734).

## Change

`check:luma-telemetry-redaction` `SCAN_TARGETS` now includes `apps/web-pwa/src/auth`, `store/signInAccount.ts`, `hooks/useSignIn.ts`, and `components/account` — so provider subjects, display labels, and session material there are held to the same no-`console.*` / no-secret-equality discipline as the vault and gun-client. Every structural guard in that code (`typeof`, `.length`, `!== undefined`) is already exempt under the #731/#733 rules, so the gate passes: **63 files scanned, PASS**.

The `services/auth-callback` boundary is `.mjs` (outside this `.ts/.tsx` scanner) and is covered by its own no-`console` discipline, verified in its security review.

## Validation

All 12 Lane D gates pass on the fully-integrated main (forbidden-claims, telemetry-redaction, signed-write-surface, aggregate-voter, forum-author/post, news-report, provider-surface, identity-lifecycle, multidevice-stubs, public-beta-compliance, public-namespace-leaks). Scanner self-tests 9/9 + redaction vitest 19/19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)