### PR TITLE
fix: stabilize public feed alert fingerprint and email MIME

### DIFF
--- a/tools/scripts/public-feed-alert-watch.mjs
+++ b/tools/scripts/public-feed-alert-watch.mjs
@@ -25,6 +25,26 @@ const NEWS_DAEMON_FAIL_CLOSED_EXIT_CODE = '78';
 // blocker strings cannot distinguish a structural `:` or `|` from the same
 // bytes inside a URL, so guessing at those delimiters can expose a suffix.
 const URL_IN_TEXT_PATTERN = /https?:\/\/\S+/gi;
+const FRESHNESS_FAILURE_REASON_CODES = new Set([
+  'latest_index_empty',
+  'latest_index_fetch_failed',
+  'latest_index_stale',
+  'latest_index_timestamp_missing',
+]);
+const FRESHNESS_BLOCKER_CLASSES = new Set([
+  'health_unhealthy',
+  'latest_index_not_fresh',
+  'openai_preflight_failed',
+  'origins_not_configured',
+]);
+const FAILURE_NUMERIC_DIAGNOSTIC_FIELDS = [
+  { source: 'http_status', target: 'httpStatus', min: 100, max: 599 },
+  { source: 'attempt', target: 'attempt', min: 0, max: 1_000_000 },
+  { source: 'age', target: 'age', min: 0, max: Number.MAX_SAFE_INTEGER },
+  { source: 'age_ms', target: 'ageMs', min: 0, max: Number.MAX_SAFE_INTEGER },
+  { source: 'max_age_ms', target: 'maxAgeMs', min: 0, max: Number.MAX_SAFE_INTEGER },
+  { source: 'count', target: 'count', min: 0, max: Number.MAX_SAFE_INTEGER },
+];
 const SEVERITY_RANK = {
   none: 0,
   warning: 1,
@@ -94,22 +114,66 @@ function sortedUniqueStrings(values) {
   return [...new Set(values.filter((value) => typeof value === 'string' && value.length > 0))].sort();
 }
 
+function structuredFailureReasonCode(value) {
+  const match = String(value ?? '').trim().toLowerCase().match(/^([a-z][a-z0-9_-]*)(?=:|$)/);
+  const candidate = match?.[1] ?? null;
+  return candidate && FRESHNESS_FAILURE_REASON_CODES.has(candidate)
+    ? candidate
+    : 'unclassified_failure';
+}
+
 function structuredFailureReasonCodes(values) {
-  return sortedUniqueStrings((Array.isArray(values) ? values : []).map((value) => {
-    const match = String(value ?? '').trim().toLowerCase().match(/^([a-z][a-z0-9_-]*)(?=:|$)/);
-    return match?.[1] ?? 'unclassified_failure';
-  }));
+  return sortedUniqueStrings((Array.isArray(values) ? values : []).map(structuredFailureReasonCode));
+}
+
+function failureNumericDiagnostics(value) {
+  const text = String(value ?? '');
+  const byTarget = new Map();
+  const add = (target, raw, min = 0, max = Number.MAX_SAFE_INTEGER) => {
+    if (!/^\d{1,15}$/.test(String(raw ?? ''))) return;
+    const parsed = Number(raw);
+    if (!Number.isSafeInteger(parsed) || parsed < min || parsed > max) return;
+    if (!byTarget.has(target)) byTarget.set(target, new Set());
+    byTarget.get(target).add(parsed);
+  };
+
+  const staleMatch = text.match(/^latest_index_stale:(\d{1,15})\/(\d{1,15})(?=$|[^a-z0-9_./])/i);
+  if (staleMatch) {
+    add('newestAgeMs', staleMatch[1]);
+    add('maxAgeMs', staleMatch[2]);
+  }
+
+  const fieldBySource = new Map(FAILURE_NUMERIC_DIAGNOSTIC_FIELDS.map((field) => [field.source, field]));
+  const pattern = /(?:^|[^a-z0-9_])(http_status|attempt|age|age_ms|max_age_ms|count)\s*[=:]\s*(\d{1,15})(?=$|[^a-z0-9_./])/gi;
+  for (const match of text.matchAll(pattern)) {
+    const field = fieldBySource.get(match[1].toLowerCase());
+    if (field) add(field.target, match[2], field.min, field.max);
+  }
+
+  return Object.fromEntries([...byTarget.entries()]
+    .sort(([left], [right]) => left < right ? -1 : left > right ? 1 : 0)
+    .map(([target, values]) => [target, [...values].sort((left, right) => left - right)]));
 }
 
 function structuredFailureDiagnostics(values) {
-  return sortedUniqueStrings((Array.isArray(values) ? values : []).map(sanitizeAlertText));
+  // Public alert projections must be identical when only arbitrary detail
+  // changes. Never add raw text or a raw-detail-derived hash here.
+  return canonicalObjectSet((Array.isArray(values) ? values : []).map((value) => ({
+    reasonCode: structuredFailureReasonCode(value),
+    numericDiagnostics: failureNumericDiagnostics(value),
+  })));
+}
+
+function blockerClass(value) {
+  const match = String(value ?? '').trim().toLowerCase().match(/^([a-z][a-z0-9_-]*)(?=:|$)/);
+  const candidate = match?.[1] ?? null;
+  return candidate && FRESHNESS_BLOCKER_CLASSES.has(candidate)
+    ? candidate
+    : 'unclassified_blocker';
 }
 
 function blockerClasses(values) {
-  return sortedUniqueStrings((values ?? []).map((value) => {
-    const match = String(value ?? '').trim().toLowerCase().match(/^([a-z][a-z0-9_-]*)(?=:|$)/);
-    return match?.[1] ?? 'unclassified_blocker';
-  }));
+  return sortedUniqueStrings((values ?? []).map(blockerClass));
 }
 
 function blockerReasonCode(value) {
@@ -222,7 +286,7 @@ function summarizeFreshness(summary) {
     schemaVersion: summary?.schemaVersion ?? null,
     generatedAt: summary?.generatedAt ?? null,
     status: summary?.status ?? null,
-    blockers: Array.isArray(summary?.blockers) ? summary.blockers.map(sanitizeAlertText) : [],
+    blockers: blockerClasses(Array.isArray(summary?.blockers) ? summary.blockers : []),
     maxAgeMs: Number.isFinite(summary?.config?.maxAgeMs) ? summary.config.maxAgeMs : null,
     originHashes: Array.isArray(summary?.config?.origins)
       ? summary.config.origins.map((origin) => hashValue(origin))

--- a/tools/scripts/public-feed-alert-watch.mjs
+++ b/tools/scripts/public-feed-alert-watch.mjs
@@ -21,7 +21,7 @@ const DEFAULT_WATCH_CLOSURE_MAX_AGE_MS = 90 * 60 * 1000;
 const NEWS_DAEMON_TRANSPORT_UNAVAILABLE_EXIT_CODE = '69';
 const NEWS_DAEMON_WRAPPER_REFUSAL_EXIT_CODE = '75';
 const NEWS_DAEMON_FAIL_CLOSED_EXIT_CODE = '78';
-const URL_IN_TEXT_PATTERN = /https?:\/\/[^\s"'<>)}\]]+?(?=:(?:[a-z][a-z0-9_-]*)(?::|$)|[\s"'<>)}\]]|$)/gi;
+const URL_IN_TEXT_PATTERN = /https?:\/\/[^\s"'<>)}\]]+?(?=:(?:[a-z][a-z0-9_-]*)(?::|\||$)|[\s"'<>)}\]]|$)/gi;
 const SEVERITY_RANK = {
   none: 0,
   warning: 1,
@@ -109,7 +109,7 @@ function blockerReasonCode(value) {
       codes.push(segment);
     }
   }
-  return codes.length > 0 ? codes.join(':') : 'unclassified_blocker';
+  return codes.length > 0 ? sortedUniqueStrings(codes).join(':') : 'unclassified_blocker';
 }
 
 function blockerReasonCodes(values) {

--- a/tools/scripts/public-feed-alert-watch.mjs
+++ b/tools/scripts/public-feed-alert-watch.mjs
@@ -11,7 +11,7 @@ import { runPublicFeedFreshnessMonitor } from './public-feed-freshness-monitor.m
 import { newsAggregatorPublisherLivenessWatchInternal } from './news-aggregator-publisher-liveness-watch.mjs';
 
 const REPORT_SCHEMA_VERSION = 'vh-public-feed-alert-watch-v1';
-const STATE_SCHEMA_VERSION = 'vh-public-feed-alert-state-v2';
+const STATE_SCHEMA_VERSION = 'vh-public-feed-alert-state-v3';
 const DEFAULT_UNIT = 'vh-news-aggregator.service';
 const DEFAULT_STATE_DIR = '.local/state/vhc/public-feed-alert';
 const DEFAULT_TIMEOUT_MS = 15_000;
@@ -87,10 +87,57 @@ function sanitizeAlertError(error, redactions = []) {
   return sanitizeAlertText(message);
 }
 
-function stableFingerprintText(value) {
-  return sanitizeAlertText(value)
-    .replace(/publisher_restart_churn:\d+\/\d+/g, 'publisher_restart_churn:<n>/<n>')
-    .replace(/\b\d{4,}\b/g, '<n>');
+function sortedUniqueStrings(values) {
+  return [...new Set(values.filter((value) => typeof value === 'string' && value.length > 0))].sort();
+}
+
+function blockerReasonCode(value) {
+  const hashMarkers = new Set(['url_hash', 'value_hash', 'snapshot_file_hash']);
+  const segments = sanitizeAlertText(value)
+    .split(/[:|]/)
+    .map((segment) => segment.trim().toLowerCase())
+    .filter(Boolean);
+  const codes = [];
+  for (let index = 0; index < segments.length; index += 1) {
+    const segment = segments[index];
+    if (hashMarkers.has(segment)) {
+      index += 1;
+      continue;
+    }
+    if (!/^[a-z][a-z0-9_-]*$/.test(segment)) continue;
+    if (index === 0 || segment.includes('_')) {
+      codes.push(segment);
+    }
+  }
+  return codes.length > 0 ? codes.join(':') : 'unclassified_blocker';
+}
+
+function blockerReasonCodes(values) {
+  return sortedUniqueStrings((values ?? []).map(blockerReasonCode));
+}
+
+function canonicalObjectSet(values) {
+  const byKey = new Map();
+  for (const value of values) {
+    const key = JSON.stringify(value);
+    if (!byKey.has(key)) byKey.set(key, value);
+  }
+  return [...byKey.entries()]
+    .sort(([left], [right]) => left < right ? -1 : left > right ? 1 : 0)
+    .map(([, value]) => value);
+}
+
+function identityHash(value) {
+  const normalized = String(value ?? '').trim();
+  return normalized ? hashValue(normalized) : null;
+}
+
+function thresholdFingerprintState(threshold) {
+  if (!threshold) return null;
+  return {
+    status: threshold.status ?? null,
+    blockerReasonCodes: blockerReasonCodes(threshold.blockers),
+  };
 }
 
 function maxSeverity(...values) {
@@ -657,9 +704,11 @@ function fingerprintFor({
   relaySnapshot,
   watchClosure,
 }) {
+  // Diagnostics retain their full secret-safe values; only this projection is
+  // reduced to stable semantic state before hashing for delivery dedupe.
   return hashValue(JSON.stringify({
     status,
-    blockers: [...blockers].map(stableFingerprintText).sort(),
+    blockerReasonCodes: blockerReasonCodes(blockers),
     publisher: {
       status: publisher.status,
       activeState: publisher.activeState,
@@ -669,45 +718,45 @@ function fingerprintFor({
     },
     freshness: {
       status: freshness.status,
-      blockers: freshness.blockers.map(stableFingerprintText),
-      latestIndexReadbacks: freshness.latestIndexReadbacks.map((entry) => ({
-        originHash: entry.originHash,
+      blockerReasonCodes: blockerReasonCodes(freshness.blockers),
+      originIdentities: sortedUniqueStrings(freshness.originHashes ?? []),
+      latestIndexReadbacks: canonicalObjectSet(freshness.latestIndexReadbacks.map((entry) => ({
+        identityHash: entry.originHash ?? null,
         status: entry.status,
         ageState: freshnessAgeState(entry),
-        recordCount: entry.recordCount,
-        failureCount: entry.failureCount,
-      })),
+      }))),
     },
     relayLiveness: {
       status: relayLiveness.status,
-      blockers: relayLiveness.blockers.map(stableFingerprintText),
-      relays: (relayLiveness.relays ?? []).map((relay) => ({
-        name: relay.name,
+      blockerReasonCodes: blockerReasonCodes(relayLiveness.blockers),
+      relays: canonicalObjectSet((relayLiveness.relays ?? []).map((relay) => ({
+        identityHash: identityHash(relay.name),
         status: relay.status,
-        blockerCount: relay.blockerCount,
-        restartCount: relay.restartCount,
-        watchdogTrips: relay.watchdogTrips,
-      })),
+      }))),
     },
     relaySnapshot: {
       status: relaySnapshot.status,
-      blockers: relaySnapshot.blockers.map(stableFingerprintText),
-      snapshots: (relaySnapshot.snapshots ?? []).map((snapshot) => ({
-        fileHash: snapshot.fileHash,
-        relay: snapshot.relay,
+      blockerReasonCodes: blockerReasonCodes(relaySnapshot.blockers),
+      snapshots: canonicalObjectSet((relaySnapshot.snapshots ?? []).map((snapshot) => ({
+        identityHash: identityHash(snapshot.relay ?? snapshot.fileHash),
         status: snapshot.status,
-        entryCount: snapshot.entryCount,
-        failureCount: snapshot.failureCount,
-        freshnessFailureCount: snapshot.freshnessFailureCount,
-      })),
+      }))),
     },
     watchClosure: {
       status: watchClosure.status,
-      blockers: watchClosure.blockers.map(stableFingerprintText),
+      blockerReasonCodes: blockerReasonCodes(watchClosure.blockers),
       verdictStatus: watchClosure.verdictStatus,
-      thresholds: watchClosure.thresholds,
+      thresholds: {
+        twentyFourHour: thresholdFingerprintState(watchClosure.thresholds?.twentyFourHour),
+        fortyEightHour: thresholdFingerprintState(watchClosure.thresholds?.fortyEightHour),
+      },
       relayMemoryStatus: watchClosure.relayMemory?.status ?? null,
       relayMemoryVerdict: watchClosure.relayMemory?.heapPlateauVerdict ?? null,
+      relayMemoryRelays: canonicalObjectSet((watchClosure.relayMemory?.relays ?? []).map((relay) => ({
+        identityHash: identityHash(relay.name),
+        status: relay.trendStatus ?? null,
+        verdict: relay.heapPlateauVerdict ?? null,
+      }))),
     },
   }), 24);
 }
@@ -732,16 +781,16 @@ function shouldDeliverAlert({
     && (!Number.isFinite(lastDeliveredAtMs) || now - lastDeliveredAtMs >= heartbeatMs);
   const changed = previousFingerprint !== null && previousFingerprint !== fingerprint;
   const firstFailure = previousFingerprint === null && status === 'fail';
-  const retryUndeliveredFailure = previousFingerprint === fingerprint
-    && status === 'fail'
-    && previousDeliveredFingerprint !== fingerprint;
+  const priorDeliveryFailed = ['failed', 'missing_channel'].includes(previousState?.lastDeliveryStatus);
+  const retryUndeliveredState = previousFingerprint === fingerprint
+    && (priorDeliveryFailed || (status === 'fail' && previousDeliveredFingerprint !== fingerprint));
   const failureOrRecoveryChanged = changed && (status === 'fail' || previousStatus === 'fail');
   let reason = 'unchanged_suppressed';
   if (testFire) {
     reason = 'test_fire';
   } else if (firstFailure) {
     reason = 'first_failure';
-  } else if (retryUndeliveredFailure) {
+  } else if (retryUndeliveredState) {
     reason = 'retry_failed_delivery';
   } else if (failureOrRecoveryChanged) {
     reason = 'state_changed';
@@ -753,7 +802,7 @@ function shouldDeliverAlert({
   return {
     deliver: testFire
       || firstFailure
-      || retryUndeliveredFailure
+      || retryUndeliveredState
       || failureOrRecoveryChanged
       || (stateSchemaMismatch && status === 'fail')
       || heartbeatDue,
@@ -850,11 +899,13 @@ function formatEmail({ to, from, subject, payload }) {
     `To: ${to}`,
     `From: ${from}`,
     `Subject: ${subject}`,
-    'Content-Type: application/json; charset=utf-8',
+    'MIME-Version: 1.0',
+    'Content-Type: text/plain; charset=utf-8',
+    'Content-Transfer-Encoding: 8bit',
     '',
     JSON.stringify(payload, null, 2),
     '',
-  ].join('\n');
+  ].join('\r\n');
 }
 
 function deliverEmail({

--- a/tools/scripts/public-feed-alert-watch.mjs
+++ b/tools/scripts/public-feed-alert-watch.mjs
@@ -278,15 +278,32 @@ function endpointIdentityHash(value) {
   }
 }
 
+function canonicalProjectionJson(value) {
+  const canonicalize = (entry) => {
+    if (Array.isArray(entry)) return entry.map((item) => canonicalize(item));
+    if (!entry || typeof entry !== 'object') return entry;
+    return Object.fromEntries(Object.keys(entry)
+      .filter((key) => entry[key] !== undefined)
+      .sort()
+      .map((key) => [key, canonicalize(entry[key])]));
+  };
+  return JSON.stringify(canonicalize(value));
+}
+
 function canonicalIdentifiedEntries(values, identityKey = 'identityHash') {
   return values
-    .map((value, index) => ({ ...value, sourceOrdinal: index + 1 }))
+    .map(({ ordinal, sourceOrdinal, ...projectedValue }) => projectedValue)
     .sort((left, right) => {
-      const leftKey = left[identityKey] ?? `~${String(left.sourceOrdinal).padStart(8, '0')}`;
-      const rightKey = right[identityKey] ?? `~${String(right.sourceOrdinal).padStart(8, '0')}`;
-      return leftKey < rightKey ? -1 : leftKey > rightKey ? 1 : 0;
+      const leftProjection = canonicalProjectionJson(left);
+      const rightProjection = canonicalProjectionJson(right);
+      const leftIdentity = left[identityKey];
+      const rightIdentity = right[identityKey];
+      const leftKey = leftIdentity ? `identified:${leftIdentity}` : `anonymous:${leftProjection}`;
+      const rightKey = rightIdentity ? `identified:${rightIdentity}` : `anonymous:${rightProjection}`;
+      if (leftKey !== rightKey) return leftKey < rightKey ? -1 : 1;
+      return leftProjection < rightProjection ? -1 : leftProjection > rightProjection ? 1 : 0;
     })
-    .map(({ sourceOrdinal, ...value }, index) => ({ ...value, ordinal: index + 1 }));
+    .map((value, index) => ({ ...value, ordinal: index + 1 }));
 }
 
 function projectedEnum(value, allowed, fallback = 'unknown') {

--- a/tools/scripts/public-feed-alert-watch.mjs
+++ b/tools/scripts/public-feed-alert-watch.mjs
@@ -75,16 +75,8 @@ function hashValue(value, length = 16) {
   return createHash('sha256').update(String(value ?? '')).digest('hex').slice(0, length);
 }
 
-function sanitizeAlertText(value, rawUrls = []) {
-  let text = String(value ?? '');
-  const exactUrls = [...new Set(rawUrls
-    .map((url) => String(url ?? ''))
-    .filter(Boolean))]
-    .sort((left, right) => right.length - left.length || left.localeCompare(right));
-  for (const url of exactUrls) {
-    text = text.split(url).join(`url_hash:${hashValue(url)}`);
-  }
-  return text.replace(URL_IN_TEXT_PATTERN, (url) => `url_hash:${hashValue(url)}`);
+function sanitizeAlertText(value) {
+  return String(value ?? '').replace(URL_IN_TEXT_PATTERN, (url) => `url_hash:${hashValue(url)}`);
 }
 
 function sanitizeAlertError(error, redactions = []) {
@@ -106,6 +98,17 @@ function structuredFailureReasonCodes(values) {
   return sortedUniqueStrings((Array.isArray(values) ? values : []).map((value) => {
     const match = String(value ?? '').trim().toLowerCase().match(/^([a-z][a-z0-9_-]*)(?=:|$)/);
     return match?.[1] ?? 'unclassified_failure';
+  }));
+}
+
+function structuredFailureDiagnostics(values) {
+  return sortedUniqueStrings((Array.isArray(values) ? values : []).map(sanitizeAlertText));
+}
+
+function blockerClasses(values) {
+  return sortedUniqueStrings((values ?? []).map((value) => {
+    const match = String(value ?? '').trim().toLowerCase().match(/^([a-z][a-z0-9_-]*)(?=:|$)/);
+    return match?.[1] ?? 'unclassified_blocker';
   }));
 }
 
@@ -210,26 +213,16 @@ function summarizeFreshnessReadback(readback) {
     maxAgeMs: Number.isFinite(readback?.maxAgeMs) ? readback.maxAgeMs : null,
     failureCount: Array.isArray(readback?.failures) ? readback.failures.length : 0,
     failureReasonCodes: structuredFailureReasonCodes(readback?.failures),
+    failureDiagnostics: structuredFailureDiagnostics(readback?.failures),
   };
 }
 
 function summarizeFreshness(summary) {
-  const rawOrigins = [
-    ...(Array.isArray(summary?.config?.origins) ? summary.config.origins : []),
-    ...(Array.isArray(summary?.healthReadbacks)
-      ? summary.healthReadbacks.map((readback) => readback?.origin)
-      : []),
-    ...(Array.isArray(summary?.latestIndexReadbacks)
-      ? summary.latestIndexReadbacks.map((readback) => readback?.origin)
-      : []),
-  ];
   return {
     schemaVersion: summary?.schemaVersion ?? null,
     generatedAt: summary?.generatedAt ?? null,
     status: summary?.status ?? null,
-    blockers: Array.isArray(summary?.blockers)
-      ? summary.blockers.map((blocker) => sanitizeAlertText(blocker, rawOrigins))
-      : [],
+    blockers: Array.isArray(summary?.blockers) ? summary.blockers.map(sanitizeAlertText) : [],
     maxAgeMs: Number.isFinite(summary?.config?.maxAgeMs) ? summary.config.maxAgeMs : null,
     originHashes: Array.isArray(summary?.config?.origins)
       ? summary.config.origins.map((origin) => hashValue(origin))
@@ -736,9 +729,14 @@ function fingerprintFor({
 }) {
   // Diagnostics retain their full secret-safe values; only this projection is
   // reduced to stable semantic state before hashing for delivery dedupe.
+  // Freshness flat blockers are disclosure-only: their fail-closed URL hashes
+  // are intentionally ignored here, while structured readback reasons drive
+  // genuine reason-set transitions.
   return hashValue(JSON.stringify({
     status,
-    blockerReasonCodes: blockerReasonCodes(blockers),
+    blockerReasonCodes: blockerReasonCodes(
+      blockers.filter((blocker) => !String(blocker).startsWith('public_feed:')),
+    ),
     publisher: {
       status: publisher.status,
       activeState: publisher.activeState,
@@ -748,7 +746,7 @@ function fingerprintFor({
     },
     freshness: {
       status: freshness.status,
-      blockerReasonCodes: blockerReasonCodes(freshness.blockers),
+      blockerClasses: blockerClasses(freshness.blockers),
       originIdentities: sortedUniqueStrings(freshness.originHashes ?? []),
       latestIndexReadbacks: canonicalObjectSet(freshness.latestIndexReadbacks.map((entry) => ({
         identityHash: entry.originHash ?? null,

--- a/tools/scripts/public-feed-alert-watch.mjs
+++ b/tools/scripts/public-feed-alert-watch.mjs
@@ -21,7 +21,10 @@ const DEFAULT_WATCH_CLOSURE_MAX_AGE_MS = 90 * 60 * 1000;
 const NEWS_DAEMON_TRANSPORT_UNAVAILABLE_EXIT_CODE = '69';
 const NEWS_DAEMON_WRAPPER_REFUSAL_EXIT_CODE = '75';
 const NEWS_DAEMON_FAIL_CLOSED_EXIT_CODE = '78';
-const URL_IN_TEXT_PATTERN = /https?:\/\/[^\s"'<>)}\]]+?(?=:(?:[a-z][a-z0-9_-]*)(?::|\||$)|[\s"'<>)}\]]|$)/gi;
+// URL-shaped text is deliberately consumed through the next whitespace. Flat
+// blocker strings cannot distinguish a structural `:` or `|` from the same
+// bytes inside a URL, so guessing at those delimiters can expose a suffix.
+const URL_IN_TEXT_PATTERN = /https?:\/\/\S+/gi;
 const SEVERITY_RANK = {
   none: 0,
   warning: 1,
@@ -72,8 +75,16 @@ function hashValue(value, length = 16) {
   return createHash('sha256').update(String(value ?? '')).digest('hex').slice(0, length);
 }
 
-function sanitizeAlertText(value) {
-  return String(value ?? '').replace(URL_IN_TEXT_PATTERN, (url) => `url_hash:${hashValue(url)}`);
+function sanitizeAlertText(value, rawUrls = []) {
+  let text = String(value ?? '');
+  const exactUrls = [...new Set(rawUrls
+    .map((url) => String(url ?? ''))
+    .filter(Boolean))]
+    .sort((left, right) => right.length - left.length || left.localeCompare(right));
+  for (const url of exactUrls) {
+    text = text.split(url).join(`url_hash:${hashValue(url)}`);
+  }
+  return text.replace(URL_IN_TEXT_PATTERN, (url) => `url_hash:${hashValue(url)}`);
 }
 
 function sanitizeAlertError(error, redactions = []) {
@@ -89,6 +100,13 @@ function sanitizeAlertError(error, redactions = []) {
 
 function sortedUniqueStrings(values) {
   return [...new Set(values.filter((value) => typeof value === 'string' && value.length > 0))].sort();
+}
+
+function structuredFailureReasonCodes(values) {
+  return sortedUniqueStrings((Array.isArray(values) ? values : []).map((value) => {
+    const match = String(value ?? '').trim().toLowerCase().match(/^([a-z][a-z0-9_-]*)(?=:|$)/);
+    return match?.[1] ?? 'unclassified_failure';
+  }));
 }
 
 function blockerReasonCode(value) {
@@ -191,15 +209,27 @@ function summarizeFreshnessReadback(readback) {
     newestAgeMs: Number.isFinite(readback?.newestAgeMs) ? readback.newestAgeMs : null,
     maxAgeMs: Number.isFinite(readback?.maxAgeMs) ? readback.maxAgeMs : null,
     failureCount: Array.isArray(readback?.failures) ? readback.failures.length : 0,
+    failureReasonCodes: structuredFailureReasonCodes(readback?.failures),
   };
 }
 
 function summarizeFreshness(summary) {
+  const rawOrigins = [
+    ...(Array.isArray(summary?.config?.origins) ? summary.config.origins : []),
+    ...(Array.isArray(summary?.healthReadbacks)
+      ? summary.healthReadbacks.map((readback) => readback?.origin)
+      : []),
+    ...(Array.isArray(summary?.latestIndexReadbacks)
+      ? summary.latestIndexReadbacks.map((readback) => readback?.origin)
+      : []),
+  ];
   return {
     schemaVersion: summary?.schemaVersion ?? null,
     generatedAt: summary?.generatedAt ?? null,
     status: summary?.status ?? null,
-    blockers: Array.isArray(summary?.blockers) ? summary.blockers.map(sanitizeAlertText) : [],
+    blockers: Array.isArray(summary?.blockers)
+      ? summary.blockers.map((blocker) => sanitizeAlertText(blocker, rawOrigins))
+      : [],
     maxAgeMs: Number.isFinite(summary?.config?.maxAgeMs) ? summary.config.maxAgeMs : null,
     originHashes: Array.isArray(summary?.config?.origins)
       ? summary.config.origins.map((origin) => hashValue(origin))
@@ -724,6 +754,7 @@ function fingerprintFor({
         identityHash: entry.originHash ?? null,
         status: entry.status,
         ageState: freshnessAgeState(entry),
+        failureReasonCodes: sortedUniqueStrings(entry.failureReasonCodes ?? []),
       }))),
     },
     relayLiveness: {

--- a/tools/scripts/public-feed-alert-watch.mjs
+++ b/tools/scripts/public-feed-alert-watch.mjs
@@ -10,7 +10,7 @@ import { pathToFileURL } from 'node:url';
 import { runPublicFeedFreshnessMonitor } from './public-feed-freshness-monitor.mjs';
 import { newsAggregatorPublisherLivenessWatchInternal } from './news-aggregator-publisher-liveness-watch.mjs';
 
-const REPORT_SCHEMA_VERSION = 'vh-public-feed-alert-watch-v1';
+const REPORT_SCHEMA_VERSION = 'vh-public-feed-alert-watch-v2';
 const STATE_SCHEMA_VERSION = 'vh-public-feed-alert-state-v3';
 const DEFAULT_UNIT = 'vh-news-aggregator.service';
 const DEFAULT_STATE_DIR = '.local/state/vhc/public-feed-alert';
@@ -21,10 +21,8 @@ const DEFAULT_WATCH_CLOSURE_MAX_AGE_MS = 90 * 60 * 1000;
 const NEWS_DAEMON_TRANSPORT_UNAVAILABLE_EXIT_CODE = '69';
 const NEWS_DAEMON_WRAPPER_REFUSAL_EXIT_CODE = '75';
 const NEWS_DAEMON_FAIL_CLOSED_EXIT_CODE = '78';
-// URL-shaped text is deliberately consumed through the next whitespace. Flat
-// blocker strings cannot distinguish a structural `:` or `|` from the same
-// bytes inside a URL, so guessing at those delimiters can expose a suffix.
-const URL_IN_TEXT_PATTERN = /https?:\/\/\S+/gi;
+// Public projections are constructed only from closed enums, exact numeric
+// grammars, hashes, and ordinals. Raw report and error text is never emitted.
 const FRESHNESS_FAILURE_REASON_CODES = new Set([
   'latest_index_empty',
   'latest_index_fetch_failed',
@@ -37,14 +35,101 @@ const FRESHNESS_BLOCKER_CLASSES = new Set([
   'openai_preflight_failed',
   'origins_not_configured',
 ]);
-const FAILURE_NUMERIC_DIAGNOSTIC_FIELDS = [
-  { source: 'http_status', target: 'httpStatus', min: 100, max: 599 },
-  { source: 'attempt', target: 'attempt', min: 0, max: 1_000_000 },
-  { source: 'age', target: 'age', min: 0, max: Number.MAX_SAFE_INTEGER },
-  { source: 'age_ms', target: 'ageMs', min: 0, max: Number.MAX_SAFE_INTEGER },
-  { source: 'max_age_ms', target: 'maxAgeMs', min: 0, max: Number.MAX_SAFE_INTEGER },
-  { source: 'count', target: 'count', min: 0, max: Number.MAX_SAFE_INTEGER },
-];
+const PASS_FAIL_STATUSES = new Set(['pass', 'fail']);
+const PASS_WARN_FAIL_STATUSES = new Set(['pass', 'warn', 'fail']);
+const REPORT_STATUSES = new Set(['pass', 'fail', 'skipped']);
+const WATCH_VERDICT_STATUSES = new Set(['pass', 'fail', 'in_progress']);
+const THRESHOLD_STATUSES = new Set(['pass', 'fail', 'not_ready']);
+const DELIVERY_STATUSES = new Set(['pending', 'sent', 'suppressed', 'failed', 'missing_channel']);
+const DELIVERY_REASONS = new Set([
+  'test_fire',
+  'first_failure',
+  'retry_failed_delivery',
+  'state_changed',
+  'heartbeat_due',
+  'unchanged_suppressed',
+]);
+const SYSTEMD_ACTIVE_STATES = new Set(['active', 'inactive', 'failed', 'activating', 'deactivating']);
+const SYSTEMD_SUB_STATES = new Set(['running', 'dead', 'failed', 'auto-restart', 'exited']);
+const SYSTEMD_RESULTS = new Set(['success', 'exit-code', 'signal', 'timeout', 'watchdog', 'start-limit-hit']);
+const HEAP_PLATEAU_VERDICTS = new Set(['heap_driver_unknown', 'heap_plateau_observed', 'heap_still_linear']);
+const RELAY_LIVENESS_REASON_CODES = new Set([
+  'docker_inspect_failed',
+  'restart_count_increased',
+  'readyz_unhealthy',
+  'readyz_failed',
+  'metrics_unhealthy',
+  'rss_hot',
+  'heap_hot',
+  'early_heap_snapshot_missing',
+  'event_loop_lag_hot',
+  'critical_readbacks_queued',
+  'watchdog_trips_increased',
+  'metrics_failed',
+]);
+const SNAPSHOT_REASON_CODES = new Set([
+  'path_not_absolute',
+  'unexpected_snapshot_filename',
+  'unexpected_snapshot_path',
+  'snapshot_missing',
+  'mtime_not_sane',
+  'snapshot_size_not_sane',
+  'snapshot_parse_failed',
+  'schema_mismatch',
+  'entries_not_array',
+  'entries_empty',
+  'entry_count_mismatch',
+  'cached_at_not_sane',
+  'newest_entry_not_sane',
+  'newest_entry_stale',
+]);
+const WATCH_CLOSURE_REASON_CODES = new Set([
+  'archive_samples_missing',
+  'archive_sample_failures',
+  'publisher_nrestarts',
+  'publisher_liveness_status',
+  'relay_liveness_status',
+  'relay_snapshot_status',
+  'public_freshness_status',
+  'runtime_failed_ticks',
+  'runtime_raw_write_failures',
+  'runtime_nonfatal_prewrite_failures',
+  'storycluster_failure_artifact_dir_missing',
+  'storycluster_failure_artifacts',
+  'storycluster_degeneracy_warnings',
+  'window_short',
+  'relay_memory_trend_fail',
+  'relay_memory_trend_warn',
+  'sample_parse_failed',
+]);
+const PROJECTED_BLOCKER_CODES = new Set([
+  'publisher_systemctl_failed',
+  'publisher_exit_69_transport_unavailable',
+  'publisher_exit_69_start_limit_parked',
+  'publisher_exit_75_wrapper_refusal',
+  'publisher_exit_78',
+  'publisher_not_running',
+  'publisher_restart_churn',
+  'public_feed',
+  'alert_delivery_failed',
+  'alert_delivery_missing_channel',
+]);
+const PROJECTED_FAMILY_REASONS = new Map([
+  ['public_feed', new Set([...FRESHNESS_BLOCKER_CLASSES, 'unclassified_blocker', 'status_fail'])],
+  ['relay_liveness', new Set([
+    ...RELAY_LIVENESS_REASON_CODES,
+    'report_missing', 'report_invalid', 'output_stale', 'generated_at_missing', 'status_fail', 'unclassified',
+  ])],
+  ['relay_snapshot', new Set([
+    ...SNAPSHOT_REASON_CODES,
+    'report_missing', 'report_invalid', 'output_stale', 'generated_at_missing', 'status_fail', 'unclassified',
+  ])],
+  ['watch_closure', new Set([
+    ...WATCH_CLOSURE_REASON_CODES,
+    'verdict_missing', 'verdict_invalid', 'output_stale', 'generated_at_missing', 'status_fail',
+    'heap_limit_source_default', 'unclassified',
+  ])],
+]);
 const SEVERITY_RANK = {
   none: 0,
   warning: 1,
@@ -68,8 +153,15 @@ function boolEnv(value, fallback = false) {
 }
 
 function nonNegativeInt(value, fallback) {
-  const parsed = Number.parseInt(String(value ?? ''), 10);
-  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+  const parsed = strictNonNegativeInteger(value);
+  return parsed === null ? fallback : parsed;
+}
+
+function strictNonNegativeInteger(value, max = Number.MAX_SAFE_INTEGER) {
+  const raw = String(value ?? '').trim();
+  if (!/^\d{1,15}$/.test(raw)) return null;
+  const parsed = Number(raw);
+  return Number.isSafeInteger(parsed) && parsed <= max ? parsed : null;
 }
 
 function resolveHome(env) {
@@ -95,21 +187,6 @@ function hashValue(value, length = 16) {
   return createHash('sha256').update(String(value ?? '')).digest('hex').slice(0, length);
 }
 
-function sanitizeAlertText(value) {
-  return String(value ?? '').replace(URL_IN_TEXT_PATTERN, (url) => `url_hash:${hashValue(url)}`);
-}
-
-function sanitizeAlertError(error, redactions = []) {
-  let message = error instanceof Error ? error.message : String(error);
-  for (const raw of redactions) {
-    const value = String(raw ?? '');
-    if (value) {
-      message = message.split(value).join(`value_hash:${hashValue(value)}`);
-    }
-  }
-  return sanitizeAlertText(message);
-}
-
 function sortedUniqueStrings(values) {
   return [...new Set(values.filter((value) => typeof value === 'string' && value.length > 0))].sort();
 }
@@ -128,31 +205,15 @@ function structuredFailureReasonCodes(values) {
 
 function failureNumericDiagnostics(value) {
   const text = String(value ?? '');
-  const byTarget = new Map();
-  const add = (target, raw, min = 0, max = Number.MAX_SAFE_INTEGER) => {
-    if (!/^\d{1,15}$/.test(String(raw ?? ''))) return;
-    const parsed = Number(raw);
-    if (!Number.isSafeInteger(parsed) || parsed < min || parsed > max) return;
-    if (!byTarget.has(target)) byTarget.set(target, new Set());
-    byTarget.get(target).add(parsed);
-  };
-
-  const staleMatch = text.match(/^latest_index_stale:(\d{1,15})\/(\d{1,15})(?=$|[^a-z0-9_./])/i);
+  const staleMatch = text.match(/^latest_index_stale:(\d{1,15})\/(\d{1,15})$/);
   if (staleMatch) {
-    add('newestAgeMs', staleMatch[1]);
-    add('maxAgeMs', staleMatch[2]);
+    const newestAgeMs = strictNonNegativeInteger(staleMatch[1]);
+    const maxAgeMs = strictNonNegativeInteger(staleMatch[2]);
+    return newestAgeMs !== null && maxAgeMs !== null
+      ? { maxAgeMs: [maxAgeMs], newestAgeMs: [newestAgeMs] }
+      : {};
   }
-
-  const fieldBySource = new Map(FAILURE_NUMERIC_DIAGNOSTIC_FIELDS.map((field) => [field.source, field]));
-  const pattern = /(?:^|[^a-z0-9_])(http_status|attempt|age|age_ms|max_age_ms|count)\s*[=:]\s*(\d{1,15})(?=$|[^a-z0-9_./])/gi;
-  for (const match of text.matchAll(pattern)) {
-    const field = fieldBySource.get(match[1].toLowerCase());
-    if (field) add(field.target, match[2], field.min, field.max);
-  }
-
-  return Object.fromEntries([...byTarget.entries()]
-    .sort(([left], [right]) => left < right ? -1 : left > right ? 1 : 0)
-    .map(([target, values]) => [target, [...values].sort((left, right) => left - right)]));
+  return {};
 }
 
 function structuredFailureDiagnostics(values) {
@@ -177,24 +238,13 @@ function blockerClasses(values) {
 }
 
 function blockerReasonCode(value) {
-  const hashMarkers = new Set(['url_hash', 'value_hash', 'snapshot_file_hash']);
-  const segments = sanitizeAlertText(value)
-    .split(/[:|]/)
-    .map((segment) => segment.trim().toLowerCase())
-    .filter(Boolean);
-  const codes = [];
-  for (let index = 0; index < segments.length; index += 1) {
-    const segment = segments[index];
-    if (hashMarkers.has(segment)) {
-      index += 1;
-      continue;
-    }
-    if (!/^[a-z][a-z0-9_-]*$/.test(segment)) continue;
-    if (index === 0 || segment.includes('_')) {
-      codes.push(segment);
-    }
+  const text = String(value ?? '').trim().toLowerCase();
+  const familyMatch = text.match(/^([a-z][a-z0-9_-]*):([a-z][a-z0-9_-]*)(?=:|$)/);
+  if (familyMatch && PROJECTED_FAMILY_REASONS.get(familyMatch[1])?.has(familyMatch[2])) {
+    return `${familyMatch[1]}:${familyMatch[2]}`;
   }
-  return codes.length > 0 ? sortedUniqueStrings(codes).join(':') : 'unclassified_blocker';
+  const codeMatch = text.match(/^([a-z][a-z0-9_-]*)(?=:|$)/);
+  return codeMatch && PROJECTED_BLOCKER_CODES.has(codeMatch[1]) ? codeMatch[1] : 'unclassified_blocker';
 }
 
 function blockerReasonCodes(values) {
@@ -212,9 +262,154 @@ function canonicalObjectSet(values) {
     .map(([, value]) => value);
 }
 
-function identityHash(value) {
-  const normalized = String(value ?? '').trim();
-  return normalized ? hashValue(normalized) : null;
+function strictRelayIdentityHash(value) {
+  const normalized = String(value ?? '').trim().toLowerCase();
+  return /^vhc-relay-[a-z0-9]+(?:-[a-z0-9]+)*$/.test(normalized) ? hashValue(normalized) : null;
+}
+
+function endpointIdentityHash(value) {
+  try {
+    const parsed = new URL(String(value ?? ''));
+    if (!['http:', 'https:'].includes(parsed.protocol)) return null;
+    const endpoint = `${parsed.protocol.toLowerCase()}//${parsed.hostname.toLowerCase()}${parsed.port ? `:${parsed.port}` : ''}`;
+    return hashValue(endpoint);
+  } catch {
+    return null;
+  }
+}
+
+function canonicalIdentifiedEntries(values, identityKey = 'identityHash') {
+  return values
+    .map((value, index) => ({ ...value, sourceOrdinal: index + 1 }))
+    .sort((left, right) => {
+      const leftKey = left[identityKey] ?? `~${String(left.sourceOrdinal).padStart(8, '0')}`;
+      const rightKey = right[identityKey] ?? `~${String(right.sourceOrdinal).padStart(8, '0')}`;
+      return leftKey < rightKey ? -1 : leftKey > rightKey ? 1 : 0;
+    })
+    .map(({ sourceOrdinal, ...value }, index) => ({ ...value, ordinal: index + 1 }));
+}
+
+function projectedEnum(value, allowed, fallback = 'unknown') {
+  const normalized = typeof value === 'string' ? value.trim().toLowerCase() : '';
+  return allowed.has(normalized) ? normalized : fallback;
+}
+
+function safeIsoTimestamp(value) {
+  const parsed = Date.parse(String(value ?? ''));
+  return Number.isFinite(parsed) ? new Date(parsed).toISOString() : null;
+}
+
+function safeNonNegativeNumber(value, { integer = false } = {}) {
+  if (!Number.isFinite(value) || value < 0 || (integer && !Number.isSafeInteger(value))) return null;
+  return value;
+}
+
+function projectedSchemaVersion(value, expected) {
+  if (value === null || value === undefined) return null;
+  return value === expected ? expected : 'unrecognized';
+}
+
+function projectedFingerprint(value) {
+  const normalized = String(value ?? '').trim().toLowerCase();
+  return /^[0-9a-f]{24}$/.test(normalized) ? normalized : null;
+}
+
+function projectAlertState(value) {
+  if (!value || typeof value !== 'object') return null;
+  const sourceStatuses = value.sourceStatuses && typeof value.sourceStatuses === 'object'
+    ? Object.fromEntries(['publisher', 'freshness', 'relayLiveness', 'relaySnapshot', 'watchClosure']
+        .map((key) => [key, projectedEnum(value.sourceStatuses[key], REPORT_STATUSES, 'fail')]))
+    : null;
+  return {
+    schemaVersion: projectedSchemaVersion(value.schemaVersion, STATE_SCHEMA_VERSION),
+    generatedAt: safeIsoTimestamp(value.generatedAt),
+    lastObservedFingerprint: projectedFingerprint(value.lastObservedFingerprint),
+    lastObservedStatus: projectedEnum(value.lastObservedStatus, PASS_FAIL_STATUSES, 'fail'),
+    lastDeliveredFingerprint: projectedFingerprint(value.lastDeliveredFingerprint),
+    lastDeliveredStatus: projectedEnum(value.lastDeliveredStatus, PASS_FAIL_STATUSES, 'fail'),
+    lastDeliveredAt: safeIsoTimestamp(value.lastDeliveredAt),
+    lastDeliveryStatus: projectedEnum(value.lastDeliveryStatus, DELIVERY_STATUSES, 'failed'),
+    lastDeliveryReason: projectedEnum(value.lastDeliveryReason, DELIVERY_REASONS, 'unchanged_suppressed'),
+    lastPublisherNRestarts: strictNonNegativeInteger(value.lastPublisherNRestarts),
+    sourceStatuses,
+  };
+}
+
+function projectedReasonCode(value, allowed, fallback = 'unclassified') {
+  const match = String(value ?? '').trim().toLowerCase().match(/^([a-z][a-z0-9_-]*)(?=:|$)/);
+  return match && allowed.has(match[1]) ? match[1] : fallback;
+}
+
+function projectedReasonCodes(values, allowed, fallback = 'unclassified') {
+  return sortedUniqueStrings((Array.isArray(values) ? values : [])
+    .map((value) => projectedReasonCode(value, allowed, fallback)));
+}
+
+function exactPair(text, pattern) {
+  const match = text.match(pattern);
+  if (!match) return null;
+  const left = strictNonNegativeInteger(match[1]);
+  const right = strictNonNegativeInteger(match[2]);
+  return left === null || right === null ? null : [left, right];
+}
+
+function relayReasonNumericDiagnostics(value, reasonCode) {
+  const text = String(value ?? '').trim().toLowerCase();
+  if (reasonCode === 'readyz_unhealthy' || reasonCode === 'metrics_unhealthy') {
+    const match = text.match(new RegExp(`^${reasonCode}:(\\d{3})$`));
+    const httpStatus = match ? strictNonNegativeInteger(match[1], 599) : null;
+    return httpStatus !== null && httpStatus >= 100 ? { httpStatus: [httpStatus] } : {};
+  }
+  if (reasonCode === 'event_loop_lag_hot') {
+    const numberPattern = '(?:\\d+(?:\\.\\d*)?|\\.\\d+)(?:e[+-]?\\d+)?';
+    const match = text.match(new RegExp(`^event_loop_lag_hot:(${numberPattern})/(${numberPattern})$`, 'i'));
+    if (!match) return {};
+    const observedMs = Number(match[1]);
+    const limitMs = Number(match[2]);
+    return Number.isFinite(observedMs) && Number.isFinite(limitMs)
+      && observedMs >= 0 && limitMs >= 0
+      && observedMs <= Number.MAX_SAFE_INTEGER && limitMs <= Number.MAX_SAFE_INTEGER
+      ? { limitMs: [limitMs], observedMs: [observedMs] }
+      : {};
+  }
+  const pair = exactPair(text, new RegExp(`^${reasonCode}:(\\d{1,15})/(\\d{1,15})$`));
+  if (!pair) return {};
+  const [observed, limit] = pair;
+  if (reasonCode === 'restart_count_increased') return { currentRestartCount: [limit], previousRestartCount: [observed] };
+  if (reasonCode === 'watchdog_trips_increased') return { currentWatchdogTrips: [limit], previousWatchdogTrips: [observed] };
+  if (reasonCode === 'rss_hot') return { limitBytes: [limit], rssBytes: [observed] };
+  if (reasonCode === 'heap_hot') return { heapUsedBytes: [observed], limitBytes: [limit] };
+  if (reasonCode === 'early_heap_snapshot_missing') return { heapUsedBytes: [observed], thresholdBytes: [limit] };
+  if (reasonCode === 'critical_readbacks_queued') return { limitCount: [limit], observedCount: [observed] };
+  return {};
+}
+
+function relayReasonDiagnostics(values) {
+  return canonicalObjectSet((Array.isArray(values) ? values : []).map((value) => {
+    const reasonCode = projectedReasonCode(value, RELAY_LIVENESS_REASON_CODES);
+    return { reasonCode, numericDiagnostics: relayReasonNumericDiagnostics(value, reasonCode) };
+  }));
+}
+
+function snapshotReasonNumericDiagnostics(value, reasonCode) {
+  const text = String(value ?? '').trim().toLowerCase();
+  if (reasonCode === 'snapshot_size_not_sane') {
+    const match = text.match(/^snapshot_size_not_sane:(\d{1,15})$/);
+    const sizeBytes = match ? strictNonNegativeInteger(match[1]) : null;
+    return sizeBytes === null ? {} : { sizeBytes: [sizeBytes] };
+  }
+  const pair = exactPair(text, new RegExp(`^${reasonCode}:(\\d{1,15})/(\\d{1,15})$`));
+  if (!pair) return {};
+  if (reasonCode === 'entry_count_mismatch') return { actualCount: [pair[0]], expectedCount: [pair[1]] };
+  if (reasonCode === 'newest_entry_stale') return { maxAgeMs: [pair[1]], newestEntryAgeMs: [pair[0]] };
+  return {};
+}
+
+function snapshotReasonDiagnostics(values) {
+  return canonicalObjectSet((Array.isArray(values) ? values : []).map((value) => {
+    const reasonCode = projectedReasonCode(value, SNAPSHOT_REASON_CODES);
+    return { reasonCode, numericDiagnostics: snapshotReasonNumericDiagnostics(value, reasonCode) };
+  }));
 }
 
 function thresholdFingerprintState(threshold) {
@@ -270,11 +465,11 @@ async function writeJson(filePath, value) {
 
 function summarizeFreshnessReadback(readback) {
   return {
-    originHash: hashValue(readback?.origin),
-    status: readback?.status ?? null,
-    recordCount: Number.isFinite(readback?.recordCount) ? readback.recordCount : null,
-    newestAgeMs: Number.isFinite(readback?.newestAgeMs) ? readback.newestAgeMs : null,
-    maxAgeMs: Number.isFinite(readback?.maxAgeMs) ? readback.maxAgeMs : null,
+    endpointHash: endpointIdentityHash(readback?.origin),
+    status: projectedEnum(readback?.status, PASS_FAIL_STATUSES, 'fail'),
+    recordCount: safeNonNegativeNumber(readback?.recordCount, { integer: true }),
+    newestAgeMs: safeNonNegativeNumber(readback?.newestAgeMs, { integer: true }),
+    maxAgeMs: safeNonNegativeNumber(readback?.maxAgeMs, { integer: true }),
     failureCount: Array.isArray(readback?.failures) ? readback.failures.length : 0,
     failureReasonCodes: structuredFailureReasonCodes(readback?.failures),
     failureDiagnostics: structuredFailureDiagnostics(readback?.failures),
@@ -282,18 +477,19 @@ function summarizeFreshnessReadback(readback) {
 }
 
 function summarizeFreshness(summary) {
+  const origins = Array.isArray(summary?.config?.origins) ? summary.config.origins : [];
+  const latestIndexReadbacks = Array.isArray(summary?.latestIndexReadbacks)
+    ? canonicalIdentifiedEntries(summary.latestIndexReadbacks.map(summarizeFreshnessReadback), 'endpointHash')
+    : [];
   return {
-    schemaVersion: summary?.schemaVersion ?? null,
-    generatedAt: summary?.generatedAt ?? null,
-    status: summary?.status ?? null,
+    schemaVersion: projectedSchemaVersion(summary?.schemaVersion, 'public-feed-freshness-monitor-v1'),
+    generatedAt: safeIsoTimestamp(summary?.generatedAt),
+    status: projectedEnum(summary?.status, PASS_FAIL_STATUSES, 'fail'),
     blockers: blockerClasses(Array.isArray(summary?.blockers) ? summary.blockers : []),
-    maxAgeMs: Number.isFinite(summary?.config?.maxAgeMs) ? summary.config.maxAgeMs : null,
-    originHashes: Array.isArray(summary?.config?.origins)
-      ? summary.config.origins.map((origin) => hashValue(origin))
-      : [],
-    latestIndexReadbacks: Array.isArray(summary?.latestIndexReadbacks)
-      ? summary.latestIndexReadbacks.map(summarizeFreshnessReadback)
-      : [],
+    maxAgeMs: safeNonNegativeNumber(summary?.config?.maxAgeMs, { integer: true }),
+    originCount: origins.length,
+    originEndpointHashes: sortedUniqueStrings(origins.map(endpointIdentityHash).filter(Boolean)),
+    latestIndexReadbacks,
   };
 }
 
@@ -312,22 +508,14 @@ function reportFreshnessBlockers({ label, report, maxAgeMs, now }) {
   const blockers = [];
   const ageMs = reportGeneratedAgeMs(report, now);
   if (ageMs === null) {
-    blockers.push(`${label}_generated_at_missing`);
+    blockers.push(`${label}:generated_at_missing`);
   } else if (ageMs > maxAgeMs) {
-    blockers.push(`${label}_output_stale:${ageMs}/${maxAgeMs}`);
+    blockers.push(`${label}:output_stale:${ageMs}/${maxAgeMs}`);
   }
   return {
     ageMs,
     blockers,
   };
-}
-
-function reportStatusBlockers({ label, report, sanitizeBlocker = sanitizeAlertText }) {
-  if (report?.status === 'pass') return [];
-  const blockers = Array.isArray(report?.blockers) && report.blockers.length > 0
-    ? report.blockers.map((blocker) => `${label}:${sanitizeBlocker(blocker)}`)
-    : [`${label}_status:${sanitizeAlertText(report?.status ?? 'missing')}`];
-  return blockers;
 }
 
 function hasBlockers(value) {
@@ -358,7 +546,7 @@ function summarizeRelayLivenessReport({ env, now }) {
   const filePath = relayLivenessFile(env);
   const maxAgeMs = nonNegativeInt(env.VH_PUBLIC_FEED_ALERT_RELAY_LIVENESS_MAX_AGE_MS, DEFAULT_RELAY_LIVENESS_MAX_AGE_MS);
   if (!enabled) {
-    return { status: 'skipped', severity: 'none', required: false, sourceFileHash: hashValue(filePath), blockers: [] };
+    return { status: 'skipped', severity: 'none', required: false, sourceRole: 'relay_liveness', blockers: [] };
   }
   const read = readJsonReport(filePath);
   if (!read.exists) {
@@ -366,11 +554,11 @@ function summarizeRelayLivenessReport({ env, now }) {
       status: 'fail',
       severity: 'critical',
       required: true,
-      sourceFileHash: hashValue(filePath),
+      sourceRole: 'relay_liveness',
       generatedAt: null,
       ageMs: null,
       maxAgeMs,
-      blockers: ['relay_liveness_report_missing'],
+      blockers: ['relay_liveness:report_missing'],
       relays: [],
     };
   }
@@ -379,11 +567,11 @@ function summarizeRelayLivenessReport({ env, now }) {
       status: 'fail',
       severity: 'critical',
       required: true,
-      sourceFileHash: hashValue(filePath),
+      sourceRole: 'relay_liveness',
       generatedAt: null,
       ageMs: null,
       maxAgeMs,
-      blockers: [`relay_liveness_report_invalid:${sanitizeAlertError(read.error)}`],
+      blockers: ['relay_liveness:report_invalid'],
       relays: [],
     };
   }
@@ -393,13 +581,35 @@ function summarizeRelayLivenessReport({ env, now }) {
     maxAgeMs,
     now,
   });
-  const statusBlockers = reportStatusBlockers({ label: 'relay_liveness', report: read.parsed });
+  const relays = Array.isArray(read.parsed.relays)
+    ? canonicalIdentifiedEntries(read.parsed.relays.map((relay) => ({
+        identityHash: strictRelayIdentityHash(relay.name),
+        status: projectedEnum(relay.status, PASS_FAIL_STATUSES, 'fail'),
+        reasonCodes: projectedReasonCodes(relay.blockers, RELAY_LIVENESS_REASON_CODES),
+        reasonDiagnostics: relayReasonDiagnostics(relay.blockers),
+        blockerCount: Array.isArray(relay.blockers) ? relay.blockers.length : 0,
+        restartCount: safeNonNegativeNumber(relay.docker?.restartCount, { integer: true }),
+        rssBytes: safeNonNegativeNumber(relay.metrics?.rssBytes, { integer: true }),
+        heapUsedBytes: safeNonNegativeNumber(relay.metrics?.heapUsedBytes, { integer: true }),
+        watchdogTrips: safeNonNegativeNumber(relay.metrics?.watchdogTrips, { integer: true }),
+        eventLoopLagP99Ms: safeNonNegativeNumber(relay.metrics?.eventLoopLagP99Ms),
+        criticalReadbacksQueued: safeNonNegativeNumber(relay.metrics?.criticalReadbacksQueued, { integer: true }),
+      })))
+    : [];
+  const relayReasonCodes = sortedUniqueStrings(relays.flatMap((relay) => relay.reasonCodes));
+  const statusBlockers = read.parsed.status === 'pass'
+    ? []
+    : relayReasonCodes.length > 0
+      ? relayReasonCodes.map((code) => code === 'unclassified'
+          ? 'relay_liveness:unclassified'
+          : `relay_liveness:${code}`)
+      : ['relay_liveness:status_fail'];
   const blockers = [
     ...freshness.blockers,
     ...statusBlockers,
   ];
   return {
-    schemaVersion: read.parsed.schemaVersion ?? null,
+    schemaVersion: projectedSchemaVersion(read.parsed.schemaVersion, 'vh-news-relay-liveness-watch-v1'),
     status: blockers.length > 0 ? 'fail' : 'pass',
     severity: hasBlockers(statusBlockers)
       ? 'critical'
@@ -407,40 +617,17 @@ function summarizeRelayLivenessReport({ env, now }) {
         ? 'warning'
         : 'none',
     required: true,
-    sourceFileHash: hashValue(filePath),
-    generatedAt: read.parsed.generatedAt ?? null,
+    sourceRole: 'relay_liveness',
+    generatedAt: safeIsoTimestamp(read.parsed.generatedAt),
     ageMs: freshness.ageMs,
     maxAgeMs,
     blockers,
-    relays: Array.isArray(read.parsed.relays)
-      ? read.parsed.relays.map((relay) => ({
-          name: String(relay.name ?? ''),
-          status: relay.status ?? null,
-          blockerCount: Array.isArray(relay.blockers) ? relay.blockers.length : 0,
-          restartCount: Number.isFinite(relay.docker?.restartCount) ? relay.docker.restartCount : null,
-          rssBytes: Number.isFinite(relay.metrics?.rssBytes) ? relay.metrics.rssBytes : null,
-          heapUsedBytes: Number.isFinite(relay.metrics?.heapUsedBytes) ? relay.metrics.heapUsedBytes : null,
-          watchdogTrips: Number.isFinite(relay.metrics?.watchdogTrips) ? relay.metrics.watchdogTrips : null,
-          eventLoopLagP99Ms: Number.isFinite(relay.metrics?.eventLoopLagP99Ms) ? relay.metrics.eventLoopLagP99Ms : null,
-          criticalReadbacksQueued: Number.isFinite(relay.metrics?.criticalReadbacksQueued)
-            ? relay.metrics.criticalReadbacksQueued
-            : null,
-        }))
-      : [],
+    relays,
   };
 }
 
 function relayNameFromSnapshotPath(filePath) {
   return String(filePath ?? '').split(/[\\/]+/).find((segment) => segment.startsWith('vhc-relay-')) ?? null;
-}
-
-function sanitizeSnapshotBlocker(blocker) {
-  const text = String(blocker ?? '');
-  const separatorIndex = text.indexOf(':');
-  if (separatorIndex > 0 && text.slice(0, separatorIndex).includes('news-latest-index-snapshot.json')) {
-    return `snapshot_file_hash:${hashValue(text.slice(0, separatorIndex))}:${sanitizeAlertText(text.slice(separatorIndex + 1))}`;
-  }
-  return sanitizeAlertText(text);
 }
 
 function summarizeRelaySnapshotReport({ env, now }) {
@@ -452,7 +639,7 @@ function summarizeRelaySnapshotReport({ env, now }) {
   const filePath = relaySnapshotFile(env);
   const maxAgeMs = nonNegativeInt(env.VH_PUBLIC_FEED_ALERT_RELAY_SNAPSHOT_MAX_AGE_MS, DEFAULT_RELAY_SNAPSHOT_MAX_AGE_MS);
   if (!enabled) {
-    return { status: 'skipped', severity: 'none', required: false, sourceFileHash: hashValue(filePath), blockers: [] };
+    return { status: 'skipped', severity: 'none', required: false, sourceRole: 'relay_snapshot', blockers: [] };
   }
   const read = readJsonReport(filePath);
   if (!read.exists) {
@@ -460,11 +647,11 @@ function summarizeRelaySnapshotReport({ env, now }) {
       status: 'fail',
       severity: 'critical',
       required: true,
-      sourceFileHash: hashValue(filePath),
+      sourceRole: 'relay_snapshot',
       generatedAt: null,
       ageMs: null,
       maxAgeMs,
-      blockers: ['relay_snapshot_report_missing'],
+      blockers: ['relay_snapshot:report_missing'],
       snapshots: [],
     };
   }
@@ -473,11 +660,11 @@ function summarizeRelaySnapshotReport({ env, now }) {
       status: 'fail',
       severity: 'critical',
       required: true,
-      sourceFileHash: hashValue(filePath),
+      sourceRole: 'relay_snapshot',
       generatedAt: null,
       ageMs: null,
       maxAgeMs,
-      blockers: [`relay_snapshot_report_invalid:${sanitizeAlertError(read.error)}`],
+      blockers: ['relay_snapshot:report_invalid'],
       snapshots: [],
     };
   }
@@ -487,46 +674,94 @@ function summarizeRelaySnapshotReport({ env, now }) {
     maxAgeMs,
     now,
   });
-  const statusBlockers = reportStatusBlockers({
-    label: 'relay_snapshot',
-    report: read.parsed,
-    sanitizeBlocker: sanitizeSnapshotBlocker,
-  });
+  const snapshots = Array.isArray(read.parsed.snapshots)
+    ? canonicalIdentifiedEntries(read.parsed.snapshots.map((snapshot) => ({
+        relayIdentityHash: strictRelayIdentityHash(relayNameFromSnapshotPath(snapshot.file)),
+        status: projectedEnum(snapshot.status, PASS_FAIL_STATUSES, 'fail'),
+        reasonCodes: projectedReasonCodes([
+          ...(Array.isArray(snapshot.failures) ? snapshot.failures : []),
+          ...(Array.isArray(snapshot.freshnessFailures) ? snapshot.freshnessFailures : []),
+        ], SNAPSHOT_REASON_CODES),
+        reasonDiagnostics: snapshotReasonDiagnostics([
+          ...(Array.isArray(snapshot.failures) ? snapshot.failures : []),
+          ...(Array.isArray(snapshot.freshnessFailures) ? snapshot.freshnessFailures : []),
+        ]),
+        entryCount: safeNonNegativeNumber(snapshot.entryCount, { integer: true }),
+        cachedAgeMs: safeNonNegativeNumber(snapshot.cachedAgeMs, { integer: true }),
+        newestEntryAgeMs: safeNonNegativeNumber(snapshot.newestEntryAgeMs, { integer: true }),
+        failureCount: Array.isArray(snapshot.failures) ? snapshot.failures.length : 0,
+        freshnessFailureCount: Array.isArray(snapshot.freshnessFailures) ? snapshot.freshnessFailures.length : 0,
+      })), 'relayIdentityHash')
+    : [];
+  const snapshotReasonCodes = sortedUniqueStrings(snapshots.flatMap((snapshot) => snapshot.reasonCodes));
+  const statusBlockers = read.parsed.status === 'pass'
+    ? []
+    : snapshotReasonCodes.length > 0
+      ? snapshotReasonCodes.map((code) => code === 'unclassified'
+          ? 'relay_snapshot:unclassified'
+          : `relay_snapshot:${code}`)
+      : ['relay_snapshot:status_fail'];
   const blockers = [
     ...freshness.blockers,
     ...statusBlockers,
   ];
   return {
-    schemaVersion: read.parsed.schemaVersion ?? null,
+    schemaVersion: projectedSchemaVersion(read.parsed.schemaVersion, 'vh-relay-latest-index-snapshot-watch-v1'),
     status: blockers.length > 0 ? 'fail' : 'pass',
     severity: blockers.length > 0 ? 'warning' : 'none',
     required: true,
-    sourceFileHash: hashValue(filePath),
-    generatedAt: read.parsed.generatedAt ?? null,
+    sourceRole: 'relay_snapshot',
+    generatedAt: safeIsoTimestamp(read.parsed.generatedAt),
     ageMs: freshness.ageMs,
     maxAgeMs,
     blockers,
-    snapshots: Array.isArray(read.parsed.snapshots)
-      ? read.parsed.snapshots.map((snapshot) => ({
-          fileHash: hashValue(snapshot.file),
-          relay: relayNameFromSnapshotPath(snapshot.file),
-          status: snapshot.status ?? null,
-          entryCount: Number.isFinite(snapshot.entryCount) ? snapshot.entryCount : null,
-          cachedAgeMs: Number.isFinite(snapshot.cachedAgeMs) ? snapshot.cachedAgeMs : null,
-          newestEntryAgeMs: Number.isFinite(snapshot.newestEntryAgeMs) ? snapshot.newestEntryAgeMs : null,
-          failureCount: Array.isArray(snapshot.failures) ? snapshot.failures.length : 0,
-          freshnessFailureCount: Array.isArray(snapshot.freshnessFailures) ? snapshot.freshnessFailures.length : 0,
-        }))
-      : [],
+    snapshots,
   };
-}
-
-function sanitizeWatchClosureBlocker(blocker) {
-  return sanitizeAlertText(blocker);
 }
 
 function defaultLimitSource(value) {
   return String(value ?? '').startsWith('default:');
+}
+
+function limitSourceClass(value) {
+  const normalized = String(value ?? '').trim();
+  if (!normalized) return 'missing';
+  return defaultLimitSource(normalized) ? 'default' : 'configured';
+}
+
+function projectWatchClosureBlocker(value) {
+  const text = String(value ?? '').trim().toLowerCase();
+  const code = projectedReasonCode(text, WATCH_CLOSURE_REASON_CODES);
+  if (code === 'unclassified') return 'watch_closure:unclassified';
+  if (code === 'window_short') {
+    const match = text.match(/^window_short:(\d{1,6}(?:\.\d{1,2})?)\/(24|48)$/);
+    return match ? `watch_closure:window_short:${match[1]}/${match[2]}` : 'watch_closure:window_short';
+  }
+  const countCodes = new Set([
+    'archive_sample_failures',
+    'runtime_failed_ticks',
+    'runtime_raw_write_failures',
+    'runtime_nonfatal_prewrite_failures',
+    'storycluster_failure_artifacts',
+    'storycluster_degeneracy_warnings',
+  ]);
+  if (countCodes.has(code)) {
+    const match = text.match(new RegExp(`^${code}:(\\d{1,15})$`));
+    return match && Number.isSafeInteger(Number(match[1]))
+      ? `watch_closure:${code}:${match[1]}`
+      : `watch_closure:${code}`;
+  }
+  if (code === 'publisher_nrestarts') {
+    const match = text.match(/^publisher_nrestarts:(\d{1,15})->(\d{1,15})$/);
+    return match && Number.isSafeInteger(Number(match[1])) && Number.isSafeInteger(Number(match[2]))
+      ? `watch_closure:publisher_nrestarts:${match[1]}/${match[2]}`
+      : 'watch_closure:publisher_nrestarts';
+  }
+  return `watch_closure:${code}`;
+}
+
+function projectWatchClosureBlockers(values) {
+  return sortedUniqueStrings((Array.isArray(values) ? values : []).map(projectWatchClosureBlocker));
 }
 
 function watchClosureProvenanceBlockers(verdict) {
@@ -534,21 +769,15 @@ function watchClosureProvenanceBlockers(verdict) {
   if (!relayMemory) return [];
   const blockers = [];
   if (defaultLimitSource(relayMemory.heapLimitSource)) {
-    blockers.push([
-      'watch_closure_heap_limit_source_default',
-      'aggregate',
-      sanitizeWatchClosureBlocker(relayMemory.heapLimitSource),
-    ].join(':'));
+    blockers.push('watch_closure:heap_limit_source_default');
   }
   if (Array.isArray(relayMemory.relays)) {
     for (const relay of relayMemory.relays) {
       if (!defaultLimitSource(relay?.heapLimitSource)) continue;
-      blockers.push(
-        `watch_closure_heap_limit_source_default:${sanitizeWatchClosureBlocker(relay?.name ?? 'unknown')}:${sanitizeWatchClosureBlocker(relay.heapLimitSource)}`,
-      );
+      blockers.push('watch_closure:heap_limit_source_default');
     }
   }
-  return blockers;
+  return sortedUniqueStrings(blockers);
 }
 
 function summarizeWatchClosureVerdict({ env, now }) {
@@ -560,7 +789,7 @@ function summarizeWatchClosureVerdict({ env, now }) {
   const filePath = watchClosureVerdictFile(env);
   const maxAgeMs = nonNegativeInt(env.VH_PUBLIC_FEED_ALERT_WATCH_CLOSURE_MAX_AGE_MS, DEFAULT_WATCH_CLOSURE_MAX_AGE_MS);
   if (!enabled) {
-    return { status: 'skipped', severity: 'none', required: false, sourceFileHash: hashValue(filePath), blockers: [] };
+    return { status: 'skipped', severity: 'none', required: false, sourceRole: 'watch_closure', blockers: [] };
   }
   const read = readJsonReport(filePath);
   if (!read.exists) {
@@ -568,11 +797,11 @@ function summarizeWatchClosureVerdict({ env, now }) {
       status: 'fail',
       severity: 'critical',
       required: true,
-      sourceFileHash: hashValue(filePath),
+      sourceRole: 'watch_closure',
       generatedAt: null,
       ageMs: null,
       maxAgeMs,
-      blockers: ['watch_closure_verdict_missing'],
+      blockers: ['watch_closure:verdict_missing'],
       verdictStatus: null,
     };
   }
@@ -581,11 +810,11 @@ function summarizeWatchClosureVerdict({ env, now }) {
       status: 'fail',
       severity: 'critical',
       required: true,
-      sourceFileHash: hashValue(filePath),
+      sourceRole: 'watch_closure',
       generatedAt: null,
       ageMs: null,
       maxAgeMs,
-      blockers: [`watch_closure_verdict_invalid:${sanitizeAlertError(read.error)}`],
+      blockers: ['watch_closure:verdict_invalid'],
       verdictStatus: null,
     };
   }
@@ -595,61 +824,62 @@ function summarizeWatchClosureVerdict({ env, now }) {
     maxAgeMs,
     now,
   });
-  const verdictFailed = read.parsed.status === 'fail';
+  const verdictStatus = projectedEnum(read.parsed.status, WATCH_VERDICT_STATUSES, 'fail');
+  const verdictFailed = verdictStatus === 'fail';
   const verdictBlockers = verdictFailed
     ? Array.isArray(read.parsed.blockers) && read.parsed.blockers.length > 0
-      ? read.parsed.blockers.map((blocker) => `watch_closure:${sanitizeWatchClosureBlocker(blocker)}`)
-      : ['watch_closure_status:fail']
+      ? projectWatchClosureBlockers(read.parsed.blockers)
+      : ['watch_closure:status_fail']
     : [];
   const provenanceBlockers = watchClosureProvenanceBlockers(read.parsed);
   const blockers = [...freshness.blockers, ...verdictBlockers, ...provenanceBlockers];
   return {
-    schemaVersion: read.parsed.schemaVersion ?? null,
+    schemaVersion: projectedSchemaVersion(read.parsed.schemaVersion, 'vh-phase5-scope-a-watch-closure-verdict-v1'),
     status: blockers.length > 0 ? 'fail' : 'pass',
     severity: blockers.length > 0 ? 'warning' : 'none',
     required: true,
-    sourceFileHash: hashValue(filePath),
-    generatedAt: read.parsed.generatedAt ?? null,
+    sourceRole: 'watch_closure',
+    generatedAt: safeIsoTimestamp(read.parsed.generatedAt),
     ageMs: freshness.ageMs,
     maxAgeMs,
     blockers,
-    verdictStatus: read.parsed.status ?? null,
-    verdictSeverity: read.parsed.severity ?? null,
-    window: read.parsed.window ?? null,
+    verdictStatus,
+    verdictSeverity: verdictStatus === 'fail' ? 'critical' : verdictStatus === 'pass' ? 'ok' : 'info',
+    window: read.parsed.window
+      ? {
+          startAt: safeIsoTimestamp(read.parsed.window.startAt),
+          cleanStartAt: safeIsoTimestamp(read.parsed.window.cleanStartAt),
+          hoursObserved: safeNonNegativeNumber(read.parsed.window.hoursObserved),
+        }
+      : null,
     thresholds: {
       twentyFourHour: read.parsed.thresholds?.twentyFourHour
         ? {
-            status: read.parsed.thresholds.twentyFourHour.status ?? null,
-            blockers: Array.isArray(read.parsed.thresholds.twentyFourHour.blockers)
-              ? read.parsed.thresholds.twentyFourHour.blockers.map(sanitizeWatchClosureBlocker)
-              : [],
+            status: projectedEnum(read.parsed.thresholds.twentyFourHour.status, THRESHOLD_STATUSES),
+            blockers: projectWatchClosureBlockers(read.parsed.thresholds.twentyFourHour.blockers),
           }
         : null,
       fortyEightHour: read.parsed.thresholds?.fortyEightHour
         ? {
-            status: read.parsed.thresholds.fortyEightHour.status ?? null,
-            blockers: Array.isArray(read.parsed.thresholds.fortyEightHour.blockers)
-              ? read.parsed.thresholds.fortyEightHour.blockers.map(sanitizeWatchClosureBlocker)
-              : [],
+            status: projectedEnum(read.parsed.thresholds.fortyEightHour.status, THRESHOLD_STATUSES),
+            blockers: projectWatchClosureBlockers(read.parsed.thresholds.fortyEightHour.blockers),
           }
         : null,
     },
     relayMemory: read.parsed.relayMemory
       ? {
-          status: read.parsed.relayMemory.status ?? null,
-          heapPlateauVerdict: read.parsed.relayMemory.heapPlateauVerdict ?? null,
-          heapLimitSource: read.parsed.relayMemory.heapLimitSource ?? null,
-          rssLimitSource: read.parsed.relayMemory.rssLimitSource ?? null,
+          status: projectedEnum(read.parsed.relayMemory.status, PASS_WARN_FAIL_STATUSES, 'fail'),
+          heapPlateauVerdict: projectedEnum(read.parsed.relayMemory.heapPlateauVerdict, HEAP_PLATEAU_VERDICTS),
+          heapLimitSourceClass: limitSourceClass(read.parsed.relayMemory.heapLimitSource),
+          rssLimitSourceClass: limitSourceClass(read.parsed.relayMemory.rssLimitSource),
           relays: Array.isArray(read.parsed.relayMemory.relays)
-            ? read.parsed.relayMemory.relays.map((relay) => ({
-                name: relay.name ?? null,
-                trendStatus: relay.trendStatus ?? null,
-                heapPlateauVerdict: relay.heapPlateauVerdict ?? null,
-                heapLimitSource: relay.heapLimitSource ?? null,
-                shortestProjectedLimitHours: Number.isFinite(relay.shortestProjectedLimitHours)
-                  ? relay.shortestProjectedLimitHours
-                  : null,
-              }))
+            ? canonicalIdentifiedEntries(read.parsed.relayMemory.relays.map((relay) => ({
+                identityHash: strictRelayIdentityHash(relay.name),
+                trendStatus: projectedEnum(relay.trendStatus, PASS_WARN_FAIL_STATUSES, 'fail'),
+                heapPlateauVerdict: projectedEnum(relay.heapPlateauVerdict, HEAP_PLATEAU_VERDICTS),
+                heapLimitSourceClass: limitSourceClass(relay.heapLimitSource),
+                shortestProjectedLimitHours: safeNonNegativeNumber(relay.shortestProjectedLimitHours),
+              })))
             : [],
         }
       : null,
@@ -676,7 +906,7 @@ function readPublisherSystemctlShow(unit, spawnSyncImpl = spawnSync) {
     encoding: 'utf8',
   });
   if (result.status !== 0) {
-    throw new Error(String(result.stderr ?? result.stdout ?? '').trim() || `systemctl_show_failed:${unit}`);
+    throw new Error('systemctl_show_failed');
   }
   return String(result.stdout ?? '');
 }
@@ -693,21 +923,23 @@ function inspectPublisherUnit({
     properties = newsAggregatorPublisherLivenessWatchInternal.parseSystemctlShow(
       systemctlShowText ?? readPublisherSystemctlShow(unit, spawnSyncImpl),
     );
-  } catch (error) {
-    blockers.push(`publisher_systemctl_failed:${sanitizeAlertError(error)}`);
+  } catch {
+    blockers.push('publisher_systemctl_failed');
   }
 
-  const activeState = properties.ActiveState ?? null;
-  const subState = properties.SubState ?? null;
-  const execMainStatus = properties.ExecMainStatus ?? null;
-  const result = properties.Result ?? null;
-  const nRestarts = Number.parseInt(String(properties.NRestarts ?? ''), 10);
+  const activeState = projectedEnum(properties.ActiveState, SYSTEMD_ACTIVE_STATES);
+  const subState = projectedEnum(properties.SubState, SYSTEMD_SUB_STATES);
+  const parsedExecMainStatus = strictNonNegativeInteger(properties.ExecMainStatus, 255);
+  const execMainStatus = parsedExecMainStatus !== null
+    ? String(parsedExecMainStatus)
+    : null;
+  const result = projectedEnum(properties.Result, SYSTEMD_RESULTS);
+  const nRestarts = strictNonNegativeInteger(properties.NRestarts);
   const running = activeState === 'active' && subState === 'running';
   const systemdRestarting = activeState === 'activating' || subState === 'auto-restart';
-  const normalizedExecMainStatus = String(execMainStatus ?? '').trim();
-  const exit69 = normalizedExecMainStatus === NEWS_DAEMON_TRANSPORT_UNAVAILABLE_EXIT_CODE;
-  const exit75 = normalizedExecMainStatus === NEWS_DAEMON_WRAPPER_REFUSAL_EXIT_CODE;
-  const exit78 = normalizedExecMainStatus === NEWS_DAEMON_FAIL_CLOSED_EXIT_CODE;
+  const exit69 = execMainStatus === NEWS_DAEMON_TRANSPORT_UNAVAILABLE_EXIT_CODE;
+  const exit75 = execMainStatus === NEWS_DAEMON_WRAPPER_REFUSAL_EXIT_CODE;
+  const exit78 = execMainStatus === NEWS_DAEMON_FAIL_CLOSED_EXIT_CODE;
   const startLimitHit = result === 'start-limit-hit';
   const exit69Restarting = !running && exit69 && systemdRestarting && !startLimitHit;
   const exit69Parked = !running && exit69 && (startLimitHit || !systemdRestarting);
@@ -741,27 +973,27 @@ function inspectPublisherUnit({
 
   if (!running && blockers.length === 0) {
     if (failureClass === 'exit_69_transport_unavailable') {
-      blockers.push(`publisher_exit_69_transport_unavailable:${activeState ?? 'missing'}/${subState ?? 'missing'}`);
+      blockers.push('publisher_exit_69_transport_unavailable');
     } else if (failureClass === 'exit_69_start_limit_parked') {
-      blockers.push(`publisher_exit_69_start_limit_parked:${activeState ?? 'missing'}/${subState ?? 'missing'}:${result ?? 'missing'}`);
+      blockers.push('publisher_exit_69_start_limit_parked');
     } else if (failureClass === 'exit_75_wrapper_refusal') {
-      blockers.push(`publisher_exit_75_wrapper_refusal:${activeState ?? 'missing'}/${subState ?? 'missing'}:${result ?? 'missing'}`);
+      blockers.push('publisher_exit_75_wrapper_refusal');
     } else if (exit78) {
-      blockers.push(`publisher_exit_78:${activeState ?? 'missing'}/${subState ?? 'missing'}`);
+      blockers.push('publisher_exit_78');
     } else {
-      blockers.push(`publisher_not_running:${activeState ?? 'missing'}/${subState ?? 'missing'}`);
+      blockers.push('publisher_not_running');
     }
   }
 
   return {
-    unit,
+    unitRole: 'publisher',
     status: blockers.length === 0 ? 'pass' : 'fail',
     blockers,
     activeState,
     subState,
     execMainStatus,
     result,
-    nRestarts: Number.isFinite(nRestarts) && nRestarts >= 0 ? nRestarts : null,
+    nRestarts,
     failureClass,
     severity,
     recoveryHint,
@@ -769,8 +1001,7 @@ function inspectPublisherUnit({
 }
 
 function previousPublisherRestartCount(previousState) {
-  const parsed = Number.parseInt(String(previousState?.lastPublisherNRestarts ?? ''), 10);
-  return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+  return strictNonNegativeInteger(previousState?.lastPublisherNRestarts);
 }
 
 function restartChurnBlocker({ publisher, previousState }) {
@@ -793,14 +1024,11 @@ function fingerprintFor({
 }) {
   // Diagnostics retain their full secret-safe values; only this projection is
   // reduced to stable semantic state before hashing for delivery dedupe.
-  // Freshness flat blockers are disclosure-only: their fail-closed URL hashes
-  // are intentionally ignored here, while structured readback reasons drive
-  // genuine reason-set transitions.
+  // Closed family/reason codes and token-free endpoint identities drive real
+  // transitions; raw report strings and secret-bearing URL components do not.
   return hashValue(JSON.stringify({
     status,
-    blockerReasonCodes: blockerReasonCodes(
-      blockers.filter((blocker) => !String(blocker).startsWith('public_feed:')),
-    ),
+    blockerReasonCodes: blockerReasonCodes(blockers),
     publisher: {
       status: publisher.status,
       activeState: publisher.activeState,
@@ -811,9 +1039,10 @@ function fingerprintFor({
     freshness: {
       status: freshness.status,
       blockerClasses: blockerClasses(freshness.blockers),
-      originIdentities: sortedUniqueStrings(freshness.originHashes ?? []),
+      originCount: freshness.originCount ?? 0,
+      originEndpointHashes: sortedUniqueStrings(freshness.originEndpointHashes ?? []),
       latestIndexReadbacks: canonicalObjectSet(freshness.latestIndexReadbacks.map((entry) => ({
-        identityHash: entry.originHash ?? null,
+        identity: entry.endpointHash ?? `ordinal:${entry.ordinal}`,
         status: entry.status,
         ageState: freshnessAgeState(entry),
         failureReasonCodes: sortedUniqueStrings(entry.failureReasonCodes ?? []),
@@ -823,16 +1052,18 @@ function fingerprintFor({
       status: relayLiveness.status,
       blockerReasonCodes: blockerReasonCodes(relayLiveness.blockers),
       relays: canonicalObjectSet((relayLiveness.relays ?? []).map((relay) => ({
-        identityHash: identityHash(relay.name),
+        identity: relay.identityHash ?? `ordinal:${relay.ordinal}`,
         status: relay.status,
+        reasonCodes: sortedUniqueStrings(relay.reasonCodes ?? []),
       }))),
     },
     relaySnapshot: {
       status: relaySnapshot.status,
       blockerReasonCodes: blockerReasonCodes(relaySnapshot.blockers),
       snapshots: canonicalObjectSet((relaySnapshot.snapshots ?? []).map((snapshot) => ({
-        identityHash: identityHash(snapshot.relay ?? snapshot.fileHash),
+        identity: snapshot.relayIdentityHash ?? `ordinal:${snapshot.ordinal}`,
         status: snapshot.status,
+        reasonCodes: sortedUniqueStrings(snapshot.reasonCodes ?? []),
       }))),
     },
     watchClosure: {
@@ -846,7 +1077,7 @@ function fingerprintFor({
       relayMemoryStatus: watchClosure.relayMemory?.status ?? null,
       relayMemoryVerdict: watchClosure.relayMemory?.heapPlateauVerdict ?? null,
       relayMemoryRelays: canonicalObjectSet((watchClosure.relayMemory?.relays ?? []).map((relay) => ({
-        identityHash: identityHash(relay.name),
+        identity: relay.identityHash ?? `ordinal:${relay.ordinal}`,
         status: relay.trendStatus ?? null,
         verdict: relay.heapPlateauVerdict ?? null,
       }))),
@@ -913,11 +1144,11 @@ function sourceStatusesFor({
   watchClosure,
 }) {
   return {
-    publisher: publisher?.status ?? null,
-    freshness: freshness?.status ?? null,
-    relayLiveness: relayLiveness?.status ?? null,
-    relaySnapshot: relaySnapshot?.status ?? null,
-    watchClosure: watchClosure?.status ?? null,
+    publisher: projectedEnum(publisher?.status, REPORT_STATUSES, 'fail'),
+    freshness: projectedEnum(freshness?.status, REPORT_STATUSES, 'fail'),
+    relayLiveness: projectedEnum(relayLiveness?.status, REPORT_STATUSES, 'fail'),
+    relaySnapshot: projectedEnum(relaySnapshot?.status, REPORT_STATUSES, 'fail'),
+    watchClosure: projectedEnum(watchClosure?.status, REPORT_STATUSES, 'fail'),
   };
 }
 
@@ -1001,14 +1232,38 @@ function formatEmail({ to, from, subject, payload }) {
   ].join('\r\n');
 }
 
+function validatedMailbox(value) {
+  const mailbox = String(value ?? '').trim();
+  if (!mailbox || /[\r\n]/.test(mailbox)) return null;
+  return /^[A-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[A-Z0-9.-]+$/i.test(mailbox) ? mailbox : null;
+}
+
+function deliveryErrorClass(channel, error) {
+  const message = error instanceof Error ? error.message : String(error ?? '');
+  if (channel === 'webhook') {
+    const httpMatch = message.match(/^webhook_http_(\d{3})$/);
+    const httpStatus = httpMatch ? Number(httpMatch[1]) : null;
+    if (Number.isInteger(httpStatus) && httpStatus >= 100 && httpStatus <= 599) {
+      return `webhook_http_${httpStatus}`;
+    }
+    return error instanceof Error && error.name === 'AbortError' ? 'webhook_timeout' : 'webhook_network';
+  }
+  if (message === 'email_address_invalid') return 'email_address_invalid';
+  if (message === 'sendmail_exit') return 'sendmail_exit';
+  return 'email_transport';
+}
+
 function deliverEmail({
   env,
   payload,
   spawnSyncImpl = spawnSync,
 }) {
-  const to = firstNonEmpty(env.VH_PUBLIC_FEED_ALERT_EMAIL_TO);
-  if (!to) return null;
-  const from = firstNonEmpty(env.VH_PUBLIC_FEED_ALERT_EMAIL_FROM, 'vhc-public-feed-alert@localhost');
+  const rawTo = firstNonEmpty(env.VH_PUBLIC_FEED_ALERT_EMAIL_TO);
+  const to = validatedMailbox(rawTo);
+  if (!rawTo) return null;
+  if (!to) throw new Error('email_address_invalid');
+  const from = validatedMailbox(firstNonEmpty(env.VH_PUBLIC_FEED_ALERT_EMAIL_FROM, 'vhc-public-feed-alert@localhost'));
+  if (!from) throw new Error('email_address_invalid');
   const sendmail = firstNonEmpty(env.VH_PUBLIC_FEED_ALERT_SENDMAIL, '/usr/sbin/sendmail');
   const subject = `[VHC] public feed alert ${payload.status} ${payload.fingerprint}`;
   const result = spawnSyncImpl(sendmail, ['-t'], {
@@ -1016,7 +1271,7 @@ function deliverEmail({
     encoding: 'utf8',
   });
   if (result.status !== 0) {
-    throw new Error(`sendmail_exit_${result.status ?? 'signal'}:${String(result.stderr ?? '').trim()}`);
+    throw new Error('sendmail_exit');
   }
   return { status: 'sent', channel: 'email' };
 }
@@ -1049,7 +1304,7 @@ async function deliverAlert({
     try {
       channels.push(await deliverWebhook({ webhookUrl, payload, timeoutMs, hmacSecret, fetchImpl }));
     } catch (error) {
-      errors.push(`webhook:${sanitizeAlertError(error, [webhookUrl])}`);
+      errors.push(deliveryErrorClass('webhook', error));
     }
   }
 
@@ -1058,7 +1313,7 @@ async function deliverAlert({
       const result = deliverEmail({ env, payload, spawnSyncImpl });
       if (result) channels.push(result);
     } catch (error) {
-      errors.push(`email:${sanitizeAlertError(error)}`);
+      errors.push(deliveryErrorClass('email', error));
     }
   }
 
@@ -1067,7 +1322,7 @@ async function deliverAlert({
       status: 'missing_channel',
       reason: deliveryDecision.reason,
       channels: [],
-      error: 'no webhook or email channel configured',
+      error: 'missing_channel',
     };
   }
 
@@ -1076,7 +1331,7 @@ async function deliverAlert({
       status: 'failed',
       reason: deliveryDecision.reason,
       channels,
-      error: errors.join('; ') || 'no channel delivered',
+      error: sortedUniqueStrings(errors).join('|') || 'delivery_channel_failed',
     };
   }
 
@@ -1136,7 +1391,7 @@ export async function runPublicFeedAlertWatch({
   const generatedAt = new Date(now).toISOString();
   const stateFile = resolveStateFile(env);
   const outputFile = resolveOutputFile(env);
-  const previousState = readJsonFile(stateFile);
+  const previousState = projectAlertState(readJsonFile(stateFile));
   const freshnessRaw = await freshnessMonitorImpl({ env, repoRoot, now });
   const freshness = summarizeFreshness(freshnessRaw);
   const publisher = inspectPublisherUnit({ env, systemctlShowText, spawnSyncImpl });
@@ -1150,8 +1405,10 @@ export async function runPublicFeedAlertWatch({
     ...(freshness.status === 'pass'
       ? []
       : freshness.blockers.length > 0
-        ? freshness.blockers.map((blocker) => `public_feed:${blocker}`)
-        : [`public_feed_status:${freshness.status ?? 'missing'}`]),
+        ? freshness.blockers.map((blocker) => FRESHNESS_BLOCKER_CLASSES.has(blocker)
+            ? `public_feed:${blocker}`
+            : 'public_feed:unclassified_blocker')
+        : ['public_feed:status_fail']),
     ...relayLiveness.blockers,
     ...relaySnapshot.blockers,
     ...watchClosure.blockers,
@@ -1190,8 +1447,8 @@ export async function runPublicFeedAlertWatch({
     severity: observedSeverity,
     blockers: observedBlockers,
     fingerprint,
-    stateFile,
-    outputFile,
+    stateFileRole: 'state',
+    outputFileRole: 'latest',
     publisher,
     freshness,
     relayLiveness,
@@ -1246,18 +1503,26 @@ export async function runPublicFeedAlertWatch({
 
 async function main() {
   const summary = await runPublicFeedAlertWatch();
-  console.info(JSON.stringify({
+  console.info(JSON.stringify(alertConsoleProjection(summary), null, 2));
+  if (summary.status !== 'pass') {
+    process.exit(1);
+  }
+}
+
+function alertConsoleProjection(summary) {
+  return {
     status: summary.status,
     observedStatus: summary.observedStatus,
     severity: summary.severity,
     blockers: summary.blockers,
     fingerprint: summary.fingerprint,
     delivery: summary.delivery,
-    outputFile: summary.outputFile,
-  }, null, 2));
-  if (summary.status !== 'pass') {
-    process.exit(1);
-  }
+    outputFileRole: summary.outputFileRole,
+  };
+}
+
+function unhandledErrorClass() {
+  return 'alert_watch_unhandled_error';
 }
 
 export const publicFeedAlertWatchInternal = {
@@ -1275,11 +1540,13 @@ export const publicFeedAlertWatchInternal = {
   summarizeWatchClosureVerdict,
   watchClosureProvenanceBlockers,
   signedWebhookHeaders,
+  alertConsoleProjection,
+  unhandledErrorClass,
 };
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  main().catch((error) => {
-    console.error('[vh:public-feed-alert-watch] failed', error);
+  main().catch(() => {
+    console.error('[vh:public-feed-alert-watch] failed', unhandledErrorClass());
     process.exit(1);
   });
 }

--- a/tools/scripts/public-feed-alert-watch.test.mjs
+++ b/tools/scripts/public-feed-alert-watch.test.mjs
@@ -2904,3 +2904,234 @@ test('CLI unhandled errors print only the fixed public error class', () => {
     for (const root of roots) rmSync(root, { recursive: true, force: true });
   }
 });
+
+test('anonymous projected identities are canonical across secret rotation and mixed-status reorder', async (t) => {
+  const now = Date.parse('2026-07-02T18:00:00.000Z');
+  const rows = [
+    {
+      name: 'freshness readbacks',
+      configure(root) {
+        return {};
+      },
+      freshness(secret, { reverse = false, changed = false } = {}) {
+        const entries = [
+          {
+            origin: `private fail origin ${secret}`,
+            status: 'fail',
+            recordCount: 0,
+            newestAgeMs: 30_000_000,
+            maxAgeMs: 21_600_000,
+            failures: ['latest_index_stale:30000000/21600000'],
+          },
+          {
+            origin: `private pass origin ${secret}`,
+            status: changed ? 'fail' : 'pass',
+            recordCount: 80,
+            newestAgeMs: 120_000,
+            maxAgeMs: 21_600_000,
+            failures: changed ? ['latest_index_empty'] : [],
+          },
+        ];
+        if (reverse) entries.reverse();
+        return freshnessSummary({
+          status: 'fail',
+          blockers: [`latest_index_not_fresh:private-origin-${secret}:latest_index_stale:30000000/21600000`],
+          config: {
+            origins: [`private fail origin ${secret}`, `private pass origin ${secret}`],
+            maxAgeMs: 21_600_000,
+          },
+          latestIndexReadbacks: entries,
+        });
+      },
+    },
+    {
+      name: 'relay liveness relays',
+      configure(root, secret, { reverse = false, changed = false } = {}) {
+        const relays = [
+          {
+            name: `private-relay-fail-${secret}`,
+            status: 'fail',
+            blockers: [`readyz_failed:${secret}`],
+            docker: { restartCount: 1 },
+            metrics: { rssBytes: 2, heapUsedBytes: 1, watchdogTrips: 0, eventLoopLagP99Ms: 3, criticalReadbacksQueued: 0 },
+          },
+          {
+            name: `private-relay-pass-${secret}`,
+            status: changed ? 'fail' : 'pass',
+            blockers: changed ? [`metrics_failed:${secret}`] : [],
+            docker: { restartCount: 0 },
+            metrics: { rssBytes: 4, heapUsedBytes: 2, watchdogTrips: 0, eventLoopLagP99Ms: 5, criticalReadbacksQueued: 0 },
+          },
+        ];
+        if (reverse) relays.reverse();
+        return writeAuxReports(root, {
+          relay: relayLivenessReport({ status: 'fail', blockers: [`private-${secret}`], relays }),
+        });
+      },
+      freshness() {
+        return freshnessSummary();
+      },
+    },
+    {
+      name: 'relay snapshots',
+      configure(root, secret, { reverse = false, changed = false } = {}) {
+        const snapshots = [
+          {
+            file: `/private/${secret}/vhc-relay-private_${secret}/fail.json`,
+            status: 'fail',
+            failures: [`snapshot_parse_failed:${secret}`],
+            entryCount: 0,
+            cachedAgeMs: 60_000,
+            newestEntryAgeMs: 30_000_000,
+            freshnessFailures: ['newest_entry_stale:30000000/21600000'],
+          },
+          {
+            file: `/private/${secret}/vhc-relay-private_${secret}/pass.json`,
+            status: changed ? 'fail' : 'pass',
+            failures: changed ? ['entries_empty'] : [],
+            entryCount: changed ? 0 : 80,
+            cachedAgeMs: 60_000,
+            newestEntryAgeMs: 120_000,
+            freshnessFailures: [],
+          },
+        ];
+        if (reverse) snapshots.reverse();
+        return writeAuxReports(root, {
+          snapshot: relaySnapshotReport({ status: 'fail', blockers: [`private-${secret}`], snapshots }),
+        });
+      },
+      freshness() {
+        return freshnessSummary();
+      },
+    },
+    {
+      name: 'watch relay memory',
+      configure(root, secret, { reverse = false, changed = false } = {}) {
+        const relays = [
+          {
+            name: `private-relay-warn-${secret}`,
+            trendStatus: 'warn',
+            heapPlateauVerdict: 'heap_still_linear',
+            heapLimitSource: 'VH_RELAY_WATCHDOG_MAX_HEAP_USED_BYTES',
+            shortestProjectedLimitHours: 24,
+          },
+          {
+            name: `private-relay-pass-${secret}`,
+            trendStatus: changed ? 'fail' : 'pass',
+            heapPlateauVerdict: changed ? 'heap_still_linear' : 'heap_plateau_observed',
+            heapLimitSource: 'VH_RELAY_WATCHDOG_MAX_HEAP_USED_BYTES',
+            shortestProjectedLimitHours: 240,
+          },
+        ];
+        if (reverse) relays.reverse();
+        return writeAuxReports(root, {
+          closure: watchClosureVerdict({
+            status: 'in_progress',
+            blockers: [],
+            relayMemory: {
+              status: 'warn',
+              heapPlateauVerdict: 'heap_plateau_observed',
+              heapLimitSource: 'VH_RELAY_WATCHDOG_MAX_HEAP_USED_BYTES',
+              rssLimitSource: 'VH_RELAY_WATCHDOG_MAX_RSS_BYTES',
+              relays,
+            },
+          }),
+        });
+      },
+      freshness() {
+        return freshnessSummary();
+      },
+    },
+  ];
+
+  for (const row of rows.slice(0, 4)) {
+    await t.test(row.name, async () => {
+      const roots = [];
+      const runVariant = async (secret, options) => {
+        const root = tempRoot();
+        roots.push(root);
+        const webhookCalls = [];
+        const mail = [];
+        const summary = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({
+          env: baseEnv(root, {
+            ...row.configure(root, secret, options),
+            VH_PUBLIC_FEED_ALERT_TEST_FIRE: '1',
+            VH_PUBLIC_FEED_ALERT_WEBHOOK_URL: 'https://hooks.example.invalid/token',
+            VH_PUBLIC_FEED_ALERT_EMAIL_TO: 'operator@example.invalid',
+          }),
+          repoRoot: root,
+          now,
+          systemctlShowText: activeSystemctl(),
+          freshnessMonitorImpl: async () => row.freshness(secret, options),
+          fetchImpl: async (url, init) => {
+            webhookCalls.push({ url, init });
+            return { ok: true, status: 204 };
+          },
+          spawnSyncImpl: (command, args, spawnOptions) => {
+            mail.push(spawnOptions.input);
+            return { status: 0, stdout: '', stderr: '' };
+          },
+        });
+        const parsedMail = parseTextEmail(mail[0]);
+        return {
+          summary,
+          webhook: JSON.parse(webhookCalls[0].init.body),
+          mime: { subject: parsedMail.headers.subject, payload: JSON.parse(parsedMail.body) },
+          latest: JSON.parse(readFileSync(path.join(root, 'latest.json'), 'utf8')),
+          console: publicFeedAlertWatchInternal.alertConsoleProjection(summary),
+        };
+      };
+
+      try {
+        const baseline = await runVariant('SYNTHETIC_ANON_SECRET_A_20260710', { reverse: false });
+        const reordered = await runVariant('SYNTHETIC_ANON_SECRET_B_20260710', { reverse: true });
+        const semanticChange = await runVariant('SYNTHETIC_ANON_SECRET_C_20260710', { changed: true });
+        assert.deepEqual(reordered, baseline);
+        assert.notEqual(semanticChange.summary.fingerprint, baseline.summary.fingerprint);
+        assert.equal(JSON.stringify(baseline).includes('SYNTHETIC_ANON_SECRET_A_20260710'), false);
+        if (row.name === 'relay liveness relays') {
+          const relays = baseline.summary.relayLiveness.relays;
+          assert.equal(relays.length, 2);
+          assert.deepEqual(relays.map((relay) => relay.ordinal), [1, 2]);
+          assert.deepEqual(relays.map((relay) => relay.identityHash), [null, null]);
+          assert.deepEqual(relays.map((relay) => relay.status).sort(), ['fail', 'pass']);
+          assert.deepEqual(relays.flatMap((relay) => relay.reasonCodes).sort(), ['readyz_failed']);
+          assert.deepEqual(relays.map((relay) => relay.rssBytes).sort((a, b) => a - b), [2, 4]);
+        }
+        if (row.name === 'relay snapshots') {
+          const snapshots = baseline.summary.relaySnapshot.snapshots;
+          assert.equal(snapshots.length, 2);
+          assert.deepEqual(snapshots.map((snapshot) => snapshot.ordinal), [1, 2]);
+          assert.deepEqual(snapshots.map((snapshot) => snapshot.relayIdentityHash), [null, null]);
+          assert.deepEqual(snapshots.map((snapshot) => snapshot.status).sort(), ['fail', 'pass']);
+          assert.deepEqual(
+            snapshots.flatMap((snapshot) => snapshot.reasonCodes).sort(),
+            ['newest_entry_stale', 'snapshot_parse_failed'],
+          );
+          assert.deepEqual(snapshots.map((snapshot) => snapshot.entryCount).sort((a, b) => a - b), [0, 80]);
+          assert.deepEqual(
+            snapshots.map((snapshot) => snapshot.newestEntryAgeMs).sort((a, b) => a - b),
+            [120_000, 30_000_000],
+          );
+        }
+        if (row.name === 'watch relay memory') {
+          const relays = baseline.summary.watchClosure.relayMemory.relays;
+          assert.equal(relays.length, 2);
+          assert.deepEqual(relays.map((relay) => relay.ordinal), [1, 2]);
+          assert.deepEqual(relays.map((relay) => relay.identityHash), [null, null]);
+          assert.deepEqual(relays.map((relay) => relay.trendStatus).sort(), ['pass', 'warn']);
+          assert.deepEqual(
+            relays.map((relay) => relay.heapPlateauVerdict).sort(),
+            ['heap_plateau_observed', 'heap_still_linear'],
+          );
+          assert.deepEqual(
+            relays.map((relay) => relay.shortestProjectedLimitHours).sort((a, b) => a - b),
+            [24, 240],
+          );
+        }
+      } finally {
+        for (const root of roots) rmSync(root, { recursive: true, force: true });
+      }
+    });
+  }
+});

--- a/tools/scripts/public-feed-alert-watch.test.mjs
+++ b/tools/scripts/public-feed-alert-watch.test.mjs
@@ -276,7 +276,10 @@ function semanticFingerprintInput() {
           recordCount: 80,
           failureCount: 8,
           failureReasonCodes: ['latest_index_stale'],
-          failureDiagnostics: ['latest_index_stale:30000000/21600000'],
+          failureDiagnostics: [{
+            reasonCode: 'latest_index_stale',
+            numericDiagnostics: { maxAgeMs: [21_600_000], newestAgeMs: [30_000_000] },
+          }],
         },
         {
           originHash: 'source-a',
@@ -348,9 +351,10 @@ test('semantic fingerprint ignores volatile values and ordering but preserves re
     'latest_index_stale',
     'latest_index_stale',
   ];
-  volatileDrift.freshness.latestIndexReadbacks[1].failureDiagnostics = [
-    'latest_index_stale:30300000/21600000',
-  ];
+  volatileDrift.freshness.latestIndexReadbacks[1].failureDiagnostics = [{
+    reasonCode: 'latest_index_stale',
+    numericDiagnostics: { maxAgeMs: [21_600_000], newestAgeMs: [30_300_000] },
+  }];
   volatileDrift.relayLiveness.relays.reverse();
   volatileDrift.relayLiveness.relays.push(structuredClone(volatileDrift.relayLiveness.relays[0]));
   volatileDrift.relayLiveness.relays[1].blockerCount = 9;
@@ -1156,7 +1160,7 @@ test('stale feed sends a webhook on state change with secret-safe aggregate payl
     const body = JSON.parse(calls[0].init.body);
     assert.equal(body.alertReason, 'first_failure');
     assert.equal(body.severity, 'critical');
-    assert.equal(body.blockers.some((blocker) => blocker.includes('url_hash:')), true);
+    assert.equal(body.blockers.includes('public_feed:latest_index_not_fresh'), true);
     assert.equal(body.freshness.latestIndexReadbacks[0].origin, undefined);
     assert.equal(body.freshness.latestIndexReadbacks[0].originHash.length, 16);
     assert.equal(JSON.stringify(body).includes('story-body-not-copied'), false);
@@ -1325,9 +1329,15 @@ test('adversarial configured origin stays fully redacted across webhook and emai
     ];
     for (const [index, payload] of webhookPayloads.entries()) {
       const freshnessBlocker = payload.freshness.blockers[0];
-      assert.match(freshnessBlocker, /^latest_index_not_fresh:url_hash:[0-9a-f]{16}$/);
+      assert.equal(freshnessBlocker, 'latest_index_not_fresh');
       assert.deepEqual(payload.freshness.latestIndexReadbacks[0].failureReasonCodes, expectedReasonSets[index]);
-      assert.deepEqual(payload.freshness.latestIndexReadbacks[0].failureDiagnostics, expectedReasonSets[index]);
+      assert.deepEqual(
+        payload.freshness.latestIndexReadbacks[0].failureDiagnostics,
+        expectedReasonSets[index].map((reasonCode) => ({
+          reasonCode,
+          numericDiagnostics: {},
+        })),
+      );
       assert.deepEqual(emailPayloads[index], payload);
     }
 
@@ -1353,7 +1363,7 @@ test('adversarial configured origin stays fully redacted across webhook and emai
   }
 });
 
-test('configured base origin cannot prefix-redact a longer failure URL across alert outputs', async () => {
+test('structured failure projections exclude arbitrary detail across every alert output', async () => {
   const root = tempRoot();
   const calls = [];
   const mail = [];
@@ -1362,29 +1372,66 @@ test('configured base origin cannot prefix-redact a longer failure URL across al
     origin,
     'private/feed?token=prefix:api_key|sk-proj-SYNTHETIC-OVERLAP-NOT-A-REAL-KEY',
   ].join('');
-  const failure = `latest_index_fetch_failed:http_status=429 attempt=3 ${failureUrl}`;
+  const nonUrlToken = 'SYNTHETIC_NONURL_TOKEN_SENTINEL_20260710';
+  const secretOnlyToken = 'SYNTHETIC_SECRET_ONLY_CHANGE_20260710';
+  const driftToken = 'SYNTHETIC_NONURL_TOKEN_DRIFT_20260710';
+  const privateValue = 'SYNTHETIC_PRIVATE_FAILURE_VALUE_20260710';
+  const hostEnvValue = 'SYNTHETIC_HOST_ENV_PRIVATE_VALUE_20260710';
+  const punctuationValue = 'SYNTHETIC_WHITESPACE_PUNCTUATION_VALUE_20260710';
+  const unknownReasonCode = 'synthetic_private_reason_code_20260710';
+  const driftUnknownReasonCode = 'synthetic_private_reason_drift_20260710';
   const privateStoryBody = 'synthetic-overlap-private-story-body';
+  const fetchFailure = [
+    'latest_index_fetch_failed:http_status=429 attempt=3',
+    `token=${nonUrlToken}`,
+    `private_value=${privateValue}`,
+    `host_env=(${hostEnvValue})`,
+    `punctuation="{${punctuationValue}}";`,
+    `url=${failureUrl}`,
+  ].join(' ');
+  const staleFailure = `latest_index_stale:30000000/21600000 token=${nonUrlToken}`;
+  const unknownFailure = `${unknownReasonCode}:count=7 private_value=${privateValue}`;
+  const secretOnlyFetchFailure = [
+    'latest_index_fetch_failed:attempt=3 http_status=429',
+    `token=${secretOnlyToken}`,
+    `private_value=CHANGED_${privateValue}`,
+    `host_env={CHANGED_${hostEnvValue}}`,
+    `url=${failureUrl}&secret_only=${secretOnlyToken}`,
+  ].join(' ');
+  const secretOnlyStaleFailure = `latest_index_stale:30000000/21600000 token=${secretOnlyToken}`;
+  const secretOnlyUnknownFailure = `different_private_reason_20260710:count=7 token=${secretOnlyToken}`;
+  const driftFetchFailure = [
+    'latest_index_fetch_failed:attempt=4 http_status=503',
+    `token=${driftToken}`,
+    `private_value=${privateValue}`,
+    `host_env=[${hostEnvValue}]`,
+    `url=${failureUrl}`,
+  ].join(' ');
+  const driftStaleFailure = `latest_index_stale:30300000/21600000 token=${driftToken}`;
+  const driftUnknownFailure = `${driftUnknownReasonCode}:count=8 host_env=${hostEnvValue}`;
+  let failures = [fetchFailure, unknownFailure, staleFailure, fetchFailure];
+  let newestAgeMs = 30_000_000;
   try {
-    const summary = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({
+    const options = {
       env: baseEnv(root, {
         VH_PUBLIC_FEED_ALERT_WEBHOOK_URL: 'https://hooks.example.invalid/token',
         VH_PUBLIC_FEED_ALERT_EMAIL_TO: 'operator@example.invalid',
         VH_PUBLIC_FEED_ALERT_SENDMAIL: '/usr/sbin/sendmail',
+        VH_SYNTHETIC_PRIVATE_HOST_VALUE: hostEnvValue,
       }),
       repoRoot: root,
-      now: Date.parse('2026-07-02T18:00:00.000Z'),
       systemctlShowText: activeSystemctl(),
       freshnessMonitorImpl: async () => freshnessSummary({
         status: 'fail',
-        blockers: [`latest_index_not_fresh:${origin}:${failure}`],
+        blockers: [`latest_index_not_fresh:${origin}:${failures.join('|')}`],
         config: { origins: [origin], maxAgeMs: 21_600_000 },
         latestIndexReadbacks: [{
           origin,
           status: 'fail',
           recordCount: 0,
-          newestAgeMs: null,
+          newestAgeMs,
           maxAgeMs: 21_600_000,
-          failures: [failure],
+          failures,
           storyIds: [privateStoryBody],
         }],
       }),
@@ -1396,28 +1443,87 @@ test('configured base origin cannot prefix-redact a longer failure URL across al
         mail.push({ command, args, input: spawnOptions.input });
         return { status: 0, stdout: '', stderr: '' };
       },
+    };
+
+    const first = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({
+      ...options,
+      now: Date.parse('2026-07-02T18:00:00.000Z'),
+    });
+    failures = [staleFailure, unknownFailure, fetchFailure, staleFailure, unknownFailure, fetchFailure];
+    const reordered = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({
+      ...options,
+      now: Date.parse('2026-07-02T18:01:00.000Z'),
+    });
+    failures = [secretOnlyFetchFailure, secretOnlyUnknownFailure, secretOnlyStaleFailure, secretOnlyFetchFailure];
+    const secretOnlyDrift = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({
+      ...options,
+      now: Date.parse('2026-07-02T18:02:00.000Z'),
+    });
+    failures = [driftUnknownFailure, driftStaleFailure, driftFetchFailure, driftFetchFailure];
+    newestAgeMs = 30_300_000;
+    const numericDrift = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({
+      ...options,
+      now: Date.parse('2026-07-02T18:03:00.000Z'),
     });
 
-    assert.equal(summary.delivery.status, 'sent');
+    assert.equal(first.delivery.status, 'sent');
+    assert.equal(reordered.fingerprint, first.fingerprint);
+    assert.equal(reordered.delivery.status, 'suppressed');
+    assert.equal(secretOnlyDrift.fingerprint, first.fingerprint);
+    assert.equal(secretOnlyDrift.delivery.status, 'suppressed');
+    assert.equal(numericDrift.fingerprint, first.fingerprint);
+    assert.equal(numericDrift.delivery.status, 'suppressed');
     assert.equal(calls.length, 1);
     assert.equal(mail.length, 1);
-    assert.deepEqual(summary.freshness.latestIndexReadbacks[0].failureReasonCodes, [
+    assert.deepEqual(first.freshness.blockers, ['latest_index_not_fresh']);
+    assert.deepEqual(first.blockers, ['public_feed:latest_index_not_fresh']);
+    assert.deepEqual(first.freshness.latestIndexReadbacks[0].failureReasonCodes, [
       'latest_index_fetch_failed',
+      'latest_index_stale',
+      'unclassified_failure',
     ]);
-    assert.match(
-      summary.freshness.latestIndexReadbacks[0].failureDiagnostics[0],
-      /^latest_index_fetch_failed:http_status=429 attempt=3 url_hash:[0-9a-f]{16}$/,
-    );
-    assert.equal(summary.freshness.latestIndexReadbacks[0].recordCount, 0);
-    assert.equal(summary.freshness.latestIndexReadbacks[0].newestAgeMs, null);
-    assert.equal(summary.freshness.latestIndexReadbacks[0].maxAgeMs, 21_600_000);
+    const expectedFirstDiagnostics = [
+      {
+        reasonCode: 'latest_index_fetch_failed',
+        numericDiagnostics: { attempt: [3], httpStatus: [429] },
+      },
+      {
+        reasonCode: 'latest_index_stale',
+        numericDiagnostics: { maxAgeMs: [21_600_000], newestAgeMs: [30_000_000] },
+      },
+      {
+        reasonCode: 'unclassified_failure',
+        numericDiagnostics: { count: [7] },
+      },
+    ];
+    assert.deepEqual(first.freshness.latestIndexReadbacks[0].failureDiagnostics, expectedFirstDiagnostics);
+    assert.deepEqual(reordered.freshness.latestIndexReadbacks[0].failureDiagnostics, expectedFirstDiagnostics);
+    assert.deepEqual(secretOnlyDrift.freshness.latestIndexReadbacks[0].failureDiagnostics, expectedFirstDiagnostics);
+    assert.deepEqual(secretOnlyDrift.freshness.latestIndexReadbacks, first.freshness.latestIndexReadbacks);
+    assert.deepEqual(numericDrift.freshness.latestIndexReadbacks[0].failureDiagnostics, [
+      {
+        reasonCode: 'latest_index_fetch_failed',
+        numericDiagnostics: { attempt: [4], httpStatus: [503] },
+      },
+      {
+        reasonCode: 'latest_index_stale',
+        numericDiagnostics: { maxAgeMs: [21_600_000], newestAgeMs: [30_300_000] },
+      },
+      {
+        reasonCode: 'unclassified_failure',
+        numericDiagnostics: { count: [8] },
+      },
+    ]);
+    assert.equal(numericDrift.freshness.latestIndexReadbacks[0].recordCount, 0);
+    assert.equal(numericDrift.freshness.latestIndexReadbacks[0].newestAgeMs, 30_300_000);
+    assert.equal(numericDrift.freshness.latestIndexReadbacks[0].maxAgeMs, 21_600_000);
 
     const webhookPayload = JSON.parse(calls[0].init.body);
     const parsedEmail = parseTextEmail(mail[0].input);
     assert.equal(parsedEmail.headers['mime-version'], '1.0');
     assert.equal(parsedEmail.headers['content-type'], 'text/plain; charset=utf-8');
     assert.deepEqual(JSON.parse(parsedEmail.body), webhookPayload);
-    const consoleOutput = JSON.stringify({
+    const consoleOutput = (summary) => JSON.stringify({
       status: summary.status,
       observedStatus: summary.observedStatus,
       severity: summary.severity,
@@ -1427,11 +1533,14 @@ test('configured base origin cannot prefix-redact a longer failure URL across al
       outputFile: summary.outputFile,
     });
     const serializedOutputs = [
-      JSON.stringify(summary),
+      JSON.stringify([first, reordered, secretOnlyDrift, numericDrift]),
       calls[0].init.body,
       mail[0].input,
       readFileSync(path.join(root, 'latest.json'), 'utf8'),
-      consoleOutput,
+      consoleOutput(first),
+      consoleOutput(reordered),
+      consoleOutput(secretOnlyDrift),
+      consoleOutput(numericDrift),
     ];
     const forbiddenFragments = [
       origin,
@@ -1440,6 +1549,15 @@ test('configured base origin cannot prefix-redact a longer failure URL across al
       'private/feed?token=',
       'prefix:api_key',
       'sk-proj-SYNTHETIC-OVERLAP-NOT-A-REAL-KEY',
+      nonUrlToken,
+      secretOnlyToken,
+      driftToken,
+      privateValue,
+      hostEnvValue,
+      punctuationValue,
+      unknownReasonCode,
+      'different_private_reason_20260710',
+      driftUnknownReasonCode,
       privateStoryBody,
     ];
     for (const output of serializedOutputs) {

--- a/tools/scripts/public-feed-alert-watch.test.mjs
+++ b/tools/scripts/public-feed-alert-watch.test.mjs
@@ -129,6 +129,22 @@ function writeJson(filePath, value) {
   writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
 }
 
+function parseTextEmail(message) {
+  const normalized = String(message).replace(/\r\n/g, '\n');
+  const separatorIndex = normalized.indexOf('\n\n');
+  assert.notEqual(separatorIndex, -1, 'email must contain a header/body separator');
+  const headers = {};
+  for (const line of normalized.slice(0, separatorIndex).split('\n')) {
+    const colonIndex = line.indexOf(':');
+    assert.notEqual(colonIndex, -1, `invalid email header: ${line}`);
+    headers[line.slice(0, colonIndex).trim().toLowerCase()] = line.slice(colonIndex + 1).trim();
+  }
+  return {
+    headers,
+    body: normalized.slice(separatorIndex + 2).trim(),
+  };
+}
+
 function relayLivenessReport(overrides = {}) {
   return {
     schemaVersion: 'vh-news-relay-liveness-watch-v1',
@@ -232,6 +248,143 @@ function writeAuxReports(root, {
     VH_PUBLIC_FEED_ALERT_WATCH_CLOSURE_VERDICT_FILE: closureFile,
   };
 }
+
+function semanticFingerprintInput() {
+  return {
+    status: 'fail',
+    blockers: [
+      'public_feed:latest_index_not_fresh:url_hash:0123456789abcdef:latest_index_stale:30000000/21600000',
+      'watch_closure:archive_sample_failures:8',
+    ],
+    publisher: {
+      status: 'fail',
+      activeState: 'failed',
+      subState: 'failed',
+      execMainStatus: '78',
+      failureClass: 'exit_78_fail_closed',
+    },
+    freshness: {
+      status: 'fail',
+      blockers: ['latest_index_not_fresh:url_hash:0123456789abcdef:latest_index_stale:30000000/21600000'],
+      originHashes: ['source-b', 'source-a'],
+      latestIndexReadbacks: [
+        { originHash: 'source-b', status: 'fail', newestAgeMs: 30_000_000, maxAgeMs: 21_600_000, recordCount: 80, failureCount: 8 },
+        { originHash: 'source-a', status: 'pass', newestAgeMs: 120_000, maxAgeMs: 21_600_000, recordCount: 79, failureCount: 0 },
+      ],
+    },
+    relayLiveness: {
+      status: 'fail',
+      blockers: ['relay_liveness:vhc-relay-b:readyz_failed'],
+      relays: [
+        { name: 'vhc-relay-b', status: 'fail', blockerCount: 1, restartCount: 8, watchdogTrips: 8 },
+        { name: 'vhc-relay-a', status: 'pass', blockerCount: 0, restartCount: 0, watchdogTrips: 0 },
+      ],
+    },
+    relaySnapshot: {
+      status: 'fail',
+      blockers: ['relay_snapshot:snapshot_file_hash:fedcba9876543210:newest_entry_stale:30000000/21600000'],
+      snapshots: [
+        { fileHash: 'snapshot-b', relay: 'vhc-relay-b', status: 'fail', entryCount: 80, failureCount: 8, freshnessFailureCount: 8 },
+        { fileHash: 'snapshot-a', relay: 'vhc-relay-a', status: 'pass', entryCount: 79, failureCount: 0, freshnessFailureCount: 0 },
+      ],
+    },
+    watchClosure: {
+      status: 'fail',
+      blockers: ['watch_closure:archive_sample_failures:8'],
+      verdictStatus: 'fail',
+      thresholds: {
+        twentyFourHour: { status: 'fail', blockers: ['archive_sample_failures:8'] },
+        fortyEightHour: { status: 'not_ready', blockers: ['window_short:33.49/48'] },
+      },
+      relayMemory: {
+        status: 'fail',
+        heapPlateauVerdict: 'heap_still_linear',
+        relays: [
+          { name: 'vhc-relay-b', trendStatus: 'fail', heapPlateauVerdict: 'heap_still_linear', shortestProjectedLimitHours: 18 },
+          { name: 'vhc-relay-a', trendStatus: 'pass', heapPlateauVerdict: 'heap_plateau_observed', shortestProjectedLimitHours: 240 },
+        ],
+      },
+    },
+  };
+}
+
+test('semantic fingerprint ignores volatile values and ordering but preserves real state transitions', () => {
+  const baseline = semanticFingerprintInput();
+  const volatileDrift = structuredClone(baseline);
+  volatileDrift.blockers = [
+    'watch_closure:archive_sample_failures:9',
+    'public_feed:latest_index_not_fresh:url_hash:0123456789abcdef:latest_index_stale:30300000/21600000',
+    'watch_closure:archive_sample_failures:9',
+  ];
+  volatileDrift.freshness.blockers = [
+    'latest_index_not_fresh:url_hash:0123456789abcdef:latest_index_stale:30300000/21600000',
+  ];
+  volatileDrift.freshness.originHashes = ['source-a', 'source-b', 'source-a'];
+  volatileDrift.freshness.latestIndexReadbacks.reverse();
+  volatileDrift.freshness.latestIndexReadbacks.push(structuredClone(volatileDrift.freshness.latestIndexReadbacks[0]));
+  volatileDrift.freshness.latestIndexReadbacks[0].recordCount = 99;
+  volatileDrift.freshness.latestIndexReadbacks[1].newestAgeMs = 30_300_000;
+  volatileDrift.freshness.latestIndexReadbacks[1].recordCount = 99;
+  volatileDrift.freshness.latestIndexReadbacks[1].failureCount = 9;
+  volatileDrift.relayLiveness.relays.reverse();
+  volatileDrift.relayLiveness.relays.push(structuredClone(volatileDrift.relayLiveness.relays[0]));
+  volatileDrift.relayLiveness.relays[1].blockerCount = 9;
+  volatileDrift.relayLiveness.relays[1].restartCount = 9;
+  volatileDrift.relayLiveness.relays[1].watchdogTrips = 9;
+  volatileDrift.relaySnapshot.snapshots.reverse();
+  volatileDrift.relaySnapshot.snapshots.push(structuredClone(volatileDrift.relaySnapshot.snapshots[0]));
+  volatileDrift.relaySnapshot.snapshots[1].entryCount = 99;
+  volatileDrift.relaySnapshot.snapshots[1].failureCount = 9;
+  volatileDrift.relaySnapshot.snapshots[1].freshnessFailureCount = 9;
+  volatileDrift.watchClosure.blockers = ['watch_closure:archive_sample_failures:9'];
+  volatileDrift.watchClosure.thresholds.twentyFourHour.blockers = ['archive_sample_failures:9'];
+  volatileDrift.watchClosure.thresholds.fortyEightHour.blockers = ['window_short:33.99/48'];
+  volatileDrift.watchClosure.relayMemory.relays.reverse();
+  volatileDrift.watchClosure.relayMemory.relays[1].shortestProjectedLimitHours = 17;
+
+  const fingerprint = publicFeedAlertWatchInternal.fingerprintFor(baseline);
+  assert.equal(publicFeedAlertWatchInternal.fingerprintFor(volatileDrift), fingerprint);
+
+  const exitClassChanged = structuredClone(baseline);
+  exitClassChanged.publisher.activeState = 'activating';
+  exitClassChanged.publisher.subState = 'auto-restart';
+  exitClassChanged.publisher.execMainStatus = '69';
+  exitClassChanged.publisher.failureClass = 'exit_69_transport_unavailable';
+  assert.notEqual(publicFeedAlertWatchInternal.fingerprintFor(exitClassChanged), fingerprint);
+
+  const thresholdChanged = structuredClone(baseline);
+  thresholdChanged.watchClosure.thresholds.twentyFourHour.status = 'pass';
+  assert.notEqual(publicFeedAlertWatchInternal.fingerprintFor(thresholdChanged), fingerprint);
+
+  const blockerReasonChanged = structuredClone(baseline);
+  blockerReasonChanged.watchClosure.blockers = ['watch_closure:runtime_failed_ticks:8'];
+  blockerReasonChanged.watchClosure.thresholds.twentyFourHour.blockers = ['runtime_failed_ticks:8'];
+  assert.notEqual(publicFeedAlertWatchInternal.fingerprintFor(blockerReasonChanged), fingerprint);
+
+  const compositeReasonChanged = structuredClone(baseline);
+  compositeReasonChanged.blockers = [
+    'public_feed:latest_index_not_fresh:url_hash:0123456789abcdef:latest_index_empty|latest_index_timestamp_missing',
+    'watch_closure:archive_sample_failures:8',
+  ];
+  compositeReasonChanged.freshness.blockers = [
+    'latest_index_not_fresh:url_hash:0123456789abcdef:latest_index_empty|latest_index_timestamp_missing',
+  ];
+  assert.notEqual(publicFeedAlertWatchInternal.fingerprintFor(compositeReasonChanged), fingerprint);
+
+  const relayChanged = structuredClone(baseline);
+  relayChanged.relayLiveness.relays[0].status = 'pass';
+  assert.notEqual(publicFeedAlertWatchInternal.fingerprintFor(relayChanged), fingerprint);
+
+  const recovered = structuredClone(baseline);
+  recovered.status = 'pass';
+  recovered.blockers = [];
+  recovered.publisher.status = 'pass';
+  recovered.publisher.activeState = 'active';
+  recovered.publisher.subState = 'running';
+  recovered.publisher.execMainStatus = '0';
+  recovered.publisher.failureClass = 'none';
+  assert.notEqual(publicFeedAlertWatchInternal.fingerprintFor(recovered), fingerprint);
+});
 
 test('passing feed and active publisher do not require an alert channel', async () => {
   const root = tempRoot();
@@ -466,6 +619,144 @@ test('stale auxiliary report output is warning severity and dedupes across age d
   }
 });
 
+test('volatile progress suppresses repeats while latest and heartbeat payloads retain full diagnostics', async () => {
+  const root = tempRoot();
+  const calls = [];
+  try {
+    function writeProgress({ nowIso, windowHours, count, entryCount }) {
+      return writeAuxReports(root, {
+        relay: relayLivenessReport({
+          generatedAt: nowIso,
+          status: 'fail',
+          blockers: ['vhc-relay-b:readyz_failed'],
+          relays: [
+            {
+              name: 'vhc-relay-b',
+              origin: 'http://127.0.0.1:8766/private',
+              status: 'fail',
+              blockers: ['readyz_failed'],
+              docker: { restartCount: count },
+              metrics: {
+                rssBytes: 1_200_000_000 + count,
+                heapUsedBytes: 920_000_000 + count,
+                watchdogTrips: count,
+                eventLoopLagP99Ms: 30 + count,
+                criticalReadbacksQueued: count,
+              },
+            },
+          ],
+        }),
+        snapshot: relaySnapshotReport({
+          generatedAt: nowIso,
+          status: 'fail',
+          blockers: [`newest_entry_stale:${30_000_000 + count}/21600000`],
+          snapshots: [
+            {
+              file: '/home/humble/.local/share/vhc/vhc-relay-b/data/news-latest-index-snapshot.json',
+              status: 'fail',
+              failures: Array.from({ length: count }, () => 'newest_entry_stale'),
+              entryCount,
+              cachedAgeMs: 60_000 + count,
+              newestEntryAgeMs: 30_000_000 + count,
+              freshnessFailures: Array.from({ length: count }, () => 'newest_entry_stale'),
+            },
+          ],
+        }),
+        closure: watchClosureVerdict({
+          generatedAt: nowIso,
+          status: 'fail',
+          severity: 'critical',
+          blockers: [
+            `archive_sample_failures:${count}`,
+            `window_short:${windowHours}/48`,
+          ],
+          thresholds: {
+            twentyFourHour: { thresholdHours: 24, status: 'fail', blockers: [`archive_sample_failures:${count}`] },
+            fortyEightHour: { thresholdHours: 48, status: 'not_ready', blockers: [`window_short:${windowHours}/48`] },
+          },
+        }),
+      });
+    }
+
+    const firstNow = Date.parse('2026-07-02T18:00:00.000Z');
+    const auxEnv = writeProgress({
+      nowIso: new Date(firstNow).toISOString(),
+      windowHours: '33.49',
+      count: 8,
+      entryCount: 80,
+    });
+    const env = baseEnv(root, {
+      ...auxEnv,
+      VH_PUBLIC_FEED_ALERT_WEBHOOK_URL: 'https://hooks.example.invalid/token',
+      VH_PUBLIC_FEED_ALERT_HEARTBEAT_MS: '600000',
+    });
+    let freshnessNow = firstNow;
+    let freshnessAgeMs = 30_000_000;
+    const options = {
+      env,
+      repoRoot: root,
+      systemctlShowText: activeSystemctl(),
+      freshnessMonitorImpl: async () => staleFreshnessSummary({
+        now: freshnessNow,
+        newestAgeMs: freshnessAgeMs,
+      }),
+      fetchImpl: async (url, init) => {
+        calls.push({ url, init });
+        return { ok: true, status: 204 };
+      },
+    };
+
+    const first = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({ ...options, now: firstNow });
+
+    const secondNow = Date.parse('2026-07-02T18:05:00.000Z');
+    freshnessNow = secondNow;
+    freshnessAgeMs = 30_300_000;
+    writeProgress({
+      nowIso: new Date(secondNow).toISOString(),
+      windowHours: '33.99',
+      count: 9,
+      entryCount: 90,
+    });
+    const second = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({ ...options, now: secondNow });
+
+    const thirdNow = Date.parse('2026-07-02T18:11:00.000Z');
+    freshnessNow = thirdNow;
+    freshnessAgeMs = 30_660_000;
+    writeProgress({
+      nowIso: new Date(thirdNow).toISOString(),
+      windowHours: '34.09',
+      count: 10,
+      entryCount: 100,
+    });
+    const third = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({ ...options, now: thirdNow });
+
+    assert.equal(second.fingerprint, first.fingerprint);
+    assert.equal(third.fingerprint, first.fingerprint);
+    assert.equal(second.delivery.status, 'suppressed');
+    assert.equal(second.delivery.reason, 'unchanged_suppressed');
+    assert.equal(third.delivery.status, 'sent');
+    assert.equal(third.delivery.reason, 'heartbeat_due');
+    assert.equal(calls.length, 2);
+
+    const latest = JSON.parse(readFileSync(path.join(root, 'latest.json'), 'utf8'));
+    assert.equal(latest.freshness.latestIndexReadbacks[0].newestAgeMs, 30_660_000);
+    assert.equal(latest.relayLiveness.relays[0].restartCount, 10);
+    assert.equal(latest.relayLiveness.relays[0].watchdogTrips, 10);
+    assert.equal(latest.relaySnapshot.snapshots[0].entryCount, 100);
+    assert.equal(latest.relaySnapshot.snapshots[0].failureCount, 10);
+    assert.deepEqual(latest.watchClosure.thresholds.fortyEightHour.blockers, ['window_short:34.09/48']);
+    assert.deepEqual(latest.watchClosure.thresholds.twentyFourHour.blockers, ['archive_sample_failures:10']);
+
+    const heartbeatPayload = JSON.parse(calls[1].init.body);
+    assert.equal(heartbeatPayload.freshness.latestIndexReadbacks[0].newestAgeMs, 30_660_000);
+    assert.equal(heartbeatPayload.relayLiveness.relays[0].restartCount, 10);
+    assert.equal(heartbeatPayload.relaySnapshot.snapshots[0].failureCount, 10);
+    assert.deepEqual(heartbeatPayload.watchClosure.thresholds.fortyEightHour.blockers, ['window_short:34.09/48']);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test('watch-closure fail verdict pages as warning with threshold provenance', async () => {
   const root = tempRoot();
   const calls = [];
@@ -569,7 +860,119 @@ test('watch-closure default heap limit provenance pages as warning', async () =>
   }
 });
 
-test('state schema migration redelivers an unchanged failure once', async () => {
+test('threshold status, blocker reason, and relay failure transitions each deliver once', async () => {
+  const root = tempRoot();
+  const calls = [];
+  try {
+    function closureWith({ twentyFourStatus, fortyEightBlocker }) {
+      return watchClosureVerdict({
+        status: 'in_progress',
+        blockers: [fortyEightBlocker],
+        thresholds: {
+          twentyFourHour: {
+            thresholdHours: 24,
+            status: twentyFourStatus,
+            blockers: twentyFourStatus === 'pass' ? [] : ['window_short:23.99/24'],
+          },
+          fortyEightHour: { thresholdHours: 48, status: 'not_ready', blockers: [fortyEightBlocker] },
+        },
+      });
+    }
+
+    const initialAux = writeAuxReports(root, {
+      closure: closureWith({ twentyFourStatus: 'not_ready', fortyEightBlocker: 'window_short:33.49/48' }),
+    });
+    const env = baseEnv(root, {
+      ...initialAux,
+      VH_PUBLIC_FEED_ALERT_WEBHOOK_URL: 'https://hooks.example.invalid/token',
+    });
+    const options = {
+      env,
+      repoRoot: root,
+      systemctlShowText: exit78Systemctl(),
+      freshnessMonitorImpl: async () => freshnessSummary(),
+      fetchImpl: async (url, init) => {
+        calls.push({ url, init });
+        return { ok: true, status: 204 };
+      },
+    };
+
+    const initial = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({
+      ...options,
+      now: Date.parse('2026-07-02T18:00:00.000Z'),
+    });
+
+    writeAuxReports(root, {
+      closure: closureWith({ twentyFourStatus: 'pass', fortyEightBlocker: 'window_short:33.49/48' }),
+    });
+    const thresholdChanged = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({
+      ...options,
+      now: Date.parse('2026-07-02T18:01:00.000Z'),
+    });
+
+    writeAuxReports(root, {
+      closure: closureWith({ twentyFourStatus: 'pass', fortyEightBlocker: 'archive_sample_failures:8' }),
+    });
+    const reasonChanged = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({
+      ...options,
+      now: Date.parse('2026-07-02T18:02:00.000Z'),
+    });
+
+    writeAuxReports(root, {
+      relay: relayLivenessReport({
+        status: 'fail',
+        blockers: ['vhc-relay-b:readyz_failed'],
+        relays: [{
+          name: 'vhc-relay-b',
+          status: 'fail',
+          blockers: ['readyz_failed'],
+          docker: { restartCount: 1 },
+          metrics: { watchdogTrips: 1 },
+        }],
+      }),
+      closure: closureWith({ twentyFourStatus: 'pass', fortyEightBlocker: 'archive_sample_failures:8' }),
+    });
+    const relayChanged = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({
+      ...options,
+      now: Date.parse('2026-07-02T18:03:00.000Z'),
+    });
+
+    writeAuxReports(root, {
+      relay: relayLivenessReport({
+        status: 'fail',
+        blockers: ['vhc-relay-b:readyz_failed'],
+        relays: [{
+          name: 'vhc-relay-b',
+          status: 'fail',
+          blockers: ['readyz_failed'],
+          docker: { restartCount: 9 },
+          metrics: { watchdogTrips: 9 },
+        }],
+      }),
+      closure: closureWith({ twentyFourStatus: 'pass', fortyEightBlocker: 'archive_sample_failures:9' }),
+    });
+    const unchanged = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({
+      ...options,
+      now: Date.parse('2026-07-02T18:04:00.000Z'),
+    });
+
+    assert.equal(initial.delivery.reason, 'first_failure');
+    assert.equal(thresholdChanged.delivery.reason, 'state_changed');
+    assert.equal(reasonChanged.delivery.reason, 'state_changed');
+    assert.equal(relayChanged.delivery.reason, 'state_changed');
+    assert.notEqual(thresholdChanged.fingerprint, initial.fingerprint);
+    assert.notEqual(reasonChanged.fingerprint, thresholdChanged.fingerprint);
+    assert.notEqual(relayChanged.fingerprint, reasonChanged.fingerprint);
+    assert.equal(unchanged.fingerprint, relayChanged.fingerprint);
+    assert.equal(unchanged.delivery.status, 'suppressed');
+    assert.equal(unchanged.delivery.reason, 'unchanged_suppressed');
+    assert.equal(calls.length, 4);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('state schema migration retries a failed delivery once and then suppresses the unresolved incident', async () => {
   const root = tempRoot();
   const calls = [];
   try {
@@ -590,13 +993,15 @@ test('state schema migration redelivers an unchanged failure once', async () => 
       freshnessMonitorImpl: async () => freshnessSummary(),
       fetchImpl: async (url, init) => {
         calls.push({ url, init });
-        return { ok: true, status: 204 };
+        return calls.length === 2
+          ? { ok: false, status: 503 }
+          : { ok: true, status: 204 };
       },
     };
 
     const first = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch(options);
     const state = JSON.parse(readFileSync(path.join(root, 'state.json'), 'utf8'));
-    assert.equal(state.schemaVersion, 'vh-public-feed-alert-state-v2');
+    assert.equal(state.schemaVersion, 'vh-public-feed-alert-state-v3');
     assert.deepEqual(state.sourceStatuses, {
       publisher: 'pass',
       freshness: 'pass',
@@ -606,15 +1011,22 @@ test('state schema migration redelivers an unchanged failure once', async () => 
     });
     writeJson(path.join(root, 'state.json'), {
       ...state,
-      schemaVersion: 'vh-public-feed-alert-state-v1',
+      schemaVersion: 'vh-public-feed-alert-state-v2',
     });
 
     const second = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch(options);
+    const third = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch(options);
+    const fourth = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch(options);
 
     assert.equal(first.fingerprint, second.fingerprint);
-    assert.equal(second.delivery.status, 'sent');
+    assert.equal(second.delivery.status, 'failed');
     assert.equal(second.delivery.reason, 'state_changed');
-    assert.equal(calls.length, 2);
+    assert.equal(second.state.schemaVersion, 'vh-public-feed-alert-state-v3');
+    assert.equal(third.delivery.status, 'sent');
+    assert.equal(third.delivery.reason, 'retry_failed_delivery');
+    assert.equal(fourth.delivery.status, 'suppressed');
+    assert.equal(fourth.delivery.reason, 'unchanged_suppressed');
+    assert.equal(calls.length, 3);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -826,19 +1238,39 @@ test('heartbeat interval can resend an unchanged state', async () => {
   }
 });
 
-test('publisher exit 78 is a fail-close alert and can deliver through sendmail', async () => {
+test('publisher exit 78 email has a readable secret-safe text body and exact safe subject', async () => {
   const root = tempRoot();
   const mail = [];
+  const privateOrigin = 'https://private.example.invalid/feed?token=synthetic-email-token';
+  const privateStoryBody = 'synthetic-private-story-body';
+  const privateSnapshotPath = '/synthetic/private-host/vhc-relay-a/data/news-latest-index-snapshot.json';
   try {
+    const freshness = staleFreshnessSummary({ origin: privateOrigin });
+    freshness.latestIndexReadbacks[0].storyIds = [privateStoryBody];
     const summary = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({
       env: baseEnv(root, {
+        ...writeAuxReports(root, {
+          snapshot: relaySnapshotReport({
+            status: 'fail',
+            blockers: [`${privateSnapshotPath}:newest_entry_stale:30000000/21600000`],
+            snapshots: [{
+              file: privateSnapshotPath,
+              status: 'fail',
+              failures: ['newest_entry_stale:30000000/21600000'],
+              entryCount: 80,
+              cachedAgeMs: 60_000,
+              newestEntryAgeMs: 30_000_000,
+              freshnessFailures: ['newest_entry_stale:30000000/21600000'],
+            }],
+          }),
+        }),
         VH_PUBLIC_FEED_ALERT_EMAIL_TO: 'operator@example.invalid',
         VH_PUBLIC_FEED_ALERT_SENDMAIL: '/usr/sbin/sendmail',
       }),
       repoRoot: root,
       now: Date.parse('2026-07-02T18:00:00.000Z'),
       systemctlShowText: exit78Systemctl(),
-      freshnessMonitorImpl: async () => freshnessSummary(),
+      freshnessMonitorImpl: async () => freshness,
       spawnSyncImpl: (command, args, options) => {
         mail.push({ command, args, input: options.input });
         return { status: 0, stdout: '', stderr: '' };
@@ -853,8 +1285,25 @@ test('publisher exit 78 is a fail-close alert and can deliver through sendmail',
     assert.match(summary.blockers.join('\n'), /publisher_exit_78/);
     assert.equal(summary.delivery.status, 'sent');
     assert.equal(mail.length, 1);
-    assert.match(mail[0].input, /operator@example\.invalid/);
-    assert.match(mail[0].input, /exit_78_fail_closed/);
+    const parsed = parseTextEmail(mail[0].input);
+    assert.equal(parsed.headers.to, 'operator@example.invalid');
+    assert.equal(parsed.headers['mime-version'], '1.0');
+    assert.equal(parsed.headers['content-type'], 'text/plain; charset=utf-8');
+    assert.equal(parsed.headers['content-transfer-encoding'], '8bit');
+    assert.equal(parsed.headers.subject, `[VHC] public feed alert fail ${summary.fingerprint}`);
+    assert.equal(parsed.headers.subject.includes('publisher_exit_78'), false);
+    assert.ok(parsed.body.length > 0);
+
+    const payload = JSON.parse(parsed.body);
+    assert.equal(payload.alertReason, 'first_failure');
+    assert.equal(payload.publisher.failureClass, 'exit_78_fail_closed');
+    assert.equal(payload.blockers.some((blocker) => blocker.startsWith('publisher_exit_78:')), true);
+    assert.equal(parsed.body.includes(privateOrigin), false);
+    assert.equal(parsed.body.includes('private.example.invalid'), false);
+    assert.equal(parsed.body.includes('synthetic-email-token'), false);
+    assert.equal(parsed.body.includes(privateStoryBody), false);
+    assert.equal(parsed.body.includes(privateSnapshotPath), false);
+    assert.equal(parsed.body.includes('/synthetic/private-host'), false);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -893,6 +1342,49 @@ test('publisher exit 69 is a warning transport alert distinct from exit 78', asy
     assert.equal(body.publisher.severity, 'warning');
     assert.equal(body.publisher.recoveryHint, 'bounded_systemd_restart_in_progress');
     assert.equal(JSON.stringify(body).includes('exit_78_fail_closed'), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('publisher exit 78 to restartable exit 69 delivers one failure-class transition', async () => {
+  const root = tempRoot();
+  const calls = [];
+  try {
+    const options = {
+      env: baseEnv(root, { VH_PUBLIC_FEED_ALERT_WEBHOOK_URL: 'https://hooks.example.invalid/token' }),
+      repoRoot: root,
+      freshnessMonitorImpl: async () => freshnessSummary(),
+      fetchImpl: async (url, init) => {
+        calls.push({ url, init });
+        return { ok: true, status: 204 };
+      },
+    };
+    const failClosed = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({
+      ...options,
+      now: Date.parse('2026-07-02T18:00:00.000Z'),
+      systemctlShowText: exit78Systemctl(),
+    });
+    const restartable = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({
+      ...options,
+      now: Date.parse('2026-07-02T18:01:00.000Z'),
+      systemctlShowText: exit69Systemctl({ nRestarts: 0 }),
+    });
+    const unchanged = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({
+      ...options,
+      now: Date.parse('2026-07-02T18:02:00.000Z'),
+      systemctlShowText: exit69Systemctl({ nRestarts: 0 }),
+    });
+
+    assert.equal(failClosed.publisher.failureClass, 'exit_78_fail_closed');
+    assert.equal(restartable.publisher.failureClass, 'exit_69_transport_unavailable');
+    assert.notEqual(restartable.fingerprint, failClosed.fingerprint);
+    assert.equal(restartable.delivery.status, 'sent');
+    assert.equal(restartable.delivery.reason, 'state_changed');
+    assert.equal(unchanged.fingerprint, restartable.fingerprint);
+    assert.equal(unchanged.delivery.status, 'suppressed');
+    assert.equal(unchanged.delivery.reason, 'unchanged_suppressed');
+    assert.equal(calls.length, 2);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -980,7 +1472,7 @@ test('publisher exit 75 wrapper refusal is critical', async () => {
   }
 });
 
-test('publisher recovery after parked exit 69 sends a state-changed pass alert', async () => {
+test('failed publisher recovery delivery retries on the next unchanged pass and then suppresses', async () => {
   const root = tempRoot();
   const calls = [];
   try {
@@ -990,7 +1482,9 @@ test('publisher recovery after parked exit 69 sends a state-changed pass alert',
       freshnessMonitorImpl: async () => freshnessSummary(),
       fetchImpl: async (url, init) => {
         calls.push({ url, init });
-        return { ok: true, status: 204 };
+        return calls.length === 2
+          ? { ok: false, status: 503 }
+          : { ok: true, status: 204 };
       },
     };
     const first = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({
@@ -1003,17 +1497,33 @@ test('publisher recovery after parked exit 69 sends a state-changed pass alert',
       now: Date.parse('2026-07-02T18:05:00.000Z'),
       systemctlShowText: activeSystemctl(),
     });
+    const third = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({
+      ...options,
+      now: Date.parse('2026-07-02T18:06:00.000Z'),
+      systemctlShowText: activeSystemctl(),
+    });
+    const fourth = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({
+      ...options,
+      now: Date.parse('2026-07-02T18:07:00.000Z'),
+      systemctlShowText: activeSystemctl(),
+    });
 
     assert.equal(first.status, 'fail');
     assert.equal(first.publisher.failureClass, 'exit_69_start_limit_parked');
-    assert.equal(second.status, 'pass');
     assert.equal(second.observedStatus, 'pass');
     assert.equal(second.publisher.failureClass, 'none');
     assert.equal(second.publisher.severity, 'none');
     assert.equal(second.publisher.recoveryHint, 'none');
-    assert.equal(second.delivery.status, 'sent');
+    assert.equal(second.delivery.status, 'failed');
     assert.equal(second.delivery.reason, 'state_changed');
-    assert.equal(calls.length, 2);
+    assert.equal(third.status, 'pass');
+    assert.equal(third.observedStatus, 'pass');
+    assert.equal(third.fingerprint, second.fingerprint);
+    assert.equal(third.delivery.status, 'sent');
+    assert.equal(third.delivery.reason, 'retry_failed_delivery');
+    assert.equal(fourth.delivery.status, 'suppressed');
+    assert.equal(fourth.delivery.reason, 'unchanged_suppressed');
+    assert.equal(calls.length, 3);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/tools/scripts/public-feed-alert-watch.test.mjs
+++ b/tools/scripts/public-feed-alert-watch.test.mjs
@@ -268,8 +268,26 @@ function semanticFingerprintInput() {
       blockers: ['latest_index_not_fresh:url_hash:0123456789abcdef:latest_index_stale:30000000/21600000'],
       originHashes: ['source-b', 'source-a'],
       latestIndexReadbacks: [
-        { originHash: 'source-b', status: 'fail', newestAgeMs: 30_000_000, maxAgeMs: 21_600_000, recordCount: 80, failureCount: 8 },
-        { originHash: 'source-a', status: 'pass', newestAgeMs: 120_000, maxAgeMs: 21_600_000, recordCount: 79, failureCount: 0 },
+        {
+          originHash: 'source-b',
+          status: 'fail',
+          newestAgeMs: 30_000_000,
+          maxAgeMs: 21_600_000,
+          recordCount: 80,
+          failureCount: 8,
+          failureReasonCodes: ['latest_index_stale'],
+          failureDiagnostics: ['latest_index_stale:30000000/21600000'],
+        },
+        {
+          originHash: 'source-a',
+          status: 'pass',
+          newestAgeMs: 120_000,
+          maxAgeMs: 21_600_000,
+          recordCount: 79,
+          failureCount: 0,
+          failureReasonCodes: [],
+          failureDiagnostics: [],
+        },
       ],
     },
     relayLiveness: {
@@ -326,6 +344,13 @@ test('semantic fingerprint ignores volatile values and ordering but preserves re
   volatileDrift.freshness.latestIndexReadbacks[1].newestAgeMs = 30_300_000;
   volatileDrift.freshness.latestIndexReadbacks[1].recordCount = 99;
   volatileDrift.freshness.latestIndexReadbacks[1].failureCount = 9;
+  volatileDrift.freshness.latestIndexReadbacks[1].failureReasonCodes = [
+    'latest_index_stale',
+    'latest_index_stale',
+  ];
+  volatileDrift.freshness.latestIndexReadbacks[1].failureDiagnostics = [
+    'latest_index_stale:30300000/21600000',
+  ];
   volatileDrift.relayLiveness.relays.reverse();
   volatileDrift.relayLiveness.relays.push(structuredClone(volatileDrift.relayLiveness.relays[0]));
   volatileDrift.relayLiveness.relays[1].blockerCount = 9;
@@ -363,22 +388,31 @@ test('semantic fingerprint ignores volatile values and ordering but preserves re
 
   const compositeReasonChanged = structuredClone(baseline);
   compositeReasonChanged.blockers = [
-    'public_feed:latest_index_not_fresh:url_hash:0123456789abcdef:latest_index_empty|latest_index_timestamp_missing',
+    'public_feed:latest_index_not_fresh:url_hash:1111111111111111',
     'watch_closure:archive_sample_failures:8',
   ];
   compositeReasonChanged.freshness.blockers = [
-    'latest_index_not_fresh:url_hash:0123456789abcdef:latest_index_empty|latest_index_timestamp_missing',
+    'latest_index_not_fresh:url_hash:1111111111111111',
+  ];
+  compositeReasonChanged.freshness.latestIndexReadbacks[0].failureReasonCodes = [
+    'latest_index_empty',
+    'latest_index_timestamp_missing',
   ];
   const compositeFingerprint = publicFeedAlertWatchInternal.fingerprintFor(compositeReasonChanged);
   assert.notEqual(compositeFingerprint, fingerprint);
 
   const compositeReasonReordered = structuredClone(compositeReasonChanged);
   compositeReasonReordered.blockers = [
-    'public_feed:latest_index_not_fresh:url_hash:0123456789abcdef:latest_index_timestamp_missing|latest_index_empty|latest_index_empty',
+    'public_feed:latest_index_not_fresh:url_hash:2222222222222222',
     'watch_closure:archive_sample_failures:8',
   ];
   compositeReasonReordered.freshness.blockers = [
-    'latest_index_not_fresh:url_hash:0123456789abcdef:latest_index_timestamp_missing|latest_index_empty|latest_index_empty',
+    'latest_index_not_fresh:url_hash:2222222222222222',
+  ];
+  compositeReasonReordered.freshness.latestIndexReadbacks[0].failureReasonCodes = [
+    'latest_index_timestamp_missing',
+    'latest_index_empty',
+    'latest_index_empty',
   ];
   assert.equal(publicFeedAlertWatchInternal.fingerprintFor(compositeReasonReordered), compositeFingerprint);
 
@@ -1291,10 +1325,9 @@ test('adversarial configured origin stays fully redacted across webhook and emai
     ];
     for (const [index, payload] of webhookPayloads.entries()) {
       const freshnessBlocker = payload.freshness.blockers[0];
-      const blockerHash = freshnessBlocker.match(/url_hash:([0-9a-f]{16}):/)?.[1];
-      assert.equal(blockerHash, payload.freshness.originHashes[0]);
-      assert.equal(blockerHash, payload.freshness.latestIndexReadbacks[0].originHash);
+      assert.match(freshnessBlocker, /^latest_index_not_fresh:url_hash:[0-9a-f]{16}$/);
       assert.deepEqual(payload.freshness.latestIndexReadbacks[0].failureReasonCodes, expectedReasonSets[index]);
+      assert.deepEqual(payload.freshness.latestIndexReadbacks[0].failureDiagnostics, expectedReasonSets[index]);
       assert.deepEqual(emailPayloads[index], payload);
     }
 
@@ -1309,6 +1342,105 @@ test('adversarial configured origin stays fully redacted across webhook and emai
       'private.example.invalid',
       'prefix:api_key',
       'sk-proj-SYNTHETIC-NOT-A-REAL-KEY',
+    ];
+    for (const output of serializedOutputs) {
+      for (const fragment of forbiddenFragments) {
+        assert.equal(output.includes(fragment), false, `alert output leaked synthetic fragment: ${fragment}`);
+      }
+    }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('configured base origin cannot prefix-redact a longer failure URL across alert outputs', async () => {
+  const root = tempRoot();
+  const calls = [];
+  const mail = [];
+  const origin = 'https://private.example.invalid/';
+  const failureUrl = [
+    origin,
+    'private/feed?token=prefix:api_key|sk-proj-SYNTHETIC-OVERLAP-NOT-A-REAL-KEY',
+  ].join('');
+  const failure = `latest_index_fetch_failed:http_status=429 attempt=3 ${failureUrl}`;
+  const privateStoryBody = 'synthetic-overlap-private-story-body';
+  try {
+    const summary = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({
+      env: baseEnv(root, {
+        VH_PUBLIC_FEED_ALERT_WEBHOOK_URL: 'https://hooks.example.invalid/token',
+        VH_PUBLIC_FEED_ALERT_EMAIL_TO: 'operator@example.invalid',
+        VH_PUBLIC_FEED_ALERT_SENDMAIL: '/usr/sbin/sendmail',
+      }),
+      repoRoot: root,
+      now: Date.parse('2026-07-02T18:00:00.000Z'),
+      systemctlShowText: activeSystemctl(),
+      freshnessMonitorImpl: async () => freshnessSummary({
+        status: 'fail',
+        blockers: [`latest_index_not_fresh:${origin}:${failure}`],
+        config: { origins: [origin], maxAgeMs: 21_600_000 },
+        latestIndexReadbacks: [{
+          origin,
+          status: 'fail',
+          recordCount: 0,
+          newestAgeMs: null,
+          maxAgeMs: 21_600_000,
+          failures: [failure],
+          storyIds: [privateStoryBody],
+        }],
+      }),
+      fetchImpl: async (url, init) => {
+        calls.push({ url, init });
+        return { ok: true, status: 204 };
+      },
+      spawnSyncImpl: (command, args, spawnOptions) => {
+        mail.push({ command, args, input: spawnOptions.input });
+        return { status: 0, stdout: '', stderr: '' };
+      },
+    });
+
+    assert.equal(summary.delivery.status, 'sent');
+    assert.equal(calls.length, 1);
+    assert.equal(mail.length, 1);
+    assert.deepEqual(summary.freshness.latestIndexReadbacks[0].failureReasonCodes, [
+      'latest_index_fetch_failed',
+    ]);
+    assert.match(
+      summary.freshness.latestIndexReadbacks[0].failureDiagnostics[0],
+      /^latest_index_fetch_failed:http_status=429 attempt=3 url_hash:[0-9a-f]{16}$/,
+    );
+    assert.equal(summary.freshness.latestIndexReadbacks[0].recordCount, 0);
+    assert.equal(summary.freshness.latestIndexReadbacks[0].newestAgeMs, null);
+    assert.equal(summary.freshness.latestIndexReadbacks[0].maxAgeMs, 21_600_000);
+
+    const webhookPayload = JSON.parse(calls[0].init.body);
+    const parsedEmail = parseTextEmail(mail[0].input);
+    assert.equal(parsedEmail.headers['mime-version'], '1.0');
+    assert.equal(parsedEmail.headers['content-type'], 'text/plain; charset=utf-8');
+    assert.deepEqual(JSON.parse(parsedEmail.body), webhookPayload);
+    const consoleOutput = JSON.stringify({
+      status: summary.status,
+      observedStatus: summary.observedStatus,
+      severity: summary.severity,
+      blockers: summary.blockers,
+      fingerprint: summary.fingerprint,
+      delivery: summary.delivery,
+      outputFile: summary.outputFile,
+    });
+    const serializedOutputs = [
+      JSON.stringify(summary),
+      calls[0].init.body,
+      mail[0].input,
+      readFileSync(path.join(root, 'latest.json'), 'utf8'),
+      consoleOutput,
+    ];
+    const forbiddenFragments = [
+      origin,
+      failureUrl,
+      'private.example.invalid',
+      'private/feed?token=',
+      'prefix:api_key',
+      'sk-proj-SYNTHETIC-OVERLAP-NOT-A-REAL-KEY',
+      privateStoryBody,
     ];
     for (const output of serializedOutputs) {
       for (const fragment of forbiddenFragments) {

--- a/tools/scripts/public-feed-alert-watch.test.mjs
+++ b/tools/scripts/public-feed-alert-watch.test.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
 import { createHmac } from 'node:crypto';
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
@@ -386,8 +387,8 @@ test('semantic fingerprint ignores volatile values and ordering but preserves re
   assert.notEqual(publicFeedAlertWatchInternal.fingerprintFor(thresholdChanged), fingerprint);
 
   const blockerReasonChanged = structuredClone(baseline);
-  blockerReasonChanged.watchClosure.blockers = ['watch_closure:runtime_failed_ticks:8'];
-  blockerReasonChanged.watchClosure.thresholds.twentyFourHour.blockers = ['runtime_failed_ticks:8'];
+  blockerReasonChanged.watchClosure.blockers = ['watch_closure_runtime_failed_ticks:8'];
+  blockerReasonChanged.watchClosure.thresholds.twentyFourHour.blockers = ['watch_closure_runtime_failed_ticks:8'];
   assert.notEqual(publicFeedAlertWatchInternal.fingerprintFor(blockerReasonChanged), fingerprint);
 
   const compositeReasonChanged = structuredClone(baseline);
@@ -525,11 +526,12 @@ test('relay liveness failures page through the existing alert delivery path', as
 
     assert.equal(summary.status, 'fail');
     assert.equal(summary.severity, 'critical');
-    assert.match(summary.blockers.join('\n'), /relay_liveness:vhc-relay-b:readyz_failed/);
+    assert.match(summary.blockers.join('\n'), /relay_liveness:readyz_failed/);
     assert.equal(summary.delivery.status, 'sent');
     const body = JSON.parse(calls[0].init.body);
     assert.equal(body.relayLiveness.status, 'fail');
-    assert.equal(body.relayLiveness.relays[0].name, 'vhc-relay-b');
+    assert.equal(body.relayLiveness.relays[0].name, undefined);
+    assert.equal(body.relayLiveness.relays[0].identityHash.length, 16);
     assert.equal(body.relayLiveness.relays[0].origin, undefined);
     assert.equal(calls[0].init.headers['x-vhc-alert-signature'], undefined);
     assert.equal(JSON.stringify(body).includes('127.0.0.1'), false);
@@ -615,11 +617,13 @@ test('relay snapshot failures redact absolute snapshot paths', async () => {
     assert.equal(summary.severity, 'warning');
     assert.equal(summary.relaySnapshot.status, 'fail');
     assert.equal(summary.relaySnapshot.severity, 'warning');
-    assert.match(summary.blockers.join('\n'), /snapshot_file_hash:/);
+    assert.match(summary.blockers.join('\n'), /relay_snapshot:newest_entry_stale/);
+    assert.equal(summary.relaySnapshot.snapshots[0].ordinal, 1);
     assert.equal(JSON.stringify(summary).includes(snapshotPath), false);
     const body = JSON.parse(calls[0].init.body);
-    assert.equal(body.relaySnapshot.snapshots[0].fileHash.length, 16);
-    assert.equal(body.relaySnapshot.snapshots[0].relay, 'vhc-relay-a');
+    assert.equal(body.relaySnapshot.snapshots[0].ordinal, 1);
+    assert.equal(body.relaySnapshot.snapshots[0].relay, undefined);
+    assert.equal(body.relaySnapshot.snapshots[0].relayIdentityHash.length, 16);
     assert.equal(JSON.stringify(body).includes('/home/humble'), false);
   } finally {
     rmSync(root, { recursive: true, force: true });
@@ -659,7 +663,7 @@ test('stale auxiliary report output is warning severity and dedupes across age d
     assert.equal(first.status, 'fail');
     assert.equal(first.severity, 'warning');
     assert.equal(first.relayLiveness.severity, 'warning');
-    assert.match(first.blockers.join('\n'), /relay_liveness_output_stale:/);
+    assert.match(first.blockers.join('\n'), /relay_liveness:output_stale:/);
     assert.equal(second.fingerprint, first.fingerprint);
     assert.equal(second.delivery.status, 'suppressed');
     assert.equal(calls.length, 1);
@@ -793,14 +797,14 @@ test('volatile progress suppresses repeats while latest and heartbeat payloads r
     assert.equal(latest.relayLiveness.relays[0].watchdogTrips, 10);
     assert.equal(latest.relaySnapshot.snapshots[0].entryCount, 100);
     assert.equal(latest.relaySnapshot.snapshots[0].failureCount, 10);
-    assert.deepEqual(latest.watchClosure.thresholds.fortyEightHour.blockers, ['window_short:34.09/48']);
-    assert.deepEqual(latest.watchClosure.thresholds.twentyFourHour.blockers, ['archive_sample_failures:10']);
+    assert.deepEqual(latest.watchClosure.thresholds.fortyEightHour.blockers, ['watch_closure:window_short:34.09/48']);
+    assert.deepEqual(latest.watchClosure.thresholds.twentyFourHour.blockers, ['watch_closure:archive_sample_failures:10']);
 
     const heartbeatPayload = JSON.parse(calls[1].init.body);
     assert.equal(heartbeatPayload.freshness.latestIndexReadbacks[0].newestAgeMs, 30_660_000);
     assert.equal(heartbeatPayload.relayLiveness.relays[0].restartCount, 10);
     assert.equal(heartbeatPayload.relaySnapshot.snapshots[0].failureCount, 10);
-    assert.deepEqual(heartbeatPayload.watchClosure.thresholds.fortyEightHour.blockers, ['window_short:34.09/48']);
+    assert.deepEqual(heartbeatPayload.watchClosure.thresholds.fortyEightHour.blockers, ['watch_closure:window_short:34.09/48']);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -857,7 +861,8 @@ test('watch-closure fail verdict pages as warning with threshold provenance', as
     assert.equal(body.severity, 'warning');
     assert.equal(body.watchClosure.thresholds.fortyEightHour.status, 'fail');
     assert.equal(body.watchClosure.relayMemory.heapPlateauVerdict, 'heap_still_linear');
-    assert.equal(body.watchClosure.relayMemory.relays[0].name, 'vhc-relay-c');
+    assert.equal(body.watchClosure.relayMemory.relays[0].name, undefined);
+    assert.equal(body.watchClosure.relayMemory.relays[0].identityHash.length, 16);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -900,10 +905,9 @@ test('watch-closure default heap limit provenance pages as warning', async () =>
     assert.equal(summary.status, 'fail');
     assert.equal(summary.severity, 'warning');
     assert.equal(summary.watchClosure.severity, 'warning');
-    assert.match(summary.blockers.join('\n'), /watch_closure_heap_limit_source_default:aggregate/);
-    assert.match(summary.blockers.join('\n'), /watch_closure_heap_limit_source_default:vhc-relay-a/);
-    assert.equal(summary.watchClosure.relayMemory.heapLimitSource, 'default:public-beta-compose');
-    assert.equal(summary.watchClosure.relayMemory.relays[0].heapLimitSource, 'default:public-beta-compose:relay-a');
+    assert.deepEqual(summary.blockers, ['watch_closure:heap_limit_source_default']);
+    assert.equal(summary.watchClosure.relayMemory.heapLimitSourceClass, 'default');
+    assert.equal(summary.watchClosure.relayMemory.relays[0].heapLimitSourceClass, 'default');
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -1101,9 +1105,9 @@ test('missing required auxiliary reports fail closed before alert timer enableme
     assert.equal(summary.status, 'fail');
     assert.equal(summary.severity, 'critical');
     assert.deepEqual(summary.blockers.filter((blocker) => blocker.endsWith('_missing')).sort(), [
-      'relay_liveness_report_missing',
-      'relay_snapshot_report_missing',
-      'watch_closure_verdict_missing',
+      'relay_liveness:report_missing',
+      'relay_snapshot:report_missing',
+      'watch_closure:verdict_missing',
     ]);
   } finally {
     rmSync(root, { recursive: true, force: true });
@@ -1162,7 +1166,9 @@ test('stale feed sends a webhook on state change with secret-safe aggregate payl
     assert.equal(body.severity, 'critical');
     assert.equal(body.blockers.includes('public_feed:latest_index_not_fresh'), true);
     assert.equal(body.freshness.latestIndexReadbacks[0].origin, undefined);
-    assert.equal(body.freshness.latestIndexReadbacks[0].originHash.length, 16);
+    assert.equal(body.freshness.latestIndexReadbacks[0].ordinal, 1);
+    assert.equal(body.freshness.latestIndexReadbacks[0].endpointHash.length, 16);
+    assert.equal(body.freshness.originEndpointHashes.length, 2);
     assert.equal(JSON.stringify(body).includes('story-body-not-copied'), false);
     assert.equal(JSON.stringify(body).includes('venn.carboncaste.io'), false);
     assert.equal(JSON.stringify(body).includes('secret-path'), false);
@@ -1389,7 +1395,7 @@ test('structured failure projections exclude arbitrary detail across every alert
     `punctuation="{${punctuationValue}}";`,
     `url=${failureUrl}`,
   ].join(' ');
-  const staleFailure = `latest_index_stale:30000000/21600000 token=${nonUrlToken}`;
+  const staleFailure = 'latest_index_stale:30000000/21600000';
   const unknownFailure = `${unknownReasonCode}:count=7 private_value=${privateValue}`;
   const secretOnlyFetchFailure = [
     'latest_index_fetch_failed:attempt=3 http_status=429',
@@ -1398,7 +1404,7 @@ test('structured failure projections exclude arbitrary detail across every alert
     `host_env={CHANGED_${hostEnvValue}}`,
     `url=${failureUrl}&secret_only=${secretOnlyToken}`,
   ].join(' ');
-  const secretOnlyStaleFailure = `latest_index_stale:30000000/21600000 token=${secretOnlyToken}`;
+  const secretOnlyStaleFailure = 'latest_index_stale:30000000/21600000';
   const secretOnlyUnknownFailure = `different_private_reason_20260710:count=7 token=${secretOnlyToken}`;
   const driftFetchFailure = [
     'latest_index_fetch_failed:attempt=4 http_status=503',
@@ -1407,7 +1413,7 @@ test('structured failure projections exclude arbitrary detail across every alert
     `host_env=[${hostEnvValue}]`,
     `url=${failureUrl}`,
   ].join(' ');
-  const driftStaleFailure = `latest_index_stale:30300000/21600000 token=${driftToken}`;
+  const driftStaleFailure = 'latest_index_stale:30300000/21600000';
   const driftUnknownFailure = `${driftUnknownReasonCode}:count=8 host_env=${hostEnvValue}`;
   let failures = [fetchFailure, unknownFailure, staleFailure, fetchFailure];
   let newestAgeMs = 30_000_000;
@@ -1485,7 +1491,7 @@ test('structured failure projections exclude arbitrary detail across every alert
     const expectedFirstDiagnostics = [
       {
         reasonCode: 'latest_index_fetch_failed',
-        numericDiagnostics: { attempt: [3], httpStatus: [429] },
+        numericDiagnostics: {},
       },
       {
         reasonCode: 'latest_index_stale',
@@ -1493,7 +1499,7 @@ test('structured failure projections exclude arbitrary detail across every alert
       },
       {
         reasonCode: 'unclassified_failure',
-        numericDiagnostics: { count: [7] },
+        numericDiagnostics: {},
       },
     ];
     assert.deepEqual(first.freshness.latestIndexReadbacks[0].failureDiagnostics, expectedFirstDiagnostics);
@@ -1503,7 +1509,7 @@ test('structured failure projections exclude arbitrary detail across every alert
     assert.deepEqual(numericDrift.freshness.latestIndexReadbacks[0].failureDiagnostics, [
       {
         reasonCode: 'latest_index_fetch_failed',
-        numericDiagnostics: { attempt: [4], httpStatus: [503] },
+        numericDiagnostics: {},
       },
       {
         reasonCode: 'latest_index_stale',
@@ -1511,7 +1517,7 @@ test('structured failure projections exclude arbitrary detail across every alert
       },
       {
         reasonCode: 'unclassified_failure',
-        numericDiagnostics: { count: [8] },
+        numericDiagnostics: {},
       },
     ]);
     assert.equal(numericDrift.freshness.latestIndexReadbacks[0].recordCount, 0);
@@ -1530,7 +1536,7 @@ test('structured failure projections exclude arbitrary detail across every alert
       blockers: summary.blockers,
       fingerprint: summary.fingerprint,
       delivery: summary.delivery,
-      outputFile: summary.outputFile,
+      outputFileRole: summary.outputFileRole,
     });
     const serializedOutputs = [
       JSON.stringify([first, reordered, secretOnlyDrift, numericDrift]),
@@ -1744,7 +1750,7 @@ test('publisher exit 78 email has a readable secret-safe text body and exact saf
     const payload = JSON.parse(parsed.body);
     assert.equal(payload.alertReason, 'first_failure');
     assert.equal(payload.publisher.failureClass, 'exit_78_fail_closed');
-    assert.equal(payload.blockers.some((blocker) => blocker.startsWith('publisher_exit_78:')), true);
+    assert.equal(payload.blockers.includes('publisher_exit_78'), true);
     assert.equal(parsed.body.includes(privateOrigin), false);
     assert.equal(parsed.body.includes('private.example.invalid'), false);
     assert.equal(parsed.body.includes('synthetic-email-token'), false);
@@ -1777,7 +1783,7 @@ test('publisher exit 69 is a warning transport alert distinct from exit 78', asy
     assert.equal(summary.publisher.failureClass, 'exit_69_transport_unavailable');
     assert.equal(summary.publisher.severity, 'warning');
     assert.equal(summary.publisher.recoveryHint, 'bounded_systemd_restart_in_progress');
-    assert.match(summary.blockers.join('\n'), /publisher_exit_69_transport_unavailable:activating\/auto-restart/);
+    assert.match(summary.blockers.join('\n'), /publisher_exit_69_transport_unavailable/);
     assert.doesNotMatch(summary.blockers.join('\n'), /publisher_exit_78/);
     assert.equal(summary.delivery.status, 'sent');
     assert.equal(summary.delivery.reason, 'first_failure');
@@ -1863,7 +1869,7 @@ test('publisher exit 69 parked by start limit is critical and not self-recoverin
     assert.equal(summary.publisher.failureClass, 'exit_69_start_limit_parked');
     assert.equal(summary.publisher.severity, 'critical');
     assert.equal(summary.publisher.recoveryHint, 'start_limit_exhausted_operator_restart_required');
-    assert.match(summary.blockers.join('\n'), /publisher_exit_69_start_limit_parked:failed\/failed:start-limit-hit/);
+    assert.match(summary.blockers.join('\n'), /publisher_exit_69_start_limit_parked/);
     assert.doesNotMatch(summary.blockers.join('\n'), /publisher_exit_78/);
     assert.equal(summary.delivery.status, 'sent');
     assert.equal(calls.length, 1);
@@ -1912,7 +1918,7 @@ test('publisher exit 75 wrapper refusal is critical', async () => {
     assert.equal(summary.publisher.failureClass, 'exit_75_wrapper_refusal');
     assert.equal(summary.publisher.severity, 'critical');
     assert.equal(summary.publisher.recoveryHint, 'operator_required');
-    assert.match(summary.blockers.join('\n'), /publisher_exit_75_wrapper_refusal:failed\/failed:exit-code/);
+    assert.match(summary.blockers.join('\n'), /publisher_exit_75_wrapper_refusal/);
     assert.equal(summary.delivery.status, 'sent');
   } finally {
     rmSync(root, { recursive: true, force: true });
@@ -2062,7 +2068,7 @@ test('webhook delivery errors redact configured webhook URL from output', async 
 
     assert.equal(summary.status, 'fail');
     assert.equal(summary.delivery.status, 'failed');
-    assert.match(summary.delivery.error, /value_hash:/);
+    assert.equal(summary.delivery.error, 'webhook_network');
     assert.equal(summary.delivery.error.includes(webhookUrl), false);
 
     const output = readFileSync(path.join(root, 'latest.json'), 'utf8');
@@ -2124,5 +2130,777 @@ test('alert output and state files are persisted for operator inspection', async
     assert.equal(state.lastDeliveredFingerprint, summary.fingerprint);
   } finally {
     rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('same-time freshness secret drift leaves every v2 public projection identical', async () => {
+  const root = tempRoot();
+  const now = Date.parse('2026-07-02T18:00:00.000Z');
+  const runVariant = async (secret) => {
+    rmSync(root, { recursive: true, force: true });
+    mkdirSync(root, { recursive: true });
+    const calls = [];
+    const mail = [];
+    const origins = [
+      `https://user:${secret}@alpha.example.invalid/feed?token=${secret}#${secret}`,
+      `https://user:${secret}@beta.example.invalid/private?token=${secret}#${secret}`,
+    ];
+    const fetchFailure = `latest_index_fetch_failed:attempt=69${secret}&count=15000${secret}&http=503${secret} url=${origins[0]}&attempt=777&count=88 ${secret}`;
+    const readbacks = [
+      {
+        origin: origins[0],
+        status: 'fail',
+        recordCount: 0,
+        newestAgeMs: 30_000_000,
+        maxAgeMs: 21_600_000,
+        failures: [fetchFailure, 'latest_index_stale:30000000/21600000'],
+        storyIds: [`story-${secret}`],
+      },
+      {
+        origin: origins[1],
+        status: 'pass',
+        recordCount: 80,
+        newestAgeMs: 120_000,
+        maxAgeMs: 21_600_000,
+        failures: [],
+        storyIds: [`story-pass-${secret}`],
+      },
+    ];
+    if (secret.includes('_B_')) {
+      origins.reverse();
+      readbacks.reverse();
+    }
+    const summary = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({
+      env: baseEnv(root, {
+        VH_PUBLIC_FEED_ALERT_WEBHOOK_URL: 'https://hooks.example.invalid/token',
+        VH_PUBLIC_FEED_ALERT_EMAIL_TO: 'operator@example.invalid',
+      }),
+      repoRoot: root,
+      now,
+      systemctlShowText: activeSystemctl(),
+      freshnessMonitorImpl: async () => freshnessSummary({
+        status: 'fail',
+        blockers: [`latest_index_not_fresh:${readbacks.find((entry) => entry.status === 'fail').origin}:${fetchFailure}`],
+        config: { origins, maxAgeMs: 21_600_000 },
+        latestIndexReadbacks: readbacks,
+      }),
+      fetchImpl: async (url, init) => {
+        calls.push({ url, init });
+        return { ok: true, status: 204 };
+      },
+      spawnSyncImpl: (command, args, options) => {
+        mail.push(options.input);
+        return { status: 0, stdout: '', stderr: '' };
+      },
+    });
+    const parsedMail = parseTextEmail(mail[0]);
+    return {
+      summary,
+      webhook: JSON.parse(calls[0].init.body),
+      mime: { subject: parsedMail.headers.subject, payload: JSON.parse(parsedMail.body) },
+      latest: JSON.parse(readFileSync(path.join(root, 'latest.json'), 'utf8')),
+      console: publicFeedAlertWatchInternal.alertConsoleProjection(summary),
+    };
+  };
+
+  try {
+    const baseline = await runVariant('SYNTHETIC_SECRET_A_20260710');
+    const drift = await runVariant('SYNTHETIC_SECRET_B_20260710');
+    assert.deepEqual(drift, baseline);
+    assert.equal(baseline.summary.schemaVersion, 'vh-public-feed-alert-watch-v2');
+    assert.equal(baseline.summary.stateFile, undefined);
+    assert.equal(baseline.summary.outputFile, undefined);
+    assert.equal(baseline.summary.stateFileRole, 'state');
+    assert.equal(baseline.summary.outputFileRole, 'latest');
+    assert.equal(baseline.summary.freshness.originCount, 2);
+    assert.equal(baseline.summary.freshness.originEndpointHashes.length, 2);
+    const failedReadback = baseline.summary.freshness.latestIndexReadbacks.find((entry) => entry.status === 'fail');
+    assert.deepEqual(failedReadback.failureDiagnostics, [
+      { reasonCode: 'latest_index_fetch_failed', numericDiagnostics: {} },
+      {
+        reasonCode: 'latest_index_stale',
+        numericDiagnostics: { maxAgeMs: [21_600_000], newestAgeMs: [30_000_000] },
+      },
+    ]);
+    const serialized = JSON.stringify(baseline);
+    assert.equal(serialized.includes('SYNTHETIC_SECRET_A_20260710'), false);
+    assert.equal(serialized.includes('private.example.invalid'), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('same-time auxiliary report detail drift leaves every public projection identical', async (t) => {
+  const now = Date.parse('2026-07-02T18:00:00.000Z');
+  const rows = [
+    {
+      name: 'relay liveness detail',
+      configure(root, secret) {
+        return writeAuxReports(root, {
+          relay: relayLivenessReport({
+            status: 'fail',
+            blockers: [`vhc-relay-a:readyz_failed:${secret}`],
+            relays: [{
+              name: 'vhc-relay-a',
+              status: 'fail',
+              blockers: [
+                `readyz_failed:${secret}`,
+                `metrics_failed:${secret}`,
+                `docker_inspect_failed:${secret}`,
+                'readyz_unhealthy:503',
+                'metrics_unhealthy:502',
+                'restart_count_increased:1/2',
+                'event_loop_lag_hot:2.5e3/3e3',
+              ],
+              docker: { restartCount: 2 },
+              metrics: {
+                rssBytes: 420_000_000,
+                heapUsedBytes: 320_000_000,
+                watchdogTrips: 1,
+                eventLoopLagP99Ms: 2_500,
+                criticalReadbacksQueued: 0,
+              },
+            }],
+          }),
+        });
+      },
+    },
+    {
+      name: 'snapshot detail',
+      configure(root, secret) {
+        const snapshotPath = `/synthetic/${secret}/vhc-relay-a/data/news-latest-index-snapshot.json`;
+        return writeAuxReports(root, {
+          snapshot: relaySnapshotReport({
+            status: 'fail',
+            blockers: [`${snapshotPath}:snapshot_parse_failed:${secret}`],
+            snapshots: [{
+              file: snapshotPath,
+              status: 'fail',
+              failures: [
+                `snapshot_parse_failed:${secret}`,
+                `schema_mismatch:${secret}`,
+                'snapshot_size_not_sane:123',
+                'entry_count_mismatch:79/80',
+                'newest_entry_stale:30000000/21600000',
+              ],
+              entryCount: 79,
+              cachedAgeMs: 60_000,
+              newestEntryAgeMs: 30_000_000,
+              freshnessFailures: ['newest_entry_stale:30000000/21600000'],
+            }],
+          }),
+        });
+      },
+    },
+    {
+      name: 'watch closure detail',
+      configure(root, secret) {
+        return writeAuxReports(root, {
+          closure: watchClosureVerdict({
+            status: 'fail',
+            severity: secret,
+            blockers: [
+              `archive_sample_failures:8 ${secret}`,
+              `private_reason_${secret}:token=${secret}`,
+              'window_short:33.49/48',
+            ],
+            window: {
+              startAt: '2026-07-02T08:00:00.000Z',
+              cleanStartAt: '2026-07-02T08:00:00.000Z',
+              hoursObserved: 33.49,
+              privateDetail: secret,
+            },
+            thresholds: {
+              twentyFourHour: { status: 'fail', blockers: [`runtime_failed_ticks:8 ${secret}`] },
+              fortyEightHour: { status: 'not_ready', blockers: ['window_short:33.49/48'] },
+            },
+            relayMemory: {
+              status: 'warn',
+              heapPlateauVerdict: 'heap_plateau_observed',
+              heapLimitSource: `default:${secret}`,
+              rssLimitSource: `configured:${secret}`,
+              relays: [{
+                name: 'vhc-relay-a',
+                trendStatus: 'warn',
+                heapPlateauVerdict: 'heap_plateau_observed',
+                heapLimitSource: `default:${secret}`,
+                shortestProjectedLimitHours: 72,
+              }],
+            },
+          }),
+        });
+      },
+    },
+  ];
+
+  for (const row of rows) {
+    await t.test(row.name, async () => {
+      const root = tempRoot();
+      const runVariant = async (secret) => {
+        rmSync(root, { recursive: true, force: true });
+        mkdirSync(root, { recursive: true });
+        const calls = [];
+        const mail = [];
+        const env = baseEnv(root, {
+          ...row.configure(root, secret),
+          VH_PUBLIC_FEED_ALERT_WEBHOOK_URL: 'https://hooks.example.invalid/token',
+          VH_PUBLIC_FEED_ALERT_EMAIL_TO: 'operator@example.invalid',
+        });
+        const summary = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({
+          env,
+          repoRoot: root,
+          now,
+          systemctlShowText: activeSystemctl(),
+          freshnessMonitorImpl: async () => freshnessSummary(),
+          fetchImpl: async (url, init) => {
+            calls.push({ url, init });
+            return { ok: true, status: 204 };
+          },
+          spawnSyncImpl: (command, args, options) => {
+            mail.push(options.input);
+            return { status: 0, stdout: '', stderr: '' };
+          },
+        });
+        const parsedMail = parseTextEmail(mail[0]);
+        return {
+          summary,
+          webhook: JSON.parse(calls[0].init.body),
+          mime: { subject: parsedMail.headers.subject, payload: JSON.parse(parsedMail.body) },
+          latest: JSON.parse(readFileSync(path.join(root, 'latest.json'), 'utf8')),
+          console: publicFeedAlertWatchInternal.alertConsoleProjection(summary),
+        };
+      };
+
+      try {
+        const baseline = await runVariant('SYNTHETIC_AUX_SECRET_A_20260710');
+        const drift = await runVariant('SYNTHETIC_AUX_SECRET_B_20260710');
+        assert.deepEqual(drift, baseline);
+        assert.equal(JSON.stringify(baseline).includes('SYNTHETIC_AUX_SECRET_A_20260710'), false);
+        if (row.name === 'relay liveness detail') {
+          const diagnostics = baseline.summary.relayLiveness.relays[0].reasonDiagnostics;
+          assert.deepEqual(
+            diagnostics.find((entry) => entry.reasonCode === 'readyz_unhealthy')?.numericDiagnostics,
+            { httpStatus: [503] },
+          );
+          assert.deepEqual(
+            diagnostics.find((entry) => entry.reasonCode === 'metrics_unhealthy')?.numericDiagnostics,
+            { httpStatus: [502] },
+          );
+          assert.deepEqual(
+            diagnostics.find((entry) => entry.reasonCode === 'restart_count_increased')?.numericDiagnostics,
+            { currentRestartCount: [2], previousRestartCount: [1] },
+          );
+          assert.deepEqual(
+            diagnostics.find((entry) => entry.reasonCode === 'event_loop_lag_hot')?.numericDiagnostics,
+            { limitMs: [3000], observedMs: [2500] },
+          );
+        }
+        if (row.name === 'snapshot detail') {
+          const diagnostics = baseline.summary.relaySnapshot.snapshots[0].reasonDiagnostics;
+          assert.deepEqual(
+            diagnostics.find((entry) => entry.reasonCode === 'snapshot_size_not_sane')?.numericDiagnostics,
+            { sizeBytes: [123] },
+          );
+          assert.deepEqual(
+            diagnostics.find((entry) => entry.reasonCode === 'entry_count_mismatch')?.numericDiagnostics,
+            { actualCount: [79], expectedCount: [80] },
+          );
+          assert.deepEqual(
+            diagnostics.find((entry) => entry.reasonCode === 'newest_entry_stale')?.numericDiagnostics,
+            { maxAgeMs: [21_600_000], newestEntryAgeMs: [30_000_000] },
+          );
+        }
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    });
+  }
+});
+
+test('poisoned prior state is canonicalized before comparison and carry-forward', async () => {
+  const now = Date.parse('2026-07-02T18:00:00.000Z');
+  const roots = [];
+  const runVariant = async (secret) => {
+    const root = tempRoot();
+    roots.push(root);
+    const stateFile = path.join(root, 'state.json');
+    writeJson(stateFile, {
+      schemaVersion: 'vh-public-feed-alert-state-v3',
+      generatedAt: `not-a-timestamp-${secret}`,
+      lastObservedFingerprint: `not-a-fingerprint-${secret}`,
+      lastObservedStatus: `not-a-status-${secret}`,
+      lastDeliveredFingerprint: `not-a-delivered-fingerprint-${secret}`,
+      lastDeliveredStatus: `not-a-delivered-status-${secret}`,
+      lastDeliveredAt: `not-a-delivery-timestamp-${secret}`,
+      lastDeliveryStatus: `not-a-delivery-state-${secret}`,
+      lastDeliveryReason: `not-a-delivery-reason-${secret}`,
+      lastPublisherNRestarts: `69-${secret}`,
+      sourceStatuses: {
+        publisher: `not-a-source-status-${secret}`,
+        freshness: `not-a-source-status-${secret}`,
+        relayLiveness: `not-a-source-status-${secret}`,
+        relaySnapshot: `not-a-source-status-${secret}`,
+        watchClosure: `not-a-source-status-${secret}`,
+      },
+    });
+    const webhookCalls = [];
+    const mail = [];
+    const summary = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({
+      env: baseEnv(root, {
+        VH_PUBLIC_FEED_ALERT_TEST_FIRE: '1',
+        VH_PUBLIC_FEED_ALERT_WEBHOOK_URL: 'https://hooks.example.invalid/token',
+        VH_PUBLIC_FEED_ALERT_EMAIL_TO: 'operator@example.invalid',
+      }),
+      repoRoot: root,
+      now,
+      systemctlShowText: [
+        'ActiveState=active',
+        'SubState=running',
+        'NRestarts=not-a-number',
+        'ExecMainStatus=0',
+        'Result=success',
+        '',
+      ].join('\n'),
+      freshnessMonitorImpl: async () => staleFreshnessSummary({ now }),
+      fetchImpl: async (url, init) => {
+        webhookCalls.push({ url, init });
+        return { ok: false, status: 503 };
+      },
+      spawnSyncImpl: (command, args, options) => {
+        mail.push(options.input);
+        return { status: 1, stdout: '', stderr: `private-sendmail-detail-${secret}` };
+      },
+    });
+    const parsedMail = parseTextEmail(mail[0]);
+    return {
+      summary,
+      webhook: JSON.parse(webhookCalls[0].init.body),
+      mime: { subject: parsedMail.headers.subject, payload: JSON.parse(parsedMail.body) },
+      latest: JSON.parse(readFileSync(path.join(root, 'latest.json'), 'utf8')),
+      console: publicFeedAlertWatchInternal.alertConsoleProjection(summary),
+    };
+  };
+
+  try {
+    const baseline = await runVariant('SYNTHETIC_STATE_SECRET_A_20260710');
+    const drift = await runVariant('SYNTHETIC_STATE_SECRET_B_20260710');
+    assert.deepEqual(drift, baseline);
+    assert.equal(baseline.summary.state.lastDeliveredFingerprint, null);
+    assert.equal(baseline.summary.state.lastDeliveredStatus, 'fail');
+    assert.equal(baseline.summary.state.lastDeliveredAt, null);
+    assert.equal(baseline.summary.state.lastPublisherNRestarts, null);
+    assert.deepEqual(baseline.summary.state.sourceStatuses, {
+      publisher: 'pass',
+      freshness: 'fail',
+      relayLiveness: 'skipped',
+      relaySnapshot: 'skipped',
+      watchClosure: 'skipped',
+    });
+    const serialized = JSON.stringify(baseline);
+    assert.equal(serialized.includes('SYNTHETIC_STATE_SECRET_A_20260710'), false);
+    assert.equal(serialized.includes('private-sendmail-detail'), false);
+  } finally {
+    for (const root of roots) rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('numeric environment values require exact decimal strings', async () => {
+  const now = Date.parse('2026-07-02T18:00:00.000Z');
+  const roots = [];
+  const runVariant = async (numericText) => {
+    const root = tempRoot();
+    roots.push(root);
+    const webhookCalls = [];
+    const summary = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({
+      env: baseEnv(root, {
+        ...writeAuxReports(root),
+        VH_PUBLIC_FEED_ALERT_TEST_FIRE: '1',
+        VH_PUBLIC_FEED_ALERT_WEBHOOK_URL: 'https://hooks.example.invalid/token',
+        VH_PUBLIC_FEED_ALERT_HEARTBEAT_MS: numericText,
+        VH_PUBLIC_FEED_ALERT_RELAY_LIVENESS_MAX_AGE_MS: numericText,
+        VH_PUBLIC_FEED_ALERT_RELAY_SNAPSHOT_MAX_AGE_MS: numericText,
+        VH_PUBLIC_FEED_ALERT_WATCH_CLOSURE_MAX_AGE_MS: numericText,
+      }),
+      repoRoot: root,
+      now,
+      systemctlShowText: activeSystemctl(),
+      freshnessMonitorImpl: async () => freshnessSummary(),
+      fetchImpl: async (url, init) => {
+        webhookCalls.push({ url, init });
+        return { ok: true, status: 204 };
+      },
+    });
+    return {
+      summary,
+      webhook: JSON.parse(webhookCalls[0].init.body),
+      latest: JSON.parse(readFileSync(path.join(root, 'latest.json'), 'utf8')),
+      console: publicFeedAlertWatchInternal.alertConsoleProjection(summary),
+    };
+  };
+
+  try {
+    const invalidBaseline = await runVariant('15000SYNTHETIC_NUMERIC_SECRET_A');
+    const invalidDrift = await runVariant('15000SYNTHETIC_NUMERIC_SECRET_B');
+    assert.deepEqual(invalidDrift, invalidBaseline);
+    assert.equal(invalidBaseline.summary.delivery.heartbeatMs, 0);
+    assert.equal(invalidBaseline.summary.relayLiveness.maxAgeMs, 15 * 60 * 1000);
+    assert.equal(invalidBaseline.summary.relaySnapshot.maxAgeMs, 45 * 60 * 1000);
+    assert.equal(invalidBaseline.summary.watchClosure.maxAgeMs, 90 * 60 * 1000);
+
+    const exact = await runVariant('15000');
+    assert.equal(exact.summary.delivery.heartbeatMs, 15_000);
+    assert.equal(exact.summary.relayLiveness.maxAgeMs, 15_000);
+    assert.equal(exact.summary.relaySnapshot.maxAgeMs, 15_000);
+    assert.equal(exact.summary.watchClosure.maxAgeMs, 15_000);
+    assert.equal(
+      exact.summary.relayLiveness.blockers.some((blocker) => blocker.startsWith('relay_liveness:output_stale:')),
+      true,
+    );
+    assert.equal(
+      exact.summary.relaySnapshot.blockers.some((blocker) => blocker.startsWith('relay_snapshot:output_stale:')),
+      true,
+    );
+    assert.equal(
+      exact.summary.watchClosure.blockers.some((blocker) => blocker.startsWith('watch_closure:output_stale:')),
+      true,
+    );
+  } finally {
+    for (const root of roots) rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('delivery timeout accepts exact digits and rejects suffixed numerics', async () => {
+  const roots = [];
+  const observeAbort = async (timeoutText) => {
+    const root = tempRoot();
+    roots.push(root);
+    let aborted = false;
+    const summary = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({
+      env: baseEnv(root, {
+        VH_PUBLIC_FEED_ALERT_TEST_FIRE: '1',
+        VH_PUBLIC_FEED_ALERT_WEBHOOK_URL: 'https://hooks.example.invalid/token',
+        VH_PUBLIC_FEED_ALERT_TIMEOUT_MS: timeoutText,
+      }),
+      repoRoot: root,
+      systemctlShowText: activeSystemctl(),
+      freshnessMonitorImpl: async () => freshnessSummary(),
+      fetchImpl: async (url, init) => new Promise((resolve) => {
+        const responseTimer = setTimeout(() => resolve({ ok: true, status: 204 }), 30);
+        init.signal.addEventListener('abort', () => {
+          aborted = true;
+          clearTimeout(responseTimer);
+          resolve({ ok: true, status: 204 });
+        }, { once: true });
+      }),
+    });
+    assert.equal(summary.delivery.status, 'sent');
+    return aborted;
+  };
+
+  try {
+    assert.equal(await observeAbort('1SYNTHETIC_TIMEOUT_SECRET'), false);
+    assert.equal(await observeAbort('1'), true);
+  } finally {
+    for (const root of roots) rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('systemd numeric classification and persisted restart count require exact digits', async () => {
+  const now = Date.parse('2026-07-02T18:00:00.000Z');
+  const roots = [];
+  const runVariant = async (suffix) => {
+    const root = tempRoot();
+    roots.push(root);
+    const webhookCalls = [];
+    const summary = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({
+      env: baseEnv(root, {
+        VH_PUBLIC_FEED_ALERT_TEST_FIRE: '1',
+        VH_PUBLIC_FEED_ALERT_WEBHOOK_URL: 'https://hooks.example.invalid/token',
+      }),
+      repoRoot: root,
+      now,
+      systemctlShowText: [
+        'ActiveState=activating',
+        'SubState=auto-restart',
+        `NRestarts=3${suffix}`,
+        `ExecMainStatus=69${suffix}`,
+        'Result=exit-code',
+        '',
+      ].join('\n'),
+      freshnessMonitorImpl: async () => freshnessSummary(),
+      fetchImpl: async (url, init) => {
+        webhookCalls.push({ url, init });
+        return { ok: true, status: 204 };
+      },
+    });
+    return {
+      summary,
+      webhook: JSON.parse(webhookCalls[0].init.body),
+      latest: JSON.parse(readFileSync(path.join(root, 'latest.json'), 'utf8')),
+      console: publicFeedAlertWatchInternal.alertConsoleProjection(summary),
+    };
+  };
+
+  try {
+    const invalidBaseline = await runVariant('SYNTHETIC_SYSTEMD_SECRET_A');
+    const invalidDrift = await runVariant('SYNTHETIC_SYSTEMD_SECRET_B');
+    assert.deepEqual(invalidDrift, invalidBaseline);
+    assert.equal(invalidBaseline.summary.publisher.execMainStatus, null);
+    assert.equal(invalidBaseline.summary.publisher.nRestarts, null);
+    assert.equal(invalidBaseline.summary.publisher.failureClass, 'unit_not_running');
+    assert.equal(invalidBaseline.summary.state.lastPublisherNRestarts, null);
+
+    const exact = await runVariant('');
+    assert.equal(exact.summary.publisher.execMainStatus, '69');
+    assert.equal(exact.summary.publisher.nRestarts, 3);
+    assert.equal(exact.summary.publisher.failureClass, 'exit_69_transport_unavailable');
+    assert.equal(exact.summary.state.lastPublisherNRestarts, 3);
+  } finally {
+    for (const root of roots) rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('CRLF mailboxes are refused before any injected header or body is emitted', async () => {
+  const now = Date.parse('2026-07-02T18:00:00.000Z');
+  const roots = [];
+  const runVariant = async ({ to, from }) => {
+    const root = tempRoot();
+    roots.push(root);
+    let sendmailCalls = 0;
+    const summary = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({
+      env: baseEnv(root, {
+        VH_PUBLIC_FEED_ALERT_TEST_FIRE: '1',
+        VH_PUBLIC_FEED_ALERT_EMAIL_TO: to,
+        VH_PUBLIC_FEED_ALERT_EMAIL_FROM: from,
+      }),
+      repoRoot: root,
+      now,
+      systemctlShowText: activeSystemctl(),
+      freshnessMonitorImpl: async () => freshnessSummary(),
+      spawnSyncImpl: () => {
+        sendmailCalls += 1;
+        return { status: 0, stdout: '', stderr: '' };
+      },
+    });
+    return {
+      summary,
+      latest: JSON.parse(readFileSync(path.join(root, 'latest.json'), 'utf8')),
+      console: publicFeedAlertWatchInternal.alertConsoleProjection(summary),
+      sendmailCalls,
+    };
+  };
+
+  try {
+    const injectedTo = await runVariant({
+      to: 'operator@example.invalid\r\nBcc: attacker@example.invalid',
+      from: 'vhc-alert@example.invalid',
+    });
+    const injectedFrom = await runVariant({
+      to: 'operator@example.invalid',
+      from: 'vhc-alert@example.invalid\r\nX-Injected: yes',
+    });
+    assert.deepEqual(injectedFrom, injectedTo);
+    assert.equal(injectedTo.sendmailCalls, 0);
+    assert.equal(injectedTo.summary.delivery.error, 'email_address_invalid');
+    const serialized = JSON.stringify(injectedTo);
+    assert.equal(serialized.includes('Bcc'), false);
+    assert.equal(serialized.includes('X-Injected'), false);
+    assert.equal(serialized.includes('attacker@example.invalid'), false);
+  } finally {
+    for (const root of roots) rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('transport provider detail maps to closed public delivery error classes', async (t) => {
+  const now = Date.parse('2026-07-02T18:00:00.000Z');
+  const rows = [
+    { name: 'webhook network detail', mode: 'network', expectedError: 'webhook_network' },
+    { name: 'webhook HTTP provider detail', mode: 'http', expectedError: 'webhook_http_503' },
+    { name: 'sendmail stderr and exit detail', mode: 'sendmail', expectedError: 'sendmail_exit' },
+  ];
+
+  for (const row of rows) {
+    await t.test(row.name, async () => {
+      const roots = [];
+      const runVariant = async (secret, sendmailStatus) => {
+        const root = tempRoot();
+        roots.push(root);
+        const webhookCalls = [];
+        const mail = [];
+        const summary = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({
+          env: baseEnv(root, {
+            VH_PUBLIC_FEED_ALERT_TEST_FIRE: '1',
+            ...(row.mode === 'sendmail'
+              ? { VH_PUBLIC_FEED_ALERT_EMAIL_TO: 'operator@example.invalid' }
+              : { VH_PUBLIC_FEED_ALERT_WEBHOOK_URL: 'https://hooks.example.invalid/token' }),
+          }),
+          repoRoot: root,
+          now,
+          systemctlShowText: activeSystemctl(),
+          freshnessMonitorImpl: async () => freshnessSummary(),
+          fetchImpl: async (url, init) => {
+            webhookCalls.push({ url, init });
+            if (row.mode === 'network') throw new Error(`private-provider-network-detail-${secret}`);
+            return {
+              ok: false,
+              status: 503,
+              statusText: `private-provider-http-detail-${secret}`,
+              providerBody: `private-provider-body-${secret}`,
+            };
+          },
+          spawnSyncImpl: (command, args, options) => {
+            mail.push(options.input);
+            return {
+              status: sendmailStatus,
+              stdout: `private-sendmail-stdout-${secret}`,
+              stderr: `private-sendmail-stderr-${secret}`,
+            };
+          },
+        });
+        const channelPayload = webhookCalls.length > 0
+          ? JSON.parse(webhookCalls[0].init.body)
+          : (() => {
+              const parsed = parseTextEmail(mail[0]);
+              return { subject: parsed.headers.subject, payload: JSON.parse(parsed.body) };
+            })();
+        return {
+          summary,
+          channelPayload,
+          latest: JSON.parse(readFileSync(path.join(root, 'latest.json'), 'utf8')),
+          console: publicFeedAlertWatchInternal.alertConsoleProjection(summary),
+        };
+      };
+
+      try {
+        const baseline = await runVariant('SYNTHETIC_TRANSPORT_SECRET_A_20260710', 1);
+        const drift = await runVariant('SYNTHETIC_TRANSPORT_SECRET_B_20260710', 75);
+        assert.deepEqual(drift, baseline);
+        assert.equal(baseline.summary.delivery.error, row.expectedError);
+        const serialized = JSON.stringify(baseline);
+        assert.equal(serialized.includes('SYNTHETIC_TRANSPORT_SECRET_A_20260710'), false);
+        assert.equal(serialized.includes('private-provider'), false);
+        assert.equal(serialized.includes('private-sendmail'), false);
+      } finally {
+        for (const root of roots) rmSync(root, { recursive: true, force: true });
+      }
+    });
+  }
+});
+
+test('systemctl stderr and unknown properties cannot alter public projections', async (t) => {
+  const now = Date.parse('2026-07-02T18:00:00.000Z');
+  const rows = [
+    {
+      name: 'systemctl command failure detail',
+      systemctlText: () => null,
+      spawnResult: (secret) => ({
+        status: 1,
+        stdout: `private-systemctl-stdout-${secret}`,
+        stderr: `private-systemctl-stderr-${secret}`,
+      }),
+      expectedBlocker: 'publisher_systemctl_failed',
+    },
+    {
+      name: 'unknown systemd property detail',
+      systemctlText: (secret) => [
+        `ActiveState=private-active-${secret}`,
+        `SubState=private-sub-${secret}`,
+        `NRestarts=3${secret}`,
+        `ExecMainStatus=69${secret}`,
+        `Result=private-result-${secret}`,
+        `PrivateProperty=${secret}`,
+        '',
+      ].join('\n'),
+      spawnResult: () => ({ status: 0, stdout: '', stderr: '' }),
+      expectedBlocker: 'publisher_not_running',
+    },
+  ];
+
+  for (const row of rows) {
+    await t.test(row.name, async () => {
+      const roots = [];
+      const runVariant = async (secret) => {
+        const root = tempRoot();
+        roots.push(root);
+        const webhookCalls = [];
+        const summary = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({
+          env: baseEnv(root, {
+            VH_PUBLIC_FEED_ALERT_TEST_FIRE: '1',
+            VH_PUBLIC_FEED_ALERT_WEBHOOK_URL: 'https://hooks.example.invalid/token',
+          }),
+          repoRoot: root,
+          now,
+          systemctlShowText: row.systemctlText(secret),
+          freshnessMonitorImpl: async () => freshnessSummary(),
+          fetchImpl: async (url, init) => {
+            webhookCalls.push({ url, init });
+            return { ok: true, status: 204 };
+          },
+          spawnSyncImpl: () => row.spawnResult(secret),
+        });
+        return {
+          summary,
+          webhook: JSON.parse(webhookCalls[0].init.body),
+          latest: JSON.parse(readFileSync(path.join(root, 'latest.json'), 'utf8')),
+          console: publicFeedAlertWatchInternal.alertConsoleProjection(summary),
+        };
+      };
+
+      try {
+        const baseline = await runVariant('SYNTHETIC_SYSTEMCTL_SECRET_A_20260710');
+        const drift = await runVariant('SYNTHETIC_SYSTEMCTL_SECRET_B_20260710');
+        assert.deepEqual(drift, baseline);
+        assert.equal(baseline.summary.publisher.blockers.includes(row.expectedBlocker), true);
+        assert.equal(baseline.summary.publisher.unitRole, 'publisher');
+        assert.equal(JSON.stringify(baseline).includes('SYNTHETIC_SYSTEMCTL_SECRET_A_20260710'), false);
+      } finally {
+        for (const root of roots) rmSync(root, { recursive: true, force: true });
+      }
+    });
+  }
+});
+
+test('CLI unhandled errors print only the fixed public error class', () => {
+  const roots = [];
+  const runVariant = (secret) => {
+    const root = tempRoot();
+    roots.push(root);
+    const blockingFile = path.join(root, `private-cli-path-${secret}`);
+    writeFileSync(blockingFile, `private-cli-file-${secret}`, 'utf8');
+    const result = spawnSync(process.execPath, [path.resolve('tools/scripts/public-feed-alert-watch.mjs')], {
+      cwd: process.cwd(),
+      env: {
+        PATH: process.env.PATH ?? '',
+        HOME: root,
+        SYNTHETIC_PRIVATE_CLI_ENV: secret,
+        VH_PUBLIC_FEED_FRESHNESS_ARTIFACT_DIR: path.join(blockingFile, 'child'),
+        VH_PUBLIC_FEED_ALERT_STATE_FILE: path.join(root, 'state.json'),
+        VH_PUBLIC_FEED_ALERT_OUTPUT_FILE: path.join(root, 'latest.json'),
+      },
+      encoding: 'utf8',
+    });
+    return {
+      status: result.status,
+      signal: result.signal,
+      stdout: result.stdout,
+      stderr: result.stderr,
+    };
+  };
+
+  try {
+    const baseline = runVariant('SYNTHETIC_CLI_SECRET_A_20260710');
+    const drift = runVariant('SYNTHETIC_CLI_SECRET_B_20260710');
+    assert.deepEqual(drift, baseline);
+    assert.equal(baseline.status, 1);
+    assert.equal(baseline.signal, null);
+    assert.equal(
+      baseline.stderr.trim(),
+      '[vh:public-feed-alert-watch] failed alert_watch_unhandled_error',
+    );
+    assert.equal(baseline.stderr.includes('Error'), false);
+    assert.equal(baseline.stderr.includes('private-cli-path'), false);
+    assert.equal(baseline.stderr.includes('SYNTHETIC_CLI_SECRET'), false);
+  } finally {
+    for (const root of roots) rmSync(root, { recursive: true, force: true });
   }
 });

--- a/tools/scripts/public-feed-alert-watch.test.mjs
+++ b/tools/scripts/public-feed-alert-watch.test.mjs
@@ -369,7 +369,18 @@ test('semantic fingerprint ignores volatile values and ordering but preserves re
   compositeReasonChanged.freshness.blockers = [
     'latest_index_not_fresh:url_hash:0123456789abcdef:latest_index_empty|latest_index_timestamp_missing',
   ];
-  assert.notEqual(publicFeedAlertWatchInternal.fingerprintFor(compositeReasonChanged), fingerprint);
+  const compositeFingerprint = publicFeedAlertWatchInternal.fingerprintFor(compositeReasonChanged);
+  assert.notEqual(compositeFingerprint, fingerprint);
+
+  const compositeReasonReordered = structuredClone(compositeReasonChanged);
+  compositeReasonReordered.blockers = [
+    'public_feed:latest_index_not_fresh:url_hash:0123456789abcdef:latest_index_timestamp_missing|latest_index_empty|latest_index_empty',
+    'watch_closure:archive_sample_failures:8',
+  ];
+  compositeReasonReordered.freshness.blockers = [
+    'latest_index_not_fresh:url_hash:0123456789abcdef:latest_index_timestamp_missing|latest_index_empty|latest_index_empty',
+  ];
+  assert.equal(publicFeedAlertWatchInternal.fingerprintFor(compositeReasonReordered), compositeFingerprint);
 
   const relayChanged = structuredClone(baseline);
   relayChanged.relayLiveness.relays[0].status = 'pass';
@@ -1118,6 +1129,71 @@ test('stale feed sends a webhook on state change with secret-safe aggregate payl
     assert.equal(JSON.stringify(body).includes('venn.carboncaste.io'), false);
     assert.equal(JSON.stringify(body).includes('secret-path'), false);
     assert.equal(JSON.stringify(body).includes('hooks.example.invalid'), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('composite blocker reason order and duplicates suppress while a changed reason set delivers once', async () => {
+  const root = tempRoot();
+  const calls = [];
+  const origin = 'https://venn.carboncaste.io/';
+  let reasons = ['latest_index_empty', 'latest_index_timestamp_missing'];
+  try {
+    const options = {
+      env: baseEnv(root, { VH_PUBLIC_FEED_ALERT_WEBHOOK_URL: 'https://hooks.example.invalid/token' }),
+      repoRoot: root,
+      systemctlShowText: activeSystemctl(),
+      freshnessMonitorImpl: async () => freshnessSummary({
+        status: 'fail',
+        blockers: [`latest_index_not_fresh:${origin}:${reasons.join('|')}`],
+        config: { origins: [origin], maxAgeMs: 21_600_000 },
+        latestIndexReadbacks: [{
+          origin,
+          status: 'fail',
+          recordCount: 0,
+          newestAgeMs: null,
+          maxAgeMs: 21_600_000,
+          failures: reasons,
+          storyIds: ['story-body-not-copied'],
+        }],
+      }),
+      fetchImpl: async (url, init) => {
+        calls.push({ url, init });
+        return { ok: true, status: 204 };
+      },
+    };
+
+    const first = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({
+      ...options,
+      now: Date.parse('2026-07-02T18:00:00.000Z'),
+    });
+    reasons = ['latest_index_timestamp_missing', 'latest_index_empty', 'latest_index_empty'];
+    const reordered = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({
+      ...options,
+      now: Date.parse('2026-07-02T18:01:00.000Z'),
+    });
+    reasons = ['latest_index_empty', 'latest_index_fetch_failed'];
+    const changed = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({
+      ...options,
+      now: Date.parse('2026-07-02T18:02:00.000Z'),
+    });
+    reasons = ['latest_index_fetch_failed', 'latest_index_empty', 'latest_index_fetch_failed'];
+    const unchanged = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({
+      ...options,
+      now: Date.parse('2026-07-02T18:03:00.000Z'),
+    });
+
+    assert.equal(reordered.fingerprint, first.fingerprint);
+    assert.equal(reordered.delivery.status, 'suppressed');
+    assert.equal(reordered.delivery.reason, 'unchanged_suppressed');
+    assert.notEqual(changed.fingerprint, first.fingerprint);
+    assert.equal(changed.delivery.status, 'sent');
+    assert.equal(changed.delivery.reason, 'state_changed');
+    assert.equal(unchanged.fingerprint, changed.fingerprint);
+    assert.equal(unchanged.delivery.status, 'suppressed');
+    assert.equal(unchanged.delivery.reason, 'unchanged_suppressed');
+    assert.equal(calls.length, 2);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/tools/scripts/public-feed-alert-watch.test.mjs
+++ b/tools/scripts/public-feed-alert-watch.test.mjs
@@ -1199,6 +1199,127 @@ test('composite blocker reason order and duplicates suppress while a changed rea
   }
 });
 
+test('adversarial configured origin stays fully redacted across webhook and email while structured reasons dedupe', async () => {
+  const root = tempRoot();
+  const calls = [];
+  const mail = [];
+  const origin = 'https://private.example.invalid/feed?token=prefix:api_key|sk-proj-SYNTHETIC-NOT-A-REAL-KEY/';
+  let reasons = ['latest_index_empty', 'latest_index_timestamp_missing'];
+  try {
+    const options = {
+      env: baseEnv(root, {
+        VH_PUBLIC_FEED_ALERT_WEBHOOK_URL: 'https://hooks.example.invalid/token',
+        VH_PUBLIC_FEED_ALERT_EMAIL_TO: 'operator@example.invalid',
+        VH_PUBLIC_FEED_ALERT_SENDMAIL: '/usr/sbin/sendmail',
+      }),
+      repoRoot: root,
+      systemctlShowText: activeSystemctl(),
+      freshnessMonitorImpl: async () => freshnessSummary({
+        status: 'fail',
+        blockers: [`latest_index_not_fresh:${origin}:${reasons.join('|')}`],
+        config: { origins: [origin], maxAgeMs: 21_600_000 },
+        latestIndexReadbacks: [{
+          origin,
+          status: 'fail',
+          recordCount: 0,
+          newestAgeMs: null,
+          maxAgeMs: 21_600_000,
+          failures: reasons,
+          storyIds: ['story-body-not-copied'],
+        }],
+      }),
+      fetchImpl: async (url, init) => {
+        calls.push({ url, init });
+        return { ok: true, status: 204 };
+      },
+      spawnSyncImpl: (command, args, spawnOptions) => {
+        mail.push({ command, args, input: spawnOptions.input });
+        return { status: 0, stdout: '', stderr: '' };
+      },
+    };
+
+    const first = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({
+      ...options,
+      now: Date.parse('2026-07-02T18:00:00.000Z'),
+    });
+    reasons = ['latest_index_timestamp_missing', 'latest_index_empty', 'latest_index_empty'];
+    const reordered = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({
+      ...options,
+      now: Date.parse('2026-07-02T18:01:00.000Z'),
+    });
+    reasons = ['latest_index_empty', 'latest_index_fetch_failed'];
+    const changed = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({
+      ...options,
+      now: Date.parse('2026-07-02T18:02:00.000Z'),
+    });
+    reasons = ['latest_index_fetch_failed', 'latest_index_empty', 'latest_index_fetch_failed'];
+    const unchanged = await publicFeedAlertWatchInternal.runPublicFeedAlertWatch({
+      ...options,
+      now: Date.parse('2026-07-02T18:03:00.000Z'),
+    });
+
+    assert.equal(reordered.fingerprint, first.fingerprint);
+    assert.equal(reordered.delivery.status, 'suppressed');
+    assert.equal(reordered.delivery.reason, 'unchanged_suppressed');
+    assert.notEqual(changed.fingerprint, first.fingerprint);
+    assert.equal(changed.delivery.status, 'sent');
+    assert.equal(changed.delivery.reason, 'state_changed');
+    assert.equal(unchanged.fingerprint, changed.fingerprint);
+    assert.equal(unchanged.delivery.status, 'suppressed');
+    assert.equal(unchanged.delivery.reason, 'unchanged_suppressed');
+    assert.deepEqual(reordered.freshness.latestIndexReadbacks[0].failureReasonCodes, [
+      'latest_index_empty',
+      'latest_index_timestamp_missing',
+    ]);
+    assert.deepEqual(unchanged.freshness.latestIndexReadbacks[0].failureReasonCodes, [
+      'latest_index_empty',
+      'latest_index_fetch_failed',
+    ]);
+    assert.equal(calls.length, 2);
+    assert.equal(mail.length, 2);
+
+    const webhookPayloads = calls.map((call) => JSON.parse(call.init.body));
+    const emailPayloads = mail.map((message) => {
+      const parsed = parseTextEmail(message.input);
+      assert.equal(parsed.headers['mime-version'], '1.0');
+      assert.equal(parsed.headers['content-type'], 'text/plain; charset=utf-8');
+      return JSON.parse(parsed.body);
+    });
+    const expectedReasonSets = [
+      ['latest_index_empty', 'latest_index_timestamp_missing'],
+      ['latest_index_empty', 'latest_index_fetch_failed'],
+    ];
+    for (const [index, payload] of webhookPayloads.entries()) {
+      const freshnessBlocker = payload.freshness.blockers[0];
+      const blockerHash = freshnessBlocker.match(/url_hash:([0-9a-f]{16}):/)?.[1];
+      assert.equal(blockerHash, payload.freshness.originHashes[0]);
+      assert.equal(blockerHash, payload.freshness.latestIndexReadbacks[0].originHash);
+      assert.deepEqual(payload.freshness.latestIndexReadbacks[0].failureReasonCodes, expectedReasonSets[index]);
+      assert.deepEqual(emailPayloads[index], payload);
+    }
+
+    const serializedOutputs = [
+      ...calls.map((call) => call.init.body),
+      ...mail.map((message) => message.input),
+      readFileSync(path.join(root, 'latest.json'), 'utf8'),
+      JSON.stringify([first, reordered, changed, unchanged]),
+    ];
+    const forbiddenFragments = [
+      origin,
+      'private.example.invalid',
+      'prefix:api_key',
+      'sk-proj-SYNTHETIC-NOT-A-REAL-KEY',
+    ];
+    for (const output of serializedOutputs) {
+      for (const fragment of forbiddenFragments) {
+        assert.equal(output.includes(fragment), false, `alert output leaked synthetic fragment: ${fragment}`);
+      }
+    }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test('same stale-feed class suppresses repeat delivery even as monitor ages advance', async () => {
   const root = tempRoot();
   const calls = [];


### PR DESCRIPTION
## Incident and stack

This Alert lane addresses the active public-beta incident class `relay_rest_story_timeout_total_0_of_3_exit_78` and the duplicate `state_changed` notifications observed while that single unresolved incident accumulated volatile watch values.

Sanitized incident evidence: the Runtime incident involved 3 relay POST deadlines at the configured 10-second bound, 0/3 validated acknowledgements against an unchanged 2/3 quorum, and a fail-closed exit 78. This PR does not change relay writes, quorum, exit mapping, or service state; it makes alert dedupe and every alert projection deterministic and secret-safe while retaining bounded numeric evidence.

This PR is intentionally stacked on `integration/wave-s1b-public-beta-2026-07-10` at `a2899ad2f32b0b09d55dfcd1f468e6eb0bc907ef`. Its exact head is `c3cff10927cf4bc8e6f00e5cd6829920dd857e6f`.

## Final boundary design

- Bump the outbound/persisted report contract to `vh-public-feed-alert-watch-v2`; keep the alert dedupe state contract independently at v3.
- Fingerprint only closed semantic state: clamped publisher/source/threshold statuses, allowlisted family/reason pairs, recovery state, and stable token-free identities.
- Preserve the existing pager incident-family prefixes (`public_feed`, `relay_liveness`, `relay_snapshot`, `watch_closure`) while allowing genuine reason changes to produce distinct fingerprints.
- Parse numeric diagnostics only from exact, reason-specific producer grammars. Arbitrary `latest_index_fetch_failed` text is always opaque; safe structured record count and age/limit values remain visible.
- Derive freshness identity only from normalized scheme, host, and explicit port; strip userinfo, path, query, and fragment. Strict safe relay names may be normalized.
- For rejected/private identities, canonically sort the already-safe semantic projection before assigning ordinals. Array reorder and secret rotation therefore cannot relabel distinct status/reason entries or false-page.
- Never publish or fingerprint arbitrary raw-derived hashes. Paths, unit values, invalid names, provider text, stderr, errors, and host-private values become fixed roles, ordinals, closed enums, or error classes.
- Canonicalize untrusted prior state before comparison or carry-forward, including fingerprints, statuses, timestamps, restart counts, delivery fields, and source statuses.
- Emit readable `text/plain; charset=utf-8` MIME JSON, reject CRLF-capable mailbox headers, and keep the subject limited to status plus fingerprint.
- Preserve failed-delivery retry, heartbeat, recovery delivery, real failure-class transitions, and schema-migration notification behavior.

## Review correction lineages

All correction lineages are covered by durable regressions:

1. Composite reason ordering and duplicates no longer change the fingerprint.
2. Hostile configured-origin suffixes cannot survive URL projection.
3. Prefix-ambiguous longer URLs cannot leak suffixes through exact-origin replacement.
4. Non-URL tokens, story/private/host values, provider text, and arbitrary failure suffixes cannot enter diagnostics, blocker text, MIME, webhook, latest artifact, console, or fingerprint.
5. Secret/query numeric drift cannot inject diagnostics; only exact closed grammars preserve safe numbers.
6. Secret-only origin/path/name/state/error drift produces identical same-time public projections and does not false-page.
7. v1 and v2 blockers retain identical pager incident-family keys for all four alert families.
8. Rejected-identity secret rotation plus source-array reorder with distinct statuses/reasons remains projection- and fingerprint-stable across freshness, relay liveness, snapshots, and watch relay-memory; genuine semantic changes remain distinct.

The independent boundary audit found no unresolved P0/P1 findings on the comprehensive v2 boundary diff. Its only P2 handoff is integration-owned dual-version pager fixtures/docs for the new report schema; direct pager compatibility already passes. The final anonymous-identity correction is being re-checked by the same official reviewer on the exact head above.

## Validation

- `corepack pnpm@9.7.1 check:public-feed:alert-watch` — 55/55
- `node --test tools/scripts/news-aggregator-publisher-liveness-watch.test.mjs` — 6/6
- `corepack pnpm@9.7.1 check:vhc-incident-response` — 58/58 plus 26-file contract, zero issues
- `corepack pnpm@9.7.1 check:public-beta-next-phase-sprint` — 8/8
- `corepack pnpm@9.7.1 docs:check` — 158 markdown files
- `node --check tools/scripts/public-feed-alert-watch.mjs` — pass
- `node --check tools/scripts/public-feed-alert-watch.test.mjs` — pass
- `git diff --check a2899ad2f32b0b09d55dfcd1f468e6eb0bc907ef..HEAD` — pass
- `GITHUB_BASE_REF=integration/wave-s1b-public-beta-2026-07-10 node tools/scripts/check-diff-coverage.mjs` — pass; no coverage-eligible source files changed

The focused boundary suite includes same-time full-projection comparisons across returned summary, webhook JSON, parsed MIME subject/body, `latest.json`, and console output for freshness/reordering, relay liveness, snapshots, watch closure, systemctl, delivery errors, poisoned prior state, and all four anonymous-identity reorder fallbacks.

Local pnpm commands emitted the existing Node engine warning because this workstation is on Node 23.10.0 while the repository declares `>=20 <23`; every listed command exited 0. Hosted CI on the supported runtime remains authoritative.

## Authority boundary

No A6, service, relay, Gmail, pager, provider, DNS, distribution, or production mutation was performed. This PR is repo-only and must not be merged by its implementer.
