### PR TITLE
Fix civic representative durability readback (#743)

### DIFF
--- a/packages/gun-client/src/civicRepresentativeAdapters.test.ts
+++ b/packages/gun-client/src/civicRepresentativeAdapters.test.ts
@@ -391,6 +391,86 @@ describe('civicRepresentativeAdapters', () => {
     }
   });
 
+  it('confirms snapshot writes after ack timeout with content-only readback when verification pin is unavailable', async () => {
+    vi.useFakeTimers();
+    const mesh = createFakeMesh();
+    const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+    const client = createClient(mesh, guard);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    mesh.setPutHandler((path, value, _cb) => {
+      mesh.writes.push({ path, value });
+      mesh.setRead(path, value);
+      // The record was signed and physically written, but the same runtime can
+      // no longer verify it. Durability confirmation must still prove landed
+      // content; consumer reads remain fail-closed below.
+      client.config.systemWriterPin = null;
+    });
+
+    const writePromise = writeCivicRepresentativeSnapshot(client, 'jurisdiction-v1', BASE_DIRECTORY);
+    const resolutionExpectation = expect(writePromise).resolves.toEqual(BASE_DIRECTORY);
+    try {
+      await vi.advanceTimersByTimeAsync(1_000);
+      await resolutionExpectation;
+      expect(mesh.writes).toHaveLength(1);
+      expect(warnSpy).toHaveBeenCalledWith('[vh:civic-reps] put ack timed out, requiring readback confirmation');
+
+      await expect(readCivicRepresentativeSnapshot(client, 'jurisdiction-v1')).resolves.toBeNull();
+    } finally {
+      warnSpy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
+  it('rejects snapshot writes when durability readback is absent or schema-invalid', async () => {
+    const cases: Array<{ name: string; readback?: unknown }> = [
+      { name: 'absent' },
+      {
+        name: 'schema-invalid',
+        readback: {
+          ...BASE_DIRECTORY,
+          jurisdictionVersion: 'jurisdiction-v1',
+          representatives: [
+            {
+              ...BASE_DIRECTORY.representatives[0]!,
+              email: 'not-an-email',
+            },
+          ],
+        },
+      },
+    ];
+
+    for (const { name, readback } of cases) {
+      vi.useFakeTimers();
+      const mesh = createFakeMesh();
+      if (readback !== undefined) {
+        mesh.setRead('civic/reps/jurisdiction-v1', readback);
+      }
+      mesh.setPutHandler((path, value, _cb) => {
+        mesh.writes.push({ path, value });
+      });
+      const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const writePromise = writeCivicRepresentativeSnapshot(
+        createClient(mesh, guard),
+        'jurisdiction-v1',
+        BASE_DIRECTORY,
+      );
+      const rejectionExpectation = expect(writePromise).rejects.toThrow(
+        'civic representative snapshot write timed out and readback did not confirm persistence',
+      );
+      try {
+        await vi.advanceTimersByTimeAsync(3_000);
+        await rejectionExpectation;
+        expect(mesh.writes, name).toHaveLength(1);
+        expect(warnSpy, name).toHaveBeenCalledWith('[vh:civic-reps] put ack timed out, requiring readback confirmation');
+      } finally {
+        warnSpy.mockRestore();
+        vi.useRealTimers();
+      }
+    }
+  });
+
   it('validates real signed system writer civic representative snapshots', async () => {
     const { mesh, client, snapshotRecord } = await createSignedSnapshotFixture();
     mesh.setRead('civic/reps/jurisdiction-v1', {
@@ -569,6 +649,50 @@ describe('civicRepresentativeAdapters', () => {
           detail: expect.objectContaining({
             event: SYSTEM_WRITER_VALIDATION_EVENT,
             reason: 'missing-pin',
+          }),
+        }),
+      );
+    } finally {
+      vi.unstubAllGlobals();
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('fails closed with system-writer-validation-failed when the civic representative snapshot signature is invalid', async () => {
+    const { mesh, client, snapshotRecord } = await createSignedSnapshotFixture();
+    mesh.setRead('civic/reps/jurisdiction-v1', {
+      ...snapshotRecord,
+      _systemSignature: `${String(snapshotRecord._systemSignature)}tampered`,
+    });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    class TestCustomEvent extends Event {
+      readonly detail: unknown;
+
+      constructor(type: string, init?: CustomEventInit) {
+        super(type);
+        this.detail = init?.detail;
+      }
+    }
+    const dispatchSpy = vi.fn(() => true);
+    vi.stubGlobal('CustomEvent', TestCustomEvent);
+    vi.stubGlobal('dispatchEvent', dispatchSpy);
+
+    try {
+      await expect(readCivicRepresentativeSnapshot(client, 'jurisdiction-v1')).resolves.toBeNull();
+      expect(warnSpy).toHaveBeenCalledWith(
+        `[vh:civic-reps] ${SYSTEM_WRITER_VALIDATION_EVENT}`,
+        expect.objectContaining({
+          event: SYSTEM_WRITER_VALIDATION_EVENT,
+          reason: 'signature-invalid',
+          path: '[REDACTED:mesh-path]',
+        }),
+      );
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: SYSTEM_WRITER_VALIDATION_EVENT,
+          detail: expect.objectContaining({
+            event: SYSTEM_WRITER_VALIDATION_EVENT,
+            reason: 'signature-invalid',
           }),
         }),
       );

--- a/packages/gun-client/src/civicRepresentativeAdapters.ts
+++ b/packages/gun-client/src/civicRepresentativeAdapters.ts
@@ -21,6 +21,7 @@ import {
 import type { VennClient } from './types';
 
 const DEFAULT_SYSTEM_WRITER_ID = 'vh-system-writer-dev-v1';
+const SYSTEM_WRITER_COMPAT_NULL_FIELDS = ['_system', '_Signature', '_WriterId', '_IssuedAt'] as const;
 
 type CivicRepresentativeSnapshotRecord = RepresentativeDirectory & Record<string, unknown> & {
   readonly jurisdictionVersion: string;
@@ -99,6 +100,9 @@ function stripSystemWriterAndBindingFields(payload: Record<string, unknown>): Re
     jurisdictionVersion: _omittedJurisdictionVersion,
     ...directoryPayload
   } = payload;
+  for (const field of SYSTEM_WRITER_COMPAT_NULL_FIELDS) {
+    delete directoryPayload[field];
+  }
   return directoryPayload;
 }
 
@@ -185,6 +189,30 @@ async function parseCivicRepresentativeSnapshotFromStoredRecord(
   }
 
   return parseLegacyCivicRepresentativeSnapshotPayload(payload);
+}
+
+/**
+ * Durability readback: confirm the directory content we just wrote actually
+ * landed, WITHOUT re-verifying our own signature. The consumer read
+ * (readCivicRepresentativeSnapshot) stays fail-closed and pin-validating; this
+ * helper only proves persistence after an ack timeout, so a writer that signs
+ * correctly but cannot verify its own system-writer record does not misreport a
+ * landed write as failed. The caller's directoriesMatch predicate requires
+ * field-for-field equality with the directory we wrote, so a concurrent forged
+ * record could confirm only by being byte-identical to ours.
+ */
+async function readCivicRepresentativeSnapshotForDurability(
+  client: VennClient,
+  jurisdictionVersion: string,
+): Promise<RepresentativeDirectory | null> {
+  const payload = stripGunMetadata(
+    await readOnce(getCivicRepresentativeSnapshotChain(client, jurisdictionVersion)),
+  );
+  if (!isRecord(payload)) {
+    return null;
+  }
+  const parsed = RepresentativeDirectorySchema.safeParse(stripSystemWriterAndBindingFields(payload));
+  return parsed.success ? parsed.data : null;
 }
 
 async function buildSystemWriterCivicRepresentativeSnapshotRecord(
@@ -307,7 +335,9 @@ export async function writeCivicRepresentativeSnapshot(
   await putWithAck(getCivicRepresentativeSnapshotChain(client, normalizedJurisdictionVersion), snapshotRecord, {
     writeClass: 'civic-representative-snapshot',
     timeoutError: 'civic representative snapshot write timed out and readback did not confirm persistence',
-    readback: () => readCivicRepresentativeSnapshot(client, normalizedJurisdictionVersion),
+    // Durability readback confirms persistence via content equality only, not
+    // signature re-verification; see readCivicRepresentativeSnapshotForDurability.
+    readback: () => readCivicRepresentativeSnapshotForDurability(client, normalizedJurisdictionVersion),
     readbackPredicate: (observed) => directoriesMatch(observed as RepresentativeDirectory | null, parsedDirectory),
   });
 

--- a/tools/scripts/check-luma-civic-reps-system-v1.mjs
+++ b/tools/scripts/check-luma-civic-reps-system-v1.mjs
@@ -86,8 +86,10 @@ for (const token of [
   'SystemWriterCivicRepresentativeSnapshotRecord',
   'buildSystemWriterCivicRepresentativeSnapshotRecord',
   'parseCivicRepresentativeSnapshotFromStoredRecord',
+  'readCivicRepresentativeSnapshotForDurability',
   'pathMatchesSnapshot',
   'stripSystemWriterAndBindingFields',
+  'SYSTEM_WRITER_COMPAT_NULL_FIELDS',
   'validateSystemWriterRecord',
   'SYSTEM_WRITER_VALIDATION_EVENT',
   'RepresentativeDirectorySchema',
@@ -105,6 +107,11 @@ requireBefore(
   'buildSystemWriterCivicRepresentativeSnapshotRecord',
   'putWithAck(getCivicRepresentativeSnapshotChain',
   'writeCivicRepresentativeSnapshot signing'
+);
+requireToken(
+  writeCivicRepresentativeSnapshot,
+  'readCivicRepresentativeSnapshotForDurability',
+  'writeCivicRepresentativeSnapshot durability readback'
 );
 
 const readCivicRepresentativeSnapshot = sliceExportedFunction(adapterSource, 'readCivicRepresentativeSnapshot');
@@ -127,8 +134,11 @@ for (const token of [
   'validates real signed system writer civic representative snapshots',
   'rejects tampered or path-mismatched system writer civic representative snapshots',
   'fails closed with system-writer-validation-failed when the civic representative snapshot pin is missing',
+  'fails closed with system-writer-validation-failed when the civic representative snapshot signature is invalid',
   'keeps legacy civic representative snapshots readable and rejects downgraded legacy fields',
   'rejects unmarked and clean legacy-marked civic representative snapshots when reject-unmarked mode is on',
+  'confirms snapshot writes after ack timeout with content-only readback when verification pin is unavailable',
+  'rejects snapshot writes when durability readback is absent or schema-invalid',
 ]) {
   requireToken(adapterTestSource, token, 'civic representative system writer tests');
 }


### PR DESCRIPTION
## Summary

Closes #743.

This brings civic representative snapshot writes in line with the district aggregate durability pattern from #738:

- keeps `readCivicRepresentativeSnapshot` as the consumer fail-closed, pin-validating read path;
- adds a writer-only `readCivicRepresentativeSnapshotForDurability` helper that strips Gun/system-writer/binding fields and validates only `RepresentativeDirectory` content for ack-timeout confirmation;
- keeps `directoriesMatch` as the confirmation boundary, so a concurrent record can confirm only if it is field-for-field equal to the directory we just wrote;
- strips the system-writer compatibility null fields (`_system`, `_Signature`, `_WriterId`, `_IssuedAt`) before directory schema validation, matching the district adapter behavior and ensuring actual signed writer output is parseable;
- pins the behavior in `check:luma-civic-reps-system-v1`.

## Tests

- `corepack pnpm@9.7.1 --filter @vh/gun-client exec vitest run src/civicRepresentativeAdapters.test.ts --config ./vitest.config.ts`
- `corepack pnpm@9.7.1 check:luma-civic-reps-system-v1`
- `corepack pnpm@9.7.1 --filter @vh/gun-client typecheck`
- `node tools/scripts/check-diff-coverage.mjs` — 100% line + branch coverage on `packages/gun-client/src/civicRepresentativeAdapters.ts`, full coverage suite passed
- `corepack pnpm@9.7.1 typecheck`
- `corepack pnpm@9.7.1 lint`
- `corepack pnpm@9.7.1 docs:check`
- `corepack pnpm@9.7.1 build`

## Notes

No live writer path is enabled by this PR. It only changes how the already-existing civic representative snapshot writer confirms persistence after an ack timeout.
