### PR TITLE
fix: bind S1B recovery to exact packet state

### DIFF
--- a/docs/ops/a6-s1b-relay-timeout-recovery-packet-2026-07-10.md
+++ b/docs/ops/a6-s1b-relay-timeout-recovery-packet-2026-07-10.md
@@ -149,6 +149,13 @@ and an unconfigured endpoint MAC are shape-validated but never treated as
 stable prestate. Unknown, malformed, duplicate, conflicting, or nonportable
 attachment state is a hard stop.
 
+The current secret-safe A6 capture is the supported host-network case: A, B,
+and C each have `HostConfig.NetworkMode=host`, one `NetworkSettings.Networks.host`
+attachment with the same valid 64-hex `NetworkID`, all 15 canonical endpoint
+keys, null IPAM/aliases/links/driver options, `GwPriority=0`, and no configured
+MAC intent. The emitted recreate command is therefore exactly `--network host`,
+and each relay verifier uses its captured `GUN_PORT` on `127.0.0.1`.
+
 Do not add `--include-recreate-commands` before all authority and review gates
 below pass. Do not generate or execute a live packet from this branch.
 

--- a/docs/ops/a6-s1b-relay-timeout-recovery-packet-2026-07-10.md
+++ b/docs/ops/a6-s1b-relay-timeout-recovery-packet-2026-07-10.md
@@ -1,13 +1,13 @@
 # A6 S1B Relay-Timeout Recovery Packet - 2026-07-10
 
-> Status: `blocked_pending_relay_restart_boundary_correction`
+> Status: `boundary_approved_exact_packet_correction_in_review`
 > Owner: VHC Ops + VHC Core Engineering
 > Last Reviewed: 2026-07-10
 > Depends On: `docs/ops/public-beta-image-deploy.md`,
 > `docs/ops/news-aggregator-production-service.md`,
 > `docs/plans/PUBLIC_BETA_NEXT_PHASE_SPRINT_CHECKLIST_2026-07-09.md`,
 > `docs/plans/PUBLIC_BETA_STATE_OF_PLAY_HANDOFF_2026-07-10.md`
-> Decision: `WAITING_FOR_LOU`
+> Decision: `NO-GO_PENDING_EXACT_PACKET_REVIEW`
 > Human incident, restart, and rollback authority: Lou
 > Repo preparation owner: VHC Core Engineering
 > Live actions performed by this document/branch: none
@@ -30,46 +30,47 @@ The A6 relay runtime is image-bound:
   route surface.
 
 Therefore the reviewed relay route change cannot become live without replacing
-the relay image and recreating the relay containers. The current S1B recovery
-checklist simultaneously says not to restart relays. That is a real authority
-contradiction. This packet does not resolve it by assumption.
+the relay image and recreating the relay containers. Lou approved PR #763 and
+the attended A/B/C restart boundary on 2026-07-10. That resolves the authority
+contradiction, but it does not waive exact-packet review. Review of the first
+candidate packet returned `NO-GO` for inspect-scope, network-prestate, and
+immutable-image binding gaps; the corrected packet must be regenerated and
+reviewed before any removal.
 
 No relay, origin, publisher, service, timer, Gmail/provider, pager, alert
 channel, or production state was changed. No live packet was generated or run.
 S1A/S1B are not recovered or green.
 
-## Boundary Correction Lou Must Decide
+## Recorded Boundary Approval And Remaining Gate
 
-Lou may either:
-
-1. approve replacing the contradictory no-relay-restart line with a one-time,
-   exact-revision, attended A/B/C rolling relay-image replacement under this
-   packet; or
-2. decline/defer it, leaving S1B blocked and every S2+ launch slice `NO-GO`.
-
-An approval must name the exact merged commit and relay image tag/digest, permit
-only `vhc-relay-a`, then `vhc-relay-b`, then `vhc-relay-c`, and preserve Lou's
-stop/rollback authority. It does not authorize origin or publisher mutation,
+Lou's recorded approval permits one attended replacement of only
+`vhc-relay-a`, then `vhc-relay-b`, then `vhc-relay-c`, with serial rollback and
+stop authority preserved. It does not authorize origin or publisher mutation,
 relay data changes, quorum/timeout changes, provider work, pager cutover,
-monitor enablement, or a live-green claim.
+monitor enablement, or a live-green claim. The remaining gate is technical:
+the corrected exact packet, capture hash, merged revision, and immutable image
+id must receive independent `GO` before the approved action starts.
 
 ## Repo-Only Preparation That Is Complete
 
 The existing image tooling now has explicit inert relay-only modes:
 
 - `tools/scripts/export-public-beta-image-artifacts.sh --relay-only` validates
-  the local relay image revision and `linux/amd64`, exports only that image, and
-  emits load commands that contain no origin artifact or origin load;
+  the local relay image revision, full `sha256:` image id, and `linux/amd64`,
+  exports only that image, and emits load commands that reject a loaded mutable
+  ref unless it resolves to that same immutable id;
 - `tools/scripts/emit-a6-public-beta-deploy-packet.sh --relay-only` requires
-  exactly the three canonical relay names and an expected relay revision,
-  excludes origin from the inspect/deploy scope, and emits no recreate commands
-  unless `--include-recreate-commands` is also explicitly supplied;
+  an inspect array containing exactly one each of `/vhc-relay-a`,
+  `/vhc-relay-b`, and `/vhc-relay-c`, plus expected relay revision and the
+  export manifest's full immutable image id. It excludes origin from the
+  inspect/deploy scope and emits no recreate commands unless
+  `--include-recreate-commands` is also explicitly supplied;
 - `tools/scripts/vhc-packet-executor.mjs` is unchanged. Its live action surface
   has not been widened to execute this rolling recovery.
 
-The generator is not a packet approval. The default output says
-`WAITING_FOR_LOU` and contains only read-only checks plus secret-safe env/snapshot
-capture instructions.
+The generator is not packet review or execution authority. Its default output
+contains only read-only checks plus secret-safe env/snapshot capture
+instructions.
 
 ## Preparation Inputs
 
@@ -81,6 +82,7 @@ Required inputs are:
 - exact merged remediation commit;
 - immutable relay image tag or digest whose OCI
   `org.opencontainers.image.revision` equals that commit;
+- full immutable relay image id from the exporter's `artifact-manifest.json`;
 - local image platform `linux/amd64`;
 - secret-safe `docker inspect` JSON for exactly `vhc-relay-a`,
   `vhc-relay-b`, and `vhc-relay-c`;
@@ -129,12 +131,23 @@ tools/scripts/emit-a6-public-beta-deploy-packet.sh \
   --inspect-json ./relay-containers.json \
   --new-relay-image vhc-public-beta-relay:<reviewed-tag-or-digest> \
   --expected-relay-revision <exact-merged-commit> \
-  --output .tmp/a6-s1b-relay-only-packet.blocked.md
+  --expected-relay-image-id <sha256:id-from-artifact-manifest> \
+  --output .tmp/a6-s1b-relay-only-packet.review.md
 ```
 
-The generator fails closed if the three canonical relay names are not selected,
-the relay image or expected revision is absent, any relay/data bind/host probe
-mapping is absent, or an origin image is supplied in relay-only mode.
+The generator fails closed unless inspect is an array of exactly three unique
+canonical A/B/C entries. Duplicates, extras, blank/malformed names, a missing or
+malformed immutable image id, absent relay/data bind/host probe mapping, or an
+origin image in relay-only mode are rejected.
+
+The captured network contract includes network name and 64-hex `NetworkID`,
+static IPAM intent, aliases, links, driver options, gateway priority, and an
+explicit configured MAC intent when present. Supported fields are recreated and
+compared before removal, immediately after recreate, after verification, and
+after rollback. Runtime-assigned endpoint ids, addresses, gateways, DNS names,
+and an unconfigured endpoint MAC are shape-validated but never treated as
+stable prestate. Unknown, malformed, duplicate, conflicting, or nonportable
+attachment state is a hard stop.
 
 Do not add `--include-recreate-commands` before all authority and review gates
 below pass. Do not generate or execute a live packet from this branch.
@@ -149,12 +162,16 @@ captured input hash, then return `GO` only if all of these are true:
 - the publisher must match the exact exit-78 parked tuple above at initial
   precheck and again as the final gate immediately before each A/B/C removal;
 - the new image is `linux/amd64` and its OCI revision equals the merged commit;
+- the mutable image ref resolves to the export manifest's full immutable image
+  id immediately before every A/B/C removal; the packet runs that immutable id,
+  and the recreated container `.Image` must equal it;
 - each relay preserves the exact prestate env set without printing values;
 - immediately before each removal, live image id/ref, env, mounts, network mode
   and attachments, ports, restart policy, user, memory, and memory-swap must
   equal the captured prestate; stale capture is a hard stop, not rollback input;
-- bind mount, network, ports, restart policy, user, and memory limits are
-  preserved from inspect evidence;
+- bind mount, semantic network attachment and `NetworkID`, ports, restart
+  policy, user, and memory limits are preserved from inspect evidence and
+  rechecked immediately after recreate, after verification, and after rollback;
 - snapshot checks cover latest-index, synthesis-lifecycle, and topic-synthesis;
 - readiness, health, Docker OOM state, and watchdog metrics are checked before
   proceeding; the pre-mutation and per-stage metric artifacts are retained and
@@ -177,20 +194,14 @@ captured input hash, then return `GO` only if all of these are true:
 Any correction requires a subsequent review by the same packet reviewer on the
 new exact head and packet hash.
 
-## Lou Approval Gate
+## Recorded Lou Approval Gate
 
-After reviewer `GO`, stop at `WAITING_FOR_LOU`. Lou's approval must explicitly
-answer all of the following:
-
-- Is the no-relay-restart boundary replaced for this exact incident packet?
-- Is the exact merged commit and relay image tag/digest approved?
-- Is attended A/B/C rolling replacement approved with publisher parked?
-- Is automatic per-relay rollback on any failed gate approved?
-- Does Lou accept that this action disturbs historical unattended-window
-  evidence and must be recorded as maintenance?
-
-Silence, general release approval, repo merge approval, or permission to update
-the A6 checkout is not relay-restart approval.
+Lou explicitly approved #763 and instructed the attended A/B/C restart on
+2026-07-10. That approval covers the boundary and automatic current-relay serial
+rollback, with the publisher parked. It remains conditioned on independent `GO`
+for the corrected exact packet. Any change to relay count/order, origin or
+publisher scope, data/quorum/timeouts, or rollback semantics invalidates the
+recorded approval and returns to `WAITING_FOR_LOU`.
 
 ## Approved Rolling Contract
 
@@ -207,20 +218,26 @@ with `--include-recreate-commands`. Its contract is:
    that absence is accepted only alongside exactly one valid uptime and RSS
    producer row. Empty/random telemetry and malformed/duplicate/nonzero trip or
    producer rows fail closed.
-2. Confirm the loaded image is `linux/amd64` and its OCI revision exactly equals
-   the approved merged commit.
+2. Confirm the loaded mutable ref resolves to the full manifest image id, is
+   `linux/amd64`, and has an OCI revision exactly equal to the approved merged
+   commit. Repeat that binding at every removal boundary, run the immutable id,
+   and require the recreated container `.Image` to equal it.
 3. Capture each relay's env privately, without rewriting defaults or printing
    values.
 4. Immediately before relay A removal, compare live image, env, bind mounts,
-   network, ports, restart policy, configured user, and memory limits with the
-   captured inspect prestate; reject any drift. Recheck the exact exit-78 parked
-   publisher tuple as the final command before removal, then replace A only.
+   semantic network attachment and `NetworkID`, ports, restart policy,
+   configured user, and memory limits with the captured inspect prestate;
+   reject any drift. Recheck the exact exit-78 parked publisher tuple and invoke
+   the atomic removal-boundary check immediately before removal, then replace A
+   only.
    A refusal in topology, watchdog/readiness, or publisher preconditions exits
    `78` with no `docker rm`, no `docker run`, and no rollback of the untouched
    relay. Rollback is reachable only after the mutation-started latch is set at
    the removal boundary.
-5. Require A readiness/health, running/non-OOM Docker state, unchanged snapshot
-   checksums, zero watchdog trips, and exact env parity.
+5. Immediately after recreate and again after verification, require exact
+   semantic topology parity including the stable network identity, plus A
+   readiness/health, running/non-OOM Docker state, unchanged snapshot checksums,
+   zero watchdog trips, and exact env parity.
 6. Probe one unique definitely-missing story id through all four endpoint-local
    contracts:
    - story with `readback=exact` returns only
@@ -251,9 +268,11 @@ with `--include-recreate-commands`. Its contract is:
 Stop before any removal on:
 
 - missing or ambiguous Lou approval;
-- commit, image, revision, architecture, or packet-hash mismatch;
-- unexpected container name, count, order, mount, port, network, user, memory,
-  restart policy, or env drift;
+- commit, immutable image id, mutable-ref binding, revision, architecture, or
+  packet-hash mismatch, including a retagged same-revision wrong image;
+- non-array inspect input; duplicate, extra, blank, malformed, or unexpected
+  container name; or mount, port, semantic network attachment/`NetworkID`, user,
+  memory, restart policy, or env drift;
 - publisher state differs in any field from exact exit-78 parked state,
   including inactive, active, activating, deactivating, or resumed between
   relay stages;

--- a/docs/ops/public-beta-image-deploy.md
+++ b/docs/ops/public-beta-image-deploy.md
@@ -320,8 +320,8 @@ tools/scripts/export-public-beta-image-artifacts.sh \
   --output-dir .tmp/public-beta-image-artifacts/<tag>
 ```
 
-The exporter refuses images whose Docker metadata platform is not
-`linux/amd64`, and by default refuses images whose
+The exporter refuses images without a full immutable `sha256:` image id, whose
+Docker metadata platform is not `linux/amd64`, and by default refuses images whose
 `org.opencontainers.image.revision` label does not match the current checkout.
 It writes:
 
@@ -347,8 +347,10 @@ tools/scripts/export-public-beta-image-artifacts.sh \
   --output-dir .tmp/public-beta-image-artifacts/<reviewed-tag>
 ```
 
-Relay-only export is still local preparation. It neither transfers nor loads the
-image, and loading the image would still not authorize a relay restart.
+Relay-only export is still local preparation. Its one-image manifest records the
+full immutable image id, and the emitted load packet rejects the loaded mutable
+ref unless it resolves to that id in addition to matching revision/platform. It
+neither transfers nor loads the image by itself.
 
 ## Emit Deploy Packet
 
@@ -390,11 +392,11 @@ into a running container. When a reviewed S1B commit changes those routes, the
 technical deployment requires a replacement relay image and a rolling container
 recreate. This is a technical fact, not live authority.
 
-The S1B recovery authority remains
-`blocked_pending_relay_restart_boundary_correction`. The standing checklist
-prohibition on relay restart must be explicitly corrected by Lou for the exact
-reviewed packet before recreate commands may be generated or used. Prepare the
-inert packet without destructive commands first:
+Lou approved PR #763 and the attended A/B/C restart boundary on 2026-07-10. The
+first exact packet review nevertheless returned `NO-GO` for fail-open capture,
+network, and immutable-image binding gaps. Prepare the corrected inert packet
+without destructive commands first; no removal is permitted until its exact
+capture and packet hash receive independent `GO`:
 
 ```bash
 tools/scripts/emit-a6-public-beta-deploy-packet.sh \
@@ -402,23 +404,36 @@ tools/scripts/emit-a6-public-beta-deploy-packet.sh \
   --inspect-json ./relay-containers.json \
   --new-relay-image vhc-public-beta-relay:<reviewed-tag-or-digest> \
   --expected-relay-revision <reviewed-merged-commit> \
