### PR TITLE
Improve headline-soak blocker diagnostics

### DIFF
--- a/docs/ops/STORY_BUNDLER_PRODUCTION_READINESS_CHECKLIST.md
+++ b/docs/ops/STORY_BUNDLER_PRODUCTION_READINESS_CHECKLIST.md
@@ -25,6 +25,10 @@ Two separate facts are true right now:
      - `sourceHealthTrend.releaseEvidence.status: "pass"`
      - `status: "blocked"` only because headline-soak release evidence is
        still red
+     - `headlineSoakTrend.latestFailureDiagnosis.failureClass:
+       "storycluster_openai_invalid_api_key"`
+     - `headlineSoakTrend.latestFailureDiagnosis.recommendedAction:
+       "repair_storycluster_openai_credential_or_endpoint"`
      - starter surface: `24` keep / `0` watch / `0` remove
    - Fresh source-health artifact:
      - `/Users/bldt/Desktop/VHC/VHC/services/news-aggregator/.tmp/news-source-admission/latest/source-health-report.json`
@@ -44,9 +48,13 @@ Two separate facts are true right now:
      - `totalSampledStories: 0`
      - `totalAuditedPairs: 0`
      - classification: `artifact_missing: 3`
-     - runtime logs show the real StoryCluster path failed before audit
-       attachment because the local OpenAI credential was rejected
-       (`invalid_api_key`, key redacted in artifacts)
+     - the combined production-readiness report now surfaces the secret-safe
+       diagnosis before operators need to open raw logs:
+       `headlineSoakTrend.latestFailureDiagnosis.failureClass:
+       "storycluster_openai_invalid_api_key"`
+     - runtime logs, if inspected, show the real StoryCluster path failed
+       before audit attachment because the local OpenAI credential was
+       rejected; the key is redacted in artifacts
    - Fresh combined readiness artifact still blocks on:
      - `headline_soak_release_evidence_failed`
 
@@ -82,6 +90,9 @@ Primary paths:
   - `/Users/bldt/Desktop/VHC/VHC/services/news-aggregator/.tmp/news-source-admission/latest/source-health-trend.json`
 - Unified readiness:
   - `/Users/bldt/Desktop/VHC/VHC/.tmp/storycluster-production-readiness/<run>/production-readiness-report.json`
+  - read `headlineSoakTrend.latestFailureDiagnosis` first when headline-soak
+    evidence is red; it is a secret-safe classifier/action summary and is the
+    preferred operator diagnostic before opening runtime logs
 - Analysis/eval artifacts:
   - `/Users/bldt/Desktop/VHC/VHC/.tmp/analysis-eval-artifacts/analysis-eval-artifacts.jsonl`
   - `/Users/bldt/Desktop/VHC/VHC/.tmp/analysis-eval-artifacts/artifacts/analysis-eval:<hash>.json`

--- a/docs/plans/RELEASE_READINESS_SPRINT_OUTLINE_2026-07-08.md
+++ b/docs/plans/RELEASE_READINESS_SPRINT_OUTLINE_2026-07-08.md
@@ -244,9 +244,13 @@ commit. The broader StoryCluster production-readiness check still blocks on
 headline-soak release evidence after this recovery: correctness and
 source-health pass, but the latest live headline-soak attempt produced no audit
 attachments because the local real StoryCluster/OpenAI path rejected its
-credential (`invalid_api_key`, redacted in artifacts). This lane is
-source-surface and release-window recovery, not a generic StoryCluster
-correctness failure.
+credential. Current production-readiness reports surface this as the
+secret-safe diagnostic
+`headlineSoakTrend.latestFailureDiagnosis.failureClass:
+"storycluster_openai_invalid_api_key"` with recommended action
+`repair_storycluster_openai_credential_or_endpoint`; raw key material remains
+redacted and must not be copied into docs or issues. This lane is source-surface
+and release-window recovery, not a generic StoryCluster correctness failure.
 
 ### Implementation steps
 
