### PR TITLE
fix: scope publisher diagnostics to runtime boundaries

### DIFF
--- a/packages/ai-engine/src/newsRuntime.test.ts
+++ b/packages/ai-engine/src/newsRuntime.test.ts
@@ -236,6 +236,30 @@ describe('newsRuntime', () => {
     expect(__internal.resolvePruneStaleBundles(BASE_CONFIG)).toBe(true);
     expect(__internal.resolvePruneStaleBundles({ ...BASE_CONFIG, pruneStaleBundles: false })).toBe(false);
 
+    const rawWrittenBundles = [
+      storyBundle('raw-0'),
+      storyBundle('raw-1'),
+      storyBundle('raw-0'),
+      ...Array.from({ length: 10 }, (_, index) => storyBundle(`raw-${index + 2}`)),
+    ];
+    const successfulRawStoryIds = new Set(rawWrittenBundles.map((bundle) => bundle.story_id));
+    successfulRawStoryIds.delete('raw-3');
+    expect(__internal.firstSuccessfulStoryIdsInPublicationOrder(
+      rawWrittenBundles,
+      successfulRawStoryIds,
+    )).toEqual([
+      'raw-0',
+      'raw-1',
+      'raw-2',
+      'raw-4',
+      'raw-5',
+      'raw-6',
+      'raw-7',
+      'raw-8',
+      'raw-9',
+      'raw-10',
+    ]);
+
     const originalProcess = globalThis.process;
     vi.stubGlobal('process', undefined);
     expect(__internal.readEnvVar('CUSTOM_RUNTIME_ENV')).toBeUndefined();
@@ -597,8 +621,12 @@ describe('newsRuntime', () => {
     orchestrateNewsPipelineMock.mockResolvedValue(batch(bundles));
 
     const releases: Array<() => void> = [];
-    const writeStoryBundle = vi.fn(async () => new Promise<void>((resolve) => {
-      releases.push(resolve);
+    const completionOrder: string[] = [];
+    const writeStoryBundle = vi.fn(async (_client, bundle: StoryBundle) => new Promise<void>((resolve) => {
+      releases.push(() => {
+        completionOrder.push(bundle.story_id);
+        resolve();
+      });
     }));
     const onSynthesisCandidate = vi.fn();
     const onTickSummary = vi.fn();
@@ -620,7 +648,7 @@ describe('newsRuntime', () => {
       'story-middle',
     ]);
 
-    releases[0]?.();
+    releases[1]?.();
     await flushTasks();
     await vi.waitFor(() => {
       expect(writeStoryBundle).toHaveBeenCalledTimes(3);
@@ -631,16 +659,18 @@ describe('newsRuntime', () => {
       'story-slowest',
     ]);
 
-    releases[1]?.();
     releases[2]?.();
+    releases[0]?.();
     await vi.waitFor(() => {
       expect(onTickSummary).toHaveBeenCalled();
     });
+    expect(completionOrder).toEqual(['story-middle', 'story-slowest', 'story-fastest']);
     expect(onSynthesisCandidate).toHaveBeenCalledTimes(3);
     expect(onTickSummary).toHaveBeenCalledWith(expect.objectContaining({
       raw_write_concurrency: 2,
       raw_write_attempted_count: 3,
       raw_wrote_count: 3,
+      first_raw_written_story_ids: ['story-fastest', 'story-middle', 'story-slowest'],
     }));
 
     handle.stop();
@@ -677,6 +707,7 @@ describe('newsRuntime', () => {
       raw_write_attempted_count: 0,
       raw_write_suppressed_count: 2,
       synthesis_candidate_suppressed_count: 2,
+      first_raw_written_story_ids: [],
     }));
 
     handle.stop();
@@ -752,6 +783,7 @@ describe('newsRuntime', () => {
       raw_wrote_count: 1,
       raw_write_failed_count: 1,
       synthesis_candidate_enqueued_count: 1,
+      first_raw_written_story_ids: ['write-succeeds'],
     }));
 
     handle.stop();
@@ -1421,6 +1453,7 @@ describe('newsRuntime', () => {
       last_stage: 'failed',
       nonfatal_prewrite_failure_count: 0,
       raw_write_attempted_count: 0,
+      first_raw_written_story_ids: [],
       error: 'writeStoryBundle adapter is required',
     }));
     handle.stop();
@@ -1454,6 +1487,7 @@ describe('newsRuntime', () => {
       failed_stage: 'writing_raw_bundles',
       last_stage: 'failed',
       nonfatal_prewrite_failure_count: 0,
+      first_raw_written_story_ids: [],
       error: expect.stringContaining('failed to publish any selected bundles'),
     }));
     expect(handle.lastRun()).toBeNull();
@@ -1542,6 +1576,7 @@ describe('newsRuntime', () => {
       nonfatal_prewrite_failure_count: 1,
       raw_write_attempted_count: 0,
       raw_wrote_count: 0,
+      first_raw_written_story_ids: [],
       error: orchestratorError.message,
     }));
     expect(handle.lastRun()).toBeNull();
@@ -1559,6 +1594,7 @@ describe('newsRuntime', () => {
       nonfatal_prewrite_failure_count: 0,
       raw_write_attempted_count: 1,
       raw_wrote_count: 1,
+      first_raw_written_story_ids: ['story-1'],
     }));
     expect(handle.lastRun()).toBeInstanceOf(Date);
 
@@ -1576,11 +1612,13 @@ describe('newsRuntime', () => {
       .mockResolvedValueOnce(undefined);
     const onError = vi.fn();
     const onSynthesisCandidate = vi.fn();
+    const onTickSummary = vi.fn();
     const handle = startNewsRuntime({
       ...BASE_CONFIG,
       writeStoryBundle,
       onError,
       onSynthesisCandidate,
+      onTickSummary,
       pollIntervalMs: 10,
       runOnStart: true,
     });
@@ -1598,6 +1636,12 @@ describe('newsRuntime', () => {
     expect(onSynthesisCandidate).toHaveBeenCalledWith(
       expect.objectContaining({ story_id: 'write-succeeds' }),
     );
+    expect(onTickSummary).toHaveBeenCalledWith(expect.objectContaining({
+      raw_write_attempted_count: 2,
+      raw_wrote_count: 1,
+      raw_write_failed_count: 1,
+      first_raw_written_story_ids: ['write-succeeds'],
+    }));
 
     handle.stop();
   });
@@ -1704,6 +1748,7 @@ describe('newsRuntime', () => {
       raw_wrote_count: 1,
       storyline_write_attempted_count: 1,
       storyline_wrote_count: 1,
+      first_raw_written_story_ids: ['story-1'],
     }));
     expect(onClusterArtifacts).toHaveBeenCalledWith(expect.objectContaining({
       rawItemCount: 3,
@@ -1830,6 +1875,7 @@ describe('newsRuntime', () => {
       raw_write_attempted_count: 0,
       raw_write_suppressed_count: 1,
       raw_wrote_count: 0,
+      first_raw_written_story_ids: [],
       storyline_write_suppressed_count: 1,
       synthesis_candidate_suppressed_count: 1,
     }));

--- a/packages/ai-engine/src/newsRuntime.ts
+++ b/packages/ai-engine/src/newsRuntime.ts
@@ -175,6 +175,7 @@ export interface NewsRuntimeTickSummary {
   readonly last_stage: NewsRuntimeTickStage;
   readonly failed_stage?: NewsRuntimeTickStage;
   readonly first_selected_story_ids: readonly string[];
+  readonly first_raw_written_story_ids?: readonly string[];
   readonly error?: string;
 }
 
@@ -594,6 +595,26 @@ function logTickSummary(summary: NewsRuntimeTickSummary): void {
   firstTickLogger('[vh:news-runtime] first tick outcome', summary);
 }
 
+function firstSuccessfulStoryIdsInPublicationOrder(
+  bundles: readonly StoryBundle[],
+  successfulStoryIds: ReadonlySet<string>,
+): string[] {
+  const orderedStoryIds: string[] = [];
+  const seenStoryIds = new Set<string>();
+  for (const bundle of bundles) {
+    const storyId = bundle.story_id;
+    if (!successfulStoryIds.has(storyId) || seenStoryIds.has(storyId)) {
+      continue;
+    }
+    seenStoryIds.add(storyId);
+    orderedStoryIds.push(storyId);
+    if (orderedStoryIds.length === 10) {
+      break;
+    }
+  }
+  return orderedStoryIds;
+}
+
 async function emitTickSummary(
   summary: NewsRuntimeTickSummary,
   onTickSummary: NewsRuntimeConfig['onTickSummary'],
@@ -724,6 +745,7 @@ export function startNewsRuntime(config: NewsRuntimeConfig): NewsRuntimeHandle {
       synthesis_candidate_suppressed_count: 0,
       nonfatal_prewrite_failure_count: 0,
       first_selected_story_ids: [],
+      first_raw_written_story_ids: [],
     });
 
     try {
@@ -793,6 +815,7 @@ export function startNewsRuntime(config: NewsRuntimeConfig): NewsRuntimeHandle {
       let rawWriteSuppressedCount = 0;
       let rawWroteCount = 0;
       let failedStoryPublishCount = 0;
+      const successfulLiveWriteStoryIds = new Set<string>();
       let synthesisCandidateEnqueuedCount = 0;
       let synthesisCandidateSuppressedCount = 0;
 
@@ -811,6 +834,7 @@ export function startNewsRuntime(config: NewsRuntimeConfig): NewsRuntimeHandle {
             try {
               await writeStoryBundle!(config.gunClient, bundle);
               rawWroteCount += 1;
+              successfulLiveWriteStoryIds.add(bundle.story_id);
             } catch (error) {
               failedStoryPublishCount += 1;
               runtimeTrace('bundle_write_failed', {
@@ -878,6 +902,7 @@ export function startNewsRuntime(config: NewsRuntimeConfig): NewsRuntimeHandle {
             try {
               await writeStoryBundle!(config.gunClient, bundle);
               rawWroteCount += 1;
+              successfulLiveWriteStoryIds.add(bundle.story_id);
             } catch (error) {
               failedStoryPublishCount += 1;
               runtimeTrace('bundle_write_failed', {
@@ -1085,6 +1110,10 @@ export function startNewsRuntime(config: NewsRuntimeConfig): NewsRuntimeHandle {
         synthesis_candidate_enqueued_count: synthesisCandidateEnqueuedCount,
         synthesis_candidate_suppressed_count: synthesisCandidateSuppressedCount,
         first_selected_story_ids: bundlesToPublish.slice(0, 10).map((bundle) => bundle.story_id),
+        first_raw_written_story_ids: firstSuccessfulStoryIdsInPublicationOrder(
+          bundlesToPublish,
+          successfulLiveWriteStoryIds,
+        ),
         last_stage: lastStage,
       }, config.onTickSummary);
       firstTickCompleted = true;
@@ -1179,6 +1208,7 @@ export function startNewsRuntime(config: NewsRuntimeConfig): NewsRuntimeHandle {
 export const __internal = {
   bundleConfidenceScore,
   defaultPrompt,
+  firstSuccessfulStoryIdsInPublicationOrder,
   hasTitlePairCanonicalSupport,
   isTruthyFlag,
   normalizeOptionalPositiveInt,

--- a/services/news-aggregator/src/daemon.production.test.ts
+++ b/services/news-aggregator/src/daemon.production.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import type {
@@ -96,6 +96,7 @@ function makeTickSummary(overrides: Partial<NewsRuntimeTickSummary> = {}): NewsR
     synthesis_candidate_suppressed_count: 1,
     nonfatal_prewrite_failure_count: 0,
     first_selected_story_ids: ['story-1'],
+    first_raw_written_story_ids: [],
     last_stage: 'completed',
     ...overrides,
   };
@@ -444,6 +445,8 @@ describe('news daemon production wiring', () => {
 
   it('honors an explicit no-write diagnostic tick limit before self-stopping', async () => {
     const tmpDir = mkdtempSync(path.join(os.tmpdir(), 'vh-news-daemon-bounded-diagnostic-'));
+    const artifactRoot = path.join(tmpDir, 'artifacts');
+    const diagnosticFile = path.join(artifactRoot, 'news-runtime-diagnostics.json');
     const runtimeHandle = {
       stop: vi.fn(),
       isRunning: vi.fn(() => true),
@@ -459,10 +462,24 @@ describe('news daemon production wiring', () => {
     vi.stubEnv('VH_NEWS_DAEMON_DIAGNOSTIC_NO_WRITE', '1');
     vi.stubEnv('VH_NEWS_DAEMON_DIAGNOSTIC_MAX_TICKS', '2');
     vi.stubEnv('VH_NEWS_DAEMON_STATE_DIR', tmpDir);
-    vi.stubEnv('VH_DAEMON_FEED_ARTIFACT_ROOT', path.join(tmpDir, 'artifacts'));
+    vi.stubEnv('VH_DAEMON_FEED_ARTIFACT_ROOT', artifactRoot);
+    vi.stubEnv('VH_DAEMON_FEED_RUN_ID', 'production-run-new');
     vi.stubGlobal('fetch', vi.fn(async () => new Response('ok', { status: 200 })));
 
     try {
+      mkdirSync(artifactRoot, { recursive: true });
+      writeFileSync(diagnosticFile, `${JSON.stringify({
+        schemaVersion: 'vh-news-runtime-diagnostics-v1',
+        generatedAt: new Date(1_700_000_000_000).toISOString(),
+        runId: 'production-run-old',
+        noWrite: true,
+        maxSummaries: 50,
+        latest: makeTickSummary({ tick_sequence: 299 }),
+        summaries: [
+          makeTickSummary({ tick_sequence: 298 }),
+          makeTickSummary({ tick_sequence: 299 }),
+        ],
+      }, null, 2)}\n`, 'utf8');
       const handle = await startNewsAggregatorDaemonFromEnv();
       const runtimeConfig = mocks.startNewsRuntime.mock.calls[0]?.[0] as {
         onTickSummary?: (summary: NewsRuntimeTickSummary) => Promise<void>;
@@ -473,6 +490,14 @@ describe('news daemon production wiring', () => {
       expect(runtimeHandle.stop).not.toHaveBeenCalled();
 
       await runtimeConfig.onTickSummary?.(makeTickSummary({ tick_sequence: 2 }));
+      const diagnostic = JSON.parse(readFileSync(diagnosticFile, 'utf8')) as {
+        runId: string | null;
+        latest: NewsRuntimeTickSummary;
+        summaries: NewsRuntimeTickSummary[];
+      };
+      expect(diagnostic.runId).toBe('production-run-new');
+      expect(diagnostic.latest.tick_sequence).toBe(2);
+      expect(diagnostic.summaries.map((item) => item.tick_sequence)).toEqual([1, 2]);
       await vi.waitFor(() => expect(runtimeHandle.stop).toHaveBeenCalledTimes(1));
       await vi.waitFor(() => expect(shutdown).toHaveBeenCalledTimes(1));
       await handle.closed;

--- a/services/news-aggregator/src/runtimeDiagnostics.test.ts
+++ b/services/news-aggregator/src/runtimeDiagnostics.test.ts
@@ -1,18 +1,21 @@
-import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { mkdtemp, readFile, rename, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { NewsRuntimeTickSummary } from '@vh/ai-engine';
 import { createRuntimeDiagnosticRecorder, resolveRuntimeDiagnosticsPath } from './runtimeDiagnostics';
 
-function summary(tickSequence: number): NewsRuntimeTickSummary {
+function summary(
+  tickSequence: number,
+  overrides: Partial<NewsRuntimeTickSummary> = {},
+): NewsRuntimeTickSummary {
   return {
     schemaVersion: 'vh-news-runtime-tick-summary-v1',
     tick_sequence: tickSequence,
     first_tick: tickSequence === 1,
     status: 'completed',
     skipped: false,
-    no_write: true,
+    no_write: false,
     started_at: new Date(1_700_000_000_000 + tickSequence).toISOString(),
     completed_at: new Date(1_700_000_001_000 + tickSequence).toISOString(),
     duration_ms: 1_000,
@@ -48,10 +51,28 @@ function summary(tickSequence: number): NewsRuntimeTickSummary {
     nonfatal_prewrite_failure_count: 0,
     last_stage: 'completed',
     first_selected_story_ids: ['story-1'],
+    first_raw_written_story_ids: [],
+    ...overrides,
   };
 }
 
+async function readSnapshot(filePath: string): Promise<DaemonRuntimeDiagnosticSnapshotForTest> {
+  return JSON.parse(await readFile(filePath, 'utf8')) as DaemonRuntimeDiagnosticSnapshotForTest;
+}
+
+interface DaemonRuntimeDiagnosticSnapshotForTest {
+  schemaVersion: string;
+  runId: string | null;
+  noWrite: boolean;
+  latest: NewsRuntimeTickSummary;
+  summaries: NewsRuntimeTickSummary[];
+}
+
 describe('runtime diagnostics recorder', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it('writes a bounded atomic diagnostic snapshot', async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), 'vh-runtime-diag-'));
     try {
@@ -63,23 +84,193 @@ describe('runtime diagnostics recorder', () => {
         maxSummaries: 2,
       });
 
-      await recorder(summary(1));
-      await recorder(summary(2));
-      await recorder(summary(3));
+      await recorder(summary(1, { no_write: true }));
+      await recorder(summary(2, { no_write: true }));
+      await recorder(summary(3, { no_write: true }));
 
-      const parsed = JSON.parse(await readFile(filePath, 'utf8')) as {
-        schemaVersion: string;
-        runId: string;
-        noWrite: boolean;
-        latest: NewsRuntimeTickSummary;
-        summaries: NewsRuntimeTickSummary[];
-      };
+      const parsed = await readSnapshot(filePath);
 
       expect(parsed.schemaVersion).toBe('vh-news-runtime-diagnostics-v1');
       expect(parsed.runId).toBe('run-1');
       expect(parsed.noWrite).toBe(true);
       expect(parsed.latest.tick_sequence).toBe(3);
       expect(parsed.summaries.map((item) => item.tick_sequence)).toEqual([2, 3]);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('resets retained summaries when a new process run id starts at tick one', async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'vh-runtime-diag-restart-'));
+    try {
+      const filePath = resolveRuntimeDiagnosticsPath({ artifactRoot: root });
+      const oldRun = createRuntimeDiagnosticRecorder({
+        artifactRoot: root,
+        runId: 'run-old',
+        maxSummaries: 2,
+      });
+      await oldRun(summary(298));
+      await oldRun(summary(299));
+
+      const newRun = createRuntimeDiagnosticRecorder({
+        artifactRoot: root,
+        runId: 'run-new',
+        maxSummaries: 2,
+      });
+      await newRun(summary(1));
+      await newRun(summary(2));
+
+      const parsed = await readSnapshot(filePath);
+      expect(parsed.runId).toBe('run-new');
+      expect(parsed.latest.tick_sequence).toBe(2);
+      expect(parsed.summaries.map((item) => item.tick_sequence)).toEqual([1, 2]);
+      expect(parsed.summaries.some((item) => item.tick_sequence >= 298)).toBe(false);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves same-run bounded ordering and tick-sequence dedupe across recorder instances', async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'vh-runtime-diag-same-run-'));
+    try {
+      const filePath = resolveRuntimeDiagnosticsPath({ artifactRoot: root });
+      const first = createRuntimeDiagnosticRecorder({ artifactRoot: root, runId: 'run-1', maxSummaries: 3 });
+      await first(summary(1));
+      await first(summary(2));
+
+      const resumed = createRuntimeDiagnosticRecorder({ artifactRoot: root, runId: 'run-1', maxSummaries: 3 });
+      await resumed(summary(2, { status: 'failed', last_stage: 'failed' }));
+      await resumed(summary(3));
+      await resumed(summary(4));
+
+      const parsed = await readSnapshot(filePath);
+      expect(parsed.summaries.map((item) => item.tick_sequence)).toEqual([2, 3, 4]);
+      expect(parsed.summaries.find((item) => item.tick_sequence === 2)?.status).toBe('failed');
+      expect(parsed.latest.tick_sequence).toBe(4);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('resets retained summaries when the same run id crosses from no-write to live mode', async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'vh-runtime-diag-write-mode-'));
+    try {
+      const filePath = resolveRuntimeDiagnosticsPath({ artifactRoot: root });
+      const noWriteRun = createRuntimeDiagnosticRecorder({
+        artifactRoot: root,
+        runId: 'run-reused',
+        noWrite: true,
+      });
+      await noWriteRun(summary(98, { no_write: true }));
+      await noWriteRun(summary(99, { no_write: true }));
+
+      const liveRun = createRuntimeDiagnosticRecorder({
+        artifactRoot: root,
+        runId: 'run-reused',
+        noWrite: false,
+      });
+      await liveRun(summary(1, { no_write: false }));
+      await liveRun(summary(2, { no_write: false }));
+
+      const parsed = await readSnapshot(filePath);
+      expect(parsed.runId).toBe('run-reused');
+      expect(parsed.noWrite).toBe(false);
+      expect(parsed.latest.tick_sequence).toBe(2);
+      expect(parsed.summaries.map((item) => item.tick_sequence)).toEqual([1, 2]);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it.each([
+    ['missing', undefined, null],
+    ['null', null, ''],
+    ['blank', '   ', null],
+    ['different', 'legacy-run', ''],
+  ])('does not relabel %s legacy run history when the current run id is unavailable', async (
+    _label,
+    legacyRunId,
+    currentRunId,
+  ) => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'vh-runtime-diag-legacy-'));
+    try {
+      const filePath = resolveRuntimeDiagnosticsPath({ artifactRoot: root });
+      await writeFile(filePath, `${JSON.stringify({
+        schemaVersion: 'vh-news-runtime-diagnostics-v1',
+        generatedAt: new Date().toISOString(),
+        ...(legacyRunId === undefined ? {} : { runId: legacyRunId }),
+        noWrite: false,
+        maxSummaries: 50,
+        latest: summary(299),
+        summaries: [summary(298), summary(299)],
+      })}\n`, 'utf8');
+
+      const recorder = createRuntimeDiagnosticRecorder({
+        artifactRoot: root,
+        runId: currentRunId,
+        maxSummaries: 2,
+      });
+      await recorder(summary(1));
+      await recorder(summary(2));
+
+      const parsed = await readSnapshot(filePath);
+      expect(parsed.runId).toBeNull();
+      expect(parsed.summaries.map((item) => item.tick_sequence)).toEqual([1, 2]);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('uses the environment only for undefined run ids while null and blank stay missing', async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'vh-runtime-diag-run-id-tristate-'));
+    try {
+      vi.stubEnv('VH_DAEMON_FEED_RUN_ID', 'run-from-env');
+      const envRoot = path.join(root, 'env');
+      const nullRoot = path.join(root, 'null');
+      const blankRoot = path.join(root, 'blank');
+
+      await createRuntimeDiagnosticRecorder({ artifactRoot: envRoot })(summary(1));
+      await createRuntimeDiagnosticRecorder({ artifactRoot: nullRoot, runId: null })(summary(1));
+      await createRuntimeDiagnosticRecorder({ artifactRoot: blankRoot, runId: '   ' })(summary(1));
+
+      expect((await readSnapshot(resolveRuntimeDiagnosticsPath({ artifactRoot: envRoot }))).runId)
+        .toBe('run-from-env');
+      expect((await readSnapshot(resolveRuntimeDiagnosticsPath({ artifactRoot: nullRoot }))).runId)
+        .toBeNull();
+      expect((await readSnapshot(resolveRuntimeDiagnosticsPath({ artifactRoot: blankRoot }))).runId)
+        .toBeNull();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps the diagnostic write atomic before advancing in-process retention', async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'vh-runtime-diag-atomic-'));
+    try {
+      const filePath = resolveRuntimeDiagnosticsPath({ artifactRoot: root });
+      const renameCalls: Array<[string, string]> = [];
+      let failRename = true;
+      const recorder = createRuntimeDiagnosticRecorder({
+        artifactRoot: root,
+        runId: 'run-atomic',
+        renameFile: async (from, to) => {
+          renameCalls.push([String(from), String(to)]);
+          if (failRename) {
+            failRename = false;
+            throw new Error('simulated atomic rename failure');
+          }
+          await rename(from, to);
+        },
+      });
+
+      await expect(recorder(summary(1))).rejects.toThrow('simulated atomic rename failure');
+      await expect(readFile(filePath, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
+      await recorder(summary(2));
+
+      expect(renameCalls).toHaveLength(2);
+      expect(renameCalls[0]?.[0]).toMatch(/\.news-runtime-diagnostics\.json\.tmp-/);
+      expect(renameCalls[0]?.[1]).toBe(filePath);
+      expect((await readSnapshot(filePath)).summaries.map((item) => item.tick_sequence)).toEqual([2]);
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/services/news-aggregator/src/runtimeDiagnostics.ts
+++ b/services/news-aggregator/src/runtimeDiagnostics.ts
@@ -15,7 +15,7 @@ export interface DaemonRuntimeDiagnosticSnapshot {
 export interface RuntimeDiagnosticRecorderOptions {
   readonly artifactRoot?: string;
   readonly explicitFile?: string;
-  readonly runId?: string;
+  readonly runId?: string | null;
   readonly noWrite?: boolean;
   readonly maxSummaries?: number;
   readonly readTextFile?: typeof readFile;
@@ -66,6 +66,45 @@ async function readExistingSnapshot(
   }
 }
 
+function normalizedSnapshotRunId(snapshot: DaemonRuntimeDiagnosticSnapshot | null): string | null {
+  const value = snapshot?.runId;
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function validRetainedSummaries(value: unknown): NewsRuntimeTickSummary[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  if (value.some((item) => (
+    !item
+    || typeof item !== 'object'
+    || !Number.isSafeInteger((item as { tick_sequence?: unknown }).tick_sequence)
+    || Number((item as { tick_sequence?: unknown }).tick_sequence) <= 0
+  ))) {
+    return [];
+  }
+  return value as NewsRuntimeTickSummary[];
+}
+
+function existingSummariesForRun(
+  snapshot: DaemonRuntimeDiagnosticSnapshot | null,
+  runId: string | null,
+  noWrite: boolean,
+): NewsRuntimeTickSummary[] {
+  // A missing run id cannot establish a process boundary, and a write-mode
+  // transition must not promote no-write evidence into a live run. Fail closed
+  // on the first write from this recorder instead of relabeling disk history as
+  // current-run evidence. Later writes use the recorder's in-memory summaries.
+  if (
+    !runId
+    || normalizedSnapshotRunId(snapshot) !== runId
+    || snapshot?.noWrite !== noWrite
+  ) {
+    return [];
+  }
+  return validRetainedSummaries(snapshot?.summaries);
+}
+
 async function writeAtomicJson(
   filePath: string,
   value: unknown,
@@ -86,14 +125,19 @@ export function createRuntimeDiagnosticRecorder(
   const renameFile = options.renameFile ?? rename;
   const mkdirFn = options.mkdirFn ?? mkdir;
   const maxSummaries = normalizePositiveInt(options.maxSummaries, 50);
-  const runId = options.runId?.trim() || process.env.VH_DAEMON_FEED_RUN_ID?.trim() || null;
+  const explicitRunId = options.runId === undefined ? undefined : options.runId?.trim() || null;
+  const runId = explicitRunId === undefined
+    ? process.env.VH_DAEMON_FEED_RUN_ID?.trim() || null
+    : explicitRunId;
   const noWrite = options.noWrite === true;
+  let inProcessSummaries: readonly NewsRuntimeTickSummary[] | null = null;
 
   return async (summary: NewsRuntimeTickSummary): Promise<DaemonRuntimeDiagnosticSnapshot> => {
     await mkdirFn(path.dirname(filePath), { recursive: true });
     const existing = await readExistingSnapshot(filePath, readTextFile);
     const summaries = [
-      ...(existing?.summaries ?? []).filter((item) => item.tick_sequence !== summary.tick_sequence),
+      ...(inProcessSummaries ?? existingSummariesForRun(existing, runId, noWrite))
+        .filter((item) => item.tick_sequence !== summary.tick_sequence),
       summary,
     ]
       .sort((left, right) => left.tick_sequence - right.tick_sequence)
@@ -110,6 +154,7 @@ export function createRuntimeDiagnosticRecorder(
     };
 
     await writeAtomicJson(filePath, snapshot, writeTextFile, renameFile);
+    inProcessSummaries = summaries;
     return snapshot;
   };
 }

--- a/tools/scripts/news-aggregator-publisher-liveness-watch.mjs
+++ b/tools/scripts/news-aggregator-publisher-liveness-watch.mjs
@@ -196,6 +196,31 @@ function diagnosticGeneratedAtMs(diagnostic) {
   return parseTimestampMs(diagnostic?.generatedAt);
 }
 
+function diagnosticSummaryRunBoundary(diagnostic) {
+  const summaries = diagnostic?.summaries;
+  const latestTickSequence = diagnostic?.latest?.tick_sequence;
+  if (!Array.isArray(summaries)) {
+    return { status: 'fail', reason: 'summaries_not_array', tickSequences: [] };
+  }
+  if (!Number.isSafeInteger(latestTickSequence) || latestTickSequence <= 0) {
+    return { status: 'fail', reason: 'latest_tick_invalid', tickSequences: [] };
+  }
+  const tickSequences = summaries.map((summary) => summary?.tick_sequence);
+  if (tickSequences.some((value) => !Number.isSafeInteger(value) || value <= 0)) {
+    return { status: 'fail', reason: 'summary_tick_invalid', tickSequences: [] };
+  }
+  if (new Set(tickSequences).size !== tickSequences.length) {
+    return { status: 'fail', reason: 'summary_tick_duplicate', tickSequences };
+  }
+  if (tickSequences.some((value, index) => index > 0 && value <= tickSequences[index - 1])) {
+    return { status: 'fail', reason: 'summary_tick_not_strictly_ordered', tickSequences };
+  }
+  if (tickSequences.some((value) => value > latestTickSequence)) {
+    return { status: 'fail', reason: 'summary_tick_after_latest', tickSequences };
+  }
+  return { status: 'pass', reason: null, tickSequences };
+}
+
 function inspectDiagnostic({
   env,
   now,
@@ -228,6 +253,13 @@ function inspectDiagnostic({
     ageMs: null,
     runId: typeof diagnosticRead.parsed?.runId === 'string' ? diagnosticRead.parsed.runId : null,
     latestTickSequence: diagnosticRead.parsed?.latest?.tick_sequence ?? null,
+    retainedSummaryCount: Array.isArray(diagnosticRead.parsed?.summaries)
+      ? diagnosticRead.parsed.summaries.length
+      : null,
+    summaryTickSequenceMin: null,
+    summaryTickSequenceMax: null,
+    summaryRunBoundaryStatus: 'unknown',
+    summaryRunBoundaryReason: null,
     status: 'unknown',
     error: diagnosticRead.error ? String(diagnosticRead.error instanceof Error ? diagnosticRead.error.message : diagnosticRead.error) : null,
   };
@@ -251,6 +283,18 @@ function inspectDiagnostic({
     blockers.push(`diagnostic_schema_mismatch:${diagnostic.schemaVersion ?? 'missing'}`);
     diagnostic.status = 'fail';
     return diagnostic;
+  }
+  const summaryRunBoundary = diagnosticSummaryRunBoundary(diagnosticRead.parsed);
+  diagnostic.summaryRunBoundaryStatus = summaryRunBoundary.status;
+  diagnostic.summaryRunBoundaryReason = summaryRunBoundary.reason;
+  diagnostic.summaryTickSequenceMin = summaryRunBoundary.tickSequences.length
+    ? Math.min(...summaryRunBoundary.tickSequences)
+    : null;
+  diagnostic.summaryTickSequenceMax = summaryRunBoundary.tickSequences.length
+    ? Math.max(...summaryRunBoundary.tickSequences)
+    : null;
+  if (summaryRunBoundary.status !== 'pass') {
+    blockers.push(`diagnostic_summary_run_boundary_invalid:${summaryRunBoundary.reason}`);
   }
   if (!diagnostic.generatedAtMs || diagnostic.generatedAtMs > now + activeEnterToleranceMs) {
     blockers.push('diagnostic_generated_at_not_sane');

--- a/tools/scripts/news-aggregator-publisher-liveness-watch.mjs
+++ b/tools/scripts/news-aggregator-publisher-liveness-watch.mjs
@@ -5,6 +5,7 @@ import { existsSync, readFileSync, statSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
+import { isDeepStrictEqual } from 'node:util';
 
 const REPORT_SCHEMA_VERSION = 'vh-news-publisher-liveness-watch-v1';
 const DIAGNOSTICS_SCHEMA_VERSION = 'vh-news-runtime-diagnostics-v1';
@@ -205,6 +206,9 @@ function diagnosticSummaryRunBoundary(diagnostic) {
   if (!Number.isSafeInteger(latestTickSequence) || latestTickSequence <= 0) {
     return { status: 'fail', reason: 'latest_tick_invalid', tickSequences: [] };
   }
+  if (summaries.length === 0) {
+    return { status: 'fail', reason: 'summaries_empty', tickSequences: [] };
+  }
   const tickSequences = summaries.map((summary) => summary?.tick_sequence);
   if (tickSequences.some((value) => !Number.isSafeInteger(value) || value <= 0)) {
     return { status: 'fail', reason: 'summary_tick_invalid', tickSequences: [] };
@@ -217,6 +221,12 @@ function diagnosticSummaryRunBoundary(diagnostic) {
   }
   if (tickSequences.some((value) => value > latestTickSequence)) {
     return { status: 'fail', reason: 'summary_tick_after_latest', tickSequences };
+  }
+  if (tickSequences.at(-1) !== latestTickSequence) {
+    return { status: 'fail', reason: 'latest_tick_not_retained', tickSequences };
+  }
+  if (!isDeepStrictEqual(summaries.at(-1), diagnostic.latest)) {
+    return { status: 'fail', reason: 'latest_summary_mismatch', tickSequences };
   }
   return { status: 'pass', reason: null, tickSequences };
 }

--- a/tools/scripts/news-aggregator-publisher-liveness-watch.test.mjs
+++ b/tools/scripts/news-aggregator-publisher-liveness-watch.test.mjs
@@ -37,18 +37,20 @@ function writeCurrentRun(filePath, overrides = {}) {
 }
 
 function writeDiagnostic(filePath, overrides = {}) {
+  const latest = overrides.latest ?? {
+    tick_sequence: 3,
+    status: 'completed',
+  };
+  const summaries = overrides.summaries ?? [latest];
   writeJson(filePath, {
     schemaVersion: newsAggregatorPublisherLivenessWatchInternal.DIAGNOSTICS_SCHEMA_VERSION,
     generatedAt: new Date(NOW - 60_000).toISOString(),
     runId: RUN_ID,
     noWrite: false,
     maxSummaries: 50,
-    latest: {
-      tick_sequence: 3,
-      status: 'completed',
-    },
-    summaries: [],
     ...overrides,
+    latest,
+    summaries,
   });
 }
 
@@ -223,6 +225,55 @@ test('publisher liveness rejects retained summaries from an older high-tick run 
     rmSync(paths.root, { recursive: true, force: true });
   }
 });
+
+for (const { label, latest, summaries, reason } of [
+  {
+    label: 'empty retained summaries',
+    latest: { tick_sequence: 3, status: 'completed' },
+    summaries: [],
+    reason: 'summaries_empty',
+  },
+  {
+    label: 'a latest tick newer than the retained maximum',
+    latest: { tick_sequence: 3, status: 'completed' },
+    summaries: [
+      { tick_sequence: 1, status: 'completed' },
+      { tick_sequence: 2, status: 'completed' },
+    ],
+    reason: 'latest_tick_not_retained',
+  },
+  {
+    label: 'a contradictory retained row at the latest tick',
+    latest: { tick_sequence: 3, status: 'completed' },
+    summaries: [{ tick_sequence: 3, status: 'failed' }],
+    reason: 'latest_summary_mismatch',
+  },
+]) {
+  test(`publisher liveness rejects ${label}`, async () => {
+    const paths = makeTempState();
+    try {
+      writeCurrentRun(paths.currentRunFile);
+      writeDiagnostic(paths.diagnosticFile, { latest, summaries });
+
+      const summary = await runNewsAggregatorPublisherLivenessWatch({
+        now: NOW,
+        env: baseEnv(paths),
+        systemctlShowText: activeSystemctl({ activeEnterMs: NOW - 60 * 60 * 1000 }),
+        journalText: '',
+      });
+
+      assert.equal(summary.status, 'fail');
+      assert.equal(summary.diagnostic.summaryRunBoundaryStatus, 'fail');
+      assert.equal(summary.diagnostic.summaryRunBoundaryReason, reason);
+      assert.match(
+        summary.blockers.join('\n'),
+        new RegExp(`diagnostic_summary_run_boundary_invalid:${reason}`),
+      );
+    } finally {
+      rmSync(paths.root, { recursive: true, force: true });
+    }
+  });
+}
 
 test('publisher liveness classifies exit 78 fail-close and guard refusal separately', async () => {
   const paths = makeTempState();

--- a/tools/scripts/news-aggregator-publisher-liveness-watch.test.mjs
+++ b/tools/scripts/news-aggregator-publisher-liveness-watch.test.mjs
@@ -191,6 +191,39 @@ test('publisher liveness allows current-run diagnostic mismatch during startup g
   }
 });
 
+test('publisher liveness rejects retained summaries from an older high-tick run even when top-level runId is current', async () => {
+  const paths = makeTempState();
+  try {
+    writeCurrentRun(paths.currentRunFile);
+    writeDiagnostic(paths.diagnosticFile, {
+      runId: RUN_ID,
+      latest: {
+        tick_sequence: 2,
+        status: 'completed',
+      },
+      summaries: [
+        { tick_sequence: 1, status: 'completed' },
+        { tick_sequence: 2, status: 'completed' },
+        { tick_sequence: 299, status: 'completed' },
+      ],
+    });
+
+    const summary = await runNewsAggregatorPublisherLivenessWatch({
+      now: NOW,
+      env: baseEnv(paths),
+      systemctlShowText: activeSystemctl({ activeEnterMs: NOW - 60 * 60 * 1000 }),
+      journalText: '',
+    });
+
+    assert.equal(summary.status, 'fail');
+    assert.equal(summary.diagnostic.summaryRunBoundaryStatus, 'fail');
+    assert.equal(summary.diagnostic.summaryRunBoundaryReason, 'summary_tick_after_latest');
+    assert.match(summary.blockers.join('\n'), /diagnostic_summary_run_boundary_invalid:summary_tick_after_latest/);
+  } finally {
+    rmSync(paths.root, { recursive: true, force: true });
+  }
+});
+
 test('publisher liveness classifies exit 78 fail-close and guard refusal separately', async () => {
   const paths = makeTempState();
   try {

--- a/tools/scripts/phase5-scope-a-watch-closure-packet.mjs
+++ b/tools/scripts/phase5-scope-a-watch-closure-packet.mjs
@@ -500,9 +500,50 @@ function summarizeArchive(samples) {
   };
 }
 
+function runtimeDiagnosticsRunBoundary(diagnostics) {
+  const blockers = [];
+  const runId = typeof diagnostics?.runId === 'string' && diagnostics.runId.trim()
+    ? diagnostics.runId.trim()
+    : null;
+  if (!runId) blockers.push('run_id_missing');
+  if (diagnostics?.schemaVersion !== 'vh-news-runtime-diagnostics-v1') {
+    blockers.push('schema_mismatch');
+  }
+  const latestTickSequence = diagnostics?.latest?.tick_sequence;
+  if (!Number.isSafeInteger(latestTickSequence) || latestTickSequence <= 0) {
+    blockers.push('latest_tick_invalid');
+  }
+  const summaries = diagnostics?.summaries;
+  const tickSequences = Array.isArray(summaries)
+    ? summaries.map((summary) => summary?.tick_sequence)
+    : [];
+  if (!Array.isArray(summaries)) {
+    blockers.push('summaries_not_array');
+  } else if (tickSequences.some((value) => !Number.isSafeInteger(value) || value <= 0)) {
+    blockers.push('summary_tick_invalid');
+  } else {
+    if (new Set(tickSequences).size !== tickSequences.length) blockers.push('summary_tick_duplicate');
+    if (tickSequences.some((value, index) => index > 0 && value <= tickSequences[index - 1])) {
+      blockers.push('summary_tick_not_strictly_ordered');
+    }
+    if (Number.isSafeInteger(latestTickSequence) && tickSequences.some((value) => value > latestTickSequence)) {
+      blockers.push('summary_tick_after_latest');
+    }
+  }
+  const safeTickSequences = tickSequences.every((value) => Number.isSafeInteger(value) && value > 0)
+    ? tickSequences
+    : [];
+  return {
+    status: blockers.length === 0 ? 'pass' : 'fail',
+    blockers,
+    tickSequences: safeTickSequences,
+  };
+}
+
 function runtimeSummaryFromDiagnostics(diagnostics) {
   if (!diagnostics) return null;
   const summaries = Array.isArray(diagnostics.summaries) ? diagnostics.summaries : [];
+  const runBoundary = runtimeDiagnosticsRunBoundary(diagnostics);
   return {
     generatedAt: diagnostics.generatedAt ?? null,
     runId: diagnostics.runId ?? null,
@@ -514,6 +555,14 @@ function runtimeSummaryFromDiagnostics(diagnostics) {
     latestRawWroteCount: diagnostics.latest?.raw_wrote_count ?? null,
     latestRawWriteFailedCount: diagnostics.latest?.raw_write_failed_count ?? null,
     latestNonfatalPrewriteFailureCount: diagnostics.latest?.nonfatal_prewrite_failure_count ?? null,
+    summaryTickSequenceMin: runBoundary.tickSequences.length
+      ? Math.min(...runBoundary.tickSequences)
+      : null,
+    summaryTickSequenceMax: runBoundary.tickSequences.length
+      ? Math.max(...runBoundary.tickSequences)
+      : null,
+    runBoundaryStatus: runBoundary.status,
+    runBoundaryBlockers: runBoundary.blockers,
   };
 }
 
@@ -532,7 +581,13 @@ function normalizeJournalSummary(summary) {
   };
 }
 
-function coreSignalBlockers({ archive, journalSummary, storyClusterArtifacts, degeneracyWarningCount }) {
+function coreSignalBlockers({
+  archive,
+  journalSummary,
+  runtimeDiagnostics,
+  storyClusterArtifacts,
+  degeneracyWarningCount,
+}) {
   const blockers = [];
   if (archive.sampleCount <= 0) blockers.push('archive_samples_missing');
   if (archive.failCount > 0) blockers.push(`archive_sample_failures:${archive.failCount}`);
@@ -560,6 +615,13 @@ function coreSignalBlockers({ archive, journalSummary, storyClusterArtifacts, de
     if ((journalSummary.rawWriteFailedCount ?? 0) > 0) blockers.push(`runtime_raw_write_failures:${journalSummary.rawWriteFailedCount}`);
     if ((journalSummary.nonfatalPrewriteFailureCount ?? 0) > 0) {
       blockers.push(`runtime_nonfatal_prewrite_failures:${journalSummary.nonfatalPrewriteFailureCount}`);
+    }
+  }
+  if (!runtimeDiagnostics) {
+    blockers.push('runtime_diagnostics_missing');
+  } else if (runtimeDiagnostics.runBoundaryStatus !== 'pass') {
+    for (const blocker of runtimeDiagnostics.runBoundaryBlockers ?? []) {
+      blockers.push(`runtime_diagnostics_run_boundary:${blocker}`);
     }
   }
   if (storyClusterArtifacts.count === null) {
@@ -706,6 +768,7 @@ export function buildPhase5ScopeAWatchClosurePacket({
   const blockers = coreSignalBlockers({
     archive,
     journalSummary,
+    runtimeDiagnostics,
     storyClusterArtifacts,
     degeneracyWarningCount,
   });

--- a/tools/scripts/phase5-scope-a-watch-closure-packet.mjs
+++ b/tools/scripts/phase5-scope-a-watch-closure-packet.mjs
@@ -5,6 +5,7 @@ import { mkdir } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
+import { isDeepStrictEqual } from 'node:util';
 import { resolveRelayWatchdogLimits } from './relay-watchdog-thresholds.mjs';
 
 const SCHEMA_VERSION = 'vh-phase5-scope-a-watch-closure-v1';
@@ -519,15 +520,28 @@ function runtimeDiagnosticsRunBoundary(diagnostics) {
     : [];
   if (!Array.isArray(summaries)) {
     blockers.push('summaries_not_array');
+  } else if (summaries.length === 0) {
+    blockers.push('summaries_empty');
   } else if (tickSequences.some((value) => !Number.isSafeInteger(value) || value <= 0)) {
     blockers.push('summary_tick_invalid');
   } else {
-    if (new Set(tickSequences).size !== tickSequences.length) blockers.push('summary_tick_duplicate');
-    if (tickSequences.some((value, index) => index > 0 && value <= tickSequences[index - 1])) {
+    const hasDuplicateTick = new Set(tickSequences).size !== tickSequences.length;
+    const hasUnorderedTick = tickSequences.some(
+      (value, index) => index > 0 && value <= tickSequences[index - 1],
+    );
+    if (hasDuplicateTick) blockers.push('summary_tick_duplicate');
+    if (hasUnorderedTick) {
       blockers.push('summary_tick_not_strictly_ordered');
     }
-    if (Number.isSafeInteger(latestTickSequence) && tickSequences.some((value) => value > latestTickSequence)) {
-      blockers.push('summary_tick_after_latest');
+    if (!hasDuplicateTick && !hasUnorderedTick && Number.isSafeInteger(latestTickSequence)) {
+      const hasTickAfterLatest = tickSequences.some((value) => value > latestTickSequence);
+      if (hasTickAfterLatest) {
+        blockers.push('summary_tick_after_latest');
+      } else if (tickSequences.at(-1) !== latestTickSequence) {
+        blockers.push('latest_tick_not_retained');
+      } else if (!isDeepStrictEqual(summaries.at(-1), diagnostics.latest)) {
+        blockers.push('latest_summary_mismatch');
+      }
     }
   }
   const safeTickSequences = tickSequences.every((value) => Number.isSafeInteger(value) && value > 0)

--- a/tools/scripts/phase5-scope-a-watch-closure-packet.test.mjs
+++ b/tools/scripts/phase5-scope-a-watch-closure-packet.test.mjs
@@ -105,24 +105,30 @@ function relay(name, rssBytes, heapUsedBytes, graph = null, earlyHeapSnapshot = 
   };
 }
 
+function runtimeTickSummary(overrides = {}) {
+  return {
+    tick_sequence: 100,
+    status: 'completed',
+    skipped: false,
+    raw_write_attempted_count: 8,
+    raw_wrote_count: 8,
+    raw_write_failed_count: 0,
+    nonfatal_prewrite_failure_count: 0,
+    ...overrides,
+  };
+}
+
 function baseEnv(root, extras = {}) {
   const storyclusterDir = path.join(root, 'storycluster/openai-failures');
   mkdirSync(storyclusterDir, { recursive: true });
   const diagnosticsFile = path.join(root, 'news-runtime-diagnostics.json');
+  const latestDiagnosticSummary = runtimeTickSummary();
   writeJson(diagnosticsFile, {
     schemaVersion: 'vh-news-runtime-diagnostics-v1',
     generatedAt: '2026-06-30T00:00:00.000Z',
     runId: 'run-1',
-    latest: {
-      tick_sequence: 100,
-      status: 'completed',
-      skipped: false,
-      raw_write_attempted_count: 8,
-      raw_wrote_count: 8,
-      raw_write_failed_count: 0,
-      nonfatal_prewrite_failure_count: 0,
-    },
-    summaries: [],
+    latest: latestDiagnosticSummary,
+    summaries: [latestDiagnosticSummary],
   });
   return {
     VH_PHASE5_SCOPE_A_WATCH_ARCHIVE_ROOT: path.join(root, 'archive'),
@@ -219,6 +225,64 @@ test('watch closure fails closed when retained summaries cross a process run bou
   assert.match(packet.thresholds.twentyFourHour.blockers.join('\n'), /runtime_diagnostics_run_boundary:summary_tick_after_latest/);
   assert.equal(verdict.status, 'fail');
 });
+
+for (const { label, summariesForLatest, blocker } of [
+  {
+    label: 'empty retained summaries',
+    summariesForLatest: () => [],
+    blocker: 'summaries_empty',
+  },
+  {
+    label: 'a latest tick newer than the retained maximum',
+    summariesForLatest: () => [
+      runtimeTickSummary({ tick_sequence: 1 }),
+      runtimeTickSummary({ tick_sequence: 2 }),
+    ],
+    blocker: 'latest_tick_not_retained',
+  },
+  {
+    label: 'a contradictory retained row at the latest tick',
+    summariesForLatest: (latest) => [{ ...latest, status: 'failed' }],
+    blocker: 'latest_summary_mismatch',
+  },
+]) {
+  test(`watch closure rejects ${label}`, () => {
+    const root = tmpDir();
+    const archiveRoot = path.join(root, 'archive');
+    makeSample(archiveRoot, '20260628T000000Z', '2026-06-28T00:00:00.000Z', [
+      relay('vhc-relay-a', 420_000_000, 320_000_000),
+    ]);
+    makeSample(archiveRoot, '20260629T000000Z', '2026-06-29T00:00:00.000Z', [
+      relay('vhc-relay-a', 421_000_000, 321_000_000),
+    ]);
+    makeSample(archiveRoot, '20260630T010000Z', '2026-06-30T01:00:00.000Z', [
+      relay('vhc-relay-a', 422_000_000, 322_000_000),
+    ]);
+    const env = baseEnv(root);
+    const latest = runtimeTickSummary({ tick_sequence: 3 });
+    writeJson(env.VH_PHASE5_SCOPE_A_WATCH_RUNTIME_DIAGNOSTICS_FILE, {
+      schemaVersion: 'vh-news-runtime-diagnostics-v1',
+      generatedAt: '2026-06-30T00:00:00.000Z',
+      runId: 'run-current',
+      latest,
+      summaries: summariesForLatest(latest),
+    });
+
+    const packet = phase5ScopeAWatchClosureInternal.buildPhase5ScopeAWatchClosurePacket({
+      env,
+      now: new Date('2026-06-30T01:00:00.000Z'),
+    });
+    const verdict = phase5ScopeAWatchClosureInternal.buildWatchClosureVerdict(packet);
+
+    assert.equal(packet.runtime.diagnostics.runBoundaryStatus, 'fail');
+    assert.deepEqual(packet.runtime.diagnostics.runBoundaryBlockers, [blocker]);
+    assert.match(
+      packet.thresholds.twentyFourHour.blockers.join('\n'),
+      new RegExp(`runtime_diagnostics_run_boundary:${blocker}`),
+    );
+    assert.equal(verdict.status, 'fail');
+  });
+}
 
 test('computes graph slopes and reports heap plateau when graph scans are complete', () => {
   const root = tmpDir();

--- a/tools/scripts/phase5-scope-a-watch-closure-packet.test.mjs
+++ b/tools/scripts/phase5-scope-a-watch-closure-packet.test.mjs
@@ -175,6 +175,51 @@ test('passes the 48h threshold when archive, runtime, StoryCluster, and relay tr
   ]);
 });
 
+test('watch closure fails closed when retained summaries cross a process run boundary', () => {
+  const root = tmpDir();
+  const archiveRoot = path.join(root, 'archive');
+  makeSample(archiveRoot, '20260628T000000Z', '2026-06-28T00:00:00.000Z', [
+    relay('vhc-relay-a', 420_000_000, 320_000_000),
+  ]);
+  makeSample(archiveRoot, '20260629T000000Z', '2026-06-29T00:00:00.000Z', [
+    relay('vhc-relay-a', 421_000_000, 321_000_000),
+  ]);
+  makeSample(archiveRoot, '20260630T010000Z', '2026-06-30T01:00:00.000Z', [
+    relay('vhc-relay-a', 422_000_000, 322_000_000),
+  ]);
+  const env = baseEnv(root);
+  writeJson(env.VH_PHASE5_SCOPE_A_WATCH_RUNTIME_DIAGNOSTICS_FILE, {
+    schemaVersion: 'vh-news-runtime-diagnostics-v1',
+    generatedAt: '2026-06-30T00:00:00.000Z',
+    runId: 'run-new',
+    latest: {
+      tick_sequence: 2,
+      status: 'completed',
+      skipped: false,
+      raw_write_attempted_count: 8,
+      raw_wrote_count: 8,
+      raw_write_failed_count: 0,
+      nonfatal_prewrite_failure_count: 0,
+    },
+    summaries: [
+      { tick_sequence: 1, status: 'completed' },
+      { tick_sequence: 2, status: 'completed' },
+      { tick_sequence: 299, status: 'completed' },
+    ],
+  });
+
+  const packet = phase5ScopeAWatchClosureInternal.buildPhase5ScopeAWatchClosurePacket({
+    env,
+    now: new Date('2026-06-30T01:00:00.000Z'),
+  });
+  const verdict = phase5ScopeAWatchClosureInternal.buildWatchClosureVerdict(packet);
+
+  assert.equal(packet.runtime.diagnostics.runBoundaryStatus, 'fail');
+  assert.deepEqual(packet.runtime.diagnostics.runBoundaryBlockers, ['summary_tick_after_latest']);
+  assert.match(packet.thresholds.twentyFourHour.blockers.join('\n'), /runtime_diagnostics_run_boundary:summary_tick_after_latest/);
+  assert.equal(verdict.status, 'fail');
+});
+
 test('computes graph slopes and reports heap plateau when graph scans are complete', () => {
   const root = tmpDir();
   const archiveRoot = path.join(root, 'archive');


### PR DESCRIPTION
## Summary
- reset retained runtime summaries across run-id and no-write/live boundaries
- preserve the new run first two ticks instead of relabeling old high tick numbers
- emit bounded successful raw-written story IDs for exact recovery readback proof
- make publisher liveness and watch closure reject empty, incomplete, or contradictory retained histories

## Validation
- AI engine: 654/654
- news aggregator: 529/529
- focused news runtime: 54/54
- liveness + watch closure: 26/26
- both focused typechecks
- docs governance, sprint guard, syntax, and diff checks

## Review
Independent first pass returned NO-GO because empty or latest-not-retained histories still passed downstream consumers. Both were corrected, contradictory same-tick rows were also closed, and the same reviewer returned GO at exact head 137a3e2a90bea1847805ea5d64171dd9adf084ca with no P0/P1/P2.

No A6, service, Gmail, provider, pager, or production mutation was performed.