-  --output .tmp/a6-s1b-relay-only-packet.blocked.md
+  --expected-relay-image-id <sha256:id-from-artifact-manifest> \
+  --output .tmp/a6-s1b-relay-only-packet.review.md
 ```
 
-This mode requires exactly `vhc-relay-a,vhc-relay-b,vhc-relay-c`, excludes the
-origin from its capture/deploy scope, preserves each relay's exact captured env
-set, data bind mount, network, ports, restart policy, user, and configured memory
-limits, and checks the new image revision plus `linux/amd64`. Before each relay
-removal it compares that captured topology to a fresh live inspect and rejects
-any image/env/mount/network/port/restart/user/memory drift. It emits no `docker
-rm` or `docker run` commands by default.
+This mode requires an inspect array containing exactly one each of
+`/vhc-relay-a`, `/vhc-relay-b`, and `/vhc-relay-c`; duplicate, extra,
+blank/malformed, or non-array input fails closed. It excludes origin from its
+capture/deploy scope, preserves each relay's exact captured env set, data bind
+mount, semantic network attachment, ports, restart policy, user, and configured
+memory limits, and checks the new image revision, full manifest image id, and
+`linux/amd64`. Before each removal it compares that captured topology to a fresh
+live inspect and rejects any image/env/mount/network/port/restart/user/memory
+drift. It emits no `docker rm` or `docker run` commands by default.
 
-Only after explicit boundary correction, exact-head packet review, and Lou's
-live-action approval may the same command add
+Semantic network prestate includes the network name and 64-hex `NetworkID`,
+static IPAM intent, aliases, links, driver options, gateway priority, and an
+explicit configured MAC intent. Supported state is encoded in `docker run` and
+rechecked immediately after recreate, after verification, and after rollback.
+Runtime-assigned endpoint ids/IPs/gateways/DNS names and an unconfigured endpoint
+MAC are not compared as stable identifiers. Unknown or nonportable attachment
+state is a hard stop.
+
+Only after the recorded boundary approval and exact-head/capture packet review
+returns `GO` may the same command add
 `--include-recreate-commands`. That gated form emits A/B/C rolling replacement,
 per-relay readiness/health, snapshot checksum, OOM/watchdog, env-parity, and all
 four exact missing-key checks for story, latest-index, hot-index, and
-synthesis-lifecycle. A failure rolls back only the current relay to its captured
+synthesis-lifecycle. Immediately before every removal the mutable ref must still
+resolve to the full expected image id; the packet runs that immutable id and
+requires recreated `.Image` equality. A failure rolls back only the current relay to its captured
 immutable image id and exits `78` before the next relay. It never emits an
 origin recreate or publisher start. The generic packet executor is not widened
 for this action.

--- a/docs/ops/public-beta-image-deploy.md
+++ b/docs/ops/public-beta-image-deploy.md
@@ -350,6 +350,8 @@ tools/scripts/export-public-beta-image-artifacts.sh \
 Relay-only export is still local preparation. Its one-image manifest records the
 full immutable image id, and the emitted load packet rejects the loaded mutable
 ref unless it resolves to that id in addition to matching revision/platform. It
+passes the exact Docker Go template to a remote `bash -s` verifier; the label key
+arrives as `org.opencontainers.image.revision` without added backslashes. It
 neither transfers nor loads the image by itself.
 
 ## Emit Deploy Packet
@@ -425,6 +427,12 @@ rechecked immediately after recreate, after verification, and after rollback.
 Runtime-assigned endpoint ids/IPs/gateways/DNS names and an unconfigured endpoint
 MAC are not compared as stable identifiers. Unknown or nonportable attachment
 state is a hard stop.
+
+The current A6 structural capture is the supported `host`/`host` case for all
+three relays: one shared valid 64-hex `NetworkID`, all 15 canonical attachment
+keys, null IPAM/aliases/links/driver options, `GwPriority=0`, and no configured
+MAC intent. Its recreate flag is exactly `--network host`, and loopback
+verification derives each relay URL from captured `GUN_PORT`.
 
 Only after the recorded boundary approval and exact-head/capture packet review
 returns `GO` may the same command add

--- a/docs/plans/PUBLIC_BETA_NEXT_PHASE_SPRINT_CHECKLIST_2026-07-09.md
+++ b/docs/plans/PUBLIC_BETA_NEXT_PHASE_SPRINT_CHECKLIST_2026-07-09.md
@@ -962,10 +962,11 @@ git diff --check
 - G3 packet preparation found an authority contradiction before any live action:
   `infra/relay/server.js` is copied into immutable relay images and is not bind
   mounted, so the new readback routes cannot deploy without controlled rolling
-  relay recreation. The checklist currently forbids relay restarts. A separate
-  repo-only packet lane is therefore `NO-GO` / `WAITING_FOR_LOU`; its first
-  independent review also returned fail-closed corrections. No packet was
-  generated or executed and no boundary is treated as approved.
+  relay recreation. Lou approved PR #763 and the attended A/B/C boundary on
+  2026-07-10. The first exact packet review then returned `NO-GO` on capture
+  cardinality, semantic network preservation, and immutable image-id binding.
+  Those corrections must receive subsequent review before the approved live
+  action begins; no relay action is claimed by this repo lane.
 
 ### Review And Merge Gate
 
@@ -994,9 +995,12 @@ only `/data`; an A6 checkout update cannot install the new exact-readback routes
 into running relays. A rolling relay image replacement is therefore technically
 required before publisher recovery can exercise the merged contract.
 
-That fact conflicts with the standing no-relay-restart line below. G3 remains
-`blocked_pending_relay_restart_boundary_correction` and `WAITING_FOR_LOU`; repo
-preparation is not authority and no live recovery is claimed.
+That fact conflicted with the standing no-relay-restart line below. Lou approved
+PR #763 and the attended A/B/C restart boundary on 2026-07-10. The first exact
+packet review then returned `NO-GO` for inspect-scope, network-prestate, and
+immutable-image binding gaps. The current state is
+`boundary_approved_exact_packet_correction_in_review`; repo preparation is not
+execution proof and no live recovery is claimed.
 
 - [x] Add inert `--relay-only` image-export and deploy-packet generation that
   excludes origin, requires exactly relay A/B/C, and defaults to no recreate
@@ -1004,6 +1008,19 @@ preparation is not authority and no live recovery is claimed.
 - [x] Preserve captured env, mount, network, ports, restart policy, user, and
   memory limits; verify exact revision plus `linux/amd64`; and fail before each
   removal if a fresh live inspect differs from that captured prestate.
+- [x] Reject relay-only inspect input unless it is an array of exactly three
+  unique canonical `/vhc-relay-a`, `/vhc-relay-b`, `/vhc-relay-c` entries;
+  reject duplicates, extras, blank/malformed names, and non-array input.
+- [x] Bind the packet to the export manifest's full immutable `sha256:` relay
+  image id, re-resolve the mutable ref immediately before every removal, run the
+  immutable id, and require recreated container `.Image` equality so a retagged
+  same-revision wrong image cannot pass.
+- [x] Preserve full portable semantic network attachment prestate: network name
+  and `NetworkID`, static IPAM intent, aliases, links, driver options, gateway
+  priority, and explicit configured MAC intent. Compare it at the removal
+  boundary, immediately after recreate, after verification, and after rollback;
+  reject unknown/nonportable state and never treat runtime endpoint ids or
+  assigned addresses as stable.
 - [x] Encode A/B/C readiness, three-snapshot integrity, liveness/OOM/watchdog,
   all-four exact missing-key probes, immediate current-relay rollback, and hard
   stop conditions.
@@ -1029,12 +1046,13 @@ preparation is not authority and no live recovery is claimed.
 - [x] Register the blocked authority packet at
   `docs/ops/a6-s1b-relay-timeout-recovery-packet-2026-07-10.md`.
 - [x] Merge S1B remediation to `main` at `98277475`.
+- [x] Merge the approved recovery-boundary packet as PR #763 at `bb934010`.
 - [ ] Generate the exact packet from the merged commit and fresh secret-safe
   inspect evidence.
 - [ ] Independent packet reviewer returns `GO` on the exact packet hash; any
   correction receives subsequent review by the same reviewer.
-- [ ] Lou explicitly replaces the no-relay-restart boundary for that exact
-  revision and authorizes attended A/B/C rolling replacement plus rollback.
+- [x] Lou explicitly replaced the no-relay-restart boundary by approving #763
+  and authorized attended A/B/C rolling replacement plus rollback on 2026-07-10.
 - [ ] The approved rolling relay packet passes and evidence is independently
   reviewed before a separate publisher recovery is considered.
 
@@ -1051,8 +1069,8 @@ Mutation boundary:
 
 - [ ] Update only to the reviewed remediation commit using the existing deploy
   packet controls.
-- [ ] Do not restart relays unless Lou first replaces this boundary for the exact
-  independently reviewed S1B relay-only packet. If approved, replace only
+- [ ] Use Lou's recorded restart approval only after the corrected exact
+  S1B relay-only packet receives independent `GO`; then replace only
   `vhc-relay-a`, then `vhc-relay-b`, then `vhc-relay-c`, with publisher parked,
   per-relay verification, and immediate serial rollback on failure.
 - [ ] Never alter quorum, increase timeouts, clear relay data, recreate origin,

--- a/docs/plans/PUBLIC_BETA_NEXT_PHASE_SPRINT_CHECKLIST_2026-07-09.md
+++ b/docs/plans/PUBLIC_BETA_NEXT_PHASE_SPRINT_CHECKLIST_2026-07-09.md
@@ -1021,6 +1021,10 @@ execution proof and no live recovery is claimed.
   boundary, immediately after recreate, after verification, and after rollback;
   reject unknown/nonportable state and never treat runtime endpoint ids or
   assigned addresses as stable.
+- [x] Exercise the current A6 `host`/`host` topology for ordered A/B/C with all
+  15 canonical attachment keys, valid shared `NetworkID`, null attachment
+  intent, `GwPriority=0`, no configured MAC, exact `--network host`, captured
+  `GUN_PORT` verifier URLs, and post-recreate/post-verification/rollback parity.
 - [x] Encode A/B/C readiness, three-snapshot integrity, liveness/OOM/watchdog,
   all-four exact missing-key probes, immediate current-relay rollback, and hard
   stop conditions.

--- a/docs/plans/PUBLIC_BETA_STATE_OF_PLAY_HANDOFF_2026-07-10.md
+++ b/docs/plans/PUBLIC_BETA_STATE_OF_PLAY_HANDOFF_2026-07-10.md
@@ -133,6 +133,12 @@ hard stop. Recreate commands remain opt-in, the generic packet executor was not
 widened, and relay deployment evidence still would not authorize publisher
 recovery or make S1B green.
 
+The current read-only A6 structure is the supported `host`/`host` case on all
+three relays: one valid shared 64-hex `NetworkID`, all 15 canonical endpoint
+keys, null IPAM/aliases/links/driver options, `GwPriority=0`, and no configured
+MAC intent. Correct packet output uses exact `--network host` and captured
+`GUN_PORT` loopback verifier URLs.
+
 The fail-closed packet contract treats parked as exactly `failed/failed`,
 `Result=exit-code`, `ExecMainStatus=78` and rechecks that tuple as the final gate
 before each A/B/C removal and after verification before GO. It also compares every stage's live

--- a/docs/plans/PUBLIC_BETA_STATE_OF_PLAY_HANDOFF_2026-07-10.md
+++ b/docs/plans/PUBLIC_BETA_STATE_OF_PLAY_HANDOFF_2026-07-10.md
@@ -4,9 +4,9 @@
 > Owner: VHC Launch Ops + VHC Core Engineering
 > Human authority: Lou
 > Technical executor: Codex
-> Current merged repo base: `main@982774750d923915617bea49997fa86df624a137`
+> Current merged repo base: `main@bb9340101b98f33e0bbf4e719d0cc6f14226ade4`
 > Merged coordination PR: #759 at reviewed head `0e5bac8f7a25a62d0d5c36c6f171b7a915d99848`
-> Current repo lane: blocked G3 recovery-packet branch; review/publish pending
+> Current repo lane: exact-packet binding correction; review/publish pending
 > Current target app: `https://venn.carboncaste.io`
 > Current auth boundary target: `https://auth.venn.carboncaste.io`
 > Support/failure mailbox: `carboncasteit@gmail.com`
@@ -103,38 +103,37 @@ into the coordination branch at `5116616a`. Final coordination head
 `0e5bac8f` passed same-reviewer audit and 9/9 hosted CI; PR #759 merged to
 `main` as `98277475`.
 
-Recovery-packet design also exposed a hard authority contradiction before any
-live action: `infra/relay/server.js` is copied into immutable relay images and
-is not bind mounted, so the reviewed route changes require controlled rolling
-relay recreation, while the current S1B boundary says not to restart relays. A
-separate repo-only packet lane is `NO-GO` / `WAITING_FOR_LOU`; its first
-independent review returned additional fail-closed corrections. No packet was
-generated or executed, and this handoff does not treat the boundary as
-corrected or approved. No A6 update, service action, relay action,
-Gmail/provider mutation, alert-channel change, or recovery was performed.
-S1A/S1B remain red and every S2+ launch slice remains blocked.
+Recovery-packet design exposed the immutable-image restart boundary before any
+live action. PR #763 supplied the repo-side boundary packet and merged to
+`main@bb934010`; Lou explicitly approved #763 and instructed an attended A/B/C
+restart on 2026-07-10. The first exact packet review then correctly returned
+`NO-GO`: its capture admitted duplicate/extra relay entries, its topology
+comparison reduced network attachment state to names, and a mutable tag with a
+matching revision could resolve to the wrong image. The correction lane remains
+repo-only pending subsequent exact-packet review. No A6 update, service action,
+relay action, Gmail/provider mutation, alert-channel change, or recovery was
+performed by this lane. S1A/S1B remain red and every S2+ launch slice remains
+blocked.
 
-G3 repo preparation also proved an authority contradiction. The exact-readback
-routes live in `infra/relay/server.js`, which the relay Dockerfile copies into an
-immutable image; public-beta compose mounts only `/data`. Updating the A6
-checkout cannot activate those routes without a rolling relay image replacement,
-but the standing recovery boundary still prohibits relay restart. The durable
-packet at
-`docs/ops/a6-s1b-relay-timeout-recovery-packet-2026-07-10.md` is therefore
-`blocked_pending_relay_restart_boundary_correction` and `WAITING_FOR_LOU`.
+The exact-readback routes live in `infra/relay/server.js`, which the relay
+Dockerfile copies into an immutable image; public-beta compose mounts only
+`/data`. Updating the A6 checkout cannot activate those routes without rolling
+relay replacement. Lou has now corrected that boundary, but independent `GO` on
+the corrected exact packet/capture/image tuple remains mandatory.
 
-Repo-only tooling now supports an inert, exactly-three-relay export/packet mode
-that excludes origin/publisher deployment, preserves captured runtime topology
-and env, checks revision/amd64 plus readiness/snapshots/OOM, probes all four
-exact missing-key contracts, and stops with current-relay rollback before the
-next relay on any failure. Recreate commands remain opt-in, the generic packet
-executor was not widened, no live packet was generated, and no relay or
-publisher action occurred. From merged `main@98277475`, an exact packet still
-needs fresh secret-safe capture, independent review, and Lou's explicit correction of the
-relay-restart boundary before any rolling action. Relay deployment evidence
-would still not authorize publisher recovery or make S1B green.
+Corrected repo-only tooling requires an inspect array containing exactly one
+each of canonical relay A/B/C and binds the packet to the export manifest's full
+immutable image id, not only a mutable tag/revision. It captures portable
+semantic network state including name, `NetworkID`, static IPAM intent, aliases,
+links, driver options, gateway priority, and configured MAC intent. Supported
+state is recreated and compared at the removal boundary, immediately after
+recreate, after verification, and after rollback; runtime-assigned endpoint ids
+and addresses are not treated as stable. Unsupported/nonportable topology is a
+hard stop. Recreate commands remain opt-in, the generic packet executor was not
+widened, and relay deployment evidence still would not authorize publisher
+recovery or make S1B green.
 
-The fail-closed packet contract now treats parked as exactly `failed/failed`,
+The fail-closed packet contract treats parked as exactly `failed/failed`,
 `Result=exit-code`, `ExecMainStatus=78` and rechecks that tuple as the final gate
 before each A/B/C removal and after verification before GO. It also compares every stage's live
 image/env/mount/network/port/restart/user/memory topology with the capture,