@@ -942,6 +946,11 @@ The release-readiness sprint is complete when all of these are true:
    `corepack pnpm@9.7.1 collect:storycluster:headline-soak` plus
    `corepack pnpm@9.7.1 check:storycluster:production-readiness` until the
    blocker is real product evidence rather than a local secret/config failure.
+   When the gate is red, read
+   `.tmp/storycluster-production-readiness/latest/production-readiness-report.json`
+   and use `headlineSoakTrend.latestFailureDiagnosis` as the first diagnostic;
+   it is designed to expose a stable failure class and action without copying
+   credential-bearing runtime logs.
 5. Draft the A6 accepted-synthesis canary packet, but do not run it until
    source health and pre-canary readbacks are green and the standing
    attended-soak preconditions are met.

--- a/packages/e2e/src/live/storycluster-production-readiness.mjs
+++ b/packages/e2e/src/live/storycluster-production-readiness.mjs
@@ -60,6 +60,10 @@ function readJson(filePath, readFile = readFileSync) {
   return JSON.parse(readFile(filePath, 'utf8'));
 }
 
+function isRecord(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
 function readRequiredArtifactJson(filePath, label, readFile = readFileSync) {
   try {
     return readJson(filePath, readFile);
@@ -260,6 +264,162 @@ function resolveCorrectnessGateStatus({
   };
 }
 
+function extractRuntimeLogLines(runtimeLogs) {
+  if (!isRecord(runtimeLogs)) {
+    return [];
+  }
+
+  return [
+    runtimeLogs.browserLogs,
+    runtimeLogs.storyclusterLogs,
+    runtimeLogs.daemonLogs,
+  ].flatMap((lines) => (Array.isArray(lines) ? lines : []))
+    .filter((line) => typeof line === 'string');
+}
+
+function classifyRuntimeLogLines(lines) {
+  const joined = lines.join('\n');
+  if (!joined) {
+    return null;
+  }
+
+  if (
+    /\binvalid_api_key\b/i.test(joined)
+    || /incorrect api key/i.test(joined)
+  ) {
+    return {
+      failureClass: 'storycluster_openai_invalid_api_key',
+      component: 'storycluster_openai',
+      recommendedAction: 'repair_storycluster_openai_credential_or_endpoint',
+    };
+  }
+
+  if (/openai/i.test(joined) && /\bHTTP 401\b/i.test(joined)) {
+    return {
+      failureClass: 'storycluster_openai_authentication_failed',
+      component: 'storycluster_openai',
+      recommendedAction: 'repair_storycluster_openai_credential_or_endpoint',
+    };
+  }
+
+  if (/remote cluster request failed/i.test(joined)) {
+    return {
+      failureClass: 'storycluster_remote_cluster_request_failed',
+      component: 'storycluster_service',
+      recommendedAction: 'inspect_storycluster_runtime_logs_and_endpoint',
+    };
+  }
+
+  return null;
+}
+
+function readOptionalJson(filePath, {
+  exists = existsSync,
+  readFile = readFileSync,
+} = {}) {
+  if (!filePath || !exists(filePath)) {
+    return { record: null, error: filePath ? 'missing' : 'path_unavailable' };
+  }
+
+  try {
+    return { record: readJson(filePath, readFile), error: null };
+  } catch {
+    return { record: null, error: 'invalid_json' };
+  }
+}
+
+function resolveLatestHeadlineSoakArtifactDir(headlineSoakTrend) {
+  return normalizeNonEmpty(headlineSoakTrend?.latestExecution?.artifactDir)
+    ?? normalizeNonEmpty(headlineSoakTrend?.latestStrictFailureExecution?.artifactDir)
+    ?? null;
+}
+
+function resolveLatestHeadlineSoakIndexPath(headlineSoakTrend) {
+  const explicitPath = normalizeNonEmpty(headlineSoakTrend?.latestExecution?.artifactPaths?.indexPath)
+    ?? normalizeNonEmpty(headlineSoakTrend?.latestStrictFailureExecution?.artifactPaths?.indexPath);
+  if (explicitPath) {
+    return explicitPath;
+  }
+
+  const artifactDir = resolveLatestHeadlineSoakArtifactDir(headlineSoakTrend);
+  return artifactDir ? path.join(artifactDir, 'release-artifact-index.json') : null;
+}
+
+export function diagnoseHeadlineSoakFailure({
+  headlineSoakTrend,
+  exists = existsSync,
+  readFile = readFileSync,
+} = {}) {
+  const latestExecution = headlineSoakTrend?.latestExecution ?? null;
+  const latestStrictFailureExecution = headlineSoakTrend?.latestStrictFailureExecution ?? null;
+  const latestFailure = latestExecution?.readinessStatus === 'not_ready'
+    ? latestExecution
+    : latestStrictFailureExecution;
+  const artifactDir = resolveLatestHeadlineSoakArtifactDir(headlineSoakTrend);
+  const indexPath = resolveLatestHeadlineSoakIndexPath(headlineSoakTrend);
+  const diagnosis = {
+    schemaVersion: 'headline-soak-failure-diagnosis-v1',
+    available: Boolean(latestFailure || artifactDir || indexPath),
+    secretSafe: true,
+    artifactDir,
+    indexPath,
+    latestReadinessStatus: latestExecution?.readinessStatus ?? null,
+    latestStrictSoakPass: latestExecution?.strictSoakPass ?? null,
+    latestPromotionBlockingReasons: latestExecution?.promotionBlockingReasons ?? [],
+    latestClassifications: latestExecution?.classifications ?? null,
+    inspectedRunCount: 0,
+    inspectedRuntimeLogCount: 0,
+    runtimeLogReadErrorCount: 0,
+    failureClass: null,
+    component: null,
+    recommendedAction: 'collect_or_inspect_headline_soak_artifacts',
+  };
+
+  const indexRead = readOptionalJson(indexPath, { exists, readFile });
+  if (!isRecord(indexRead.record)) {
+    diagnosis.indexReadError = indexRead.error;
+    if ((latestExecution?.classifications?.artifact_missing ?? 0) > 0) {
+      diagnosis.failureClass = 'headline_soak_artifact_missing';
+      diagnosis.component = 'headline_soak_audit';
+      diagnosis.recommendedAction = 'inspect_headline_soak_runtime_logs';
+    }
+    return diagnosis;
+  }
+
+  const runs = Array.isArray(indexRead.record.runs) ? indexRead.record.runs : [];
+  diagnosis.inspectedRunCount = runs.length;
+
+  for (const run of runs) {
+    if (!isRecord(run) || run.pass === true) {
+      continue;
+    }
+    const runtimeLogsPath = normalizeNonEmpty(run.runtimeLogsPath)
+      ?? normalizeNonEmpty(run.artifactPaths?.runtimeLogsPath);
+    const runtimeRead = readOptionalJson(runtimeLogsPath, { exists, readFile });
+    if (!isRecord(runtimeRead.record)) {
+      diagnosis.runtimeLogReadErrorCount += 1;
+      continue;
+    }
+
+    diagnosis.inspectedRuntimeLogCount += 1;
+    const classification = classifyRuntimeLogLines(extractRuntimeLogLines(runtimeRead.record));
+    if (classification) {
+      return {
+        ...diagnosis,
+        ...classification,
+      };
+    }
+  }
+
+  if ((latestExecution?.classifications?.artifact_missing ?? 0) > 0) {
+    diagnosis.failureClass = 'headline_soak_artifact_missing';
+    diagnosis.component = 'headline_soak_audit';
+    diagnosis.recommendedAction = 'inspect_headline_soak_runtime_logs';
+  }
+
+  return diagnosis;
+}
+
 export function loadProductionReadinessArtifacts({
   repoRoot = DEFAULT_REPO_ROOT,
   sourceHealthReportPath,
@@ -315,6 +475,11 @@ export function loadProductionReadinessArtifacts({
     'headline-soak-trend',
     readFile,
   );
+  const headlineSoakFailureDiagnosis = diagnoseHeadlineSoakFailure({
+    headlineSoakTrend,
+    exists,
+    readFile,
+  });
   const correctnessGate = resolveCorrectnessGateStatus({
     rule,
     correctnessGateStatusPath,
@@ -355,6 +520,7 @@ export function loadProductionReadinessArtifacts({
     sourceHealthReport,
     sourceHealthTrend,
     headlineSoakTrend,
+    headlineSoakFailureDiagnosis,
     continuityTrend,
     sourceHealthFreshness: assessArtifactFreshness(
       resolvedSourceHealthReportPath,
@@ -384,6 +550,7 @@ export function buildProductionReadinessDecision({
   sourceHealthReport,
   sourceHealthTrend,
   headlineSoakTrend,
+  headlineSoakFailureDiagnosis,
   continuityTrendPath,
   continuityTrend,
   continuityFreshness,
@@ -489,6 +656,7 @@ export function buildProductionReadinessDecision({
       executionCount: headlineSoakTrend?.executionCount ?? null,
       promotableExecutionCount: headlineSoakTrend?.promotableExecutionCount ?? null,
       latestExecution: headlineSoakTrend?.latestExecution ?? null,
+      latestFailureDiagnosis: headlineSoakFailureDiagnosis ?? null,
     },
     continuityTelemetry: {
       trendPath: continuityTrendPath,
@@ -591,6 +759,7 @@ export const storyclusterProductionReadinessInternal = {
   parseBoolean,
   parseCorrectnessStatus,
   readRequiredArtifactJson,
+  diagnoseHeadlineSoakFailure,
   resolveArtifactTimestamp,
   resolveCorrectnessGateStatus,
   resolvePreferredHeadlineSoakTrendPath,

--- a/packages/e2e/src/live/storycluster-production-readiness.vitest.mjs
+++ b/packages/e2e/src/live/storycluster-production-readiness.vitest.mjs
@@ -163,6 +163,99 @@ describe('storycluster-production-readiness', () => {
     expect(decision.continuityTelemetry.error).toMatch(/invalid production-readiness artifact JSON \(continuity-trend\)/);
   });
 
+  it('diagnoses headline-soak OpenAI credential failures without copying secret-bearing log text', () => {
+    const files = new Map([
+      ['/repo/.tmp/daemon-feed-semantic-soak/123/release-artifact-index.json', JSON.stringify({
+        runs: [{
+          run: 1,
+          pass: false,
+          classification: 'artifact_missing',
+          runtimeLogsPath: '/repo/.tmp/daemon-feed-semantic-soak/123/run-1.runtime-logs.json',
+        }],
+      })],
+      ['/repo/.tmp/daemon-feed-semantic-soak/123/run-1.runtime-logs.json', JSON.stringify({
+        daemonLogs: [
+          'remote cluster request failed: HTTP 503',
+          'storycluster stage language_translation failed: OpenAI chat request failed: HTTP 401 {"error":{"message":"Incorrect API key provided: sk-[REDACTED]","code":"invalid_api_key"}}',
+        ],
+      })],
+    ]);
+
+    const diagnosis = storyclusterProductionReadinessInternal.diagnoseHeadlineSoakFailure({
+      headlineSoakTrend: {
+        latestExecution: {
+          artifactDir: '/repo/.tmp/daemon-feed-semantic-soak/123',
+          strictSoakPass: false,
+          readinessStatus: 'not_ready',
+          promotionBlockingReasons: ['insufficient_sample_fill_rate'],
+          classifications: { artifact_missing: 1 },
+          artifactPaths: {
+            indexPath: '/repo/.tmp/daemon-feed-semantic-soak/123/release-artifact-index.json',
+          },
+        },
+      },
+      exists: (filePath) => files.has(filePath),
+      readFile: (filePath) => files.get(filePath),
+    });
+
+    expect(diagnosis).toMatchObject({
+      secretSafe: true,
+      failureClass: 'storycluster_openai_invalid_api_key',
+      component: 'storycluster_openai',
+      recommendedAction: 'repair_storycluster_openai_credential_or_endpoint',
+      inspectedRunCount: 1,
+      inspectedRuntimeLogCount: 1,
+    });
+    expect(JSON.stringify(diagnosis)).not.toMatch(/sk-|Incorrect API key provided|OpenAI chat request failed/);
+  });
+
+  it('embeds headline-soak failure diagnosis in the production-readiness report', () => {
+    const rule = buildProductionReadinessRule('/repo');
+    const decision = buildProductionReadinessDecision({
+      rule,
+      correctnessStatus: 'pass',
+      artifactDir: '/repo/.tmp/storycluster-production-readiness/1',
+      reportPath: '/repo/.tmp/storycluster-production-readiness/1/production-readiness-report.json',
+      latestArtifactDir: '/repo/.tmp/storycluster-production-readiness/latest',
+      latestReportPath: '/repo/.tmp/storycluster-production-readiness/latest/production-readiness-report.json',
+      sourceHealthReportPath: '/repo/source-health-report.json',
+      sourceHealthTrendPath: '/repo/source-health-trend.json',
+      headlineSoakTrendPath: '/repo/headline-soak-trend-index.json',
+      sourceHealthFreshness: { stale: false },
+      headlineSoakFreshness: { stale: false },
+      sourceHealthReport: {
+        releaseEvidence: { status: 'pass', reasons: [] },
+        observability: { enabledSourceCount: 12, contributingSourceCount: 12, corroboratingSourceCount: 12 },
+      },
+      sourceHealthTrend: { releaseEvidence: { status: 'pass', reasons: [] } },
+      headlineSoakTrend: {
+        releaseEvidence: { status: 'fail', reasons: ['latest_headline_soak_execution_not_promotable'] },
+        executionCount: 2,
+        promotableExecutionCount: 1,
+        latestExecution: { readinessStatus: 'not_ready' },
+      },
+      headlineSoakFailureDiagnosis: {
+        schemaVersion: 'headline-soak-failure-diagnosis-v1',
+        secretSafe: true,
+        failureClass: 'storycluster_openai_invalid_api_key',
+        component: 'storycluster_openai',
+        recommendedAction: 'repair_storycluster_openai_credential_or_endpoint',
+      },
+    });
+
+    expect(decision).toMatchObject({
+      status: 'blocked',
+      reasons: ['headline_soak_release_evidence_failed'],
+      headlineSoakTrend: {
+        latestFailureDiagnosis: {
+          secretSafe: true,
+          failureClass: 'storycluster_openai_invalid_api_key',
+          recommendedAction: 'repair_storycluster_openai_credential_or_endpoint',
+        },
+      },
+    });
+  });
+
   it('builds pass, review, and blocked release decisions', () => {
     const rule = buildProductionReadinessRule('/repo');
     const base = {


### PR DESCRIPTION
## Summary
- add a secret-safe headline-soak failure diagnosis to the StoryCluster production-readiness report
- classify the current artifact-missing headline-soak failure as `storycluster_openai_invalid_api_key` when runtime logs show the redacted OpenAI invalid-key path
- document `headlineSoakTrend.latestFailureDiagnosis` as the first operator diagnostic in the release sprint and story-bundler checklist

## Validation
- `corepack pnpm@9.7.1 --filter @vh/e2e exec vitest run src/live/storycluster-production-readiness.vitest.mjs --reporter=verbose`
- `corepack pnpm@9.7.1 --filter @vh/e2e typecheck`
- `corepack pnpm@9.7.1 docs:check`
- `git diff --check`
- `corepack pnpm@9.7.1 lint`
- `node tools/scripts/check-diff-coverage.mjs`
- `corepack pnpm@9.7.1 report:storycluster:production-readiness` (expected blocked; report now includes `latestFailureDiagnosis.failureClass=storycluster_openai_invalid_api_key`)
- `corepack pnpm@9.7.1 check:storycluster:production-readiness` (expected exit 1; correctness and source health pass, final blocker remains `headline_soak_release_evidence_failed`)

## Current blocker after this PR
This does not clear release readiness. It makes the remaining blocker actionable: repair the StoryCluster/OpenAI credential or endpoint, rerun headline soak collection, then rerun `check:storycluster:production-readiness` until headline-soak release evidence passes.