### PR TITLE
Harden MVP vote and identity readiness

### DIFF
--- a/apps/web-pwa/package.json
+++ b/apps/web-pwa/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "prebuild": "pnpm -w prebuild:guards",
+    "prebuild": "corepack pnpm@9.7.1 -w prebuild:guards",
     "build": "vite build",
     "preview": "vite preview --host --port 5173 --strictPort",
     "test": "vitest run src",

--- a/apps/web-pwa/src/components/feed/CellVoteControls.test.tsx
+++ b/apps/web-pwa/src/components/feed/CellVoteControls.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { VoteAdmissionReceipt } from '@vh/data-model';
 import { CellVoteControls } from './CellVoteControls';
 import { useSentimentState } from '../../hooks/useSentimentState';
+import { VOTE_DENIAL_REASONS } from '../../hooks/voteAdmission';
 
 const useConstituencyProofMock = vi.hoisted(() => vi.fn());
 const usePointAggregateMock = vi.hoisted(() => vi.fn());
@@ -161,6 +162,35 @@ describe('CellVoteControls', () => {
     fireEvent.click(screen.getByTestId('cell-vote-agree-point-abc'));
 
     expect(screen.getByTestId('cell-vote-denial-point-abc')).toHaveTextContent(
+      'Daily vote limit reached',
+    );
+  });
+
+  it.each([
+    [VOTE_DENIAL_REASONS.MISSING_SYNTHESIS_CONTEXT, 'Waiting for synthesis context'],
+    [
+      VOTE_DENIAL_REASONS.NON_CURRENT_SYNTHESIS,
+      'This synthesis just updated — reopen to save your stance',
+    ],
+    [VOTE_DENIAL_REASONS.MISSING_PROOF, 'Create or sign in to save your stance'],
+    [VOTE_DENIAL_REASONS.INVALID_PROOF, 'Create or sign in to save your stance'],
+    [VOTE_DENIAL_REASONS.MISSING_IDENTITY, 'Create or sign in to save your stance'],
+    [
+      VOTE_DENIAL_REASONS.EXPIRED_IDENTITY,
+      'Your session expired — sign in again to save your stance',
+    ],
+    [VOTE_DENIAL_REASONS.WRITE_QUEUE_FAILURE, 'Could not save your stance — please try again'],
+    [VOTE_DENIAL_REASONS.MISSING_POINT_ID, 'Could not save your stance — please try again'],
+    ['some unrecognized reason', 'Could not save your stance — please try again'],
+  ])('maps denial reason %s to actionable copy (not a false rate-limit)', (reason, expected) => {
+    seedValidProof();
+    vi.spyOn(useSentimentState.getState(), 'setAgreement').mockReturnValue(deniedReceipt(reason));
+
+    render(<CellVoteControls {...BASE_PROPS} />);
+    fireEvent.click(screen.getByTestId('cell-vote-agree-point-abc'));
+
+    expect(screen.getByTestId('cell-vote-denial-point-abc')).toHaveTextContent(expected);
+    expect(screen.getByTestId('cell-vote-denial-point-abc')).not.toHaveTextContent(
       'Daily vote limit reached',
     );
   });

--- a/apps/web-pwa/src/components/feed/CellVoteControls.tsx
+++ b/apps/web-pwa/src/components/feed/CellVoteControls.tsx
@@ -17,6 +17,35 @@ export interface CellVoteControlsProps {
   readonly pointLabel?: string;
 }
 
+/**
+ * Map an admission-denial reason to user-facing cell copy. Every canonical
+ * `VOTE_DENIAL_REASONS` value gets an actionable message; budget/daily-cap
+ * denials arrive as free-form reasons and are matched by `limit`. The catch-all
+ * is a neutral retry prompt — never the daily-limit copy, so a signed-out or
+ * expired user is not falsely told they hit a vote cap.
+ */
+function denialCopy(reason: string): string {
+  switch (reason) {
+    case VOTE_DENIAL_REASONS.MISSING_SYNTHESIS_CONTEXT:
+      return 'Waiting for synthesis context';
+    case VOTE_DENIAL_REASONS.NON_CURRENT_SYNTHESIS:
+      return 'This synthesis just updated — reopen to save your stance';
+    case VOTE_DENIAL_REASONS.MISSING_PROOF:
+    case VOTE_DENIAL_REASONS.INVALID_PROOF:
+    case VOTE_DENIAL_REASONS.MISSING_IDENTITY:
+      return 'Create or sign in to save your stance';
+    case VOTE_DENIAL_REASONS.EXPIRED_IDENTITY:
+      return 'Your session expired — sign in again to save your stance';
+    case VOTE_DENIAL_REASONS.WRITE_QUEUE_FAILURE:
+    case VOTE_DENIAL_REASONS.MISSING_POINT_ID:
+      return 'Could not save your stance — please try again';
+    default:
+      return reason.toLowerCase().includes('limit')
+        ? 'Daily vote limit reached'
+        : 'Could not save your stance — please try again';
+  }
+}
+
 function biasTableDiagnosticsEnabled(): boolean {
   const viteValue = (import.meta as unknown as { env?: Record<string, unknown> }).env
     ?.VITE_BIAS_TABLE_DIAGNOSTICS;
@@ -220,13 +249,7 @@ export const CellVoteControls: React.FC<CellVoteControlsProps> = ({
     ],
   );
 
-  const denialText = denial
-    ? denial.includes('synthesis context')
-      ? 'Waiting for synthesis context'
-      : denial.includes('constituency') || denial.includes('proof')
-        ? 'Create or sign in to save your stance'
-        : 'Daily vote limit reached'
-    : null;
+  const denialText = denial ? denialCopy(denial) : null;
 
   return (
     <div

--- a/apps/web-pwa/src/components/feed/NewsCardBack.report.test.tsx
+++ b/apps/web-pwa/src/components/feed/NewsCardBack.report.test.tsx
@@ -89,4 +89,65 @@ describe('NewsCardBack report intake', () => {
     expect(screen.getByTestId('news-card-summary-topic-1')).toHaveTextContent('Accepted synthesis summary.');
     expect(screen.queryByTestId('news-card-synthesis-correction-topic-1')).not.toBeInTheDocument();
   });
+
+  it.each([
+    ['in-range', 1_700_000_000_000, true],
+    ['out-of-range (RangeError source)', 1e16, false],
+  ])('renders a %s correction timestamp without crashing', (_label, createdAt, expectIso) => {
+    const correction = {
+      schemaVersion: 'topic-synthesis-correction-v1' as const,
+      correction_id: 'corr-1',
+      topic_id: 'topic-1',
+      synthesis_id: 'synthesis-1',
+      epoch: 3,
+      status: 'suppressed' as const,
+      reason_code: 'bad_frame' as const,
+      operator_id: 'op-1',
+      created_at: createdAt,
+      audit: { action: 'synthesis_correction' as const },
+    };
+
+    expect(() =>
+      render(
+        <NewsCardBack
+          headline="Launch housing bundle"
+          topicId="topic-1"
+          storyId="story-1"
+          summary="Accepted synthesis summary."
+          summaryBasisLabel="Topic synthesis v2"
+          frameRows={[]}
+          frameBasisLabel="Topic synthesis frames"
+          analysisProvider={null}
+          galleryImages={[]}
+          relatedCoverage={[]}
+          relatedLinks={[]}
+          storylineHeadline={null}
+          storylineStoryCount={0}
+          analysisFeedbackStatus={null}
+          analysisError={null}
+          retryAnalysis={() => undefined}
+          synthesisLoading={false}
+          synthesisError={null}
+          synthesisUnavailable={false}
+          analysis={null}
+          analysisId={null}
+          synthesisId="synthesis-1"
+          synthesisProvenance={null}
+          synthesisCorrection={correction}
+          epoch={3}
+          sourceViewer={null}
+          discussionThread={null}
+          fallbackCommentCount={0}
+          createThread={null}
+          onCollapse={() => undefined}
+        />,
+      ),
+    ).not.toThrow();
+
+    const block = screen.getByTestId('news-card-synthesis-correction-topic-1');
+    expect(block).toHaveTextContent('Operator op-1');
+    // In-range renders an ISO timestamp (2023-…); the out-of-range value
+    // degrades to no timestamp rather than throwing a RangeError during render.
+    expect(block.textContent?.includes('2023-11-14T')).toBe(expectIso);
+  });
 });

