### PR TITLE
Preserve newer VaultV2 data on old-bundle writes (#739)

### DIFF
--- a/packages/identity-vault/src/types.ts
+++ b/packages/identity-vault/src/types.ts
@@ -181,6 +181,35 @@ export const SIGN_IN_SESSION_COMPARTMENT_KEYS: ReadonlySet<string> = new Set([
 ]);
 
 /**
+ * The top-level keys this bundle's VaultV2 owns. MUST mirror the whitelist that
+ * normalizeVaultV2 (vault.ts) rebuilds from. Any stored top-level key NOT in this
+ * set is a newer-bundle compartment this bundle does not understand; the write
+ * path preserves it from the authenticated stored record rather than dropping it.
+ */
+export const VAULT_V2_KNOWN_TOP_LEVEL_KEYS: ReadonlySet<string> = new Set([
+  'schemaVersion',
+  'identityRecord',
+  'deviceCredential',
+  'seaDevicePair',
+  'delegationSigningKey',
+  'walletBinding',
+  'operatorAuthorizationToken',
+  'signInSession'
+]);
+
+/**
+ * The closed-key-set compartments and their owned key sets. Their strict
+ * validators reject unknown keys, so a newer-bundle field inside one of them
+ * would be lost on an old-bundle write unless the write path re-attaches it from
+ * the authenticated stored record (outside the owned key set).
+ */
+export const VAULT_V2_CLOSED_COMPARTMENT_KEY_SETS: ReadonlyMap<string, ReadonlySet<string>> = new Map([
+  ['walletBinding', WALLET_BINDING_COMPARTMENT_KEYS],
+  ['operatorAuthorizationToken', OPERATOR_AUTHORIZATION_TOKEN_COMPARTMENT_KEYS],
+  ['signInSession', SIGN_IN_SESSION_COMPARTMENT_KEYS]
+]);
+
+/**
  * Copy only the known keys of a plain-object compartment; non-object inputs
  * (null, arrays, primitives) pass through unchanged so the caller's validator
  * can reject them. Single source for the read-side salvage strippers (vault

--- a/packages/identity-vault/src/vault.test.ts
+++ b/packages/identity-vault/src/vault.test.ts
@@ -24,8 +24,8 @@ import {
   LEGACY_VAULT_VERSION,
   VAULT_VERSION
 } from './types';
-import type { DelegationSigningKeyCompartment, Identity, VaultRecord } from './types';
-import { encrypt, generateMasterKey } from './crypto';
+import type { DelegationSigningKeyCompartment, Identity, VaultRecord, VaultV2 } from './types';
+import { decrypt, encrypt, generateMasterKey } from './crypto';
 import {
   base64UrlToBytes,
   delegationSigningKey,
@@ -101,6 +101,19 @@ async function writeEncryptedVaultRecord(version: number, payload: unknown): Pro
 
 async function writeLegacyVaultRecord(identity: unknown): Promise<void> {
   await writeEncryptedVaultRecord(LEGACY_VAULT_VERSION, identity);
+}
+
+// Decrypt the raw stored vault blob directly (bypassing the salvaged read view,
+// which strips unknown fields out of closed compartments) to prove what actually
+// persisted at rest.
+async function decryptRawRecord(): Promise<Record<string, unknown> | null> {
+  const db = await openVaultDb();
+  const record = await idbGet<VaultRecord>(db, VAULT_STORE, IDENTITY_KEY);
+  const key = await idbGet<CryptoKey>(db, KEYS_STORE, MASTER_KEY);
+  db.close();
+  if (!record || !key) return null;
+  const plaintext = await decrypt(key, record.iv, record.ciphertext);
+  return plaintext ? (JSON.parse(new TextDecoder().decode(plaintext)) as Record<string, unknown>) : null;
 }
 
 beforeEach(async () => {
@@ -1501,7 +1514,7 @@ describe('Forward-compat salvage (shape-invalid v2 never deletes)', () => {
     expect(await readRawRecord()).toBeDefined();
   });
 
-  it('preserves an unknown top-level compartment in the read view; a save still drops it', async () => {
+  it('preserves an unknown future top-level compartment across an old-bundle write', async () => {
     await writeEncryptedVaultRecord(VAULT_VERSION, {
       schemaVersion: 2,
       identityRecord: LEGACY_IDENTITY,
@@ -1513,13 +1526,200 @@ describe('Forward-compat salvage (shape-invalid v2 never deletes)', () => {
     expect((vault as unknown as Record<string, unknown>).futureCompartment).toEqual({ hello: 1 });
     expect(await readRawRecord()).toBeDefined();
 
-    // Documented limitation: any old-tab save rebuilds from the known-key
-    // whitelist (normalizeVaultV2), silently dropping the unknown
-    // compartment. The salvage protects reads only.
+    // An old-bundle save no longer drops the unknown compartment: the write path
+    // re-attaches it from the authenticated stored record (merge-from-raw), so
+    // newer-bundle data survives at rest.
     await saveVaultV2(vault!);
     const after = await loadVaultV2();
     expect(after?.identityRecord).toEqual(LEGACY_IDENTITY);
-    expect((after as unknown as Record<string, unknown>).futureCompartment).toBeUndefined();
+    expect((after as unknown as Record<string, unknown>).futureCompartment).toEqual({ hello: 1 });
+
+    // Re-decrypt the stored blob directly to prove it persisted at rest (not
+    // just reconstructed in the read view).
+    const storedRaw = await decryptRawRecord();
+    expect((storedRaw as Record<string, unknown>).futureCompartment).toEqual({ hello: 1 });
+  });
+
+  it('preserves an unknown future field inside a closed compartment while an old-bundle write updates its owned fields', async () => {
+    const storedBinding = {
+      schemaVersion: 1,
+      address: '0x1111111111111111111111111111111111111111',
+      chainId: '1',
+      providerKind: 'browser-injected',
+      boundPrincipalNullifier: 'principal-a',
+      boundAt: 1,
+      updatedAt: 1,
+      chainMetadata: { rollup: 'future-field' }
+    };
+    await writeEncryptedVaultRecord(VAULT_VERSION, {
+      schemaVersion: 2,
+      identityRecord: LEGACY_IDENTITY,
+      walletBinding: storedBinding
+    });
+
+    // An old bundle rewrites the wallet binding's OWNED fields only (it does not
+    // know `chainMetadata`; the salvaged read view already stripped it).
+    const updatedOwnedBinding = {
+      schemaVersion: 1,
+      address: '0x2222222222222222222222222222222222222222',
+      chainId: '10',
+      providerKind: 'browser-injected',
+      boundPrincipalNullifier: 'principal-a',
+      boundAt: 1,
+      updatedAt: 2
+    };
+    await saveVaultV2({
+      schemaVersion: 2,
+      identityRecord: LEGACY_IDENTITY,
+      walletBinding: updatedOwnedBinding
+    } as VaultV2);
+
+    // At rest: the owned fields are the NEW values AND the future field survived.
+    const raw = await decryptRawRecord();
+    expect(raw?.walletBinding).toEqual({ ...updatedOwnedBinding, chainMetadata: { rollup: 'future-field' } });
+
+    // The salvaged read view still strips the unknown field (this bundle ignores it).
+    const view = await loadVaultV2();
+    expect(view?.walletBinding).toEqual(updatedOwnedBinding);
+  });
+
+  it('does not preserve object/prototype magic keys from stored forward-compat data', async () => {
+    const storedBinding = {
+      schemaVersion: 1,
+      address: '0x1111111111111111111111111111111111111111',
+      chainId: '1',
+      providerKind: 'browser-injected',
+      boundPrincipalNullifier: 'principal-a',
+      boundAt: 1,
+      updatedAt: 1,
+      chainMetadata: { rollup: 'future-field' },
+      constructor: { poisoned: true },
+      prototype: { poisoned: true },
+      ['__proto__']: { polluted: true }
+    };
+    await writeEncryptedVaultRecord(VAULT_VERSION, {
+      schemaVersion: 2,
+      identityRecord: LEGACY_IDENTITY,
+      walletBinding: storedBinding,
+      futureCompartment: { hello: 1 },
+      constructor: { poisoned: true },
+      prototype: { poisoned: true },
+      ['__proto__']: { polluted: true }
+    });
+
+    await saveVaultV2({
+      schemaVersion: 2,
+      identityRecord: LEGACY_IDENTITY,
+      walletBinding: {
+        schemaVersion: 1,
+        address: '0x2222222222222222222222222222222222222222',
+        chainId: '10',
+        providerKind: 'browser-injected',
+        boundPrincipalNullifier: 'principal-a',
+        boundAt: 1,
+        updatedAt: 2
+      }
+    } as VaultV2);
+
+    const raw = await decryptRawRecord();
+    expect(raw?.futureCompartment).toEqual({ hello: 1 });
+    expect(Object.prototype.hasOwnProperty.call(raw, 'constructor')).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(raw, 'prototype')).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(raw, '__proto__')).toBe(false);
+    expect(raw?.walletBinding).toEqual({
+      schemaVersion: 1,
+      address: '0x2222222222222222222222222222222222222222',
+      chainId: '10',
+      providerKind: 'browser-injected',
+      boundPrincipalNullifier: 'principal-a',
+      boundAt: 1,
+      updatedAt: 2,
+      chainMetadata: { rollup: 'future-field' }
+    });
+  });
+
+  it('does not preserve caller-supplied keys that were not in the authenticated stored record', async () => {
+    // Clean stored record — no future data present.
+    await writeEncryptedVaultRecord(VAULT_VERSION, {
+      schemaVersion: 2,
+      identityRecord: LEGACY_IDENTITY
+    });
+
+    // A caller injects an unknown top-level compartment; preservation sources
+    // ONLY from the stored record, so it must never be persisted.
+    await saveVaultV2({
+      schemaVersion: 2,
+      identityRecord: LEGACY_IDENTITY,
+      callerInjected: { evil: true }
+    } as unknown as VaultV2);
+
+    const raw = await decryptRawRecord();
+    expect(raw?.callerInjected).toBeUndefined();
+    expect(raw?.identityRecord).toEqual(LEGACY_IDENTITY);
+
+    // A caller cannot inject an unknown FIELD into a closed compartment either:
+    // the strict validator throws in normalizeVaultV2, so the write is skipped
+    // (withDb fails closed) and the malformed compartment never persists.
+    const validSession = {
+      schemaVersion: 1,
+      providerId: 'google',
+      providerSubject: 'google-subject-1',
+      boundPrincipalNullifier: 'principal-signin-1',
+      boundAt: 1,
+      updatedAt: 1
+    };
+    await saveVaultV2({
+      schemaVersion: 2,
+      identityRecord: LEGACY_IDENTITY,
+      signInSession: { ...validSession, callerField: 'evil' }
+    } as unknown as VaultV2);
+    const rawAfterMalformed = await decryptRawRecord();
+    expect(rawAfterMalformed?.signInSession).toBeUndefined();
+    expect(rawAfterMalformed?.identityRecord).toEqual(LEGACY_IDENTITY);
+  });
+
+  it('rejects a malformed owned compartment on write and leaves the prior stored record intact', async () => {
+    const goodBinding = {
+      schemaVersion: 1,
+      address: '0x3333333333333333333333333333333333333333',
+      chainId: '1',
+      providerKind: 'browser-injected',
+      boundPrincipalNullifier: 'principal-b',
+      boundAt: 1,
+      updatedAt: 1
+    };
+    await writeEncryptedVaultRecord(VAULT_VERSION, {
+      schemaVersion: 2,
+      identityRecord: LEGACY_IDENTITY,
+      walletBinding: goodBinding
+    });
+
+    // A malformed owned walletBinding (wrong field type) throws in
+    // normalizeVaultV2 before any persistence — the merge does not relax it, so
+    // the write fails closed and the prior stored record is untouched.
+    await saveVaultV2({
+      schemaVersion: 2,
+      identityRecord: LEGACY_IDENTITY,
+      walletBinding: { schemaVersion: 1, address: 123 } as never
+    } as VaultV2);
+
+    const raw = await decryptRawRecord();
+    expect(raw?.walletBinding).toEqual(goodBinding);
+  });
+
+  it('does not merge from a stored v2 record whose decrypted payload is not a valid v2 vault', async () => {
+    // Outer record.version is v2 but the decrypted inner schemaVersion is wrong:
+    // the write-path merge read rejects it and the save proceeds fresh.
+    await writeEncryptedVaultRecord(VAULT_VERSION, { schemaVersion: 99, identityRecord: LEGACY_IDENTITY });
+    await saveIdentity(TEST_IDENTITY);
+    expect(await loadIdentity()).toEqual(TEST_IDENTITY);
+    expect((await decryptRawRecord())?.schemaVersion).toBe(VAULT_VERSION);
+
+    // Non-object decrypted payload (array): the merge read rejects it too.
+    await deleteDatabase('vh-vault');
+    await writeEncryptedVaultRecord(VAULT_VERSION, [1, 2, 3]);
+    await saveIdentity(TEST_IDENTITY);
+    expect(await loadIdentity()).toEqual(TEST_IDENTITY);
   });
 
   it('drops a hostile non-object signInSession compartment and salvages the rest', async () => {

--- a/packages/identity-vault/src/vault.ts
+++ b/packages/identity-vault/src/vault.ts
@@ -19,6 +19,8 @@ import {
   OPERATOR_AUTHORIZATION_TOKEN_COMPARTMENT_KEYS,
   SIGN_IN_SESSION_COMPARTMENT_KEYS,
   stripToKnownKeys,
+  VAULT_V2_CLOSED_COMPARTMENT_KEY_SETS,
+  VAULT_V2_KNOWN_TOP_LEVEL_KEYS,
   WALLET_BINDING_COMPARTMENT_KEYS,
 } from './types';
 import type {
@@ -198,12 +200,11 @@ async function loadVaultV2FromDb(db: IDBDatabase): Promise<VaultV2 | null> {
     // never rewrites the stored record. idbDelete stays reserved for decrypt
     // and JSON-parse failures (genuine tamper/key mismatch) above.
     //
-    // LIMITATION (see salvageVaultV2): an old-tab WRITE still rebuilds the
-    // vault from this bundle's known keys via normalizeVaultV2 and drops any
-    // newer-bundle compartment/field. So write-side merge-from-raw preservation
-    // MUST land before any new VaultV2 compartment/field ships, or an old-tab
-    // write will destroy it. Read-side salvage only narrows the damage from
-    // "whole vault wiped on read" to "unknown fields dropped on the next write".
+    // Old-tab WRITES no longer erase newer-bundle data: saveVaultV2ToDb merges
+    // unknown top-level compartments and unknown closed-compartment fields
+    // forward from the authenticated stored record (see
+    // preserveForwardCompatData), so a bundle that does not know a newer field
+    // preserves rather than drops it.
     return salvageVaultV2(parsed);
   }
 
@@ -242,9 +243,107 @@ async function decryptVaultRecord(
   }
 }
 
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isPreservableForwardCompatKey(key: string): boolean {
+  return key !== '__proto__' && key !== 'prototype' && key !== 'constructor';
+}
+
+/**
+ * Read the RAW decrypted stored v2 vault object (unsalvaged, unnormalized) so the
+ * write path can preserve newer-bundle data this bundle does not own. Unlike the
+ * salvaged read view, this keeps unknown fields inside closed compartments
+ * intact. Returns null when no v2 record exists. Genuine tamper/decrypt failures
+ * still delete via decryptVaultRecord (unchanged); the write then proceeds fresh.
+ */
+async function loadRawStoredVaultV2ForMerge(db: IDBDatabase): Promise<Record<string, unknown> | null> {
+  const record = await idbGet<VaultRecord>(db, VAULT_STORE, IDENTITY_KEY);
+  if (!record || record.version !== VAULT_VERSION) {
+    return null;
+  }
+  const parsed = await decryptVaultRecord(db, record);
+  if (!isValidIdentity(parsed) || (parsed as { schemaVersion?: unknown }).schemaVersion !== VAULT_VERSION) {
+    return null;
+  }
+  return parsed as Record<string, unknown>;
+}
+
+/**
+ * Preserve forward-compat data from the authenticated stored vault when writing.
+ * normalizeVaultV2 (called first) rebuilt `normalized` from THIS bundle's known
+ * keys, dropping unknown top-level compartments and (via the closed-key-set
+ * validators) unknown fields inside walletBinding/operatorAuthorizationToken/
+ * signInSession. Without this merge, an old-bundle write would erase a newer
+ * bundle's compartment/field at rest. This re-attaches such newer-bundle data —
+ * but ONLY from `storedRaw` (the already-decrypted, self-authored encrypted
+ * store), NEVER from the write caller's input, and only OUTSIDE this bundle's
+ * owned key set. JS object/prototype magic keys are deliberately not preserved.
+ * Current-bundle-owned fields always win the merge, so strict validation is
+ * never bypassed and the write caller cannot smuggle in keys that were not
+ * already present in the authenticated stored record.
+ *
+ * Caveat: a modified closed compartment re-pairs this bundle's fresh owned fields
+ * with the stored newer-bundle field; if that field was semantically tied to the
+ * prior compartment state it may be stale until the newer bundle rewrites it.
+ * Preserving is preferred over dropping (which would be unrecoverable data loss).
+ */
+function preserveForwardCompatData(
+  normalized: VaultV2,
+  storedRaw: Record<string, unknown> | null
+): VaultV2 {
+  if (!storedRaw) {
+    return normalized;
+  }
+  const result: Record<string, unknown> = { ...normalized };
+
+  // (1) Re-attach unknown newer-bundle top-level compartments. normalizeVaultV2
+  // rebuilt `result` from this bundle's known keys, so any stored key outside
+  // that set is a newer-bundle compartment; the caller cannot smuggle one in
+  // (it is dropped there too), so this only ever restores stored data.
+  for (const [key, storedValue] of Object.entries(storedRaw)) {
+    if (VAULT_V2_KNOWN_TOP_LEVEL_KEYS.has(key) || !isPreservableForwardCompatKey(key)) {
+      continue;
+    }
+    result[key] = storedValue;
+  }
+
+  // (2) Re-attach unknown future FIELDS inside closed-key-set compartments the
+  // current write also touches. The strict validators reject unknown keys, so
+  // normalizeVaultV2 stripped them; restore them from the stored record only,
+  // with current-owned fields winning the merge.
+  for (const [compartmentKey, ownedKeys] of VAULT_V2_CLOSED_COMPARTMENT_KEY_SETS) {
+    const written = result[compartmentKey];
+    const stored = storedRaw[compartmentKey];
+    if (!isPlainObject(written)) {
+      continue;
+    }
+    if (!isPlainObject(stored)) {
+      continue;
+    }
+    const foreign: Record<string, unknown> = {};
+    for (const [fieldKey, fieldValue] of Object.entries(stored)) {
+      if (!ownedKeys.has(fieldKey) && isPreservableForwardCompatKey(fieldKey)) {
+        foreign[fieldKey] = fieldValue;
+      }
+    }
+    if (Object.keys(foreign).length > 0) {
+      result[compartmentKey] = { ...foreign, ...written };
+    }
+  }
+
+  // The untyped map carries preserved newer-bundle keys that are intentionally
+  // outside the VaultV2 type; every current-bundle-owned field was validated by
+  // normalizeVaultV2 before the merge.
+  return result as unknown as VaultV2;
+}
+
 async function saveVaultV2ToDb(db: IDBDatabase, vault: VaultV2): Promise<void> {
   const key = await ensureMasterKey(db);
-  const plaintext = encoder.encode(JSON.stringify(normalizeVaultV2(vault)));
+  const normalized = normalizeVaultV2(vault);
+  const storedRaw = await loadRawStoredVaultV2ForMerge(db);
+  const plaintext = encoder.encode(JSON.stringify(preserveForwardCompatData(normalized, storedRaw)));
   const { iv, ciphertext } = await encrypt(key, plaintext);
 
   const record: VaultRecord = {
@@ -305,10 +404,12 @@ function salvageClosedCompartment(
  *    deviceCredential/seaDevicePair/delegationSigningKey compartments (their
  *    strict validation lives in their compartment accessors, mirroring
  *    normalizeVaultV2) and any unknown top-level compartment from a newer
- *    bundle, which is preserved in the read view (write-side
- *    normalizeVaultV2 still drops it on save).
+ *    bundle, which is preserved in the read view (and, on save, re-attached
+ *    from the authenticated stored record by preserveForwardCompatData rather
+ *    than dropped).
  * Write-side strictness is unchanged: normalizeVaultV2 keeps throwing on
- * invalid compartments.
+ * invalid compartments; the write-path merge only re-attaches unknown data that
+ * was already present in the decrypted stored record, never caller input.
  */
 function salvageVaultV2(parsed: unknown): VaultV2 | null {
   if (


### PR DESCRIPTION
Closes #739.

PR #738 fixed VaultV2 read-side salvage so a shape-invalid newer record no longer deletes the whole encrypted vault, but left a documented write-side limitation: an old-bundle write rebuilt the vault from its own known keys (`normalizeVaultV2`), silently dropping any newer-bundle top-level compartment or closed-compartment field. That turned a read-side forward-compat fix into data loss on the next write.

## Fix
`saveVaultV2ToDb` (the single write chokepoint for all four public write paths — `saveIdentity`, `clearIdentity`, `saveVaultV2`, `updateVaultV2`) now, **after** the strict `normalizeVaultV2`, merges forward-compat data from the raw decrypted stored vault before encrypting:
- unknown newer-bundle **top-level compartments** are re-attached; and
- unknown future **fields inside the closed-key-set compartments** (walletBinding / operatorAuthorizationToken / signInSession) are restored, with current-owned fields winning the merge.

## Security invariant
The preservation source is **always** the already-decrypted, self-authored stored record, **never** the write caller's input:
- `normalizeVaultV2` drops unknown top-level keys, so a caller cannot introduce an unknown top-level compartment; and
- the strict closed-compartment validators reject unknown fields, so a caller cannot smuggle a field into a closed compartment (that write fails closed).

Write-side strictness is therefore unchanged (malformed owned compartments still fail closed and never persist), and the existing tamper / decrypt / JSON-parse delete paths are untouched. The known-key and closed-compartment key sets are single-sourced in `types.ts` (`VAULT_V2_KNOWN_TOP_LEVEL_KEYS` / `VAULT_V2_CLOSED_COMPARTMENT_KEY_SETS`), mirroring `normalizeVaultV2`'s whitelist.

## Caveat (documented in code)
A modified closed compartment re-pairs this bundle's fresh owned fields with the stored newer-bundle field; if that field was semantically tied to the prior compartment state it may be stale until the newer bundle rewrites it. Preserving is preferred over dropping (which would be unrecoverable loss).

## Validation
- **100% per-file line + branch diff coverage** on `vault.ts` and `types.ts`.
- Regression + negative coverage (the four acceptance criteria): preserve an unknown top-level compartment across a write (verified at rest by decrypting the raw blob); preserve an unknown closed-compartment field while updating owned fields; caller-supplied keys not in the store are never preserved; malformed owned compartments fail closed with the prior record intact.
- The #738 limitation-documenting test and comments are updated to the new behavior.
- Full identity-vault package + vault consumer tests (useSignIn/useIdentity/auth, 82 tests) + `check:luma-vault-compartments` / `check:luma-wallet-binding` / typecheck all green. The account-identity e2e gate runs in cloud CI.

## Non-goals honored
No new VaultV2 compartment added; read-side accessors unchanged; encrypted storage format unchanged.

Draft: opened for cloud CI + review. Not merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)