@@ -142,8 +141,10 @@ preserves and rejects pre-existing watchdog-trip evidence before counters can
 reset, never prints hostile unexpected 404 bodies, and normalizes each rollback
 failure class to a closed reason and exit `78`. Deterministic adversarial tests
 cover transitional/resumed publisher state, every captured topology dimension,
-pre-existing trips, secret-bearing bodies, and rollback remove/run/readiness/
-checksum failures. These are repo safeguards, not live proof or authority.
+duplicate/extra/malformed capture scope, same-revision wrong-image binding,
+runtime endpoint churn, pre-existing trips, secret-bearing bodies, and rollback
+remove/run/readiness/checksum failures. These are repo safeguards, not live
+proof.
 
 Pre-mutation refusals are isolated from rollback: topology,
 readiness/watchdog, or publisher failure exits `78` without removing, running,
@@ -161,22 +162,22 @@ publisher resume during/post-verification.
 Current branch:
 
 ```text
-coord/s1b-relay-recovery-packet-2026-07-10
+coord/s1b-exact-packet-binding-2026-07-10
 ```
 
 Current review state:
 
 ```text
-G3 blocked recovery-packet branch
-PR: pending final same-reviewer GO and publish
-decision: WAITING_FOR_LOU
-live packet: not generated
+G3 exact-packet correction branch
+base: main@bb934010 (merged PR #763)
+decision: NO-GO_PENDING_EXACT_PACKET_REVIEW
+live action: not started
 ```
 
 Current `main` at handoff:
 
 ```text
-982774750d923915617bea49997fa86df624a137 Merge PR #759: public beta S1B release-readiness remediation
+bb9340101b98f33e0bbf4e719d0cc6f14226ade4 Merge PR #763: approved S1B relay recovery packet
 ```
 
 Merged S1B PRs:
@@ -185,6 +186,7 @@ Merged S1B PRs:
 - #761 Runtime lane.
 - #762 Cross-lane integration.
 - #759 Coordination and `main` merge.
+- #763 Approved relay-restart boundary and recovery-packet preparation.
 
 Open non-release follow-up issues at handoff:
 
@@ -477,24 +479,24 @@ These are the blockers that matter before tester distribution.
 
 Do this in order.
 
-### 1. Preserve the merged S1B base
+### 1. Preserve the merged S1B and approved boundary base
 
-PR #759 is already merged. Do not replay its repo work. Treat
-`main@982774750d923915617bea49997fa86df624a137` as the S1B remediation base and
-verify it before preparing any exact recovery packet.
+PRs #759 and #763 are already merged. Do not replay their repo work. Treat
+`main@bb9340101b98f33e0bbf4e719d0cc6f14226ade4` as the approved recovery-boundary
+base and verify it before preparing any corrected exact recovery packet.
 
 Before acting:
 
 ```bash
 git fetch origin --prune
-gh pr view 759 --json number,title,headRefName,headRefOid,state,mergedAt,mergeCommit,statusCheckRollup,url
+gh pr view 763 --json number,title,headRefName,headRefOid,state,mergedAt,mergeCommit,statusCheckRollup,url
 git rev-parse origin/main
 git status --short --branch
 ```
 
-### 2. Preserve S1A finding and finish G3 packet review
+### 2. Preserve S1A finding and finish the exact-packet correction/review
 
-Do not mutate A6. Do not restart services. Do not repair credentials yet.
+Do not mutate A6 from an unreviewed packet. Do not repair credentials yet.
 
 Preserve the classified S1A finding:
 
