### PR TITLE
Extend reject-unmarked system-writer mode to remaining migrated adapters (#740)

### DIFF
--- a/docs/specs/spec-luma-service-v0.md
+++ b/docs/specs/spec-luma-service-v0.md
@@ -764,6 +764,20 @@ directory snapshot system-writer migration.
 `pnpm check:luma-discovery-index-system-v1` guards the discovery item/index page
 system-writer migration.
 
+The optional client flag `VH_GUN_REJECT_UNMARKED_SYSTEM_RECORDS` (default OFF)
+now spans ALL migrated system-writer read classes: news story bundles,
+synthesis-lifecycle, latest/hot index entries, topic synthesis/digest/correction,
+discovery items and index pages, storyline groups, topic-engagement summaries,
+civic-representative snapshots, and analysis artifacts and latest pointers. When
+enabled, each adapter refuses unmarked (and clean legacy-marked) schema-valid
+records for its class with an observable `system-writer-validation-failed` /
+`unmarked-record-rejected` event, and skips any legacy scalar/relay fallback that
+could re-admit the class; district-aggregate summaries are already
+unconditionally fail-closed. Each class's `check:luma-*-system-v1` gate pins the
+reject-unmarked branch and its flag-on test so the enforcement cannot silently
+regress. Legacy acceptance is unchanged while the flag is absent/false; flipping
+it on in a deployed profile remains an operator decision.
+
 `AggregateVoterNodeV1` uses schema version `aggregate-voter-node-v1`,
 `_protocolVersion: 'luma-public-v1'`, `_writerKind: 'luma'`,
 `_authorScheme: 'voter-v1'`, and `SignedWriteEnvelope.audience =

--- a/packages/gun-client/src/analysisAdapters.test.ts
+++ b/packages/gun-client/src/analysisAdapters.test.ts
@@ -248,6 +248,19 @@ async function signSystemWriterTestRecord(
   };
 }
 
+function withRejectUnmarkedFlag(): () => void {
+  const target = globalThis as { __VH_IMPORT_META_ENV__?: Record<string, unknown> };
+  const previous = target.__VH_IMPORT_META_ENV__;
+  target.__VH_IMPORT_META_ENV__ = { VITE_VH_GUN_REJECT_UNMARKED_SYSTEM_RECORDS: 'true' };
+  return () => {
+    if (previous === undefined) {
+      delete target.__VH_IMPORT_META_ENV__;
+    } else {
+      target.__VH_IMPORT_META_ENV__ = previous;
+    }
+  };
+}
+
 describe('analysisAdapters', () => {
   it('builds story analysis root chain and guards nested writes', async () => {
     const mesh = createFakeMesh();
@@ -614,6 +627,90 @@ describe('analysisAdapters', () => {
 
     await expect(readAnalysis(client, 'story-1', 'analysis-1')).resolves.toEqual(ARTIFACT);
     await expect(readLatestAnalysis(client, 'story-1')).resolves.toEqual(ARTIFACT);
+  });
+
+  it('rejects unmarked and clean legacy-marked analysis artifacts and pointers when reject-unmarked mode is on', async () => {
+    const { mesh, client, artifactRecord, pointerRecord } = await createSignedAnalysisFixture();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    class TestCustomEvent extends Event {
+      readonly detail: unknown;
+
+      constructor(type: string, init?: CustomEventInit) {
+        super(type);
+        this.detail = init?.detail;
+      }
+    }
+    const dispatchSpy = vi.fn(() => true);
+    vi.stubGlobal('CustomEvent', TestCustomEvent);
+    vi.stubGlobal('dispatchEvent', dispatchSpy);
+    const restoreFlag = withRejectUnmarkedFlag();
+
+    const bareArtifact = {
+      __analysis_artifact_codec: 'analysis-artifact-json-v1',
+      artifact_json: JSON.stringify(ARTIFACT),
+      story_id: ARTIFACT.story_id,
+      analysisKey: ARTIFACT.analysisKey,
+      provenance_hash: ARTIFACT.provenance_hash,
+      model_scope: ARTIFACT.model_scope,
+      created_at: ARTIFACT.created_at,
+    };
+    const legacyArtifact = { ...bareArtifact, _writerKind: 'legacy', _protocolVersion: SYSTEM_WRITER_PROTOCOL_VERSION };
+    const barePointer = {
+      analysisKey: ARTIFACT.analysisKey,
+      provenance_hash: ARTIFACT.provenance_hash,
+      model_scope: ARTIFACT.model_scope,
+      created_at: ARTIFACT.created_at,
+      bundle_identity: ARTIFACT.bundle_identity,
+    };
+    const legacyPointer = { ...barePointer, _writerKind: 'legacy', _protocolVersion: SYSTEM_WRITER_PROTOCOL_VERSION };
+
+    try {
+      // Signed records still read back flag-on.
+      mesh.setRead('news/stories/story-1/analysis/analysis-1', artifactRecord);
+      mesh.setRead('news/stories/story-1/analysis_latest', pointerRecord);
+      await expect(readAnalysis(client, 'story-1', 'analysis-1')).resolves.toEqual(ARTIFACT);
+      await expect(readLatestAnalysis(client, 'story-1')).resolves.toEqual(ARTIFACT);
+
+      // Bare-unmarked AND clean legacy-marked artifacts are refused flag-on.
+      for (const record of [bareArtifact, legacyArtifact]) {
+        warnSpy.mockClear();
+        mesh.setRead('news/stories/story-1/analysis/analysis-1', record);
+        await expect(readAnalysis(client, 'story-1', 'analysis-1')).resolves.toBeNull();
+        expect(warnSpy).toHaveBeenCalledWith(
+          `[vh:analysis] ${SYSTEM_WRITER_VALIDATION_EVENT}`,
+          expect.objectContaining({
+            event: SYSTEM_WRITER_VALIDATION_EVENT,
+            reason: 'unmarked-record-rejected',
+          }),
+        );
+      }
+
+      // Bare-unmarked AND clean legacy-marked latest pointers are refused flag-on
+      // (parseLatestPointerFromStoredRecord returns { state: 'blocked' }).
+      for (const record of [barePointer, legacyPointer]) {
+        warnSpy.mockClear();
+        mesh.setRead('news/stories/story-1/analysis_latest', record);
+        await expect(readLatestAnalysis(client, 'story-1')).resolves.toBeNull();
+        expect(warnSpy).toHaveBeenCalledWith(
+          `[vh:analysis] ${SYSTEM_WRITER_VALIDATION_EVENT}`,
+          expect.objectContaining({
+            event: SYSTEM_WRITER_VALIDATION_EVENT,
+            reason: 'unmarked-record-rejected',
+          }),
+        );
+      }
+
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: SYSTEM_WRITER_VALIDATION_EVENT,
+          detail: expect.objectContaining({ reason: 'unmarked-record-rejected' }),
+        }),
+      );
+    } finally {
+      restoreFlag();
+      vi.unstubAllGlobals();
+      warnSpy.mockRestore();
+    }
   });
 
   it('readAnalysis rejects tampered or path-mismatched system writer artifacts', async () => {

--- a/packages/gun-client/src/analysisAdapters.ts
+++ b/packages/gun-client/src/analysisAdapters.ts
@@ -13,6 +13,8 @@ import {
   SYSTEM_WRITER_PROTOCOL_VERSION,
   SYSTEM_WRITER_VALIDATION_EVENT,
   buildSignedSystemWriterRecord,
+  rejectUnmarkedSystemRecords,
+  unmarkedRecordRejectedFailure,
   validateSystemWriterRecord,
   type SystemWriterRecordFields,
   type SystemWriterValidationFailure,
@@ -423,6 +425,11 @@ async function parseStoryAnalysisArtifactFromStoredRecord(
     return null;
   }
 
+  if (rejectUnmarkedSystemRecords()) {
+    emitSystemWriterValidationFailure(unmarkedRecordRejectedFailure(storyAnalysisPath(storyId, analysisKey)));
+    return null;
+  }
+
   const parsed = parseStoryAnalysisArtifactPayload(payload);
   if (!parsed) {
     return null;
@@ -468,6 +475,11 @@ async function parseLatestPointerFromStoredRecord(
   }
 
   if (carriesLumaProtocolFields(payload)) {
+    return { state: 'blocked' };
+  }
+
+  if (rejectUnmarkedSystemRecords()) {
+    emitSystemWriterValidationFailure(unmarkedRecordRejectedFailure(storyAnalysisLatestPath(storyId)));
     return { state: 'blocked' };
   }
 

--- a/packages/gun-client/src/civicRepresentativeAdapters.test.ts
+++ b/packages/gun-client/src/civicRepresentativeAdapters.test.ts
@@ -247,6 +247,19 @@ async function createSignedSnapshotFixture(): Promise<{
   return { mesh, client, snapshotRecord };
 }
 
+function withRejectUnmarkedFlag(): () => void {
+  const target = globalThis as { __VH_IMPORT_META_ENV__?: Record<string, unknown> };
+  const previous = target.__VH_IMPORT_META_ENV__;
+  target.__VH_IMPORT_META_ENV__ = { VITE_VH_GUN_REJECT_UNMARKED_SYSTEM_RECORDS: 'true' };
+  return () => {
+    if (previous === undefined) {
+      delete target.__VH_IMPORT_META_ENV__;
+    } else {
+      target.__VH_IMPORT_META_ENV__ = previous;
+    }
+  };
+}
+
 describe('civicRepresentativeAdapters', () => {
   it('rejects blank jurisdiction versions before chain access', async () => {
     const mesh = createFakeMesh();
@@ -386,6 +399,55 @@ describe('civicRepresentativeAdapters', () => {
     });
 
     await expect(readCivicRepresentativeSnapshot(client, 'jurisdiction-v1')).resolves.toEqual(BASE_DIRECTORY);
+  });
+
+  it('rejects unmarked and clean legacy-marked civic representative snapshots when reject-unmarked mode is on', async () => {
+    const { mesh, client, snapshotRecord } = await createSignedSnapshotFixture();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    class TestCustomEvent extends Event {
+      readonly detail: unknown;
+
+      constructor(type: string, init?: CustomEventInit) {
+        super(type);
+        this.detail = init?.detail;
+      }
+    }
+    const dispatchSpy = vi.fn(() => true);
+    vi.stubGlobal('CustomEvent', TestCustomEvent);
+    vi.stubGlobal('dispatchEvent', dispatchSpy);
+    const restoreFlag = withRejectUnmarkedFlag();
+
+    try {
+      // Signed snapshots still read back flag-on.
+      mesh.setRead('civic/reps/jurisdiction-v1', { _: { '#': 'metadata' }, ...snapshotRecord });
+      await expect(readCivicRepresentativeSnapshot(client, 'jurisdiction-v1')).resolves.toEqual(BASE_DIRECTORY);
+
+      // Bare-unmarked AND clean legacy-marked snapshots are refused flag-on.
+      const legacyMarked = { _writerKind: 'legacy', _protocolVersion: SYSTEM_WRITER_PROTOCOL_VERSION, ...BASE_DIRECTORY };
+      for (const record of [{ ...BASE_DIRECTORY }, legacyMarked]) {
+        warnSpy.mockClear();
+        mesh.setRead('civic/reps/jurisdiction-v1', record);
+        await expect(readCivicRepresentativeSnapshot(client, 'jurisdiction-v1')).resolves.toBeNull();
+        expect(warnSpy).toHaveBeenCalledWith(
+          `[vh:civic-reps] ${SYSTEM_WRITER_VALIDATION_EVENT}`,
+          expect.objectContaining({
+            event: SYSTEM_WRITER_VALIDATION_EVENT,
+            reason: 'unmarked-record-rejected',
+          }),
+        );
+      }
+
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: SYSTEM_WRITER_VALIDATION_EVENT,
+          detail: expect.objectContaining({ reason: 'unmarked-record-rejected' }),
+        }),
+      );
+    } finally {
+      restoreFlag();
+      vi.unstubAllGlobals();
+      warnSpy.mockRestore();
+    }
   });
 
   it('returns null for non-record, timed-out, and late civic representative snapshot reads', async () => {

--- a/packages/gun-client/src/civicRepresentativeAdapters.ts
+++ b/packages/gun-client/src/civicRepresentativeAdapters.ts
@@ -12,6 +12,8 @@ import {
   SYSTEM_WRITER_VALIDATION_EVENT,
   buildSignedSystemWriterRecord,
   isSystemWriterPin,
+  rejectUnmarkedSystemRecords,
+  unmarkedRecordRejectedFailure,
   validateSystemWriterRecord,
   type SystemWriterRecordFields,
   type SystemWriterValidationFailure,
@@ -174,6 +176,11 @@ async function parseCivicRepresentativeSnapshotFromStoredRecord(
   }
 
   if (carriesLumaProtocolFields(payload)) {
+    return null;
+  }
+
+  if (rejectUnmarkedSystemRecords()) {
+    emitSystemWriterValidationFailure(unmarkedRecordRejectedFailure(civicRepresentativeSnapshotPath(jurisdictionVersion)));
     return null;
   }
 

--- a/packages/gun-client/src/discoveryAdapters.test.ts
+++ b/packages/gun-client/src/discoveryAdapters.test.ts
@@ -259,6 +259,19 @@ async function createSignedDiscoveryFixture(): Promise<{
   return { mesh, client, itemRecord, indexRecord, sign: hooks.sign };
 }
 
+function withRejectUnmarkedFlag(): () => void {
+  const target = globalThis as { __VH_IMPORT_META_ENV__?: Record<string, unknown> };
+  const previous = target.__VH_IMPORT_META_ENV__;
+  target.__VH_IMPORT_META_ENV__ = { VITE_VH_GUN_REJECT_UNMARKED_SYSTEM_RECORDS: 'true' };
+  return () => {
+    if (previous === undefined) {
+      delete target.__VH_IMPORT_META_ENV__;
+    } else {
+      target.__VH_IMPORT_META_ENV__ = previous;
+    }
+  };
+}
+
 describe('discoveryAdapters', () => {
   it('rejects blank, multi-segment, and private MY_ACTIVITY discovery paths before chain access', async () => {
     const mesh = createFakeMesh();
@@ -622,6 +635,74 @@ describe('discoveryAdapters', () => {
         }),
       );
     } finally {
+      vi.unstubAllGlobals();
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('rejects unmarked and clean legacy-marked discovery records when reject-unmarked mode is on', async () => {
+    const { mesh, client, itemRecord, indexRecord } = await createSignedDiscoveryFixture();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    class TestCustomEvent extends Event {
+      readonly detail: unknown;
+
+      constructor(type: string, init?: CustomEventInit) {
+        super(type);
+        this.detail = init?.detail;
+      }
+    }
+    const dispatchSpy = vi.fn(() => true);
+    vi.stubGlobal('CustomEvent', TestCustomEvent);
+    vi.stubGlobal('dispatchEvent', dispatchSpy);
+    const restoreFlag = withRejectUnmarkedFlag();
+
+    const legacyItem = { _writerKind: 'legacy', _protocolVersion: SYSTEM_WRITER_PROTOCOL_VERSION, ...BASE_ITEM };
+    const legacyIndex = { _writerKind: 'legacy', _protocolVersion: SYSTEM_WRITER_PROTOCOL_VERSION, ...BASE_INDEX_PAGE };
+
+    try {
+      // Signed records still read back flag-on (the marked branch runs and
+      // validates before the reject-unmarked check).
+      mesh.setRead('discovery/items/topic-1', { _: { '#': 'metadata' }, ...itemRecord });
+      mesh.setRead('discovery/index/ALL/LATEST/page-1', { _: { '#': 'metadata' }, ...indexRecord });
+      await expect(readDiscoveryItem(client, 'topic-1')).resolves.toEqual(BASE_ITEM);
+      await expect(readDiscoveryIndexPage(client, 'ALL', 'LATEST', 'page-1')).resolves.toEqual(BASE_INDEX_PAGE);
+
+      // Bare-unmarked AND clean legacy-marked item records are refused flag-on.
+      for (const record of [{ ...BASE_ITEM }, legacyItem]) {
+        warnSpy.mockClear();
+        mesh.setRead('discovery/items/topic-1', record);
+        await expect(readDiscoveryItem(client, 'topic-1')).resolves.toBeNull();
+        expect(warnSpy).toHaveBeenCalledWith(
+          `[vh:discovery] ${SYSTEM_WRITER_VALIDATION_EVENT}`,
+          expect.objectContaining({
+            event: SYSTEM_WRITER_VALIDATION_EVENT,
+            reason: 'unmarked-record-rejected',
+          }),
+        );
+      }
+
+      // Bare-unmarked AND clean legacy-marked index pages are refused flag-on.
+      for (const record of [{ ...BASE_INDEX_PAGE }, legacyIndex]) {
+        warnSpy.mockClear();
+        mesh.setRead('discovery/index/ALL/LATEST/page-1', record);
+        await expect(readDiscoveryIndexPage(client, 'ALL', 'LATEST', 'page-1')).resolves.toBeNull();
+        expect(warnSpy).toHaveBeenCalledWith(
+          `[vh:discovery] ${SYSTEM_WRITER_VALIDATION_EVENT}`,
+          expect.objectContaining({
+            event: SYSTEM_WRITER_VALIDATION_EVENT,
+            reason: 'unmarked-record-rejected',
+          }),
+        );
+      }
+
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: SYSTEM_WRITER_VALIDATION_EVENT,
+          detail: expect.objectContaining({ reason: 'unmarked-record-rejected' }),
+        }),
+      );
+    } finally {
+      restoreFlag();
       vi.unstubAllGlobals();
       warnSpy.mockRestore();
     }

--- a/packages/gun-client/src/discoveryAdapters.ts
+++ b/packages/gun-client/src/discoveryAdapters.ts
@@ -18,6 +18,8 @@ import {
   SYSTEM_WRITER_VALIDATION_EVENT,
   buildSignedSystemWriterRecord,
   isSystemWriterPin,
+  rejectUnmarkedSystemRecords,
+  unmarkedRecordRejectedFailure,
   validateSystemWriterRecord,
   type SystemWriterRecordFields,
   type SystemWriterValidationFailure,
@@ -284,6 +286,11 @@ async function parseDiscoveryItemFromStoredRecord(
     return null;
   }
 
+  if (rejectUnmarkedSystemRecords()) {
+    emitSystemWriterValidationFailure(unmarkedRecordRejectedFailure(discoveryItemPath(topicId)));
+    return null;
+  }
+
   const parsed = parseLegacyDiscoveryItemPayload(payload);
   return itemPathMatches(parsed, topicId) ? parsed : null;
 }
@@ -317,6 +324,11 @@ async function parseDiscoveryIndexPageFromStoredRecord(
   }
 
   if (carriesLumaProtocolFields(payload)) {
+    return null;
+  }
+
+  if (rejectUnmarkedSystemRecords()) {
+    emitSystemWriterValidationFailure(unmarkedRecordRejectedFailure(discoveryIndexPagePath(filter, sort, cursor)));
     return null;
   }
 

--- a/packages/gun-client/src/newsAdapters.ts
+++ b/packages/gun-client/src/newsAdapters.ts
@@ -7,12 +7,14 @@ import {
 import { lumaLog } from '@vh/luma-sdk';
 import { createGuardedChain, type ChainWithGet } from './chain';
 import { writeWithDurability, type DurableWriteResult } from './durableWrite';
-import { readGunBooleanFlag, readGunTimeoutMs } from './runtimeConfig';
+import { readGunTimeoutMs } from './runtimeConfig';
 import {
   SYSTEM_WRITER_KIND,
   SYSTEM_WRITER_PROTOCOL_VERSION,
   SYSTEM_WRITER_VALIDATION_EVENT,
   buildSignedSystemWriterRecord,
+  rejectUnmarkedSystemRecords,
+  unmarkedRecordRejectedFailure,
   validateSystemWriterRecord,
   type SystemWriterRecordFields,
   type SystemWriterValidationFailure,
@@ -1642,38 +1644,6 @@ function emitSystemWriterValidationFailure(
       new CustomEvent(SYSTEM_WRITER_VALIDATION_EVENT, { detail: failure })
     );
   }
-}
-
-// Evaluated lazily per parse so operators (and tests) can toggle it without a
-// module reload; absent flag preserves legacy-accept behavior exactly.
-// Reject-unmarked mode (default OFF). When enabled, unmarked schema-valid
-// records are refused instead of legacy-accepted.
-//
-// SCOPE — this flag currently hardens ONLY the record classes read through this
-// module and synthesisAdapters: news story bundles, synthesis-lifecycle, latest
-// and hot index entries (including the relay `stories`/`lifecycle` convenience
-// fields), and topic synthesis / digest / correction. District-aggregate
-// summaries are unconditionally fail-closed (no flag needed). The flag does NOT
-// yet cover discovery items/index pages, storyline groups, topic-engagement
-// summaries, civic-representative snapshots, or analysis artifacts/pointers —
-// those adapters keep an open legacy-accept branch regardless of the flag.
-// Extending them is tracked follow-up work; until then an operator enabling the
-// flag must treat those surfaces as still legacy-accepting.
-function rejectUnmarkedSystemRecords(): boolean {
-  return readGunBooleanFlag(
-    ['VITE_VH_GUN_REJECT_UNMARKED_SYSTEM_RECORDS', 'VH_GUN_REJECT_UNMARKED_SYSTEM_RECORDS'],
-    false,
-  );
-}
-
-function unmarkedRecordRejectedFailure(path: string): SystemWriterValidationFailure {
-  return {
-    valid: false,
-    event: SYSTEM_WRITER_VALIDATION_EVENT,
-    reason: 'unmarked-record-rejected',
-    path,
-    message: 'Unmarked record rejected: reject-unmarked mode requires system-writer records',
-  };
 }
 
 async function parseStoryBundleFromStoredRecord(

--- a/packages/gun-client/src/storylineAdapters.test.ts
+++ b/packages/gun-client/src/storylineAdapters.test.ts
@@ -216,6 +216,19 @@ const STORYLINE: StorylineGroup = {
   updated_at: 456,
 };
 
+function withRejectUnmarkedFlag(): () => void {
+  const target = globalThis as { __VH_IMPORT_META_ENV__?: Record<string, unknown> };
+  const previous = target.__VH_IMPORT_META_ENV__;
+  target.__VH_IMPORT_META_ENV__ = { VITE_VH_GUN_REJECT_UNMARKED_SYSTEM_RECORDS: 'true' };
+  return () => {
+    if (previous === undefined) {
+      delete target.__VH_IMPORT_META_ENV__;
+    } else {
+      target.__VH_IMPORT_META_ENV__ = previous;
+    }
+  };
+}
+
 describe('storylineAdapters', () => {
   it('builds storyline root and node chains with guarded paths', async () => {
     const mesh = createFakeMesh();
@@ -281,6 +294,69 @@ describe('storylineAdapters', () => {
     });
 
     await expect(readNewsStoryline(client, STORYLINE.storyline_id)).resolves.toEqual(STORYLINE);
+  });
+
+  it('rejects unmarked and clean legacy-marked storyline records when reject-unmarked mode is on', async () => {
+    const mesh = createFakeMesh();
+    const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+    const hooks = await createRealSystemWriterHooks();
+    const client = createClient(mesh, guard, {
+      systemWriterPin: hooks.pin,
+      systemWriterSign: hooks.sign,
+      systemWriterVerify: undefined,
+    });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const dispatchSpy = vi.fn(() => true);
+    vi.stubGlobal('CustomEvent', class TestCustomEvent {
+      type: string;
+      detail: unknown;
+      constructor(type: string, init?: { detail?: unknown }) {
+        this.type = type;
+        this.detail = init?.detail;
+      }
+    });
+    vi.stubGlobal('dispatchEvent', dispatchSpy);
+
+    // A real signed record to prove flag-on still accepts marked records.
+    await writeNewsStoryline(client, STORYLINE);
+    const signedRecord = expectSystemStorylineRecord(mesh.writes[0]?.value);
+    const restoreFlag = withRejectUnmarkedFlag();
+
+    try {
+      mesh.setRead('news/storylines/storyline-1', signedRecord);
+      await expect(readNewsStoryline(client, 'storyline-1')).resolves.toEqual(STORYLINE);
+
+      // Bare-unmarked AND clean legacy-marked records are refused flag-on.
+      const bare = storylineAdaptersInternal.encodeStorylineGroup(STORYLINE);
+      const legacyMarked = {
+        ...storylineAdaptersInternal.encodeStorylineGroup(STORYLINE),
+        _protocolVersion: SYSTEM_WRITER_PROTOCOL_VERSION,
+        _writerKind: 'legacy',
+      };
+      for (const record of [bare, legacyMarked]) {
+        warnSpy.mockClear();
+        mesh.setRead('news/storylines/storyline-1', record);
+        await expect(readNewsStoryline(client, 'storyline-1')).resolves.toBeNull();
+        expect(warnSpy).toHaveBeenCalledWith(
+          '[vh:storylines] system-writer-validation-failed',
+          expect.objectContaining({
+            event: 'system-writer-validation-failed',
+            reason: 'unmarked-record-rejected',
+          }),
+        );
+      }
+
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'system-writer-validation-failed',
+          detail: expect.objectContaining({ reason: 'unmarked-record-rejected' }),
+        }),
+      );
+    } finally {
+      restoreFlag();
+      vi.unstubAllGlobals();
+      warnSpy.mockRestore();
+    }
   });
 
   it('readNewsStoryline validates signed system storyline records through the shared system-writer validator', async () => {

--- a/packages/gun-client/src/storylineAdapters.ts
+++ b/packages/gun-client/src/storylineAdapters.ts
@@ -8,6 +8,8 @@ import {
   SYSTEM_WRITER_PROTOCOL_VERSION,
   SYSTEM_WRITER_VALIDATION_EVENT,
   canonicalizeSystemWriterRecordBytes,
+  rejectUnmarkedSystemRecords,
+  unmarkedRecordRejectedFailure,
   validateSystemWriterRecord,
   type SystemWriterRecordFields,
   type SystemWriterValidationFailure,
@@ -268,6 +270,11 @@ async function parseStorylineGroupFromStoredRecord(
   }
 
   if (carriesLumaProtocolFields(payload)) {
+    return null;
+  }
+
+  if (rejectUnmarkedSystemRecords()) {
+    emitSystemWriterValidationFailure(unmarkedRecordRejectedFailure(storylinePath(storylineId)));
     return null;
   }
 

--- a/packages/gun-client/src/synthesisAdapters.ts
+++ b/packages/gun-client/src/synthesisAdapters.ts
@@ -14,12 +14,14 @@ import { lumaLog } from '@vh/luma-sdk';
 import { createGuardedChain, putWithAckTimeout, type ChainWithGet } from './chain';
 import { writeWithDurability } from './durableWrite';
 import { resolveRelayRestEndpointFromPeer } from './relayRestFallback';
-import { readGunBooleanFlag, readGunTimeoutMs } from './runtimeConfig';
+import { readGunTimeoutMs } from './runtimeConfig';
 import {
   SYSTEM_WRITER_KIND,
   SYSTEM_WRITER_PROTOCOL_VERSION,
   SYSTEM_WRITER_VALIDATION_EVENT,
   buildSignedSystemWriterRecord,
+  rejectUnmarkedSystemRecords,
+  unmarkedRecordRejectedFailure,
   validateSystemWriterRecord,
   type SystemWriterRecordFields,
   type SystemWriterValidationFailure,
@@ -96,14 +98,6 @@ const RELAY_REST_READ_TIMEOUT_MS = readGunTimeoutMs(
   ['VITE_VH_GUN_SYNTHESIS_RELAY_READ_TIMEOUT_MS', 'VH_GUN_SYNTHESIS_RELAY_READ_TIMEOUT_MS'],
   8_000,
 );
-// Evaluated lazily per parse so operators (and tests) can toggle it without a
-// module reload; absent flag preserves legacy-accept behavior exactly.
-function rejectUnmarkedSystemRecords(): boolean {
-  return readGunBooleanFlag(
-    ['VITE_VH_GUN_REJECT_UNMARKED_SYSTEM_RECORDS', 'VH_GUN_REJECT_UNMARKED_SYSTEM_RECORDS'],
-    false,
-  );
-}
 function topicEpochCandidatesPath(topicId: string, epoch: string): string {
   return `vh/topics/${topicId}/epochs/${epoch}/candidates/`;
 }
@@ -457,16 +451,6 @@ function emitSystemWriterValidationFailure(failure: SystemWriterValidationFailur
       new CustomEvent(SYSTEM_WRITER_VALIDATION_EVENT, { detail: failure })
     );
   }
-}
-
-function unmarkedRecordRejectedFailure(path: string): SystemWriterValidationFailure {
-  return {
-    valid: false,
-    event: SYSTEM_WRITER_VALIDATION_EVENT,
-    reason: 'unmarked-record-rejected',
-    path,
-    message: 'Unmarked record rejected: reject-unmarked mode requires system-writer records',
-  };
 }
 
 function pathMatchesSynthesis(

--- a/packages/gun-client/src/systemWriter.ts
+++ b/packages/gun-client/src/systemWriter.ts
@@ -1,4 +1,5 @@
 import canonicalize from 'canonicalize';
+import { readGunBooleanFlag } from './runtimeConfig';
 
 export const SYSTEM_WRITER_PROTOCOL_VERSION = 'luma-public-v1' as const;
 export const SYSTEM_WRITER_SIGNATURE_SUITE = 'jcs-ed25519-sha256-v1' as const;
@@ -128,6 +129,47 @@ export interface SystemWriterValidationFailure {
 export type SystemWriterValidationResult =
   | SystemWriterValidationSuccess
   | SystemWriterValidationFailure;
+
+/**
+ * Reject-unmarked system-writer mode (default OFF). When enabled, an adapter
+ * refuses unmarked (and clean legacy-marked) schema-valid records for a migrated
+ * system-writer class instead of legacy-accepting them. Shared single source so
+ * the env-var names and default cannot drift across the adapters that consult it.
+ * Evaluated lazily per parse so operators (and tests) can toggle it without a
+ * module reload; absent flag preserves legacy-accept behavior exactly.
+ *
+ * SCOPE — the flag now hardens ALL migrated system-writer record classes read by
+ * the gun-client adapters: news story bundles, synthesis-lifecycle, latest/hot
+ * index entries (incl. relay `stories`/`lifecycle` convenience fields), topic
+ * synthesis / digest / correction, discovery items + index pages, storyline
+ * groups, topic-engagement summaries, civic-representative snapshots, and
+ * analysis artifacts + latest pointers. District-aggregate summaries are
+ * unconditionally fail-closed (no flag needed). Each adapter consulting this flag
+ * has a corresponding `check:luma-*-system-v1` gate pinning the reject-unmarked
+ * branch, so the enforcement cannot silently regress. Flipping the flag on in a
+ * deployed profile remains an operator decision, sequenced after live records
+ * are confirmed marked.
+ */
+export function rejectUnmarkedSystemRecords(): boolean {
+  return readGunBooleanFlag(
+    ['VITE_VH_GUN_REJECT_UNMARKED_SYSTEM_RECORDS', 'VH_GUN_REJECT_UNMARKED_SYSTEM_RECORDS'],
+    false,
+  );
+}
+
+/**
+ * The validation failure an adapter emits when reject-unmarked mode refuses an
+ * unmarked record. Shared so every adapter reports the same reason/message.
+ */
+export function unmarkedRecordRejectedFailure(path: string): SystemWriterValidationFailure {
+  return {
+    valid: false,
+    event: SYSTEM_WRITER_VALIDATION_EVENT,
+    reason: 'unmarked-record-rejected',
+    path,
+    message: 'Unmarked record rejected: reject-unmarked mode requires system-writer records',
+  };
+}
 
 interface AllowedSystemWriterPath {
   readonly recordClass: SystemWriterAllowedClass;

--- a/packages/gun-client/src/topicEngagementAdapters.test.ts
+++ b/packages/gun-client/src/topicEngagementAdapters.test.ts
@@ -268,6 +268,19 @@ async function createSignedSummaryFixture(): Promise<{
   return { mesh, client, summaryRecord };
 }
 
+function withRejectUnmarkedFlag(): () => void {
+  const target = globalThis as { __VH_IMPORT_META_ENV__?: Record<string, unknown> };
+  const previous = target.__VH_IMPORT_META_ENV__;
+  target.__VH_IMPORT_META_ENV__ = { VITE_VH_GUN_REJECT_UNMARKED_SYSTEM_RECORDS: 'true' };
+  return () => {
+    if (previous === undefined) {
+      delete target.__VH_IMPORT_META_ENV__;
+    } else {
+      target.__VH_IMPORT_META_ENV__ = previous;
+    }
+  };
+}
+
 describe('topicEngagementAdapters', () => {
   afterEach(() => {
     vi.useRealTimers();
@@ -525,6 +538,55 @@ describe('topicEngagementAdapters', () => {
     });
 
     await expect(readTopicEngagementSummary(client, 'topic-1')).resolves.toEqual(BASE_SUMMARY);
+  });
+
+  it('rejects unmarked and clean legacy-marked topic engagement summaries when reject-unmarked mode is on', async () => {
+    const { mesh, client, summaryRecord } = await createSignedSummaryFixture();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    class TestCustomEvent extends Event {
+      readonly detail: unknown;
+
+      constructor(type: string, init?: CustomEventInit) {
+        super(type);
+        this.detail = init?.detail;
+      }
+    }
+    const dispatchSpy = vi.fn(() => true);
+    vi.stubGlobal('CustomEvent', TestCustomEvent);
+    vi.stubGlobal('dispatchEvent', dispatchSpy);
+    const restoreFlag = withRejectUnmarkedFlag();
+
+    try {
+      // Signed summaries still read back flag-on.
+      mesh.setRead('aggregates/topics/topic-1/engagement/summary', { _: { '#': 'metadata' }, ...summaryRecord });
+      await expect(readTopicEngagementSummary(client, 'topic-1')).resolves.toEqual(BASE_SUMMARY);
+
+      // Bare-unmarked AND clean legacy-marked summaries are refused flag-on.
+      const legacyMarked = { ...BASE_SUMMARY, _writerKind: 'legacy', _protocolVersion: SYSTEM_WRITER_PROTOCOL_VERSION };
+      for (const record of [{ ...BASE_SUMMARY }, legacyMarked]) {
+        warnSpy.mockClear();
+        mesh.setRead('aggregates/topics/topic-1/engagement/summary', record);
+        await expect(readTopicEngagementSummary(client, 'topic-1')).resolves.toBeNull();
+        expect(warnSpy).toHaveBeenCalledWith(
+          `[vh:topic-engagement] ${SYSTEM_WRITER_VALIDATION_EVENT}`,
+          expect.objectContaining({
+            event: SYSTEM_WRITER_VALIDATION_EVENT,
+            reason: 'unmarked-record-rejected',
+          }),
+        );
+      }
+
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: SYSTEM_WRITER_VALIDATION_EVENT,
+          detail: expect.objectContaining({ reason: 'unmarked-record-rejected' }),
+        }),
+      );
+    } finally {
+      restoreFlag();
+      vi.unstubAllGlobals();
+      warnSpy.mockRestore();
+    }
   });
 
   it('rejects tampered or path-mismatched system writer topic engagement summaries', async () => {

--- a/packages/gun-client/src/topicEngagementAdapters.ts
+++ b/packages/gun-client/src/topicEngagementAdapters.ts
@@ -15,6 +15,8 @@ import {
   SYSTEM_WRITER_PROTOCOL_VERSION,
   SYSTEM_WRITER_VALIDATION_EVENT,
   buildSignedSystemWriterRecord,
+  rejectUnmarkedSystemRecords,
+  unmarkedRecordRejectedFailure,
   validateSystemWriterRecord,
   type SystemWriterRecordFields,
   type SystemWriterValidationFailure,
@@ -208,6 +210,11 @@ async function parseTopicEngagementSummaryFromStoredRecord(
   }
 
   if (carriesLumaProtocolFields(payload)) {
+    return null;
+  }
+
+  if (rejectUnmarkedSystemRecords()) {
+    emitSystemWriterValidationFailure(unmarkedRecordRejectedFailure(topicEngagementSummaryPath(topicId)));
     return null;
   }
 

--- a/tools/scripts/check-luma-civic-reps-system-v1.mjs
+++ b/tools/scripts/check-luma-civic-reps-system-v1.mjs
@@ -118,6 +118,7 @@ const snapshotParser = sliceFunction(adapterSource, 'parseCivicRepresentativeSna
 requireToken(snapshotParser, 'validateSystemWriterRecord', 'parseCivicRepresentativeSnapshotFromStoredRecord');
 requireToken(snapshotParser, 'emitSystemWriterValidationFailure', 'parseCivicRepresentativeSnapshotFromStoredRecord');
 requireToken(snapshotParser, 'carriesLumaProtocolFields', 'parseCivicRepresentativeSnapshotFromStoredRecord');
+requireToken(snapshotParser, 'rejectUnmarkedSystemRecords', 'parseCivicRepresentativeSnapshotFromStoredRecord');
 requireToken(snapshotParser, 'return null', 'parseCivicRepresentativeSnapshotFromStoredRecord');
 
 for (const token of [
@@ -127,6 +128,7 @@ for (const token of [
   'rejects tampered or path-mismatched system writer civic representative snapshots',
   'fails closed with system-writer-validation-failed when the civic representative snapshot pin is missing',
   'keeps legacy civic representative snapshots readable and rejects downgraded legacy fields',
+  'rejects unmarked and clean legacy-marked civic representative snapshots when reject-unmarked mode is on',
 ]) {
   requireToken(adapterTestSource, token, 'civic representative system writer tests');
 }

--- a/tools/scripts/check-luma-discovery-index-system-v1.mjs
+++ b/tools/scripts/check-luma-discovery-index-system-v1.mjs
@@ -192,6 +192,7 @@ for (const parserName of [
   requireToken(parser, 'validateSystemWriterRecord', parserName);
   requireToken(parser, 'emitSystemWriterValidationFailure', parserName);
   requireToken(parser, 'carriesLumaProtocolFields', parserName);
+  requireToken(parser, 'rejectUnmarkedSystemRecords', parserName);
   requireToken(parser, 'return null', parserName);
 }
 
@@ -203,6 +204,7 @@ for (const token of [
   'fails closed with system-writer-validation-failed when the discovery pin is missing',
   'keeps legacy discovery records readable and rejects downgraded legacy fields',
   'rejects invalid or private discovery payloads before persistence',
+  'rejects unmarked and clean legacy-marked discovery records when reject-unmarked mode is on',
 ]) {
   requireToken(adapterTestSource, token, 'discovery system writer tests');
 }

--- a/tools/scripts/check-luma-news-analysis-system-v1.mjs
+++ b/tools/scripts/check-luma-news-analysis-system-v1.mjs
@@ -79,6 +79,8 @@ for (const token of [
   'parseStoryAnalysisArtifactFromStoredRecord',
   'parseLatestPointerFromStoredRecord',
   'validateSystemWriterRecord',
+  'rejectUnmarkedSystemRecords',
+  'unmarkedRecordRejectedFailure',
   'system writer signer is required for news analysis writes',
   'system writer signer is required for news analysis latest-pointer writes',
   'SYSTEM_WRITER_VALIDATION_EVENT',
@@ -100,6 +102,7 @@ for (const token of [
   'keeps safe legacy-marked analysis artifacts and latest pointers read-compatible',
   'listAnalyses validates system children and excludes invalid signed entries',
   'writeAnalysis fails before persistence when system signing is unavailable or malformed',
+  'rejects unmarked and clean legacy-marked analysis artifacts and pointers when reject-unmarked mode is on',
 ]) {
   requireToken(analysisAdapterTestSource, token, 'analysis system writer tests');
 }

--- a/tools/scripts/check-luma-news-storyline-system-v1.mjs
+++ b/tools/scripts/check-luma-news-storyline-system-v1.mjs
@@ -87,6 +87,9 @@ forbidToken(storylineWriter, 'signedWriteEnvelope', 'writeNewsStoryline');
 const readStoryline = sliceExportedFunction(storylineAdapterSource, 'readNewsStoryline');
 requireToken(readStoryline, 'parseStorylineGroupFromStoredRecord', 'readNewsStoryline');
 
+const storylineParser = sliceFunction(storylineAdapterSource, 'parseStorylineGroupFromStoredRecord');
+requireToken(storylineParser, 'rejectUnmarkedSystemRecords', 'parseStorylineGroupFromStoredRecord');
+
 const storylineRecordBuilder = sliceFunction(storylineAdapterSource, 'buildSystemWriterStorylineRecord');
 for (const token of ['_authorScheme', 'signedWriteEnvelope', 'createSignedWriteEnvelope', 'canPerform(']) {
   forbidToken(storylineRecordBuilder, token, 'system storyline record builder');
@@ -112,6 +115,7 @@ for (const token of [
   'writeNewsStoryline fails closed without a system writer signer and does not write a bare storyline',
   'writeNewsStoryline resolves active-pin and default system writer ids without signer material',
   'writeNewsStoryline rejects invalid system writer timestamps and signatures',
+  'rejects unmarked and clean legacy-marked storyline records when reject-unmarked mode is on',
 ]) {
   requireToken(storylineAdapterTestSource, token, 'news storyline system writer tests');
 }

--- a/tools/scripts/check-luma-topic-engagement-summary-system-v1.mjs
+++ b/tools/scripts/check-luma-topic-engagement-summary-system-v1.mjs
@@ -114,6 +114,7 @@ const summaryParser = sliceFunction(adapterSource, 'parseTopicEngagementSummaryF
 requireToken(summaryParser, 'validateSystemWriterRecord', 'parseTopicEngagementSummaryFromStoredRecord');
 requireToken(summaryParser, 'emitSystemWriterValidationFailure', 'parseTopicEngagementSummaryFromStoredRecord');
 requireToken(summaryParser, 'carriesLumaProtocolFields', 'parseTopicEngagementSummaryFromStoredRecord');
+requireToken(summaryParser, 'rejectUnmarkedSystemRecords', 'parseTopicEngagementSummaryFromStoredRecord');
 requireToken(summaryParser, 'return null', 'parseTopicEngagementSummaryFromStoredRecord');
 
 for (const token of [
@@ -123,6 +124,7 @@ for (const token of [
   'keeps legacy topic engagement summaries readable and rejects downgraded legacy fields',
   'blocks validly signed topic engagement summaries whose top-level topic does not match',
   'does not persist an unsigned topic engagement summary when signer metadata is unavailable or malformed',
+  'rejects unmarked and clean legacy-marked topic engagement summaries when reject-unmarked mode is on',
 ]) {
   requireToken(adapterTestSource, token, 'topic engagement summary system writer tests');
 }

--- a/tools/scripts/check-luma-topic-synthesis-system-v1.mjs
+++ b/tools/scripts/check-luma-topic-synthesis-system-v1.mjs
@@ -103,7 +103,7 @@ for (const token of [
   'readTopicLatestSynthesisStatus',
   'validateSystemWriterRecord',
   'SYSTEM_WRITER_VALIDATION_EVENT',
-  "'unmarked-record-rejected'",
+  'unmarkedRecordRejectedFailure',
   'rejectUnmarkedSystemRecords',
   'system writer signer is required for topic synthesis writes',
   'system writer signer is required for topic synthesis latest writes',


### PR DESCRIPTION
Closes #740.

Extends `VH_GUN_REJECT_UNMARKED_SYSTEM_RECORDS` (default **OFF**) — previously covering only news story/synthesis/index/topic-synthesis-digest-correction — to the five migrated system-writer classes it did not yet reach:

- discovery items + index pages
- storyline groups
- topic-engagement summaries
- civic-representative snapshots
- analysis artifacts + latest pointers

When the flag is on, each adapter now refuses unmarked (and clean legacy-marked) schema-valid records for its class with an observable `system-writer-validation-failed` / `unmarked-record-rejected` event. **Legacy acceptance is byte-unchanged while the flag is absent/false.** None of these adapters has a scalar/relay fallback, so each fix is a single reject branch placed after the `carriesLumaProtocolFields` guard and before the legacy-accept.

## Notable design choice
The duplicated `rejectUnmarkedSystemRecords()` + `unmarkedRecordRejectedFailure()` helpers (byte-identical copies in newsAdapters + synthesisAdapters, at risk of env-var-name drift as the flag spread) are **extracted into `systemWriter.ts`** as a single shared source; all seven adapters now import them, and the authoritative scope comment lives with the helper. Verified gate-safe: the two gates that pin `rejectUnmarkedSystemRecords` (synthesis + digest) do so via substring-includes that the call sites still satisfy; the synthesis gate's adapter pin was updated from the moved reason literal to the now-shared call.

## Validation
- **100% per-file line + branch diff coverage** on all 8 changed gun-client source files.
- Flag-off compatibility + flag-on fail-closed tests added for each of the five adapters (signed still reads; unmarked and clean legacy-marked rejected with the emitted event).
- Each `check:luma-*-system-v1` gate extended to pin the reject-unmarked branch inside the parse function and the flag-on test name, so the enforcement cannot silently regress — all system-v1 gates green, plus telemetry-redaction / signed-write-surface / namespace-leaks / typecheck / docs-governance.
- `spec-luma-service-v0.md` updated to document the full flag scope.

## Non-goals honored
District-aggregate summaries remain unconditionally fail-closed (untouched). Legacy compatibility is unchanged while the flag is false. Flipping the flag on in a deployed profile remains an operator decision.

Draft: opened for cloud CI + review. Not merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)