### PR TITLE
fix: recover relay availability after bounded readback

### DIFF
--- a/infra/relay/server.js
+++ b/infra/relay/server.js
@@ -2893,12 +2893,28 @@ async function readNewsStoryRecord(gun, storyId, options = {}) {
   const storyTimeoutMs = options.timeoutMs ?? numberEnv('VH_RELAY_NEWS_STORY_REST_READ_TIMEOUT_MS', 1_500);
   const allowSnapshotFallback = options.allowSnapshotFallback !== false
     && boolEnv('VH_RELAY_NEWS_STORY_SNAPSHOT_FALLBACK', true);
+  const preferCompleteRecord = options.preferCompleteRecord === true;
   const parseReadResult = (result) => {
     if (result.kind === 'direct') {
       const direct = stripGunMetadata(result.value);
       const envelope = direct && typeof direct === 'object'
         ? parseStoryBundleEnvelope(direct.__story_bundle_json)
         : null;
+      if (preferCompleteRecord && direct && typeof direct === 'object') {
+        // The compatibility scalar is sufficient for the public story-body
+        // response, but it is not the complete signed system-writer record
+        // required to reconcile an unacknowledged POST. Suppress only this
+        // legacy scalar-only shape; other malformed direct rows must still be
+        // returned so the caller can fail closed on signed-record validation.
+        const directKeys = Object.keys(direct);
+        if (directKeys.length === 0 || directKeys.every((key) => key === '__story_bundle_json')) {
+          return null;
+        }
+        return {
+          record: direct,
+          story: envelope?.story_id === storyId ? envelope : { story_id: storyId },
+        };
+      }
       if (envelope?.story_id === storyId) {
         return {
           record: direct,
@@ -2916,18 +2932,32 @@ async function readNewsStoryRecord(gun, storyId, options = {}) {
     }
     return null;
   };
-  const pending = storyChains.flatMap((storyChain) => [
+  const directPending = storyChains.map((storyChain) =>
     readOnce(storyChain, storyTimeoutMs).then((value) => ({ kind: 'direct', value })),
+  );
+  const scalarPending = storyChains.map((storyChain) =>
     readNonNullOnce(storyChain.get('__story_bundle_json'), storyTimeoutMs)
       .then((value) => ({ kind: 'scalar', value })),
-  ]);
-  while (pending.length > 0) {
-    const { index, result } = await Promise.race(
-      pending.map((promise, index) => promise.then((result) => ({ index, result }))),
-    );
-    pending.splice(index, 1);
-    const parsed = parseReadResult(result);
-    if (parsed) return parsed;
+  );
+  const firstParsed = async (work) => {
+    const pending = [...work];
+    while (pending.length > 0) {
+      const { index, result } = await Promise.race(
+        pending.map((promise, index) => promise.then((result) => ({ index, result }))),
+      );
+      pending.splice(index, 1);
+      const parsed = parseReadResult(result);
+      if (parsed) return parsed;
+    }
+    return null;
+  };
+  if (preferCompleteRecord) {
+    const direct = await firstParsed(directPending);
+    if (direct) return direct;
+    return null;
+  } else {
+    const first = await firstParsed([...directPending, ...scalarPending]);
+    if (first) return first;
   }
   return allowSnapshotFallback ? readNewsStoryRecordFromLatestIndexSnapshot(storyId) : null;
 }
@@ -2944,6 +2974,72 @@ async function readNewsSynthesisLifecycleRecord(gun, storyId, options = {}) {
   const direct = parseNewsSynthesisLifecycleRecord(await readOnce(lifecycleChain, timeoutMs), storyId);
   if (direct || options.allowSnapshotFallback === false) return direct;
   return readNewsSynthesisLifecycleRecordFromSnapshot(storyId);
+}
+
+function isCompleteSignedNewsSynthesisLifecycleRecord(record, storyId) {
+  const statusValues = new Set([
+    'pending',
+    'in_progress',
+    'accepted_available',
+    'retryable_failure',
+    'terminal_unavailable',
+    'suppressed',
+  ]);
+  const frameTableValues = new Set([
+    'frame_table_pending',
+    'frame_table_ready',
+    'frame_table_unavailable',
+  ]);
+  return Boolean(
+    record
+    && typeof record === 'object'
+    && record.schemaVersion === 'vh-news-synthesis-lifecycle-v1'
+    && record.story_id === storyId
+    && typeof record.topic_id === 'string'
+    && record.topic_id.trim()
+    && typeof record.source_set_revision === 'string'
+    && record.source_set_revision.trim()
+    && Number.isFinite(record.source_count)
+    && record.source_count >= 0
+    && Number.isFinite(record.canonical_source_count)
+    && record.canonical_source_count >= 0
+    && statusValues.has(record.status)
+    && typeof record.retryable === 'boolean'
+    && frameTableValues.has(record.frame_table_state)
+    && Number.isFinite(record.updated_at)
+    && record.updated_at >= 0
+    && typeof record._protocolVersion === 'string'
+    && record._protocolVersion.trim()
+    && record._writerKind === 'system'
+    && typeof record._systemWriterId === 'string'
+    && record._systemWriterId.trim()
+    && Number.isFinite(record._systemIssuedAt)
+    && record._systemIssuedAt >= 0
+    && typeof record._systemSignature === 'string'
+    && record._systemSignature.trim()
+  );
+}
+
+async function readNewsSynthesisLifecycleExactRecord(gun, storyId, options = {}) {
+  const lifecycleChain = gun
+    .get('vh')
+    .get('news')
+    .get('stories')
+    .get(storyId)
+    .get('synthesis_lifecycle')
+    .get('latest');
+  const timeoutMs = options.timeoutMs ?? numberEnv('VH_RELAY_NEWS_LIFECYCLE_REST_READ_TIMEOUT_MS', 750);
+  const deadline = Date.now() + timeoutMs;
+  do {
+    const remainingMs = Math.max(1, deadline - Date.now());
+    const direct = stripGunMetadata(await readOnce(lifecycleChain, Math.min(remainingMs, 250)));
+    if (isCompleteSignedNewsSynthesisLifecycleRecord(direct, storyId)) {
+      return direct;
+    }
+    if (Date.now() >= deadline) break;
+    await new Promise((resolve) => setTimeout(resolve, Math.min(25, Math.max(1, deadline - Date.now()))));
+  } while (Date.now() < deadline);
+  return null;
 }
 
 async function readNewsSynthesisLifecycleRecordFromFields(gun, storyId, options = {}) {
@@ -6112,11 +6208,12 @@ const server = http.createServer((req, res) => {
 
   if (req.method === 'GET' && pathname === '/vh/news/story') {
     const storyId = parsedUrl.searchParams.get('story_id')?.trim();
+    const exactReadback = parsedUrl.searchParams.get('readback') === 'exact';
     if (!storyId) {
       sendJson(res, 400, { ok: false, error: 'story_id-required' });
       return;
     }
-    void readNewsStoryRecord(gun, storyId)
+    void readNewsStoryRecord(gun, storyId, { preferCompleteRecord: exactReadback })
       .then((result) => {
         if (!result) {
           sendJson(res, 404, { ok: false, error: 'news-story-not-found', story_id: storyId });
@@ -6143,6 +6240,7 @@ const server = http.createServer((req, res) => {
   }
 
   if (req.method === 'GET' && pathname === '/vh/news/latest-index') {
+    const storyId = parsedUrl.searchParams.get('story_id')?.trim();
     const limit = parsedUrl.searchParams.get('limit');
     const includeRoot = boolEnv('VH_RELAY_NEWS_INDEX_REST_INCLUDE_ROOT', false)
       || parsedUrl.searchParams.get('include_root') === 'true';
@@ -6161,6 +6259,37 @@ const server = http.createServer((req, res) => {
         error: 'latest-index-persist-mode-unsupported',
         supported_persist_values: ['false'],
       });
+      return;
+    }
+    if (storyId) {
+      void readNewsLatestIndexRecord(
+        gun,
+        storyId,
+        numberEnv('VH_RELAY_NEWS_LATEST_INDEX_REST_READ_TIMEOUT_MS', 1_500),
+      )
+        .then((record) => {
+          if (!record) {
+            sendJson(res, 404, {
+              ok: false,
+              error: 'news-latest-index-not-found',
+              story_id: storyId,
+            });
+            return;
+          }
+          sendJson(res, 200, {
+            ok: true,
+            story_id: storyId,
+            record,
+          });
+        })
+        .catch((error) => {
+          sendJson(res, 502, {
+            ok: false,
+            error_class: 'vh-relay-502',
+            error: error instanceof Error ? error.message : String(error),
+            story_id: storyId,
+          });
+        });
       return;
     }
     void readNewsLatestIndexRecordsWithEmptyRetry(
@@ -6215,10 +6344,42 @@ const server = http.createServer((req, res) => {
   }
 
   if (req.method === 'GET' && pathname === '/vh/news/hot-index') {
+    const storyId = parsedUrl.searchParams.get('story_id')?.trim();
     const limit = parsedUrl.searchParams.get('limit');
     const includeRoot = boolEnv('VH_RELAY_NEWS_HOT_INDEX_REST_INCLUDE_ROOT', false)
       || parsedUrl.searchParams.get('include_root') === 'true';
     const scanLimit = parsedUrl.searchParams.get('scan_limit');
+    if (storyId) {
+      void readNewsHotIndexRecord(
+        gun,
+        storyId,
+        numberEnv('VH_RELAY_NEWS_HOT_INDEX_REST_READ_TIMEOUT_MS', 1_500),
+      )
+        .then((record) => {
+          if (!record) {
+            sendJson(res, 404, {
+              ok: false,
+              error: 'news-hot-index-not-found',
+              story_id: storyId,
+            });
+            return;
+          }
+          sendJson(res, 200, {
+            ok: true,
+            story_id: storyId,
+            record,
+          });
+        })
+        .catch((error) => {
+          sendJson(res, 502, {
+            ok: false,
+            error_class: 'vh-relay-502',
+            error: error instanceof Error ? error.message : String(error),
+            story_id: storyId,
+          });
+        });
+      return;
+    }
     void readNewsHotIndexRecords(gun, { limit, includeRoot, scanLimit })
       .then((result) => {
         const payload = {
@@ -6245,16 +6406,19 @@ const server = http.createServer((req, res) => {
 
   if (req.method === 'GET' && pathname === '/vh/news/synthesis-lifecycle') {
     const storyId = parsedUrl.searchParams.get('story_id')?.trim();
+    const exactReadback = parsedUrl.searchParams.get('readback') === 'exact';
     if (!storyId) {
       sendJson(res, 400, { ok: false, error: 'story_id-required' });
       return;
     }
-    void Promise.all([
-      readNewsSynthesisLifecycleRecord(gun, storyId).catch(() => null),
-      readNewsSynthesisLifecycleRecordFromFields(gun, storyId).catch(() => null),
-    ])
-      .then(([direct, fromFields]) => {
-        const lifecycle = direct ?? fromFields;
+    const lifecycleRead = exactReadback
+      ? readNewsSynthesisLifecycleExactRecord(gun, storyId)
+      : Promise.all([
+        readNewsSynthesisLifecycleRecord(gun, storyId).catch(() => null),
+        readNewsSynthesisLifecycleRecordFromFields(gun, storyId).catch(() => null),
+      ]).then(([direct, fromFields]) => direct ?? fromFields);
+    void lifecycleRead
+      .then((lifecycle) => {
         if (!lifecycle) {
           sendJson(res, 404, {
             ok: false,

--- a/infra/relay/server.js
+++ b/infra/relay/server.js
@@ -2962,6 +2962,526 @@ async function readNewsStoryRecord(gun, storyId, options = {}) {
   return allowSnapshotFallback ? readNewsStoryRecordFromLatestIndexSnapshot(storyId) : null;
 }
 
+const NEWS_EXACT_SYSTEM_WRITER_KEYS = [
+  '_system',
+  '_Signature',
+  '_WriterId',
+  '_IssuedAt',
+  '_protocolVersion',
+  '_writerKind',
+  '_systemWriterId',
+  '_systemIssuedAt',
+  '_systemSignature',
+];
+const NEWS_EXACT_LEGACY_SYSTEM_WRITER_KEYS = [
+  '_system',
+  '_Signature',
+  '_WriterId',
+  '_IssuedAt',
+];
+const NEWS_EXACT_STORY_KEYS = new Set([
+  '__story_bundle_json',
+  'story_id',
+  'created_at',
+  'schemaVersion',
+  ...NEWS_EXACT_SYSTEM_WRITER_KEYS,
+]);
+const NEWS_EXACT_STORY_RELATION_KEYS = new Set([
+  'synthesis_lifecycle',
+  'analysis',
+  'analysis_latest',
+]);
+const NEWS_EXACT_GUN_LINK_KEYS = new Set(['#']);
+const NEWS_EXACT_STORY_BUNDLE_KEYS = new Set([
+  'schemaVersion',
+  'story_id',
+  'topic_id',
+  'storyline_id',
+  'headline',
+  'summary_hint',
+  'cluster_window_start',
+  'cluster_window_end',
+  'sources',
+  'primary_sources',
+  'secondary_assets',
+  'related_links',
+  'cluster_features',
+  'provenance_hash',
+  'created_at',
+]);
+const NEWS_EXACT_STORY_SOURCE_KEYS = new Set([
+  'source_id',
+  'publisher',
+  'url',
+  'url_hash',
+  'published_at',
+  'title',
+  'imageUrl',
+]);
+const NEWS_EXACT_CLUSTER_FEATURE_KEYS = new Set([
+  'entity_keys',
+  'time_bucket',
+  'semantic_signature',
+  'coverage_score',
+  'velocity_score',
+  'confidence_score',
+  'primary_language',
+  'translation_applied',
+]);
+const NEWS_EXACT_INDEX_METADATA_KEYS = [
+  'product_state_schema_version',
+  'topic_id',
+  'source_set_revision',
+  'source_count',
+  'canonical_source_count',
+  'story_created_at',
+  'cluster_window_start',
+];
+const NEWS_EXACT_LATEST_INDEX_KEYS = new Set([
+  'story_id',
+  'latest_activity_at',
+  ...NEWS_EXACT_INDEX_METADATA_KEYS,
+  ...NEWS_EXACT_SYSTEM_WRITER_KEYS,
+]);
+const NEWS_EXACT_HOT_INDEX_KEYS = new Set([
+  'story_id',
+  'hotness',
+  ...NEWS_EXACT_INDEX_METADATA_KEYS,
+  ...NEWS_EXACT_SYSTEM_WRITER_KEYS,
+]);
+const NEWS_EXACT_LIFECYCLE_KEYS = new Set([
+  'schemaVersion',
+  'story_id',
+  'topic_id',
+  'source_set_revision',
+  'source_count',
+  'canonical_source_count',
+  'status',
+  'retryable',
+  'reason',
+  'synthesis_id',
+  'epoch',
+  'frame_table_state',
+  'updated_at',
+  ...NEWS_EXACT_SYSTEM_WRITER_KEYS,
+]);
+
+function newsExactRecordHasOnlyKeys(record, allowedKeys) {
+  return isPlainRecord(record) && Object.keys(record).every((key) => allowedKeys.has(key));
+}
+
+function isNewsExactNonEmptyString(value) {
+  return typeof value === 'string' && value.length > 0;
+}
+
+function isNewsExactFiniteNumber(value) {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function isNewsExactUrl(value) {
+  if (!isNewsExactNonEmptyString(value)) return false;
+  try {
+    new URL(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isNewsExactOptional(record, key, validate) {
+  return !(key in record) || validate(record[key]);
+}
+
+function isNewsExactStorySource(value) {
+  return Boolean(
+    newsExactRecordHasOnlyKeys(value, NEWS_EXACT_STORY_SOURCE_KEYS)
+    && isNewsExactNonEmptyString(value.source_id)
+    && isNewsExactNonEmptyString(value.publisher)
+    && isNewsExactUrl(value.url)
+    && isNewsExactNonEmptyString(value.url_hash)
+    && isNewsExactNonEmptyString(value.title)
+    && isNewsExactOptional(value, 'published_at', isNewsExactFiniteNumber)
+    && isNewsExactOptional(value, 'imageUrl', isNewsExactUrl)
+  );
+}
+
+function isNewsExactStorySourceList(value, minimumLength = 0) {
+  return Array.isArray(value)
+    && value.length >= minimumLength
+    && value.every((source) => isNewsExactStorySource(source));
+}
+
+function isNewsExactUnitScore(value) {
+  return isNewsExactFiniteNumber(value) && value >= 0 && value <= 1;
+}
+
+function isNewsExactClusterFeatures(value) {
+  return Boolean(
+    newsExactRecordHasOnlyKeys(value, NEWS_EXACT_CLUSTER_FEATURE_KEYS)
+    && Array.isArray(value.entity_keys)
+    && value.entity_keys.length > 0
+    && value.entity_keys.every((key) => isNewsExactNonEmptyString(key))
+    && isNewsExactNonEmptyString(value.time_bucket)
+    && isNewsExactNonEmptyString(value.semantic_signature)
+    && isNewsExactOptional(value, 'coverage_score', isNewsExactUnitScore)
+    && isNewsExactOptional(value, 'velocity_score', isNewsExactUnitScore)
+    && isNewsExactOptional(value, 'confidence_score', isNewsExactUnitScore)
+    && isNewsExactOptional(
+      value,
+      'primary_language',
+      (language) => typeof language === 'string' && language.length >= 2 && language.length <= 12,
+    )
+    && isNewsExactOptional(value, 'translation_applied', (translated) => typeof translated === 'boolean')
+  );
+}
+
+function isClosedNewsExactStoryBundle(story) {
+  return Boolean(
+    newsExactRecordHasOnlyKeys(story, NEWS_EXACT_STORY_BUNDLE_KEYS)
+    && story.schemaVersion === 'story-bundle-v0'
+    && isNewsExactNonEmptyString(story.story_id)
+    && isNewsExactNonEmptyString(story.topic_id)
+    && isNewsExactNonEmptyString(story.headline)
+    && isNewsExactFiniteNumber(story.cluster_window_start)
+    && isNewsExactFiniteNumber(story.cluster_window_end)
+    && isNewsExactStorySourceList(story.sources, 1)
+    && isNewsExactClusterFeatures(story.cluster_features)
+    && isNewsExactNonEmptyString(story.provenance_hash)
+    && isNewsExactFiniteNumber(story.created_at)
+    && isNewsExactOptional(story, 'storyline_id', isNewsExactNonEmptyString)
+    && isNewsExactOptional(story, 'summary_hint', (summary) => typeof summary === 'string')
+    && isNewsExactOptional(story, 'primary_sources', (sources) => isNewsExactStorySourceList(sources, 1))
+    && isNewsExactOptional(story, 'secondary_assets', (sources) => isNewsExactStorySourceList(sources))
+    && isNewsExactOptional(story, 'related_links', (sources) => isNewsExactStorySourceList(sources))
+  );
+}
+
+function isExpectedNewsExactStoryRelation(value, storyId, relationKey) {
+  return newsExactRecordHasOnlyKeys(value, NEWS_EXACT_GUN_LINK_KEYS)
+    && Object.keys(value).length === 1
+    && value['#'] === `vh/news/stories/${storyId}/${relationKey}`;
+}
+
+function projectSafeNewsStoryExactRecord(record, storyId) {
+  if (!isPlainRecord(record)) return null;
+  const projected = {};
+  for (const [key, value] of Object.entries(record)) {
+    if (NEWS_EXACT_STORY_RELATION_KEYS.has(key)) {
+      if (!isExpectedNewsExactStoryRelation(value, storyId, key)) return null;
+      continue;
+    }
+    projected[key] = value;
+  }
+  if (!newsExactRecordHasOnlyKeys(projected, NEWS_EXACT_STORY_KEYS)) return null;
+  const story = parseStoryBundleEnvelope(projected.__story_bundle_json);
+  return isClosedNewsExactStoryBundle(story) && story.story_id === storyId ? projected : null;
+}
+
+function mergeNewsExactStoryRelationsFromGraph(gun, storyId, record) {
+  if (!isPlainRecord(record)) return record;
+  const rawStory = stripGunMetadata(
+    gun?._?.root?.graph?.[`vh/news/stories/${storyId}`],
+  );
+  if (!isPlainRecord(rawStory)) return record;
+  const merged = { ...record };
+  for (const relationKey of NEWS_EXACT_STORY_RELATION_KEYS) {
+    if (relationKey in rawStory) merged[relationKey] = rawStory[relationKey];
+  }
+  return merged;
+}
+
+function createNewsExactStorySelfPeerSession(storyId, absoluteDeadline) {
+  const peerGun = Gun({
+    peers: [selfGunPeerUrl()],
+    localStorage: false,
+    radisk: false,
+    file: false,
+    stats: false,
+    axe: false,
+  });
+  const storySoul = `vh/news/stories/${storyId}`;
+  const storyChain = peerGun.get(storySoul);
+  const relationChains = [...NEWS_EXACT_STORY_RELATION_KEYS].map((relationKey) =>
+    storyChain.get(relationKey));
+  const sessionBudgetMs = Math.max(1, absoluteDeadline - Date.now());
+  const defaultSettleMs = Math.min(100, Math.max(25, Math.floor(sessionBudgetMs / 4)));
+  const configuredSettleMs = numberEnv(
+    'VH_RELAY_NEWS_STORY_EXACT_SELF_PEER_SETTLE_MS',
+    defaultSettleMs,
+  );
+  const settleMs = Math.max(1, Math.min(sessionBudgetMs, configuredSettleMs));
+  let closed = false;
+  let peerConnected = false;
+  let parentCompleted = false;
+  let parentGeneration = 0;
+  let parentUpdatedAt = 0;
+  let lastReturnedGeneration = -1;
+  let lastReturnedAt = 0;
+  const parentWaiters = new Set();
+  const notifyParentWaiters = () => {
+    for (const resolve of parentWaiters) resolve();
+    parentWaiters.clear();
+  };
+  const noteParentUpdate = () => {
+    parentGeneration += 1;
+    parentUpdatedAt = Date.now();
+    notifyParentWaiters();
+  };
+  const waitForParentUpdateOrTimeout = (timeoutMs) => new Promise((resolve) => {
+    let settled = false;
+    let timer;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      if (timer !== undefined) clearTimeout(timer);
+      parentWaiters.delete(finish);
+      resolve();
+    };
+    timer = setTimeout(finish, timeoutMs);
+    parentWaiters.add(finish);
+    if (closed) finish();
+  });
+  const peerConnectedSubscription = peerGun._.root.on('hi', function onPeerConnected(peer) {
+    this.to.next(peer);
+    peerConnected = true;
+    notifyParentWaiters();
+  });
+  storyChain.on(() => {
+    parentCompleted = true;
+    noteParentUpdate();
+  });
+  for (const relationChain of relationChains) {
+    relationChain.on(noteParentUpdate);
+  }
+  const close = () => {
+    if (closed) return;
+    closed = true;
+    notifyParentWaiters();
+    try {
+      peerConnectedSubscription?.off?.();
+      storyChain.off?.();
+      for (const relationChain of relationChains) relationChain.off?.();
+      const root = peerGun?._?.root;
+      for (const peer of Object.values(root?.opt?.peers ?? {})) {
+        root?.opt?.mesh?.bye?.(peer);
+      }
+      peerGun.off?.();
+    } catch {
+      // Best-effort loopback Gun client cleanup.
+    }
+  };
+  return {
+    async read() {
+      if (closed || Date.now() >= absoluteDeadline) return { kind: 'unavailable' };
+      const remainingMs = Math.max(1, absoluteDeadline - Date.now());
+      const defaultReadTimeoutMs = Math.min(100, Math.max(1, Math.floor(remainingMs / 2)));
+      const configuredReadTimeoutMs = numberEnv(
+        'VH_RELAY_NEWS_STORY_EXACT_SELF_PEER_READ_TIMEOUT_MS',
+        defaultReadTimeoutMs,
+      );
+      const readTimeoutMs = Math.max(1, Math.min(remainingMs, configuredReadTimeoutMs));
+      try {
+        if (!parentCompleted && !peerConnected) {
+          await waitForParentUpdateOrTimeout(readTimeoutMs);
+        }
+        if (!parentCompleted) {
+          return peerConnected
+            ? { kind: 'complete', record: null }
+            : { kind: 'unavailable' };
+        }
+        while (!closed && Date.now() < absoluteDeadline) {
+          const observedGeneration = parentGeneration;
+          const now = Date.now();
+          const quietRemainingMs = Math.max(0, settleMs - (now - parentUpdatedAt));
+          const repeatRemainingMs = parentGeneration === lastReturnedGeneration
+            ? Math.max(0, settleMs - (now - lastReturnedAt))
+            : 0;
+          const settlementRemainingMs = Math.max(quietRemainingMs, repeatRemainingMs);
+          if (settlementRemainingMs <= 0) break;
+          const deadlineRemainingMs = Math.max(1, absoluteDeadline - Date.now());
+          await waitForParentUpdateOrTimeout(Math.min(settlementRemainingMs, deadlineRemainingMs));
+          if (parentGeneration !== observedGeneration) continue;
+        }
+        const settledAt = Date.now();
+        if (
+          closed
+          || settledAt - parentUpdatedAt < settleMs
+          || (
+            parentGeneration === lastReturnedGeneration
+            && settledAt - lastReturnedAt < settleMs
+          )
+        ) {
+          return { kind: 'unavailable' };
+        }
+        const rawStory = stripGunMetadata(peerGun?._?.root?.graph?.[storySoul]);
+        lastReturnedGeneration = parentGeneration;
+        lastReturnedAt = settledAt;
+        return {
+          kind: 'complete',
+          record: isPlainRecord(rawStory) ? rawStory : null,
+          generation: parentGeneration,
+        };
+      } catch {
+        return { kind: 'unavailable' };
+      }
+    },
+    close,
+  };
+}
+
+function newsExactRecordResult(record, extra = {}) {
+  return { kind: 'record', record, ...extra };
+}
+
+function newsExactMissingResult() {
+  return { kind: 'missing' };
+}
+
+function newsExactUnsafeResult() {
+  return { kind: 'unsafe' };
+}
+
+function newsExactUnavailableResult() {
+  return { kind: 'unavailable' };
+}
+
+function isCompleteSignedSystemWriterRecord(record) {
+  return Boolean(
+    isPlainRecord(record)
+    && NEWS_EXACT_LEGACY_SYSTEM_WRITER_KEYS.every((key) => !(key in record) || record[key] === null)
+    && record._protocolVersion === 'luma-public-v1'
+    && record._writerKind === 'system'
+    && typeof record._systemWriterId === 'string'
+    && record._systemWriterId.trim() === record._systemWriterId
+    && record._systemWriterId.length > 0
+    && Number.isFinite(record._systemIssuedAt)
+    && record._systemIssuedAt >= 0
+    && typeof record._systemSignature === 'string'
+    && record._systemSignature.trim() === record._systemSignature
+    && record._systemSignature.length > 0
+  );
+}
+
+function isCompleteSignedNewsStoryRecord(record, storyId) {
+  const story = parseStoryBundleEnvelope(record?.__story_bundle_json);
+  return Boolean(
+    isCompleteSignedSystemWriterRecord(record)
+    && record.story_id === storyId
+    && story?.story_id === storyId
+    && record.schemaVersion === story.schemaVersion
+    && record.created_at === story.created_at
+  );
+}
+
+function newsExactScalarRecordFingerprint(record) {
+  return JSON.stringify(
+    Object.keys(record)
+      .sort()
+      .map((key) => [key, record[key]]),
+  );
+}
+
+async function readNewsStoryExactRecord(gun, storyId, options = {}) {
+  const storyChains = [
+    gun.get('vh/news/stories').get(storyId),
+    gun.get(`vh/news/stories/${storyId}`),
+    gun.get('vh').get('news').get('stories').get(storyId),
+  ];
+  const timeoutMs = options.timeoutMs ?? numberEnv('VH_RELAY_NEWS_STORY_REST_READ_TIMEOUT_MS', 1_500);
+  const deadline = Date.now() + timeoutMs;
+  const selfPeerSession = createNewsExactStorySelfPeerSession(storyId, deadline);
+  let selfPeerVertex = null;
+  let sawPresent = false;
+  let sawUnsafeOrConflict = false;
+  let stableSafeFingerprint = null;
+  let stableSafeGeneration = null;
+  let stableSafeObservationCount = 0;
+
+  try {
+    do {
+      const remainingMs = Math.max(1, deadline - Date.now());
+      const [storyValues, freshVertex] = await Promise.all([
+        Promise.all(storyChains.map((chain) => readOnce(chain, Math.min(remainingMs, 250)))),
+        selfPeerSession.read(),
+      ]);
+      selfPeerVertex = freshVertex;
+      const observations = storyValues.map((value) => ({
+        present: value !== null && value !== undefined,
+        direct: mergeNewsExactStoryRelationsFromGraph(
+          gun,
+          storyId,
+          stripGunMetadata(value),
+        ),
+      }));
+      if (selfPeerVertex.kind === 'complete' && isPlainRecord(selfPeerVertex.record)) {
+        observations.push({
+          present: true,
+          direct: selfPeerVertex.record,
+          authoritative: true,
+          generation: selfPeerVertex.generation,
+        });
+      }
+      const safeCandidates = [];
+      let batchUnsafe = false;
+      let authoritativeSafeFingerprint = null;
+      let authoritativeSafeGeneration = null;
+      for (const observed of observations) {
+        if (observed.present) sawPresent = true;
+        if (!observed.present) continue;
+        const direct = projectSafeNewsStoryExactRecord(observed.direct, storyId);
+        if (!direct || !isCompleteSignedNewsStoryRecord(direct, storyId)) {
+          batchUnsafe = true;
+          continue;
+        }
+        safeCandidates.push(direct);
+        if (observed.authoritative === true) {
+          authoritativeSafeFingerprint = newsExactScalarRecordFingerprint(direct);
+          authoritativeSafeGeneration = observed.generation;
+        }
+      }
+      const fingerprints = new Set(safeCandidates.map(newsExactScalarRecordFingerprint));
+      if (fingerprints.size > 1) batchUnsafe = true;
+      if (batchUnsafe) {
+        sawUnsafeOrConflict = true;
+        stableSafeFingerprint = null;
+        stableSafeGeneration = null;
+        stableSafeObservationCount = 0;
+      } else if (
+        safeCandidates.length > 0
+        && authoritativeSafeFingerprint !== null
+        && Number.isInteger(authoritativeSafeGeneration)
+      ) {
+        const fingerprint = fingerprints.values().next().value;
+        if (
+          fingerprint === stableSafeFingerprint
+          && authoritativeSafeGeneration === stableSafeGeneration
+        ) {
+          stableSafeObservationCount += 1;
+        } else {
+          stableSafeFingerprint = fingerprint;
+          stableSafeGeneration = authoritativeSafeGeneration;
+          stableSafeObservationCount = 1;
+        }
+        if (stableSafeObservationCount >= 2) {
+          const direct = safeCandidates[0];
+          return newsExactRecordResult(direct, {
+            story: parseStoryBundleEnvelope(direct.__story_bundle_json),
+          });
+        }
+      }
+      if (Date.now() >= deadline) break;
+      await new Promise((resolve) =>
+        setTimeout(resolve, Math.min(25, Math.max(1, deadline - Date.now()))));
+    } while (Date.now() < deadline);
+
+    if (sawUnsafeOrConflict) return newsExactUnsafeResult();
+    if (selfPeerVertex?.kind === 'unavailable' || sawPresent) return newsExactUnavailableResult();
+    return newsExactMissingResult();
+  } finally {
+    selfPeerSession.close();
+  }
+}
+
 async function readNewsSynthesisLifecycleRecord(gun, storyId, options = {}) {
   const lifecycleChain = gun
     .get('vh')
@@ -2991,8 +3511,7 @@ function isCompleteSignedNewsSynthesisLifecycleRecord(record, storyId) {
     'frame_table_unavailable',
   ]);
   return Boolean(
-    record
-    && typeof record === 'object'
+    isCompleteSignedSystemWriterRecord(record)
     && record.schemaVersion === 'vh-news-synthesis-lifecycle-v1'
     && record.story_id === storyId
     && typeof record.topic_id === 'string'
@@ -3008,15 +3527,13 @@ function isCompleteSignedNewsSynthesisLifecycleRecord(record, storyId) {
     && frameTableValues.has(record.frame_table_state)
     && Number.isFinite(record.updated_at)
     && record.updated_at >= 0
-    && typeof record._protocolVersion === 'string'
-    && record._protocolVersion.trim()
-    && record._writerKind === 'system'
-    && typeof record._systemWriterId === 'string'
-    && record._systemWriterId.trim()
-    && Number.isFinite(record._systemIssuedAt)
-    && record._systemIssuedAt >= 0
-    && typeof record._systemSignature === 'string'
-    && record._systemSignature.trim()
+    && isNewsExactOptional(record, 'reason', isNewsExactNonEmptyString)
+    && isNewsExactOptional(record, 'synthesis_id', isNewsExactNonEmptyString)
+    && isNewsExactOptional(
+      record,
+      'epoch',
+      (epoch) => isNewsExactFiniteNumber(epoch) && epoch >= 0,
+    )
   );
 }
 
@@ -3030,16 +3547,22 @@ async function readNewsSynthesisLifecycleExactRecord(gun, storyId, options = {})
     .get('latest');
   const timeoutMs = options.timeoutMs ?? numberEnv('VH_RELAY_NEWS_LIFECYCLE_REST_READ_TIMEOUT_MS', 750);
   const deadline = Date.now() + timeoutMs;
+  let sawPresent = false;
   do {
     const remainingMs = Math.max(1, deadline - Date.now());
-    const direct = stripGunMetadata(await readOnce(lifecycleChain, Math.min(remainingMs, 250)));
-    if (isCompleteSignedNewsSynthesisLifecycleRecord(direct, storyId)) {
-      return direct;
+    const raw = await readOnce(lifecycleChain, Math.min(remainingMs, 250));
+    if (raw !== null && raw !== undefined) sawPresent = true;
+    const direct = stripGunMetadata(raw);
+    if (
+      newsExactRecordHasOnlyKeys(direct, NEWS_EXACT_LIFECYCLE_KEYS)
+      && isCompleteSignedNewsSynthesisLifecycleRecord(direct, storyId)
+    ) {
+      return newsExactRecordResult(direct);
     }
     if (Date.now() >= deadline) break;
     await new Promise((resolve) => setTimeout(resolve, Math.min(25, Math.max(1, deadline - Date.now()))));
   } while (Date.now() < deadline);
-  return null;
+  return sawPresent ? newsExactUnsafeResult() : newsExactMissingResult();
 }
 
 async function readNewsSynthesisLifecycleRecordFromFields(gun, storyId, options = {}) {
@@ -3625,6 +4148,94 @@ async function readLinkedGunRecord(gun, value, timeoutMs) {
   if (!soul) return value;
   const linked = stripGunMetadata(await readOnce(gun.get(soul), timeoutMs));
   return linked !== null && linked !== undefined ? linked : value;
+}
+
+function isCompleteSignedNewsLatestIndexRecord(record, storyId) {
+  return Boolean(
+    isCompleteSignedSystemWriterRecord(record)
+    && record.story_id === storyId
+    && isNewsExactFiniteNumber(record.latest_activity_at)
+    && record.latest_activity_at >= 0
+    && isCompleteNewsExactIndexMetadata(record)
+  );
+}
+
+function isCompleteSignedNewsHotIndexRecord(record, storyId) {
+  return Boolean(
+    isCompleteSignedSystemWriterRecord(record)
+    && record.story_id === storyId
+    && isNewsExactFiniteNumber(record.hotness)
+    && record.hotness >= 0
+    && isCompleteNewsExactIndexMetadata(record)
+  );
+}
+
+function isCompleteNewsExactIndexMetadata(record) {
+  const isNonnegativeNumber = (value) => isNewsExactFiniteNumber(value) && value >= 0;
+  return Boolean(
+    isNewsExactOptional(
+      record,
+      'product_state_schema_version',
+      (version) => version === 'vh-news-product-feed-index-v1',
+    )
+    && isNewsExactOptional(record, 'topic_id', isNewsExactNonEmptyString)
+    && isNewsExactOptional(record, 'source_set_revision', isNewsExactNonEmptyString)
+    && isNewsExactOptional(record, 'source_count', isNonnegativeNumber)
+    && isNewsExactOptional(record, 'canonical_source_count', isNonnegativeNumber)
+    && isNewsExactOptional(record, 'story_created_at', isNonnegativeNumber)
+    && isNewsExactOptional(record, 'cluster_window_start', isNonnegativeNumber)
+  );
+}
+
+async function readNewsIndexExactRecord(
+  gun,
+  indexName,
+  storyId,
+  allowedKeys,
+  validate,
+  timeoutMs,
+) {
+  const indexChain = gun.get('vh').get('news').get('index').get(indexName);
+  const deadline = Date.now() + timeoutMs;
+  let sawPresent = false;
+  do {
+    const remainingMs = Math.max(1, deadline - Date.now());
+    const rawValue = await readOnce(indexChain.get(storyId), Math.min(remainingMs, 250));
+    if (rawValue !== null && rawValue !== undefined) sawPresent = true;
+    const raw = stripGunMetadata(rawValue);
+    const linkedRemainingMs = Math.max(1, deadline - Date.now());
+    const record = stripGunMetadata(
+      await readLinkedGunRecord(gun, raw, Math.min(linkedRemainingMs, 250)),
+    );
+    if (newsExactRecordHasOnlyKeys(record, allowedKeys) && validate(record, storyId)) {
+      return newsExactRecordResult(record);
+    }
+    if (Date.now() >= deadline) break;
+    await new Promise((resolve) => setTimeout(resolve, Math.min(25, Math.max(1, deadline - Date.now()))));
+  } while (Date.now() < deadline);
+  return sawPresent ? newsExactUnsafeResult() : newsExactMissingResult();
+}
+
+function readNewsLatestIndexExactRecord(gun, storyId, timeoutMs = 1_500) {
+  return readNewsIndexExactRecord(
+    gun,
+    'latest',
+    storyId,
+    NEWS_EXACT_LATEST_INDEX_KEYS,
+    isCompleteSignedNewsLatestIndexRecord,
+    timeoutMs,
+  );
+}
+
+function readNewsHotIndexExactRecord(gun, storyId, timeoutMs = 1_500) {
+  return readNewsIndexExactRecord(
+    gun,
+    'hot',
+    storyId,
+    NEWS_EXACT_HOT_INDEX_KEYS,
+    isCompleteSignedNewsHotIndexRecord,
+    timeoutMs,
+  );
 }
 
 async function readNewsLatestIndexRecord(gun, storyId, timeoutMs = 1_500) {
@@ -6067,6 +6678,33 @@ async function handleWriteRoute(req, res, pathname, kind, write) {
   }
 }
 
+function sendNewsExactReadbackFailure(res, outcome, missingError, storyId) {
+  if (outcome.kind === 'record') return false;
+  if (outcome.kind === 'missing') {
+    sendJson(res, 404, {
+      ok: false,
+      error: missingError,
+      story_id: storyId,
+    });
+    return true;
+  }
+  if (outcome.kind === 'unavailable') {
+    sendJson(res, 503, {
+      ok: false,
+      error: 'news-exact-readback-unavailable',
+      story_id: storyId,
+    });
+    return true;
+  }
+  sendJson(res, 409, {
+    ok: false,
+    error_class: 'relay-write-safety',
+    error: 'news-exact-readback-present-unsafe',
+    story_id: storyId,
+  });
+  return true;
+}
+
 const server = http.createServer((req, res) => {
   metrics.httpRequests += 1;
   res.on('finish', () => {
@@ -6213,19 +6851,22 @@ const server = http.createServer((req, res) => {
       sendJson(res, 400, { ok: false, error: 'story_id-required' });
       return;
     }
-    void readNewsStoryRecord(gun, storyId, { preferCompleteRecord: exactReadback })
-      .then((result) => {
-        if (!result) {
-          sendJson(res, 404, { ok: false, error: 'news-story-not-found', story_id: storyId });
-          return;
-        }
+    const storyRead = exactReadback
+      ? readNewsStoryExactRecord(gun, storyId)
+      : readNewsStoryRecord(gun, storyId).then((result) =>
+        result
+          ? newsExactRecordResult(result.record, { story: result.story, source: result.source })
+          : newsExactMissingResult());
+    void storyRead
+      .then((outcome) => {
+        if (sendNewsExactReadbackFailure(res, outcome, 'news-story-not-found', storyId)) return;
         sendJson(res, 200, {
           ok: true,
-          story_id: result.story.story_id,
-          topic_id: result.story.topic_id,
-          source: result.source ?? 'story-body',
-          story: result.story,
-          record: result.record,
+          story_id: outcome.story.story_id,
+          topic_id: outcome.story.topic_id,
+          source: outcome.source ?? 'story-body',
+          story: outcome.story,
+          record: outcome.record,
         });
       })
       .catch((error) => {
@@ -6262,24 +6903,17 @@ const server = http.createServer((req, res) => {
       return;
     }
     if (storyId) {
-      void readNewsLatestIndexRecord(
+      void readNewsLatestIndexExactRecord(
         gun,
         storyId,
         numberEnv('VH_RELAY_NEWS_LATEST_INDEX_REST_READ_TIMEOUT_MS', 1_500),
       )
-        .then((record) => {
-          if (!record) {
-            sendJson(res, 404, {
-              ok: false,
-              error: 'news-latest-index-not-found',
-              story_id: storyId,
-            });
-            return;
-          }
+        .then((outcome) => {
+          if (sendNewsExactReadbackFailure(res, outcome, 'news-latest-index-not-found', storyId)) return;
           sendJson(res, 200, {
             ok: true,
             story_id: storyId,
-            record,
+            record: outcome.record,
           });
         })
         .catch((error) => {
@@ -6350,24 +6984,17 @@ const server = http.createServer((req, res) => {
       || parsedUrl.searchParams.get('include_root') === 'true';
     const scanLimit = parsedUrl.searchParams.get('scan_limit');
     if (storyId) {
-      void readNewsHotIndexRecord(
+      void readNewsHotIndexExactRecord(
         gun,
         storyId,
         numberEnv('VH_RELAY_NEWS_HOT_INDEX_REST_READ_TIMEOUT_MS', 1_500),
       )
-        .then((record) => {
-          if (!record) {
-            sendJson(res, 404, {
-              ok: false,
-              error: 'news-hot-index-not-found',
-              story_id: storyId,
-            });
-            return;
-          }
+        .then((outcome) => {
+          if (sendNewsExactReadbackFailure(res, outcome, 'news-hot-index-not-found', storyId)) return;
           sendJson(res, 200, {
             ok: true,
             story_id: storyId,
-            record,
+            record: outcome.record,
           });
         })
         .catch((error) => {
@@ -6416,17 +7043,19 @@ const server = http.createServer((req, res) => {
       : Promise.all([
         readNewsSynthesisLifecycleRecord(gun, storyId).catch(() => null),
         readNewsSynthesisLifecycleRecordFromFields(gun, storyId).catch(() => null),
-      ]).then(([direct, fromFields]) => direct ?? fromFields);
+      ]).then(([direct, fromFields]) => {
+        const lifecycle = direct ?? fromFields;
+        return lifecycle ? newsExactRecordResult(lifecycle) : newsExactMissingResult();
+      });
     void lifecycleRead
-      .then((lifecycle) => {
-        if (!lifecycle) {
-          sendJson(res, 404, {
-            ok: false,
-            error: 'news-synthesis-lifecycle-not-found',
-            story_id: storyId,
-          });
-          return;
-        }
+      .then((outcome) => {
+        if (sendNewsExactReadbackFailure(
+          res,
+          outcome,
+          'news-synthesis-lifecycle-not-found',
+          storyId,
+        )) return;
+        const lifecycle = outcome.record;
         sendJson(res, 200, {
           ok: true,
           story_id: storyId,

--- a/packages/e2e/src/live/relay-server.vitest.mjs
+++ b/packages/e2e/src/live/relay-server.vitest.mjs
@@ -1349,12 +1349,13 @@ describe('infra relay server', () => {
     await expect(requestJson(
       `http://127.0.0.1:${writer.port}/vh/news/synthesis-lifecycle?story_id=${record.story_id}&readback=exact`,
     )).resolves.toMatchObject({
-      statusCode: 404,
-      body: expect.objectContaining({
+      statusCode: 409,
+      body: {
         ok: false,
-        error: 'news-synthesis-lifecycle-not-found',
+        error_class: 'relay-write-safety',
+        error: 'news-exact-readback-present-unsafe',
         story_id: record.story_id,
-      }),
+      },
     });
 
     await new Promise((resolve) => {
@@ -1530,16 +1531,53 @@ describe('infra relay server', () => {
       VH_RELAY_NEWS_LATEST_INDEX_REST_READ_TIMEOUT_MS: '500',
       VH_RELAY_NEWS_HOT_INDEX_REST_READ_TIMEOUT_MS: '500',
     });
-    const story = makeRelayNewsStory('story-exact-signed-readback', 1778991500000, [
-      {
-        source_id: 'source-exact-signed-readback',
-        publisher: 'Exact Signed Readback',
-        url: 'https://example.com/exact-signed-readback',
-        url_hash: 'exact-signed-readback',
-        published_at: 1778991500000,
-        title: 'Exact signed readback story',
+    const source = {
+      source_id: 'source-exact-signed-readback',
+      publisher: 'Exact Signed Readback',
+      url: 'https://example.com/exact-signed-readback',
+      url_hash: 'exact-signed-readback',
+      published_at: 1778991500000,
+      title: 'Exact signed readback story',
+      imageUrl: 'https://example.com/exact-signed-readback.jpg',
+    };
+    const baseStory = makeRelayNewsStory('story-exact-signed-readback', 1778991500000, [source]);
+    const story = {
+      ...baseStory,
+      storyline_id: 'storyline-exact-signed-readback',
+      summary_hint: '',
+      primary_sources: [
+        {
+          ...source,
+          source_id: 'source-exact-primary',
+          url: 'https://example.com/exact-primary',
+          url_hash: 'exact-primary',
+        },
+      ],
+      secondary_assets: [
+        {
+          ...source,
+          source_id: 'source-exact-secondary',
+          url: 'https://example.com/exact-secondary',
+          url_hash: 'exact-secondary',
+        },
+      ],
+      related_links: [
+        {
+          ...source,
+          source_id: 'source-exact-related',
+          url: 'https://example.com/exact-related',
+          url_hash: 'exact-related',
+        },
+      ],
+      cluster_features: {
+        ...baseStory.cluster_features,
+        coverage_score: 0,
+        velocity_score: 1,
+        confidence_score: 0.5,
+        primary_language: 'en-CA',
+        translation_applied: false,
       },
-    ]);
+    };
     const signedFields = {
       _system: null,
       _Signature: null,
@@ -1596,20 +1634,57 @@ describe('infra relay server', () => {
         });
       }
     }
+    const relationGun = createRelayGunClient(port);
+    const storySoul = `vh/news/stories/${story.story_id}`;
+    try {
+      await putGunObjectAndWaitForField(
+        relationGun.get(storySoul).get('analysis').get('analysis-fixture'),
+        { fixture: 'analysis-record' },
+        'fixture',
+        'analysis-record',
+      );
+      await putGunObjectAndWaitForField(
+        relationGun.get(storySoul).get('analysis_latest'),
+        { fixture: 'analysis-latest-record' },
+        'fixture',
+        'analysis-latest-record',
+      );
+      const expectedRelations = {
+        synthesis_lifecycle: `${storySoul}/synthesis_lifecycle`,
+        analysis: `${storySoul}/analysis`,
+        analysis_latest: `${storySoul}/analysis_latest`,
+      };
+      const relationDeadline = Date.now() + 5_000;
+      let observedRelations = null;
+      while (Date.now() < relationDeadline) {
+        observedRelations = await readGunOnce(relationGun.get(storySoul), 500);
+        if (Object.entries(expectedRelations).every(([key, soul]) =>
+          observedRelations?.[key]?.['#'] === soul)) {
+          break;
+        }
+      }
+      expect(observedRelations).toEqual(expect.objectContaining({
+        synthesis_lifecycle: { '#': expectedRelations.synthesis_lifecycle },
+        analysis: { '#': expectedRelations.analysis },
+        analysis_latest: { '#': expectedRelations.analysis_latest },
+      }));
+    } finally {
+      relationGun.off();
+    }
     expect(existsSync(snapshotFile)).toBe(true);
     const snapshotBeforeReadbacks = readFileSync(snapshotFile, 'utf8');
 
     const readbacks = [
       { route: '/vh/news/story', record: storyRecord, extraQuery: '&readback=exact' },
-      { route: '/vh/news/latest-index', record: latestRecord, extraQuery: '&persist=false' },
-      { route: '/vh/news/hot-index', record: hotRecord },
+      { route: '/vh/news/latest-index', record: latestRecord, extraQuery: '&readback=exact&persist=false' },
+      { route: '/vh/news/hot-index', record: hotRecord, extraQuery: '&readback=exact' },
       { route: '/vh/news/synthesis-lifecycle', record: lifecycleRecord, extraQuery: '&readback=exact' },
     ];
     for (const readback of readbacks) {
       const result = await requestJson(
         `http://127.0.0.1:${port}${readback.route}?story_id=${encodeURIComponent(story.story_id)}${readback.extraQuery ?? ''}`,
       );
-      expect(result).toMatchObject({
+      expect(result, readback.route).toMatchObject({
         statusCode: 200,
         body: expect.objectContaining({
           ok: true,
@@ -1629,27 +1704,34 @@ describe('infra relay server', () => {
           expect(result.body.record[key]).toEqual(value);
         }
       }
+      if (readback.route === '/vh/news/story') {
+        expect(result.body.record).not.toHaveProperty('synthesis_lifecycle');
+        expect(result.body.record).not.toHaveProperty('analysis');
+        expect(result.body.record).not.toHaveProperty('analysis_latest');
+        expect(result.body.record.__story_bundle_json).toBe(storyRecord.__story_bundle_json);
+      }
     }
     expect(readFileSync(snapshotFile, 'utf8')).toBe(snapshotBeforeReadbacks);
 
-    await expect(requestJson(`http://127.0.0.1:${port}/vh/news/latest-index?story_id=story-missing&persist=false`))
-      .resolves.toMatchObject({
+    const missingReadbacks = [
+      { route: '/vh/news/story', error: 'news-story-not-found', extraQuery: '&readback=exact' },
+      { route: '/vh/news/latest-index', error: 'news-latest-index-not-found', extraQuery: '&readback=exact&persist=false' },
+      { route: '/vh/news/hot-index', error: 'news-hot-index-not-found', extraQuery: '&readback=exact' },
+      { route: '/vh/news/synthesis-lifecycle', error: 'news-synthesis-lifecycle-not-found', extraQuery: '&readback=exact' },
+    ];
+    const missingResults = await Promise.all(missingReadbacks.map((readback) => requestJson(
+      `http://127.0.0.1:${port}${readback.route}?story_id=story-missing${readback.extraQuery}`,
+    )));
+    for (let index = 0; index < missingReadbacks.length; index += 1) {
+      expect(missingResults[index], missingReadbacks[index].route).toMatchObject({
         statusCode: 404,
-        body: expect.objectContaining({
+        body: {
           ok: false,
-          error: 'news-latest-index-not-found',
+          error: missingReadbacks[index].error,
           story_id: 'story-missing',
-        }),
+        },
       });
-    await expect(requestJson(`http://127.0.0.1:${port}/vh/news/hot-index?story_id=story-missing`))
-      .resolves.toMatchObject({
-        statusCode: 404,
-        body: expect.objectContaining({
-          ok: false,
-          error: 'news-hot-index-not-found',
-          story_id: 'story-missing',
-        }),
-      });
+    }
     expect(readFileSync(snapshotFile, 'utf8')).toBe(snapshotBeforeReadbacks);
 
     await expect(requestJson(`http://127.0.0.1:${port}/vh/news/latest-index?limit=3&persist=false`))
@@ -1669,6 +1751,984 @@ describe('infra relay server', () => {
         }),
       });
   }, 30_000);
+
+  it('rejects persisted wrong story relation souls and never exposes Gun-normalized extra fields', async () => {
+    const persistentDir = mkdtempSync(path.join(os.tmpdir(), 'vh-relay-relation-test-'));
+    tempDirs.add(persistentDir);
+    const relayEnv = {
+      GUN_FILE: path.join(persistentDir, 'data'),
+      VH_RELAY_NEWS_STORY_REST_READ_TIMEOUT_MS: '600',
+    };
+    const firstRelay = await startRelay(children, tempDirs, relayEnv);
+    const port = firstRelay.port;
+    const signedFields = {
+      _system: null,
+      _Signature: null,
+      _WriterId: null,
+      _IssuedAt: null,
+      _protocolVersion: 'luma-public-v1',
+      _writerKind: 'system',
+      _systemWriterId: 'vh-public-beta-news-system-writer-relation-test',
+      _systemIssuedAt: 1778991900100,
+      _systemSignature: 'relation-test-signature',
+    };
+    const relationKeys = ['synthesis_lifecycle', 'analysis', 'analysis_latest'];
+    const gun = createRelayGunClient(port);
+    const observerGun = createRelayGunClient(port);
+    const waitForParentRelation = async (storySoul, key, expectedSoul) => {
+      const deadline = Date.now() + 5_000;
+      let observed = null;
+      while (Date.now() < deadline) {
+        observed = await readGunOnce(observerGun.get(storySoul), 500);
+        const rawRelation = observerGun._.root.graph?.[storySoul]?.[key];
+        if (rawRelation?.['#'] === expectedSoul) return rawRelation;
+      }
+      throw new Error(`gun-parent-relation-readback-timeout:${key}:${JSON.stringify(observed?.[key])}`);
+    };
+    const makeSignedStoryRecord = (story) => ({
+      __story_bundle_json: JSON.stringify(story),
+      story_id: story.story_id,
+      created_at: story.created_at,
+      schemaVersion: story.schemaVersion,
+      ...signedFields,
+    });
+    const wrongSoulMarkers = [];
+    const normalizedExtraMarkers = [];
+    const wrongRelationCases = [];
+    const normalizedExtraCases = [];
+    try {
+      for (let index = 0; index < relationKeys.length; index += 1) {
+        const key = relationKeys[index];
+        const story = makeRelayNewsStory(`story-exact-wrong-${key}`, 1778991900200 + index, [{
+          source_id: `source-exact-wrong-${key}`,
+          publisher: `Wrong relation ${key}`,
+          url: `https://example.com/wrong-relation-${key}`,
+          url_hash: `wrong-relation-${key}`,
+          title: `Wrong relation ${key}`,
+        }]);
+        const record = makeSignedStoryRecord(story);
+        await expect(requestJson(`http://127.0.0.1:${port}/vh/news/story`, {
+          method: 'POST',
+          body: { record },
+        })).resolves.toMatchObject({ statusCode: 200, body: expect.objectContaining({ ok: true }) });
+        const storySoul = `vh/news/stories/${story.story_id}`;
+        const wrongSoul = `${storySoul}/${key}-wrong-soul-secret`;
+        wrongSoulMarkers.push(wrongSoul);
+        gun.get(wrongSoul).put({ fixture: `wrong-${key}` });
+        const targetDeadline = Date.now() + 5_000;
+        let observedTarget = null;
+        while (Date.now() < targetDeadline) {
+          observedTarget = await readGunOnce(observerGun.get(wrongSoul), 500);
+          if (observedTarget?.fixture === `wrong-${key}`) break;
+        }
+        expect(observedTarget?.fixture, key).toBe(`wrong-${key}`);
+        gun.get(storySoul).put({ [key]: gun.get(wrongSoul) });
+        await waitForParentRelation(storySoul, key, wrongSoul);
+        wrongRelationCases.push({ key, story, record, wrongSoul });
+      }
+
+      for (let index = 0; index < relationKeys.length; index += 1) {
+        const key = relationKeys[index];
+        const story = makeRelayNewsStory(`story-exact-extra-${key}`, 1778991900300 + index, [{
+          source_id: `source-exact-extra-${key}`,
+          publisher: `Extra relation ${key}`,
+          url: `https://example.com/extra-relation-${key}`,
+          url_hash: `extra-relation-${key}`,
+          title: `Extra relation ${key}`,
+        }]);
+        const record = makeSignedStoryRecord(story);
+        await expect(requestJson(`http://127.0.0.1:${port}/vh/news/story`, {
+          method: 'POST',
+          body: { record },
+        })).resolves.toMatchObject({ statusCode: 200, body: expect.objectContaining({ ok: true }) });
+        const storySoul = `vh/news/stories/${story.story_id}`;
+        const expectedSoul = `${storySoul}/${key}`;
+        const extraMarker = `extra-relation-field-secret-${key}`;
+        normalizedExtraMarkers.push(extraMarker);
+        const invalidLinkShape = { '#': expectedSoul, note: extraMarker };
+        expect(Gun.valid(invalidLinkShape), key).toBe(false);
+        gun.get(storySoul).put({ [key]: invalidLinkShape });
+        await expect(readGunOnce(observerGun.get(expectedSoul).get('note'))).resolves.toBe(extraMarker);
+        const parentRelation = await waitForParentRelation(storySoul, key, expectedSoul);
+        expect(parentRelation, key).toEqual({ '#': expectedSoul });
+        normalizedExtraCases.push({ key, story, record, extraMarker });
+      }
+    } finally {
+      gun.off();
+      observerGun.off();
+    }
+    await delay(500);
+    await new Promise((resolve) => {
+      firstRelay.child.once('exit', resolve);
+      if (!firstRelay.child.kill('SIGKILL')) resolve();
+    });
+    children.delete(firstRelay.child);
+    const restartedRelay = await startRelay(children, tempDirs, relayEnv);
+    const restartedObserverGun = createRelayGunClient(restartedRelay.port);
+
+    for (const { key, story, record, wrongSoul } of wrongRelationCases) {
+      const storySoul = `vh/news/stories/${story.story_id}`;
+      await readGunOnce(restartedObserverGun.get(storySoul), 1_000);
+      const restartedRelation = restartedObserverGun._.root.graph?.[storySoul]?.[key] ?? null;
+      if (restartedRelation !== null) {
+        expect(restartedRelation, key).toEqual({ '#': wrongSoul });
+      }
+      const exact = await requestJson(
+        `http://127.0.0.1:${restartedRelay.port}/vh/news/story?story_id=${story.story_id}&readback=exact`,
+      );
+      if (exact.statusCode === 200) {
+        expect(restartedRelation, key).toBeNull();
+        expect(exact.statusCode, key).toBe(200);
+        expect(exact.body.record, key).toEqual(expect.objectContaining({
+          story_id: record.story_id,
+          schemaVersion: record.schemaVersion,
+          created_at: record.created_at,
+        }));
+        expect(exact.body.record, key).not.toHaveProperty(key);
+      } else {
+        expect(exact.statusCode, key).toBe(409);
+        expect(exact.body, key).toEqual({
+          ok: false,
+          error_class: 'relay-write-safety',
+          error: 'news-exact-readback-present-unsafe',
+          story_id: story.story_id,
+        });
+      }
+      expect(exact.raw, key).not.toContain(wrongSoul);
+    }
+    for (const { key, story, record, extraMarker } of normalizedExtraCases) {
+      const exact = await requestJson(
+        `http://127.0.0.1:${restartedRelay.port}/vh/news/story?story_id=${story.story_id}&readback=exact`,
+      );
+      expect(exact.statusCode, key).toBe(200);
+      expect(exact.body.record, key).toEqual(expect.objectContaining({
+        story_id: record.story_id,
+        schemaVersion: record.schemaVersion,
+        created_at: record.created_at,
+        _protocolVersion: record._protocolVersion,
+        _writerKind: record._writerKind,
+        _systemWriterId: record._systemWriterId,
+        _systemIssuedAt: record._systemIssuedAt,
+        _systemSignature: record._systemSignature,
+      }));
+      expect(exact.body.record, key).not.toHaveProperty(key);
+      expect(exact.raw, key).not.toContain(extraMarker);
+    }
+    restartedObserverGun.off();
+    const relayOutput = [
+      firstRelay.child.stdoutText,
+      firstRelay.child.stderrText,
+      restartedRelay.child.stdoutText,
+      restartedRelay.child.stderrText,
+    ].join('\n');
+    for (const detail of [...wrongSoulMarkers, ...normalizedExtraMarkers]) {
+      expect(relayOutput).not.toContain(detail);
+    }
+  }, 45_000);
+
+  it('returns unavailable when the exact self-peer cannot connect and cleans up every loopback session', async () => {
+    const activeConnections = async (port) => {
+      const metrics = await fetchText(`http://127.0.0.1:${port}/metrics`);
+      expect(metrics.statusCode).toBe(200);
+      const match = metrics.body.match(/^vh_relay_active_connections\s+([0-9]+)$/m);
+      expect(match).not.toBeNull();
+      return Number(match[1]);
+    };
+    const waitForConnectionBaseline = async (port, baseline) => {
+      const deadline = Date.now() + 5_000;
+      let observed = null;
+      while (Date.now() < deadline) {
+        observed = await activeConnections(port);
+        if (observed === baseline) return;
+        await delay(50);
+      }
+      expect(observed).toBe(baseline);
+    };
+    const signedFields = {
+      _system: null,
+      _Signature: null,
+      _WriterId: null,
+      _IssuedAt: null,
+      _protocolVersion: 'luma-public-v1',
+      _writerKind: 'system',
+      _systemWriterId: 'vh-public-beta-news-system-writer-self-peer-test',
+      _systemIssuedAt: 1778991950100,
+      _systemSignature: 'self-peer-test-signature',
+    };
+    const writeStory = async (port, story) => {
+      const record = {
+        __story_bundle_json: JSON.stringify(story),
+        story_id: story.story_id,
+        created_at: story.created_at,
+        schemaVersion: story.schemaVersion,
+        ...signedFields,
+      };
+      await expect(requestJson(`http://127.0.0.1:${port}/vh/news/story`, {
+        method: 'POST',
+        body: { record },
+      })).resolves.toMatchObject({
+        statusCode: 200,
+        body: expect.objectContaining({ ok: true, story_id: story.story_id }),
+      });
+      return record;
+    };
+    const unavailableRelay = await startRelay(children, tempDirs, {
+      VH_RELAY_MAX_ACTIVE_CONNECTIONS: '1',
+      VH_RELAY_NEWS_STORY_REST_READ_TIMEOUT_MS: '25',
+      VH_RELAY_NEWS_STORY_EXACT_SELF_PEER_READ_TIMEOUT_MS: '1',
+    });
+    const unavailableStory = makeRelayNewsStory('story-exact-self-peer-unavailable', 1778991950200, [{
+      source_id: 'source-exact-self-peer-unavailable',
+      publisher: 'Exact self-peer unavailable',
+      url: 'https://example.com/exact-self-peer-unavailable',
+      url_hash: 'exact-self-peer-unavailable',
+      title: 'Exact self-peer unavailable',
+    }]);
+    await writeStory(unavailableRelay.port, unavailableStory);
+    const unavailableBaseline = await activeConnections(unavailableRelay.port);
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      const result = await requestJson(
+        `http://127.0.0.1:${unavailableRelay.port}/vh/news/story?story_id=${unavailableStory.story_id}&readback=exact`,
+      );
+      expect(result).toMatchObject({
+        statusCode: 503,
+        body: {
+          ok: false,
+          error: 'news-exact-readback-unavailable',
+          story_id: unavailableStory.story_id,
+        },
+      });
+    }
+    await waitForConnectionBaseline(unavailableRelay.port, unavailableBaseline);
+
+    const availableRelay = await startRelay(children, tempDirs, {
+      VH_RELAY_NEWS_STORY_REST_READ_TIMEOUT_MS: '800',
+      VH_RELAY_NEWS_STORY_EXACT_SELF_PEER_READ_TIMEOUT_MS: '200',
+    });
+    const availableStory = makeRelayNewsStory('story-exact-self-peer-available', 1778991950300, [{
+      source_id: 'source-exact-self-peer-available',
+      publisher: 'Exact self-peer available',
+      url: 'https://example.com/exact-self-peer-available',
+      url_hash: 'exact-self-peer-available',
+      title: 'Exact self-peer available',
+    }]);
+    const availableRecord = await writeStory(availableRelay.port, availableStory);
+    const availableBaseline = await activeConnections(availableRelay.port);
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      const result = await requestJson(
+        `http://127.0.0.1:${availableRelay.port}/vh/news/story?story_id=${availableStory.story_id}&readback=exact`,
+      );
+      expect(result.statusCode).toBe(200);
+      expect(result.body.record).toEqual(expect.objectContaining({
+        story_id: availableRecord.story_id,
+        schemaVersion: availableRecord.schemaVersion,
+        created_at: availableRecord.created_at,
+        _systemSignature: availableRecord._systemSignature,
+      }));
+    }
+    await waitForConnectionBaseline(availableRelay.port, availableBaseline);
+  }, 30_000);
+
+  it('waits for a stable fresh story vertex before accepting exact readback', async () => {
+    const routeTimeoutMs = 1_000;
+    const settleMs = 250;
+    const { port } = await startRelay(children, tempDirs, {
+      VH_RELAY_NEWS_STORY_REST_READ_TIMEOUT_MS: String(routeTimeoutMs),
+      VH_RELAY_NEWS_STORY_EXACT_SELF_PEER_READ_TIMEOUT_MS: '200',
+      VH_RELAY_NEWS_STORY_EXACT_SELF_PEER_SETTLE_MS: String(settleMs),
+    });
+    const signedFields = {
+      _protocolVersion: 'luma-public-v1',
+      _writerKind: 'system',
+      _systemWriterId: 'vh-public-beta-news-system-writer-settlement-test',
+      _systemIssuedAt: 1778991970100,
+      _systemSignature: 'settlement-test-signature',
+    };
+    const writeStory = async (story) => {
+      const record = {
+        __story_bundle_json: JSON.stringify(story),
+        story_id: story.story_id,
+        created_at: story.created_at,
+        schemaVersion: story.schemaVersion,
+        ...signedFields,
+      };
+      await expect(requestJson(`http://127.0.0.1:${port}/vh/news/story`, {
+        method: 'POST',
+        body: { record },
+      })).resolves.toMatchObject({
+        statusCode: 200,
+        body: expect.objectContaining({ ok: true, story_id: story.story_id }),
+      });
+      return record;
+    };
+    const activeConnections = async () => {
+      const metrics = await fetchText(`http://127.0.0.1:${port}/metrics`);
+      expect(metrics.statusCode).toBe(200);
+      const match = metrics.body.match(/^vh_relay_active_connections\s+([0-9]+)$/m);
+      expect(match).not.toBeNull();
+      return Number(match[1]);
+    };
+
+    const validStory = makeRelayNewsStory('story-exact-stable-valid', 1778991970200, [{
+      source_id: 'source-exact-stable-valid',
+      publisher: 'Exact stable valid',
+      url: 'https://example.com/exact-stable-valid',
+      url_hash: 'exact-stable-valid',
+      title: 'Exact stable valid',
+    }]);
+    const validRecord = await writeStory(validStory);
+    const validStartedAt = Date.now();
+    const validExact = await requestJson(
+      `http://127.0.0.1:${port}/vh/news/story?story_id=${validStory.story_id}&readback=exact`,
+    );
+    expect(validExact.statusCode).toBe(200);
+    expect(validExact.body.record).toEqual(expect.objectContaining({
+      story_id: validRecord.story_id,
+      _systemSignature: validRecord._systemSignature,
+    }));
+    const validElapsedMs = Date.now() - validStartedAt;
+    expect(validElapsedMs).toBeGreaterThanOrEqual(settleMs * 2);
+    expect(validElapsedMs).toBeLessThan(routeTimeoutMs);
+
+    const delayedStory = makeRelayNewsStory('story-exact-delayed-relation', 1778991970300, [{
+      source_id: 'source-exact-delayed-relation',
+      publisher: 'Exact delayed relation',
+      url: 'https://example.com/exact-delayed-relation',
+      url_hash: 'exact-delayed-relation',
+      title: 'Exact delayed relation',
+    }]);
+    await writeStory(delayedStory);
+    const storySoul = `vh/news/stories/${delayedStory.story_id}`;
+    const writerGun = createRelayGunClient(port);
+    try {
+      await expect(readGunOnce(writerGun.get(storySoul), 1_000)).resolves.toEqual(
+        expect.objectContaining({ story_id: delayedStory.story_id }),
+      );
+      const baselineConnections = await activeConnections();
+      let exactSettled = false;
+      const exactPromise = requestJson(
+        `http://127.0.0.1:${port}/vh/news/story?story_id=${delayedStory.story_id}&readback=exact`,
+      ).finally(() => {
+        exactSettled = true;
+      });
+      const connectionDeadline = Date.now() + 2_000;
+      let observedConnections = baselineConnections;
+      while (Date.now() < connectionDeadline && observedConnections <= baselineConnections) {
+        observedConnections = await activeConnections();
+        if (observedConnections <= baselineConnections) await delay(10);
+      }
+      expect(observedConnections).toBeGreaterThan(baselineConnections);
+      await delay(settleMs + 75);
+      expect(exactSettled).toBe(false);
+
+      const delayedRelationValue = 'delayed-invalid-analysis-relation';
+      await putGunValueAndWaitForReadback(
+        writerGun.get(storySoul).get('analysis'),
+        delayedRelationValue,
+      );
+      const delayedExact = await exactPromise;
+      expect(delayedExact).toMatchObject({
+        statusCode: 409,
+        body: {
+          ok: false,
+          error_class: 'relay-write-safety',
+          error: 'news-exact-readback-present-unsafe',
+          story_id: delayedStory.story_id,
+        },
+      });
+      expect(delayedExact.raw).not.toContain(delayedRelationValue);
+    } finally {
+      writerGun.off();
+    }
+  }, 30_000);
+
+  it('restarts both settlement windows when a valid relation changes the fresh generation', async () => {
+    const routeTimeoutMs = 1_500;
+    const settleMs = 250;
+    const { port } = await startRelay(children, tempDirs, {
+      VH_RELAY_NEWS_STORY_REST_READ_TIMEOUT_MS: String(routeTimeoutMs),
+      VH_RELAY_NEWS_STORY_EXACT_SELF_PEER_READ_TIMEOUT_MS: '200',
+      VH_RELAY_NEWS_STORY_EXACT_SELF_PEER_SETTLE_MS: String(settleMs),
+    });
+    const story = makeRelayNewsStory('story-exact-valid-relation-generation', 1778991980200, [{
+      source_id: 'source-exact-valid-relation-generation',
+      publisher: 'Exact valid relation generation',
+      url: 'https://example.com/exact-valid-relation-generation',
+      url_hash: 'exact-valid-relation-generation',
+      title: 'Exact valid relation generation',
+    }]);
+    const record = {
+      __story_bundle_json: JSON.stringify(story),
+      story_id: story.story_id,
+      created_at: story.created_at,
+      schemaVersion: story.schemaVersion,
+      _protocolVersion: 'luma-public-v1',
+      _writerKind: 'system',
+      _systemWriterId: 'vh-public-beta-news-system-writer-generation-test',
+      _systemIssuedAt: 1778991980100,
+      _systemSignature: 'generation-test-signature',
+    };
+    await expect(requestJson(`http://127.0.0.1:${port}/vh/news/story`, {
+      method: 'POST',
+      body: { record },
+    })).resolves.toMatchObject({
+      statusCode: 200,
+      body: expect.objectContaining({ ok: true, story_id: story.story_id }),
+    });
+    const activeConnections = async () => {
+      const metrics = await fetchText(`http://127.0.0.1:${port}/metrics`);
+      expect(metrics.statusCode).toBe(200);
+      const match = metrics.body.match(/^vh_relay_active_connections\s+([0-9]+)$/m);
+      expect(match).not.toBeNull();
+      return Number(match[1]);
+    };
+    const storySoul = `vh/news/stories/${story.story_id}`;
+    const analysisSoul = `${storySoul}/analysis`;
+    const writerGun = createRelayGunClient(port);
+    try {
+      await expect(readGunOnce(writerGun.get(storySoul), 1_000)).resolves.toEqual(
+        expect.objectContaining({ story_id: story.story_id }),
+      );
+      const baselineConnections = await activeConnections();
+      const exactState = { settled: false };
+      const exactStartedAt = Date.now();
+      const exactPromise = requestJson(
+        `http://127.0.0.1:${port}/vh/news/story?story_id=${story.story_id}&readback=exact`,
+      ).finally(() => {
+        exactState.settled = true;
+      });
+      const connectionDeadline = Date.now() + 2_000;
+      let observedConnections = baselineConnections;
+      while (Date.now() < connectionDeadline && observedConnections <= baselineConnections) {
+        observedConnections = await activeConnections();
+        if (observedConnections <= baselineConnections) await delay(10);
+      }
+      expect(observedConnections).toBeGreaterThan(baselineConnections);
+      await delay(settleMs + 75);
+      expect(exactState.settled).toBe(false);
+
+      await putGunObjectAndWaitForField(
+        writerGun.get(analysisSoul),
+        { fixture: 'valid-analysis-relation' },
+        'fixture',
+        'valid-analysis-relation',
+      );
+      writerGun.get(storySoul).put({ analysis: writerGun.get(analysisSoul) });
+      const relationDeadline = Date.now() + 2_000;
+      let observedRelation = null;
+      while (Date.now() < relationDeadline) {
+        await readGunOnce(writerGun.get(storySoul), 250);
+        observedRelation = writerGun._.root.graph?.[storySoul]?.analysis ?? null;
+        if (observedRelation?.['#'] === analysisSoul) break;
+      }
+      expect(observedRelation).toEqual({ '#': analysisSoul });
+      expect(exactState.settled).toBe(false);
+      await delay(settleMs + 75);
+      expect(exactState.settled).toBe(false);
+
+      const exact = await exactPromise;
+      expect(exact.statusCode).toBe(200);
+      expect(exact.body.record).toEqual(expect.objectContaining({
+        story_id: record.story_id,
+        _systemSignature: record._systemSignature,
+      }));
+      expect(exact.body.record).not.toHaveProperty('analysis');
+      expect(Date.now() - exactStartedAt).toBeLessThan(routeTimeoutMs);
+    } finally {
+      writerGun.off();
+    }
+  }, 30_000);
+
+  it('settles partial exact records and rejects persistent unsafe records without disclosing fields', async () => {
+    const { port, child } = await startRelay(children, tempDirs, {
+      VH_RELAY_NEWS_STORY_REST_READ_TIMEOUT_MS: '800',
+      VH_RELAY_NEWS_LIFECYCLE_REST_READ_TIMEOUT_MS: '800',
+      VH_RELAY_NEWS_LATEST_INDEX_REST_READ_TIMEOUT_MS: '800',
+      VH_RELAY_NEWS_HOT_INDEX_REST_READ_TIMEOUT_MS: '800',
+    });
+    const signedFields = {
+      _protocolVersion: 'luma-public-v1',
+      _writerKind: 'system',
+      _systemWriterId: 'vh-public-beta-news-system-writer-adversarial-test',
+      _systemIssuedAt: 1778992000100,
+      _systemSignature: 'adversarial-test-signature',
+    };
+    const makeRecords = (story) => ({
+      story: {
+        __story_bundle_json: JSON.stringify(story),
+        story_id: story.story_id,
+        created_at: story.created_at,
+        schemaVersion: story.schemaVersion,
+        ...signedFields,
+      },
+      latest: {
+        ...makeRelayLatestIndexRecord(story),
+        ...signedFields,
+      },
+      hot: {
+        story_id: story.story_id,
+        hotness: 0.81,
+        product_state_schema_version: 'vh-news-product-feed-index-v1',
+        topic_id: story.topic_id,
+        source_set_revision: story.provenance_hash,
+        source_count: story.sources.length,
+        canonical_source_count: story.sources.length,
+        story_created_at: story.created_at,
+        cluster_window_start: story.cluster_window_start,
+        ...signedFields,
+      },
+      lifecycle: {
+        ...makeRelaySynthesisLifecycleRecord(story, { updatedAt: 1778992000200 }),
+        ...signedFields,
+      },
+    });
+    const withoutSigning = (record) => Object.fromEntries(
+      Object.entries(record).filter(([key]) => ![
+        '_protocolVersion',
+        '_writerKind',
+        '_systemWriterId',
+        '_systemIssuedAt',
+        '_systemSignature',
+      ].includes(key)),
+    );
+    const makeRouteCases = (storyId, records) => [
+      {
+        name: 'story',
+        route: '/vh/news/story',
+        query: '&readback=exact',
+        record: records.story,
+      },
+      {
+        name: 'latest',
+        route: '/vh/news/latest-index',
+        query: '&readback=exact&persist=false',
+        record: records.latest,
+      },
+      {
+        name: 'hot',
+        route: '/vh/news/hot-index',
+        query: '&readback=exact',
+        record: records.hot,
+      },
+      {
+        name: 'lifecycle',
+        route: '/vh/news/synthesis-lifecycle',
+        query: '&readback=exact',
+        record: records.lifecycle,
+      },
+    ];
+    const postRecord = (testCase, record = testCase.record) => requestJson(
+      `http://127.0.0.1:${port}${testCase.route}`,
+      { method: 'POST', body: { record } },
+    );
+    const getExact = (testCase, storyId) => requestJson(
+      `http://127.0.0.1:${port}${testCase.route}?story_id=${encodeURIComponent(storyId)}${testCase.query}`,
+    );
+    const settlingStory = makeRelayNewsStory('story-exact-settling', 1778992000000, [
+      {
+        source_id: 'source-exact-settling',
+        publisher: 'Exact Settling',
+        url: 'https://example.com/exact-settling',
+        url_hash: 'exact-settling',
+        published_at: 1778992000000,
+        title: 'Exact settling story',
+      },
+    ]);
+    const settlingCases = makeRouteCases(settlingStory.story_id, makeRecords(settlingStory));
+
+    for (const testCase of settlingCases) {
+      await expect(postRecord(testCase, withoutSigning(testCase.record)), testCase.name)
+        .resolves.toMatchObject({
+          statusCode: 200,
+          body: expect.objectContaining({ ok: true, story_id: settlingStory.story_id }),
+        });
+    }
+    const persistentPartialResults = await Promise.all(
+      settlingCases.map((testCase) => getExact(testCase, settlingStory.story_id)),
+    );
+    for (let index = 0; index < settlingCases.length; index += 1) {
+      expect(persistentPartialResults[index].statusCode, settlingCases[index].name).toBe(409);
+      expect(persistentPartialResults[index].body, settlingCases[index].name).toEqual({
+        ok: false,
+        error_class: 'relay-write-safety',
+        error: 'news-exact-readback-present-unsafe',
+        story_id: settlingStory.story_id,
+      });
+    }
+    const settlingRequests = settlingCases.map((testCase) => getExact(testCase, settlingStory.story_id));
+    await delay(100);
+    const fullWriteResults = await Promise.all(settlingCases.map((testCase) => postRecord(testCase)));
+    for (let index = 0; index < settlingCases.length; index += 1) {
+      expect(fullWriteResults[index], settlingCases[index].name).toMatchObject({
+        statusCode: 200,
+        body: expect.objectContaining({ ok: true, story_id: settlingStory.story_id }),
+      });
+    }
+    const settledResults = await Promise.all(settlingRequests);
+    for (let index = 0; index < settlingCases.length; index += 1) {
+      expect(settledResults[index], settlingCases[index].name).toMatchObject({
+        statusCode: 200,
+        body: expect.objectContaining({
+          ok: true,
+          story_id: settlingStory.story_id,
+          record: expect.objectContaining(settlingCases[index].record),
+        }),
+      });
+    }
+
+    const secretKey = 'private_secret';
+    const secretValue = 'must-never-cross-exact-readback-boundary';
+    const unsafeCases = ['story', 'latest', 'hot', 'lifecycle'].map((name, index) => {
+      const story = makeRelayNewsStory(`story-exact-persistent-unsafe-${name}`, 1778992100000 + index, [
+        {
+          source_id: `source-exact-persistent-unsafe-${name}`,
+          publisher: `Exact Persistent Unsafe ${name}`,
+          url: `https://example.com/exact-persistent-unsafe-${name}`,
+          url_hash: `exact-persistent-unsafe-${name}`,
+          published_at: 1778992100000 + index,
+          title: `Exact persistent unsafe ${name} story`,
+        },
+      ]);
+      const testCase = makeRouteCases(story.story_id, makeRecords(story))
+        .find((candidate) => candidate.name === name);
+      return {
+        ...testCase,
+        storyId: story.story_id,
+        record: { ...testCase.record, [secretKey]: secretValue },
+      };
+    });
+    const makeAdversarialStory = (suffix, timestamp = 1778992150000) => makeRelayNewsStory(
+      `story-exact-${suffix}`,
+      timestamp,
+      [{
+        source_id: `source-exact-${suffix}`,
+        publisher: `Exact ${suffix}`,
+        url: `https://example.com/exact-${suffix}`,
+        url_hash: `exact-${suffix}`,
+        published_at: timestamp,
+        title: `Exact ${suffix} story`,
+      }],
+    );
+    const rootSecret = 'root-private-metadata-secret';
+    const sourceSecret = 'source-private-metadata-secret';
+    const clusterSecret = 'cluster-private-metadata-secret';
+    const primarySourcesSecret = 'primary-sources-container-secret';
+    const relationSecrets = {
+      synthesis_lifecycle: 'invalid-synthesis-lifecycle-relation-secret',
+      analysis: 'invalid-analysis-relation-secret',
+      analysis_latest: 'invalid-analysis-latest-relation-secret',
+    };
+    const invalidPublishedAtSecret = 'invalid-published-at-secret';
+    const outerCreatedAtSecret = 'outer-created-at-secret';
+    const outerSchemaSecret = 'outer-schema-secret';
+    const legacyFieldSecrets = {
+      _system: 'legacy-system-secret',
+      _Signature: 'legacy-signature-secret',
+      _WriterId: 'legacy-writer-id-secret',
+      _IssuedAt: 'legacy-issued-at-secret',
+    };
+    const modernFieldSecrets = {
+      _protocolVersion: 'modern-protocol-secret',
+      _writerKind: 'modern-writer-kind-secret',
+      _systemWriterId: ' modern-writer-id-secret',
+      _systemIssuedAt: 'modern-issued-at-secret',
+      _systemSignature: ' modern-signature-secret',
+    };
+    const latestMetadataSecret = 'latest-source-count-secret';
+    const hotMetadataSecret = 'hot-cluster-window-secret';
+    const hotMetadataObjectSecret = 'hot-source-count-object-secret';
+    const lifecycleFieldSecret = 'lifecycle-retryable-secret';
+    const rootUnknownStory = makeAdversarialStory('unknown-root');
+    const sourceUnknownStory = makeAdversarialStory('unknown-source', 1778992150001);
+    const clusterUnknownStory = makeAdversarialStory('unknown-cluster', 1778992150002);
+    const malformedPrimarySourcesStory = makeAdversarialStory('malformed-primary-sources', 1778992150003);
+    const outOfRangeScoreStory = makeAdversarialStory('out-of-range-score', 1778992150004);
+    const invalidPublishedAtStory = makeAdversarialStory('invalid-published-at', 1778992150005);
+    const adversarialStoryCases = [
+      {
+        name: 'story-unknown-root-key',
+        story: { ...rootUnknownStory, private_metadata: { note: rootSecret } },
+      },
+      {
+        name: 'story-unknown-source-key',
+        story: {
+          ...sourceUnknownStory,
+          sources: [{ ...sourceUnknownStory.sources[0], private_metadata: { note: sourceSecret } }],
+        },
+      },
+      {
+        name: 'story-unknown-cluster-key',
+        story: {
+          ...clusterUnknownStory,
+          cluster_features: {
+            ...clusterUnknownStory.cluster_features,
+            private_metadata: { note: clusterSecret },
+          },
+        },
+      },
+      {
+        name: 'story-malformed-allowed-container',
+        story: {
+          ...malformedPrimarySourcesStory,
+          primary_sources: { note: primarySourcesSecret },
+        },
+      },
+      {
+        name: 'story-malformed-allowed-score',
+        story: {
+          ...outOfRangeScoreStory,
+          cluster_features: { ...outOfRangeScoreStory.cluster_features, coverage_score: 2 },
+        },
+      },
+      {
+        name: 'story-malformed-allowed-source-value',
+        story: {
+          ...invalidPublishedAtStory,
+          sources: [{ ...invalidPublishedAtStory.sources[0], published_at: invalidPublishedAtSecret }],
+        },
+      },
+    ].map(({ name, story }) => ({
+      name,
+      storyId: story.story_id,
+      testCase: makeRouteCases(story.story_id, makeRecords(story))[0],
+    }));
+    const invalidRelationCases = Object.entries(relationSecrets).map(([relationKey, secret], index) => {
+      const story = makeAdversarialStory(`invalid-${relationKey}-relation`, 1778992150006 + index);
+      const storyCase = makeRouteCases(story.story_id, makeRecords(story))[0];
+      return {
+        name: `story-invalid-${relationKey}-relation`,
+        storyId: story.story_id,
+        testCase: {
+          ...storyCase,
+          record: { ...storyCase.record, [relationKey]: secret },
+        },
+      };
+    });
+    const outerFieldCases = [
+      { name: 'outer-created-at', field: 'created_at', value: outerCreatedAtSecret },
+      { name: 'outer-schema', field: 'schemaVersion', value: outerSchemaSecret },
+      ...Object.entries(legacyFieldSecrets).map(([field, value]) => ({
+        name: `outer-${field}`,
+        field,
+        value,
+      })),
+      ...Object.entries(modernFieldSecrets).map(([field, value]) => ({
+        name: `outer-${field}`,
+        field,
+        value,
+      })),
+    ].map(({ name, field, value }, index) => {
+      const story = makeAdversarialStory(name, 1778992150100 + index);
+      const storyCase = makeRouteCases(story.story_id, makeRecords(story))[0];
+      return {
+        name: `story-${name}`,
+        storyId: story.story_id,
+        testCase: { ...storyCase, record: { ...storyCase.record, [field]: value } },
+      };
+    });
+    const latestSmugglingStory = makeAdversarialStory('latest-allowed-field-smuggling', 1778992150200);
+    const hotSmugglingStory = makeAdversarialStory('hot-allowed-field-smuggling', 1778992150201);
+    const lifecycleSmugglingStory = makeAdversarialStory('lifecycle-allowed-field-smuggling', 1778992150202);
+    const hotObjectSmugglingStory = makeAdversarialStory('hot-object-field-smuggling', 1778992150203);
+    const latestSmugglingCase = makeRouteCases(
+      latestSmugglingStory.story_id,
+      makeRecords(latestSmugglingStory),
+    )[1];
+    const hotSmugglingCase = makeRouteCases(
+      hotSmugglingStory.story_id,
+      makeRecords(hotSmugglingStory),
+    )[2];
+    const lifecycleSmugglingCase = makeRouteCases(
+      lifecycleSmugglingStory.story_id,
+      makeRecords(lifecycleSmugglingStory),
+    )[3];
+    const hotObjectSmugglingCase = makeRouteCases(
+      hotObjectSmugglingStory.story_id,
+      makeRecords(hotObjectSmugglingStory),
+    )[2];
+    const { source_count: _hotObjectSourceCount, ...hotObjectSmugglingRecord } =
+      hotObjectSmugglingCase.record;
+    const allowedFieldSmugglingCases = [
+      {
+        name: 'latest-allowed-field-smuggling',
+        storyId: latestSmugglingStory.story_id,
+        testCase: {
+          ...latestSmugglingCase,
+          record: { ...latestSmugglingCase.record, source_count: latestMetadataSecret },
+        },
+      },
+      {
+        name: 'hot-allowed-field-smuggling',
+        storyId: hotSmugglingStory.story_id,
+        testCase: {
+          ...hotSmugglingCase,
+          record: { ...hotSmugglingCase.record, cluster_window_start: hotMetadataSecret },
+        },
+      },
+      {
+        name: 'lifecycle-allowed-field-smuggling',
+        storyId: lifecycleSmugglingStory.story_id,
+        testCase: {
+          ...lifecycleSmugglingCase,
+          record: { ...lifecycleSmugglingCase.record, retryable: lifecycleFieldSecret },
+        },
+      },
+      {
+        name: 'hot-object-field-smuggling',
+        storyId: hotObjectSmugglingStory.story_id,
+        testCase: { ...hotObjectSmugglingCase, record: hotObjectSmugglingRecord },
+      },
+    ];
+    const detailValues = [
+      secretKey,
+      secretValue,
+      rootSecret,
+      sourceSecret,
+      clusterSecret,
+      primarySourcesSecret,
+      ...Object.values(relationSecrets),
+      invalidPublishedAtSecret,
+      outerCreatedAtSecret,
+      outerSchemaSecret,
+      ...Object.values(legacyFieldSecrets),
+      ...Object.values(modernFieldSecrets),
+      latestMetadataSecret,
+      hotMetadataSecret,
+      hotMetadataObjectSecret,
+      lifecycleFieldSecret,
+    ];
+    const adversarialCases = [
+      ...adversarialStoryCases,
+      ...invalidRelationCases,
+      ...outerFieldCases,
+      ...allowedFieldSmugglingCases,
+    ];
+
+    for (const testCase of [
+      ...unsafeCases,
+      ...adversarialCases.map(({ testCase }) => testCase),
+    ]) {
+      const response = await postRecord(testCase);
+      expect(response.statusCode, testCase.name).toBe(200);
+      expect(response.body, testCase.name).toMatchObject({ ok: true });
+      for (const detail of detailValues) {
+        expect(response.raw).not.toContain(detail);
+      }
+    }
+    const smugglingGun = createRelayGunClient(port);
+    const smugglingObserverGun = createRelayGunClient(port);
+    try {
+      smugglingGun
+          .get('vh')
+          .get('news')
+          .get('index')
+          .get('hot')
+          .get(hotObjectSmugglingStory.story_id)
+          .put({ source_count: { note: hotMetadataObjectSecret } });
+      const hotSoul = `vh/news/index/hot/${hotObjectSmugglingStory.story_id}`;
+      const sourceCountSoul = `${hotSoul}/source_count`;
+      const observerDeadline = Date.now() + 5_000;
+      let observedHotRecord = null;
+      while (Date.now() < observerDeadline) {
+        observedHotRecord = await readGunOnce(smugglingObserverGun.get(hotSoul), 500);
+        const rawSourceCount = smugglingObserverGun._.root.graph?.[hotSoul]?.source_count;
+        if (rawSourceCount?.['#'] === sourceCountSoul) break;
+      }
+      expect(smugglingObserverGun._.root.graph?.[hotSoul]?.source_count)
+        .toEqual({ '#': sourceCountSoul });
+      await expect(readGunOnce(smugglingObserverGun.get(sourceCountSoul).get('note')))
+        .resolves.toBe(hotMetadataObjectSecret);
+    } finally {
+      smugglingGun.off();
+      smugglingObserverGun.off();
+    }
+    const unsafeRequestCases = [
+      ...unsafeCases.map((testCase) => ({
+        name: testCase.name,
+        storyId: testCase.storyId,
+        testCase,
+      })),
+      ...adversarialCases,
+    ];
+    const unsafeResponses = [];
+    for (let offset = 0; offset < unsafeRequestCases.length; offset += 6) {
+      unsafeResponses.push(...await Promise.all(
+        unsafeRequestCases.slice(offset, offset + 6).map(({ testCase, storyId }) =>
+          getExact(testCase, storyId)),
+      ));
+    }
+    for (let index = 0; index < unsafeResponses.length; index += 1) {
+      const response = unsafeResponses[index];
+      const testCase = unsafeRequestCases[index];
+      expect(response.statusCode, testCase.name).toBe(409);
+      expect(response.body, testCase.name).toEqual({
+        ok: false,
+        error_class: 'relay-write-safety',
+        error: 'news-exact-readback-present-unsafe',
+        story_id: testCase.storyId,
+      });
+      for (const detail of detailValues) {
+        expect(response.raw).not.toContain(detail);
+      }
+    }
+    for (const detail of detailValues) {
+      expect(`${child.stdoutText}\n${child.stderrText}`).not.toContain(detail);
+    }
+  }, 30_000);
+
+  it('never uses snapshot-only evidence for any exact news readback route', async () => {
+    const snapshotDir = mkdtempSync(path.join(os.tmpdir(), 'vh-relay-exact-snapshot-refusal-test-'));
+    tempDirs.add(snapshotDir);
+    const snapshotFile = path.join(snapshotDir, 'news-latest-index-snapshot.json');
+    const story = makeRelayNewsStory('story-exact-snapshot-only', 1778992200000, [
+      {
+        source_id: 'source-exact-snapshot-only',
+        publisher: 'Exact Snapshot Only',
+        url: 'https://example.com/exact-snapshot-only',
+        url_hash: 'exact-snapshot-only',
+        published_at: 1778992200000,
+        title: 'Exact snapshot-only story',
+      },
+    ]);
+    writeLatestIndexSnapshotFile(snapshotFile, story);
+    const snapshotBefore = readFileSync(snapshotFile, 'utf8');
+    const { port } = await startRelay(children, tempDirs, {
+      VH_RELAY_NEWS_INDEX_SNAPSHOT_FILE: snapshotFile,
+      VH_RELAY_NEWS_INDEX_REST_PREFER_SNAPSHOT: 'true',
+      VH_RELAY_NEWS_INDEX_SERVE_STALE_SNAPSHOT_ON_EMPTY: 'true',
+      VH_RELAY_NEWS_STORY_REST_READ_TIMEOUT_MS: '100',
+      VH_RELAY_NEWS_LIFECYCLE_REST_READ_TIMEOUT_MS: '100',
+      VH_RELAY_NEWS_LATEST_INDEX_REST_READ_TIMEOUT_MS: '100',
+      VH_RELAY_NEWS_HOT_INDEX_REST_READ_TIMEOUT_MS: '100',
+    });
+
+    await expect(requestJson(
+      `http://127.0.0.1:${port}/vh/news/story?story_id=${story.story_id}`,
+    )).resolves.toMatchObject({
+      statusCode: 200,
+      body: expect.objectContaining({ ok: true, story_id: story.story_id }),
+    });
+    const exactRoutes = [
+      { route: '/vh/news/story', error: 'news-story-not-found', query: '&readback=exact' },
+      { route: '/vh/news/latest-index', error: 'news-latest-index-not-found', query: '&readback=exact&persist=false' },
+      { route: '/vh/news/hot-index', error: 'news-hot-index-not-found', query: '&readback=exact' },
+      { route: '/vh/news/synthesis-lifecycle', error: 'news-synthesis-lifecycle-not-found', query: '&readback=exact' },
+    ];
+    const results = await Promise.all(exactRoutes.map((testCase) => requestJson(
+      `http://127.0.0.1:${port}${testCase.route}?story_id=${encodeURIComponent(story.story_id)}${testCase.query}`,
+    )));
+    for (let index = 0; index < exactRoutes.length; index += 1) {
+      expect(results[index], exactRoutes[index].route).toMatchObject({
+        statusCode: 404,
+        body: {
+          ok: false,
+          error: exactRoutes[index].error,
+          story_id: story.story_id,
+        },
+      });
+    }
+    expect(readFileSync(snapshotFile, 'utf8')).toBe(snapshotBefore);
+  }, 15_000);
 
   it('pauses snapshot maintenance while critical public-news write readbacks are active', async () => {
     const snapshotDir = mkdtempSync(path.join(os.tmpdir(), 'vh-relay-critical-readback-test-'));
@@ -4198,12 +5258,13 @@ describe('infra relay server', () => {
     await expect(requestJson(
       `http://127.0.0.1:${port}/vh/news/story?story_id=${story.story_id}&readback=exact`,
     )).resolves.toMatchObject({
-      statusCode: 404,
-      body: expect.objectContaining({
+      statusCode: 409,
+      body: {
         ok: false,
-        error: 'news-story-not-found',
+        error_class: 'relay-write-safety',
+        error: 'news-exact-readback-present-unsafe',
         story_id: story.story_id,
-      }),
+      },
     });
     gun.off();
   }, 15_000);

--- a/packages/e2e/src/live/relay-server.vitest.mjs
+++ b/packages/e2e/src/live/relay-server.vitest.mjs
@@ -1346,6 +1346,16 @@ describe('infra relay server', () => {
         status: record.status,
       }),
     });
+    await expect(requestJson(
+      `http://127.0.0.1:${writer.port}/vh/news/synthesis-lifecycle?story_id=${record.story_id}&readback=exact`,
+    )).resolves.toMatchObject({
+      statusCode: 404,
+      body: expect.objectContaining({
+        ok: false,
+        error: 'news-synthesis-lifecycle-not-found',
+        story_id: record.story_id,
+      }),
+    });
 
     await new Promise((resolve) => {
       if (writer.child.exitCode !== null) {
@@ -1359,7 +1369,10 @@ describe('infra relay server', () => {
       }, 1_000);
     });
     children.delete(writer.child);
-    const reader = await startRelay(children, tempDirs, env);
+    const reader = await startRelay(children, tempDirs, {
+      ...env,
+      GUN_FILE: path.join(snapshotDir, 'empty-reader-data'),
+    });
 
     await expect(requestJson(
       `http://127.0.0.1:${reader.port}/vh/news/synthesis-lifecycle?story_id=${record.story_id}`,
@@ -1373,6 +1386,16 @@ describe('infra relay server', () => {
         record: expect.objectContaining({
           synthesis_id: record.synthesis_id,
         }),
+      }),
+    });
+    await expect(requestJson(
+      `http://127.0.0.1:${reader.port}/vh/news/synthesis-lifecycle?story_id=${record.story_id}&readback=exact`,
+    )).resolves.toMatchObject({
+      statusCode: 404,
+      body: expect.objectContaining({
+        ok: false,
+        error: 'news-synthesis-lifecycle-not-found',
+        story_id: record.story_id,
       }),
     });
   });
@@ -1493,6 +1516,159 @@ describe('infra relay server', () => {
         }),
       });
   });
+
+  it('serves all four exact signed readbacks without mutating snapshots and keeps duplicate POSTs idempotent', async () => {
+    const snapshotDir = mkdtempSync(path.join(os.tmpdir(), 'vh-relay-exact-news-readback-test-'));
+    tempDirs.add(snapshotDir);
+    const snapshotFile = path.join(snapshotDir, 'news-latest-index-snapshot.json');
+    const { port } = await startRelay(children, tempDirs, {
+      VH_RELAY_NEWS_INDEX_SNAPSHOT_FILE: snapshotFile,
+      VH_RELAY_NEWS_INDEX_REST_MAX_RECORDS: '3',
+      VH_RELAY_NEWS_INDEX_REST_SCAN_RECORDS: '3',
+      VH_RELAY_NEWS_STORY_REST_READ_TIMEOUT_MS: '500',
+      VH_RELAY_NEWS_LIFECYCLE_REST_READ_TIMEOUT_MS: '500',
+      VH_RELAY_NEWS_LATEST_INDEX_REST_READ_TIMEOUT_MS: '500',
+      VH_RELAY_NEWS_HOT_INDEX_REST_READ_TIMEOUT_MS: '500',
+    });
+    const story = makeRelayNewsStory('story-exact-signed-readback', 1778991500000, [
+      {
+        source_id: 'source-exact-signed-readback',
+        publisher: 'Exact Signed Readback',
+        url: 'https://example.com/exact-signed-readback',
+        url_hash: 'exact-signed-readback',
+        published_at: 1778991500000,
+        title: 'Exact signed readback story',
+      },
+    ]);
+    const signedFields = {
+      _system: null,
+      _Signature: null,
+      _WriterId: null,
+      _IssuedAt: null,
+      _protocolVersion: 'luma-public-v1',
+      _writerKind: 'system',
+      _systemWriterId: 'vh-public-beta-news-system-writer-exact-test',
+      _systemIssuedAt: 1778991500100,
+      _systemSignature: 'exact-test-signature',
+    };
+    const storyRecord = {
+      __story_bundle_json: JSON.stringify(story),
+      story_id: story.story_id,
+      created_at: story.created_at,
+      schemaVersion: story.schemaVersion,
+      ...signedFields,
+    };
+    const latestRecord = {
+      ...makeRelayLatestIndexRecord(story),
+      ...signedFields,
+    };
+    const hotRecord = {
+      story_id: story.story_id,
+      hotness: 0.73,
+      product_state_schema_version: 'vh-news-product-feed-index-v1',
+      topic_id: story.topic_id,
+      source_set_revision: story.provenance_hash,
+      source_count: story.sources.length,
+      canonical_source_count: story.sources.length,
+      story_created_at: story.created_at,
+      cluster_window_start: story.cluster_window_start,
+      ...signedFields,
+    };
+    const lifecycleRecord = {
+      ...makeRelaySynthesisLifecycleRecord(story, { updatedAt: 1778991500200 }),
+      ...signedFields,
+    };
+    const writes = [
+      { route: '/vh/news/story', record: storyRecord },
+      { route: '/vh/news/latest-index', record: latestRecord },
+      { route: '/vh/news/hot-index', record: hotRecord },
+      { route: '/vh/news/synthesis-lifecycle', record: lifecycleRecord },
+    ];
+
+    for (const write of writes) {
+      for (let duplicate = 0; duplicate < 2; duplicate += 1) {
+        await expect(requestJson(`http://127.0.0.1:${port}${write.route}`, {
+          method: 'POST',
+          body: { record: write.record },
+        })).resolves.toMatchObject({
+          statusCode: 200,
+          body: expect.objectContaining({ ok: true, story_id: story.story_id }),
+        });
+      }
+    }
+    expect(existsSync(snapshotFile)).toBe(true);
+    const snapshotBeforeReadbacks = readFileSync(snapshotFile, 'utf8');
+
+    const readbacks = [
+      { route: '/vh/news/story', record: storyRecord, extraQuery: '&readback=exact' },
+      { route: '/vh/news/latest-index', record: latestRecord, extraQuery: '&persist=false' },
+      { route: '/vh/news/hot-index', record: hotRecord },
+      { route: '/vh/news/synthesis-lifecycle', record: lifecycleRecord, extraQuery: '&readback=exact' },
+    ];
+    for (const readback of readbacks) {
+      const result = await requestJson(
+        `http://127.0.0.1:${port}${readback.route}?story_id=${encodeURIComponent(story.story_id)}${readback.extraQuery ?? ''}`,
+      );
+      expect(result).toMatchObject({
+        statusCode: 200,
+        body: expect.objectContaining({
+          ok: true,
+          story_id: story.story_id,
+          record: expect.objectContaining({
+            story_id: story.story_id,
+            _protocolVersion: readback.record._protocolVersion,
+            _writerKind: readback.record._writerKind,
+            _systemWriterId: readback.record._systemWriterId,
+            _systemIssuedAt: readback.record._systemIssuedAt,
+            _systemSignature: readback.record._systemSignature,
+          }),
+        }),
+      });
+      for (const [key, value] of Object.entries(readback.record)) {
+        if (value !== null) {
+          expect(result.body.record[key]).toEqual(value);
+        }
+      }
+    }
+    expect(readFileSync(snapshotFile, 'utf8')).toBe(snapshotBeforeReadbacks);
+
+    await expect(requestJson(`http://127.0.0.1:${port}/vh/news/latest-index?story_id=story-missing&persist=false`))
+      .resolves.toMatchObject({
+        statusCode: 404,
+        body: expect.objectContaining({
+          ok: false,
+          error: 'news-latest-index-not-found',
+          story_id: 'story-missing',
+        }),
+      });
+    await expect(requestJson(`http://127.0.0.1:${port}/vh/news/hot-index?story_id=story-missing`))
+      .resolves.toMatchObject({
+        statusCode: 404,
+        body: expect.objectContaining({
+          ok: false,
+          error: 'news-hot-index-not-found',
+          story_id: 'story-missing',
+        }),
+      });
+    expect(readFileSync(snapshotFile, 'utf8')).toBe(snapshotBeforeReadbacks);
+
+    await expect(requestJson(`http://127.0.0.1:${port}/vh/news/latest-index?limit=3&persist=false`))
+      .resolves.toMatchObject({
+        statusCode: 200,
+        body: expect.objectContaining({
+          ok: true,
+          records: expect.objectContaining({ [story.story_id]: expect.any(Object) }),
+        }),
+      });
+    await expect(requestJson(`http://127.0.0.1:${port}/vh/news/hot-index?limit=3`))
+      .resolves.toMatchObject({
+        statusCode: 200,
+        body: expect.objectContaining({
+          ok: true,
+          records: expect.objectContaining({ [story.story_id]: expect.any(Object) }),
+        }),
+      });
+  }, 30_000);
 
   it('pauses snapshot maintenance while critical public-news write readbacks are active', async () => {
     const snapshotDir = mkdtempSync(path.join(os.tmpdir(), 'vh-relay-critical-readback-test-'));
@@ -4019,6 +4195,16 @@ describe('infra relay server', () => {
         }),
       });
     expect(Date.now() - startedAt).toBeLessThan(800);
+    await expect(requestJson(
+      `http://127.0.0.1:${port}/vh/news/story?story_id=${story.story_id}&readback=exact`,
+    )).resolves.toMatchObject({
+      statusCode: 404,
+      body: expect.objectContaining({
+        ok: false,
+        error: 'news-story-not-found',
+        story_id: story.story_id,
+      }),
+    });
     gun.off();
   }, 15_000);
 

--- a/packages/gun-client/src/newsAdapters.test.ts
+++ b/packages/gun-client/src/newsAdapters.test.ts
@@ -16,6 +16,7 @@ import {
   SYSTEM_WRITER_KIND,
   SYSTEM_WRITER_PROTOCOL_VERSION,
   SYSTEM_WRITER_VALIDATION_EVENT,
+  buildSignedSystemWriterRecord,
   type SystemWriterPin,
   type SystemWriterSignHook,
 } from './systemWriter';
@@ -69,7 +70,9 @@ import {
   writeNewsLatestIndexEntry,
   writeNewsSynthesisLifecycleStatus,
   writeNewsStory,
+  RelayRestAvailabilityTotalFailureError,
   RelayRestTransportTotalFailureError,
+  isRelayRestAvailabilityTotalFailureError,
   isRelayRestTransportTotalFailureError,
 } from './newsAdapters';
 
@@ -702,7 +705,7 @@ describe('newsAdapters', () => {
       vi.stubGlobal('fetch', fetchMock);
 
       await expect(writeNewsStory(client, STORY)).rejects.toThrow(
-        'VH_RELAY_DAEMON_TOKEN or VH_NEWS_RELAY_REST_WRITE_TOKENS[https://gun-a.example.test] is required for relay REST news writes',
+        'Relay daemon token is required for relay REST news write target relay-1',
       );
       expect(mesh.writes).toEqual([]);
       expect(fetchMock).not.toHaveBeenCalled();
@@ -739,7 +742,7 @@ describe('newsAdapters', () => {
 
       await expect(
         writeNewsLatestIndexEntry(client, STORY.story_id, STORY.cluster_window_end, STORY),
-      ).rejects.toThrow('Relay REST news write failed for /vh/news/latest-index: 1/2 succeeded');
+      ).rejects.toThrow('Relay REST news write failed for /vh/news/latest-index: 1/2 confirmed');
       expect(mesh.writes).toEqual([]);
       expect(fetchMock.mock.calls.map(([input]) => new URL(String(input)).origin)).toEqual([
         'https://gun-a.example.test',
@@ -794,7 +797,7 @@ describe('newsAdapters', () => {
         relay_success_count: 2,
         relay_target_count: 3,
         relay_required_success_count: 2,
-        relay_failed_endpoint_labels: ['https://gun-b.example.test'],
+        relay_failed_endpoint_labels: ['relay-2'],
         min_success_configured: true,
       }));
     } finally {
@@ -848,7 +851,7 @@ describe('newsAdapters', () => {
 
       await expect(
         writeNewsLatestIndexEntry(client, STORY.story_id, STORY.cluster_window_end, STORY),
-      ).rejects.toThrow(/failed=https:\/\/gun-b\.example\.test:relay-backpressure/);
+      ).rejects.toThrow(/relay-2:http_response:relay-backpressure/);
       expect(mesh.writes).toEqual([]);
     } finally {
       vi.unstubAllGlobals();
@@ -888,7 +891,7 @@ describe('newsAdapters', () => {
 
       await expect(
         writeNewsLatestIndexEntry(client, STORY.story_id, STORY.cluster_window_end, STORY),
-      ).rejects.toThrow(/failed=https:\/\/gun-b\.example\.test:http-503; https:\/\/gun-c\.example\.test:http-503/);
+      ).rejects.toThrow(/relay-2:http_response:http-503; relay-3:http_response:http-503/);
       expect(mesh.writes).toEqual([]);
     } finally {
       vi.unstubAllGlobals();
@@ -929,7 +932,7 @@ describe('newsAdapters', () => {
       await expect(
         writeNewsLatestIndexEntry(client, STORY.story_id, STORY.cluster_window_end, STORY),
       ).rejects.toThrow(
-        'Relay REST news write failed for /vh/news/latest-index: 1/3 succeeded; required=2',
+        'Relay REST news write failed for /vh/news/latest-index: 1/3 confirmed; required=2',
       );
       expect(mesh.writes).toEqual([]);
     } finally {
@@ -958,20 +961,30 @@ describe('newsAdapters', () => {
         status: 200,
         headers: { 'content-type': 'application/json' },
       });
-      const fetchMock = vi
-        .fn()
-        .mockRejectedValueOnce(new TypeError('fetch failed'))
-        .mockRejectedValueOnce(new TypeError('fetch failed'))
-        .mockRejectedValueOnce(new TypeError('fetch failed'))
-        .mockResolvedValueOnce(okResponse())
-        .mockResolvedValueOnce(okResponse())
-        .mockResolvedValueOnce(okResponse());
+      let postCount = 0;
+      const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+        if (init?.method === 'GET') {
+          return new Response(JSON.stringify({ ok: false, error: 'news-latest-index-not-found' }), {
+            status: 404,
+            headers: { 'content-type': 'application/json' },
+          });
+        }
+        postCount += 1;
+        if (postCount <= 3) {
+          throw new TypeError('fetch failed');
+        }
+        return okResponse();
+      });
       vi.stubGlobal('fetch', fetchMock);
 
       await expect(
         writeNewsLatestIndexEntry(client, STORY.story_id, STORY.cluster_window_end, STORY),
       ).resolves.toBeUndefined();
-      expect(fetchMock).toHaveBeenCalledTimes(6);
+      expect(fetchMock).toHaveBeenCalledTimes(9);
+      const postBodies = fetchMock.mock.calls
+        .filter(([, init]) => init?.method === 'POST')
+        .map(([, init]) => init?.body);
+      expect(new Set(postBodies).size).toBe(1);
     } finally {
       vi.unstubAllGlobals();
       restoreEnv();
@@ -1068,14 +1081,17 @@ describe('newsAdapters', () => {
         status: 200,
         headers: { 'content-type': 'application/json' },
       });
-      const fetchMock = vi
-        .fn()
-        .mockRejectedValueOnce(new TypeError('fetch failed'))
-        .mockRejectedValueOnce(new TypeError('fetch failed'))
-        .mockRejectedValueOnce(new TypeError('fetch failed'))
-        .mockResolvedValueOnce(okResponse())
-        .mockResolvedValueOnce(okResponse())
-        .mockResolvedValueOnce(okResponse());
+      let postCount = 0;
+      const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+        if (init?.method === 'GET') {
+          return new Response(JSON.stringify({ ok: false }), { status: 404 });
+        }
+        postCount += 1;
+        if (postCount <= 3) {
+          throw new TypeError('fetch failed');
+        }
+        return okResponse();
+      });
       vi.stubGlobal('fetch', fetchMock);
 
       await expect(newsAdapterInternal.writeNewsRecordViaRelayRest({
@@ -1086,9 +1102,9 @@ describe('newsAdapters', () => {
         validate: (payload) => payload.ok === true,
       })).resolves.toBeUndefined();
 
-      expect(fetchMock).toHaveBeenCalledTimes(6);
+      expect(fetchMock).toHaveBeenCalledTimes(9);
       expect(warn).toHaveBeenCalledWith(
-        '[vh:news] relay REST write transport-unavailable; retrying',
+        '[vh:news] relay REST write availability-total; retrying unresolved targets',
         expect.objectContaining({
           attempt: 1,
           max_attempts: 2,
@@ -1132,10 +1148,11 @@ describe('newsAdapters', () => {
       );
       expect(failure).toBeInstanceOf(Error);
       expect(isRelayRestTransportTotalFailureError(failure)).toBe(true);
-      expect((failure as Error).message).toContain('0/3 succeeded');
-      expect((failure as Error).message).toContain('transport_unavailable_attempts=2');
+      expect((failure as Error).message).toContain('0/3 confirmed');
+      expect((failure as Error).message).toContain('availability_total_attempts=2');
       expect((failure as RelayRestTransportTotalFailureError).attemptCount).toBe(2);
-      expect(fetchMock).toHaveBeenCalledTimes(6);
+      expect(isRelayRestAvailabilityTotalFailureError(failure)).toBe(true);
+      expect(fetchMock).toHaveBeenCalledTimes(12);
       expect(mesh.writes).toEqual([]);
     } finally {
       vi.unstubAllGlobals();
@@ -1180,8 +1197,9 @@ describe('newsAdapters', () => {
       );
       expect(failure).toBeInstanceOf(Error);
       expect(isRelayRestTransportTotalFailureError(failure)).toBe(false);
-      expect((failure as Error).message).toContain('0/3 succeeded');
-      expect(fetchMock).toHaveBeenCalledTimes(3);
+      expect((failure as Error).message).toContain('0/3 confirmed');
+      expect(fetchMock.mock.calls.filter(([, init]) => init?.method === 'POST')).toHaveLength(3);
+      expect(fetchMock.mock.calls.filter(([, init]) => init?.method === 'GET')).toHaveLength(2);
     } finally {
       vi.unstubAllGlobals();
       restoreEnv();
@@ -1189,7 +1207,7 @@ describe('newsAdapters', () => {
     }
   });
 
-  it('writeNewsLatestIndexEntry does not retry abort/timeout failures', async () => {
+  it('writeNewsLatestIndexEntry reconciles and bounded-retries abort/deadline availability-total', async () => {
     const restoreRuntimeConfig = withGunClientRuntimeConfig({
       VH_NEWS_RELAY_REST_WRITE_FIRST: 'true',
       VH_NEWS_RELAY_REST_WRITE_ORIGINS: '["https://gun-a.example.test","https://gun-b.example.test","https://gun-c.example.test"]',
@@ -1209,11 +1227,12 @@ describe('newsAdapters', () => {
         error.name = 'AbortError';
         return error;
       };
-      const fetchMock = vi
-        .fn()
-        .mockRejectedValueOnce(abortError())
-        .mockRejectedValueOnce(abortError())
-        .mockRejectedValueOnce(abortError());
+      const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+        if (init?.method === 'GET') {
+          return new Response(JSON.stringify({ ok: false }), { status: 404 });
+        }
+        throw abortError();
+      });
       vi.stubGlobal('fetch', fetchMock);
 
       const failure = await writeNewsLatestIndexEntry(
@@ -1227,7 +1246,10 @@ describe('newsAdapters', () => {
       );
       expect(failure).toBeInstanceOf(Error);
       expect(isRelayRestTransportTotalFailureError(failure)).toBe(false);
-      expect(fetchMock).toHaveBeenCalledTimes(3);
+      expect(isRelayRestAvailabilityTotalFailureError(failure)).toBe(true);
+      expect(failure).toBeInstanceOf(RelayRestAvailabilityTotalFailureError);
+      expect((failure as RelayRestAvailabilityTotalFailureError).attemptCount).toBe(3);
+      expect(fetchMock).toHaveBeenCalledTimes(18);
     } finally {
       vi.unstubAllGlobals();
       restoreEnv();
@@ -1235,7 +1257,7 @@ describe('newsAdapters', () => {
     }
   });
 
-  it('writeNewsLatestIndexEntry does not retry undici dispatcher timeouts wrapped as fetch failed', async () => {
+  it('writeNewsLatestIndexEntry reconciles undici response deadlines before bounded retry', async () => {
     const restoreRuntimeConfig = withGunClientRuntimeConfig({
       VH_NEWS_RELAY_REST_WRITE_FIRST: 'true',
       VH_NEWS_RELAY_REST_WRITE_ORIGINS: '["https://gun-a.example.test","https://gun-b.example.test","https://gun-c.example.test"]',
@@ -1257,11 +1279,12 @@ describe('newsAdapters', () => {
         (cause as NodeJS.ErrnoException).code = 'UND_ERR_HEADERS_TIMEOUT';
         return new TypeError('fetch failed', { cause });
       };
-      const fetchMock = vi
-        .fn()
-        .mockRejectedValueOnce(headersTimeout())
-        .mockRejectedValueOnce(headersTimeout())
-        .mockRejectedValueOnce(headersTimeout());
+      const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+        if (init?.method === 'GET') {
+          return new Response(JSON.stringify({ ok: false }), { status: 404 });
+        }
+        throw headersTimeout();
+      });
       vi.stubGlobal('fetch', fetchMock);
 
       const failure = await writeNewsLatestIndexEntry(
@@ -1275,6 +1298,122 @@ describe('newsAdapters', () => {
       );
       expect(failure).toBeInstanceOf(Error);
       expect(isRelayRestTransportTotalFailureError(failure)).toBe(false);
+      expect(isRelayRestAvailabilityTotalFailureError(failure)).toBe(true);
+      expect((failure as RelayRestAvailabilityTotalFailureError).attemptCount).toBe(3);
+      expect(fetchMock).toHaveBeenCalledTimes(18);
+    } finally {
+      vi.unstubAllGlobals();
+      restoreEnv();
+      restoreRuntimeConfig();
+    }
+  });
+
+  it('reconciles response-leg body deadlines and resets while recording received HTTP headers', async () => {
+    const restoreRuntimeConfig = withGunClientRuntimeConfig({
+      VH_NEWS_RELAY_REST_WRITE_FIRST: 'true',
+      VH_NEWS_RELAY_REST_WRITE_ORIGINS: '["https://gun-a.example.test","https://gun-b.example.test","https://gun-c.example.test"]',
+      VH_NEWS_RELAY_REST_WRITE_MIN_SUCCESS: '2',
+      VH_NEWS_RELAY_REST_TRANSPORT_RETRY_COUNT: '0',
+    });
+    const restoreEnv = withProcessEnv({ VH_RELAY_DAEMON_TOKEN: 'relay-token-redacted' });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      const mesh = createFakeMesh();
+      const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+      const client = createClient(mesh, guard);
+      const cases = [
+        {
+          summaryKey: 'deadline_unacknowledged_count',
+          failure: () => {
+            const cause = new Error('Body Timeout Error');
+            (cause as NodeJS.ErrnoException).code = 'UND_ERR_BODY_TIMEOUT';
+            return new TypeError('fetch failed', { cause });
+          },
+        },
+        {
+          summaryKey: 'network_unacknowledged_count',
+          failure: () => new TypeError('fetch failed', { cause: new Error('socket hang up') }),
+        },
+      ] as const;
+      for (const testCase of cases) {
+        const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+          if (init?.method === 'GET') {
+            return new Response(JSON.stringify({ ok: false }), { status: 404 });
+          }
+          return {
+            ok: true,
+            status: 200,
+            text: async () => { throw testCase.failure(); },
+          } as Response;
+        });
+        vi.stubGlobal('fetch', fetchMock);
+
+        const failure = await writeNewsLatestIndexEntry(
+          client,
+          STORY.story_id,
+          STORY.cluster_window_end,
+          STORY,
+        ).then(() => null, (error: unknown) => error);
+
+        expect(failure).toBeInstanceOf(RelayRestAvailabilityTotalFailureError);
+        expect(isRelayRestTransportTotalFailureError(failure)).toBe(false);
+        expect(warn).toHaveBeenCalledWith(
+          '[vh:news] relay REST write failed closed',
+          expect.objectContaining({
+            relay_attempt_summaries: [expect.objectContaining({
+              [testCase.summaryKey]: 3,
+              http_response_received_count: 3,
+              validation_failure_count: 0,
+            })],
+          }),
+        );
+        expect(fetchMock.mock.calls.filter(([, init]) => init?.method === 'POST')).toHaveLength(3);
+        expect(fetchMock.mock.calls.filter(([, init]) => init?.method === 'GET')).toHaveLength(3);
+        vi.unstubAllGlobals();
+        warn.mockClear();
+      }
+    } finally {
+      warn.mockRestore();
+      vi.unstubAllGlobals();
+      restoreEnv();
+      restoreRuntimeConfig();
+    }
+  });
+
+  it('keeps explicit HTTP failures non-retryable when their response body stream fails', async () => {
+    const restoreRuntimeConfig = withGunClientRuntimeConfig({
+      VH_NEWS_RELAY_REST_WRITE_FIRST: 'true',
+      VH_NEWS_RELAY_REST_WRITE_ORIGINS: '["https://gun-a.example.test","https://gun-b.example.test","https://gun-c.example.test"]',
+      VH_NEWS_RELAY_REST_WRITE_MIN_SUCCESS: '2',
+      VH_NEWS_RELAY_REST_TRANSPORT_RETRY_COUNT: '2',
+      VH_NEWS_RELAY_REST_TRANSPORT_RETRY_BACKOFF_MS: '0',
+    });
+    const restoreEnv = withProcessEnv({ VH_RELAY_DAEMON_TOKEN: 'relay-token-redacted' });
+    try {
+      const mesh = createFakeMesh();
+      const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+      const client = createClient(mesh, guard);
+      const fetchMock = vi.fn(async () => ({
+        ok: false,
+        status: 503,
+        text: async () => {
+          const cause = new Error('Body Timeout Error');
+          (cause as NodeJS.ErrnoException).code = 'UND_ERR_BODY_TIMEOUT';
+          throw new TypeError('fetch failed', { cause });
+        },
+      }) as Response);
+      vi.stubGlobal('fetch', fetchMock);
+
+      const failure = await writeNewsLatestIndexEntry(
+        client,
+        STORY.story_id,
+        STORY.cluster_window_end,
+        STORY,
+      ).then(() => null, (error: unknown) => error);
+
+      expect(failure).toBeInstanceOf(Error);
+      expect(isRelayRestAvailabilityTotalFailureError(failure)).toBe(false);
+      expect((failure as Error).message).toContain('http-503');
       expect(fetchMock).toHaveBeenCalledTimes(3);
     } finally {
       vi.unstubAllGlobals();
@@ -1311,7 +1450,519 @@ describe('newsAdapters', () => {
       );
       expect(isRelayRestTransportTotalFailureError(failure)).toBe(true);
       expect((failure as RelayRestTransportTotalFailureError).attemptCount).toBe(1);
-      expect(fetchMock).toHaveBeenCalledTimes(3);
+      expect(isRelayRestAvailabilityTotalFailureError(failure)).toBe(true);
+      expect(fetchMock).toHaveBeenCalledTimes(6);
+    } finally {
+      vi.unstubAllGlobals();
+      restoreEnv();
+      restoreRuntimeConfig();
+    }
+  });
+
+  it('starts every relay POST before any endpoint in the attempt settles', async () => {
+    const restoreRuntimeConfig = withGunClientRuntimeConfig({
+      VH_NEWS_RELAY_REST_WRITE_FIRST: 'true',
+      VH_NEWS_RELAY_REST_WRITE_ORIGINS: '["https://gun-a.example.test","https://gun-b.example.test","https://gun-c.example.test"]',
+      VH_NEWS_RELAY_REST_WRITE_MIN_SUCCESS: '2',
+      VH_NEWS_RELAY_REST_TRANSPORT_RETRY_COUNT: '0',
+    });
+    const restoreEnv = withProcessEnv({ VH_RELAY_DAEMON_TOKEN: 'relay-token-redacted' });
+    const releases: Array<() => void> = [];
+    try {
+      const mesh = createFakeMesh();
+      const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+      const client = createClient(mesh, guard);
+      const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((resolve) => {
+          const callIndex = releases.length;
+          releases.push(() => resolve(new Response(JSON.stringify({
+            ok: callIndex < 2,
+            story_id: STORY.story_id,
+          }), {
+            status: callIndex < 2 ? 200 : 503,
+            headers: { 'content-type': 'application/json' },
+          })));
+          expect(init?.method).toBe('POST');
+          expect(new URL(String(input)).pathname).toBe('/vh/news/latest-index');
+        }));
+      vi.stubGlobal('fetch', fetchMock);
+
+      const write = writeNewsLatestIndexEntry(client, STORY.story_id, STORY.cluster_window_end, STORY);
+      await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3));
+      expect(releases).toHaveLength(3);
+      releases.forEach((release) => release());
+      await expect(write).resolves.toBeUndefined();
+      const bodies = fetchMock.mock.calls.map(([, init]) => init?.body);
+      expect(new Set(bodies).size).toBe(1);
+    } finally {
+      releases.forEach((release) => release());
+      vi.unstubAllGlobals();
+      restoreEnv();
+      restoreRuntimeConfig();
+    }
+  });
+
+  it('reconciles exact signed records for all four critical routes without resending', async () => {
+    const restoreRuntimeConfig = withGunClientRuntimeConfig({
+      VH_NEWS_RELAY_REST_WRITE_ORIGINS: '["https://gun-a.example.test","https://gun-b.example.test","https://gun-c.example.test"]',
+      VH_NEWS_RELAY_REST_WRITE_MIN_SUCCESS: '2',
+      VH_NEWS_RELAY_REST_TRANSPORT_RETRY_COUNT: '1',
+      VH_NEWS_RELAY_REST_TRANSPORT_RETRY_BACKOFF_MS: '0',
+    });
+    const restoreEnv = withProcessEnv({ VH_RELAY_DAEMON_TOKEN: 'relay-token-redacted' });
+    try {
+      const hooks = await createRealSystemWriterHooks();
+      const mesh = createFakeMesh();
+      const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+      const client = createClient(mesh, guard, {
+        systemWriterPin: hooks.pin,
+        systemWriterSign: hooks.sign,
+      });
+      const lifecycle = buildNewsSynthesisLifecycleRecord({
+        story: STORY,
+        status: 'pending',
+        updatedAt: 1_700_000_050_000,
+      });
+      const cases = [
+        {
+          path: '/vh/news/story' as const,
+          bindingPath: `vh/news/stories/${STORY.story_id}/`,
+          payload: {
+            __story_bundle_json: JSON.stringify(STORY),
+            story_id: STORY.story_id,
+            created_at: STORY.created_at,
+            schemaVersion: STORY.schemaVersion,
+          },
+        },
+        {
+          path: '/vh/news/latest-index' as const,
+          bindingPath: `vh/news/index/latest/${STORY.story_id}/`,
+          payload: { story_id: STORY.story_id, latest_activity_at: STORY.cluster_window_end },
+        },
+        {
+          path: '/vh/news/hot-index' as const,
+          bindingPath: `vh/news/index/hot/${STORY.story_id}/`,
+          payload: { story_id: STORY.story_id, hotness: 0.75 },
+        },
+        {
+          path: '/vh/news/synthesis-lifecycle' as const,
+          bindingPath: `vh/news/stories/${STORY.story_id}/synthesis_lifecycle/latest/`,
+          payload: lifecycle,
+        },
+      ];
+
+      for (const testCase of cases) {
+        const record = await buildSignedSystemWriterRecord({
+          path: testCase.bindingPath,
+          payload: testCase.payload,
+          sign: hooks.sign,
+          pin: hooks.pin,
+          writerId: TEST_SYSTEM_WRITER_ID,
+          now: () => TEST_SYSTEM_ISSUED_AT,
+          defaultWriterId: TEST_SYSTEM_WRITER_ID,
+          missingSignerError: 'test signer required',
+        });
+        const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+          const url = new URL(String(input));
+          if (init?.method === 'POST') {
+            const error = new Error('This operation was aborted');
+            error.name = 'AbortError';
+            throw error;
+          }
+          expect(url.searchParams.get('story_id')).toBe(STORY.story_id);
+          if (testCase.path === '/vh/news/story') {
+            expect(url.searchParams.get('readback')).toBe('exact');
+          } else if (testCase.path === '/vh/news/latest-index') {
+            expect(url.searchParams.get('persist')).toBe('false');
+          } else if (testCase.path === '/vh/news/synthesis-lifecycle') {
+            expect(url.searchParams.get('readback')).toBe('exact');
+          }
+          if (url.origin === 'https://gun-c.example.test') {
+            return new Response(JSON.stringify({ ok: false }), { status: 404 });
+          }
+          return new Response(JSON.stringify({ ok: true, story_id: STORY.story_id, record }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          });
+        });
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(newsAdapterInternal.writeNewsRecordViaRelayRest({
+          client,
+          path: testCase.path,
+          record,
+          writeClass: `test-${testCase.path}`,
+          validate: () => true,
+        })).resolves.toBeUndefined();
+
+        expect(fetchMock.mock.calls.filter(([, init]) => init?.method === 'POST')).toHaveLength(3);
+        expect(fetchMock.mock.calls.filter(([, init]) => init?.method === 'GET')).toHaveLength(3);
+      }
+    } finally {
+      vi.unstubAllGlobals();
+      restoreEnv();
+      restoreRuntimeConfig();
+    }
+  });
+
+  it('combines one signed readback with one unresolved-endpoint retry without rewriting the confirmed relay', async () => {
+    const restoreRuntimeConfig = withGunClientRuntimeConfig({
+      VH_NEWS_RELAY_REST_WRITE_ORIGINS: '["https://gun-a.example.test","https://gun-b.example.test","https://gun-c.example.test"]',
+      VH_NEWS_RELAY_REST_WRITE_MIN_SUCCESS: '2',
+      VH_NEWS_RELAY_REST_TRANSPORT_RETRY_COUNT: '1',
+      VH_NEWS_RELAY_REST_TRANSPORT_RETRY_BACKOFF_MS: '0',
+    });
+    const restoreEnv = withProcessEnv({ VH_RELAY_DAEMON_TOKEN: 'relay-token-redacted' });
+    try {
+      const hooks = await createRealSystemWriterHooks();
+      const mesh = createFakeMesh();
+      const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+      const client = createClient(mesh, guard, { systemWriterPin: hooks.pin, systemWriterSign: hooks.sign });
+      const record = await buildSignedSystemWriterRecord({
+        path: `vh/news/index/latest/${STORY.story_id}/`,
+        payload: { story_id: STORY.story_id, latest_activity_at: STORY.cluster_window_end },
+        sign: hooks.sign,
+        pin: hooks.pin,
+        writerId: TEST_SYSTEM_WRITER_ID,
+        now: () => TEST_SYSTEM_ISSUED_AT,
+        defaultWriterId: TEST_SYSTEM_WRITER_ID,
+        missingSignerError: 'test signer required',
+      });
+      const postCounts = new Map<string, number>();
+      const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = new URL(String(input));
+        if (init?.method === 'GET') {
+          return url.origin === 'https://gun-a.example.test'
+            ? new Response(JSON.stringify({ ok: true, story_id: STORY.story_id, record }), { status: 200 })
+            : new Response(JSON.stringify({ ok: false }), { status: 404 });
+        }
+        const count = (postCounts.get(url.origin) ?? 0) + 1;
+        postCounts.set(url.origin, count);
+        if (url.origin === 'https://gun-b.example.test' && count === 2) {
+          return new Response(JSON.stringify({ ok: true, story_id: STORY.story_id }), { status: 200 });
+        }
+        const error = new Error('This operation was aborted');
+        error.name = 'AbortError';
+        throw error;
+      });
+      vi.stubGlobal('fetch', fetchMock);
+
+      await expect(newsAdapterInternal.writeNewsRecordViaRelayRest({
+        client,
+        path: '/vh/news/latest-index',
+        record,
+        writeClass: 'news-latest-index',
+        validate: (payload) => payload.ok === true && payload.story_id === STORY.story_id,
+      })).resolves.toBeUndefined();
+
+      expect(postCounts.get('https://gun-a.example.test')).toBe(1);
+      expect(postCounts.get('https://gun-b.example.test')).toBe(2);
+      expect(postCounts.get('https://gun-c.example.test')).toBe(2);
+      const postBodies = fetchMock.mock.calls
+        .filter(([, init]) => init?.method === 'POST')
+        .map(([, init]) => init?.body);
+      expect(new Set(postBodies).size).toBe(1);
+    } finally {
+      vi.unstubAllGlobals();
+      restoreEnv();
+      restoreRuntimeConfig();
+    }
+  });
+
+  it('combines an acknowledged POST with an exact signed readback without retrying the unresolved mixed attempt', async () => {
+    const restoreRuntimeConfig = withGunClientRuntimeConfig({
+      VH_NEWS_RELAY_REST_WRITE_ORIGINS: '["https://gun-a.example.test","https://gun-b.example.test","https://gun-c.example.test"]',
+      VH_NEWS_RELAY_REST_WRITE_MIN_SUCCESS: '2',
+      VH_NEWS_RELAY_REST_TRANSPORT_RETRY_COUNT: '2',
+      VH_NEWS_RELAY_REST_TRANSPORT_RETRY_BACKOFF_MS: '0',
+    });
+    const restoreEnv = withProcessEnv({ VH_RELAY_DAEMON_TOKEN: 'relay-token-redacted' });
+    try {
+      const hooks = await createRealSystemWriterHooks();
+      const mesh = createFakeMesh();
+      const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+      const client = createClient(mesh, guard, { systemWriterPin: hooks.pin, systemWriterSign: hooks.sign });
+      const record = await buildSignedSystemWriterRecord({
+        path: `vh/news/index/latest/${STORY.story_id}/`,
+        payload: { story_id: STORY.story_id, latest_activity_at: STORY.cluster_window_end },
+        sign: hooks.sign,
+        pin: hooks.pin,
+        writerId: TEST_SYSTEM_WRITER_ID,
+        now: () => TEST_SYSTEM_ISSUED_AT,
+        defaultWriterId: TEST_SYSTEM_WRITER_ID,
+        missingSignerError: 'test signer required',
+      });
+      const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = new URL(String(input));
+        if (init?.method === 'GET') {
+          return url.origin === 'https://gun-b.example.test'
+            ? new Response(JSON.stringify({ ok: true, story_id: STORY.story_id, record }), { status: 200 })
+            : new Response(JSON.stringify({ ok: false }), { status: 404 });
+        }
+        if (url.origin === 'https://gun-a.example.test') {
+          return new Response(JSON.stringify({ ok: true, story_id: STORY.story_id }), { status: 200 });
+        }
+        const error = new Error('This operation was aborted');
+        error.name = 'AbortError';
+        throw error;
+      });
+      vi.stubGlobal('fetch', fetchMock);
+
+      await expect(newsAdapterInternal.writeNewsRecordViaRelayRest({
+        client,
+        path: '/vh/news/latest-index',
+        record,
+        writeClass: 'news-latest-index',
+        validate: (payload) => payload.ok === true && payload.story_id === STORY.story_id,
+      })).resolves.toBeUndefined();
+
+      expect(fetchMock.mock.calls.filter(([, init]) => init?.method === 'POST')).toHaveLength(3);
+      expect(fetchMock.mock.calls.filter(([, init]) => init?.method === 'GET')).toHaveLength(2);
+    } finally {
+      vi.unstubAllGlobals();
+      restoreEnv();
+      restoreRuntimeConfig();
+    }
+  });
+
+  it('keeps conflicting, invalid, and tampered timeout readbacks fail-closed and unbranded', async () => {
+    const restoreRuntimeConfig = withGunClientRuntimeConfig({
+      VH_NEWS_RELAY_REST_WRITE_ORIGINS: '["https://gun-a.example.test","https://gun-b.example.test","https://gun-c.example.test"]',
+      VH_NEWS_RELAY_REST_WRITE_MIN_SUCCESS: '2',
+      VH_NEWS_RELAY_REST_TRANSPORT_RETRY_COUNT: '2',
+      VH_NEWS_RELAY_REST_TRANSPORT_RETRY_BACKOFF_MS: '0',
+    });
+    const restoreEnv = withProcessEnv({ VH_RELAY_DAEMON_TOKEN: 'relay-token-redacted' });
+    try {
+      const hooks = await createRealSystemWriterHooks();
+      const mesh = createFakeMesh();
+      const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+      const client = createClient(mesh, guard, { systemWriterPin: hooks.pin, systemWriterSign: hooks.sign });
+      const record = await buildSignedSystemWriterRecord({
+        path: `vh/news/index/latest/${STORY.story_id}/`,
+        payload: { story_id: STORY.story_id, latest_activity_at: STORY.cluster_window_end },
+        sign: hooks.sign,
+        pin: hooks.pin,
+        writerId: TEST_SYSTEM_WRITER_ID,
+        now: () => TEST_SYSTEM_ISSUED_AT,
+        defaultWriterId: TEST_SYSTEM_WRITER_ID,
+        missingSignerError: 'test signer required',
+      });
+      const conflicting = await buildSignedSystemWriterRecord({
+        path: `vh/news/index/latest/${STORY.story_id}/`,
+        payload: { story_id: STORY.story_id, latest_activity_at: STORY.cluster_window_end + 1 },
+        sign: hooks.sign,
+        pin: hooks.pin,
+        writerId: TEST_SYSTEM_WRITER_ID,
+        now: () => TEST_SYSTEM_ISSUED_AT,
+        defaultWriterId: TEST_SYSTEM_WRITER_ID,
+        missingSignerError: 'test signer required',
+      });
+      const unsafeRecords = [
+        conflicting,
+        { story_id: STORY.story_id, latest_activity_at: STORY.cluster_window_end },
+        { ...record, latest_activity_at: STORY.cluster_window_end + 1 },
+      ];
+
+      for (const unsafeRecord of unsafeRecords) {
+        const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+          const url = new URL(String(input));
+          if (init?.method === 'POST') {
+            const error = new Error('This operation was aborted');
+            error.name = 'AbortError';
+            throw error;
+          }
+          return url.origin === 'https://gun-a.example.test'
+            ? new Response(JSON.stringify({ ok: true, story_id: STORY.story_id, record: unsafeRecord }), { status: 200 })
+            : new Response(JSON.stringify({ ok: false }), { status: 404 });
+        });
+        vi.stubGlobal('fetch', fetchMock);
+        const failure = await newsAdapterInternal.writeNewsRecordViaRelayRest({
+          client,
+          path: '/vh/news/latest-index',
+          record,
+          writeClass: 'news-latest-index',
+          validate: () => true,
+        }).then(() => null, (error: unknown) => error);
+        expect(failure).toBeInstanceOf(Error);
+        expect((failure as Error).message).toContain('validation_failure_count=1');
+        expect(isRelayRestAvailabilityTotalFailureError(failure)).toBe(false);
+        expect(fetchMock.mock.calls.filter(([, init]) => init?.method === 'POST')).toHaveLength(3);
+      }
+    } finally {
+      vi.unstubAllGlobals();
+      restoreEnv();
+      restoreRuntimeConfig();
+    }
+  });
+
+  it('never accepts a synthesized unsigned story record as timeout reconciliation proof', async () => {
+    const restoreRuntimeConfig = withGunClientRuntimeConfig({
+      VH_NEWS_RELAY_REST_WRITE_ORIGINS: '["https://gun-a.example.test","https://gun-b.example.test","https://gun-c.example.test"]',
+      VH_NEWS_RELAY_REST_WRITE_MIN_SUCCESS: '2',
+      VH_NEWS_RELAY_REST_TRANSPORT_RETRY_COUNT: '1',
+      VH_NEWS_RELAY_REST_TRANSPORT_RETRY_BACKOFF_MS: '0',
+    });
+    const restoreEnv = withProcessEnv({ VH_RELAY_DAEMON_TOKEN: 'relay-token-redacted' });
+    try {
+      const hooks = await createRealSystemWriterHooks();
+      const mesh = createFakeMesh();
+      const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+      const client = createClient(mesh, guard, { systemWriterPin: hooks.pin, systemWriterSign: hooks.sign });
+      const record = await buildSignedSystemWriterRecord({
+        path: `vh/news/stories/${STORY.story_id}/`,
+        payload: {
+          __story_bundle_json: JSON.stringify(STORY),
+          story_id: STORY.story_id,
+          created_at: STORY.created_at,
+          schemaVersion: STORY.schemaVersion,
+        },
+        sign: hooks.sign,
+        pin: hooks.pin,
+        writerId: TEST_SYSTEM_WRITER_ID,
+        now: () => TEST_SYSTEM_ISSUED_AT,
+        defaultWriterId: TEST_SYSTEM_WRITER_ID,
+        missingSignerError: 'test signer required',
+      });
+      const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+        if (init?.method === 'POST') {
+          const error = new Error('This operation was aborted');
+          error.name = 'AbortError';
+          throw error;
+        }
+        return new Response(JSON.stringify({
+          ok: true,
+          story_id: STORY.story_id,
+          record: {
+            __story_bundle_json: JSON.stringify(STORY),
+            story_id: STORY.story_id,
+          },
+        }), { status: 200 });
+      });
+      vi.stubGlobal('fetch', fetchMock);
+
+      const failure = await newsAdapterInternal.writeNewsRecordViaRelayRest({
+        client,
+        path: '/vh/news/story',
+        record,
+        writeClass: 'news-story',
+        validate: () => true,
+      }).then(() => null, (error: unknown) => error);
+      expect(failure).toBeInstanceOf(Error);
+      expect((failure as Error).message).toContain('validation_failure_count=3');
+      expect(isRelayRestAvailabilityTotalFailureError(failure)).toBe(false);
+      expect(fetchMock.mock.calls.filter(([, init]) => init?.method === 'POST')).toHaveLength(3);
+      for (const [input, init] of fetchMock.mock.calls) {
+        if (init?.method === 'GET') {
+          expect(new URL(String(input)).searchParams.get('readback')).toBe('exact');
+        }
+      }
+    } finally {
+      vi.unstubAllGlobals();
+      restoreEnv();
+      restoreRuntimeConfig();
+    }
+  });
+
+  it('keeps write failure telemetry ordinal and excludes origins, tokens, response bodies, and story content', async () => {
+    const restoreRuntimeConfig = withGunClientRuntimeConfig({
+      VH_NEWS_RELAY_REST_WRITE_FIRST: 'true',
+      VH_NEWS_RELAY_REST_WRITE_ORIGINS: '["https://private-a.example.test","https://private-b.example.test","https://private-c.example.test"]',
+      VH_NEWS_RELAY_REST_WRITE_MIN_SUCCESS: '2',
+    });
+    const restoreEnv = withProcessEnv({ VH_RELAY_DAEMON_TOKEN: 'secret-daemon-token-value' });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      const mesh = createFakeMesh();
+      const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+      const client = createClient(mesh, guard);
+      vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+        ok: false,
+        error: 'relay failure',
+        token: 'secret-response-token-value',
+        story_body: STORY.headline,
+      }), { status: 503 })));
+      const failure = await writeNewsLatestIndexEntry(client, STORY.story_id, STORY.cluster_window_end, STORY)
+        .then(() => null, (error: unknown) => error);
+      const evidence = JSON.stringify({
+        failure: failure instanceof Error ? failure.message : failure,
+        logs: warn.mock.calls,
+      });
+      expect(evidence).toContain('relay-1');
+      expect(evidence).toContain('relay-2');
+      expect(evidence).toContain('relay-3');
+      expect(evidence).not.toContain('private-a.example.test');
+      expect(evidence).not.toContain('private-b.example.test');
+      expect(evidence).not.toContain('private-c.example.test');
+      expect(evidence).not.toContain('secret-daemon-token-value');
+      expect(evidence).not.toContain('secret-response-token-value');
+      expect(evidence).not.toContain(STORY.headline);
+    } finally {
+      warn.mockRestore();
+      vi.unstubAllGlobals();
+      restoreEnv();
+      restoreRuntimeConfig();
+    }
+  });
+
+  it('preserves quorum and exit-78 classes for partial, HTTP, validation, and mixed outcomes', async () => {
+    const restoreRuntimeConfig = withGunClientRuntimeConfig({
+      VH_NEWS_RELAY_REST_WRITE_FIRST: 'true',
+      VH_NEWS_RELAY_REST_WRITE_ORIGINS: '["https://gun-a.example.test","https://gun-b.example.test","https://gun-c.example.test"]',
+      VH_NEWS_RELAY_REST_WRITE_MIN_SUCCESS: '2',
+      VH_NEWS_RELAY_REST_TRANSPORT_RETRY_COUNT: '2',
+      VH_NEWS_RELAY_REST_TRANSPORT_RETRY_BACKOFF_MS: '0',
+    });
+    const restoreEnv = withProcessEnv({ VH_RELAY_DAEMON_TOKEN: 'relay-token-redacted' });
+    try {
+      const mesh = createFakeMesh();
+      const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+      const client = createClient(mesh, guard);
+      const run = async (responses: readonly ('ok' | 'deadline' | '503' | 'invalid')[]) => {
+        let postIndex = 0;
+        const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+          if (init?.method === 'GET') {
+            return new Response(JSON.stringify({ ok: false }), { status: 404 });
+          }
+          expect(init?.method).toBe('POST');
+          const response = responses[postIndex++]!;
+          if (response === 'deadline') {
+            const error = new Error('This operation was aborted');
+            error.name = 'AbortError';
+            throw error;
+          }
+          if (response === '503') {
+            return new Response('relay-backpressure', { status: 503 });
+          }
+          return new Response(JSON.stringify({
+            ok: response === 'ok',
+            story_id: response === 'ok' ? STORY.story_id : 'wrong-story',
+          }), { status: 200 });
+        });
+        vi.stubGlobal('fetch', fetchMock);
+        const result = await writeNewsLatestIndexEntry(client, STORY.story_id, STORY.cluster_window_end, STORY)
+          .then(() => null, (error: unknown) => error);
+        expect(fetchMock.mock.calls.filter(([, init]) => init?.method === 'POST')).toHaveLength(3);
+        return result;
+      };
+
+      const partial = await run(['ok', 'deadline', 'deadline']);
+      expect(partial).toBeInstanceOf(Error);
+      expect(isRelayRestAvailabilityTotalFailureError(partial)).toBe(false);
+
+      const mixed = await run(['deadline', '503', 'invalid']);
+      expect(mixed).toBeInstanceOf(Error);
+      expect(isRelayRestAvailabilityTotalFailureError(mixed)).toBe(false);
+
+      const backpressure = await run(['503', '503', '503']);
+      expect(backpressure).toBeInstanceOf(Error);
+      expect((backpressure as Error).message).toContain('relay-backpressure');
+      expect(isRelayRestAvailabilityTotalFailureError(backpressure)).toBe(false);
+
+      await expect((async () => {
+        const outcome = await run(['ok', 'ok', 'deadline']);
+        if (outcome) throw outcome;
+      })()).resolves.toBeUndefined();
     } finally {
       vi.unstubAllGlobals();
       restoreEnv();
@@ -1370,7 +2021,8 @@ describe('newsAdapters', () => {
   it('resolves relay REST quorum edge cases without posting', () => {
     expect(() => newsAdapterInternal.resolveNewsRelayRestWriteQuorum(0))
       .toThrow('Relay REST news write quorum requires at least one resolved endpoint');
-    expect(newsAdapterInternal.relayRestEndpointLabel('not a url')).toBe('invalid-relay-endpoint');
+    expect(newsAdapterInternal.relayRestEndpointLabel('https://private-relay.example.test', 0)).toBe('relay-1');
+    expect(newsAdapterInternal.relayRestEndpointLabel('https://different-private-relay.example.test', 1)).toBe('relay-2');
 
     const restoreZeroConfig = withGunClientRuntimeConfig({
       VH_NEWS_RELAY_REST_WRITE_MIN_SUCCESS: '0',
@@ -1536,7 +2188,7 @@ describe('newsAdapters', () => {
         writeClass: 'news-story',
         validate: (payload) => payload.ok === true,
       })).rejects.toThrow(
-        'VH_RELAY_DAEMON_TOKEN or VH_NEWS_RELAY_REST_WRITE_TOKENS[https://gun-b.example.test] is required for relay REST news writes',
+        'Relay daemon token is required for relay REST news write target relay-2',
       );
       expect(fetchMock).not.toHaveBeenCalled();
     } finally {
@@ -1605,7 +2257,7 @@ describe('newsAdapters', () => {
     }
   });
 
-  it('writeNewsRecordViaRelayRest records thrown fetch failures in the fail-closed error', async () => {
+  it('writeNewsRecordViaRelayRest classifies unexpected thrown failures without leaking raw error text', async () => {
     const restoreEnv = withProcessEnv({ VH_RELAY_DAEMON_TOKEN: 'relay-token-redacted' });
     const restoreRuntimeConfig = withGunClientRuntimeConfig({
       VH_NEWS_RELAY_REST_WRITE_REQUIRE_ALL: 'false',
@@ -1620,23 +2272,28 @@ describe('newsAdapters', () => {
         throw new Error('relay offline');
       }));
 
-      await expect(newsAdapterInternal.writeNewsRecordViaRelayRest({
+      const errorFailure = await newsAdapterInternal.writeNewsRecordViaRelayRest({
         client,
         path: '/vh/news/story',
         record: { story_id: STORY.story_id },
         writeClass: 'news-story',
         validate: () => true,
-      })).rejects.toThrow('relay offline');
+      }).then(() => null, (error: unknown) => error);
+      expect(errorFailure).toBeInstanceOf(Error);
+      expect((errorFailure as Error).message).toContain('relay-1:validation_failure:validation_failure');
+      expect((errorFailure as Error).message).not.toContain('relay offline');
       vi.stubGlobal('fetch', vi.fn(async () => {
         throw 'relay offline string';
       }));
-      await expect(newsAdapterInternal.writeNewsRecordViaRelayRest({
+      const stringFailure = await newsAdapterInternal.writeNewsRecordViaRelayRest({
         client,
         path: '/vh/news/story',
         record: { story_id: STORY.story_id },
         writeClass: 'news-story',
         validate: () => true,
-      })).rejects.toThrow('relay offline string');
+      }).then(() => null, (error: unknown) => error);
+      expect(stringFailure).toBeInstanceOf(Error);
+      expect((stringFailure as Error).message).not.toContain('relay offline string');
       expect(newsAdapterInternal.shouldRequireAllNewsRelayRestWrites()).toBe(false);
     } finally {
       vi.unstubAllGlobals();

--- a/packages/gun-client/src/newsAdapters.test.ts
+++ b/packages/gun-client/src/newsAdapters.test.ts
@@ -1643,12 +1643,9 @@ describe('newsAdapters', () => {
             throw error;
           }
           expect(url.searchParams.get('story_id')).toBe(STORY.story_id);
-          if (testCase.path === '/vh/news/story') {
-            expect(url.searchParams.get('readback')).toBe('exact');
-          } else if (testCase.path === '/vh/news/latest-index') {
+          expect(url.searchParams.get('readback')).toBe('exact');
+          if (testCase.path === '/vh/news/latest-index') {
             expect(url.searchParams.get('persist')).toBe('false');
-          } else if (testCase.path === '/vh/news/synthesis-lifecycle') {
-            expect(url.searchParams.get('readback')).toBe('exact');
           }
           if (url.origin === 'https://gun-c.example.test') {
             return new Response(JSON.stringify({ ok: false }), { status: 404 });
@@ -1683,6 +1680,7 @@ describe('newsAdapters', () => {
       VH_NEWS_RELAY_REST_WRITE_ORIGINS: '["https://gun-a.example.test","https://gun-b.example.test","https://gun-c.example.test"]',
       VH_NEWS_RELAY_REST_WRITE_MIN_SUCCESS: '2',
       VH_NEWS_RELAY_REST_TRANSPORT_RETRY_COUNT: '0',
+      VH_NEWS_RELAY_REST_READ_TIMEOUT_MS: 'invalid-test-timeout',
     });
     const restoreEnv = withProcessEnv({ VH_RELAY_DAEMON_TOKEN: 'relay-token-redacted' });
     try {
@@ -1692,6 +1690,39 @@ describe('newsAdapters', () => {
       const cases = [
         {
           readback: () => new Response(JSON.stringify({ ok: false }), { status: 502 }),
+          availabilityTotal: true,
+        },
+        {
+          readback: () => new Response(JSON.stringify({
+            ok: false,
+            error_class: 'relay-write-safety',
+            error: 'news-exact-readback-present-unsafe',
+          }), { status: 409 }),
+          availabilityTotal: false,
+        },
+        {
+          readback: () => new Response(JSON.stringify({
+            ok: false,
+            error_class: 'relay-write-safety',
+            error: 'intermediary-conflict',
+          }), { status: 409 }),
+          availabilityTotal: true,
+        },
+        {
+          readback: () => new Response(JSON.stringify({
+            ok: false,
+            error: 'news-exact-readback-present-unsafe',
+          }), { status: 409 }),
+          availabilityTotal: true,
+        },
+        {
+          readback: () => ({
+            ok: false,
+            status: 409,
+            text: async () => {
+              throw new TypeError('conflict body stream failed before present evidence');
+            },
+          }) as Response,
           availabilityTotal: true,
         },
         {
@@ -1705,7 +1736,47 @@ describe('newsAdapters', () => {
               throw new TypeError('terminated', { cause });
             },
           }) as Response,
-          availabilityTotal: true,
+          availabilityTotal: false,
+        },
+        {
+          readback: (() => {
+            let callCount = 0;
+            return () => {
+              callCount += 1;
+              if (callCount === 1) {
+                return new Response(JSON.stringify({
+                  ok: true,
+                  record: { story_id: STORY.story_id },
+                }), { status: 200 });
+              }
+              return {
+                ok: true,
+                status: 200,
+                text: async () => {
+                  throw new TypeError('terminated after present readback');
+                },
+              } as Response;
+            };
+          })(),
+          availabilityTotal: false,
+          expectedGetCount: 4,
+        },
+        {
+          readback: (() => {
+            let callCount = 0;
+            return () => {
+              callCount += 1;
+              if (callCount === 1) {
+                return new Response(JSON.stringify({
+                  ok: true,
+                  record: { story_id: STORY.story_id },
+                }), { status: 200 });
+              }
+              throw new TypeError('fetch failed after present readback');
+            };
+          })(),
+          availabilityTotal: false,
+          expectedGetCount: 4,
         },
         {
           readback: () => new Response('{', { status: 200 }),
@@ -1741,9 +1812,418 @@ describe('newsAdapters', () => {
         expect(failure).toBeInstanceOf(Error);
         expect(isRelayRestAvailabilityTotalFailureError(failure)).toBe(testCase.availabilityTotal);
         expect(fetchMock.mock.calls.filter(([, init]) => init?.method === 'POST')).toHaveLength(3);
-        expect(fetchMock.mock.calls.filter(([, init]) => init?.method === 'GET')).toHaveLength(3);
+        const expectedGetCount = 'expectedGetCount' in testCase ? testCase.expectedGetCount : 3;
+        expect(fetchMock.mock.calls.filter(([, init]) => init?.method === 'GET'))
+          .toHaveLength(expectedGetCount);
         vi.unstubAllGlobals();
       }
+    } finally {
+      vi.unstubAllGlobals();
+      restoreEnv();
+      restoreRuntimeConfig();
+    }
+  });
+
+  it('latches present readback evidence across later unavailable and malformed transitions', async () => {
+    const restoreRuntimeConfig = withGunClientRuntimeConfig({
+      VH_NEWS_RELAY_REST_WRITE_ORIGINS: '["https://gun-a.example.test","https://gun-b.example.test","https://gun-c.example.test"]',
+      VH_NEWS_RELAY_REST_WRITE_MIN_SUCCESS: '2',
+      VH_NEWS_RELAY_REST_TRANSPORT_RETRY_COUNT: '0',
+      VH_NEWS_RELAY_REST_READ_TIMEOUT_MS: '250',
+    });
+    const restoreEnv = withProcessEnv({ VH_RELAY_DAEMON_TOKEN: 'relay-token-redacted' });
+    try {
+      const mesh = createFakeMesh();
+      const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+      const client = createClient(mesh, guard);
+      const cases = [
+        {
+          name: '404',
+          next: () => new Response(JSON.stringify({ ok: false }), { status: 404 }),
+        },
+        {
+          name: '502',
+          next: () => new Response(JSON.stringify({ ok: false }), { status: 502 }),
+        },
+        {
+          name: 'wrong classified 409',
+          next: () => new Response(JSON.stringify({
+            ok: false,
+            error_class: 'relay-write-safety',
+            error: 'intermediary-conflict',
+          }), { status: 409 }),
+        },
+        {
+          name: 'incomplete 409',
+          next: () => new Response(JSON.stringify({
+            ok: false,
+            error: 'news-exact-readback-present-unsafe',
+          }), { status: 409 }),
+        },
+        {
+          name: 'body failure',
+          next: () => ({
+            ok: true,
+            status: 200,
+            text: async () => {
+              throw new TypeError('terminated after present readback');
+            },
+          }) as Response,
+        },
+        {
+          name: 'fetch failure',
+          next: () => {
+            throw new TypeError('fetch failed after present readback');
+          },
+        },
+        {
+          name: 'abort',
+          next: () => {
+            const error = new Error('This operation was aborted');
+            error.name = 'AbortError';
+            throw error;
+          },
+        },
+      ] as const;
+
+      for (const testCase of cases) {
+        const readCounts = new Map<string, number>();
+        const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+          if (init?.method === 'POST') {
+            const error = new Error('This operation was aborted');
+            error.name = 'AbortError';
+            throw error;
+          }
+          const origin = new URL(String(input)).origin;
+          const readCount = (readCounts.get(origin) ?? 0) + 1;
+          readCounts.set(origin, readCount);
+          if (readCount === 1) {
+            return new Response(JSON.stringify({
+              ok: true,
+              record: { story_id: STORY.story_id },
+            }), { status: 200 });
+          }
+          return testCase.next();
+        });
+        vi.stubGlobal('fetch', fetchMock);
+
+        const failure = await newsAdapterInternal.writeNewsRecordViaRelayRest({
+          client,
+          path: '/vh/news/latest-index',
+          record: { story_id: STORY.story_id, latest_activity_at: STORY.cluster_window_end },
+          writeClass: 'news-latest-index',
+          validate: () => true,
+        }).then(() => null, (error: unknown) => error);
+
+        expect(failure, testCase.name).toBeInstanceOf(Error);
+        expect(isRelayRestAvailabilityTotalFailureError(failure), testCase.name).toBe(false);
+        expect(fetchMock.mock.calls.filter(([, init]) => init?.method === 'POST'), testCase.name)
+          .toHaveLength(3);
+        expect(fetchMock.mock.calls.filter(([, init]) => init?.method === 'GET'), testCase.name)
+          .toHaveLength(6);
+        expect([...readCounts.values()], testCase.name).toEqual([2, 2, 2]);
+        vi.unstubAllGlobals();
+      }
+    } finally {
+      vi.unstubAllGlobals();
+      restoreEnv();
+      restoreRuntimeConfig();
+    }
+  });
+
+  it('keeps a present readback fail-closed when validation crosses the read deadline', async () => {
+    const restoreRuntimeConfig = withGunClientRuntimeConfig({
+      VH_NEWS_RELAY_REST_WRITE_ORIGINS: '["https://gun-a.example.test","https://gun-b.example.test","https://gun-c.example.test"]',
+      VH_NEWS_RELAY_REST_WRITE_MIN_SUCCESS: '2',
+      VH_NEWS_RELAY_REST_TRANSPORT_RETRY_COUNT: '0',
+      VH_NEWS_RELAY_REST_READ_TIMEOUT_MS: '25',
+    });
+    const restoreEnv = withProcessEnv({ VH_RELAY_DAEMON_TOKEN: 'relay-token-redacted' });
+    try {
+      const mesh = createFakeMesh();
+      const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+      const client = createClient(mesh, guard);
+      const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+        if (init?.method === 'POST') {
+          const error = new Error('This operation was aborted');
+          error.name = 'AbortError';
+          throw error;
+        }
+        return {
+          ok: true,
+          status: 200,
+          text: async () => {
+            await new Promise((resolve) => setTimeout(resolve, 35));
+            return JSON.stringify({
+              ok: true,
+              record: { story_id: STORY.story_id },
+            });
+          },
+        } as Response;
+      });
+      vi.stubGlobal('fetch', fetchMock);
+
+      const failure = await newsAdapterInternal.writeNewsRecordViaRelayRest({
+        client,
+        path: '/vh/news/latest-index',
+        record: { story_id: STORY.story_id, latest_activity_at: STORY.cluster_window_end },
+        writeClass: 'news-latest-index',
+        validate: () => true,
+      }).then(() => null, (error: unknown) => error);
+
+      expect(failure).toBeInstanceOf(Error);
+      expect(isRelayRestAvailabilityTotalFailureError(failure)).toBe(false);
+      expect(fetchMock.mock.calls.filter(([, init]) => init?.method === 'GET')).toHaveLength(3);
+    } finally {
+      vi.unstubAllGlobals();
+      restoreEnv();
+      restoreRuntimeConfig();
+    }
+  });
+
+  it('bounds hung readback bodies and signature verification with the absolute read deadline', async () => {
+    const restoreRuntimeConfig = withGunClientRuntimeConfig({
+      VH_NEWS_RELAY_REST_WRITE_ORIGINS: '["https://gun-a.example.test","https://gun-b.example.test","https://gun-c.example.test"]',
+      VH_NEWS_RELAY_REST_WRITE_MIN_SUCCESS: '2',
+      VH_NEWS_RELAY_REST_TRANSPORT_RETRY_COUNT: '0',
+      VH_NEWS_RELAY_REST_READ_TIMEOUT_MS: '40',
+    });
+    const restoreEnv = withProcessEnv({ VH_RELAY_DAEMON_TOKEN: 'relay-token-redacted' });
+    try {
+      const hooks = await createRealSystemWriterHooks();
+      const record = await buildSignedSystemWriterRecord({
+        path: `vh/news/index/latest/${STORY.story_id}/`,
+        payload: { story_id: STORY.story_id, latest_activity_at: STORY.cluster_window_end },
+        sign: hooks.sign,
+        pin: hooks.pin,
+        writerId: TEST_SYSTEM_WRITER_ID,
+        now: () => TEST_SYSTEM_ISSUED_AT,
+        defaultWriterId: TEST_SYSTEM_WRITER_ID,
+        missingSignerError: 'test signer required',
+      });
+      const cases = [
+        {
+          name: 'body',
+          clientOptions: {},
+          readback: () => ({
+            ok: true,
+            status: 200,
+            text: () => new Promise<string>(() => {}),
+          }) as Response,
+        },
+        {
+          name: 'signature verification',
+          clientOptions: {
+            systemWriterPin: hooks.pin,
+            systemWriterVerify: () => new Promise<boolean>(() => {}),
+          },
+          readback: () => new Response(JSON.stringify({
+            ok: true,
+            record,
+          }), { status: 200 }),
+        },
+      ] as const;
+
+      for (const testCase of cases) {
+        const mesh = createFakeMesh();
+        const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+        const client = createClient(mesh, guard, testCase.clientOptions);
+        const readbackSignals: AbortSignal[] = [];
+        const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+          if (init?.method === 'POST') {
+            const error = new Error('This operation was aborted');
+            error.name = 'AbortError';
+            throw error;
+          }
+          if (init?.signal) readbackSignals.push(init.signal);
+          return testCase.readback();
+        });
+        vi.stubGlobal('fetch', fetchMock);
+
+        const startedAt = Date.now();
+        const failure = await newsAdapterInternal.writeNewsRecordViaRelayRest({
+          client,
+          path: '/vh/news/latest-index',
+          record,
+          writeClass: 'news-latest-index',
+          validate: () => true,
+        }).then(() => null, (error: unknown) => error);
+        const elapsedMs = Date.now() - startedAt;
+
+        expect(failure, testCase.name).toBeInstanceOf(Error);
+        expect(isRelayRestAvailabilityTotalFailureError(failure), testCase.name).toBe(false);
+        expect(elapsedMs, testCase.name).toBeLessThan(250);
+        expect(fetchMock.mock.calls.filter(([, init]) => init?.method === 'GET'), testCase.name)
+          .toHaveLength(3);
+        expect(readbackSignals, testCase.name).toHaveLength(3);
+        expect(readbackSignals.every((signal) => signal.aborted), testCase.name).toBe(true);
+        vi.unstubAllGlobals();
+      }
+    } finally {
+      vi.unstubAllGlobals();
+      restoreEnv();
+      restoreRuntimeConfig();
+    }
+  });
+
+  it('bounds a pre-present readback fetch stall without changing availability-total classification', async () => {
+    const restoreRuntimeConfig = withGunClientRuntimeConfig({
+      VH_NEWS_RELAY_REST_WRITE_ORIGINS: '["https://gun-a.example.test","https://gun-b.example.test","https://gun-c.example.test"]',
+      VH_NEWS_RELAY_REST_WRITE_MIN_SUCCESS: '2',
+      VH_NEWS_RELAY_REST_TRANSPORT_RETRY_COUNT: '0',
+      VH_NEWS_RELAY_REST_READ_TIMEOUT_MS: '40',
+    });
+    const restoreEnv = withProcessEnv({ VH_RELAY_DAEMON_TOKEN: 'relay-token-redacted' });
+    try {
+      const mesh = createFakeMesh();
+      const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+      const client = createClient(mesh, guard);
+      const readbackSignals: AbortSignal[] = [];
+      const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+        if (init?.method === 'POST') {
+          const error = new Error('This operation was aborted');
+          error.name = 'AbortError';
+          throw error;
+        }
+        if (init?.signal) readbackSignals.push(init.signal);
+        return new Promise<Response>(() => {});
+      });
+      vi.stubGlobal('fetch', fetchMock);
+
+      const startedAt = Date.now();
+      const failure = await newsAdapterInternal.writeNewsRecordViaRelayRest({
+        client,
+        path: '/vh/news/latest-index',
+        record: { story_id: STORY.story_id, latest_activity_at: STORY.cluster_window_end },
+        writeClass: 'news-latest-index',
+        validate: () => true,
+      }).then(() => null, (error: unknown) => error);
+      const elapsedMs = Date.now() - startedAt;
+
+      expect(failure).toBeInstanceOf(Error);
+      expect(isRelayRestAvailabilityTotalFailureError(failure)).toBe(true);
+      expect(elapsedMs).toBeLessThan(250);
+      expect(fetchMock.mock.calls.filter(([, init]) => init?.method === 'GET')).toHaveLength(3);
+      expect(readbackSignals).toHaveLength(3);
+      expect(readbackSignals.every((signal) => signal.aborted)).toBe(true);
+    } finally {
+      vi.unstubAllGlobals();
+      restoreEnv();
+      restoreRuntimeConfig();
+    }
+  });
+
+  it('keeps a read deadline that expires before the first fetch retry-eligible', async () => {
+    const restoreRuntimeConfig = withGunClientRuntimeConfig({
+      VH_NEWS_RELAY_REST_WRITE_ORIGINS: '["https://gun-a.example.test","https://gun-b.example.test","https://gun-c.example.test"]',
+      VH_NEWS_RELAY_REST_WRITE_MIN_SUCCESS: '2',
+      VH_NEWS_RELAY_REST_TRANSPORT_RETRY_COUNT: '0',
+      VH_NEWS_RELAY_REST_READ_TIMEOUT_MS: '25',
+    });
+    const restoreEnv = withProcessEnv({ VH_RELAY_DAEMON_TOKEN: 'relay-token-redacted' });
+    let mockedNow = 1_700_000_000_000;
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => {
+      mockedNow += 100;
+      return mockedNow;
+    });
+    try {
+      const mesh = createFakeMesh();
+      const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+      const client = createClient(mesh, guard);
+      const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+        if (init?.method === 'GET') {
+          throw new Error('readback fetch must not start after its deadline');
+        }
+        const error = new Error('This operation was aborted');
+        error.name = 'AbortError';
+        throw error;
+      });
+      vi.stubGlobal('fetch', fetchMock);
+
+      const failure = await newsAdapterInternal.writeNewsRecordViaRelayRest({
+        client,
+        path: '/vh/news/latest-index',
+        record: { story_id: STORY.story_id, latest_activity_at: STORY.cluster_window_end },
+        writeClass: 'news-latest-index',
+        validate: () => true,
+      }).then(() => null, (error: unknown) => error);
+
+      expect(failure).toBeInstanceOf(Error);
+      expect(isRelayRestAvailabilityTotalFailureError(failure)).toBe(true);
+      expect(fetchMock.mock.calls.filter(([, init]) => init?.method === 'GET')).toHaveLength(0);
+    } finally {
+      nowSpy.mockRestore();
+      vi.unstubAllGlobals();
+      restoreEnv();
+      restoreRuntimeConfig();
+    }
+  });
+
+  it('polls safe partial exact readbacks until two expected signed records settle', async () => {
+    const restoreRuntimeConfig = withGunClientRuntimeConfig({
+      VH_NEWS_RELAY_REST_WRITE_ORIGINS: '["https://gun-a.example.test","https://gun-b.example.test","https://gun-c.example.test"]',
+      VH_NEWS_RELAY_REST_WRITE_MIN_SUCCESS: '2',
+      VH_NEWS_RELAY_REST_TRANSPORT_RETRY_COUNT: '0',
+      VH_NEWS_RELAY_REST_READ_TIMEOUT_MS: '250',
+    });
+    const restoreEnv = withProcessEnv({ VH_RELAY_DAEMON_TOKEN: 'relay-token-redacted' });
+    try {
+      const hooks = await createRealSystemWriterHooks();
+      const mesh = createFakeMesh();
+      const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+      const client = createClient(mesh, guard, {
+        systemWriterPin: hooks.pin,
+        systemWriterSign: hooks.sign,
+      });
+      const record = await buildSignedSystemWriterRecord({
+        path: `vh/news/index/latest/${STORY.story_id}/`,
+        payload: { story_id: STORY.story_id, latest_activity_at: STORY.cluster_window_end },
+        sign: hooks.sign,
+        pin: hooks.pin,
+        writerId: TEST_SYSTEM_WRITER_ID,
+        now: () => TEST_SYSTEM_ISSUED_AT,
+        defaultWriterId: TEST_SYSTEM_WRITER_ID,
+        missingSignerError: 'test signer required',
+      });
+      const getCounts = new Map<string, number>();
+      const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = new URL(String(input));
+        if (init?.method === 'POST') {
+          const error = new Error('This operation was aborted');
+          error.name = 'AbortError';
+          throw error;
+        }
+        expect(url.searchParams.get('readback')).toBe('exact');
+        expect(url.searchParams.get('persist')).toBe('false');
+        const count = (getCounts.get(url.origin) ?? 0) + 1;
+        getCounts.set(url.origin, count);
+        if (url.origin === 'https://gun-c.example.test') {
+          return new Response(JSON.stringify({ ok: false }), { status: 404 });
+        }
+        return new Response(JSON.stringify({
+          ok: true,
+          story_id: STORY.story_id,
+          record: count === 1
+            ? { story_id: STORY.story_id, latest_activity_at: STORY.cluster_window_end }
+            : record,
+        }), { status: 200 });
+      });
+      vi.stubGlobal('fetch', fetchMock);
+
+      await expect(newsAdapterInternal.writeNewsRecordViaRelayRest({
+        client,
+        path: '/vh/news/latest-index',
+        record,
+        writeClass: 'news-latest-index',
+        validate: () => true,
+      })).resolves.toBeUndefined();
+
+      expect(fetchMock.mock.calls.filter(([, init]) => init?.method === 'POST')).toHaveLength(3);
+      expect(getCounts).toEqual(new Map([
+        ['https://gun-a.example.test', 2],
+        ['https://gun-b.example.test', 2],
+        ['https://gun-c.example.test', 1],
+      ]));
     } finally {
       vi.unstubAllGlobals();
       restoreEnv();
@@ -1877,6 +2357,7 @@ describe('newsAdapters', () => {
       VH_NEWS_RELAY_REST_WRITE_MIN_SUCCESS: '2',
       VH_NEWS_RELAY_REST_TRANSPORT_RETRY_COUNT: '2',
       VH_NEWS_RELAY_REST_TRANSPORT_RETRY_BACKOFF_MS: '0',
+      VH_NEWS_RELAY_REST_READ_TIMEOUT_MS: '100',
     });
     const restoreEnv = withProcessEnv({ VH_RELAY_DAEMON_TOKEN: 'relay-token-redacted' });
     try {
@@ -1948,6 +2429,7 @@ describe('newsAdapters', () => {
       VH_NEWS_RELAY_REST_WRITE_MIN_SUCCESS: '2',
       VH_NEWS_RELAY_REST_TRANSPORT_RETRY_COUNT: '1',
       VH_NEWS_RELAY_REST_TRANSPORT_RETRY_BACKOFF_MS: '0',
+      VH_NEWS_RELAY_REST_READ_TIMEOUT_MS: '100',
     });
     const restoreEnv = withProcessEnv({ VH_RELAY_DAEMON_TOKEN: 'relay-token-redacted' });
     try {

--- a/packages/gun-client/src/newsAdapters.test.ts
+++ b/packages/gun-client/src/newsAdapters.test.ts
@@ -993,6 +993,20 @@ describe('newsAdapters', () => {
   });
 
   it('classifies only network-level thrown relay write failures as transport-class', () => {
+    expect(newsAdapterInternal.isDeadlineRelayWriteFailure('timeout')).toBe(false);
+    expect(newsAdapterInternal.isDeadlineRelayWriteFailure(new Error('request timeout'))).toBe(true);
+    expect(newsAdapterInternal.isDeadlineRelayWriteFailure(
+      new TypeError('fetch failed', { cause: 'UND_ERR_BODY_TIMEOUT' }),
+    )).toBe(true);
+    expect(newsAdapterInternal.isDeadlineRelayWriteFailure(
+      new TypeError('fetch failed', { cause: new Error('Body Timeout Error') }),
+    )).toBe(true);
+    const deadlineCauseWithCode = new Error('deadline elapsed');
+    (deadlineCauseWithCode as NodeJS.ErrnoException).code = 'UND_ERR_BODY_TIMEOUT';
+    expect(newsAdapterInternal.isDeadlineRelayWriteFailure(
+      new TypeError('fetch failed', { cause: deadlineCauseWithCode }),
+    )).toBe(true);
+    expect(newsAdapterInternal.isDeadlineRelayWriteFailure(new TypeError('fetch failed'))).toBe(false);
     expect(newsAdapterInternal.isTransportClassRelayWriteFailure('fetch failed')).toBe(false);
     expect(newsAdapterInternal.isTransportClassRelayWriteFailure(new TypeError('fetch failed'))).toBe(true);
     expect(newsAdapterInternal.isTransportClassRelayWriteFailure(new Error('ordinary application error'))).toBe(false);
@@ -1021,6 +1035,13 @@ describe('newsAdapters', () => {
     expect(newsAdapterInternal.isTransportClassRelayWriteFailure(
       new TypeError('fetch failed', { cause: bodyTimeoutCause }),
     )).toBe(false);
+
+    const socketResetCause = new Error('other side closed');
+    socketResetCause.name = 'SocketError';
+    (socketResetCause as NodeJS.ErrnoException).code = 'UND_ERR_SOCKET';
+    expect(newsAdapterInternal.isTransportClassRelayWriteFailure(
+      new TypeError('terminated', { cause: socketResetCause }),
+    )).toBe(true);
   });
 
   it('resolves relay REST transport retry plan with defaults, clamps, and fallback parsing', () => {
@@ -1332,7 +1353,12 @@ describe('newsAdapters', () => {
         },
         {
           summaryKey: 'network_unacknowledged_count',
-          failure: () => new TypeError('fetch failed', { cause: new Error('socket hang up') }),
+          failure: () => {
+            const cause = new Error('other side closed');
+            cause.name = 'SocketError';
+            (cause as NodeJS.ErrnoException).code = 'UND_ERR_SOCKET';
+            return new TypeError('terminated', { cause });
+          },
         },
       ] as const;
       for (const testCase of cases) {
@@ -1374,6 +1400,53 @@ describe('newsAdapters', () => {
       }
     } finally {
       warn.mockRestore();
+      vi.unstubAllGlobals();
+      restoreEnv();
+      restoreRuntimeConfig();
+    }
+  });
+
+  it('keeps ordinary 2xx body failures and malformed acknowledgements fail-closed', async () => {
+    const restoreRuntimeConfig = withGunClientRuntimeConfig({
+      VH_NEWS_RELAY_REST_WRITE_FIRST: 'true',
+      VH_NEWS_RELAY_REST_WRITE_ORIGINS: '["https://gun-a.example.test","https://gun-b.example.test","https://gun-c.example.test"]',
+      VH_NEWS_RELAY_REST_WRITE_MIN_SUCCESS: '2',
+      VH_NEWS_RELAY_REST_TRANSPORT_RETRY_COUNT: '2',
+      VH_NEWS_RELAY_REST_TRANSPORT_RETRY_BACKOFF_MS: '0',
+    });
+    const restoreEnv = withProcessEnv({ VH_RELAY_DAEMON_TOKEN: 'relay-token-redacted' });
+    try {
+      const mesh = createFakeMesh();
+      const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+      const client = createClient(mesh, guard);
+      const cases = [
+        { body: async () => { throw new Error('ordinary body decoder failure'); } },
+        { body: async () => '{' },
+        { body: async () => '' },
+      ] as const;
+
+      for (const testCase of cases) {
+        const fetchMock = vi.fn(async () => ({
+          ok: true,
+          status: 200,
+          text: testCase.body,
+        }) as Response);
+        vi.stubGlobal('fetch', fetchMock);
+
+        const failure = await writeNewsLatestIndexEntry(
+          client,
+          STORY.story_id,
+          STORY.cluster_window_end,
+          STORY,
+        ).then(() => null, (error: unknown) => error);
+
+        expect(failure).toBeInstanceOf(Error);
+        expect(isRelayRestAvailabilityTotalFailureError(failure)).toBe(false);
+        expect((failure as Error).message).toContain('validation_failure');
+        expect(fetchMock).toHaveBeenCalledTimes(3);
+        vi.unstubAllGlobals();
+      }
+    } finally {
       vi.unstubAllGlobals();
       restoreEnv();
       restoreRuntimeConfig();
@@ -1597,6 +1670,79 @@ describe('newsAdapters', () => {
 
         expect(fetchMock.mock.calls.filter(([, init]) => init?.method === 'POST')).toHaveLength(3);
         expect(fetchMock.mock.calls.filter(([, init]) => init?.method === 'GET')).toHaveLength(3);
+      }
+    } finally {
+      vi.unstubAllGlobals();
+      restoreEnv();
+      restoreRuntimeConfig();
+    }
+  });
+
+  it('distinguishes unavailable readbacks from malformed write-safety evidence', async () => {
+    const restoreRuntimeConfig = withGunClientRuntimeConfig({
+      VH_NEWS_RELAY_REST_WRITE_ORIGINS: '["https://gun-a.example.test","https://gun-b.example.test","https://gun-c.example.test"]',
+      VH_NEWS_RELAY_REST_WRITE_MIN_SUCCESS: '2',
+      VH_NEWS_RELAY_REST_TRANSPORT_RETRY_COUNT: '0',
+    });
+    const restoreEnv = withProcessEnv({ VH_RELAY_DAEMON_TOKEN: 'relay-token-redacted' });
+    try {
+      const mesh = createFakeMesh();
+      const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+      const client = createClient(mesh, guard);
+      const cases = [
+        {
+          readback: () => new Response(JSON.stringify({ ok: false }), { status: 502 }),
+          availabilityTotal: true,
+        },
+        {
+          readback: () => ({
+            ok: true,
+            status: 200,
+            text: async () => {
+              const cause = new Error('other side closed');
+              cause.name = 'SocketError';
+              (cause as NodeJS.ErrnoException).code = 'UND_ERR_SOCKET';
+              throw new TypeError('terminated', { cause });
+            },
+          }) as Response,
+          availabilityTotal: true,
+        },
+        {
+          readback: () => new Response('{', { status: 200 }),
+          availabilityTotal: false,
+        },
+        {
+          readback: () => new Response('', { status: 200 }),
+          availabilityTotal: false,
+        },
+        {
+          readback: () => new Response(JSON.stringify({ ok: true }), { status: 200 }),
+          availabilityTotal: false,
+        },
+      ] as const;
+
+      for (const testCase of cases) {
+        const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+          if (init?.method === 'GET') return testCase.readback();
+          const error = new Error('This operation was aborted');
+          error.name = 'AbortError';
+          throw error;
+        });
+        vi.stubGlobal('fetch', fetchMock);
+
+        const failure = await newsAdapterInternal.writeNewsRecordViaRelayRest({
+          client,
+          path: '/vh/news/latest-index',
+          record: { story_id: STORY.story_id, latest_activity_at: STORY.cluster_window_end },
+          writeClass: 'news-latest-index',
+          validate: () => true,
+        }).then(() => null, (error: unknown) => error);
+
+        expect(failure).toBeInstanceOf(Error);
+        expect(isRelayRestAvailabilityTotalFailureError(failure)).toBe(testCase.availabilityTotal);
+        expect(fetchMock.mock.calls.filter(([, init]) => init?.method === 'POST')).toHaveLength(3);
+        expect(fetchMock.mock.calls.filter(([, init]) => init?.method === 'GET')).toHaveLength(3);
+        vi.unstubAllGlobals();
       }
     } finally {
       vi.unstubAllGlobals();
@@ -1963,6 +2109,35 @@ describe('newsAdapters', () => {
         const outcome = await run(['ok', 'ok', 'deadline']);
         if (outcome) throw outcome;
       })()).resolves.toBeUndefined();
+    } finally {
+      vi.unstubAllGlobals();
+      restoreEnv();
+      restoreRuntimeConfig();
+    }
+  });
+
+  it('writeNewsRecordViaRelayRest rejects missing or blank stable record keys before posting', async () => {
+    const restoreRuntimeConfig = withGunClientRuntimeConfig({
+      VH_NEWS_RELAY_REST_WRITE_ORIGINS: '["https://gun-a.example.test"]',
+    });
+    const restoreEnv = withProcessEnv({ VH_RELAY_DAEMON_TOKEN: 'relay-token-redacted' });
+    try {
+      const mesh = createFakeMesh();
+      const guard = { validateWrite: vi.fn() } as unknown as TopologyGuard;
+      const client = createClient(mesh, guard);
+      const fetchMock = vi.fn();
+      vi.stubGlobal('fetch', fetchMock);
+
+      for (const record of [{}, { story_id: '   ' }]) {
+        await expect(newsAdapterInternal.writeNewsRecordViaRelayRest({
+          client,
+          path: '/vh/news/story',
+          record,
+          writeClass: 'news-story',
+          validate: () => true,
+        })).rejects.toThrow('record key is required');
+      }
+      expect(fetchMock).not.toHaveBeenCalled();
     } finally {
       vi.unstubAllGlobals();
       restoreEnv();

--- a/packages/gun-client/src/newsAdapters.ts
+++ b/packages/gun-client/src/newsAdapters.ts
@@ -505,6 +505,9 @@ function isTransportClassRelayWriteFailure(error: unknown): boolean {
   if (/UND_ERR_HEADERS_TIMEOUT|UND_ERR_BODY_TIMEOUT|HeadersTimeoutError|BodyTimeoutError|headers timeout|body timeout/i.test(causeText)) {
     return false;
   }
+  if (/UND_ERR_SOCKET|SocketError|other side closed/i.test(causeText)) {
+    return true;
+  }
   const combined = `${error.message} ${causeText}`;
   return /fetch failed|getaddrinfo|econnrefused|enotfound|eai_again|econnreset|ehostunreach|enetunreach|socket hang up|network/i.test(combined);
 }
@@ -2556,45 +2559,60 @@ async function readBackRelayRestWrite(input: {
 }): Promise<RelayRestReadbackResult> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), RELAY_REST_READ_TIMEOUT_MS);
-  try {
-    const response = await fetch(relayRestReadbackEndpoint(input.target.endpoint, input.recordKey), {
-      method: 'GET',
-      headers: { accept: 'application/json' },
-      signal: controller.signal,
-    });
-    if (response.status === 404) {
-      return { target: input.target, kind: 'missing' };
-    }
-    if (!response.ok) {
+  const execute = async (): Promise<RelayRestReadbackResult> => {
+    try {
+      const response = await fetch(relayRestReadbackEndpoint(input.target.endpoint, input.recordKey), {
+        method: 'GET',
+        headers: { accept: 'application/json' },
+        signal: controller.signal,
+      });
+      if (response.status === 404) {
+        return { target: input.target, kind: 'missing' };
+      }
+      if (!response.ok) {
+        return { target: input.target, kind: 'unavailable' };
+      }
+      let body: string;
+      try {
+        body = await response.text();
+      } catch {
+        return { target: input.target, kind: 'unavailable' };
+      }
+      const payload = (() => {
+        try {
+          return body.trim() ? JSON.parse(body) as { record?: unknown } : null;
+        } catch {
+          return null;
+        }
+      })();
+      if (!isRecord(payload?.record)) {
+        return { target: input.target, kind: 'write_safety_failure' };
+      }
+      const validation = await validateSystemWriterRecord({
+        path: relayRestRecordBindingPath(input.path, input.recordKey),
+        record: payload.record,
+        pin: input.client.config.systemWriterPin,
+        verify: input.client.config.systemWriterVerify,
+      });
+      if (!validation.valid) {
+        return { target: input.target, kind: 'write_safety_failure' };
+      }
+      const expectedSignature = input.expectedRecord._systemSignature;
+      if (
+        validation.canonicalRecord !== input.expectedCanonicalRecord
+        || typeof expectedSignature !== 'string'
+        || validation.record._systemSignature !== expectedSignature
+      ) {
+        return { target: input.target, kind: 'write_safety_failure' };
+      }
+      return { target: input.target, kind: 'confirmed' };
+    } catch {
       return { target: input.target, kind: 'unavailable' };
     }
-    const payload = await response.json().catch(() => null) as { record?: unknown } | null;
-    if (!isRecord(payload?.record)) {
-      return { target: input.target, kind: 'write_safety_failure' };
-    }
-    const validation = await validateSystemWriterRecord({
-      path: relayRestRecordBindingPath(input.path, input.recordKey),
-      record: payload.record,
-      pin: input.client.config.systemWriterPin,
-      verify: input.client.config.systemWriterVerify,
-    });
-    if (!validation.valid) {
-      return { target: input.target, kind: 'write_safety_failure' };
-    }
-    const expectedSignature = input.expectedRecord._systemSignature;
-    if (
-      validation.canonicalRecord !== input.expectedCanonicalRecord
-      || typeof expectedSignature !== 'string'
-      || validation.record._systemSignature !== expectedSignature
-    ) {
-      return { target: input.target, kind: 'write_safety_failure' };
-    }
-    return { target: input.target, kind: 'confirmed' };
-  } catch {
-    return { target: input.target, kind: 'unavailable' };
-  } finally {
-    clearTimeout(timeout);
-  }
+  };
+  const result = await execute();
+  clearTimeout(timeout);
+  return result;
 }
 
 async function writeNewsRecordViaRelayRest(input: {
@@ -2634,28 +2652,63 @@ async function writeNewsRecordViaRelayRest(input: {
     const outcomes = await Promise.all(targets.map(async (target): Promise<RelayRestWriteEndpointOutcome> => {
       const controller = new AbortController();
       const timeout = setTimeout(() => controller.abort(), RELAY_REST_WRITE_TIMEOUT_MS);
-      try {
-        const response = await fetch(target.endpoint, {
-          method: 'POST',
-          headers: {
-            'content-type': 'application/json',
-            ...target.headers,
-          },
-          body: serializedBody,
-          signal: controller.signal,
-        });
-        if (!response.ok) {
-          const body = await response.text().catch(() => '');
+      const execute = async (): Promise<RelayRestWriteEndpointOutcome> => {
+        try {
+          const response = await fetch(target.endpoint, {
+            method: 'POST',
+            headers: {
+              'content-type': 'application/json',
+              ...target.headers,
+            },
+            body: serializedBody,
+            signal: controller.signal,
+          });
+          if (!response.ok) {
+            const body = await response.text().catch(() => '');
+            return {
+              target,
+              kind: 'http_response',
+              httpResponseReceived: true,
+              detail: classifyRelayRestHttpFailure(response.status, body),
+            };
+          }
+          let body: string;
+          try {
+            body = await response.text();
+          } catch (error) {
+            const kind: RelayRestWriteEndpointResultKind = isDeadlineRelayWriteFailure(error)
+              ? 'deadline_unacknowledged'
+              : isTransportClassRelayWriteFailure(error)
+                ? 'network_unacknowledged'
+                : 'validation_failure';
+            return {
+              target,
+              kind,
+              httpResponseReceived: true,
+              detail: kind,
+            };
+          }
+          const payload = (() => {
+            try {
+              return body.trim() ? JSON.parse(body) as Record<string, unknown> : null;
+            } catch {
+              return null;
+            }
+          })();
+          if (payload && input.validate(payload)) {
+            return {
+              target,
+              kind: 'acknowledged_success',
+              httpResponseReceived: true,
+              detail: 'acknowledged',
+            };
+          }
           return {
             target,
-            kind: 'http_response',
+            kind: 'validation_failure',
             httpResponseReceived: true,
-            detail: classifyRelayRestHttpFailure(response.status, body),
+            detail: 'response-validation-failed',
           };
-        }
-        let body: string;
-        try {
-          body = await response.text();
         } catch (error) {
           const kind: RelayRestWriteEndpointResultKind = isDeadlineRelayWriteFailure(error)
             ? 'deadline_unacknowledged'
@@ -2665,46 +2718,14 @@ async function writeNewsRecordViaRelayRest(input: {
           return {
             target,
             kind,
-            httpResponseReceived: true,
+            httpResponseReceived: false,
             detail: kind,
           };
         }
-        const payload = (() => {
-          try {
-            return body.trim() ? JSON.parse(body) as Record<string, unknown> : null;
-          } catch {
-            return null;
-          }
-        })();
-        if (payload && input.validate(payload)) {
-          return {
-            target,
-            kind: 'acknowledged_success',
-            httpResponseReceived: true,
-            detail: 'acknowledged',
-          };
-        }
-        return {
-          target,
-          kind: 'validation_failure',
-          httpResponseReceived: true,
-          detail: 'response-validation-failed',
-        };
-      } catch (error) {
-        const kind: RelayRestWriteEndpointResultKind = isDeadlineRelayWriteFailure(error)
-          ? 'deadline_unacknowledged'
-          : isTransportClassRelayWriteFailure(error)
-            ? 'network_unacknowledged'
-            : 'validation_failure';
-        return {
-          target,
-          kind,
-          httpResponseReceived: false,
-          detail: kind,
-        };
-      } finally {
-        clearTimeout(timeout);
-      }
+      };
+      const outcome = await execute();
+      clearTimeout(timeout);
+      return outcome;
     }));
     return { outcomes };
   };
@@ -2811,10 +2832,9 @@ async function writeNewsRecordViaRelayRest(input: {
     if (!isAvailabilityOnlyOutcome(fanout.outcomes) || attempt >= maxAttempts) {
       break;
     }
+    // Quorum validation guarantees requiredSuccessCount <= relayTargets.length;
+    // because this branch is below quorum, at least one target is unresolved.
     targetsForAttempt = relayTargets.filter((target) => !confirmedTargetIndexes.has(target.index));
-    if (targetsForAttempt.length === 0) {
-      break;
-    }
     const backoffIndex = Math.min(attempt - 1, retryPlan.backoffMs.length - 1);
     const delayMs = retryPlan.backoffMs[backoffIndex]!;
     lumaLog('warn', '[vh:news] relay REST write availability-total; retrying unresolved targets', {
@@ -3866,6 +3886,7 @@ export const newsAdapterInternal = {
   resolveRelayRestWriteEndpoints,
   resolveNewsRelayRestWriteQuorum,
   resolveRelayRestTransportRetryPlan,
+  isDeadlineRelayWriteFailure,
   isTransportClassRelayWriteFailure,
   shouldRequireAllNewsRelayRestWrites,
   shouldWriteNewsViaRelayRestFirst,

--- a/packages/gun-client/src/newsAdapters.ts
+++ b/packages/gun-client/src/newsAdapters.ts
@@ -160,8 +160,12 @@ const READ_ONCE_TIMEOUT_MS = readGunTimeoutMs(
   ['VITE_VH_GUN_READ_TIMEOUT_MS', 'VH_GUN_READ_TIMEOUT_MS'],
   2_500,
 );
+const RELAY_REST_READ_TIMEOUT_ENV = [
+  'VITE_VH_NEWS_RELAY_REST_READ_TIMEOUT_MS',
+  'VH_NEWS_RELAY_REST_READ_TIMEOUT_MS',
+] as const;
 const RELAY_REST_READ_TIMEOUT_MS = readGunTimeoutMs(
-  ['VITE_VH_NEWS_RELAY_REST_READ_TIMEOUT_MS', 'VH_NEWS_RELAY_REST_READ_TIMEOUT_MS'],
+  RELAY_REST_READ_TIMEOUT_ENV,
   10_000,
 );
 const RELAY_REST_WRITE_TIMEOUT_MS = readGunTimeoutMs(
@@ -2532,14 +2536,20 @@ function relayRestReadbackEndpoint(endpoint: string, recordKey: string): string 
   const url = new URL(endpoint);
   url.search = '';
   url.searchParams.set('story_id', recordKey);
-  if (url.pathname === '/vh/news/story') {
-    url.searchParams.set('readback', 'exact');
-  } else if (url.pathname === '/vh/news/latest-index') {
+  url.searchParams.set('readback', 'exact');
+  if (url.pathname === '/vh/news/latest-index') {
     url.searchParams.set('persist', 'false');
-  } else if (url.pathname === '/vh/news/synthesis-lifecycle') {
-    url.searchParams.set('readback', 'exact');
   }
   return url.toString();
+}
+
+function resolveRelayRestReadbackDeadlineMs(): number {
+  const raw = readFirstRuntimeString(RELAY_REST_READ_TIMEOUT_ENV);
+  if (raw === undefined) return RELAY_REST_READ_TIMEOUT_MS;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed > 0
+    ? Math.min(RELAY_REST_READ_TIMEOUT_MS, Math.max(25, Math.floor(parsed)))
+    : RELAY_REST_READ_TIMEOUT_MS;
 }
 
 type RelayRestReadbackResultKind = 'confirmed' | 'missing' | 'unavailable' | 'write_safety_failure';
@@ -2557,62 +2567,109 @@ async function readBackRelayRestWrite(input: {
   readonly expectedCanonicalRecord: string;
   readonly target: RelayRestWriteTarget;
 }): Promise<RelayRestReadbackResult> {
+  const deadlineMs = resolveRelayRestReadbackDeadlineMs();
+  const deadline = Date.now() + deadlineMs;
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), RELAY_REST_READ_TIMEOUT_MS);
+  let sawPresent = false;
   const execute = async (): Promise<RelayRestReadbackResult> => {
     try {
-      const response = await fetch(relayRestReadbackEndpoint(input.target.endpoint, input.recordKey), {
-        method: 'GET',
-        headers: { accept: 'application/json' },
-        signal: controller.signal,
-      });
-      if (response.status === 404) {
-        return { target: input.target, kind: 'missing' };
-      }
-      if (!response.ok) {
-        return { target: input.target, kind: 'unavailable' };
-      }
-      let body: string;
-      try {
-        body = await response.text();
-      } catch {
-        return { target: input.target, kind: 'unavailable' };
-      }
-      const payload = (() => {
-        try {
-          return body.trim() ? JSON.parse(body) as { record?: unknown } : null;
-        } catch {
-          return null;
+      while (Date.now() < deadline) {
+        const response = await fetch(relayRestReadbackEndpoint(input.target.endpoint, input.recordKey), {
+          method: 'GET',
+          headers: { accept: 'application/json' },
+          signal: controller.signal,
+        });
+        if (response.status === 404) {
+          return {
+            target: input.target,
+            kind: sawPresent ? 'write_safety_failure' : 'missing',
+          };
         }
-      })();
-      if (!isRecord(payload?.record)) {
-        return { target: input.target, kind: 'write_safety_failure' };
+        if (!response.ok && response.status !== 409) {
+          return {
+            target: input.target,
+            kind: sawPresent ? 'write_safety_failure' : 'unavailable',
+          };
+        }
+        if (response.ok) {
+          sawPresent = true;
+        }
+        let body: string;
+        try {
+          body = await response.text();
+        } catch {
+          return {
+            target: input.target,
+            kind: sawPresent ? 'write_safety_failure' : 'unavailable',
+          };
+        }
+        const payload = (() => {
+          try {
+            return body.trim() ? JSON.parse(body) as Record<string, unknown> : null;
+          } catch {
+            return null;
+          }
+        })();
+        if (response.status === 409) {
+          return {
+            target: input.target,
+            kind: payload?.error_class === 'relay-write-safety'
+              && payload.error === 'news-exact-readback-present-unsafe'
+              ? 'write_safety_failure'
+              : sawPresent
+                ? 'write_safety_failure'
+                : 'unavailable',
+          };
+        }
+        if (!isRecord(payload?.record)) {
+          return { target: input.target, kind: 'write_safety_failure' };
+        }
+        const validation = await validateSystemWriterRecord({
+          path: relayRestRecordBindingPath(input.path, input.recordKey),
+          record: payload.record,
+          pin: input.client.config.systemWriterPin,
+          verify: input.client.config.systemWriterVerify,
+        });
+        const expectedSignature = input.expectedRecord._systemSignature;
+        if (
+          validation.valid
+          && validation.canonicalRecord === input.expectedCanonicalRecord
+          && typeof expectedSignature === 'string'
+          && validation.record._systemSignature === expectedSignature
+        ) {
+          return { target: input.target, kind: 'confirmed' };
+        }
+        const remainingMs = deadline - Date.now();
+        if (remainingMs <= 0) break;
+        await sleepMs(Math.min(25, remainingMs));
       }
-      const validation = await validateSystemWriterRecord({
-        path: relayRestRecordBindingPath(input.path, input.recordKey),
-        record: payload.record,
-        pin: input.client.config.systemWriterPin,
-        verify: input.client.config.systemWriterVerify,
-      });
-      if (!validation.valid) {
-        return { target: input.target, kind: 'write_safety_failure' };
-      }
-      const expectedSignature = input.expectedRecord._systemSignature;
-      if (
-        validation.canonicalRecord !== input.expectedCanonicalRecord
-        || typeof expectedSignature !== 'string'
-        || validation.record._systemSignature !== expectedSignature
-      ) {
-        return { target: input.target, kind: 'write_safety_failure' };
-      }
-      return { target: input.target, kind: 'confirmed' };
+      return {
+        target: input.target,
+        kind: sawPresent ? 'write_safety_failure' : 'unavailable',
+      };
     } catch {
-      return { target: input.target, kind: 'unavailable' };
+      return {
+        target: input.target,
+        kind: sawPresent ? 'write_safety_failure' : 'unavailable',
+      };
     }
   };
-  const result = await execute();
-  clearTimeout(timeout);
-  return result;
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const deadlineResult = new Promise<RelayRestReadbackResult>((resolve) => {
+    timeout = setTimeout(() => {
+      controller.abort();
+      resolve({
+        target: input.target,
+        kind: sawPresent ? 'write_safety_failure' : 'unavailable',
+      });
+    }, deadlineMs);
+  });
+  try {
+    return await Promise.race([execute(), deadlineResult]);
+  } finally {
+    if (timeout !== undefined) clearTimeout(timeout);
+    controller.abort();
+  }
 }
 
 async function writeNewsRecordViaRelayRest(input: {

--- a/packages/gun-client/src/newsAdapters.ts
+++ b/packages/gun-client/src/newsAdapters.ts
@@ -13,6 +13,7 @@ import {
   SYSTEM_WRITER_PROTOCOL_VERSION,
   SYSTEM_WRITER_VALIDATION_EVENT,
   buildSignedSystemWriterRecord,
+  canonicalizeSystemWriterRecordForSigning,
   rejectUnmarkedSystemRecords,
   unmarkedRecordRejectedFailure,
   validateSystemWriterRecord,
@@ -347,12 +348,8 @@ function resolveNewsRelayRestWriteQuorum(endpointCount: number): RelayRestWriteQ
   };
 }
 
-function relayRestEndpointLabel(endpoint: string): string {
-  try {
-    return new URL(endpoint).origin;
-  } catch {
-    return 'invalid-relay-endpoint';
-  }
+function relayRestEndpointLabel(_endpoint: string, index = 0): string {
+  return `relay-${Math.max(0, Math.floor(index)) + 1}`;
 }
 
 function normalizeLatestIndexReadLimit(limit: unknown, fallback = RELAY_REST_INDEX_LIMIT): number {
@@ -433,21 +430,16 @@ function relayRestNetworkClassification(error: unknown): string {
 }
 
 /**
- * Thrown when a relay REST news write fan-out gets ZERO relay successes and
- * every per-relay failure is transport-class (the fetch itself threw — DNS
- * resolution, connection refusal, connection reset — with no HTTP response
- * received from any relay). No relay ACKNOWLEDGED the write. A response-leg
- * reset can, in principle, occur after a relay applied the write, and the
- * network-level cause may be relay-side (fleet down, TLS failure) rather
- * than host-side — so this classification means "unacknowledged everywhere",
- * not "provably unpublished" or "host network at fault". Retrying is safe
- * regardless: the record is encoded once and re-sent byte-identical, and all
- * relay news writes are id-keyed idempotent upserts (created_at is
- * first-write-wins server-side), so a re-send cannot double-publish or
- * diverge state.
+ * Thrown when a relay REST news write fan-out remains totally unavailable
+ * after bounded endpoint-local reconciliation: zero relays produced a
+ * validated acknowledgement and every endpoint was network- or
+ * deadline-unacknowledged. A response-leg failure can occur after a relay
+ * applied the write, so this means "unacknowledged everywhere", not
+ * "provably unpublished". Any bounded retry reuses the byte-identical signed,
+ * id-keyed record and targets only endpoints that readback did not confirm.
  */
-export class RelayRestTransportTotalFailureError extends Error {
-  readonly relayRestTransportTotalFailure = true;
+export class RelayRestAvailabilityTotalFailureError extends Error {
+  readonly relayRestAvailabilityTotalFailure = true;
 
   readonly path: string;
 
@@ -455,10 +447,30 @@ export class RelayRestTransportTotalFailureError extends Error {
 
   constructor(message: string, options: { readonly path: string; readonly attemptCount: number }) {
     super(message);
-    this.name = 'RelayRestTransportTotalFailureError';
+    this.name = 'RelayRestAvailabilityTotalFailureError';
     this.path = options.path;
     this.attemptCount = options.attemptCount;
   }
+}
+
+export class RelayRestTransportTotalFailureError extends RelayRestAvailabilityTotalFailureError {
+  readonly relayRestTransportTotalFailure = true;
+
+  constructor(message: string, options: { readonly path: string; readonly attemptCount: number }) {
+    super(message, options);
+    this.name = 'RelayRestTransportTotalFailureError';
+  }
+}
+
+/** Brand-based compatibility guard for both new and legacy availability errors. */
+export function isRelayRestAvailabilityTotalFailureError(
+  error: unknown,
+): error is RelayRestAvailabilityTotalFailureError {
+  return error instanceof Error
+    && (
+      (error as { relayRestAvailabilityTotalFailure?: unknown }).relayRestAvailabilityTotalFailure === true
+      || (error as { relayRestTransportTotalFailure?: unknown }).relayRestTransportTotalFailure === true
+    );
 }
 
 /** Brand-based guard so duplicated package instances cannot break detection. */
@@ -471,10 +483,10 @@ export function isRelayRestTransportTotalFailureError(
 
 /**
  * Transport-class means the fetch threw with a network-level cause and no
- * HTTP response was ever received. Aborts/timeouts are deliberately NOT
- * transport-class: a hung relay may have received the request, and masking
- * relay-side slowness with retries would hide capacity problems that the
- * backpressure path (#675) exists to surface.
+ * HTTP response was ever received. Aborts and response deadlines remain a
+ * distinct unacknowledged class because the relay may have committed before
+ * its response leg failed; they become retry-eligible only after the bounded
+ * signed-readback reconciliation in writeNewsRecordViaRelayRest.
  */
 function isTransportClassRelayWriteFailure(error: unknown): boolean {
   if (!(error instanceof Error)) return false;
@@ -486,10 +498,10 @@ function isTransportClassRelayWriteFailure(error: unknown): boolean {
       ? ''
       : String(cause);
   // undici wraps dispatcher timeouts as TypeError('fetch failed') with the
-  // real cause underneath. A headers/body timeout means the request WAS
-  // delivered and the relay is hanging — that is relay-side slowness, not
-  // transport-total, so it must keep single-pass semantics like aborts.
-  // (UND_ERR_CONNECT_TIMEOUT stays transport-class: TCP never opened.)
+  // real cause underneath. A headers/body timeout means the request was
+  // delivered and must remain deadline-unacknowledged rather than the legacy
+  // transport subtype. (UND_ERR_CONNECT_TIMEOUT stays transport-class: TCP
+  // never opened.)
   if (/UND_ERR_HEADERS_TIMEOUT|UND_ERR_BODY_TIMEOUT|HeadersTimeoutError|BodyTimeoutError|headers timeout|body timeout/i.test(causeText)) {
     return false;
   }
@@ -2420,17 +2432,169 @@ function resolveRelayRestWriteEndpoints(client: VennClient, path: NewsRelayRestW
   );
 }
 
-function requireNewsRelayDaemonAuthHeaders(endpoint: string): Record<string, string> {
+function requireNewsRelayDaemonAuthHeaders(endpoint: string, endpointLabel: string): Record<string, string> {
   const headers = createRelayDaemonAuthHeadersForEndpoint(endpoint, {
     tokenMapEnvNames: RELAY_REST_NEWS_WRITE_TOKEN_MAP_ENV,
   });
   if (!headers.Authorization) {
-    const origin = new URL(endpoint).origin;
-    throw new Error(
-      `VH_RELAY_DAEMON_TOKEN or VH_NEWS_RELAY_REST_WRITE_TOKENS[${origin}] is required for relay REST news writes`,
-    );
+    throw new Error(`Relay daemon token is required for relay REST news write target ${endpointLabel}`);
   }
   return headers;
+}
+
+type RelayRestWriteEndpointResultKind =
+  | 'acknowledged_success'
+  | 'network_unacknowledged'
+  | 'deadline_unacknowledged'
+  | 'http_response'
+  | 'validation_failure';
+
+interface RelayRestWriteTarget {
+  readonly endpoint: string;
+  readonly endpointLabel: string;
+  readonly index: number;
+  readonly headers: Record<string, string>;
+}
+
+interface RelayRestWriteEndpointOutcome {
+  readonly target: RelayRestWriteTarget;
+  readonly kind: RelayRestWriteEndpointResultKind;
+  readonly httpResponseReceived: boolean;
+  readonly detail: string;
+}
+
+interface RelayRestWriteAttemptSummary {
+  readonly attempt: number;
+  readonly duration_ms: number;
+  readonly target_count: number;
+  readonly acknowledged_count: number;
+  readonly network_unacknowledged_count: number;
+  readonly deadline_unacknowledged_count: number;
+  readonly readback_confirmed_count: number;
+  readonly http_response_received_count: number;
+  readonly http_response_count: number;
+  readonly validation_failure_count: number;
+}
+
+function isDeadlineRelayWriteFailure(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  if (error.name === 'AbortError' || /abort|timeout/i.test(error.message)) return true;
+  const cause = (error as { cause?: unknown }).cause;
+  const causeText = cause instanceof Error
+    ? `${(cause as NodeJS.ErrnoException).code ?? ''} ${cause.name} ${cause.message}`
+    : cause === undefined || cause === null
+      ? ''
+      : String(cause);
+  return /UND_ERR_HEADERS_TIMEOUT|UND_ERR_BODY_TIMEOUT|HeadersTimeoutError|BodyTimeoutError|headers timeout|body timeout/i
+    .test(causeText);
+}
+
+function summarizeRelayRestWriteAttempt(
+  attempt: number,
+  durationMs: number,
+  outcomes: readonly RelayRestWriteEndpointOutcome[],
+  readbackConfirmedCount = 0,
+  readbackValidationFailureCount = 0,
+): RelayRestWriteAttemptSummary {
+  const count = (kind: RelayRestWriteEndpointResultKind): number =>
+    outcomes.filter((outcome) => outcome.kind === kind).length;
+  return {
+    attempt,
+    duration_ms: Math.max(0, durationMs),
+    target_count: outcomes.length,
+    acknowledged_count: count('acknowledged_success'),
+    network_unacknowledged_count: count('network_unacknowledged'),
+    deadline_unacknowledged_count: count('deadline_unacknowledged'),
+    readback_confirmed_count: readbackConfirmedCount,
+    http_response_received_count: outcomes.filter((outcome) => outcome.httpResponseReceived).length,
+    http_response_count: count('http_response'),
+    validation_failure_count: count('validation_failure') + readbackValidationFailureCount,
+  };
+}
+
+function relayRestRecordBindingPath(path: NewsRelayRestWritePath, recordKey: string): string {
+  switch (path) {
+    case '/vh/news/story':
+      return storyPath(recordKey);
+    case '/vh/news/latest-index':
+      return latestIndexEntryPath(recordKey);
+    case '/vh/news/hot-index':
+      return hotIndexEntryPath(recordKey);
+    case '/vh/news/synthesis-lifecycle':
+      return synthesisLifecycleLatestPath(recordKey);
+  }
+}
+
+function relayRestReadbackEndpoint(endpoint: string, recordKey: string): string {
+  const url = new URL(endpoint);
+  url.search = '';
+  url.searchParams.set('story_id', recordKey);
+  if (url.pathname === '/vh/news/story') {
+    url.searchParams.set('readback', 'exact');
+  } else if (url.pathname === '/vh/news/latest-index') {
+    url.searchParams.set('persist', 'false');
+  } else if (url.pathname === '/vh/news/synthesis-lifecycle') {
+    url.searchParams.set('readback', 'exact');
+  }
+  return url.toString();
+}
+
+type RelayRestReadbackResultKind = 'confirmed' | 'missing' | 'unavailable' | 'write_safety_failure';
+
+interface RelayRestReadbackResult {
+  readonly target: RelayRestWriteTarget;
+  readonly kind: RelayRestReadbackResultKind;
+}
+
+async function readBackRelayRestWrite(input: {
+  readonly client: VennClient;
+  readonly path: NewsRelayRestWritePath;
+  readonly recordKey: string;
+  readonly expectedRecord: Record<string, unknown>;
+  readonly expectedCanonicalRecord: string;
+  readonly target: RelayRestWriteTarget;
+}): Promise<RelayRestReadbackResult> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), RELAY_REST_READ_TIMEOUT_MS);
+  try {
+    const response = await fetch(relayRestReadbackEndpoint(input.target.endpoint, input.recordKey), {
+      method: 'GET',
+      headers: { accept: 'application/json' },
+      signal: controller.signal,
+    });
+    if (response.status === 404) {
+      return { target: input.target, kind: 'missing' };
+    }
+    if (!response.ok) {
+      return { target: input.target, kind: 'unavailable' };
+    }
+    const payload = await response.json().catch(() => null) as { record?: unknown } | null;
+    if (!isRecord(payload?.record)) {
+      return { target: input.target, kind: 'write_safety_failure' };
+    }
+    const validation = await validateSystemWriterRecord({
+      path: relayRestRecordBindingPath(input.path, input.recordKey),
+      record: payload.record,
+      pin: input.client.config.systemWriterPin,
+      verify: input.client.config.systemWriterVerify,
+    });
+    if (!validation.valid) {
+      return { target: input.target, kind: 'write_safety_failure' };
+    }
+    const expectedSignature = input.expectedRecord._systemSignature;
+    if (
+      validation.canonicalRecord !== input.expectedCanonicalRecord
+      || typeof expectedSignature !== 'string'
+      || validation.record._systemSignature !== expectedSignature
+    ) {
+      return { target: input.target, kind: 'write_safety_failure' };
+    }
+    return { target: input.target, kind: 'confirmed' };
+  } catch {
+    return { target: input.target, kind: 'unavailable' };
+  } finally {
+    clearTimeout(timeout);
+  }
 }
 
 async function writeNewsRecordViaRelayRest(input: {
@@ -2448,39 +2612,63 @@ async function writeNewsRecordViaRelayRest(input: {
     throw new Error(`No relay REST endpoints configured for ${input.path}`);
   }
   const quorum = resolveNewsRelayRestWriteQuorum(endpoints.length);
-  const relayTargets = endpoints.map((endpoint) => ({
-    endpoint,
-    headers: requireNewsRelayDaemonAuthHeaders(endpoint),
-  }));
-
-  interface RelayRestWriteFanoutOutcome {
-    readonly successCount: number;
-    readonly failures: readonly string[];
-    readonly failedEndpointLabels: readonly string[];
-    readonly transportClassFailureCount: number;
+  const serializedBody = JSON.stringify({ record: input.record });
+  const recordKey = typeof input.record.story_id === 'string' ? input.record.story_id.trim() : '';
+  if (!recordKey) {
+    throw new Error(`Relay REST news write record key is required for ${input.path}`);
   }
+  const expectedCanonicalRecord = canonicalizeSystemWriterRecordForSigning(input.record);
+  const relayTargets = endpoints.map((endpoint, index) => {
+    const endpointLabel = relayRestEndpointLabel(endpoint, index);
+    return {
+      endpoint,
+      endpointLabel,
+      index,
+      headers: requireNewsRelayDaemonAuthHeaders(endpoint, endpointLabel),
+    };
+  });
 
-  const attemptFanout = async (): Promise<RelayRestWriteFanoutOutcome> => {
-    const failures: string[] = [];
-    const failedEndpointLabels: string[] = [];
-    let successCount = 0;
-    let transportClassFailureCount = 0;
-
-    for (const { endpoint, headers } of relayTargets) {
-      const endpointLabel = relayRestEndpointLabel(endpoint);
+  const attemptFanout = async (
+    targets: readonly RelayRestWriteTarget[],
+  ): Promise<{ readonly outcomes: readonly RelayRestWriteEndpointOutcome[] }> => {
+    const outcomes = await Promise.all(targets.map(async (target): Promise<RelayRestWriteEndpointOutcome> => {
       const controller = new AbortController();
       const timeout = setTimeout(() => controller.abort(), RELAY_REST_WRITE_TIMEOUT_MS);
       try {
-        const response = await fetch(endpoint, {
+        const response = await fetch(target.endpoint, {
           method: 'POST',
           headers: {
             'content-type': 'application/json',
-            ...headers,
+            ...target.headers,
           },
-          body: JSON.stringify({ record: input.record }),
+          body: serializedBody,
           signal: controller.signal,
         });
-        const body = await response.text().catch(() => '');
+        if (!response.ok) {
+          const body = await response.text().catch(() => '');
+          return {
+            target,
+            kind: 'http_response',
+            httpResponseReceived: true,
+            detail: classifyRelayRestHttpFailure(response.status, body),
+          };
+        }
+        let body: string;
+        try {
+          body = await response.text();
+        } catch (error) {
+          const kind: RelayRestWriteEndpointResultKind = isDeadlineRelayWriteFailure(error)
+            ? 'deadline_unacknowledged'
+            : isTransportClassRelayWriteFailure(error)
+              ? 'network_unacknowledged'
+              : 'validation_failure';
+          return {
+            target,
+            kind,
+            httpResponseReceived: true,
+            detail: kind,
+          };
+        }
         const payload = (() => {
           try {
             return body.trim() ? JSON.parse(body) as Record<string, unknown> : null;
@@ -2488,83 +2676,198 @@ async function writeNewsRecordViaRelayRest(input: {
             return null;
           }
         })();
-        if (response.ok && payload && input.validate(payload)) {
-          successCount += 1;
-          continue;
+        if (payload && input.validate(payload)) {
+          return {
+            target,
+            kind: 'acknowledged_success',
+            httpResponseReceived: true,
+            detail: 'acknowledged',
+          };
         }
-        const classification = classifyRelayRestHttpFailure(response.status, body);
-        failedEndpointLabels.push(endpointLabel);
-        failures.push(`${endpointLabel}:${classification}`);
+        return {
+          target,
+          kind: 'validation_failure',
+          httpResponseReceived: true,
+          detail: 'response-validation-failed',
+        };
       } catch (error) {
-        if (isTransportClassRelayWriteFailure(error)) {
-          transportClassFailureCount += 1;
-        }
-        failedEndpointLabels.push(endpointLabel);
-        failures.push(`${endpointLabel}:${error instanceof Error ? error.message : String(error)}`);
+        const kind: RelayRestWriteEndpointResultKind = isDeadlineRelayWriteFailure(error)
+          ? 'deadline_unacknowledged'
+          : isTransportClassRelayWriteFailure(error)
+            ? 'network_unacknowledged'
+            : 'validation_failure';
+        return {
+          target,
+          kind,
+          httpResponseReceived: false,
+          detail: kind,
+        };
       } finally {
         clearTimeout(timeout);
       }
-    }
-
-    return { successCount, failures, failedEndpointLabels, transportClassFailureCount };
+    }));
+    return { outcomes };
   };
 
-  const isTransportTotalOutcome = (outcome: RelayRestWriteFanoutOutcome): boolean =>
-    outcome.successCount === 0 && outcome.transportClassFailureCount >= endpoints.length;
+  const isAvailabilityOnlyOutcome = (outcomes: readonly RelayRestWriteEndpointOutcome[]): boolean =>
+    outcomes.length > 0 && outcomes.every((outcome) =>
+      outcome.kind === 'network_unacknowledged' || outcome.kind === 'deadline_unacknowledged');
 
   const retryPlan = resolveRelayRestTransportRetryPlan();
   const maxAttempts = 1 + retryPlan.retries;
-  let outcome: RelayRestWriteFanoutOutcome | undefined;
-  let attemptsUsed = 0;
+  const confirmedTargetIndexes = new Set<number>();
+  const attemptSummaries: RelayRestWriteAttemptSummary[] = [];
+  let targetsForAttempt: readonly RelayRestWriteTarget[] = relayTargets;
+  let lastOutcomes: readonly RelayRestWriteEndpointOutcome[] = [];
 
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
-    attemptsUsed = attempt;
-    outcome = await attemptFanout();
+    const attemptStartedAt = Date.now();
+    const fanout = await attemptFanout(targetsForAttempt);
+    lastOutcomes = fanout.outcomes;
+    for (const outcome of fanout.outcomes) {
+      if (outcome.kind === 'acknowledged_success') {
+        confirmedTargetIndexes.add(outcome.target.index);
+      }
+    }
 
-    if (outcome.successCount >= quorum.requiredSuccessCount) {
+    let readbackConfirmedCount = 0;
+    let readbackValidationFailureCount = 0;
+    const readbackEligibleOutcomes = fanout.outcomes.filter((outcome) =>
+      outcome.kind === 'network_unacknowledged' || outcome.kind === 'deadline_unacknowledged');
+    if (
+      confirmedTargetIndexes.size < quorum.requiredSuccessCount
+      && readbackEligibleOutcomes.length > 0
+    ) {
+      const readbacks = await Promise.all(readbackEligibleOutcomes.map((outcome) =>
+        readBackRelayRestWrite({
+          client: input.client,
+          path: input.path,
+          recordKey,
+          expectedRecord: input.record,
+          expectedCanonicalRecord,
+          target: outcome.target,
+        })));
+      for (const readback of readbacks) {
+        if (readback.kind === 'confirmed') {
+          confirmedTargetIndexes.add(readback.target.index);
+          readbackConfirmedCount += 1;
+        } else if (readback.kind === 'write_safety_failure') {
+          readbackValidationFailureCount += 1;
+        }
+      }
+      if (readbackValidationFailureCount > 0) {
+        attemptSummaries.push(summarizeRelayRestWriteAttempt(
+          attempt,
+          Date.now() - attemptStartedAt,
+          fanout.outcomes,
+          readbackConfirmedCount,
+          readbackValidationFailureCount,
+        ));
+        lumaLog('warn', '[vh:news] relay REST write failed closed', {
+          write_class: input.writeClass,
+          path: input.path,
+          relay_target_count: endpoints.length,
+          relay_required_success_count: quorum.requiredSuccessCount,
+          relay_confirmed_count: confirmedTargetIndexes.size,
+          relay_write_attempt_count: attemptSummaries.length,
+          relay_final_availability_classification: 'write_safety_failure',
+          relay_attempt_summaries: attemptSummaries,
+        });
+        throw new Error(
+          `Relay REST news write safety readback failed for ${input.path}: validation_failure_count=${readbackValidationFailureCount}`,
+        );
+      }
+    }
+
+    const attemptSummary = summarizeRelayRestWriteAttempt(
+      attempt,
+      Date.now() - attemptStartedAt,
+      fanout.outcomes,
+      readbackConfirmedCount,
+      readbackValidationFailureCount,
+    );
+    attemptSummaries.push(attemptSummary);
+
+    if (confirmedTargetIndexes.size >= quorum.requiredSuccessCount) {
       lumaLog('info', '[vh:news] relay REST write completed', {
         write_class: input.writeClass,
         path: input.path,
-        relay_success_count: outcome.successCount,
+        relay_success_count: confirmedTargetIndexes.size,
         relay_target_count: endpoints.length,
         relay_required_success_count: quorum.requiredSuccessCount,
-        relay_failed_endpoint_labels: outcome.failedEndpointLabels,
+        relay_failed_endpoint_labels: relayTargets
+          .filter((target) => !confirmedTargetIndexes.has(target.index))
+          .map((target) => target.endpointLabel),
         require_all: quorum.requireAll,
         min_success_configured: quorum.minSuccessConfigured,
         relay_write_attempt: attempt,
+        relay_write_attempt_count: attemptSummaries.length,
+        relay_final_availability_classification: 'quorum_satisfied',
+        relay_attempt_summaries: attemptSummaries,
       });
       return;
     }
 
-    // Retry ONLY the transport-total case: zero relays acked and every
-    // failure was network-level, so nothing was published anywhere and the
-    // id-keyed upsert is safe to re-send. Any relay-returned response (500,
-    // 503 backpressure, 4xx) or abort/timeout keeps single-pass semantics.
-    if (!isTransportTotalOutcome(outcome) || attempt >= maxAttempts) {
+    if (!isAvailabilityOnlyOutcome(fanout.outcomes) || attempt >= maxAttempts) {
+      break;
+    }
+    targetsForAttempt = relayTargets.filter((target) => !confirmedTargetIndexes.has(target.index));
+    if (targetsForAttempt.length === 0) {
       break;
     }
     const backoffIndex = Math.min(attempt - 1, retryPlan.backoffMs.length - 1);
     const delayMs = retryPlan.backoffMs[backoffIndex]!;
-    lumaLog('warn', '[vh:news] relay REST write transport-unavailable; retrying', {
+    lumaLog('warn', '[vh:news] relay REST write availability-total; retrying unresolved targets', {
       write_class: input.writeClass,
       path: input.path,
       relay_target_count: endpoints.length,
-      relay_failed_endpoint_labels: outcome.failedEndpointLabels,
+      relay_unresolved_endpoint_labels: targetsForAttempt.map((target) => target.endpointLabel),
+      relay_confirmed_count: confirmedTargetIndexes.size,
       attempt,
       max_attempts: maxAttempts,
       retry_delay_ms: delayMs,
+      relay_attempt_summary: attemptSummary,
     });
     if (delayMs > 0) {
       await sleepMs(delayMs);
     }
   }
 
-  const finalOutcome = outcome as RelayRestWriteFanoutOutcome;
-  const failureMessage = `Relay REST news write failed for ${input.path}: ${finalOutcome.successCount}/${endpoints.length} succeeded; required=${quorum.requiredSuccessCount}; failed=${finalOutcome.failures.join('; ')}`;
-  if (isTransportTotalOutcome(finalOutcome)) {
-    throw new RelayRestTransportTotalFailureError(
-      `${failureMessage}; transport_unavailable_attempts=${attemptsUsed}`,
-      { path: input.path, attemptCount: attemptsUsed },
+  const safeOutcomes = lastOutcomes
+    .map((outcome) => `${outcome.target.endpointLabel}:${outcome.kind}:${outcome.detail}`)
+    .join('; ');
+  const failureMessage = `Relay REST news write failed for ${input.path}: ${confirmedTargetIndexes.size}/${endpoints.length} confirmed; required=${quorum.requiredSuccessCount}; outcomes=${safeOutcomes}`;
+  const availabilityTotal = confirmedTargetIndexes.size === 0 && isAvailabilityOnlyOutcome(lastOutcomes);
+  const finalClassification = availabilityTotal
+    ? 'availability_total'
+    : confirmedTargetIndexes.size > 0
+      ? 'partial_quorum'
+      : lastOutcomes.some((outcome) => outcome.kind === 'http_response')
+        ? 'http_response_failure'
+        : 'validation_failure';
+  lumaLog('warn', '[vh:news] relay REST write failed closed', {
+    write_class: input.writeClass,
+    path: input.path,
+    relay_target_count: endpoints.length,
+    relay_required_success_count: quorum.requiredSuccessCount,
+    relay_confirmed_count: confirmedTargetIndexes.size,
+    relay_write_attempt_count: attemptSummaries.length,
+    relay_final_availability_classification: finalClassification,
+    relay_attempt_summaries: attemptSummaries,
+  });
+  if (availabilityTotal) {
+    const options = { path: input.path, attemptCount: attemptSummaries.length };
+    const pureTransportTotal = lastOutcomes.every((outcome) =>
+      outcome.kind === 'network_unacknowledged' && !outcome.httpResponseReceived);
+    if (pureTransportTotal) {
+      throw new RelayRestTransportTotalFailureError(
+        `${failureMessage}; availability_total_attempts=${attemptSummaries.length}`,
+        options,
+      );
+    }
+    throw new RelayRestAvailabilityTotalFailureError(
+      `${failureMessage}; availability_total_attempts=${attemptSummaries.length}`,
+      options,
     );
   }
   throw new Error(failureMessage);

--- a/services/news-aggregator/src/daemon.coverage.test.ts
+++ b/services/news-aggregator/src/daemon.coverage.test.ts
@@ -91,16 +91,23 @@ describe('news daemon coverage guards', () => {
     expect(__internal.NEWS_DAEMON_TRANSPORT_UNAVAILABLE_EXIT_CODE).not.toBe(75);
   });
 
-  it('resolves EX_UNAVAILABLE only for branded transport-total relay failures', () => {
+  it('resolves EX_UNAVAILABLE for availability-total and legacy transport-total relay failures', () => {
+    const availabilityTotal = Object.assign(new Error('Relay REST deadline availability-total'), {
+      relayRestAvailabilityTotalFailure: true,
+    });
     const transportTotal = Object.assign(new Error('Relay REST news write failed: 0/3 succeeded'), {
       relayRestTransportTotalFailure: true,
     });
+    expect(__internal.resolveFailClosedExitCode(availabilityTotal)).toBe(69);
     expect(__internal.resolveFailClosedExitCode(transportTotal)).toBe(69);
     expect(__internal.resolveFailClosedExitCode(new Error('Relay REST news write failed: 1/3 succeeded'))).toBe(78);
     expect(__internal.resolveFailClosedExitCode(undefined)).toBe(78);
     expect(__internal.resolveFailClosedExitCode('fetch failed')).toBe(78);
     expect(
       __internal.resolveFailClosedExitCode({ relayRestTransportTotalFailure: true }),
+    ).toBe(78);
+    expect(
+      __internal.resolveFailClosedExitCode({ relayRestAvailabilityTotalFailure: true }),
     ).toBe(78);
   });
 

--- a/services/news-aggregator/src/daemon.ts
+++ b/services/news-aggregator/src/daemon.ts
@@ -1144,8 +1144,11 @@ export async function startNewsAggregatorDaemonFromEnv(): Promise<NewsAggregator
         closeExitCode = resolveFailClosedExitCode(error);
         if (closeExitCode === NEWS_DAEMON_TRANSPORT_UNAVAILABLE_EXIT_CODE) {
           console.error(
-            '[vh:news-daemon] fail-close cause is relay transport-total (no relay acknowledged the write); exiting EX_UNAVAILABLE for bounded systemd restart',
-            { exit_code: NEWS_DAEMON_TRANSPORT_UNAVAILABLE_EXIT_CODE },
+            '[vh:news-daemon] fail-close cause is relay availability-total after bounded signed readback; exiting EX_UNAVAILABLE for bounded systemd restart',
+            {
+              exit_code: NEWS_DAEMON_TRANSPORT_UNAVAILABLE_EXIT_CODE,
+              availability_classification: 'availability_total',
+            },
           );
         }
         setTimeout(() => {

--- a/services/news-aggregator/src/daemonCli.ts
+++ b/services/news-aggregator/src/daemonCli.ts
@@ -1,15 +1,16 @@
 import { pathToFileURL } from 'node:url';
-import { isRelayRestTransportTotalFailureError } from '@vh/gun-client';
+import { isRelayRestAvailabilityTotalFailureError } from '@vh/gun-client';
 
 export type ProcessLifecycle = Pick<typeof process, 'once' | 'exit'>;
 export type CliLogger = Pick<Console, 'info' | 'error'>;
 export const NEWS_DAEMON_FAIL_CLOSED_EXIT_CODE = 78;
 
 /**
- * EX_UNAVAILABLE: the fail-close cause was a relay transport-total failure —
- * zero relays ACKNOWLEDGED the write (network-level fetch failure on every
- * endpoint, no HTTP response received), so no write-safety invariant is in
- * doubt and the writes are id-keyed idempotent upserts. systemd restarts this
+ * EX_UNAVAILABLE: the fail-close cause was a relay availability-total failure —
+ * zero relays produced a validated acknowledgement after bounded endpoint-local
+ * reconciliation and every POST remained network/deadline-unacknowledged. No
+ * write-safety invariant is in doubt and the writes are id-keyed idempotent
+ * upserts. systemd restarts this
  * exit code (`Restart=on-failure`; only 78 is in `RestartPreventExitStatus`),
  * bounded by `StartLimitBurst`/`StartLimitIntervalSec`, giving transient
  * network blips a bounded self-recovery path while genuine write-safety halts
@@ -24,12 +25,12 @@ export const NEWS_DAEMON_FAIL_CLOSED_EXIT_CODE = 78;
 export const NEWS_DAEMON_TRANSPORT_UNAVAILABLE_EXIT_CODE = 69;
 
 /**
- * Fail-close always halts the process; only the exit code differs. Transport-
+ * Fail-close always halts the process; only the exit code differs. Availability-
  * total relay failures exit EX_UNAVAILABLE(69) for bounded systemd restart;
  * every other fail-close cause keeps the non-restarting write-safety code 78.
  */
 export function resolveFailClosedExitCode(error: unknown): number {
-  return isRelayRestTransportTotalFailureError(error)
+  return isRelayRestAvailabilityTotalFailureError(error)
     ? NEWS_DAEMON_TRANSPORT_UNAVAILABLE_EXIT_CODE
     : NEWS_DAEMON_FAIL_CLOSED_EXIT_CODE;
 }

--- a/services/news-aggregator/src/daemonWriteLane.test.ts
+++ b/services/news-aggregator/src/daemonWriteLane.test.ts
@@ -224,6 +224,9 @@ describe('daemonWriteLane', () => {
     expect(pendingError).toBeInstanceOf(Error);
     expect((pendingError as Error).message).toContain('daemon write lane stopped after failure: news_bundle');
     expect((pendingError as { relayRestTransportTotalFailure?: unknown }).relayRestTransportTotalFailure).toBe(true);
+    expect(
+      (pendingError as { relayRestAvailabilityTotalFailure?: unknown }).relayRestAvailabilityTotalFailure,
+    ).toBe(true);
 
     // Later writes on the stopped lane carry the brand too: a restart is the
     // correct recovery for a lane stopped by a transport-total event.
@@ -231,6 +234,9 @@ describe('daemonWriteLane', () => {
       .run('news_bundle', { story_id: 'story-c' }, async () => 'unreachable')
       .then(() => null, (error: unknown) => error);
     expect((laterError as { relayRestTransportTotalFailure?: unknown }).relayRestTransportTotalFailure).toBe(true);
+    expect(
+      (laterError as { relayRestAvailabilityTotalFailure?: unknown }).relayRestAvailabilityTotalFailure,
+    ).toBe(true);
 
     // A lane stopped by a NON-transport failure keeps plain rejections.
     const plainLane = createDaemonWriteLaneRegistry({
@@ -247,6 +253,49 @@ describe('daemonWriteLane', () => {
       .run('news_bundle', { story_id: 'story-e' }, async () => 'unreachable')
       .then(() => null, (error: unknown) => error);
     expect((plainStopError as { relayRestTransportTotalFailure?: unknown }).relayRestTransportTotalFailure).toBeUndefined();
+    expect(
+      (plainStopError as { relayRestAvailabilityTotalFailure?: unknown }).relayRestAvailabilityTotalFailure,
+    ).toBeUndefined();
+  });
+
+  it('propagates the availability-total brand without relabeling deadline failures as legacy transport-total', async () => {
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    const lane = createDaemonWriteLaneRegistry({
+      logger,
+      defaultConcurrency: 1,
+      stopClassOnFailure: (writeClass) => writeClass === 'news_bundle',
+    });
+    const availabilityTotal = Object.assign(
+      new Error('Relay REST deadline availability-total after signed readback'),
+      { relayRestAvailabilityTotalFailure: true },
+    );
+    let rejectFirst: ((error: Error) => void) | null = null;
+    const first = lane.run('news_bundle', {}, () => new Promise<never>((_resolve, reject) => {
+      rejectFirst = reject;
+    }));
+    const pending = lane.run('news_bundle', {}, async () => 'unreachable');
+    while (!rejectFirst) {
+      await flushMicrotasks();
+    }
+    rejectFirst(availabilityTotal);
+
+    await expect(first).rejects.toBe(availabilityTotal);
+    const pendingError = await pending.then(() => null, (error: unknown) => error);
+    expect(
+      (pendingError as { relayRestAvailabilityTotalFailure?: unknown }).relayRestAvailabilityTotalFailure,
+    ).toBe(true);
+    expect(
+      (pendingError as { relayRestTransportTotalFailure?: unknown }).relayRestTransportTotalFailure,
+    ).toBeUndefined();
+
+    const laterError = await lane.run('news_bundle', {}, async () => 'unreachable')
+      .then(() => null, (error: unknown) => error);
+    expect(
+      (laterError as { relayRestAvailabilityTotalFailure?: unknown }).relayRestAvailabilityTotalFailure,
+    ).toBe(true);
+    expect(
+      (laterError as { relayRestTransportTotalFailure?: unknown }).relayRestTransportTotalFailure,
+    ).toBeUndefined();
   });
 
   it('paces product-feed repair writes with dedicated concurrency-one lanes', async () => {

--- a/services/news-aggregator/src/daemonWriteLane.ts
+++ b/services/news-aggregator/src/daemonWriteLane.ts
@@ -34,22 +34,35 @@ interface LaneState {
   failedCount: number;
   durations: number[];
   stopped: boolean;
+  stoppedByAvailabilityTotalFailure: boolean;
   stoppedByTransportTotalFailure: boolean;
 }
 
-// Mirrors the RelayRestTransportTotalFailureError brand from @vh/gun-client.
+// Mirrors the availability/legacy transport brands from @vh/gun-client.
 // Lane-stopped rejection errors must carry the brand of the error that stopped
 // the lane, or the daemon's fail-close exit-code classification sees a plain
-// Error and a transport-total event loses its bounded-restart exit code.
+// Error and an availability-total event loses its bounded-restart exit code.
+const AVAILABILITY_TOTAL_BRAND = 'relayRestAvailabilityTotalFailure';
 const TRANSPORT_TOTAL_BRAND = 'relayRestTransportTotalFailure';
+
+function isAvailabilityTotalBrandedError(error: unknown): boolean {
+  return error instanceof Error
+    && (
+      (error as { relayRestAvailabilityTotalFailure?: unknown }).relayRestAvailabilityTotalFailure === true
+      || (error as { relayRestTransportTotalFailure?: unknown }).relayRestTransportTotalFailure === true
+    );
+}
 
 function isTransportTotalBrandedError(error: unknown): boolean {
   return error instanceof Error
     && (error as { relayRestTransportTotalFailure?: unknown }).relayRestTransportTotalFailure === true;
 }
 
-function laneStoppedError(writeClass: string, transportTotal: boolean): Error {
+function laneStoppedError(writeClass: string, availabilityTotal: boolean, transportTotal: boolean): Error {
   const error = new Error(`daemon write lane stopped after failure: ${writeClass}`);
+  if (availabilityTotal) {
+    (error as { relayRestAvailabilityTotalFailure?: boolean })[AVAILABILITY_TOTAL_BRAND] = true;
+  }
   if (transportTotal) {
     (error as { relayRestTransportTotalFailure?: boolean })[TRANSPORT_TOTAL_BRAND] = true;
   }
@@ -103,6 +116,7 @@ export function createDaemonWriteLaneRegistry(
       failedCount: 0,
       durations: [],
       stopped: false,
+      stoppedByAvailabilityTotalFailure: false,
       stoppedByTransportTotalFailure: false,
     };
     lanes.set(writeClass, created);
@@ -183,10 +197,15 @@ export function createDaemonWriteLaneRegistry(
           });
           if (shouldStopClassOnFailure(writeClass) && !state.stopped) {
             state.stopped = true;
+            state.stoppedByAvailabilityTotalFailure = isAvailabilityTotalBrandedError(error);
             state.stoppedByTransportTotalFailure = isTransportTotalBrandedError(error);
             const pending = state.pending.splice(0);
             for (const pendingItem of pending) {
-              pendingItem.reject(laneStoppedError(writeClass, state.stoppedByTransportTotalFailure));
+              pendingItem.reject(laneStoppedError(
+                writeClass,
+                state.stoppedByAvailabilityTotalFailure,
+                state.stoppedByTransportTotalFailure,
+              ));
             }
             logger.error('[vh:news-daemon] write lane stopped after failure', {
               write_class: writeClass,
@@ -211,7 +230,11 @@ export function createDaemonWriteLaneRegistry(
       }
       const state = stateFor(writeClass);
       if (state.stopped) {
-        return Promise.reject(laneStoppedError(writeClass, state.stoppedByTransportTotalFailure));
+        return Promise.reject(laneStoppedError(
+          writeClass,
+          state.stoppedByAvailabilityTotalFailure,
+          state.stoppedByTransportTotalFailure,
+        ));
       }
       return new Promise<T>((resolve, reject) => {
         state.pending.push({


### PR DESCRIPTION
## Incident and stack

This Runtime lane addresses sanitized incident class `relay_rest_story_timeout_total_0_of_3_exit_78`.

Sanitized evidence: all 3 relay POSTs reached the configured 10-second client deadline, 0/3 produced validated acknowledgements, the raw-write quorum remained 2/3, and the daemon parked on exit 78. No relay origin, token, response body, story body, or host-private value is included here.

The lane lineage is stacked from `integration/wave-s1b-public-beta-2026-07-10` at `a2899ad2f32b0b09d55dfcd1f468e6eb0bc907ef`. The integration wave must be rebuilt from this reviewed head plus the reviewed Alert lane before coordinator PR #759 consumes it.

## What changed

- Fan out one byte-identical signed POST attempt to all relay endpoints concurrently with independent deadlines.
- Reconcile only network/deadline-unacknowledged endpoints through bounded endpoint-local readback; retry only unresolved endpoints after an availability-only attempt.
- Expose nonmutating by-key exact readback for story, latest-index, hot-index, and synthesis-lifecycle.
- Keep story exact readback closed over the data-model StoryBundle schema, strict outer mirrors, strict modern signer shape, and strict optional metadata types.
- Allow only the legitimate `synthesis_lifecycle`, `analysis`, and `analysis_latest` structural relations with their exact expected Gun souls; validate them but never return them.
- Reconcile the warm relay view against one bounded fresh loopback peer's full raw story vertex. A connected peer proving absence returns 404, present unsafe/conflicting evidence returns detail-free 409, and inability to obtain independent proof returns 503.
- Treat parent and relation subscription events as one generation stream. A 200 requires two identical authoritative observations with the same generation and fingerprint, each separated by a full fixed quiet window; any intervening update resets settlement.
- Latch any 2xx as present evidence in the client, so later 404, 5xx, malformed 409, body/fetch failure, or abort cannot be downgraded to availability-total.
- Bound the complete client readback operation, including body streaming and signature verification, by one absolute deadline and abort/clear every owned resource.
- Preserve generalized availability-total branding and daemon exit 69 for exhausted total unavailability. Conflicting, invalid, tampered, unsigned, malformed, mixed, HTTP, validation, and partial-quorum failures remain unbranded exit 78.
- Preserve ordinal-only telemetry, 2/3 quorum, byte-identical retries, and duplicate POST idempotency.

## Correctness proof

The real relay process now proves, on all four routes:

- signed exact 200 readback and true missing 404;
- persistent unsigned, incomplete, malformed, unknown-field, invalid-mirror, invalid-signer, wrong-relation, and route-specific allowed-field smuggling all fail closed without response/log leakage;
- all optional StoryBundle fields and all three legitimate story relations remain compatible;
- fresh full-vertex inspection detects relation/scalar conflicts that a warm Gun cache could otherwise hide;
- a delayed invalid relation arriving after the first quiet observation but during the second settlement window resets authority and produces 409;
- a delayed valid relation changes generation without changing the public fingerprint and still forces two new quiet observations before 200;
- a valid relation-free story completes two full settlement windows inside the route deadline;
- exact self-peer unavailability returns 503, and repeated success/failure sessions restore active connections to baseline;
- transient partial-to-complete settlement remains accepted only after stable safe evidence;
- snapshot-only evidence never satisfies exact readback;
- exact GETs do not mutate the latest-index snapshot.

Client coverage proves the present-evidence latch across 404/5xx/wrong 409/body/fetch/abort transitions on every configured origin, absolute body/verifier deadlines, pre-present availability classification, safe partial polling, and canonical/signature mismatch failure.

## Validation at `2a7b010929368180399b4575f69d6285f01382ef`

- `corepack pnpm@9.7.1 --filter @vh/gun-client test -- newsAdapters.test.ts` — 187/187
- `corepack pnpm@9.7.1 --filter @vh/gun-client typecheck` — pass
- `GITHUB_BASE_REF=integration/wave-s1b-public-beta-2026-07-10 node tools/scripts/check-diff-coverage.mjs` — 336 files and 5,354/5,354 tests; changed `newsAdapters.ts` 3,139/3,139 lines and 1,226/1,226 branches
- `corepack pnpm@9.7.1 --filter @vh/news-aggregator test -- daemonWriteLane.test.ts daemon.coverage.test.ts` — 23/23
- `corepack pnpm@9.7.1 --filter @vh/news-aggregator typecheck` — pass
- `corepack pnpm@9.7.1 exec vitest run packages/ai-engine/src/newsRuntime.test.ts` — 54/54
- `corepack pnpm@9.7.1 --filter @vh/e2e exec vitest run src/live/relay-server.vitest.mjs --config ./vitest.config.ts` — 60/60
- `corepack pnpm@9.7.1 check:public-feed:alert-watch` — 25/25 on this Runtime base
- publisher-liveness watch — 6/6
- incident response — 58/58 plus 26-file contract pass
- next-phase sprint guard — 8/8
- launch closeout — 19 MVP gates, 11 launch-content items, and 11 command surfaces
- docs governance — 158 markdown files
- relay syntax and `git diff --check` — pass

The wrong-relation, delayed-invalid, delayed-valid-generation, and partial-settlement group passed four consecutive runs (16/16). One earlier full relay run encountered two unrelated empty-root fixture races; both passed immediately together in isolation and then passed in every later clean full run. Local pnpm commands emitted the existing Node engine warning because this workstation is on Node 23.10.0 while the repository declares `>=20 <23`; every listed final-gate command exited 0. Supported-runtime CI on this exact head remains merge authority.

No A6, relay container, service, Gmail, provider, pager, or production mutation was performed.
