### PR TITLE
Document account sign-in release rehearsal

### DIFF
--- a/docs/foundational/STATUS.md
+++ b/docs/foundational/STATUS.md
@@ -7,8 +7,8 @@
 
 
 **Last Updated:** 2026-07-09
-**Version:** 0.9.10 (release-readiness source-health lane after #747 sprint outline)
-**Assessment:** Controlled beta candidate with the repo-side Functioning MVP lanes implemented and the deferred hardening/follow-up sequence merged. This source-health lane is based on `main@6db555a5` after #747 added the release-readiness sprint outline; it removes the dead `ap-topnews` starter source and pins source/storycluster script dispatch through `corepack pnpm@9.7.1`. Repo-side MVP capabilities now include accepted-current synthesis detail gating, point-stance persistence and aggregate engagement, Apple/Google/X account shell foundations, beta-local LUMA account binding, district/office aggregate mapping, system-writer hardening, VaultV2 forward-compatible writes, and all migrated system-writer read classes covered by default-off reject-unmarked mode. The latest consolidated release-evidence packet is still from `main@1a83434b` and remains **blocked** by live/operator surfaces: public accepted-synthesis/feed gates still depend on A6/operator enablement, and the packet must be regenerated at the intended release commit. A 2026-07-09 source-health rerun on this lane is `ready` with 24 enabled keep sources, no watch/remove sources, and `releaseEvidence.status: pass` after the configured five-run window; the broader StoryCluster production-readiness report still blocks on headline-soak release evidence because the local real StoryCluster/OpenAI path rejected its credential (`invalid_api_key`, redacted in artifacts). The stale packet's LUMA MVP gate passes, but the full release packet must be regenerated on the intended release commit after live/operator blockers clear. Live A6 state is separately proven only through `main@47ba218d` after Slice 0 alert enablement and the post-Slice-0 stale-feed recovery; do not infer that newer repo commits are deployed on A6 unless an operator readback says so. While A6 stays fresh, the posture remains wait/watch: no publisher/relay restart, pager cutover, Codex live execution, retention/compaction/memory remediation, or accepted-synthesis enablement without its own operator packet.
+**Version:** 0.9.11 (release-readiness runsheet update after #748 source-health merge)
+**Assessment:** Controlled beta candidate with the repo-side Functioning MVP lanes implemented and the deferred hardening/follow-up sequence merged. The repository includes #748 at merge commit `0a85b2f8`, which removed the dead `ap-topnews` starter source and pinned source/storycluster script dispatch through `corepack pnpm@9.7.1`. Repo-side MVP capabilities now include accepted-current synthesis detail gating, point-stance persistence and aggregate engagement, Apple/Google/X account shell foundations, beta-local LUMA account binding, district/office aggregate mapping, system-writer hardening, VaultV2 forward-compatible writes, and all migrated system-writer read classes covered by default-off reject-unmarked mode. The latest consolidated release-evidence packet is still from `main@1a83434b` and remains **blocked** by live/operator surfaces: public accepted-synthesis/feed gates still depend on A6/operator enablement, and the packet must be regenerated at the intended release commit. A 2026-07-09 source-health rerun after #748 is `ready` with 24 enabled keep sources, no watch/remove sources, and `releaseEvidence.status: pass` after the configured five-run window; the broader StoryCluster production-readiness report still blocks on headline-soak release evidence because the local real StoryCluster/OpenAI path rejected its credential (`invalid_api_key`, redacted in artifacts). The beta session runsheet now contains the manual account sign-in and account-to-LUMA binding rehearsal required before any tester-facing sign-in claim. The stale packet's LUMA MVP gate passes, but the full release packet must be regenerated on the intended release commit after live/operator blockers clear. Live A6 state is separately proven only through `main@47ba218d` after Slice 0 alert enablement and the post-Slice-0 stale-feed recovery; do not infer that newer repo commits are deployed on A6 unless an operator readback says so. While A6 stays fresh, the posture remains wait/watch: no publisher/relay restart, pager cutover, Codex live execution, retention/compaction/memory remediation, or accepted-synthesis enablement without its own operator packet.
 
 > ⚠️ **This document reflects actual implementation status, not target architecture.**
 > For the full vision, see `System_Architecture.md` and whitepapers in `docs/`.
@@ -27,7 +27,7 @@
 | **HERMES Forum** | 🟢 Implemented + 240-char reply cap + article CTA | ⚠️ Partial |
 | **HERMES Docs** | 🟢 Foundation + CollabEditor wired into ArticleEditor (flag-gated) | ❌ No |
 | **HERMES Bridge (Civic Action Kit)** | 🟡 Full UI (5 components), trust/XP/budget enforcement, local receipt capture, and feed-card rendering support; unified feed publication remains partial | ❌ No |
-| **News Aggregator** | 🟢/🟡 Phase 5 Scope A fresh after Slice 0 and the post-Slice-0 stale-feed recovery on A6: capped raw-only publisher proven at `main@47ba218d`, StoryCluster-backed raw bundle publication, 2-of-3 relay REST quorum, pending lifecycle rows, host-local liveness/freshness monitors, enabled interim email alerting, watch-closure timer, #706 total-transport restartability, #707 exit-69 alert classification, #708 first-tick ingest cap, #722 incident-response/pager primitives, #723 StoryCluster production-timeout fix, #744 watch-closure restart-baseline fix, #691 graph diagnostics, #692/#703 early heap capture wiring, #704/#705 relay deploy verification, #694 staggered relay watchdog ceilings, and #701 off-graph driver verdict. #687 remains closed for the launched raw StoryCluster rerank path. Accepted synthesis/storylines are repo-capable but not yet proven/enabled on live A6. | ⚠️ Scope A fresh and paging by email; off-graph heap retainer not yet named; no post-recovery 500 MB -> 700 MB heap pair yet; branch-local source-health release evidence passes after pruning `ap-topnews`; StoryCluster production-readiness still needs a valid live headline-soak credential/endpoint; Scope B/live accepted synthesis enablement pending operator packet |
+| **News Aggregator** | 🟢/🟡 Phase 5 Scope A fresh after Slice 0 and the post-Slice-0 stale-feed recovery on A6: capped raw-only publisher proven at `main@47ba218d`, StoryCluster-backed raw bundle publication, 2-of-3 relay REST quorum, pending lifecycle rows, host-local liveness/freshness monitors, enabled interim email alerting, watch-closure timer, #706 total-transport restartability, #707 exit-69 alert classification, #708 first-tick ingest cap, #722 incident-response/pager primitives, #723 StoryCluster production-timeout fix, #744 watch-closure restart-baseline fix, #691 graph diagnostics, #692/#703 early heap capture wiring, #704/#705 relay deploy verification, #694 staggered relay watchdog ceilings, and #701 off-graph driver verdict. #687 remains closed for the launched raw StoryCluster rerank path. Accepted synthesis/storylines are repo-capable but not yet proven/enabled on live A6. | ⚠️ Scope A fresh and paging by email; off-graph heap retainer not yet named; no post-recovery 500 MB -> 700 MB heap pair yet; post-#748 source-health release evidence passes after pruning `ap-topnews`; StoryCluster production-readiness still needs a valid live headline-soak credential/endpoint; Scope B/live accepted synthesis enablement pending operator packet |
 | **Discovery Feed** | 🟢 Implemented with compact one-feed chrome, first-use orientation, fixture-backed integrity/semantic release gates, storyline-aware ranking/presentation, and deep-link focus state; public semantic soak remains smoke-only | ⚠️ Partial |
 | **Delegation Runtime** | 🟢 Store + hooks + control panel + 8/8 budget keys (all wired or deferred-with-rationale) | ⚠️ Partial |
 | **Linked-Social** | 🟡 Substrate + notification ingestion + feed cards | ⚠️ Partial |
@@ -64,8 +64,8 @@ Current policy state:
   at `2026-07-06T22:44:08.567Z` with `ingested_item_count=24`,
   `selected_bundle_count=8`, `raw_wrote_count=8`, and
   `raw_write_failed_count=0`, and publisher/freshness/relay/snapshot/alert
-  readbacks passing. Newer repo commits through the #747 base
-  (`main@6db555a5`) are not automatically live on A6.
+  readbacks passing. Newer repo commits after that A6 proof, including #748,
+  are not automatically live on A6.
 - Current repo-side Functioning MVP state is materially newer than the live A6
   raw-feed state:
   - #728 accepted-current synthesis detail and votability gating;
@@ -86,17 +86,17 @@ Current policy state:
   - latest release pipeline artifact:
     `.tmp/release-evidence-pipeline/latest/release-evidence-pipeline-report.json`;
   - latest artifact commit: `1a83434b0d33278369791891ba9212fcc6b859f6`, not
-    the #747/source-health branch base `main@6db555a5`;
+    the post-#748 source-health evidence base;
   - pipeline status: `blocked`;
   - `check:luma:mvp-production-readiness`: `pass` in that packet;
   - blocking release-gate classes in the stale packet: source-health release
     evidence before the `ap-topnews` source-surface fix plus public
     accepted-synthesis/feed gates that require operator-owned A6
     enablement/evidence refresh;
-  - branch-local source-health evidence on 2026-07-09 now passes with 24 keep
+  - post-#748 source-health evidence on 2026-07-09 now passes with 24 keep
     sources after pruning `ap-topnews`; the consolidated packet still needs a
     fresh run on the intended release commit;
-  - branch-local StoryCluster production-readiness evidence on 2026-07-09 has
+  - post-#748 StoryCluster production-readiness evidence on 2026-07-09 has
     correctness and source-health passing, but remains blocked by
     `headline_soak_release_evidence_failed` because the real local
     StoryCluster/OpenAI path rejected its credential (`invalid_api_key`,
@@ -356,7 +356,7 @@ Current truth for the news bundler and feed hardening lane:
   raw path as of the 2026-06-28 stability bake:
   - #687 first deployed the durable rerank fix at
     `baf1dd5f41958473c93db04e4d6007e4df7b074f`;
-  - this lane is based on `main@6db555a5`, with #691-#708 diagnostics,
+  - the repo includes #748 (`0a85b2f8`), with #691-#708 diagnostics,
     publisher-priority, relay-stagger, total-transport restartability, alert
     classification, first-tick ingest-cap, #722 incident-response/pager
     primitives, #723 StoryCluster timeout bounding, #744 watch-closure baseline

--- a/docs/ops/BETA_SESSION_RUNSHEET.md
+++ b/docs/ops/BETA_SESSION_RUNSHEET.md
@@ -2,7 +2,7 @@
 
 > Status: Operational Runbook
 > Owner: VHC Ops
-> Last Reviewed: 2026-04-26
+> Last Reviewed: 2026-07-09
 > Depends On: docs/README.md, docs/CANON_MAP.md
 
 
@@ -88,6 +88,48 @@ Private escalation operator protocol:
    available repository moderation/edit controls when available and continue
    only from public-safe status text.
 
+### 0.2 Account sign-in deployment readiness
+
+Run this gate before any tester-facing session that advertises Apple, Google,
+or X sign-in, account continuity, or account recovery. Account sign-in is a
+continuity/recovery feature only. It is not LUMA Silver, verified-human,
+one-human-one-vote, Sybil resistance, residency proof, or cross-device identity
+merge.
+
+Required deployment facts:
+
+1. The PWA build must have `VITE_AUTH_CALLBACK_BASE_URL` set to the deployed
+   auth-callback boundary outside A6.
+2. The auth-callback boundary must be reachable at:
+
+   ```
+   curl -sf https://<AUTH_CALLBACK_BASE_URL>/api/health
+   ```
+
+3. The health response may expose only booleans and reason codes. It must not
+   expose provider client secrets, tokens, provider subjects, private keys,
+   state HMAC keys, or raw provider error bodies.
+4. Every provider visible in tester copy or UI must be configured in health:
+   `providersConfigured.apple`, `providersConfigured.google`, and/or
+   `providersConfigured.x`.
+5. If a provider is not configured, hide that provider from tester copy and do
+   not count it as rehearsed. A narrowed beta may proceed only if the release
+   envelope explicitly does not advertise the missing provider.
+
+Required local sanity commands before live provider rehearsal:
+
+```
+corepack pnpm@9.7.1 --filter @vh/auth-callback build
+corepack pnpm@9.7.1 --filter @vh/auth-callback test
+corepack pnpm@9.7.1 check:auth-callback
+corepack pnpm@9.7.1 check:account-identity-controls
+corepack pnpm@9.7.1 check:luma-forbidden-claims
+corepack pnpm@9.7.1 check:luma-telemetry-redaction
+```
+
+If any of these fail, do not open a sign-in rehearsal. Fix the repo or
+deployment first.
+
 ### 1. Infrastructure health
 
 ```
@@ -152,6 +194,49 @@ it as a FAIL, not a pass.
 local echo) and no privacy leak observed. Any failure is a session blocker and,
 for a release rehearsal, blocks the Slice F2 evidence packet.
 
+### 4. Account sign-in and account-to-LUMA binding rehearsal
+
+This procedure is required for any release rehearsal that advertises sign-in or
+registration. Run it after the daily gates and before tester invites. Use one
+clean browser profile per tester identity; do not use incognito for release
+evidence because identity persistence is part of the claim.
+
+For each advertised provider (`apple`, `google`, `x`):
+
+| Step | Action | Expected |
+|------|--------|----------|
+| 1 | Open `<BASE_URL>/account/identity` in a clean browser profile. | The `Identity` panel loads. If no identity exists, `Create identity` is visible. |
+| 2 | Click `Create identity` if needed. | The page shows `Beta-local identity on this device`; it does not render a raw nullifier, session token, numeric trust score, provider subject, or provider token. |
+| 3 | In `Sign-in accounts`, confirm the provider row is visible only if the provider is advertised for this session. | `signin-provider-<provider>` exists; the status starts as `Not connected`, `Signed out`, or `Session expired — reconnect`. Missing providers are removed from tester copy. |
+| 4 | Click the provider's `Connect` control and complete the provider authorization. | Browser returns through `/auth/callback` to the account page without exposing the PKCE verifier in the URL. |
+| 5 | Check the provider row. | `signin-status-<provider>` shows `Connected`; no raw provider token, provider subject, client secret, or nullifier is visible in page text. |
+| 6 | Confirm the copy boundary in the sign-in panel. | The panel describes sign-in as account continuity/profile recovery and includes the negative uniqueness boundary (`not a proof of a unique person` or equivalent). It does not claim verified-human, one-human-one-vote, Silver, Sybil resistance, residency, anonymity, or same-human continuity. |
+| 7 | Reload the page. | The provider remains connected and the beta-local identity remains present on this device. |
+| 8 | Click the provider `Disconnect` control. | The provider status changes to `Signed out`; the page does not claim network deletion or deletion of public activity. |
+| 9 | Reconnect the same provider in the same browser profile. | The provider returns to `Connected`; the local beta-LUMA identity is preserved unless the operator explicitly uses `Reset identity`. |
+| 10 | Click `Reset identity`, type `reset`, and confirm only in a rehearsal browser/profile. | The identity rotates; the reset dialog states previous public history remains under the old pseudonym and connected sign-in accounts must be re-bound. |
+| 11 | After reset, inspect `Sign-in accounts`. | No provider row remains silently connected to the pre-reset identity; the provider must require re-bind before further account-continuity claims. |
+
+**Cross-device boundary check.** Repeat steps 1-7 for the same provider in a
+second clean browser profile. The second profile must get its own beta-local
+identity. Do not claim that sign-in merges votes, proves the same human, or
+transfers the old browser's LUMA principal. If copy or telemetry implies that
+cross-device sign-in proves same-human continuity, the rehearsal fails.
+
+**Secret and privacy spot-check.** During one provider run, inspect the browser
+URL, network requests, console, local telemetry, and public mesh paths touched
+by the session. Record only booleans in the evidence packet. Do not paste raw
+provider subjects, email addresses, nullifiers, PKCE verifiers, state values,
+client secrets, access/refresh/id tokens, or provider error bodies into issue
+comments, PRs, session notes, or release artifacts.
+
+**Required:** every advertised provider passes the provider matrix above; the
+same-browser sign-out/sign-in path preserves the local beta-LUMA identity; Reset
+Identity clears account binding and requires re-bind; a second browser profile
+does not get or claim the first browser's LUMA principal; no forbidden claim or
+secret leak is observed. Any failure blocks sign-in claims and, if sign-in is
+required by the release envelope, blocks the release rehearsal.
+
 ---
 
 ## Flip-Switch Criteria (dev-small -> beta-scale)
@@ -202,6 +287,9 @@ Profile:        dev-small | beta-scale
 Production readiness: release_ready | review_required | blocked (reason)
 Headline soak:  pass | warn | fail (reason)
 Source scout:   top promotable candidate | none | blocked (reason)
+Auth callback:  PASS | FAIL (reason) | not in envelope
+Advertised providers: apple PASS/FAIL/hidden, google PASS/FAIL/hidden, x PASS/FAIL/hidden
+Account/LUMA:   PASS (same-browser preserved, reset cleared, cross-browser distinct) | FAIL (reason)
 Strict gate:    PASS N/N | FAIL (reason)
 3-browser:      PASS | FAIL at step N (reason)
 Cross-client:   PASS (convergence proven, not local echo) | FAIL (reason)
@@ -220,6 +308,7 @@ Flip-switch:    eligible (day N of 2) | not eligible (reason)
 ## Beta Policy (communicate to testers)
 
 1. **Identity:** single browser profile per tester. No incognito, no storage clears, no device switching. Clearing browser data = new identity; prior votes become orphaned.
-2. **Vote mutation:** last-write-wins per user. You can change your vote; aggregate updates accordingly.
-3. **Degradation:** if the bias table doesn't load within ~10s after clicking a headline, reload once. If it still doesn't load, report to operator. Do not repeatedly click — it burns analysis budget.
-4. **Feedback:** report live-session issues immediately to the operator with: what you clicked, what you expected, what you saw, browser console screenshot if possible. Out-of-session public beta support uses `/support`; do not post private details into public GitHub issues.
+2. **Account sign-in:** Apple/Google/X sign-in, when enabled, is for account continuity and profile recovery on this beta surface. It does not verify a unique person, merge LUMA identities across browsers/devices, prove residency, or make votes one-human-one-vote.
+3. **Vote mutation:** last-write-wins per user. You can change your vote; aggregate updates accordingly.
+4. **Degradation:** if the bias table doesn't load within ~10s after clicking a headline, reload once. If it still doesn't load, report to operator. Do not repeatedly click — it burns analysis budget.
+5. **Feedback:** report live-session issues immediately to the operator with: what you clicked, what you expected, what you saw, browser console screenshot if possible. Out-of-session public beta support uses `/support`; do not post private details into public GitHub issues.

--- a/docs/plans/RELEASE_READINESS_SPRINT_OUTLINE_2026-07-08.md
+++ b/docs/plans/RELEASE_READINESS_SPRINT_OUTLINE_2026-07-08.md
@@ -948,8 +948,11 @@ The release-readiness sprint is complete when all of these are true:
 6. Stand up the auth-callback edge host, start Apple provider registration,
    and plan the origin-image rebuild that bakes the auth and CSP env into the
    deployed PWA.
-7. Extend `docs/ops/BETA_SESSION_RUNSHEET.md` with the sign-in and
-   account-binding rehearsal steps via a small repo PR.
+7. Keep the sign-in/account-binding rehearsal in
+   `docs/ops/BETA_SESSION_RUNSHEET.md` current with the deployed
+   auth-callback/provider surface; the runsheet now defines provider health,
+   same-browser sign-out/sign-in preservation, Reset Identity re-bind, and
+   cross-browser distinct-principal checks.
 8. Regenerate release evidence only after the live blockers are cleared.
 9. Run the 3-browser rehearsal against the deployed target.
 10. Ship `dev-small` tester invites with claim-safe copy.

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test:storycluster:quality": "corepack pnpm@9.7.1 --filter @vh/storycluster-engine exec vitest run src/vectorBackend.test.ts src/server.test.ts src/stageRunner.pipeline.test.ts src/coherenceAudit.test.ts src/storyclusterQualityGate.test.ts --config ./vitest.config.ts --reporter=verbose",
     "test:storycluster:live-benchmark": "corepack pnpm@9.7.1 --filter @vh/storycluster-engine exec vitest run src/liveBenchmark.integration.test.ts --config ./vitest.config.ts --reporter=verbose",
     "test:storycluster:correctness": "corepack pnpm@9.7.1 --filter @vh/storycluster-engine exec vitest run src/benchmarkCorpusKnownEventOngoingFixtures.test.ts src/storyclusterKnownEventOngoingReplay.test.ts src/storyclusterQualityGate.test.ts --config ./vitest.config.ts --reporter=verbose && corepack pnpm@9.7.1 --filter @vh/e2e test:live:daemon-feed:build && corepack pnpm@9.7.1 --filter @vh/e2e test:live:daemon-feed:semantic-gate",
-    "check:account-identity-controls": "pnpm --filter @vh/e2e check:account-identity-controls",
+    "check:account-identity-controls": "corepack pnpm@9.7.1 --filter @vh/e2e check:account-identity-controls",
     "check:storycluster:correctness": "node ./packages/e2e/src/live/storycluster-correctness-gate.mjs",
     "test:storycluster:gates": "corepack pnpm@9.7.1 --filter @vh/e2e test:live:daemon-feed:build && corepack pnpm@9.7.1 --filter @vh/e2e test:live:daemon-feed:gates",
     "test:storycluster:publisher-canary": "corepack pnpm@9.7.1 --filter @vh/e2e test:live:daemon-feed:build && corepack pnpm@9.7.1 --filter @vh/e2e test:live:daemon-feed:publisher-canary",

--- a/packages/e2e/playwright.config.ts
+++ b/packages/e2e/playwright.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
         },
     ],
     webServer: {
-        command: `cd ../.. && VITE_E2E_MODE=true pnpm --filter @vh/web-pwa preview --host 127.0.0.1 --port ${Number.isFinite(e2ePort) ? e2ePort : 5173}`,
+        command: `cd ../.. && VITE_E2E_MODE=true corepack pnpm@9.7.1 --filter @vh/web-pwa preview --host 127.0.0.1 --port ${Number.isFinite(e2ePort) ? e2ePort : 5173}`,
         url: baseURL,
         reuseExistingServer: false,
         timeout: 120 * 1000,


### PR DESCRIPTION
## Summary

Advances the release-readiness sprint’s repo-side runsheet work for account registration/sign-in and account-to-LUMA binding.

This PR updates `docs/ops/BETA_SESSION_RUNSHEET.md` with the canonical operator procedure for:
- auth-callback deployment readiness and health checks;
- provider visibility/configuration rules for Apple, Google, and X;
- same-browser sign-out/sign-in preservation of the beta-local LUMA identity;
- Reset Identity clearing account binding and requiring re-bind;
- cross-browser distinct-principal verification;
- secret/privacy spot checks and release evidence fields.

It also updates STATUS and the sprint outline to reflect post-#748 state, and pins the account identity gate plus default Playwright webServer command to `corepack pnpm@9.7.1`, closing the ambient-pnpm failure exposed while validating this runsheet.

## Validation

Passed locally:
- `COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack pnpm@9.7.1 docs:check`
- `COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack pnpm@9.7.1 check:auth-callback`
- `COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack pnpm@9.7.1 check:account-identity-controls`
- `COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack pnpm@9.7.1 check:luma-forbidden-claims`
- `COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack pnpm@9.7.1 check:luma-telemetry-redaction`
- `git diff --check`

## State

This does not deploy auth-callback, configure provider secrets, run live Apple/Google/X OAuth, touch A6, enable accepted synthesis, or change tester copy. Those remain release/operator actions in the sprint outline.

The two untracked distribution-readiness docs remain untracked and untouched.
