### PR TITLE
Fix watch closure restart baseline

### DIFF
--- a/tools/scripts/phase5-scope-a-watch-closure-packet.mjs
+++ b/tools/scripts/phase5-scope-a-watch-closure-packet.mjs
@@ -453,6 +453,9 @@ function summarizeRelayMemory(samples, windowStartMs, env) {
 
 function summarizeArchive(samples) {
   const latest = samples.at(-1) ?? null;
+  const publisherRestartCounts = samples
+    .map((sample) => sample.publisher?.unit?.nRestarts)
+    .filter((value) => Number.isFinite(value));
   return {
     sampleCount: samples.length,
     firstSampleAt: samples[0]?.generatedAt ?? null,
@@ -460,6 +463,8 @@ function summarizeArchive(samples) {
     passCount: samples.filter((sample) => sample.manifest?.status === 'pass').length,
     failCount: samples.filter((sample) => sample.manifest?.status !== 'pass').length,
     blockers: samples.flatMap((sample) => sample.manifest?.blockers ?? []),
+    publisherRestartCountMin: publisherRestartCounts.length ? Math.min(...publisherRestartCounts) : null,
+    publisherRestartCountMax: publisherRestartCounts.length ? Math.max(...publisherRestartCounts) : null,
     latestPublisher: latest?.publisher
       ? {
           status: latest.publisher.status ?? null,
@@ -531,7 +536,13 @@ function coreSignalBlockers({ archive, journalSummary, storyClusterArtifacts, de
   const blockers = [];
   if (archive.sampleCount <= 0) blockers.push('archive_samples_missing');
   if (archive.failCount > 0) blockers.push(`archive_sample_failures:${archive.failCount}`);
-  if (archive.latestPublisher?.nRestarts !== 0) blockers.push(`publisher_nrestarts:${archive.latestPublisher?.nRestarts}`);
+  if (
+    archive.publisherRestartCountMin !== null
+    && archive.publisherRestartCountMax !== null
+    && archive.publisherRestartCountMax > archive.publisherRestartCountMin
+  ) {
+    blockers.push(`publisher_nrestarts:${archive.publisherRestartCountMin}->${archive.publisherRestartCountMax}`);
+  }
   if (archive.latestPublisher?.status && archive.latestPublisher.status !== 'pass') {
     blockers.push(`publisher_liveness_status:${archive.latestPublisher.status}`);
   }
@@ -613,6 +624,8 @@ function buildWatchClosureVerdict(packet) {
       failCount: packet.archive.failCount,
       latestPublisherStatus: packet.archive.latestPublisher?.status ?? null,
       latestPublisherNRestarts: packet.archive.latestPublisher?.nRestarts ?? null,
+      publisherRestartCountMin: packet.archive.publisherRestartCountMin,
+      publisherRestartCountMax: packet.archive.publisherRestartCountMax,
       latestRelayStatus: packet.archive.latestRelay?.status ?? null,
       latestRelaySnapshotStatus: packet.archive.latestRelaySnapshot?.status ?? null,
       latestPublicFreshnessStatus: packet.archive.latestPublicFreshness?.status ?? null,

--- a/tools/scripts/phase5-scope-a-watch-closure-packet.test.mjs
+++ b/tools/scripts/phase5-scope-a-watch-closure-packet.test.mjs
@@ -20,7 +20,7 @@ function writeJson(filePath, value) {
   writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
 }
 
-function makeSample(root, sampleId, generatedAt, relays) {
+function makeSample(root, sampleId, generatedAt, relays, options = {}) {
   const sampleDir = path.join(root, sampleId);
   writeJson(path.join(sampleDir, 'manifest.json'), {
     schemaVersion: 'vh-phase5-scope-a-soak-archive-v1',
@@ -38,7 +38,7 @@ function makeSample(root, sampleId, generatedAt, relays) {
       activeState: 'active',
       subState: 'running',
       execMainStatus: '0',
-      nRestarts: 0,
+      nRestarts: options.publisherNRestarts ?? 0,
     },
   });
   writeJson(path.join(sampleDir, 'relay-liveness.json'), {
@@ -264,6 +264,57 @@ test('blocks the 48h threshold when relay heap trend projects below the safe hor
   assert.equal(packet.relayMemory.status, 'fail');
   assert.equal(packet.thresholds.fortyEightHour.status, 'fail');
   assert.deepEqual(packet.thresholds.fortyEightHour.blockers, ['relay_memory_trend_fail']);
+});
+
+test('does not block on publisher restart counters that predate the clean window', () => {
+  const root = tmpDir();
+  const archiveRoot = path.join(root, 'archive');
+  makeSample(archiveRoot, '20260628T000000Z', '2026-06-28T00:00:00.000Z', [
+    relay('vhc-relay-a', 420_000_000, 320_000_000),
+  ], { publisherNRestarts: 1 });
+  makeSample(archiveRoot, '20260629T000000Z', '2026-06-29T00:00:00.000Z', [
+    relay('vhc-relay-a', 421_000_000, 321_000_000),
+  ], { publisherNRestarts: 1 });
+  makeSample(archiveRoot, '20260630T010000Z', '2026-06-30T01:00:00.000Z', [
+    relay('vhc-relay-a', 422_000_000, 322_000_000),
+  ], { publisherNRestarts: 1 });
+
+  const packet = phase5ScopeAWatchClosureInternal.buildPhase5ScopeAWatchClosurePacket({
+    env: baseEnv(root),
+    now: new Date('2026-06-30T01:00:00.000Z'),
+  });
+
+  assert.equal(packet.archive.publisherRestartCountMin, 1);
+  assert.equal(packet.archive.publisherRestartCountMax, 1);
+  assert.equal(packet.archive.latestPublisher.nRestarts, 1);
+  assert.equal(packet.thresholds.twentyFourHour.status, 'pass');
+  assert.equal(packet.thresholds.fortyEightHour.status, 'pass');
+  assert.equal(packet.status, 'pass');
+});
+
+test('blocks when the publisher restart counter increases inside the clean window', () => {
+  const root = tmpDir();
+  const archiveRoot = path.join(root, 'archive');
+  makeSample(archiveRoot, '20260628T000000Z', '2026-06-28T00:00:00.000Z', [
+    relay('vhc-relay-a', 420_000_000, 320_000_000),
+  ], { publisherNRestarts: 0 });
+  makeSample(archiveRoot, '20260629T000000Z', '2026-06-29T00:00:00.000Z', [
+    relay('vhc-relay-a', 421_000_000, 321_000_000),
+  ], { publisherNRestarts: 1 });
+  makeSample(archiveRoot, '20260630T010000Z', '2026-06-30T01:00:00.000Z', [
+    relay('vhc-relay-a', 422_000_000, 322_000_000),
+  ], { publisherNRestarts: 1 });
+
+  const packet = phase5ScopeAWatchClosureInternal.buildPhase5ScopeAWatchClosurePacket({
+    env: baseEnv(root),
+    now: new Date('2026-06-30T01:00:00.000Z'),
+  });
+
+  assert.equal(packet.archive.publisherRestartCountMin, 0);
+  assert.equal(packet.archive.publisherRestartCountMax, 1);
+  assert.deepEqual(packet.thresholds.twentyFourHour.blockers, ['publisher_nrestarts:0->1']);
+  assert.deepEqual(packet.thresholds.fortyEightHour.blockers, ['publisher_nrestarts:0->1']);
+  assert.equal(packet.status, 'in_progress');
 });
 
 test('builds a compact secret-safe verdict for watch automation and alert intake', () => {


### PR DESCRIPTION
## Summary
- Treat publisher restarts as clean-window counter deltas instead of absolute `NRestarts` values.
- Preserve min/max restart evidence in the watch-closure packet and verdict archive summary.
- Add regressions for nonzero baseline counters and in-window restart churn.

## Verification
- `pnpm run check:scope-a-watch-closure`
- `pnpm --filter @vh/gun-client... build && pnpm run check:public-feed:alert-watch`

## A6 deploy note
- Cherry-picked the monitor fix to `/home/humble/VHC` as `9d615777`.
- Re-anchored `VH_PHASE5_SCOPE_A_WATCH_CLEAN_START_AT` to `2026-07-08T14:05:07.448Z`, the first passing soak sample after the two relay-liveness failed samples.
- Reran `vh-phase5-scope-a-watch-closure.service` and `vh-public-feed-alert-watch.service`; both exited `0/SUCCESS`, and `systemctl --user --failed` is empty.