@@ -502,11 +504,11 @@ Preserve the classified S1A finding:
 relay_rest_story_timeout_total_0_of_3_exit_78
 ```
 
-Runtime, Alert, integration, hosted CI, and the `main` merge are complete. Do
-not replay them. Finish only the repo-side G3 packet review on the exact branch
-head, then stop at `WAITING_FOR_LOU`. Generating an exact host packet, rolling
-relay images, updating A6, and restarting the parked publisher are incident
-mutations, not routine launch-enablement actions.
+Runtime, Alert, integration, hosted CI, #759, and #763 are complete. Do not
+replay them. Finish the exact capture/image/network binding correction and
+subsequent review on the exact branch and packet hash. Lou's recorded approval
+then permits only the attended A/B/C rolling relay action; publisher restart
+remains a separate reviewed incident mutation.
 
 ### 3. Only after S1A/S1B exit green, repair StoryCluster credential/endpoint
 
@@ -741,7 +743,8 @@ Do not:
 - treat green CI on #759 as release readiness;
 - treat monitor `status: pass` as release clearance;
 - mutate A6 before S1A readback/classification;
-- restart relays from this sprint;
+- restart relays except through Lou's approved, independently reviewed exact
+  A/B/C packet;
 - restart publisher unless the approved path requires it;
 - deploy auth or configure providers before the active mailbox critical is
   classified/cleared or Lou explicitly authorizes return to release work;
@@ -754,16 +757,15 @@ Do not:
 
 ## Plain-English Current Status
 
-The repo-side S1B remediation is reviewed, CI-green, and merged through #759 at
-`main@98277475`. The product MVP is largely built at repo level.
+The repo-side S1B remediation and approved restart-boundary packet are merged
+through #763 at `main@bb934010`. The product MVP is largely built at repo level.
 
 The live release is still blocked. The alert mailbox is doing its job and is
 still reporting a public-feed critical. S1A readback has already proved this is
 a real parked-publisher incident, not setup noise. The next dev's first real
-job is not Cloudflare, Google, Apple, A6 update, or canary. It is to finish the
-repo-only G3 packet review, stop at `WAITING_FOR_LOU`, and obtain an explicit
-boundary correction and attended recovery authorization before any relay or
-publisher action.
+job is not Cloudflare, Google, Apple, broad A6 update, or canary. It is to finish
+the exact-packet correction and subsequent review, then execute only Lou's
+approved attended A/B/C relay action. Publisher recovery remains separate.
 
 Once S1A/S1B are green, the path is straightforward: repair StoryCluster
 credentials, stand up auth, register Apple/Google, redeploy the PWA origin,

--- a/tools/scripts/emit-a6-public-beta-deploy-packet.sh
+++ b/tools/scripts/emit-a6-public-beta-deploy-packet.sh
@@ -512,7 +512,7 @@ function relayOnlyNetworkFlags(container) {
   if (network.gw_priority !== 0) components.push(`gw-priority=${network.gw_priority}`);
   const networkSpec = components.length === 1 ? network.name : components.join(',');
   return [
-    `--network ${shellSingleQuote(networkSpec)}`,
+    components.length === 1 ? `--network ${network.name}` : `--network ${shellSingleQuote(networkSpec)}`,
     network.mac_address_intent ? `--mac-address ${shellSingleQuote(network.mac_address_intent)}` : '',
     ...network.links.map((link) => `--link ${shellSingleQuote(link)}`),
   ].filter(Boolean);

--- a/tools/scripts/emit-a6-public-beta-deploy-packet.sh
+++ b/tools/scripts/emit-a6-public-beta-deploy-packet.sh
@@ -7,6 +7,7 @@ NEW_ORIGIN_IMAGE=""
 NEW_RELAY_IMAGE=""
 EXPECTED_ORIGIN_REVISION=""
 EXPECTED_RELAY_REVISION=""
+EXPECTED_RELAY_IMAGE_ID=""
 ANALYSIS_TARGET="http://127.0.0.1:3001"
 ORIGIN_NAME="vhc-public-origin"
 RELAY_NAMES="vhc-relay-a,vhc-relay-b,vhc-relay-c"
@@ -31,6 +32,8 @@ Required with --include-recreate-commands:
                               Release commit expected from origin /healthz after deploy
   --expected-relay-revision <sha>
                               Release commit required from the relay OCI label in relay-only mode
+  --expected-relay-image-id <sha256:id>
+                              Full immutable relay image id from artifact-manifest.json (relay-only)
 
 Options:
   --analysis-target <url>     Corrected origin analysis target (default http://127.0.0.1:3001)
@@ -63,6 +66,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --expected-relay-revision)
       EXPECTED_RELAY_REVISION="${2:-}"
+      shift 2
+      ;;
+    --expected-relay-image-id)
+      EXPECTED_RELAY_IMAGE_ID="${2:-}"
       shift 2
       ;;
     --analysis-target)
@@ -126,6 +133,10 @@ if [[ "${RELAY_ONLY}" == "true" ]]; then
     echo "--expected-relay-revision must be a full lowercase git object id" >&2
     exit 64
   fi
+  if [[ ! "${EXPECTED_RELAY_IMAGE_ID}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+    echo "--expected-relay-image-id is required with --relay-only and must be a full lowercase sha256 image id from artifact-manifest.json" >&2
+    exit 64
+  fi
 elif [[ -z "${NEW_ORIGIN_IMAGE}" ]]; then
   echo "--new-origin-image is required unless --relay-only is set" >&2
   exit 64
@@ -141,6 +152,7 @@ emit_packet() {
   NEW_RELAY_IMAGE="${NEW_RELAY_IMAGE}" \
   EXPECTED_ORIGIN_REVISION="${EXPECTED_ORIGIN_REVISION}" \
   EXPECTED_RELAY_REVISION="${EXPECTED_RELAY_REVISION}" \
+  EXPECTED_RELAY_IMAGE_ID="${EXPECTED_RELAY_IMAGE_ID}" \
   ANALYSIS_TARGET="${ANALYSIS_TARGET}" \
   ORIGIN_NAME="${ORIGIN_NAME}" \
   RELAY_NAMES="${RELAY_NAMES}" \
@@ -148,12 +160,14 @@ emit_packet() {
   RELAY_ONLY="${RELAY_ONLY}" \
   node --input-type=module <<'NODE'
 import { readFileSync } from 'node:fs';
+import { isIP } from 'node:net';
 
 const inspectJson = process.env.INSPECT_JSON;
 const newOriginImage = process.env.NEW_ORIGIN_IMAGE;
 const newRelayImage = process.env.NEW_RELAY_IMAGE;
 const expectedOriginRevision = process.env.EXPECTED_ORIGIN_REVISION || '';
 const expectedRelayRevision = process.env.EXPECTED_RELAY_REVISION || '';
+const expectedRelayImageId = process.env.EXPECTED_RELAY_IMAGE_ID || '';
 const analysisTarget = process.env.ANALYSIS_TARGET;
 const originName = process.env.ORIGIN_NAME;
 const relayNames = (process.env.RELAY_NAMES || '').split(',').map((name) => name.trim()).filter(Boolean);
@@ -165,10 +179,37 @@ const relayHeapThresholdByName = new Map(relayNames.map((name, index) => [
   name,
   relayHeapThresholdDefaults[index] ?? relayHeapThresholdDefaults.at(-1),
 ]));
-const containers = JSON.parse(readFileSync(inspectJson, 'utf8'));
+let containers;
+try {
+  containers = JSON.parse(readFileSync(inspectJson, 'utf8'));
+} catch {
+  console.error('inspect JSON must be valid JSON');
+  process.exit(78);
+}
 
 function cleanName(container) {
   return String(container?.Name || '').replace(/^\//, '');
+}
+
+if (!Array.isArray(containers)) {
+  console.error('inspect JSON must be an array');
+  process.exit(78);
+}
+if (relayOnly) {
+  const canonicalNames = ['vhc-relay-a', 'vhc-relay-b', 'vhc-relay-c'];
+  const capturedNames = containers.map((container) => {
+    if (!container || typeof container !== 'object' || Array.isArray(container)) return '';
+    const rawName = container.Name;
+    return typeof rawName === 'string' && /^\/vhc-relay-[abc]$/.test(rawName)
+      ? rawName.slice(1)
+      : '';
+  });
+  const uniqueNames = new Set(capturedNames);
+  const exactCanonicalSet = canonicalNames.every((name) => uniqueNames.has(name));
+  if (containers.length !== 3 || uniqueNames.size !== 3 || capturedNames.includes('') || !exactCanonicalSet) {
+    console.error('relay-only inspect JSON must be an array of exactly three unique canonical entries: /vhc-relay-a, /vhc-relay-b, /vhc-relay-c');
+    process.exit(78);
+  }
 }
 
 const byName = new Map(containers.map((container) => [cleanName(container), container]));
@@ -188,6 +229,141 @@ function envNames(container) {
 
 function networkNames(container) {
   return Object.keys(container?.NetworkSettings?.Networks || {}).sort();
+}
+
+const supportedNetworkAttachmentFields = new Set([
+  'IPAMConfig',
+  'Links',
+  'Aliases',
+  'NetworkID',
+  'EndpointID',
+  'Gateway',
+  'IPAddress',
+  'IPPrefixLen',
+  'IPv6Gateway',
+  'GlobalIPv6Address',
+  'GlobalIPv6PrefixLen',
+  'MacAddress',
+  'DriverOpts',
+  'GwPriority',
+  'DNSNames',
+]);
+
+function plainObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function topologyError(code) {
+  throw new Error(code);
+}
+
+function portableStringList(value, code, options = {}) {
+  if (value === null || value === undefined) return [];
+  if (!Array.isArray(value)) topologyError(`${code}_shape_unsupported`);
+  const out = value.map((item) => {
+    if (typeof item !== 'string' || item.length === 0 || /[\0\r\n]/.test(item)) {
+      topologyError(`${code}_value_unsupported`);
+    }
+    if (options.noComma && item.includes(',')) topologyError(`${code}_value_nonportable`);
+    return item;
+  });
+  if (new Set(out).size !== out.length) topologyError(`${code}_duplicates_unsupported`);
+  return out.sort();
+}
+
+function portableIp(value, family, code) {
+  const text = String(value || '');
+  if (text && isIP(text) !== family) topologyError(`${code}_invalid`);
+  return text;
+}
+
+function semanticNetworkAttachment(container) {
+  const networks = container?.NetworkSettings?.Networks;
+  if (!plainObject(networks)) topologyError('networks_shape_unsupported');
+  const names = Object.keys(networks);
+  if (names.length !== 1) topologyError('exactly_one_network_required');
+  const name = names[0];
+  if (!/^[A-Za-z0-9][A-Za-z0-9_.-]*$/.test(name)) topologyError('network_name_nonportable');
+  if (String(container?.HostConfig?.NetworkMode || '') !== name) topologyError('network_mode_attachment_mismatch');
+  const endpoint = networks[name];
+  if (!plainObject(endpoint)) topologyError('network_attachment_shape_unsupported');
+  for (const key of Object.keys(endpoint)) {
+    if (!supportedNetworkAttachmentFields.has(key)) topologyError(`unsupported_network_attachment_field_${key}`);
+  }
+  const networkId = String(endpoint.NetworkID || '');
+  if (!/^[0-9a-f]{64}$/.test(networkId)) topologyError('network_id_missing_or_malformed');
+
+  const ipam = endpoint.IPAMConfig ?? {};
+  if (!plainObject(ipam)) topologyError('network_ipam_shape_unsupported');
+  const supportedIpamFields = new Set(['IPv4Address', 'IPv6Address', 'LinkLocalIPs']);
+  for (const key of Object.keys(ipam)) {
+    if (!supportedIpamFields.has(key)) topologyError(`unsupported_network_ipam_field_${key}`);
+  }
+  const ipv4Address = portableIp(ipam.IPv4Address, 4, 'network_static_ipv4');
+  const ipv6Address = portableIp(ipam.IPv6Address, 6, 'network_static_ipv6');
+  const linkLocalIps = portableStringList(ipam.LinkLocalIPs, 'network_link_local_ip', { noComma: true });
+  for (const address of linkLocalIps) {
+    if (isIP(address) === 0) topologyError('network_link_local_ip_invalid');
+  }
+
+  const containerId = String(container?.Id || '').replace(/^sha256:/, '');
+  const runtimeIdAliases = new Set([containerId, containerId.slice(0, 12)].filter(Boolean));
+  const aliases = portableStringList(endpoint.Aliases, 'network_alias', { noComma: true })
+    .filter((alias) => !runtimeIdAliases.has(alias));
+  if (aliases.some((alias) => !/^[A-Za-z0-9][A-Za-z0-9_.-]*$/.test(alias))) topologyError('network_alias_nonportable');
+  const endpointLinks = portableStringList(endpoint.Links, 'network_endpoint_link');
+  const hostLinks = portableStringList(container?.HostConfig?.Links, 'network_host_link');
+  if (endpointLinks.length > 0 && hostLinks.length > 0 && JSON.stringify(endpointLinks) !== JSON.stringify(hostLinks)) {
+    topologyError('network_link_state_nonportable');
+  }
+  const links = hostLinks.length > 0 ? hostLinks : endpointLinks;
+
+  const driverOpts = endpoint.DriverOpts ?? {};
+  if (!plainObject(driverOpts)) topologyError('network_driver_opts_shape_unsupported');
+  const normalizedDriverOpts = Object.entries(driverOpts).map(([key, value]) => {
+    if (!key || /[=,\0\r\n]/.test(key) || typeof value !== 'string' || /[,\0\r\n]/.test(value)) {
+      topologyError('network_driver_opt_nonportable');
+    }
+    return { key, value };
+  }).sort((left, right) => JSON.stringify(left).localeCompare(JSON.stringify(right)));
+
+  const gwPriorityValue = endpoint.GwPriority ?? 0;
+  if (!Number.isSafeInteger(gwPriorityValue)) topologyError('network_gw_priority_shape_unsupported');
+
+  for (const key of ['EndpointID', 'Gateway', 'IPAddress', 'IPv6Gateway', 'GlobalIPv6Address', 'MacAddress']) {
+    if (endpoint[key] !== undefined && endpoint[key] !== null && typeof endpoint[key] !== 'string') {
+      topologyError(`network_runtime_${key.toLowerCase()}_shape_unsupported`);
+    }
+  }
+  for (const key of ['IPPrefixLen', 'GlobalIPv6PrefixLen']) {
+    if (endpoint[key] !== undefined && endpoint[key] !== null && !Number.isSafeInteger(endpoint[key])) {
+      topologyError(`network_runtime_${key.toLowerCase()}_shape_unsupported`);
+    }
+  }
+  portableStringList(endpoint.DNSNames, 'network_runtime_dns_name');
+
+  const macAddressIntent = String(container?.Config?.MacAddress || '');
+  if (macAddressIntent && !/^[0-9a-f]{2}(?::[0-9a-f]{2}){5}$/i.test(macAddressIntent)) {
+    topologyError('network_static_mac_invalid');
+  }
+  if (macAddressIntent && String(endpoint.MacAddress || '').toLowerCase() !== macAddressIntent.toLowerCase()) {
+    topologyError('network_static_mac_state_nonportable');
+  }
+
+  return {
+    name,
+    network_id: networkId,
+    ipam_config: {
+      ipv4_address: ipv4Address,
+      ipv6_address: ipv6Address,
+      link_local_ips: linkLocalIps,
+    },
+    aliases,
+    links,
+    driver_opts: normalizedDriverOpts,
+    gw_priority: gwPriorityValue,
+    mac_address_intent: macAddressIntent.toLowerCase(),
+  };
 }
 
 function portFlags(container) {
@@ -291,7 +467,7 @@ function capturedRelayTopology(container) {
     memory: Number(container?.HostConfig?.Memory || 0),
     memory_swap: Number(container?.HostConfig?.MemorySwap || 0),
     network_mode: String(container?.HostConfig?.NetworkMode || ''),
-    networks: networkNames(container),
+    network: semanticNetworkAttachment(container),
     port_bindings: portBindings,
     mounts,
   };
@@ -323,6 +499,23 @@ function memoryFlags(options = {}) {
 function primaryNetworkFlag(container) {
   const names = networkNames(container);
   return names.length > 0 ? `--network ${names[0]}` : '';
+}
+
+function relayOnlyNetworkFlags(container) {
+  const network = semanticNetworkAttachment(container);
+  const components = [`name=${network.name}`];
+  if (network.ipam_config.ipv4_address) components.push(`ip=${network.ipam_config.ipv4_address}`);
+  if (network.ipam_config.ipv6_address) components.push(`ip6=${network.ipam_config.ipv6_address}`);
+  for (const address of network.ipam_config.link_local_ips) components.push(`link-local-ip=${address}`);
+  for (const alias of network.aliases) components.push(`alias=${alias}`);
+  for (const option of network.driver_opts) components.push(`driver-opt=${option.key}=${option.value}`);
+  if (network.gw_priority !== 0) components.push(`gw-priority=${network.gw_priority}`);
+  const networkSpec = components.length === 1 ? network.name : components.join(',');
+  return [
+    `--network ${shellSingleQuote(networkSpec)}`,
+    network.mac_address_intent ? `--mac-address ${shellSingleQuote(network.mac_address_intent)}` : '',
+    ...network.links.map((link) => `--link ${shellSingleQuote(link)}`),
+  ].filter(Boolean);
 }
 
 function shellJoin(parts) {
@@ -473,7 +666,7 @@ function relayOnlyRunCommandFor(name, image) {
     restartFlag(container),
     memory > 0 ? `--memory ${memory}` : '',
     memorySwap > 0 ? `--memory-swap ${memorySwap}` : '',
-    primaryNetworkFlag(container),
+    ...relayOnlyNetworkFlags(container),
     user ? `--user ${shellSingleQuote(user)}` : '',
     `--env-file ${envPath}`,
     ...portFlags(container),
@@ -497,6 +690,32 @@ function relayOnlyVerifierFunction() {
     '  fi',
     '}',
     '',
+    'assert_relay_image_binding() {',
+    '  local image_ref="$1"',
+    '  local expected_id="$2"',
+    '  local expected_revision="$3"',
+    '  local observed id platform revision',
+    '  if ! observed="$(sudo docker image inspect "${image_ref}" --format \'{{.Id}}|{{.Os}}/{{.Architecture}}|{{index .Config.Labels "org.opencontainers.image.revision"}}\' 2>/dev/null)"; then echo "relay_image_binding_unavailable" >&2; return 78; fi',
+    '  IFS="|" read -r id platform revision <<<"${observed}"',
+    '  if [[ "${id}" != "${expected_id}" || "${platform}" != "linux/amd64" || "${revision}" != "${expected_revision}" ]]; then echo "relay_image_binding_mismatch" >&2; return 78; fi',
+    '}',
+    '',
+    'assert_image_id_available() {',
+    '  local expected_id="$1"',
+    '  local observed',
+    '  if ! observed="$(sudo docker image inspect "${expected_id}" --format \'{{.Id}}\' 2>/dev/null)" || [[ "${observed}" != "${expected_id}" ]]; then echo "rollback_image_id_unavailable" >&2; return 78; fi',
+    '}',
+    '',
+    'assert_relay_removal_boundary() {',
+    '  local name="$1"',
+    '  local expected_topology="$2"',
+    '  local image_ref="$3"',
+    '  local expected_id="$4"',
+    '  local expected_revision="$5"',
+    '  assert_live_topology_parity "${name}" "${expected_topology}" || return 78',
+    '  assert_relay_image_binding "${image_ref}" "${expected_id}" "${expected_revision}" || return 78',
+    '}',
+    '',
     'assert_live_topology_parity() {',
     '  local name="$1"',
     '  local expected_base64="$2"',
@@ -508,7 +727,60 @@ function relayOnlyVerifierFunction() {
     '  fi',
     '  chmod 600 "${observed}" || return 78',
     '  if ! EXPECTED_TOPOLOGY_BASE64="${expected_base64}" OBSERVED_INSPECT="${observed}" EXPECTED_ENV="${expected_env}" python3 <<\'PY\'',
-    'import base64, json, os, sys',
+    'import base64, ipaddress, json, os, re, sys',
+    'SUPPORTED_ATTACHMENT_FIELDS = {"IPAMConfig", "Links", "Aliases", "NetworkID", "EndpointID", "Gateway", "IPAddress", "IPPrefixLen", "IPv6Gateway", "GlobalIPv6Address", "GlobalIPv6PrefixLen", "MacAddress", "DriverOpts", "GwPriority", "DNSNames"}',
+    'def closed(condition=True):',
+    '    if condition: raise ValueError("closed")',
+    'def strings(value, no_comma=False):',
+    '    if value is None: return []',
+    '    closed(not isinstance(value, list))',
+    '    closed(any(not isinstance(item, str) or not item or any(char in item for char in "\\x00\\r\\n") or (no_comma and "," in item) for item in value))',
+    '    closed(len(set(value)) != len(value))',
+    '    return sorted(value)',
+    'def ip(value, family):',
+    '    text = str(value or "")',
+    '    if text: closed(ipaddress.ip_address(text).version != family)',
+    '    return text',
+    'def network(container):',
+    '    networks = (container.get("NetworkSettings") or {}).get("Networks")',
+    '    closed(not isinstance(networks, dict) or len(networks) != 1)',
+    '    name, endpoint = next(iter(networks.items()))',
+    '    closed(not isinstance(name, str) or re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_.-]*", name) is None or not isinstance(endpoint, dict))',
+    '    closed(str((container.get("HostConfig") or {}).get("NetworkMode") or "") != name)',
+    '    closed(any(key not in SUPPORTED_ATTACHMENT_FIELDS for key in endpoint))',
+    '    network_id = str(endpoint.get("NetworkID") or "")',
+    '    closed(re.fullmatch(r"[0-9a-f]{64}", network_id) is None)',
+    '    ipam = endpoint.get("IPAMConfig") or {}',
+    '    closed(not isinstance(ipam, dict) or any(key not in {"IPv4Address", "IPv6Address", "LinkLocalIPs"} for key in ipam))',
+    '    link_local_ips = strings(ipam.get("LinkLocalIPs"), no_comma=True)',
+    '    for address in link_local_ips: ipaddress.ip_address(address)',
+    '    container_id = str(container.get("Id") or "").removeprefix("sha256:")',
+    '    runtime_aliases = {value for value in (container_id, container_id[:12]) if value}',
+    '    aliases = [value for value in strings(endpoint.get("Aliases"), no_comma=True) if value not in runtime_aliases]',
+    '    closed(any(re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_.-]*", alias) is None for alias in aliases))',
+    '    endpoint_links = strings(endpoint.get("Links"))',
+    '    host_links = strings((container.get("HostConfig") or {}).get("Links"))',
+    '    closed(bool(endpoint_links and host_links and endpoint_links != host_links))',
+    '    links = host_links if host_links else endpoint_links',
+    '    driver_opts = endpoint.get("DriverOpts") or {}',
+    '    closed(not isinstance(driver_opts, dict))',
+    '    normalized_driver_opts = []',
+    '    for key, value in driver_opts.items():',
+    '        closed(not isinstance(key, str) or not key or any(char in key for char in "=,\\x00\\r\\n") or not isinstance(value, str) or any(char in value for char in ",\\x00\\r\\n"))',
+    '        normalized_driver_opts.append({"key": key, "value": value})',
+    '    normalized_driver_opts.sort(key=lambda item: json.dumps(item, sort_keys=True))',
+    '    gw_priority = endpoint.get("GwPriority", 0)',
+    '    closed(not isinstance(gw_priority, int) or isinstance(gw_priority, bool))',
+    '    for key in ("EndpointID", "Gateway", "IPAddress", "IPv6Gateway", "GlobalIPv6Address", "MacAddress"):',
+    '        closed(endpoint.get(key) is not None and not isinstance(endpoint.get(key), str))',
+    '    for key in ("IPPrefixLen", "GlobalIPv6PrefixLen"):',
+    '        closed(endpoint.get(key) is not None and (not isinstance(endpoint.get(key), int) or isinstance(endpoint.get(key), bool)))',
+    '    strings(endpoint.get("DNSNames"))',
+    '    config = container.get("Config") or {}',
+    '    mac_intent = str(config.get("MacAddress") or "").lower()',
+    '    closed(bool(mac_intent and re.fullmatch(r"[0-9a-f]{2}(?::[0-9a-f]{2}){5}", mac_intent) is None))',
+    '    closed(bool(mac_intent and str(endpoint.get("MacAddress") or "").lower() != mac_intent))',
+    '    return {"name": name, "network_id": network_id, "ipam_config": {"ipv4_address": ip(ipam.get("IPv4Address"), 4), "ipv6_address": ip(ipam.get("IPv6Address"), 6), "link_local_ips": link_local_ips}, "aliases": aliases, "links": links, "driver_opts": normalized_driver_opts, "gw_priority": gw_priority, "mac_address_intent": mac_intent}',
     'def normalize(container):',
     '    bindings = container.get("HostConfig", {}).get("PortBindings") or {}',
     '    ports = []',
@@ -524,8 +796,7 @@ function relayOnlyVerifierFunction() {
     '    host = container.get("HostConfig") or {}',
     '    config = container.get("Config") or {}',
     '    restart = host.get("RestartPolicy") or {}',
-    '    networks = sorted((container.get("NetworkSettings", {}).get("Networks") or {}).keys())',
-    '    return {"image_id": str(container.get("Image") or ""), "image_ref": str(config.get("Image") or ""), "user": str(config.get("User") or ""), "restart": {"name": str(restart.get("Name") or ""), "maximum_retry_count": int(restart.get("MaximumRetryCount") or 0)}, "memory": int(host.get("Memory") or 0), "memory_swap": int(host.get("MemorySwap") or 0), "network_mode": str(host.get("NetworkMode") or ""), "networks": networks, "port_bindings": ports, "mounts": mounts}',
+    '    return {"image_id": str(container.get("Image") or ""), "image_ref": str(config.get("Image") or ""), "user": str(config.get("User") or ""), "restart": {"name": str(restart.get("Name") or ""), "maximum_retry_count": int(restart.get("MaximumRetryCount") or 0)}, "memory": int(host.get("Memory") or 0), "memory_swap": int(host.get("MemorySwap") or 0), "network_mode": str(host.get("NetworkMode") or ""), "network": network(container), "port_bindings": ports, "mounts": mounts}',
     'try:',
     '    expected = json.loads(base64.b64decode(os.environ["EXPECTED_TOPOLOGY_BASE64"]).decode("utf-8"))',
     '    observed_payload = json.load(open(os.environ["OBSERVED_INSPECT"], encoding="utf-8"))',
@@ -733,6 +1004,16 @@ for (const name of relayNames) {
   if (relayOnly && networkNames(container).length !== 1) {
     blockers.push(`${name}: relay-only recovery requires exactly one captured network`);
   }
+  if (relayOnly) {
+    if (!/^sha256:[0-9a-f]{64}$/.test(String(container?.Image || ''))) {
+      blockers.push(`${name}: captured rollback image id is missing or malformed`);
+    }
+    try {
+      semanticNetworkAttachment(container);
+    } catch (error) {
+      blockers.push(`${name}: ${error instanceof Error ? error.message : 'network_topology_unsupported'}`);
+    }
+  }
 }
 
 const lines = [];
@@ -741,7 +1022,7 @@ lines.push(relayOnly ? '# A6 S1B Relay-Only Recovery Packet' : '# A6 Public-Beta
 lines.push('');
 lines.push('Generated from captured `docker inspect` JSON. This packet is secret-safe: it records env var names and uses host-side env-file capture commands without printing values.');
 if (relayOnly) {
-  lines.push('Status: `WAITING_FOR_LOU`. Generation is repo-side preparation only; no command in this packet is authorized until Lou explicitly corrects the relay-restart boundary and approves the exact reviewed packet.');
+  lines.push('Status: `REVIEW_REQUIRED`. Generation is repo-side preparation only; no mutation command in this packet is executable until recorded Lou authority covers its exact scope and independent review returns GO on its exact capture/image/packet tuple.');
   lines.push('Scope is exactly `vhc-relay-a`, `vhc-relay-b`, then `vhc-relay-c`. Origin and publisher deployment are excluded. The publisher must remain parked throughout.');
 }
 lines.push('');
@@ -751,6 +1032,7 @@ if (!relayOnly) lines.push(`- new origin image: \`${newOriginImage}\``);
 lines.push(`- new relay image: \`${newRelayImage}\``);
 if (relayOnly) {
   lines.push(`- expected relay revision: \`${expectedRelayRevision}\``);
+  lines.push(`- expected immutable relay image id: \`${expectedRelayImageId}\``);
   lines.push('- required relay platform: `linux/amd64`');
 } else {
   lines.push(`- expected origin revision: \`${expectedOriginRevision || 'not asserted'}\``);
@@ -876,14 +1158,12 @@ lines.push('');
 if (relayOnly) {
   lines.push('## Relay Image Preflight');
   lines.push('');
-  lines.push('This read-only gate must pass before any container removal. It proves the locally loaded relay image is the reviewed commit and the A6 architecture; a tag match alone is insufficient.');
+  lines.push('This read-only gate must pass before any container removal. It proves the locally loaded relay reference resolves to the full immutable image id recorded by `artifact-manifest.json`, the reviewed commit, and the A6 architecture; a tag or revision match alone is insufficient.');
   lines.push('');
   lines.push('```bash');
   lines.push('set -euo pipefail');
-  lines.push(`relay_image_platform="$(sudo docker image inspect ${shellSingleQuote(newRelayImage)} --format '{{.Os}}/{{.Architecture}}')"`);
-  lines.push('if [[ "${relay_image_platform}" != "linux/amd64" ]]; then echo "relay image platform mismatch: ${relay_image_platform}" >&2; exit 78; fi');
-  lines.push(`relay_image_revision="$(sudo docker image inspect ${shellSingleQuote(newRelayImage)} --format '{{index .Config.Labels "org.opencontainers.image.revision"}}')"`);
-  lines.push(`if [[ "\${relay_image_revision}" != ${shellSingleQuote(expectedRelayRevision)} ]]; then echo "relay image revision mismatch" >&2; exit 78; fi`);
+  lines.push(`relay_image_binding="$(sudo docker image inspect ${shellSingleQuote(newRelayImage)} --format '{{.Id}}|{{.Os}}/{{.Architecture}}|{{index .Config.Labels "org.opencontainers.image.revision"}}')"`);
+  lines.push(`if [[ "\${relay_image_binding}" != ${shellSingleQuote(`${expectedRelayImageId}|linux/amd64|${expectedRelayRevision}`)} ]]; then echo "relay image immutable binding mismatch" >&2; exit 78; fi`);
   lines.push('```');
   lines.push('');
 }
@@ -892,7 +1172,7 @@ if (includeRecreate) {
   if (relayOnly) {
     lines.push('## Approval-Gated Relay-Only Rolling Recovery');
     lines.push('');
-    lines.push('Hard authority gate: do not run this section until Lou explicitly approves replacing the contradictory no-relay-restart boundary for this exact reviewed revision. Approval is limited to A, then B, then C; it does not authorize origin, publisher, data, quorum, timeout, recipient, provider, pager, or monitor mutation.');
+    lines.push('Hard execution gate: do not run this section unless recorded Lou authority covers this exact reviewed revision, capture, image id, packet hash, and A/B/C scope, and independent packet review is GO. Approval is limited to A, then B, then C; it does not authorize origin, publisher, data, quorum, timeout, recipient, provider, pager, or monitor mutation.');
     lines.push('');
     lines.push('Each relay is verified before the next is touched. A fresh live/captured topology comparison and authenticated zero-trip prestate run for that relay, then the publisher must still be exactly `failed/failed`, `Result=exit-code`, `ExecMainStatus=78` as the final gate before removal. An absent watchdog-trip row is semantic zero only when exactly one valid uptime row and one positive process-RSS row authenticate the payload. Any precondition refusal exits `78` without remove, run, or rollback; only the mutation-started latch at the removal boundary enables recovery. After runtime verification, the publisher is checked again before GO. Any failure after mutation begins immediately recreates only the current relay from its captured immutable image id, verifies readiness/topology/snapshot/OOM state, and exits `78`. Never continue to the next relay after rollback.');
     lines.push('');
@@ -907,6 +1187,10 @@ if (includeRecreate) {
       const origin = relayLocalOrigin(name);
       const rollbackImage = container.Image || container.Config?.Image || '<captured-relay-image-id>';
       const expectedTopology = capturedRelayTopologyBase64(container);
+      const deployedTopology = capturedRelayTopology(container);
+      deployedTopology.image_id = expectedRelayImageId;
+      deployedTopology.image_ref = expectedRelayImageId;
+      const deployedTopologyBase64 = Buffer.from(JSON.stringify(deployedTopology), 'utf8').toString('base64');
       const rollbackTopology = capturedRelayTopology(container);
       rollbackTopology.image_id = rollbackImage;
       rollbackTopology.image_ref = rollbackImage;
@@ -916,6 +1200,7 @@ if (includeRecreate) {
       lines.push('if ! {');
       lines.push(`  assert_live_topology_parity ${shellSingleQuote(name)} ${shellSingleQuote(expectedTopology)} &&`);
       lines.push(`  assert_relay_prestate ${shellSingleQuote(name)} ${shellSingleQuote(origin)} ${shellSingleQuote(`prestage-${stage.toLowerCase()}`)} &&`);
+      lines.push(`  assert_relay_removal_boundary ${shellSingleQuote(name)} ${shellSingleQuote(expectedTopology)} ${shellSingleQuote(newRelayImage)} ${shellSingleQuote(expectedRelayImageId)} ${shellSingleQuote(expectedRelayRevision)} &&`);
       lines.push('  assert_publisher_parked');
       lines.push('}; then');
       lines.push(`  echo "${name}: pre_mutation_refused_no_change" >&2`);
@@ -924,15 +1209,17 @@ if (includeRecreate) {
       lines.push('relay_mutation_started=true');
       lines.push('if ! {');
       lines.push(`  sudo docker rm -f ${name} &&`);
-      lines.push(`${relayOnlyRunCommandFor(name, newRelayImage)} &&`.split('\n').map((line) => `  ${line}`).join('\n'));
-      lines.push(`  test "$(sudo docker inspect ${name} --format '{{.Config.Image}}')" = ${shellSingleQuote(newRelayImage)} &&`);
-      lines.push(`  test "$(sudo docker image inspect "$(sudo docker inspect ${name} --format '{{.Image}}')" --format '{{.Os}}/{{.Architecture}}')" = "linux/amd64" &&`);
-      lines.push(`  test "$(sudo docker image inspect "$(sudo docker inspect ${name} --format '{{.Image}}')" --format '{{index .Config.Labels "org.opencontainers.image.revision"}}')" = ${shellSingleQuote(expectedRelayRevision)} &&`);
+      lines.push(`${relayOnlyRunCommandFor(name, expectedRelayImageId)} &&`.split('\n').map((line) => `  ${line}`).join('\n'));
+      lines.push(`  test "$(sudo docker inspect ${name} --format '{{.Config.Image}}')" = ${shellSingleQuote(expectedRelayImageId)} &&`);
+      lines.push(`  test "$(sudo docker inspect ${name} --format '{{.Image}}')" = ${shellSingleQuote(expectedRelayImageId)} &&`);
+      lines.push(`  assert_live_topology_parity ${shellSingleQuote(name)} ${shellSingleQuote(deployedTopologyBase64)} &&`);
       lines.push(`  verify_relay_only_runtime ${shellSingleQuote(name)} ${shellSingleQuote(origin)} ${shellSingleQuote(dataDestination)} ${shellSingleQuote(expectedRelayRevision)} &&`);
+      lines.push(`  assert_live_topology_parity ${shellSingleQuote(name)} ${shellSingleQuote(deployedTopologyBase64)} &&`);
       lines.push('  assert_publisher_parked');
       lines.push('}; then');
       lines.push('  if [[ "${relay_mutation_started}" != "true" ]]; then echo "relay_mutation_latch_missing" >&2; exit 78; fi');
       lines.push(`  echo "${name}: verification failed; rolling back only this relay and stopping" >&2`);
+      lines.push(`  if ! assert_image_id_available ${shellSingleQuote(rollbackImage)}; then exit 78; fi`);
       lines.push(`  if sudo docker inspect ${name} >/dev/null 2>&1; then`);
       lines.push(`    if ! sudo docker rm -f ${name} >/dev/null 2>&1; then echo "${name}: rollback_remove_failed" >&2; exit 78; fi`);
       lines.push('  fi');
@@ -942,6 +1229,7 @@ if (includeRecreate) {
       lines.push('    exit 78');
       lines.push('  fi');
       lines.push(`  if ! chmod 600 /tmp/vhc-public-beta-deploy/${name}.rollback.start.out; then echo "${name}: rollback_evidence_permission_failed" >&2; exit 78; fi`);
+      lines.push(`  if ! assert_live_topology_parity ${shellSingleQuote(name)} ${shellSingleQuote(rollbackTopologyBase64)}; then echo "${name}: rollback_topology_failed" >&2; exit 78; fi`);
       lines.push('  rollback_attempt=1');
       lines.push('  rollback_ready=false');
       lines.push('  while [[ "${rollback_attempt}" -le 60 ]]; do');
@@ -964,7 +1252,7 @@ if (includeRecreate) {
     lines.push('');
     lines.push('## Hard Stop Conditions');
     lines.push('');
-    lines.push('- Stop before container removal on absent explicit Lou approval, wrong commit/revision, non-`linux/amd64` image, publisher state other than exact failed/failed exit 78, missing relay, any live/captured image/env/mount/network/port/restart/user/memory drift, unreadable or changed snapshot, pre-existing OOM/watchdog trip, unauthenticated or malformed metrics, or non-green readiness. A pre-mutation refusal does not invoke rollback.');
+    lines.push('- Stop before container removal on absent recorded Lou authority or exact packet-review GO, non-array/duplicate/extra/malformed relay capture, wrong immutable image id or mutable-ref binding (including same-revision retag), wrong commit/revision, non-`linux/amd64` image, publisher state other than exact failed/failed exit 78, missing relay, any live/captured image/env/mount/semantic-network/NetworkID/port/restart/user/memory drift, unsupported network attachment state, unreadable or changed snapshot, pre-existing OOM/watchdog trip, unauthenticated or malformed metrics, or non-green readiness. A pre-mutation refusal does not invoke rollback.');
     lines.push('- After mutation begins, roll back the current relay and stop on publisher transition/resume during verification, readiness/health failure, environment mismatch, snapshot checksum drift, OOM/watchdog trip, wrong image id/revision/platform, or any of the four exact missing-key probes returning anything other than its closed 404 body. Unexpected bodies remain private; only a closed reason code may print.');
     lines.push('- Never batch removals, skip A/B/C order, continue after rollback, clear data, alter quorum/timeouts, start the publisher, recreate origin, or use the generic packet executor for this action.');
     lines.push('');

--- a/tools/scripts/export-public-beta-image-artifacts.sh
+++ b/tools/scripts/export-public-beta-image-artifacts.sh
@@ -146,6 +146,10 @@ inspect_image() {
     revision=""
   fi
   local actual_platform="${os_name}/${arch}"
+  if [[ ! "${id}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+    printf '%s image id is not a full immutable sha256 id (%s)\n' "${label}" "${image}" >&2
+    exit 78
+  fi
   if [[ "${actual_platform}" != "${PLATFORM}" ]]; then
     printf '%s image platform mismatch: expected %s, got %s (%s)\n' "${label}" "${PLATFORM}" "${actual_platform}" "${image}" >&2
     exit 78
@@ -298,6 +302,7 @@ This packet is approval-required and relay-only. It loads one reviewed relay ima
 
 - ${RELAY_IMAGE}: \`${relay_tar}\`
   - sha256: \`${relay_sha}\`
+  - immutable image id: \`${relay_id}\`
   - platform: \`${relay_os}/${relay_arch}\`
   - revision: \`${relay_revision:-<empty>}\`
 
@@ -312,7 +317,7 @@ scp $(bash_quote "${relay_tar}") "\${SSH_HOST}:\${REMOTE_DIR}/${relay_file}"
 scp $(bash_quote "${checksums_file}") "\${SSH_HOST}:\${REMOTE_DIR}/SHA256SUMS"
 ssh "\${SSH_HOST}" "cd \${REMOTE_DIR} && sha256sum -c SHA256SUMS"
 ssh "\${SSH_HOST}" "docker load -i \${REMOTE_DIR}/${relay_file}"
-ssh "\${SSH_HOST}" 'docker image inspect ${RELAY_IMAGE} --format "{{.RepoTags}} {{.Id}} {{.Os}}/{{.Architecture}} {{index .Config.Labels \"org.opencontainers.image.revision\"}}"'
+ssh "\${SSH_HOST}" 'test "\$(docker image inspect $(bash_quote "${RELAY_IMAGE}") --format "{{.Id}}|{{.Os}}/{{.Architecture}}|{{index .Config.Labels \\\"org.opencontainers.image.revision\\\"}}")" = $(bash_quote "${relay_id}|${relay_os}/${relay_arch}|${relay_revision}")'
 \`\`\`
 
 ## Abort Criteria
@@ -320,6 +325,7 @@ ssh "\${SSH_HOST}" 'docker image inspect ${RELAY_IMAGE} --format "{{.RepoTags}} 
 - Abort if \`sha256sum -c SHA256SUMS\` fails.
 - Abort if the loaded relay image is not \`${PLATFORM}\`.
 - Abort if the loaded relay image revision is not \`${SOURCE_REVISION:-<revision-check-skipped>}\`.
+- Abort if the loaded relay reference does not resolve to immutable image id \`${relay_id}\`; a matching tag or revision is insufficient.
 - Loading this image is not approval to restart relays, deploy origin, start publisher writes, run exact-readback probes, or re-enable monitors.
 EOF
 } > "${packet_file}"
@@ -384,3 +390,4 @@ if [[ "${RELAY_ONLY}" != "true" ]]; then
   printf 'origin_sha256=%s\n' "${origin_sha}"
 fi
 printf 'relay_sha256=%s\n' "${relay_sha}"
+printf 'relay_image_id=%s\n' "${relay_id}"

--- a/tools/scripts/export-public-beta-image-artifacts.sh
+++ b/tools/scripts/export-public-beta-image-artifacts.sh
@@ -317,7 +317,14 @@ scp $(bash_quote "${relay_tar}") "\${SSH_HOST}:\${REMOTE_DIR}/${relay_file}"
 scp $(bash_quote "${checksums_file}") "\${SSH_HOST}:\${REMOTE_DIR}/SHA256SUMS"
 ssh "\${SSH_HOST}" "cd \${REMOTE_DIR} && sha256sum -c SHA256SUMS"
 ssh "\${SSH_HOST}" "docker load -i \${REMOTE_DIR}/${relay_file}"
-ssh "\${SSH_HOST}" 'test "\$(docker image inspect $(bash_quote "${RELAY_IMAGE}") --format "{{.Id}}|{{.Os}}/{{.Architecture}}|{{index .Config.Labels \\\"org.opencontainers.image.revision\\\"}}")" = $(bash_quote "${relay_id}|${relay_os}/${relay_arch}|${relay_revision}")'
+ssh "\${SSH_HOST}" "bash -s -- $(bash_quote "${RELAY_IMAGE}") $(bash_quote "${relay_id}|${relay_os}/${relay_arch}|${relay_revision}")" <<'VHC_RELAY_IMAGE_BINDING'
+set -euo pipefail
+observed="\$(docker image inspect "\$1" --format '{{.Id}}|{{.Os}}/{{.Architecture}}|{{index .Config.Labels "org.opencontainers.image.revision"}}')"
+if [[ "\${observed}" != "\$2" ]]; then
+  echo "relay_loaded_image_binding_mismatch" >&2
+  exit 78
+fi
+VHC_RELAY_IMAGE_BINDING
 \`\`\`
 
 ## Abort Criteria

--- a/tools/scripts/public-beta-image-deploy.test.mjs
+++ b/tools/scripts/public-beta-image-deploy.test.mjs
@@ -289,6 +289,59 @@ exit 2
     assert.equal(malformedImageId.status, 78);
     assert.match(malformedImageId.stderr, /full immutable sha256 id/);
 
+    const remoteBin = path.join(root, 'remote-bin');
+    mkdirSync(remoteBin);
+    const writeRemoteExecutable = (name, contents) => {
+      const file = path.join(remoteBin, name);
+      writeFileSync(file, contents, 'utf8');
+      chmodSync(file, 0o755);
+    };
+    const remoteFormatFile = path.join(root, 'remote-format.txt');
+    const remoteRefFile = path.join(root, 'remote-ref.txt');
+    writeRemoteExecutable('scp', '#!/usr/bin/env bash\nexit 0\n');
+    writeRemoteExecutable('ssh', `#!/usr/bin/env bash
+set -euo pipefail
+shift
+if [[ "\${1:-}" == bash\\ -s\\ --* ]]; then
+  exec bash -c "$1"
+fi
+exit 0
+`);
+    writeRemoteExecutable('docker', `#!/usr/bin/env bash
+set -euo pipefail
+test "\${1:-}" = image
+test "\${2:-}" = inspect
+test "\${4:-}" = --format
+printf '%s' "\${3:-}" > "\${FAKE_REMOTE_REF_FILE:?}"
+printf '%s' "\${5:-}" > "\${FAKE_REMOTE_FORMAT_FILE:?}"
+printf '%s|%s|%s\n' "\${FAKE_REMOTE_IMAGE_ID:?}" "\${FAKE_REMOTE_PLATFORM:?}" "\${FAKE_REMOTE_REVISION:?}"
+`);
+    const remoteEnv = {
+      ...process.env,
+      PATH: `${remoteBin}:${process.env.PATH}`,
+      FAKE_REMOTE_REF_FILE: remoteRefFile,
+      FAKE_REMOTE_FORMAT_FILE: remoteFormatFile,
+      FAKE_REMOTE_IMAGE_ID: REVIEWED_RELAY_IMAGE_ID,
+      FAKE_REMOTE_PLATFORM: 'linux/amd64',
+      FAKE_REMOTE_REVISION: REVIEWED_RELAY_REVISION,
+    };
+    const executedBinding = run('bash', [], { input: `${loadBlock}\n`, env: remoteEnv });
+    assert.equal(executedBinding.status, 0, executedBinding.stderr);
+    assert.equal(readFileSync(remoteRefFile, 'utf8'), 'vhc-public-beta-relay:reviewed');
+    assert.equal(
+      readFileSync(remoteFormatFile, 'utf8'),
+      '{{.Id}}|{{.Os}}/{{.Architecture}}|{{index .Config.Labels "org.opencontainers.image.revision"}}',
+    );
+    for (const [label, override] of [
+      ['image-id', { FAKE_REMOTE_IMAGE_ID: `sha256:${'9'.repeat(64)}` }],
+      ['platform', { FAKE_REMOTE_PLATFORM: 'linux/arm64' }],
+      ['revision', { FAKE_REMOTE_REVISION: '0'.repeat(40) }],
+    ]) {
+      const rejectedBinding = run('bash', [], { input: `${loadBlock}\n`, env: { ...remoteEnv, ...override } });
+      assert.equal(rejectedBinding.status, 78, `${label}: ${rejectedBinding.stderr}`);
+      assert.match(rejectedBinding.stderr, /relay_loaded_image_binding_mismatch/);
+    }
+
     const skippedRevision = run('bash', [
       EXPORT_SCRIPT,
       '--relay-only',
@@ -883,6 +936,74 @@ test('relay-only deploy packet preserves every supported network attachment inte
     const postVerificationTopology = stageA.indexOf("assert_live_topology_parity 'vhc-relay-a'", postRecreateTopology + 1);
     assert.ok(beforeRemoval >= 0 && beforeRemoval < remove && remove < postRecreateTopology && postRecreateTopology < verify && verify < postVerificationTopology, stageA);
     assert.ok((stageA.match(/assert_live_topology_parity 'vhc-relay-a'/g) || []).length >= 5, stageA);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('relay-only deploy packet preserves the exact current A6 host-network A-B-C topology through recreate and rollback', () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), 'vh-public-beta-relay-only-host-network-'));
+  try {
+    const inspectPath = path.join(root, 'inspect.json');
+    const relays = [
+      applyCurrentA6HostNetworkAttachment(makeHostNetworkRelay('vhc-relay-a', '/home/humble/.local/share/vhc/vhc-relay-a/data', '8765')),
+      applyCurrentA6HostNetworkAttachment(makeHostNetworkRelay('vhc-relay-b', '/home/humble/.local/share/vhc/vhc-relay-b/data', '8766')),
+      applyCurrentA6HostNetworkAttachment(makeHostNetworkRelay('vhc-relay-c', '/home/humble/.local/share/vhc/vhc-relay-c/data', '8767')),
+    ];
+    writeFileSync(inspectPath, JSON.stringify(relays), 'utf8');
+    const result = run('bash', relayOnlyPacketArgs(inspectPath));
+    assert.equal(result.status, 0, result.stderr);
+    const packet = result.stdout;
+    assert.match(packet, /--network host/);
+    assert.doesNotMatch(packet, /--network 'host'/);
+
+    const expectedBase64 = packet.match(/assert_live_topology_parity 'vhc-relay-a' '([^']+)'/)?.[1];
+    assert.ok(expectedBase64);
+    const topology = JSON.parse(Buffer.from(expectedBase64, 'base64').toString('utf8'));
+    assert.equal(topology.network_mode, 'host');
+    assert.deepEqual(topology.network, {
+      name: 'host',
+      network_id: DEFAULT_NETWORK_ID,
+      ipam_config: { ipv4_address: '', ipv6_address: '', link_local_ips: [] },
+      aliases: [],
+      links: [],
+      driver_opts: [],
+      gw_priority: 0,
+      mac_address_intent: '',
+    });
+
+    const stages = [
+      ['A', 'vhc-relay-a', '8765', '# Stage B:'],
+      ['B', 'vhc-relay-b', '8766', '# Stage C:'],
+      ['C', 'vhc-relay-c', '8767', '```'],
+    ];
+    for (const [stageName, name, port, nextMarker] of stages) {
+      const start = packet.indexOf(`# Stage ${stageName}:`);
+      const end = packet.indexOf(nextMarker, start + 1);
+      const stage = packet.slice(start, end > start ? end : undefined);
+      const boundary = stage.indexOf(`assert_relay_removal_boundary '${name}'`);
+      const remove = stage.indexOf(`sudo docker rm -f ${name} &&`);
+      const recreateParity = stage.indexOf(`assert_live_topology_parity '${name}'`, remove);
+      const runtimeVerify = stage.indexOf(`verify_relay_only_runtime '${name}' 'http://127.0.0.1:${port}'`, recreateParity);
+      const verifiedParity = stage.indexOf(`assert_live_topology_parity '${name}'`, recreateParity + 1);
+      const rollbackRun = stage.indexOf(`${name}.rollback.start.out`, verifiedParity);
+      const rollbackParity = stage.indexOf(`assert_live_topology_parity '${name}'`, rollbackRun);
+      const rollbackReadiness = stage.indexOf(`${name}.rollback.readyz.json`, rollbackParity);
+      const finalRollbackParity = stage.indexOf(`assert_live_topology_parity '${name}'`, rollbackParity + 1);
+      assert.ok(
+        boundary >= 0
+          && boundary < remove
+          && remove < recreateParity
+          && recreateParity < runtimeVerify
+          && runtimeVerify < verifiedParity
+          && verifiedParity < rollbackRun
+          && rollbackRun < rollbackParity
+          && rollbackParity < rollbackReadiness
+          && rollbackReadiness < finalRollbackParity,
+        stage,
+      );
+      assert.ok((stage.match(/--network host/g) || []).length >= 2, stage);
+    }
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -1596,6 +1717,32 @@ function applyCurrentA6NetworkAttachment(container) {
     DriverOpts: null,
     GwPriority: 0,
     DNSNames: [],
+  };
+  return container;
+}
+
+function applyCurrentA6HostNetworkAttachment(container) {
+  container.Config.MacAddress = '';
+  container.HostConfig.NetworkMode = 'host';
+  container.HostConfig.Links = null;
+  container.NetworkSettings.Networks = {
+    host: {
+      IPAMConfig: null,
+      Links: null,
+      Aliases: null,
+      NetworkID: DEFAULT_NETWORK_ID,
+      EndpointID: 'runtime-host-endpoint-id',
+      Gateway: '',
+      IPAddress: '',
+      IPPrefixLen: 0,
+      IPv6Gateway: '',
+      GlobalIPv6Address: '',
+      GlobalIPv6PrefixLen: 0,
+      MacAddress: '',
+      DriverOpts: null,
+      GwPriority: 0,
+      DNSNames: null,
+    },
   };
   return container;
 }

--- a/tools/scripts/public-beta-image-deploy.test.mjs
+++ b/tools/scripts/public-beta-image-deploy.test.mjs
@@ -14,6 +14,9 @@ const PACKET_SCRIPT = path.join(REPO_ROOT, 'tools/scripts/emit-a6-public-beta-de
 const RECOVER_PROVENANCE_SCRIPT = path.join(REPO_ROOT, 'tools/scripts/recover-public-beta-origin-provenance.mjs');
 const PUBLIC_BETA_COMPOSE = path.join(REPO_ROOT, 'infra/docker/docker-compose.public-beta.yml');
 const REVIEWED_RELAY_REVISION = '231962bcf73e2730cb2f0234fd9d65c2fc9f69cd';
+const REVIEWED_RELAY_IMAGE_ID = `sha256:${'a'.repeat(64)}`;
+const DEFAULT_NETWORK_ID = 'b'.repeat(64);
+const CURRENT_RELAY_A_IMAGE_ID = `sha256:${'1'.repeat(64)}`;
 
 function run(command, args, options = {}) {
   return spawnSync(command, args, {
@@ -115,9 +118,9 @@ if [[ "\${1:-}" == "image" && "\${2:-}" == "inspect" ]]; then
   arch="\${FAKE_DOCKER_ARCH:-amd64}"
   revision="\${FAKE_DOCKER_REVISION:-test-revision}"
   case "\${image}" in
-    *origin*) id="sha256:origin-image-id" ;;
-    *relay*) id="sha256:relay-image-id" ;;
-    *) id="sha256:unknown-image-id" ;;
+    *origin*) id="sha256:${'c'.repeat(64)}" ;;
+    *relay*) id="sha256:${'d'.repeat(64)}" ;;
+    *) id="sha256:${'e'.repeat(64)}" ;;
   esac
   printf '%s|linux|%s|%s|2026-06-14T00:00:00Z\\n' "\${id}" "\${arch}" "\${revision}"
   exit 0
@@ -221,7 +224,7 @@ test('relay-only image exporter emits exactly one reviewed relay artifact and no
       `#!/usr/bin/env bash
 set -euo pipefail
 if [[ "\${1:-}" == "image" && "\${2:-}" == "inspect" ]]; then
-  printf 'sha256:relay-image-id|linux|amd64|${REVIEWED_RELAY_REVISION}|2026-07-10T00:00:00Z\\n'
+  printf '%s|linux|amd64|${REVIEWED_RELAY_REVISION}|2026-07-10T00:00:00Z\\n' "\${FAKE_DOCKER_IMAGE_ID:-${REVIEWED_RELAY_IMAGE_ID}}"
   exit 0
 fi
 if [[ "\${1:-}" == "save" ]]; then
@@ -262,7 +265,29 @@ exit 2
     assert.equal(manifest.relay_only, true);
     assert.equal(manifest.images.length, 1);
     assert.equal(manifest.images[0].image, 'vhc-public-beta-relay:reviewed');
+    assert.equal(manifest.images[0].image_id, REVIEWED_RELAY_IMAGE_ID);
     assert.equal(manifest.images[0].revision, REVIEWED_RELAY_REVISION);
+    assert.match(packet, new RegExp(REVIEWED_RELAY_IMAGE_ID));
+    assert.match(result.stdout, new RegExp(`relay_image_id=${REVIEWED_RELAY_IMAGE_ID}`));
+    const loadBlock = packet.match(/```bash\n([\s\S]*?)\n```/)?.[1];
+    assert.ok(loadBlock);
+    const loadSyntax = run('bash', ['-n'], { input: `${loadBlock}\n` });
+    assert.equal(loadSyntax.status, 0, loadSyntax.stderr);
+
+    const malformedImageId = run('bash', [
+      EXPORT_SCRIPT,
+      '--relay-only',
+      '--relay-image',
+      'vhc-public-beta-relay:reviewed',
+      '--output-dir',
+      path.join(root, 'malformed-image-id'),
+      '--source-revision',
+      REVIEWED_RELAY_REVISION,
+    ], {
+      env: { ...process.env, PATH: `${bin}:${process.env.PATH}`, FAKE_DOCKER_IMAGE_ID: 'sha256:short' },
+    });
+    assert.equal(malformedImageId.status, 78);
+    assert.match(malformedImageId.stderr, /full immutable sha256 id/);
 
     const skippedRevision = run('bash', [
       EXPORT_SCRIPT,
@@ -740,10 +765,12 @@ test('relay-only deploy packet is inert by default and excludes origin from capt
       'vhc-public-beta-relay:reviewed',
       '--expected-relay-revision',
       REVIEWED_RELAY_REVISION,
+      '--expected-relay-image-id',
+      REVIEWED_RELAY_IMAGE_ID,
     ]);
     assert.equal(result.status, 0, result.stderr);
     assert.match(result.stdout, /A6 S1B Relay-Only Recovery Packet/);
-    assert.match(result.stdout, /Status: `WAITING_FOR_LOU`/);
+    assert.match(result.stdout, /Status: `REVIEW_REQUIRED`/);
     assert.ok(result.stdout.includes(`expected relay revision: \`${REVIEWED_RELAY_REVISION}\``));
     assert.match(result.stdout, /required relay platform: `linux\/amd64`/);
     assert.match(result.stdout, /requires exactly `vhc-relay-a`, `vhc-relay-b`, then `vhc-relay-c`|Scope is exactly `vhc-relay-a`, `vhc-relay-b`, then `vhc-relay-c`/);
@@ -752,8 +779,8 @@ test('relay-only deploy packet is inert by default and excludes origin from capt
     assert.doesNotMatch(result.stdout, /vhc-public-origin|Origin Deploy|new origin image/);
     assert.doesNotMatch(result.stdout, /VH_RELAY_RESOURCE_WATCHDOG_ENABLED=true/);
     assert.doesNotMatch(result.stdout, /do-not-print/);
-    assert.match(result.stdout, /relay_image_platform=.*\.Os.*\.Architecture/);
-    assert.match(result.stdout, /relay_image_revision=.*org\.opencontainers\.image\.revision/);
+    assert.match(result.stdout, /relay_image_binding=.*\.Id.*\.Os.*\.Architecture.*org\.opencontainers\.image\.revision/);
+    assert.ok(result.stdout.includes(REVIEWED_RELAY_IMAGE_ID));
 
     const abbreviatedRevision = run('bash', [
       PACKET_SCRIPT,
@@ -772,6 +799,140 @@ test('relay-only deploy packet is inert by default and excludes origin from capt
   }
 });
 
+test('relay-only deploy packet accepts only an exact unique canonical A-B-C inspect array and full image id', () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), 'vh-public-beta-relay-only-capture-shape-'));
+  try {
+    const canonical = [
+      makeRelay('vhc-relay-a', '/home/humble/.local/share/vhc/vhc-relay-a/data'),
+      makeRelay('vhc-relay-b', '/home/humble/.local/share/vhc/vhc-relay-b/data'),
+      makeRelay('vhc-relay-c', '/home/humble/.local/share/vhc/vhc-relay-c/data'),
+    ];
+    const cases = [
+      ['object-not-array', { relays: canonical }],
+      ['missing-c', canonical.slice(0, 2)],
+      ['duplicate-a', [canonical[0], structuredClone(canonical[0]), canonical[2]]],
+      ['extra-entry', [...canonical, makeContainer('vhc-public-origin', 'origin:old', [], [], {})]],
+      ['blank-name', canonical.map((relay, index) => index === 1 ? { ...relay, Name: '' } : relay)],
+      ['malformed-name', canonical.map((relay, index) => index === 1 ? { ...relay, Name: 'vhc-relay-b' } : relay)],
+      ['wrong-canonical-name', canonical.map((relay, index) => index === 1 ? { ...relay, Name: '/relay-b' } : relay)],
+    ];
+    for (const [label, payload] of cases) {
+      const inspectPath = path.join(root, `${label}.json`);
+      writeFileSync(inspectPath, JSON.stringify(payload), 'utf8');
+      const result = run('bash', relayOnlyPacketArgs(inspectPath, { recreate: false }));
+      assert.equal(result.status, 78, `${label}: ${result.stderr}`);
+      assert.match(result.stderr, /inspect JSON must be an array|exactly three unique canonical entries/);
+    }
+
+    const inspectPath = path.join(root, 'canonical.json');
+    writeFileSync(inspectPath, JSON.stringify(canonical), 'utf8');
+    const malformedIdArgs = relayOnlyPacketArgs(inspectPath, { recreate: false, imageId: 'sha256:short' });
+    const malformedId = run('bash', malformedIdArgs);
+    assert.equal(malformedId.status, 64);
+    assert.match(malformedId.stderr, /full lowercase sha256 image id from artifact-manifest\.json/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('relay-only deploy packet preserves every supported network attachment intent and ignores runtime endpoint identity', () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), 'vh-public-beta-relay-only-network-intent-'));
+  try {
+    const inspectPath = path.join(root, 'inspect.json');
+    const relays = [
+      applyFullNetworkAttachment(makeRelay('vhc-relay-a', '/home/humble/.local/share/vhc/vhc-relay-a/data')),
+      applyCurrentA6NetworkAttachment(makeRelay('vhc-relay-b', '/home/humble/.local/share/vhc/vhc-relay-b/data')),
+      applyCurrentA6NetworkAttachment(makeRelay('vhc-relay-c', '/home/humble/.local/share/vhc/vhc-relay-c/data')),
+    ];
+    writeFileSync(inspectPath, JSON.stringify(relays), 'utf8');
+    const result = run('bash', relayOnlyPacketArgs(inspectPath));
+    assert.equal(result.status, 0, result.stderr);
+    const packet = result.stdout;
+    assert.match(packet, /--network 'name=vh_public_beta,ip=10\.10\.0\.10,ip6=fd00::10,link-local-ip=169\.254\.10\.10,alias=relay-a,driver-opt=com\.example\.mode=locked,gw-priority=7'/);
+    assert.match(packet, /--mac-address '02:42:ac:11:00:0a'/);
+    assert.match(packet, /--link 'database:db'/);
+    assert.ok(packet.includes(`assert_relay_removal_boundary 'vhc-relay-a'`));
+    assert.ok(packet.includes(`'vhc-public-beta-relay:reviewed' '${REVIEWED_RELAY_IMAGE_ID}' '${REVIEWED_RELAY_REVISION}'`));
+    assert.match(packet, new RegExp(`sudo docker run -d[\\s\\S]*${REVIEWED_RELAY_IMAGE_ID}`));
+    assert.doesNotMatch(packet, /sudo docker run -d[\s\S]*vhc-public-beta-relay:reviewed(?:\s|$)/);
+
+    const expectedBase64 = packet.match(/assert_live_topology_parity 'vhc-relay-a' '([^']+)'/)?.[1];
+    assert.ok(expectedBase64);
+    const topology = JSON.parse(Buffer.from(expectedBase64, 'base64').toString('utf8'));
+    assert.deepEqual(topology.network, {
+      name: 'vh_public_beta',
+      network_id: DEFAULT_NETWORK_ID,
+      ipam_config: {
+        ipv4_address: '10.10.0.10',
+        ipv6_address: 'fd00::10',
+        link_local_ips: ['169.254.10.10'],
+      },
+      aliases: ['relay-a'],
+      links: ['database:db'],
+      driver_opts: [{ key: 'com.example.mode', value: 'locked' }],
+      gw_priority: 7,
+      mac_address_intent: '02:42:ac:11:00:0a',
+    });
+    assert.doesNotMatch(JSON.stringify(topology), /runtime-endpoint-id|10\.10\.0\.211|fd00::211/);
+
+    const stageA = packet.slice(packet.indexOf('# Stage A:'), packet.indexOf('# Stage B:'));
+    const beforeRemoval = stageA.indexOf("assert_relay_removal_boundary 'vhc-relay-a'");
+    const remove = stageA.indexOf('sudo docker rm -f vhc-relay-a &&');
+    const postRecreateTopology = stageA.indexOf("assert_live_topology_parity 'vhc-relay-a'", remove);
+    const verify = stageA.indexOf("verify_relay_only_runtime 'vhc-relay-a'", postRecreateTopology);
+    const postVerificationTopology = stageA.indexOf("assert_live_topology_parity 'vhc-relay-a'", postRecreateTopology + 1);
+    assert.ok(beforeRemoval >= 0 && beforeRemoval < remove && remove < postRecreateTopology && postRecreateTopology < verify && verify < postVerificationTopology, stageA);
+    assert.ok((stageA.match(/assert_live_topology_parity 'vhc-relay-a'/g) || []).length >= 5, stageA);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('relay-only deploy packet rejects unsupported or nonportable network attachment shapes', () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), 'vh-public-beta-relay-only-network-reject-'));
+  try {
+    const base = () => [
+      applyFullNetworkAttachment(makeRelay('vhc-relay-a', '/home/humble/.local/share/vhc/vhc-relay-a/data')),
+      makeRelay('vhc-relay-b', '/home/humble/.local/share/vhc/vhc-relay-b/data'),
+      makeRelay('vhc-relay-c', '/home/humble/.local/share/vhc/vhc-relay-c/data'),
+    ];
+    const cases = [
+      ['unknown-attachment-field', (relay) => { relay.NetworkSettings.Networks.vh_public_beta.UnsupportedField = true; }],
+      ['unknown-ipam-field', (relay) => { relay.NetworkSettings.Networks.vh_public_beta.IPAMConfig.Address = '10.0.0.1'; }],
+      ['ipam-shape', (relay) => { relay.NetworkSettings.Networks.vh_public_beta.IPAMConfig = []; }],
+      ['duplicate-link-local', (relay) => { relay.NetworkSettings.Networks.vh_public_beta.IPAMConfig.LinkLocalIPs = ['169.254.1.1', '169.254.1.1']; }],
+      ['duplicate-alias', (relay) => { relay.NetworkSettings.Networks.vh_public_beta.Aliases = ['relay-a', 'relay-a']; }],
+      ['nonportable-alias', (relay) => { relay.NetworkSettings.Networks.vh_public_beta.Aliases = ['relay,a']; }],
+      ['driver-opts-shape', (relay) => { relay.NetworkSettings.Networks.vh_public_beta.DriverOpts = []; }],
+      ['driver-opt-nonportable', (relay) => { relay.NetworkSettings.Networks.vh_public_beta.DriverOpts = { mode: 'a,b' }; }],
+      ['gw-priority-shape', (relay) => { relay.NetworkSettings.Networks.vh_public_beta.GwPriority = '7'; }],
+      ['conflicting-links', (relay) => { relay.NetworkSettings.Networks.vh_public_beta.Links = ['other:alias']; }],
+      ['missing-network-id', (relay) => { relay.NetworkSettings.Networks.vh_public_beta.NetworkID = ''; }],
+      ['network-mode-attachment-mismatch', (relay) => { relay.HostConfig.NetworkMode = 'other_network'; }],
+      ['multiple-networks', (relay) => { relay.NetworkSettings.Networks.extra = { NetworkID: '9'.repeat(64) }; }],
+      ['malformed-runtime-endpoint', (relay) => { relay.NetworkSettings.Networks.vh_public_beta.EndpointID = { secret: 'DO_NOT_LEAK' }; }],
+      ['malformed-runtime-prefix', (relay) => { relay.NetworkSettings.Networks.vh_public_beta.IPPrefixLen = '24'; }],
+      ['malformed-runtime-dns', (relay) => { relay.NetworkSettings.Networks.vh_public_beta.DNSNames = 'relay-a'; }],
+      ['malformed-host-links', (relay) => { relay.HostConfig.Links = 'database:db'; }],
+      ['invalid-static-mac', (relay) => { relay.Config.MacAddress = 'not-a-mac'; }],
+      ['mismatched-static-mac', (relay) => { relay.Config.MacAddress = '02:42:ac:11:00:0b'; }],
+      ['malformed-rollback-image-id', (relay) => { relay.Image = 'sha256:short'; }],
+    ];
+    for (const [label, mutate] of cases) {
+      const relays = base();
+      mutate(relays[0]);
+      const inspectPath = path.join(root, `${label}.json`);
+      writeFileSync(inspectPath, JSON.stringify(relays), 'utf8');
+      const result = run('bash', relayOnlyPacketArgs(inspectPath));
+      assert.equal(result.status, 78, `${label}: ${result.stderr}\n${result.stdout}`);
+      assert.match(result.stdout, /Packet Blockers/);
+      assert.doesNotMatch(`${result.stdout}\n${result.stderr}`, /DO_NOT_LEAK/);
+    }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test('relay-only deploy packet gates an A-B-C rolling recovery with exact probes and serial rollback', () => {
   const root = mkdtempSync(path.join(os.tmpdir(), 'vh-public-beta-relay-only-recreate-'));
   try {
@@ -781,6 +942,7 @@ test('relay-only deploy packet gates an A-B-C rolling recovery with exact probes
       makeRelay('vhc-relay-b', '/home/humble/.local/share/vhc/vhc-relay-b/data'),
       makeRelay('vhc-relay-c', '/home/humble/.local/share/vhc/vhc-relay-c/data'),
     ];
+    applyFullNetworkAttachment(relays[0]);
     relays[0].Config.User = '1000:1000';
     relays[0].HostConfig.Memory = 2415919104;
     relays[0].HostConfig.MemorySwap = 2415919104;
@@ -794,11 +956,13 @@ test('relay-only deploy packet gates an A-B-C rolling recovery with exact probes
       'vhc-public-beta-relay:reviewed',
       '--expected-relay-revision',
       REVIEWED_RELAY_REVISION,
+      '--expected-relay-image-id',
+      REVIEWED_RELAY_IMAGE_ID,
       '--include-recreate-commands',
     ]);
     assert.equal(result.status, 0, result.stderr);
     const packet = result.stdout;
-    assert.match(packet, /Hard authority gate: do not run this section until Lou explicitly approves/);
+    assert.match(packet, /Hard execution gate: do not run this section unless recorded Lou authority/);
     const stageA = packet.indexOf('# Stage A: re-prove parked publisher and exact live/captured prestate, then replace only vhc-relay-a.');
     const goA = packet.indexOf('vhc-relay-a: GO for next relay');
     const stageB = packet.indexOf('# Stage B: re-prove parked publisher and exact live/captured prestate, then replace only vhc-relay-b.');
@@ -824,7 +988,7 @@ test('relay-only deploy packet gates an A-B-C rolling recovery with exact probes
     assert.match(packet, /\/vh\/news\/synthesis-lifecycle.*readback=exact.*news-synthesis-lifecycle-not-found/);
     for (const name of ['vhc-relay-a', 'vhc-relay-b', 'vhc-relay-c']) {
       assert.match(packet, new RegExp(`${name}: verification failed; rolling back only this relay and stopping`));
-      assert.match(packet, new RegExp(`sha256:${name}`));
+      assert.ok(packet.includes(relays.find((relay) => relay.Name === `/${name}`).Image));
       const stageStart = packet.indexOf(`# Stage ${name.endsWith('-a') ? 'A' : name.endsWith('-b') ? 'B' : 'C'}:`);
       const remove = packet.indexOf(`sudo docker rm -f ${name} &&`, stageStart);
       const publisherCheck = packet.indexOf('assert_publisher_parked', stageStart);
@@ -929,6 +1093,7 @@ test('relay-only approval block keeps precondition refusal nonmutating and close
       makeRelay('vhc-relay-b', '/home/humble/.local/share/vhc/vhc-relay-b/data'),
       makeRelay('vhc-relay-c', '/home/humble/.local/share/vhc/vhc-relay-c/data'),
     ];
+    applyFullNetworkAttachment(relays[0]);
     relays[0].Config.User = '1000:1000';
     relays[0].HostConfig.Memory = 2415919104;
     relays[0].HostConfig.MemorySwap = 2415919104;
@@ -942,6 +1107,8 @@ test('relay-only approval block keeps precondition refusal nonmutating and close
       'vhc-public-beta-relay:reviewed',
       '--expected-relay-revision',
       REVIEWED_RELAY_REVISION,
+      '--expected-relay-image-id',
+      REVIEWED_RELAY_IMAGE_ID,
       '--include-recreate-commands',
     ]);
     assert.equal(emitted.status, 0, emitted.stderr);
@@ -1001,9 +1168,11 @@ if [[ "\${command}" == "image" ]]; then
   while [[ $# -gt 0 ]]; do
     if [[ "$1" == "--format" ]]; then format="\${2:-}"; shift 2; else shift; fi
   done
-  if [[ "\${format}" == *Architecture* ]]; then printf 'linux/amd64\n';
+  if [[ "\${format}" == *'|'* ]]; then printf '%s|linux/amd64|${REVIEWED_RELAY_REVISION}\n' "\${FAKE_RELAY_BINDING_ID:-${REVIEWED_RELAY_IMAGE_ID}}";
+  elif [[ "\${format}" == *Architecture* ]]; then printf 'linux/amd64\n';
   elif [[ "\${format}" == *org.opencontainers.image.revision* ]]; then printf '%s\n' '${REVIEWED_RELAY_REVISION}';
-  else printf 'sha256:reviewed-image\n'; fi
+  elif [[ "\${image}" == sha256:* ]]; then printf '%s\n' "\${image}";
+  else printf '${REVIEWED_RELAY_IMAGE_ID}\n'; fi
   exit 0
 fi
 if [[ "\${command}" == "inspect" ]]; then
@@ -1019,9 +1188,9 @@ if [[ "\${command}" == "inspect" ]]; then
   elif [[ "\${format}" == *State.Running* ]]; then printf 'true\n';
   elif [[ "\${format}" == *State.OOMKilled* ]]; then printf 'false\n';
   elif [[ "\${format}" == *Config.Image* ]]; then
-    if [[ "\${state}" == "new" ]]; then printf 'vhc-public-beta-relay:reviewed\n'; else printf 'sha256:vhc-relay-a\n'; fi
+    if [[ "\${state}" == "new" ]]; then printf '${REVIEWED_RELAY_IMAGE_ID}\n'; else printf '${CURRENT_RELAY_A_IMAGE_ID}\n'; fi
   elif [[ "\${format}" == *'.Image'* ]]; then
-    if [[ "\${state}" == "new" ]]; then printf 'sha256:reviewed-image\n'; else printf 'sha256:vhc-relay-a\n'; fi
+    if [[ "\${state}" == "new" ]]; then printf '${REVIEWED_RELAY_IMAGE_ID}\n'; else printf '${CURRENT_RELAY_A_IMAGE_ID}\n'; fi
   elif [[ "\${format}" == *Config.Env* ]]; then printf '%s\n' 'NODE_ENV=production' 'GUN_FILE=/data' 'VH_RELAY_DAEMON_TOKEN=do-not-print';
   else exit 2; fi
   exit 0
@@ -1039,7 +1208,7 @@ if [[ "\${command}" == "run" ]]; then
   image="\${*: -1}"
   printf 'run:%s\n' "\${image}" >> "\${FAKE_DOCKER_LOG:?}"
   if [[ "\${FAKE_ROLLBACK_FAILURE:-}" == "start" && "\${count}" -ge 2 ]]; then exit 1; fi
-  if [[ "\${image}" == *reviewed* ]]; then printf 'new\n' > "\${FAKE_DOCKER_STATE_FILE}"; else printf 'rollback\n' > "\${FAKE_DOCKER_STATE_FILE}"; fi
+  if [[ "\${image}" == '${REVIEWED_RELAY_IMAGE_ID}' ]]; then printf 'new\n' > "\${FAKE_DOCKER_STATE_FILE}"; else printf 'rollback\n' > "\${FAKE_DOCKER_STATE_FILE}"; fi
   printf 'fake-container-id\n'
   exit 0
 fi
@@ -1157,6 +1326,13 @@ printf 'rm-b\n' >> '${files.mutationLog}'`, {
       ['memory swap', (relay) => { relay.HostConfig.MemorySwap += 1; }],
       ['network mode', (relay) => { relay.HostConfig.NetworkMode = 'host'; }],
       ['networks', (relay) => { relay.NetworkSettings.Networks = { drift: {} }; }],
+      ['network id', (relay) => { relay.NetworkSettings.Networks.vh_public_beta.NetworkID = '9'.repeat(64); }],
+      ['static ipv4 intent', (relay) => { relay.NetworkSettings.Networks.vh_public_beta.IPAMConfig.IPv4Address = '10.10.0.11'; }],
+      ['aliases', (relay) => { relay.NetworkSettings.Networks.vh_public_beta.Aliases.push('new-alias'); }],
+      ['links', (relay) => { relay.HostConfig.Links = ['other:alias']; relay.NetworkSettings.Networks.vh_public_beta.Links = ['other:alias']; }],
+      ['driver opts', (relay) => { relay.NetworkSettings.Networks.vh_public_beta.DriverOpts['com.example.mode'] = 'changed'; }],
+      ['gateway priority', (relay) => { relay.NetworkSettings.Networks.vh_public_beta.GwPriority = 8; }],
+      ['static mac intent', (relay) => { relay.Config.MacAddress = '02:42:ac:11:00:0b'; relay.NetworkSettings.Networks.vh_public_beta.MacAddress = '02:42:ac:11:00:0b'; }],
       ['ports', (relay) => { relay.HostConfig.PortBindings['7777/tcp'][0].HostPort = '9999'; }],
       ['mounts', (relay) => { relay.Mounts[0].Source = '/HOSTILE_SECRET_DO_NOT_LEAK'; }],
       ['env', (relay) => { relay.Config.Env.push('PRIVATE=HOSTILE_SECRET_DO_NOT_LEAK'); }],
@@ -1170,6 +1346,22 @@ printf 'rm-b\n' >> '${files.mutationLog}'`, {
       assert.equal(rejected.status, 78, `${label}: ${rejected.stderr}`);
       assert.match(rejected.stderr, /captured_live_topology_parity_failed/);
       assert.doesNotMatch(rejected.stderr, /HOSTILE_SECRET_DO_NOT_LEAK/);
+    }
+
+    const runtimeOnlyMutations = [
+      (relay) => { relay.NetworkSettings.Networks.vh_public_beta.EndpointID = 'different-runtime-endpoint'; },
+      (relay) => { relay.NetworkSettings.Networks.vh_public_beta.Gateway = '10.10.0.254'; },
+      (relay) => { relay.NetworkSettings.Networks.vh_public_beta.IPAddress = '10.10.0.222'; relay.NetworkSettings.Networks.vh_public_beta.IPPrefixLen = 25; },
+      (relay) => { relay.NetworkSettings.Networks.vh_public_beta.GlobalIPv6Address = 'fd00::222'; relay.NetworkSettings.Networks.vh_public_beta.GlobalIPv6PrefixLen = 96; },
+      (relay) => { relay.NetworkSettings.Networks.vh_public_beta.DNSNames = ['different-runtime-name']; },
+    ];
+    for (const mutate of runtimeOnlyMutations) {
+      const changed = structuredClone(relays[0]);
+      mutate(changed);
+      writeFileSync(files.liveInspect, JSON.stringify([changed]), 'utf8');
+      resetFakes();
+      const accepted = runBash(topologyScript, { FAKE_INSPECT_JSON: files.liveInspect, FAKE_PUBLISHER_SEQUENCE: 'failed,failed,exit-code,78' });
+      assert.equal(accepted.status, 0, accepted.stderr);
     }
 
     const prestateScript = `${helpers}\nassert_relay_prestate 'vhc-relay-a' 'http://127.0.0.1:8765' 'prestage-a'`;
@@ -1228,13 +1420,19 @@ printf 'rm-b\n' >> '${files.mutationLog}'`, {
         overrides: 'assert_live_topology_parity() { return 0; }\nassert_relay_prestate() { return 0; }',
         publisher: 'active,running,success,0',
       },
+      {
+        label: 'same-revision-wrong-image-id',
+        overrides: 'assert_live_topology_parity() { return 0; }\nassert_relay_prestate() { return 0; }\nassert_publisher_parked() { return 0; }',
+        publisher: 'failed,failed,exit-code,78',
+        env: { FAKE_RELAY_BINDING_ID: `sha256:${'8'.repeat(64)}` },
+      },
     ];
     for (const precondition of preconditionCases) {
       resetFakes();
       const rejected = runBash(`${helpers}
 ${precondition.overrides}
 verify_relay_only_runtime() { return 0; }
-${stageA}`, { FAKE_PUBLISHER_SEQUENCE: precondition.publisher });
+${stageA}`, { FAKE_PUBLISHER_SEQUENCE: precondition.publisher, ...precondition.env });
       assert.equal(rejected.status, 78, `${precondition.label}: ${rejected.stderr}`);
       assert.match(rejected.stderr, /pre_mutation_refused_no_change/);
       assert.doesNotMatch(rejected.stderr, /verification failed|rollback_/);
@@ -1257,8 +1455,8 @@ ${stageA}`, {
     assert.match(resumedAfterVerification.stderr, /rollback_completed_closed/);
     const resumedDockerLog = readFileSync(files.dockerLog, 'utf8');
     assert.equal((resumedDockerLog.match(/^rm:vhc-relay-a$/gm) || []).length, 2, resumedDockerLog);
-    assert.match(resumedDockerLog, /run:vhc-public-beta-relay:reviewed/);
-    assert.match(resumedDockerLog, /run:sha256:vhc-relay-a/);
+    assert.ok(resumedDockerLog.includes(`run:${REVIEWED_RELAY_IMAGE_ID}`));
+    assert.ok(resumedDockerLog.includes(`run:${CURRENT_RELAY_A_IMAGE_ID}`));
     assert.doesNotMatch(resumedDockerLog, /vhc-relay-b|vhc-relay-c/);
 
     const rollbackHarness = `${helpers}
@@ -1352,6 +1550,72 @@ function makeRelay(name, dataDir) {
   }], { '7777/tcp': [{ HostIp: '127.0.0.1', HostPort: hostPort }] });
 }
 
+function applyFullNetworkAttachment(container) {
+  const runtimeId = 'f'.repeat(64);
+  container.Id = runtimeId;
+  container.Config.MacAddress = '02:42:ac:11:00:0a';
+  container.HostConfig.Links = ['database:db'];
+  container.NetworkSettings.Networks.vh_public_beta = {
+    IPAMConfig: {
+      IPv4Address: '10.10.0.10',
+      IPv6Address: 'fd00::10',
+      LinkLocalIPs: ['169.254.10.10'],
+    },
+    Links: ['database:db'],
+    Aliases: ['relay-a', runtimeId.slice(0, 12)],
+    NetworkID: DEFAULT_NETWORK_ID,
+    EndpointID: 'runtime-endpoint-id',
+    Gateway: '10.10.0.1',
+    IPAddress: '10.10.0.211',
+    IPPrefixLen: 24,
+    IPv6Gateway: 'fd00::1',
+    GlobalIPv6Address: 'fd00::211',
+    GlobalIPv6PrefixLen: 64,
+    MacAddress: '02:42:ac:11:00:0a',
+    DriverOpts: { 'com.example.mode': 'locked' },
+    GwPriority: 7,
+    DNSNames: ['relay-a', runtimeId.slice(0, 12)],
+  };
+  return container;
+}
+
+function applyCurrentA6NetworkAttachment(container) {
+  container.NetworkSettings.Networks.vh_public_beta = {
+    IPAMConfig: null,
+    Links: [],
+    Aliases: [],
+    NetworkID: DEFAULT_NETWORK_ID,
+    EndpointID: 'runtime-endpoint-id',
+    Gateway: '172.30.0.1',
+    IPAddress: '172.30.0.10',
+    IPPrefixLen: 16,
+    IPv6Gateway: '',
+    GlobalIPv6Address: '',
+    GlobalIPv6PrefixLen: 0,
+    MacAddress: '02:42:ac:1e:00:0a',
+    DriverOpts: null,
+    GwPriority: 0,
+    DNSNames: [],
+  };
+  return container;
+}
+
+function relayOnlyPacketArgs(inspectPath, options = {}) {
+  return [
+    PACKET_SCRIPT,
+    '--relay-only',
+    '--inspect-json',
+    inspectPath,
+    '--new-relay-image',
+    options.image || 'vhc-public-beta-relay:reviewed',
+    '--expected-relay-revision',
+    REVIEWED_RELAY_REVISION,
+    '--expected-relay-image-id',
+    options.imageId || REVIEWED_RELAY_IMAGE_ID,
+    ...(options.recreate === false ? [] : ['--include-recreate-commands']),
+  ];
+}
+
 function makeHostNetworkRelay(name, dataDir, gunPort) {
   return makeContainer(name, 'vhc-public-beta-relay:old', [
     'NODE_ENV=production',
@@ -1370,20 +1634,30 @@ function makeHostNetworkRelay(name, dataDir, gunPort) {
 function makeContainer(name, image, env, mounts, portBindings, options = {}) {
   return {
     Name: `/${name}`,
-    Image: `sha256:${name}`,
+    Image: name === 'vhc-relay-a'
+      ? CURRENT_RELAY_A_IMAGE_ID
+      : name === 'vhc-relay-b'
+        ? `sha256:${'2'.repeat(64)}`
+        : name === 'vhc-relay-c'
+          ? `sha256:${'3'.repeat(64)}`
+          : `sha256:${'4'.repeat(64)}`,
     Config: {
       Image: image,
       Env: env,
+      MacAddress: options.macAddress || '',
     },
     HostConfig: {
       RestartPolicy: { Name: 'unless-stopped', MaximumRetryCount: 0 },
       PortBindings: portBindings,
       NetworkMode: options.networkMode || 'vh_public_beta',
+      Links: options.links || null,
     },
     Mounts: mounts,
     NetworkSettings: {
       Networks: options.networks || {
-        vh_public_beta: {},
+        vh_public_beta: {
+          NetworkID: DEFAULT_NETWORK_ID,
+        },
       },
     },
   };

--- a/tools/scripts/public-beta-next-phase-sprint.test.mjs
+++ b/tools/scripts/public-beta-next-phase-sprint.test.mjs
@@ -140,6 +140,8 @@ test('G3 fails closed on the immutable relay image and restart-authority contrad
     'array of exactly three',
     'semantic network attachment prestate',
     'runtime endpoint ids',
+    'current A6 `host`/`host` topology',
+    'exact `--network host`',
   ]) {
     assertIncludes(checklist, token, `G3 checklist token ${token}`);
   }
@@ -155,6 +157,9 @@ test('G3 fails closed on the immutable relay image and restart-authority contrad
     '64-hex `NetworkID`',
     'Runtime-assigned endpoint ids',
     'same-revision wrong image',
+    '`HostConfig.NetworkMode=host`',
+    'all 15 canonical endpoint',
+    '`--network host`',
     'story with `readback=exact`',
     'latest-index `story_id`',
     'hot-index `story_id`',
@@ -179,6 +184,8 @@ test('G3 fails closed on the immutable relay image and restart-authority contrad
   assertIncludes(deployPacketScript, '--expected-relay-revision', 'deploy expected relay revision');
   assertIncludes(deployPacketScript, '--expected-relay-image-id', 'deploy expected immutable relay image id');
   assertIncludes(exportScript, '--relay-only', 'export relay-only flag');
+  assertIncludes(exportScript, 'bash -s --', 'export remote binding verifier shell');
+  assertIncludes(exportScript, `--format '{{.Id}}|{{.Os}}/{{.Architecture}}|{{index .Config.Labels "org.opencontainers.image.revision"}}'`, 'export exact remote Docker format');
   assert.ok(!packetExecutor.includes('relay_only'), 'packet executor must not gain a relay-only action');
   assert.ok(!packetExecutor.includes('--relay-only'), 'packet executor must not pass the relay-only flag');
   assert.throws(() => buildExecutorPlan({

--- a/tools/scripts/public-beta-next-phase-sprint.test.mjs
+++ b/tools/scripts/public-beta-next-phase-sprint.test.mjs
@@ -118,8 +118,8 @@ test('S1B pins the real daemon exit consumer and readback inventory', () => {
 
 test('G3 fails closed on the immutable relay image and restart-authority contradiction', () => {
   for (const token of [
-    '`blocked_pending_relay_restart_boundary_correction`',
-    '`WAITING_FOR_LOU`',
+    '`boundary_approved_exact_packet_correction_in_review`',
+    '`NO-GO`',
     '`infra/relay/server.js`',
     'immutable image',
     'public-beta compose mounts',
@@ -136,16 +136,25 @@ test('G3 fails closed on the immutable relay image and restart-authority contrad
     'absent watchdog-trip row as semantic zero only with exactly one valid uptime',
     'empty/random, malformed, duplicate, or nonzero telemetry',
     'hostile/unexpected exact-readback bodies private',
+    'export manifest\'s full immutable `sha256:` relay',
+    'array of exactly three',
+    'semantic network attachment prestate',
+    'runtime endpoint ids',
   ]) {
     assertIncludes(checklist, token, `G3 checklist token ${token}`);
   }
   for (const token of [
-    'Status: `blocked_pending_relay_restart_boundary_correction`',
-    'Decision: `WAITING_FOR_LOU`',
+    'Status: `boundary_approved_exact_packet_correction_in_review`',
+    'Decision: `NO-GO_PENDING_EXACT_PACKET_REVIEW`',
     'COPY server.js /app/server.js',
     'bind-mounts only `/data`',
     '--relay-only',
     '--expected-relay-revision',
+    '--expected-relay-image-id',
+    'artifact-manifest.json',
+    '64-hex `NetworkID`',
+    'Runtime-assigned endpoint ids',
+    'same-revision wrong image',
     'story with `readback=exact`',
     'latest-index `story_id`',
     'hot-index `story_id`',
@@ -168,6 +177,7 @@ test('G3 fails closed on the immutable relay image and restart-authority contrad
   assertIncludes(canon, RECOVERY_PACKET_PATH, 'G3 recovery packet canon route');
   assertIncludes(deployPacketScript, '--relay-only', 'deploy relay-only flag');
   assertIncludes(deployPacketScript, '--expected-relay-revision', 'deploy expected relay revision');
+  assertIncludes(deployPacketScript, '--expected-relay-image-id', 'deploy expected immutable relay image id');
   assertIncludes(exportScript, '--relay-only', 'export relay-only flag');
   assert.ok(!packetExecutor.includes('relay_only'), 'packet executor must not gain a relay-only action');
   assert.ok(!packetExecutor.includes('--relay-only'), 'packet executor must not pass the relay-only flag');


### PR DESCRIPTION
## Summary
- require exact ordered A/B/C capture and immutable full relay image IDs
- preserve and verify semantic host-network topology through recreate and rollback
- execute-test the remote image binding command and reject same-revision wrong IDs
- update the S1B packet, handoff, checklist, and governance guards

## Validation
- 18/18 public-beta image deploy tests
- 9/9 next-phase sprint guards
- launch closeout 19/11/11
- docs governance 159 files
- both shell syntax checks
- git diff --check

## Review
Independent first pass returned NO-GO on remote quoting and missing exact host-network coverage. Both were corrected, then the same reviewer returned GO at exact head 242cf27b634a3dfc87a954932d55fe79e0cf50e2 with no P0/P1/P2.

No A6, publisher, Gmail, provider, pager, or production mutation was performed.