--- a/apps/web-pwa/src/components/feed/NewsCardBack.tsx
+++ b/apps/web-pwa/src/components/feed/NewsCardBack.tsx
@@ -12,6 +12,17 @@ import { RemovalIndicator } from './RemovalIndicator';
 import { SourceViewerFrame } from './SourceViewerFrame';
 import { deriveAcceptedSynthesisReadState } from './useAcceptedSynthesis';
 
+/**
+ * Format an epoch-ms timestamp as ISO, returning null for values outside the
+ * representable Date range. `created_at` is an unbounded nonnegative integer
+ * from a mesh record, so `new Date(n).toISOString()` throws a RangeError on
+ * absurd values; a null render degrades gracefully instead of crashing the card.
+ */
+function toIsoOrNull(epochMs: number): string | null {
+  const date = new Date(epochMs);
+  return Number.isNaN(date.getTime()) ? null : date.toISOString();
+}
+
 export interface NewsCardMediaAsset {
   readonly sourceId: string;
   readonly publisher: string;
@@ -144,7 +155,7 @@ export const NewsCardBack: React.FC<NewsCardBackProps> = ({
     (row) => Boolean(row.frame_point_id?.trim() && row.reframe_point_id?.trim()),
   );
   const correctionBlocksSynthesis = Boolean(synthesisCorrection);
-  const correctionTimestamp = synthesisCorrection ? new Date(synthesisCorrection.created_at).toISOString() : null;
+  const correctionTimestamp = synthesisCorrection ? toIsoOrNull(synthesisCorrection.created_at) : null;
   const correctionStateLabel = synthesisCorrection?.status === 'suppressed'
     ? 'Accepted synthesis suppressed'
     : 'Accepted synthesis unavailable';

--- a/apps/web-pwa/src/hooks/intentQueue.test.ts
+++ b/apps/web-pwa/src/hooks/intentQueue.test.ts
@@ -5,7 +5,10 @@ const storage = new Map<string, string>();
 
 vi.mock('../utils/safeStorage', () => ({
   safeGetItem: (key: string) => storage.get(key) ?? null,
-  safeSetItem: (key: string, value: string) => storage.set(key, value),
+  safeSetItem: (key: string, value: string) => {
+    storage.set(key, value);
+    return true;
+  },
 }));
 
 interface TestIntent {
@@ -86,7 +89,7 @@ describe('createIntentQueue', () => {
     expect(queue.getPending()).toEqual([{ intent_id: 'b', seq: 20 }]);
   });
 
-  it('survives malformed persisted data and storage write failures', () => {
+  it('survives malformed persisted data and reports storage write failures', () => {
     storage.set('vh_corrupt_intent_queue_v1', '{bad json');
     const corruptQueue = createQueue('vh_corrupt_intent_queue_v1');
     expect(corruptQueue.getPending()).toEqual([]);
@@ -95,7 +98,33 @@ describe('createIntentQueue', () => {
       throw new Error('quota');
     });
     const queue = createQueue('vh_storage_failure_intent_queue_v1');
-    expect(() => queue.enqueue({ intent_id: 'safe', seq: 1 })).not.toThrow();
+    let persisted = true;
+    // A failed durable write is reported (false), not swallowed as success,
+    // and never throws.
+    expect(() => {
+      persisted = queue.enqueue({ intent_id: 'safe', seq: 1 });
+    }).not.toThrow();
+    expect(persisted).toBe(false);
     setItemSpy.mockRestore();
+  });
+
+  it('reports a persist failure (not a throw) when a record cannot be serialized', () => {
+    const queue = createQueue('vh_unserializable_intent_queue_v1');
+    let persisted = true;
+    // A BigInt makes JSON.stringify throw inside persist; the failure must be
+    // reported as a non-durable write rather than propagating.
+    expect(() => {
+      persisted = queue.enqueue({ intent_id: 'x', seq: 1, bad: 1n } as unknown as TestIntent);
+    }).not.toThrow();
+    expect(persisted).toBe(false);
+  });
+
+  it('returns true when a record is durably queued and for an idempotent no-op', () => {
+    const queue = createLwwQueue();
+    expect(queue.enqueue({ intent_id: 'a', seq: 1 })).toBe(true);
+    // Same id, not newer: idempotent no-op still reports durable.
+    expect(queue.enqueue({ intent_id: 'a', seq: 1 })).toBe(true);
+    // Same id, newer: LWW replace persists.
+    expect(queue.enqueue({ intent_id: 'a', seq: 5 })).toBe(true);
   });
 });

--- a/apps/web-pwa/src/hooks/intentQueue.ts
+++ b/apps/web-pwa/src/hooks/intentQueue.ts
@@ -15,7 +15,13 @@ export interface IntentQueueOptions<T> {
 }
 
 export interface IntentQueue<T> {
-  enqueue(record: T): void;
+  /**
+   * Persist a record. Returns `true` when the record is durably queued
+   * (written, or already present from a prior enqueue), `false` when the
+   * durable write failed — so callers can surface a persistence failure rather
+   * than assume success.
+   */
+  enqueue(record: T): boolean;
   markProjected(intentId: string): void;
   getPending(): T[];
   replay(
@@ -33,11 +39,13 @@ function loadQueue<T>(storageKey: string): T[] {
   }
 }
 
-function persistQueue<T>(storageKey: string, queue: readonly T[]): void {
+function persistQueue<T>(storageKey: string, queue: readonly T[]): boolean {
   try {
-    safeSetItem(storageKey, JSON.stringify(queue));
+    return safeSetItem(storageKey, JSON.stringify(queue));
   } catch {
-    /* ignore — quota exceeded, disabled storage, etc. */
+    // Serialization failed (unexpected for plain intent records) — treat as a
+    // non-durable write so the caller can surface it.
+    return false;
   }
 }
 
@@ -46,7 +54,7 @@ export function createIntentQueue<T>(options: IntentQueueOptions<T>): IntentQueu
   const persist = (queue: readonly T[]) => persistQueue(options.storageKey, queue);
 
   return {
-    enqueue(record: T): void {
+    enqueue(record: T): boolean {
       const queue = load();
       const intentId = options.getId(record);
       const existingIndex = queue.findIndex((queued) => options.getId(queued) === intentId);
@@ -57,16 +65,17 @@ export function createIntentQueue<T>(options: IntentQueueOptions<T>): IntentQueu
         // first-enqueued record (pure idempotency).
         if (options.compareLww && options.compareLww(record, queue[existingIndex]!) > 0) {
           queue[existingIndex] = record;
-          persist(queue);
+          return persist(queue);
         }
-        return;
+        // Already durably queued; nothing new to write.
+        return true;
       }
 
       queue.push(record);
       while (queue.length > options.maxQueueSize) {
         queue.shift();
       }
-      persist(queue);
+      return persist(queue);
     },
 
     markProjected(intentId: string): void {

--- a/apps/web-pwa/src/hooks/useSentimentState.test.ts
+++ b/apps/web-pwa/src/hooks/useSentimentState.test.ts
@@ -2401,9 +2401,11 @@ describe('useSentimentState', () => {
 
     await flushProjection();
 
+    // The warning logs the reason string only — never the raw Error object,
+    // which could carry proof/nullifier-derived material.
     expect(warnSpy).toHaveBeenCalledWith(
       '[vh:sentiment] Failed to enqueue vote intent:',
-      expect.any(Error),
+      'intent-derive-failed',
     );
     expect(localStorage.getItem('vh_vote_intent_queue_v1')).toBeNull();
     expect(scheduleReplaySpy).not.toHaveBeenCalled();

--- a/apps/web-pwa/src/hooks/useSignIn.test.ts
+++ b/apps/web-pwa/src/hooks/useSignIn.test.ts
@@ -8,6 +8,7 @@ const {
   completeSignInMock,
   bindSignInSessionMock,
   loadSignInSessionMock,
+  clearSignInSessionMock,
   matchesPrincipalMock,
   SignInErrorClass,
 } = vi.hoisted(() => {
@@ -24,6 +25,7 @@ const {
     completeSignInMock: vi.fn(),
     bindSignInSessionMock: vi.fn(),
     loadSignInSessionMock: vi.fn(),
+    clearSignInSessionMock: vi.fn(),
     matchesPrincipalMock: vi.fn(),
     SignInErrorClass,
   };
@@ -42,6 +44,7 @@ vi.mock('../auth/signInBinding', () => ({
 
 vi.mock('@vh/identity-vault', () => ({
   loadSignInSession: (...a: unknown[]) => loadSignInSessionMock(...(a as [])),
+  clearSignInSession: (...a: unknown[]) => clearSignInSessionMock(...(a as [])),
   signInSessionMatchesPrincipal: (...a: unknown[]) => matchesPrincipalMock(...(a as [])),
 }));
 
@@ -64,6 +67,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   availableSignInProvidersMock.mockReturnValue(['apple']);
   loadSignInSessionMock.mockResolvedValue(null);
+  clearSignInSessionMock.mockResolvedValue(undefined);
   matchesPrincipalMock.mockReturnValue(false);
 });
 
@@ -178,6 +182,87 @@ describe('useSignIn', () => {
       });
     });
     expect(getSignInAccount('apple')?.status).toBe('signed-out');
+  });
+
+  it('signOutProvider clears the vault session so disconnect survives reload', async () => {
+    const { result } = renderHook(() => useSignIn(bridge()));
+    act(() => {
+      result.current.signOutProvider({
+        schemaVersion: 'sign-in-account-v1',
+        providerId: 'apple',
+        displayLabel: 'a@b.com',
+        status: 'signed-in',
+        createdAt: 1,
+        updatedAt: 1,
+      });
+    });
+    expect(getSignInAccount('apple')?.status).toBe('signed-out');
+    // The vault compartment must be cleared, otherwise the hydration effect
+    // re-upserts `signed-in` on the next mount/reload (silent reconnect).
+    await waitFor(() => expect(clearSignInSessionMock).toHaveBeenCalledTimes(1));
+  });
+
+  it('does not clear a different provider vault session when signing out a stale account row', async () => {
+    loadSignInSessionMock.mockResolvedValue({
+      providerId: 'google',
+      boundPrincipalNullifier: 'principal-1',
+      providerSubject: 'subject-google',
+      boundAt: 1,
+      updatedAt: 1,
+      schemaVersion: 1,
+    });
+    const { result } = renderHook(() => useSignIn(bridge({ activeNullifier: 'principal-1' })));
+
+    act(() => {
+      result.current.signOutProvider({
+        schemaVersion: 'sign-in-account-v1',
+        providerId: 'apple',
+        status: 'signed-in',
+        createdAt: 1,
+        updatedAt: 1,
+      });
+    });
+
+    await waitFor(() => expect(loadSignInSessionMock).toHaveBeenCalledTimes(2));
+    expect(clearSignInSessionMock).not.toHaveBeenCalled();
+    expect(getSignInAccount('apple')?.status).toBe('signed-out');
+  });
+
+  it('signOutProvider tolerates a vault clear failure', async () => {
+    clearSignInSessionMock.mockRejectedValue(new Error('vault locked'));
+    const { result } = renderHook(() => useSignIn(bridge()));
+    act(() => {
+      result.current.signOutProvider({
+        schemaVersion: 'sign-in-account-v1',
+        providerId: 'apple',
+        status: 'signed-in',
+        createdAt: 1,
+        updatedAt: 1,
+      });
+    });
+    await Promise.resolve();
+    expect(getSignInAccount('apple')?.status).toBe('signed-out');
+  });
+
+  it('reflects an expired vault session as expired, not connected', async () => {
+    loadSignInSessionMock.mockResolvedValue({
+      providerId: 'google',
+      displayLabel: 'g@e.com',
+      expiresAt: 1,
+    });
+    matchesPrincipalMock.mockReturnValue(true);
+    renderHook(() => useSignIn(bridge({ activeNullifier: 'principal-1' })));
+    await waitFor(() => expect(getSignInAccount('google')?.status).toBe('expired'));
+  });
+
+  it('reflects a session with a future expiry as connected', async () => {
+    loadSignInSessionMock.mockResolvedValue({
+      providerId: 'google',
+      expiresAt: Date.now() + 3_600_000,
+    });
+    matchesPrincipalMock.mockReturnValue(true);
+    renderHook(() => useSignIn(bridge({ activeNullifier: 'principal-1' })));
+    await waitFor(() => expect(getSignInAccount('google')?.status).toBe('signed-in'));
   });
 
   it('signOutProvider handles a record without a display label', () => {

--- a/apps/web-pwa/src/hooks/useSignIn.ts
+++ b/apps/web-pwa/src/hooks/useSignIn.ts
@@ -1,5 +1,9 @@
 import { useCallback, useEffect, useState } from 'react';
-import { loadSignInSession, signInSessionMatchesPrincipal } from '@vh/identity-vault';
+import {
+  clearSignInSession,
+  loadSignInSession,
+  signInSessionMatchesPrincipal,
+} from '@vh/identity-vault';
 import type { SignInSessionCompartment } from '@vh/identity-vault';
 import {
   availableSignInProviders,
@@ -18,6 +22,18 @@ import type { SignInAccountRecord } from '@vh/data-model';
 import { getPublishedIdentity } from '../store/identityProvider';
 
 export type SignInPhase = 'idle' | 'starting' | 'completing' | 'error';
+
+/**
+ * A session is expired when it carries an `expiresAt` at or before now. A
+ * session with no `expiresAt` (provider returned no expiry) is treated as
+ * non-expiring — the conservative default that preserves prior behavior.
+ */
+function isSignInSessionExpired(
+  session: SignInSessionCompartment,
+  now: number = Date.now(),
+): boolean {
+  return typeof session.expiresAt === 'number' && session.expiresAt <= now;
+}
 
 /**
  * Identity actions this hook needs, satisfied by useIdentity(). Kept as a
@@ -69,13 +85,16 @@ export function useSignIn(identity: SignInIdentityBridge): UseSignInResult {
         session = null;
       }
       if (cancelled || !session) return;
-      if (signInSessionMatchesPrincipal(session, nullifier)) {
-        upsertSignInAccount({
-          providerId: session.providerId,
-          ...(session.displayLabel !== undefined ? { displayLabel: session.displayLabel } : {}),
-          status: 'signed-in',
-        });
-      }
+      if (!signInSessionMatchesPrincipal(session, nullifier)) return;
+      // An expired provider session must not read as "Connected": surface it as
+      // `expired` so the UI prompts a fresh sign-in instead of implying
+      // continuity that no longer holds.
+      const status = isSignInSessionExpired(session) ? 'expired' : 'signed-in';
+      upsertSignInAccount({
+        providerId: session.providerId,
+        ...(session.displayLabel !== undefined ? { displayLabel: session.displayLabel } : {}),
+        status,
+      });
     })();
     return () => {
       cancelled = true;
@@ -126,6 +145,23 @@ export function useSignIn(identity: SignInIdentityBridge): UseSignInResult {
       ...(record.displayLabel !== undefined ? { displayLabel: record.displayLabel } : {}),
       status: 'signed-out',
     });
+    // Disconnect must remove the on-device account link (SignInProviderSection
+    // copy), not just flip the in-memory status: without clearing the vault
+    // compartment the hydration effect re-upserts `signed-in` on the next mount
+    // or reload, so the account silently reconnects and providerSubject stays
+    // bound. Only clear the active vault session for the provider being
+    // disconnected so signing out a stale account row cannot disconnect a
+    // different provider that is currently bound to this LUMA identity.
+    void (async () => {
+      try {
+        const session = await loadSignInSession();
+        if (!session || session.providerId === record.providerId) {
+          await clearSignInSession();
+        }
+      } catch {
+        /* best-effort: vault unavailable — UI is already signed-out this session */
+      }
+    })();
   }, []);
 
   return {

--- a/apps/web-pwa/src/hooks/voteAdmission.test.ts
+++ b/apps/web-pwa/src/hooks/voteAdmission.test.ts
@@ -175,6 +175,39 @@ describe('voteAdmission', () => {
       }
     });
 
+    it('reports a Write queue failure when derivation succeeds but the durable write fails', async () => {
+      const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+      // Derivation succeeds (valid nullifier) but the persist fails (quota):
+      // the intent must not be reported as durable.
+      const setItemSpy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+        throw new Error('QuotaExceededError');
+      });
+
+      const result = await enqueueDurableVoteIntent({
+        constituencyProof: proofFor('valid-nullifier'),
+        topicId: 'topic-1',
+        synthesisId: 'synth-1',
+        epoch: 0,
+        pointId: 'point-1',
+        agreement: 1,
+        weight: 1,
+        emittedAt: 123,
+      });
+
+      expect(result).toEqual({ ok: false, error: 'vote intent persistence failed' });
+      expect(infoSpy).toHaveBeenCalledWith(
+        '[vh:vote:admission]',
+        expect.objectContaining({
+          topic_id: 'topic-1',
+          point_id: 'point-1',
+          admitted: false,
+          reason: VOTE_DENIAL_REASONS.WRITE_QUEUE_FAILURE,
+        }),
+      );
+      setItemSpy.mockRestore();
+    });
+
     it('stringifies a non-Error rejection into the failure result', async () => {
       vi.spyOn(console, 'info').mockImplementation(() => {});
       vi.spyOn(console, 'warn').mockImplementation(() => {});

--- a/apps/web-pwa/src/hooks/voteAdmission.ts
+++ b/apps/web-pwa/src/hooks/voteAdmission.ts
@@ -193,20 +193,33 @@ export async function enqueueDurableVoteIntent(params: {
       seq: params.emittedAt,
       emitted_at: params.emittedAt,
     };
-    enqueueIntent(record);
+    if (!enqueueIntent(record)) {
+      // The durable write failed (quota exceeded, disabled/blocked storage).
+      // Surface it as a Write queue failure rather than reporting a persisted
+      // intent that was silently dropped — admission success must mean
+      // "receipt + durable intent", not "receipt + hope".
+      logWriteQueueFailure(params.topicId, params.pointId);
+      return { ok: false, error: 'vote intent persistence failed' };
+    }
     return { ok: true, record };
   } catch (err) {
     const error = err instanceof Error ? err.message : String(err);
-    console.warn('[vh:sentiment] Failed to enqueue vote intent:', err);
-    // Reason-only telemetry — never carries proof/nullifier material.
-    logVoteAdmission({
-      topic_id: params.topicId,
-      point_id: params.pointId,
-      admitted: false,
-      reason: VOTE_DENIAL_REASONS.WRITE_QUEUE_FAILURE,
-    });
+    // Reason-only log — never carries the raw error object, which could hold
+    // proof/nullifier-derived material.
+    console.warn('[vh:sentiment] Failed to enqueue vote intent:', error);
+    logWriteQueueFailure(params.topicId, params.pointId);
     return { ok: false, error };
   }
+}
+
+/** Reason-only Write queue failure telemetry — never carries proof material. */
+function logWriteQueueFailure(topicId: string, pointId: string): void {
+  logVoteAdmission({
+    topic_id: topicId,
+    point_id: pointId,
+    admitted: false,
+    reason: VOTE_DENIAL_REASONS.WRITE_QUEUE_FAILURE,
+  });
 }
 
 /**

--- a/apps/web-pwa/src/hooks/voteIntentQueue.ts
+++ b/apps/web-pwa/src/hooks/voteIntentQueue.ts
@@ -58,9 +58,13 @@ const queue = createIntentQueue<VoteIntentRecord>({
  * a same-intent_id record that wins compareIntentLww replaces the queued one so
  * a mutate-while-pending vote is not lost. When the queue exceeds
  * MAX_QUEUE_SIZE, the oldest intent is evicted.
+ *
+ * Returns `true` when the intent is durably queued and `false` when the durable
+ * write failed, so the admission path can emit a `Write queue failure` denial
+ * instead of reporting a persisted vote that was silently dropped.
  */
-export function enqueueIntent(record: VoteIntentRecord): void {
-  queue.enqueue(record);
+export function enqueueIntent(record: VoteIntentRecord): boolean {
+  return queue.enqueue(record);
 }
 
 /**

--- a/apps/web-pwa/src/hooks/voteIntentReplayTriggers.test.ts
+++ b/apps/web-pwa/src/hooks/voteIntentReplayTriggers.test.ts
@@ -1,0 +1,109 @@
+/* @vitest-environment jsdom */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { getPendingIntentsMock, scheduleReplayMock } = vi.hoisted(() => ({
+  getPendingIntentsMock: vi.fn(),
+  scheduleReplayMock: vi.fn(),
+}));
+
+vi.mock('./voteIntentQueue', () => ({
+  getPendingIntents: (...a: unknown[]) => getPendingIntentsMock(...(a as [])),
+}));
+
+vi.mock('./voteIntentMaterializer', () => ({
+  scheduleVoteIntentReplay: (...a: unknown[]) => scheduleReplayMock(...(a as [])),
+}));
+
+import { installVoteIntentReplayTriggers } from './voteIntentReplayTriggers';
+
+function setVisibility(state: DocumentVisibilityState): void {
+  Object.defineProperty(document, 'visibilityState', {
+    configurable: true,
+    get: () => state,
+  });
+}
+
+describe('installVoteIntentReplayTriggers', () => {
+  let uninstall: () => void = () => {};
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getPendingIntentsMock.mockReturnValue([]);
+    setVisibility('visible');
+  });
+
+  afterEach(() => {
+    uninstall();
+  });
+
+  it('is a no-op returning a safe uninstall when window is unavailable (SSR)', () => {
+    getPendingIntentsMock.mockReturnValue([{ intent_id: 'a' }]);
+    vi.stubGlobal('window', undefined);
+    try {
+      const uninstallSSR = installVoteIntentReplayTriggers();
+      expect(scheduleReplayMock).not.toHaveBeenCalled();
+      expect(() => uninstallSSR()).not.toThrow();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+    uninstall = () => {};
+  });
+
+  it('drains on startup only when intents are pending', () => {
+    getPendingIntentsMock.mockReturnValue([{ intent_id: 'a' }]);
+    uninstall = installVoteIntentReplayTriggers();
+    expect(scheduleReplayMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not drain on startup when the queue is empty', () => {
+    getPendingIntentsMock.mockReturnValue([]);
+    uninstall = installVoteIntentReplayTriggers();
+    expect(scheduleReplayMock).not.toHaveBeenCalled();
+  });
+
+  it('drains when connectivity returns', () => {
+    uninstall = installVoteIntentReplayTriggers();
+    scheduleReplayMock.mockClear();
+    getPendingIntentsMock.mockReturnValue([{ intent_id: 'a' }]);
+    window.dispatchEvent(new Event('online'));
+    expect(scheduleReplayMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('drains when a backgrounded tab becomes visible, not when hidden', () => {
+    uninstall = installVoteIntentReplayTriggers();
+    scheduleReplayMock.mockClear();
+    getPendingIntentsMock.mockReturnValue([{ intent_id: 'a' }]);
+
+    setVisibility('hidden');
+    document.dispatchEvent(new Event('visibilitychange'));
+    expect(scheduleReplayMock).not.toHaveBeenCalled();
+
+    setVisibility('visible');
+    document.dispatchEvent(new Event('visibilitychange'));
+    expect(scheduleReplayMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('is idempotent when installed more than once', () => {
+    getPendingIntentsMock.mockReturnValue([{ intent_id: 'a' }]);
+    uninstall = installVoteIntentReplayTriggers();
+    const secondUninstall = installVoteIntentReplayTriggers();
+
+    expect(secondUninstall).toBe(uninstall);
+    expect(scheduleReplayMock).toHaveBeenCalledTimes(1);
+
+    scheduleReplayMock.mockClear();
+    window.dispatchEvent(new Event('online'));
+    expect(scheduleReplayMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('removes its listeners on uninstall', () => {
+    const install = installVoteIntentReplayTriggers();
+    scheduleReplayMock.mockClear();
+    install();
+    getPendingIntentsMock.mockReturnValue([{ intent_id: 'a' }]);
+    window.dispatchEvent(new Event('online'));
+    document.dispatchEvent(new Event('visibilitychange'));
+    expect(scheduleReplayMock).not.toHaveBeenCalled();
+    uninstall = () => {};
+  });
+});

--- a/apps/web-pwa/src/hooks/voteIntentReplayTriggers.ts
+++ b/apps/web-pwa/src/hooks/voteIntentReplayTriggers.ts
@@ -1,0 +1,54 @@
+import { getPendingIntents } from './voteIntentQueue';
+import { scheduleVoteIntentReplay } from './voteIntentMaterializer';
+
+let installedUninstall: (() => void) | null = null;
+
+/**
+ * App-lifecycle drain triggers for the durable vote-intent queue.
+ *
+ * Without these, a queued intent only ever materializes when the user casts
+ * *another* vote (the sole caller of `scheduleVoteIntentReplay`) — so a vote
+ * cast offline, or one whose first replay failed, could sit in localStorage
+ * indefinitely, violating the durable-enqueue contract ("admitted → materialize
+ * or surface failure"). Installing these at bootstrap drains on startup, when
+ * connectivity returns, and when a backgrounded tab becomes visible again.
+ *
+ * Draining is gated on there being pending intents so an empty queue produces
+ * no replay work or log noise. `scheduleVoteIntentReplay` is itself idempotent
+ * (it no-ops while a replay is in flight), so overlapping triggers are safe.
+ */
+export function installVoteIntentReplayTriggers(): () => void {
+  if (typeof window === 'undefined') {
+    return () => {};
+  }
+  if (installedUninstall) {
+    return installedUninstall;
+  }
+
+  const drainIfPending = (): void => {
+    if (getPendingIntents().length > 0) {
+      scheduleVoteIntentReplay();
+    }
+  };
+
+  const onOnline = (): void => drainIfPending();
+  const onVisible = (): void => {
+    if (document.visibilityState === 'visible') {
+      drainIfPending();
+    }
+  };
+
+  window.addEventListener('online', onOnline);
+  document.addEventListener('visibilitychange', onVisible);
+
+  // Initial drain for intents left pending by a prior session.
+  drainIfPending();
+
+  installedUninstall = () => {
+    window.removeEventListener('online', onOnline);
+    document.removeEventListener('visibilitychange', onVisible);
+    installedUninstall = null;
+  };
+
+  return installedUninstall;
+}

--- a/apps/web-pwa/src/main.tsx
+++ b/apps/web-pwa/src/main.tsx
@@ -6,6 +6,7 @@ import { routeTree } from './routes';
 import './index.css';
 import { ThemeProvider } from './components/ThemeProvider';
 import { startHealthMonitor } from './hooks/useHealthMonitor';
+import { installVoteIntentReplayTriggers } from './hooks/voteIntentReplayTriggers';
 
 const DevModelPicker = import.meta.env.DEV
   ? lazy(() => import('./components/dev/DevModelPicker'))
@@ -23,6 +24,9 @@ if (typeof window !== 'undefined' && window.location.search) {
 console.info('[vh:web-pwa] main.tsx executing, mounting router...');
 if (typeof window !== 'undefined') {
   startHealthMonitor();
+  // Drain the durable vote-intent queue on startup / reconnect / tab-visible so
+  // intents left pending by a prior session materialize without another vote.
+  installVoteIntentReplayTriggers();
 }
 
 const router = createRouter({ routeTree });

--- a/apps/web-pwa/src/utils/safeStorage.test.ts
+++ b/apps/web-pwa/src/utils/safeStorage.test.ts
@@ -29,7 +29,7 @@ describe('safeStorage', () => {
   });
 
   it('reads, writes, and removes values when localStorage exists', () => {
-    safeSetItem('k1', 'v1');
+    expect(safeSetItem('k1', 'v1')).toBe(true);
     expect(safeGetItem('k1')).toBe('v1');
 
     safeRemoveItem('k1');
@@ -44,7 +44,7 @@ describe('safeStorage', () => {
     vi.stubGlobal('localStorage', undefined);
 
     expect(safeGetItem('k1')).toBeNull();
-    expect(() => safeSetItem('k1', 'v1')).not.toThrow();
+    expect(safeSetItem('k1', 'v1')).toBe(false);
     expect(() => safeRemoveItem('k1')).not.toThrow();
   });
 
@@ -62,7 +62,7 @@ describe('safeStorage', () => {
     });
 
     expect(safeGetItem('k1')).toBeNull();
-    expect(() => safeSetItem('k1', 'v1')).not.toThrow();
+    expect(safeSetItem('k1', 'v1')).toBe(false);
     expect(() => safeRemoveItem('k1')).not.toThrow();
   });
 
@@ -79,7 +79,7 @@ describe('safeStorage', () => {
 
     try {
       expect(safeGetItem('k1')).toBeNull();
-      expect(() => safeSetItem('k1', 'v1')).not.toThrow();
+      expect(safeSetItem('k1', 'v1')).toBe(false);
       expect(() => safeRemoveItem('k1')).not.toThrow();
     } finally {
       if (original) {

--- a/apps/web-pwa/src/utils/safeStorage.ts
+++ b/apps/web-pwa/src/utils/safeStorage.ts
@@ -21,12 +21,22 @@ export function safeGetItem(key: string): string | null {
   }
 }
 
-export function safeSetItem(key: string, value: string): void {
-  if (!canUseStorage()) return;
+/**
+ * Write to localStorage. Returns `true` when the value was written, `false`
+ * when storage is unavailable or the write failed (quota exceeded, disabled
+ * storage, private-mode restrictions). Callers that need durability (e.g. the
+ * vote-intent queue) inspect the result so a failed write surfaces instead of
+ * being silently dropped; callers that treat storage as best-effort can ignore
+ * it.
+ */
+export function safeSetItem(key: string, value: string): boolean {
+  if (!canUseStorage()) return false;
   try {
     localStorage.setItem(key, value);
+    return true;
   } catch {
-    // Silently ignore (quota exceeded, etc.)
+    // Quota exceeded, disabled/blocked storage, etc.
+    return false;
   }
 }
 

--- a/apps/web-pwa/vite.config.ts
+++ b/apps/web-pwa/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig, type Plugin } from 'vite';
+import { defineConfig, type Plugin, type ViteDevServer } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'node:path';
 import type { IncomingMessage, ServerResponse } from 'node:http';
@@ -97,8 +97,8 @@ function htmlToReadableText(rawHtml: string): string {
 function createArticleTextProxyPlugin(): Plugin {
   return {
     name: 'vh-article-text-proxy',
-    configureServer(server) {
-      server.middlewares.use('/article-text', async (req, res) => {
+    configureServer(server: ViteDevServer) {
+      server.middlewares.use('/article-text', async (req: IncomingMessage, res: ServerResponse) => {
         if (!req.url) {
           sendJson(res, 400, { error: 'Missing request URL' });
           return;
@@ -203,7 +203,7 @@ function createArticleTextProxyPlugin(): Plugin {
         }
       });
     },
-  };
+  } as Plugin;
 }
 
 function readBooleanEnv(value: string | undefined): boolean {
@@ -231,8 +231,8 @@ async function readJsonRequestBody(req: IncomingMessage): Promise<unknown> {
 function createAnalysisRelayPlugin(): Plugin {
   return {
     name: 'vh-analysis-relay',
-    configureServer(server) {
-      server.middlewares.use('/api/analyze/health', async (req, res) => {
+    configureServer(server: ViteDevServer) {
+      server.middlewares.use('/api/analyze/health', async (req: IncomingMessage, res: ServerResponse) => {
         if ((req.method ?? 'GET').toUpperCase() !== 'GET') { sendJson(res, 405, { error: 'Method not allowed' }); return; }
         const c = resolveAnalysisRelayConfig(process.env as Record<string, string | undefined>);
         if (!c) { sendJson(res, 503, { ok: false, error: 'Relay not configured' }); return; }
@@ -261,12 +261,12 @@ function createAnalysisRelayPlugin(): Plugin {
           });
         }
       });
-      server.middlewares.use('/api/analyze/config', (req, res) => {
+      server.middlewares.use('/api/analyze/config', (req: IncomingMessage, res: ServerResponse) => {
         if ((req.method ?? 'GET').toUpperCase() !== 'GET') { sendJson(res, 405, { error: 'Method not allowed' }); return; }
         const c = resolveAnalysisRelayConfig(process.env as Record<string, string | undefined>);
         sendJson(res, 200, { configured: !!c, model: c?.modelOverride ?? 'default', provider_id: c?.providerId ?? 'not-configured', upstream_url: c ? '[configured]' : 'not-configured', analyses_limit: c?.analysesLimit ?? 0, analyses_per_topic_limit: c?.analysesPerTopicLimit ?? 0 });
       });
-      server.middlewares.use('/api/analyze', async (req, res) => {
+      server.middlewares.use('/api/analyze', async (req: IncomingMessage, res: ServerResponse) => {
         if ((req.method ?? 'GET').toUpperCase() !== 'POST') {
           sendJson(res, 405, { error: 'Method not allowed' });
           return;
@@ -283,7 +283,7 @@ function createAnalysisRelayPlugin(): Plugin {
         }
       });
     },
-  };
+  } as Plugin;
 }
 
 function escapeHtmlAttribute(value: string): string {
@@ -297,7 +297,7 @@ function escapeHtmlAttribute(value: string): string {
 function createCspHtmlPlugin(): Plugin {
   return {
     name: 'vh-csp-html',
-    transformIndexHtml(html) {
+    transformIndexHtml(html: string) {
       const csp = escapeHtmlAttribute(buildCspContent(process.env.VITE_VH_CSP_CONNECT_SRC, {
         strictConnectSrc: readBooleanEnv(process.env.VITE_VH_CSP_STRICT_CONNECT_SRC),
       }));
@@ -306,7 +306,7 @@ function createCspHtmlPlugin(): Plugin {
         `$1${csp}$3`,
       );
     },
-  };
+  } as Plugin;
 }
 
 export default defineConfig({

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "node": ">=20.0.0 <23.0.0"
   },
   "scripts": {
-    "prebuild:guards": "pnpm --dir tools/scripts/vh exec tsx ../guards/checkProductionFlags.ts",
+    "prebuild:guards": "corepack pnpm@9.7.1 --dir tools/scripts/vh exec tsx ../guards/checkProductionFlags.ts",
     "build": "pnpm -r --workspace-root=false build",
     "typecheck": "pnpm -r --workspace-root=false typecheck",
     "test": "pnpm -r --workspace-root=false test",

--- a/packages/e2e/src/luma/mvp-production-readiness.mjs
+++ b/packages/e2e/src/luma/mvp-production-readiness.mjs
@@ -19,6 +19,7 @@ const __dirname = path.dirname(__filename);
 const repoRoot = path.resolve(__dirname, '../../../..');
 const latestDir = path.join(repoRoot, '.tmp/luma-mvp-production-readiness/latest');
 const latestReportPath = path.join(latestDir, 'luma-mvp-production-readiness-report.json');
+const packageJsonPath = path.join(repoRoot, 'package.json');
 
 const lumaCoverageReportPath = path.join(
   repoRoot,
@@ -60,6 +61,7 @@ const REQUIRED_GUARDS = Object.freeze([
   'pnpm check:luma-topic-engagement-summary-system-v1',
   'pnpm check:luma-civic-reps-system-v1',
   'pnpm check:luma-discovery-index-system-v1',
+  'pnpm check:district-aggregate-thresholds',
   'pnpm check:public-beta-compliance',
 ]);
 
@@ -157,13 +159,37 @@ function splitCommand(command) {
   return [bin, args];
 }
 
-function runCommand(command, options = {}) {
+function repoPackageManagerSpec() {
+  try {
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+    const packageManager = typeof packageJson.packageManager === 'string'
+      ? packageJson.packageManager.trim()
+      : '';
+    return packageManager.split('+')[0] || 'pnpm@9.7.1';
+  } catch {
+    return 'pnpm@9.7.1';
+  }
+}
+
+export function resolveCommandInvocation(command) {
   const [bin, args] = Array.isArray(command) ? command : splitCommand(command);
+  if (bin === 'pnpm') {
+    return ['corepack', [repoPackageManagerSpec(), ...args]];
+  }
+  return [bin, args];
+}
+
+function runCommand(command, options = {}) {
+  const [bin, args] = resolveCommandInvocation(command);
   const echo = options.echo ?? true;
   return new Promise((resolve) => {
     const child = spawn(bin, args, {
       cwd: repoRoot,
-      env: { ...process.env, CI: process.env.CI ?? 'true' },
+      env: {
+        ...process.env,
+        CI: process.env.CI ?? 'true',
+        COREPACK_ENABLE_DOWNLOAD_PROMPT: process.env.COREPACK_ENABLE_DOWNLOAD_PROMPT ?? '0',
+      },
       stdio: ['ignore', 'pipe', 'pipe'],
     });
     let stdout = '';

--- a/packages/e2e/src/luma/mvp-production-readiness.vitest.mjs
+++ b/packages/e2e/src/luma/mvp-production-readiness.vitest.mjs
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   evaluateEvidenceCommitCompatibility,
   meshPublicWssProofStatus,
+  resolveCommandInvocation,
   validateActionPolicySurface,
   validateEmbeddedMeshLumaCoverage,
   validateReleaseClaimSurface,
@@ -29,6 +30,17 @@ describe('LUMA MVP production-readiness static checks', () => {
       id: 'release_claim_boundaries',
       status: 'pass',
     });
+  });
+
+  it('runs child pnpm guards through the repo-pinned Corepack package manager', () => {
+    expect(resolveCommandInvocation('pnpm check:public-beta-compliance')).toEqual([
+      'corepack',
+      ['pnpm@9.7.1', 'check:public-beta-compliance'],
+    ]);
+    expect(resolveCommandInvocation(['git', ['status', '--short']])).toEqual([
+      'git',
+      ['status', '--short'],
+    ]);
   });
 
   it('accepts skipped synthetic mesh rows when explicit LUMA coverage is embedded and passing', () => {


### PR DESCRIPTION
## Summary
- harden durable vote-intent persistence so admission fails closed when local durable enqueue fails
- add lifecycle replay triggers for queued vote intents and make trigger installation idempotent
- tighten sign-in/account binding behavior for expired sessions and stale-provider sign-out
- make denial copy specific/actionable, tolerate out-of-range correction timestamps, and restore web typecheck/build script reliability under repo-pinned pnpm
- run LUMA MVP readiness child guards through the repo package manager and include district aggregate thresholds in the wrapper

## Validation
- corepack pnpm@9.7.1 exec vitest run apps/web-pwa/src/hooks/useSignIn.test.ts apps/web-pwa/src/hooks/voteIntentReplayTriggers.test.ts apps/web-pwa/src/hooks/intentQueue.test.ts apps/web-pwa/src/hooks/voteAdmission.test.ts apps/web-pwa/src/components/feed/CellVoteControls.test.tsx apps/web-pwa/src/components/feed/NewsCardBack.report.test.tsx apps/web-pwa/src/utils/safeStorage.test.ts apps/web-pwa/src/hooks/useSentimentState.test.ts apps/web-pwa/src/hooks/voteIntentQueue.test.ts
- corepack pnpm@9.7.1 --filter @vh/e2e exec vitest run src/luma/mvp-production-readiness.vitest.mjs --config ./vitest.config.ts
- corepack pnpm@9.7.1 --filter @vh/web-pwa typecheck
- corepack pnpm@9.7.1 --filter @vh/web-pwa build
- corepack pnpm@9.7.1 check:district-aggregate-thresholds
- corepack pnpm@9.7.1 check:public-beta-compliance
- corepack pnpm@9.7.1 check:luma-forbidden-claims
- corepack pnpm@9.7.1 docs:check
- git diff --check

## Known blocker
- `corepack pnpm@9.7.1 check:luma:mvp-production-readiness` now runs all child guards under pnpm 9.7.1 and those child guards pass, but the wrapper remains `blocked` because this branch is dirty while running locally and committed mesh/LUMA evidence is for `de4fb56edb5a35b8ded1846da9c1c34d78f8c0f3`, not current `eaa64c62b4cd792bd9946a53180f552eddbce4f7`. That is an evidence refresh blocker, not a child guard or package-manager failure.

## Notes
- No live A6 action, pager change, or Codex executor/autonomy change was made.
- The two untracked distribution readiness docs remain untracked and preserved locally.
