### PR TITLE
Harden S1 publisher recovery control plane

### DIFF
--- a/infra/systemd/user/vh-news-aggregator.service
+++ b/infra/systemd/user/vh-news-aggregator.service
@@ -8,12 +8,20 @@ StartLimitBurst=3
 
 [Service]
 Type=simple
-# Override VHC_REPO, WorkingDirectory, ExecStart, and VH_NEWS_DAEMON_ENV_FILE in a drop-in if the checkout or env file differs.
+# Replace the fail-closed revision placeholder before installation. Override paths in a drop-in if the checkout or env file differs.
 Environment=VHC_REPO=/home/humble/VHC
 Environment=VH_NEWS_DAEMON_ENV_FILE=%h/.config/vhc/news-aggregator.env
+Environment=VH_NEWS_DAEMON_EXPECTED_REVISION=REPLACE_WITH_FULL_40_HEX_COMMIT
+Environment=VH_NEWS_DAEMON_SYSTEMD_UNIT=vh-news-aggregator.service
+Environment=VH_NEWS_DAEMON_RESTART_AUTHORITY_FILE=%h/.local/state/vhc/news-aggregator/recovery/automatic-restart-authority.json
+Environment=VH_NEWS_DAEMON_RESTART_PERMIT_FILE=%h/.local/state/vhc/news-aggregator/recovery/automatic-restart-permit.json
+Environment=VH_NEWS_DAEMON_ATTENDED_START_PERMIT_FILE=%h/.local/state/vhc/news-aggregator/recovery/attended-start-permit.json
+Environment=VH_NEWS_DAEMON_ATTENDED_START_RECEIPT_FILE=%h/.local/state/vhc/news-aggregator/recovery/attended-start-consumption-receipt.json
 Environment=PATH=/home/humble/.local/bin:/usr/local/bin:/usr/bin:/bin
 WorkingDirectory=/home/humble/VHC
+ExecStartPre=/usr/bin/env bash /home/humble/VHC/tools/scripts/check-news-aggregator-expected-revision.sh REPLACE_WITH_FULL_40_HEX_COMMIT
 ExecStart=/usr/bin/env bash /home/humble/VHC/tools/scripts/start-news-aggregator-daemon-production.sh
+ExecStopPost=/usr/bin/env bash /home/humble/VHC/tools/scripts/record-news-aggregator-restartable-exit.sh REPLACE_WITH_FULL_40_HEX_COMMIT
 Restart=no
 RestartForceExitStatus=69
 RestartSec=30

--- a/infra/systemd/user/vh-news-aggregator.service
+++ b/infra/systemd/user/vh-news-aggregator.service
@@ -14,8 +14,8 @@ Environment=VH_NEWS_DAEMON_ENV_FILE=%h/.config/vhc/news-aggregator.env
 Environment=PATH=/home/humble/.local/bin:/usr/local/bin:/usr/bin:/bin
 WorkingDirectory=/home/humble/VHC
 ExecStart=/usr/bin/env bash /home/humble/VHC/tools/scripts/start-news-aggregator-daemon-production.sh
-Restart=on-failure
-RestartPreventExitStatus=78
+Restart=no
+RestartForceExitStatus=69
 RestartSec=30
 KillSignal=SIGTERM
 TimeoutStopSec=30

--- a/services/news-aggregator/src/daemonCli.ts
+++ b/services/news-aggregator/src/daemonCli.ts
@@ -10,8 +10,8 @@ export const NEWS_DAEMON_FAIL_CLOSED_EXIT_CODE = 78;
  * zero relays produced a validated acknowledgement after bounded endpoint-local
  * reconciliation and every POST remained network/deadline-unacknowledged. No
  * write-safety invariant is in doubt and the writes are id-keyed idempotent
- * upserts. systemd restarts this
- * exit code (`Restart=on-failure`; only 78 is in `RestartPreventExitStatus`),
+ * upserts. systemd restarts exactly this exit code (`Restart=no` with
+ * `RestartForceExitStatus=69`),
  * bounded by `StartLimitBurst`/`StartLimitIntervalSec`, giving transient
  * network blips a bounded self-recovery path while genuine write-safety halts
  * stay parked on 78 for operator inspection.

--- a/tools/scripts/check-news-aggregator-expected-revision.sh
+++ b/tools/scripts/check-news-aggregator-expected-revision.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="${VHC_REPO:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+EXPECTED_REVISION="${1:-${VH_NEWS_DAEMON_EXPECTED_REVISION:-}}"
+COMMON_SH="${REPO_ROOT}/tools/scripts/lib/news-aggregator-publisher-recovery-common.sh"
+
+if [[ ! -r "${COMMON_SH}" ]]; then
+  echo "[vh:publisher-recovery] exact-checkout guard is unavailable" >&2
+  exit 78
+fi
+# shellcheck disable=SC1090
+source "${COMMON_SH}"
+vh_publisher_require_exact_checkout "${REPO_ROOT}" "${EXPECTED_REVISION}"

--- a/tools/scripts/install-news-aggregator-production-service.sh
+++ b/tools/scripts/install-news-aggregator-production-service.sh
@@ -2,6 +2,9 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+COMMON_SH="${REPO_ROOT}/tools/scripts/lib/news-aggregator-publisher-recovery-common.sh"
+# shellcheck disable=SC1090
+source "${COMMON_SH}"
 UNIT_DIR="${HOME}/.config/systemd/user"
 ENV_FILE="${VH_NEWS_DAEMON_ENV_FILE:-${HOME}/.config/vhc/news-aggregator.env}"
 SERVICE_PATH="%h/.local/bin:%h/.hermes/node/bin:/usr/local/bin:/usr/bin:/bin"
@@ -10,34 +13,50 @@ ENABLE_PUBLISHER_LIVENESS_WATCH=false
 ENABLE_RELAY_LIVENESS_WATCH=false
 ENABLE_SOAK_ARCHIVE=false
 ENABLE_WATCH_CLOSURE=false
-START_PUBLISHER=false
+EXPECTED_REVISION=""
 
-for arg in "$@"; do
-  case "${arg}" in
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --expected-revision)
+      if [[ "$#" -lt 2 ]]; then
+        echo "--expected-revision requires a full commit id" >&2
+        exit 64
+      fi
+      EXPECTED_REVISION="$2"
+      shift 2
+      ;;
     --enable-watch)
       ENABLE_WATCH=true
+      shift
       ;;
     --enable-publisher-liveness-watch)
       ENABLE_PUBLISHER_LIVENESS_WATCH=true
+      shift
       ;;
     --enable-relay-liveness-watch)
       ENABLE_RELAY_LIVENESS_WATCH=true
+      shift
       ;;
     --enable-soak-archive)
       ENABLE_SOAK_ARCHIVE=true
+      shift
       ;;
     --enable-watch-closure)
       ENABLE_WATCH_CLOSURE=true
+      shift
       ;;
     --start-publisher)
-      START_PUBLISHER=true
+      echo "--start-publisher is retired; use news-aggregator-publisher-recovery-control.sh after reviewed preflight evidence" >&2
+      exit 78
       ;;
     *)
-      echo "Unknown argument: ${arg}" >&2
+      echo "Unknown argument: $1" >&2
       exit 64
       ;;
   esac
 done
+
+vh_publisher_require_exact_checkout "${REPO_ROOT}" "${EXPECTED_REVISION}"
 
 require_user_linger() {
   local user_name="${VHC_SYSTEMD_USER:-${USER:-}}"
@@ -85,9 +104,15 @@ StartLimitBurst=3
 Type=simple
 Environment=VHC_REPO=${REPO_ROOT}
 Environment=VH_NEWS_DAEMON_ENV_FILE=${ENV_FILE}
+Environment=VH_NEWS_DAEMON_EXPECTED_REVISION=${EXPECTED_REVISION}
+Environment=VH_NEWS_DAEMON_SYSTEMD_UNIT=vh-news-aggregator.service
+Environment=VH_NEWS_DAEMON_RESTART_AUTHORITY_FILE=%h/.local/state/vhc/news-aggregator/recovery/automatic-restart-authority.json
+Environment=VH_NEWS_DAEMON_RESTART_PERMIT_FILE=%h/.local/state/vhc/news-aggregator/recovery/automatic-restart-permit.json
 Environment=PATH=${SERVICE_PATH}
 WorkingDirectory=${REPO_ROOT}
+ExecStartPre=/usr/bin/env bash ${REPO_ROOT}/tools/scripts/check-news-aggregator-expected-revision.sh ${EXPECTED_REVISION}
 ExecStart=/usr/bin/env bash ${REPO_ROOT}/tools/scripts/start-news-aggregator-daemon-production.sh
+ExecStopPost=/usr/bin/env bash ${REPO_ROOT}/tools/scripts/record-news-aggregator-restartable-exit.sh ${EXPECTED_REVISION}
 Restart=on-failure
 RestartPreventExitStatus=78
 RestartSec=30
@@ -106,9 +131,11 @@ Documentation=file:${REPO_ROOT}/docs/ops/news-aggregator-production-service.md
 [Service]
 Type=oneshot
 Environment=VHC_REPO=${REPO_ROOT}
+Environment=VH_NEWS_DAEMON_EXPECTED_REVISION=${EXPECTED_REVISION}
 Environment=VH_RELAY_SNAPSHOT_WATCH_OUTPUT_FILE=%h/.local/state/vhc/relay-snapshot-watch/latest.json
 Environment=PATH=${SERVICE_PATH}
 WorkingDirectory=${REPO_ROOT}
+ExecStartPre=/usr/bin/env bash ${REPO_ROOT}/tools/scripts/check-news-aggregator-expected-revision.sh ${EXPECTED_REVISION}
 ExecStart=/usr/bin/env node ${REPO_ROOT}/tools/scripts/relay-latest-index-snapshot-watch.mjs
 EOF
 
@@ -121,9 +148,11 @@ Documentation=file:${REPO_ROOT}/docs/ops/news-aggregator-production-service.md
 Type=oneshot
 Environment=VHC_REPO=${REPO_ROOT}
 Environment=VH_NEWS_DAEMON_ENV_FILE=${ENV_FILE}
+Environment=VH_NEWS_DAEMON_EXPECTED_REVISION=${EXPECTED_REVISION}
 Environment=VH_NEWS_PUBLISHER_LIVENESS_OUTPUT_FILE=%h/.local/state/vhc/news-aggregator/publisher-liveness/latest.json
 Environment=PATH=${SERVICE_PATH}
 WorkingDirectory=${REPO_ROOT}
+ExecStartPre=/usr/bin/env bash ${REPO_ROOT}/tools/scripts/check-news-aggregator-expected-revision.sh ${EXPECTED_REVISION}
 ExecStart=/usr/bin/env bash -c 'set -a; source "${ENV_FILE}"; set +a; exec node "${REPO_ROOT}/tools/scripts/news-aggregator-publisher-liveness-watch.mjs"'
 EOF
 
@@ -150,12 +179,14 @@ Documentation=file:${REPO_ROOT}/docs/ops/news-aggregator-production-service.md
 [Service]
 Type=oneshot
 Environment=VHC_REPO=${REPO_ROOT}
+Environment=VH_NEWS_DAEMON_EXPECTED_REVISION=${EXPECTED_REVISION}
 Environment=VH_RELAY_LIVENESS_OUTPUT_FILE=%h/.local/state/vhc/relay-liveness/latest.json
 Environment=VH_RELAY_LIVENESS_RESTART_ON_FAIL=true
 Environment=VH_RELAY_LIVENESS_RESTART_MAX_PER_RUN=1
 Environment=VH_RELAY_LIVENESS_RESTART_MIN_INTERVAL_MS=600000
 Environment=PATH=${SERVICE_PATH}
 WorkingDirectory=${REPO_ROOT}
+ExecStartPre=/usr/bin/env bash ${REPO_ROOT}/tools/scripts/check-news-aggregator-expected-revision.sh ${EXPECTED_REVISION}
 ExecStart=/usr/bin/env node ${REPO_ROOT}/tools/scripts/news-relay-liveness-watch.mjs
 EOF
 
@@ -197,10 +228,12 @@ Documentation=file:${REPO_ROOT}/docs/ops/news-aggregator-production-service.md
 [Service]
 Type=oneshot
 Environment=VHC_REPO=${REPO_ROOT}
+Environment=VH_NEWS_DAEMON_EXPECTED_REVISION=${EXPECTED_REVISION}
 Environment=VH_PHASE5_SCOPE_A_SOAK_ARCHIVE_ROOT=%h/.local/state/vhc/phase5-scope-a-soak
 Environment=VH_PHASE5_SCOPE_A_SOAK_RUN_PUBLIC_MONITOR=true
 Environment=PATH=${SERVICE_PATH}
 WorkingDirectory=${REPO_ROOT}
+ExecStartPre=/usr/bin/env bash ${REPO_ROOT}/tools/scripts/check-news-aggregator-expected-revision.sh ${EXPECTED_REVISION}
 ExecStart=/usr/bin/env node ${REPO_ROOT}/tools/scripts/archive-phase5-scope-a-soak-sample.mjs
 EOF
 
@@ -227,6 +260,7 @@ Documentation=file:${REPO_ROOT}/docs/ops/news-aggregator-production-service.md
 [Service]
 Type=oneshot
 Environment=VHC_REPO=${REPO_ROOT}
+Environment=VH_NEWS_DAEMON_EXPECTED_REVISION=${EXPECTED_REVISION}
 Environment=VH_PHASE5_SCOPE_A_WATCH_ARCHIVE_ROOT=%h/.local/state/vhc/phase5-scope-a-soak
 Environment=VH_PHASE5_SCOPE_A_WATCH_RUNTIME_DIAGNOSTICS_FILE=%h/.local/state/vhc/news-aggregator/artifacts/news-runtime-diagnostics.json
 Environment=VH_PHASE5_SCOPE_A_WATCH_STORYCLUSTER_FAILURE_DIR=%h/.local/state/vhc/storycluster-engine/openai-failures
@@ -234,6 +268,7 @@ Environment=VH_PHASE5_SCOPE_A_WATCH_OUTPUT_FILE=%h/.local/state/vhc/phase5-scope
 Environment=VH_PHASE5_SCOPE_A_WATCH_VERDICT_FILE=%h/.local/state/vhc/phase5-scope-a-watch-closure/verdict.json
 Environment=PATH=${SERVICE_PATH}
 WorkingDirectory=${REPO_ROOT}
+ExecStartPre=/usr/bin/env bash ${REPO_ROOT}/tools/scripts/check-news-aggregator-expected-revision.sh ${EXPECTED_REVISION}
 ExecStart=/usr/bin/env bash -c 'if [ -f "%h/.config/vhc/phase5-scope-a-watch-closure.env" ]; then set -a; source "%h/.config/vhc/phase5-scope-a-watch-closure.env"; set +a; fi; exec node "${REPO_ROOT}/tools/scripts/phase5-scope-a-watch-closure-packet.mjs"'
 EOF
 
@@ -323,14 +358,4 @@ if [[ "${ENABLE_WATCH_CLOSURE}" == "true" ]]; then
   echo "Enabled Phase 5 Scope A watch closure timer"
 fi
 
-if [[ "${START_PUBLISHER}" == "true" ]]; then
-  if [[ "${VH_NEWS_DAEMON_START_APPROVED:-}" != "1" ]]; then
-    echo "--start-publisher requires VH_NEWS_DAEMON_START_APPROVED=1" >&2
-    exit 78
-  fi
-  systemctl --user set-environment VH_NEWS_DAEMON_START_APPROVED=1
-  systemctl --user enable --now vh-news-aggregator.service
-  echo "Enabled and started vh-news-aggregator.service with systemd manager approval env"
-else
-  echo "Publisher service installed but not started"
-fi
+echo "Publisher service installed for exact revision ${EXPECTED_REVISION} but not started"

--- a/tools/scripts/install-news-aggregator-production-service.sh
+++ b/tools/scripts/install-news-aggregator-production-service.sh
@@ -3,6 +3,10 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 COMMON_SH="${REPO_ROOT}/tools/scripts/lib/news-aggregator-publisher-recovery-common.sh"
+if [[ ! -r "${COMMON_SH}" ]]; then
+  echo "Publisher recovery common checks are unavailable" >&2
+  exit 78
+fi
 # shellcheck disable=SC1090
 source "${COMMON_SH}"
 UNIT_DIR="${HOME}/.config/systemd/user"
@@ -108,13 +112,14 @@ Environment=VH_NEWS_DAEMON_EXPECTED_REVISION=${EXPECTED_REVISION}
 Environment=VH_NEWS_DAEMON_SYSTEMD_UNIT=vh-news-aggregator.service
 Environment=VH_NEWS_DAEMON_RESTART_AUTHORITY_FILE=%h/.local/state/vhc/news-aggregator/recovery/automatic-restart-authority.json
 Environment=VH_NEWS_DAEMON_RESTART_PERMIT_FILE=%h/.local/state/vhc/news-aggregator/recovery/automatic-restart-permit.json
+Environment=VH_NEWS_DAEMON_ATTENDED_START_PERMIT_FILE=%h/.local/state/vhc/news-aggregator/recovery/attended-start-permit.json
 Environment=PATH=${SERVICE_PATH}
 WorkingDirectory=${REPO_ROOT}
 ExecStartPre=/usr/bin/env bash ${REPO_ROOT}/tools/scripts/check-news-aggregator-expected-revision.sh ${EXPECTED_REVISION}
 ExecStart=/usr/bin/env bash ${REPO_ROOT}/tools/scripts/start-news-aggregator-daemon-production.sh
 ExecStopPost=/usr/bin/env bash ${REPO_ROOT}/tools/scripts/record-news-aggregator-restartable-exit.sh ${EXPECTED_REVISION}
-Restart=on-failure
-RestartPreventExitStatus=78
+Restart=no
+RestartForceExitStatus=69
 RestartSec=30
 KillSignal=SIGTERM
 TimeoutStopSec=30

--- a/tools/scripts/install-news-aggregator-production-service.sh
+++ b/tools/scripts/install-news-aggregator-production-service.sh
@@ -113,6 +113,7 @@ Environment=VH_NEWS_DAEMON_SYSTEMD_UNIT=vh-news-aggregator.service
 Environment=VH_NEWS_DAEMON_RESTART_AUTHORITY_FILE=%h/.local/state/vhc/news-aggregator/recovery/automatic-restart-authority.json
 Environment=VH_NEWS_DAEMON_RESTART_PERMIT_FILE=%h/.local/state/vhc/news-aggregator/recovery/automatic-restart-permit.json
 Environment=VH_NEWS_DAEMON_ATTENDED_START_PERMIT_FILE=%h/.local/state/vhc/news-aggregator/recovery/attended-start-permit.json
+Environment=VH_NEWS_DAEMON_ATTENDED_START_RECEIPT_FILE=%h/.local/state/vhc/news-aggregator/recovery/attended-start-consumption-receipt.json
 Environment=PATH=${SERVICE_PATH}
 WorkingDirectory=${REPO_ROOT}
 ExecStartPre=/usr/bin/env bash ${REPO_ROOT}/tools/scripts/check-news-aggregator-expected-revision.sh ${EXPECTED_REVISION}

--- a/tools/scripts/lib/news-aggregator-publisher-recovery-common.sh
+++ b/tools/scripts/lib/news-aggregator-publisher-recovery-common.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# Shared fail-closed checks for the production publisher installer, ExecStart,
+# and attended recovery controller. Callers must enable `set -euo pipefail`.
+
+vh_publisher_is_full_revision() {
+  [[ "${1:-}" =~ ^[0-9a-f]{40}$ ]]
+}
+
+vh_publisher_require_full_revision() {
+  local revision="${1:-}"
+  if ! vh_publisher_is_full_revision "${revision}"; then
+    echo "[vh:publisher-recovery] expected revision must be a full lowercase commit id" >&2
+    return 78
+  fi
+}
+
+vh_publisher_require_exact_checkout() {
+  local repo_root="${1:-}"
+  local expected_revision="${2:-}"
+  local observed_revision tracked_status
+
+  vh_publisher_require_full_revision "${expected_revision}" || return $?
+  if [[ -z "${repo_root}" || ! -d "${repo_root}" ]]; then
+    echo "[vh:publisher-recovery] repository checkout is unavailable" >&2
+    return 78
+  fi
+  if ! observed_revision="$(command git -C "${repo_root}" rev-parse --verify HEAD 2>/dev/null)"; then
+    echo "[vh:publisher-recovery] unable to resolve checkout revision" >&2
+    return 78
+  fi
+  if [[ "${observed_revision}" != "${expected_revision}" ]]; then
+    echo "[vh:publisher-recovery] checkout revision does not match the reviewed revision" >&2
+    return 78
+  fi
+  if ! tracked_status="$(command git -C "${repo_root}" status --porcelain=v1 --untracked-files=no 2>/dev/null)"; then
+    echo "[vh:publisher-recovery] unable to verify tracked checkout cleanliness" >&2
+    return 78
+  fi
+  if [[ -n "${tracked_status}" ]]; then
+    echo "[vh:publisher-recovery] tracked checkout is dirty" >&2
+    return 78
+  fi
+}

--- a/tools/scripts/news-aggregator-publisher-automatic-restart-authority.mjs
+++ b/tools/scripts/news-aggregator-publisher-automatic-restart-authority.mjs
@@ -82,7 +82,7 @@ async function requirePrivateParent(filePath, { create = false } = {}) {
   }
 }
 
-async function readPrivateJson(filePath, label) {
+async function readPrivateJsonWithBytes(filePath, label) {
   if (!path.isAbsolute(filePath)) fail(`${label}_path_not_absolute`);
   await requirePrivateParent(filePath);
   let stat;
@@ -96,13 +96,18 @@ async function readPrivateJson(filePath, label) {
   if ((stat.mode & 0o777) !== 0o600) fail(`${label}_mode_not_0600`);
   if (stat.size <= 0 || stat.size > MAX_FILE_BYTES) fail(`${label}_size_invalid`);
   try {
-    const parsed = JSON.parse(await readFile(filePath, 'utf8'));
+    const bytes = await readFile(filePath);
+    const parsed = JSON.parse(bytes.toString('utf8'));
     if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) fail(`${label}_shape_invalid`);
-    return parsed;
+    return { parsed, bytes };
   } catch (error) {
     if (error instanceof RestartAuthorityError) throw error;
     fail(`${label}_json_invalid`);
   }
+}
+
+async function readPrivateJson(filePath, label) {
+  return (await readPrivateJsonWithBytes(filePath, label)).parsed;
 }
 
 async function writePrivateAtomic(filePath, payload, { replace = false } = {}) {
@@ -154,13 +159,13 @@ async function writePrivateAtomic(filePath, payload, { replace = false } = {}) {
   }
 }
 
-function parseLinuxProcStat(value) {
+export function parseLinuxProcStat(value) {
   const closingParen = value.lastIndexOf(')');
   if (closingParen < 0) fail('controller_identity_invalid');
   const fields = value.slice(closingParen + 1).trim().split(/\s+/);
   const state = fields[0];
   const startTicks = fields[19];
-  if (!state || state === 'Z' || state === 'X' || !/^\d+$/.test(startTicks ?? '')) {
+  if (!state || ['Z', 'X', 'T', 't'].includes(state) || !/^\d+$/.test(startTicks ?? '')) {
     fail('controller_not_live');
   }
   return { state, startTicks };
@@ -236,9 +241,12 @@ function validateAttendedEvidenceBindings(value) {
     'relayCaptureSha256',
     'mailboxSha256',
     'mailboxCriticalCount',
+    'systemWriterPinSha256',
   ];
   if (!exactKeys(value, keys)) fail('attended_evidence_bindings_invalid');
-  for (const key of keys.slice(0, 5)) sha256(value[key], 'attended_evidence_bindings_invalid');
+  for (const key of [...keys.slice(0, 5), 'systemWriterPinSha256']) {
+    sha256(value[key], 'attended_evidence_bindings_invalid');
+  }
   if (!Number.isSafeInteger(value.mailboxCriticalCount) || value.mailboxCriticalCount < 0) {
     fail('attended_evidence_bindings_invalid');
   }
@@ -246,6 +254,10 @@ function validateAttendedEvidenceBindings(value) {
 }
 
 async function takePrivateJson(filePath, label) {
+  return (await takePrivateJsonWithBytes(filePath, label)).parsed;
+}
+
+async function takePrivateJsonWithBytes(filePath, label) {
   if (!path.isAbsolute(filePath)) fail(`${label}_path_not_absolute`);
   await requirePrivateParent(filePath);
   const consumed = `${filePath}.consuming-${process.pid}-${randomUUID()}`;
@@ -256,7 +268,7 @@ async function takePrivateJson(filePath, label) {
     fail(`${label}_consume_failed`);
   }
   try {
-    return await readPrivateJson(consumed, label);
+    return await readPrivateJsonWithBytes(consumed, label);
   } finally {
     await removeAndVerify(consumed, `consumed_${label}`);
   }
@@ -267,6 +279,11 @@ export async function issueAttendedStartPermit(options) {
   const baselineNRestarts = nonNegativeInt(options.baselineNRestarts, 'baseline_nrestarts_invalid');
   const evidenceBindings = validateAttendedEvidenceBindings(options.evidenceBindings);
   if (!path.isAbsolute(options.startControlOutput ?? '')) fail('start_control_output_invalid');
+  if (!path.isAbsolute(options.attendedPermitFile ?? '')
+    || !path.isAbsolute(options.attendedReceiptFile ?? '')
+    || path.dirname(options.attendedPermitFile) !== path.dirname(options.attendedReceiptFile)) {
+    fail('attended_paths_invalid');
+  }
   const nowMs = options.nowMs ?? Date.now();
   const maxAgeMs = Number(options.maxAgeMs ?? DEFAULT_PERMIT_MAX_AGE_MS);
   if (!Number.isSafeInteger(maxAgeMs) || maxAgeMs <= 0 || maxAgeMs > 10 * 60 * 1000) {
@@ -287,6 +304,8 @@ export async function issueAttendedStartPermit(options) {
     evidenceBindings,
     controllerIdentity,
   };
+  await requirePrivateParent(options.attendedPermitFile, { create: true });
+  await removeAndVerify(options.attendedReceiptFile, 'attended_receipt');
   await writePrivateAtomic(options.attendedPermitFile, payload);
   return {
     status: 'attended_start_permit_issued',
@@ -297,6 +316,15 @@ export async function issueAttendedStartPermit(options) {
 export async function consumeAttendedStartPermit(options) {
   const expectedRevision = revision(options.expectedRevision);
   const currentNRestarts = nonNegativeInt(options.currentNRestarts, 'current_nrestarts_invalid');
+  const systemWriterPinSha256 = sha256(
+    options.systemWriterPinSha256,
+    'system_writer_pin_sha256_invalid',
+  );
+  if (!path.isAbsolute(options.attendedPermitFile ?? '')
+    || !path.isAbsolute(options.attendedReceiptFile ?? '')
+    || path.dirname(options.attendedPermitFile) !== path.dirname(options.attendedReceiptFile)) {
+    fail('attended_paths_invalid');
+  }
   const nowMs = options.nowMs ?? Date.now();
   const permit = await takePrivateJson(options.attendedPermitFile, 'attended_permit');
   const createdAtMs = Date.parse(permit.createdAt ?? '');
@@ -316,6 +344,9 @@ export async function consumeAttendedStartPermit(options) {
     fail('attended_permit_contract_invalid');
   }
   validateAttendedEvidenceBindings(permit.evidenceBindings);
+  if (permit.evidenceBindings.systemWriterPinSha256 !== systemWriterPinSha256) {
+    fail('attended_system_writer_pin_mismatch');
+  }
   const expectedIdentity = validateControllerIdentity(permit.controllerIdentity);
   const currentIdentity = validateControllerIdentity(
     options.controllerIdentity ?? await processIdentity(expectedIdentity.pid),
@@ -323,12 +354,128 @@ export async function consumeAttendedStartPermit(options) {
   if (JSON.stringify(currentIdentity) !== JSON.stringify(expectedIdentity)) {
     fail('attended_controller_identity_changed');
   }
+  const permitBindingSha256 = createHash('sha256').update(JSON.stringify(permit)).digest('hex');
+  const receipt = {
+    schemaVersion: 'vh-news-publisher-attended-start-consumption-receipt-v1',
+    status: 'consumed_pending_controller_validation',
+    revision: expectedRevision,
+    consumedAt: new Date(nowMs).toISOString(),
+    permitBindingSha256,
+    baselineNRestarts: permit.baselineNRestarts,
+    currentNRestarts,
+    startControlOutput: permit.startControlOutput,
+    systemWriterPinSha256,
+    evidenceBindings: structuredClone(permit.evidenceBindings),
+    controllerIdentity: structuredClone(expectedIdentity),
+  };
+  await writePrivateAtomic(options.attendedReceiptFile, receipt);
   return {
     status: 'attended_start_authorized',
     currentNRestarts,
-    permitBindingSha256: createHash('sha256').update(JSON.stringify(permit)).digest('hex'),
+    permitBindingSha256,
     evidenceBindings: structuredClone(permit.evidenceBindings),
   };
+}
+
+export async function consumeAttendedStartReceipt(options) {
+  const expectedRevision = revision(options.expectedRevision);
+  const currentNRestarts = nonNegativeInt(options.currentNRestarts, 'current_nrestarts_invalid');
+  const expectedPermitBindingSha256 = sha256(
+    options.expectedPermitBindingSha256,
+    'expected_permit_binding_sha256_invalid',
+  );
+  const expectedEvidenceBindings = validateAttendedEvidenceBindings(options.evidenceBindings);
+  if (!path.isAbsolute(options.startControlOutput ?? '')) fail('start_control_output_invalid');
+  const nowMs = options.nowMs ?? Date.now();
+  const maxAgeMs = Number(options.maxAgeMs ?? DEFAULT_PERMIT_MAX_AGE_MS);
+  if (!Number.isSafeInteger(maxAgeMs) || maxAgeMs <= 0 || maxAgeMs > 10 * 60 * 1000) {
+    fail('receipt_max_age_invalid');
+  }
+  const { parsed: receipt, bytes } = await takePrivateJsonWithBytes(
+    options.attendedReceiptFile,
+    'attended_receipt',
+  );
+  const consumedAtMs = Date.parse(receipt.consumedAt ?? '');
+  if (!exactKeys(receipt, [
+    'schemaVersion', 'status', 'revision', 'consumedAt', 'permitBindingSha256',
+    'baselineNRestarts', 'currentNRestarts', 'startControlOutput', 'systemWriterPinSha256',
+    'evidenceBindings', 'controllerIdentity',
+  ])
+    || receipt.schemaVersion !== 'vh-news-publisher-attended-start-consumption-receipt-v1'
+    || receipt.status !== 'consumed_pending_controller_validation'
+    || receipt.revision !== expectedRevision
+    || receipt.permitBindingSha256 !== expectedPermitBindingSha256
+    || receipt.baselineNRestarts !== currentNRestarts
+    || receipt.currentNRestarts !== currentNRestarts
+    || receipt.startControlOutput !== path.resolve(options.startControlOutput)
+    || receipt.systemWriterPinSha256 !== expectedEvidenceBindings.systemWriterPinSha256
+    || JSON.stringify(receipt.evidenceBindings) !== JSON.stringify(expectedEvidenceBindings)
+    || !Number.isFinite(consumedAtMs) || consumedAtMs > nowMs + 5_000
+    || nowMs - consumedAtMs > maxAgeMs) {
+    fail('attended_receipt_contract_invalid');
+  }
+  const expectedIdentity = validateControllerIdentity(receipt.controllerIdentity);
+  const currentIdentity = validateControllerIdentity(
+    options.controllerIdentity ?? await processIdentity(options.controllerPid ?? expectedIdentity.pid),
+  );
+  if (JSON.stringify(currentIdentity) !== JSON.stringify(expectedIdentity)) {
+    fail('attended_receipt_controller_identity_changed');
+  }
+  return {
+    status: 'attended_start_receipt_consumed',
+    permitBindingSha256: receipt.permitBindingSha256,
+    receiptSha256: createHash('sha256').update(bytes).digest('hex'),
+    systemWriterPinSha256: receipt.systemWriterPinSha256,
+    currentNRestarts,
+    evidenceBindings: structuredClone(receipt.evidenceBindings),
+  };
+}
+
+export async function normalizeCanonicalRecoveryDirectory(options) {
+  if (!path.isAbsolute(options.homeDirectory ?? '') || !path.isAbsolute(options.directory ?? '')) {
+    fail('canonical_recovery_directory_invalid');
+  }
+  const expected = path.join(
+    path.resolve(options.homeDirectory),
+    '.local/state/vhc/news-aggregator/recovery',
+  );
+  if (path.resolve(options.directory) !== expected) fail('canonical_recovery_directory_invalid');
+  try {
+    await mkdir(expected, { recursive: true, mode: 0o700 });
+  } catch {
+    fail('canonical_recovery_directory_create_failed');
+  }
+  let stat;
+  let canonical;
+  try {
+    stat = await lstat(expected);
+    canonical = await realpath(expected);
+  } catch {
+    fail('canonical_recovery_directory_unavailable');
+  }
+  if (stat.isSymbolicLink() || !stat.isDirectory() || canonical !== expected) {
+    fail('canonical_recovery_directory_not_regular');
+  }
+  if (typeof process.getuid === 'function' && stat.uid !== process.getuid()) {
+    fail('canonical_recovery_directory_wrong_owner');
+  }
+  const mode = stat.mode & 0o777;
+  if (mode === 0o755) {
+    try {
+      await chmod(expected, 0o700);
+      stat = await lstat(expected);
+    } catch {
+      fail('canonical_recovery_directory_normalize_failed');
+    }
+  } else if (mode !== 0o700) {
+    fail('canonical_recovery_directory_mode_invalid');
+  }
+  if (stat.isSymbolicLink() || !stat.isDirectory()
+    || (typeof process.getuid === 'function' && stat.uid !== process.getuid())
+    || (stat.mode & 0o777) !== 0o700) {
+    fail('canonical_recovery_directory_normalize_failed');
+  }
+  return { status: 'canonical_recovery_directory_private', directory: expected };
 }
 
 function parseArgs(argv) {
@@ -441,6 +588,7 @@ export async function consumeAutomaticRestartPermit(options) {
 }
 
 export async function disarmRestartAuthority(options) {
+  if (options.attendedReceiptFile) await removeAndVerify(options.attendedReceiptFile, 'attended_receipt');
   if (options.attendedPermitFile) await removeAndVerify(options.attendedPermitFile, 'attended_permit');
   await removeAndVerify(options.permitFile, 'permit');
   await removeAndVerify(options.authorityFile, 'authority');
@@ -451,11 +599,14 @@ async function main() {
   const authorityValue = values.get('--authority-file');
   const permitValue = values.get('--permit-file');
   const attendedPermitValue = values.get('--attended-permit-file');
+  const attendedReceiptValue = values.get('--attended-receipt-file');
   const needsAutomaticPaths = ['arm', 'record-exit', 'consume', 'disarm'].includes(command);
-  const needsAttendedPath = ['issue-attended', 'consume-attended'].includes(command);
+  const needsAttendedPaths = ['issue-attended', 'consume-attended'].includes(command);
+  const needsReceiptPath = ['issue-attended', 'consume-attended', 'consume-attended-receipt'].includes(command);
   if ((needsAutomaticPaths && (!authorityValue || !permitValue
       || !path.isAbsolute(authorityValue) || !path.isAbsolute(permitValue)))
-    || (needsAttendedPath && (!attendedPermitValue || !path.isAbsolute(attendedPermitValue)))) {
+    || (needsAttendedPaths && (!attendedPermitValue || !path.isAbsolute(attendedPermitValue)))
+    || (needsReceiptPath && (!attendedReceiptValue || !path.isAbsolute(attendedReceiptValue)))) {
     fail('restart_paths_invalid');
   }
   const common = {
@@ -463,6 +614,7 @@ async function main() {
     ...(authorityValue ? { authorityFile: path.resolve(authorityValue) } : {}),
     ...(permitValue ? { permitFile: path.resolve(permitValue) } : {}),
     ...(attendedPermitValue ? { attendedPermitFile: path.resolve(attendedPermitValue) } : {}),
+    ...(attendedReceiptValue ? { attendedReceiptFile: path.resolve(attendedReceiptValue) } : {}),
   };
   let result = { status: 'pass' };
   if (command === 'arm') {
@@ -500,6 +652,28 @@ async function main() {
     result = await consumeAttendedStartPermit({
       ...common,
       currentNRestarts: values.get('--current-nrestarts'),
+      systemWriterPinSha256: values.get('--system-writer-pin-sha256'),
+    });
+  } else if (command === 'consume-attended-receipt') {
+    let evidenceBindings;
+    try {
+      evidenceBindings = JSON.parse(values.get('--evidence-bindings-json') ?? '');
+    } catch {
+      fail('attended_evidence_bindings_invalid');
+    }
+    result = await consumeAttendedStartReceipt({
+      ...common,
+      expectedPermitBindingSha256: values.get('--expected-permit-binding-sha256'),
+      currentNRestarts: values.get('--current-nrestarts'),
+      startControlOutput: values.get('--start-control-output'),
+      evidenceBindings,
+      controllerPid: values.get('--controller-pid'),
+      maxAgeMs: values.get('--max-age-ms'),
+    });
+  } else if (command === 'normalize-recovery-dir') {
+    result = await normalizeCanonicalRecoveryDirectory({
+      directory: values.get('--directory'),
+      homeDirectory: values.get('--home-directory'),
     });
   } else if (command === 'disarm') {
     await disarmRestartAuthority(common);

--- a/tools/scripts/news-aggregator-publisher-automatic-restart-authority.mjs
+++ b/tools/scripts/news-aggregator-publisher-automatic-restart-authority.mjs
@@ -1,0 +1,306 @@
+#!/usr/bin/env node
+
+import { randomUUID } from 'node:crypto';
+import { chmod, lstat, mkdir, open, readFile, realpath, rename, rm } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const MAX_FILE_BYTES = 64 * 1024;
+const DEFAULT_PERMIT_MAX_AGE_MS = 120_000;
+
+class RestartAuthorityError extends Error {
+  constructor(code) {
+    super(code);
+    this.code = code;
+  }
+}
+
+function fail(code) {
+  throw new RestartAuthorityError(code);
+}
+
+function revision(value) {
+  if (typeof value !== 'string' || !/^[0-9a-f]{40}$/.test(value)) fail('revision_invalid');
+  return value;
+}
+
+function nonNegativeInt(value, code) {
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < 0) fail(code);
+  return parsed;
+}
+
+async function bestEffortRemove(filePath) {
+  await rm(filePath, { force: true }).catch(() => undefined);
+}
+
+async function removeAndVerify(filePath, label) {
+  try {
+    await rm(filePath, { force: true });
+  } catch {
+    fail(`${label}_remove_failed`);
+  }
+  try {
+    await lstat(filePath);
+    fail(`${label}_remove_failed`);
+  } catch (error) {
+    if (error instanceof RestartAuthorityError) throw error;
+    if (error?.code !== 'ENOENT') fail(`${label}_remove_verify_failed`);
+  }
+}
+
+async function requirePrivateParent(filePath, { create = false } = {}) {
+  const parent = path.dirname(filePath);
+  if (create) await mkdir(parent, { recursive: true, mode: 0o700 });
+  let stat;
+  try {
+    stat = await lstat(parent);
+  } catch {
+    fail('parent_missing');
+  }
+  if (stat.isSymbolicLink() || !stat.isDirectory()) fail('parent_not_regular_directory');
+  if (typeof process.getuid === 'function' && stat.uid !== process.getuid()) fail('parent_wrong_owner');
+  if ((stat.mode & 0o777) !== 0o700) fail('parent_mode_not_0700');
+  try {
+    if (await realpath(parent) !== path.resolve(parent)) fail('parent_contains_symlink');
+  } catch (error) {
+    if (error instanceof RestartAuthorityError) throw error;
+    fail('parent_realpath_failed');
+  }
+}
+
+async function readPrivateJson(filePath, label) {
+  if (!path.isAbsolute(filePath)) fail(`${label}_path_not_absolute`);
+  await requirePrivateParent(filePath);
+  let stat;
+  try {
+    stat = await lstat(filePath);
+  } catch {
+    fail(`${label}_missing`);
+  }
+  if (stat.isSymbolicLink() || !stat.isFile()) fail(`${label}_not_regular`);
+  if (typeof process.getuid === 'function' && stat.uid !== process.getuid()) fail(`${label}_wrong_owner`);
+  if ((stat.mode & 0o777) !== 0o600) fail(`${label}_mode_not_0600`);
+  if (stat.size <= 0 || stat.size > MAX_FILE_BYTES) fail(`${label}_size_invalid`);
+  try {
+    const parsed = JSON.parse(await readFile(filePath, 'utf8'));
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) fail(`${label}_shape_invalid`);
+    return parsed;
+  } catch (error) {
+    if (error instanceof RestartAuthorityError) throw error;
+    fail(`${label}_json_invalid`);
+  }
+}
+
+async function writePrivateAtomic(filePath, payload, { replace = false } = {}) {
+  if (!path.isAbsolute(filePath)) fail('output_path_not_absolute');
+  const parent = path.dirname(filePath);
+  await requirePrivateParent(filePath, { create: true });
+  if (!replace) {
+    try {
+      await lstat(filePath);
+      fail('output_exists');
+    } catch (error) {
+      if (error instanceof RestartAuthorityError) throw error;
+      if (error?.code !== 'ENOENT') throw error;
+    }
+  } else {
+    try {
+      const existing = await lstat(filePath);
+      if (existing.isSymbolicLink() || !existing.isFile()
+        || (typeof process.getuid === 'function' && existing.uid !== process.getuid())
+        || (existing.mode & 0o777) !== 0o600) {
+        fail('replace_target_unsafe');
+      }
+    } catch (error) {
+      if (error instanceof RestartAuthorityError) throw error;
+      if (error?.code !== 'ENOENT') throw error;
+    }
+  }
+  const temp = path.join(parent, `.${path.basename(filePath)}.tmp-${process.pid}-${Date.now()}`);
+  let handle;
+  try {
+    handle = await open(temp, 'wx', 0o600);
+    await handle.writeFile(`${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+    await handle.sync();
+    await handle.close();
+    handle = undefined;
+    await chmod(temp, 0o600);
+    await requirePrivateParent(filePath);
+    await rename(temp, filePath);
+    await chmod(filePath, 0o600);
+  } catch (error) {
+    await handle?.close().catch(() => undefined);
+    await bestEffortRemove(temp);
+    throw error;
+  }
+}
+
+function parseArgs(argv) {
+  const [command, ...rest] = argv;
+  const values = new Map();
+  for (let index = 0; index < rest.length; index += 2) {
+    const flag = rest[index];
+    const value = rest[index + 1];
+    if (!flag?.startsWith('--') || value === undefined || values.has(flag)) fail('arguments_invalid');
+    values.set(flag, value);
+  }
+  return { command, values };
+}
+
+export async function armRestartAuthority(options) {
+  const expectedRevision = revision(options.expectedRevision);
+  const baselineNRestarts = nonNegativeInt(options.baselineNRestarts, 'baseline_nrestarts_invalid');
+  if (path.dirname(options.authorityFile) !== path.dirname(options.permitFile)) fail('restart_paths_parent_mismatch');
+  await requirePrivateParent(options.authorityFile, { create: true });
+  await requirePrivateParent(options.permitFile);
+  await removeAndVerify(options.permitFile, 'permit');
+  await writePrivateAtomic(options.authorityFile, {
+    schemaVersion: 'vh-news-publisher-automatic-restart-authority-v1',
+    status: 'armed',
+    revision: expectedRevision,
+    authorizedAt: new Date(options.nowMs ?? Date.now()).toISOString(),
+    baselineNRestarts,
+    allowedExitStatus: 69,
+    nextInvocationRequiresNRestartsIncrement: true,
+  }, { replace: true });
+}
+
+export async function recordRestartableExit(options) {
+  const exactExit69 = options.serviceResult === 'exit-code'
+    && options.exitCode === 'exited'
+    && String(options.exitStatus) === '69';
+  if (!exactExit69) {
+    await removeAndVerify(options.permitFile, 'permit');
+    return { status: 'ignored_non_restartable_exit' };
+  }
+  const expectedRevision = revision(options.expectedRevision);
+  const previousNRestarts = nonNegativeInt(options.previousNRestarts, 'previous_nrestarts_invalid');
+  if (previousNRestarts >= Number.MAX_SAFE_INTEGER) fail('previous_nrestarts_invalid');
+  const nowMs = options.nowMs ?? Date.now();
+  let authority;
+  try {
+    authority = await readPrivateJson(options.authorityFile, 'authority');
+  } catch (error) {
+    await removeAndVerify(options.permitFile, 'permit');
+    throw error;
+  }
+  const authorizedAtMs = Date.parse(authority.authorizedAt ?? '');
+  if (authority.schemaVersion !== 'vh-news-publisher-automatic-restart-authority-v1'
+    || authority.status !== 'armed' || authority.revision !== expectedRevision
+    || authority.allowedExitStatus !== 69
+    || authority.nextInvocationRequiresNRestartsIncrement !== true
+    || !Number.isSafeInteger(authority.baselineNRestarts)
+    || !Number.isFinite(authorizedAtMs) || authorizedAtMs > nowMs + 5_000
+    || previousNRestarts < authority.baselineNRestarts) {
+    await removeAndVerify(options.permitFile, 'permit');
+    fail('authority_contract_invalid');
+  }
+  await writePrivateAtomic(options.permitFile, {
+    schemaVersion: 'vh-news-publisher-automatic-restart-permit-v1',
+    status: 'pending_single_use',
+    revision: expectedRevision,
+    createdAt: new Date(nowMs).toISOString(),
+    previousNRestarts,
+    expectedNRestarts: previousNRestarts + 1,
+    serviceResult: 'exit-code',
+    exitCode: 'exited',
+    exitStatus: 69,
+  });
+  return { status: 'permit_recorded', previousNRestarts, expectedNRestarts: previousNRestarts + 1 };
+}
+
+export async function consumeAutomaticRestartPermit(options) {
+  const expectedRevision = revision(options.expectedRevision);
+  const currentNRestarts = nonNegativeInt(options.currentNRestarts, 'current_nrestarts_invalid');
+  const nowMs = options.nowMs ?? Date.now();
+  const maxAgeMs = Number(options.maxAgeMs ?? DEFAULT_PERMIT_MAX_AGE_MS);
+  if (!Number.isSafeInteger(maxAgeMs) || maxAgeMs <= 0 || maxAgeMs > 10 * 60 * 1000) fail('permit_max_age_invalid');
+  let authority;
+  let permit;
+  try {
+    authority = await readPrivateJson(options.authorityFile, 'authority');
+    permit = await readPrivateJson(options.permitFile, 'permit');
+  } catch (error) {
+    await removeAndVerify(options.permitFile, 'permit');
+    throw error;
+  }
+  const createdAtMs = Date.parse(permit.createdAt ?? '');
+  const authorizedAtMs = Date.parse(authority.authorizedAt ?? '');
+  if (authority.schemaVersion !== 'vh-news-publisher-automatic-restart-authority-v1'
+    || authority.status !== 'armed' || authority.revision !== expectedRevision
+    || permit.schemaVersion !== 'vh-news-publisher-automatic-restart-permit-v1'
+    || permit.status !== 'pending_single_use' || permit.revision !== expectedRevision
+    || permit.serviceResult !== 'exit-code' || permit.exitCode !== 'exited' || permit.exitStatus !== 69
+    || !Number.isSafeInteger(permit.previousNRestarts)
+    || permit.previousNRestarts >= Number.MAX_SAFE_INTEGER
+    || !Number.isSafeInteger(authority.baselineNRestarts)
+    || permit.previousNRestarts < authority.baselineNRestarts
+    || permit.expectedNRestarts !== permit.previousNRestarts + 1
+    || currentNRestarts !== permit.expectedNRestarts
+    || !Number.isFinite(authorizedAtMs) || authorizedAtMs > nowMs + 5_000
+    || !Number.isFinite(createdAtMs) || createdAtMs < authorizedAtMs
+    || createdAtMs > nowMs + 5_000 || nowMs - createdAtMs > maxAgeMs) {
+    await removeAndVerify(options.permitFile, 'permit');
+    fail('permit_contract_invalid');
+  }
+  const consumed = `${options.permitFile}.consuming-${process.pid}-${randomUUID()}`;
+  try {
+    await rename(options.permitFile, consumed);
+    const moved = await readPrivateJson(consumed, 'permit');
+    if (JSON.stringify(moved) !== JSON.stringify(permit)) fail('permit_changed_during_consume');
+  } finally {
+    await removeAndVerify(consumed, 'consumed_permit');
+  }
+  return { status: 'automatic_restart_authorized', currentNRestarts };
+}
+
+export async function disarmRestartAuthority(options) {
+  await removeAndVerify(options.permitFile, 'permit');
+  await removeAndVerify(options.authorityFile, 'authority');
+}
+
+async function main() {
+  const { command, values } = parseArgs(process.argv.slice(2));
+  const authorityValue = values.get('--authority-file');
+  const permitValue = values.get('--permit-file');
+  if (!authorityValue || !permitValue
+    || !path.isAbsolute(authorityValue) || !path.isAbsolute(permitValue)) {
+    fail('restart_paths_invalid');
+  }
+  const common = {
+    expectedRevision: values.get('--expected-revision'),
+    authorityFile: path.resolve(authorityValue),
+    permitFile: path.resolve(permitValue),
+  };
+  let result = { status: 'pass' };
+  if (command === 'arm') {
+    await armRestartAuthority({ ...common, baselineNRestarts: values.get('--baseline-nrestarts') });
+  } else if (command === 'record-exit') {
+    result = await recordRestartableExit({
+      ...common,
+      serviceResult: values.get('--service-result'),
+      exitCode: values.get('--exit-code'),
+      exitStatus: values.get('--exit-status'),
+      previousNRestarts: values.get('--previous-nrestarts'),
+    });
+  } else if (command === 'consume') {
+    result = await consumeAutomaticRestartPermit({
+      ...common,
+      currentNRestarts: values.get('--current-nrestarts'),
+      maxAgeMs: values.get('--max-age-ms'),
+    });
+  } else if (command === 'disarm') {
+    await disarmRestartAuthority(common);
+  } else {
+    fail('command_invalid');
+  }
+  console.info(JSON.stringify(result));
+}
+
+if (path.resolve(fileURLToPath(import.meta.url)) === path.resolve(process.argv[1] ?? '')) {
+  main().catch((error) => {
+    console.error(`[vh:publisher-recovery] ${error instanceof RestartAuthorityError ? error.code : 'restart_authority_unexpected_failure'}`);
+    process.exit(78);
+  });
+}

--- a/tools/scripts/news-aggregator-publisher-automatic-restart-authority.mjs
+++ b/tools/scripts/news-aggregator-publisher-automatic-restart-authority.mjs
@@ -1,12 +1,15 @@
 #!/usr/bin/env node
 
-import { randomUUID } from 'node:crypto';
-import { chmod, lstat, mkdir, open, readFile, realpath, rename, rm } from 'node:fs/promises';
+import { createHash, randomUUID } from 'node:crypto';
+import { execFile } from 'node:child_process';
+import { chmod, link, lstat, mkdir, open, readFile, realpath, rename, rm } from 'node:fs/promises';
 import path from 'node:path';
+import { promisify } from 'node:util';
 import { fileURLToPath } from 'node:url';
 
 const MAX_FILE_BYTES = 64 * 1024;
 const DEFAULT_PERMIT_MAX_AGE_MS = 120_000;
+const execFileAsync = promisify(execFile);
 
 class RestartAuthorityError extends Error {
   constructor(code) {
@@ -28,6 +31,16 @@ function nonNegativeInt(value, code) {
   const parsed = Number(value);
   if (!Number.isSafeInteger(parsed) || parsed < 0) fail(code);
   return parsed;
+}
+
+function sha256(value, code = 'sha256_invalid') {
+  if (typeof value !== 'string' || !/^[0-9a-f]{64}$/.test(value)) fail(code);
+  return value;
+}
+
+function exactKeys(value, keys) {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    && JSON.stringify(Object.keys(value).sort()) === JSON.stringify([...keys].sort());
 }
 
 async function bestEffortRemove(filePath) {
@@ -127,13 +140,195 @@ async function writePrivateAtomic(filePath, payload, { replace = false } = {}) {
     handle = undefined;
     await chmod(temp, 0o600);
     await requirePrivateParent(filePath);
-    await rename(temp, filePath);
-    await chmod(filePath, 0o600);
+    if (replace) {
+      await rename(temp, filePath);
+      await chmod(filePath, 0o600);
+    } else {
+      await link(temp, filePath);
+      await bestEffortRemove(temp);
+    }
   } catch (error) {
     await handle?.close().catch(() => undefined);
     await bestEffortRemove(temp);
     throw error;
   }
+}
+
+function parseLinuxProcStat(value) {
+  const closingParen = value.lastIndexOf(')');
+  if (closingParen < 0) fail('controller_identity_invalid');
+  const fields = value.slice(closingParen + 1).trim().split(/\s+/);
+  const state = fields[0];
+  const startTicks = fields[19];
+  if (!state || state === 'Z' || state === 'X' || !/^\d+$/.test(startTicks ?? '')) {
+    fail('controller_not_live');
+  }
+  return { state, startTicks };
+}
+
+async function processIdentity(pid) {
+  const parsedPid = Number(pid);
+  if (!Number.isSafeInteger(parsedPid) || parsedPid <= 1) fail('controller_pid_invalid');
+  if (process.platform === 'linux') {
+    let bootId;
+    let stat;
+    try {
+      [bootId, stat] = await Promise.all([
+        readFile('/proc/sys/kernel/random/boot_id', 'utf8'),
+        readFile(`/proc/${parsedPid}/stat`, 'utf8'),
+      ]);
+    } catch {
+      fail('controller_not_live');
+    }
+    const normalizedBootId = bootId.trim().toLowerCase();
+    if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.test(normalizedBootId)) {
+      fail('controller_identity_invalid');
+    }
+    const parsedStat = parseLinuxProcStat(stat);
+    return {
+      scheme: 'linux-proc-v1',
+      pid: parsedPid,
+      bootId: normalizedBootId,
+      processStartId: parsedStat.startTicks,
+    };
+  }
+
+  // The production service is Linux/systemd. This fallback keeps repository
+  // tests and local dry runs deterministic on macOS without weakening the
+  // Linux identity contract used on A6.
+  let processStart;
+  let bootIdentity;
+  try {
+    const [{ stdout: processStdout }, { stdout: bootStdout }] = await Promise.all([
+      execFileAsync('/bin/ps', ['-o', 'lstart=', '-p', String(parsedPid)], { encoding: 'utf8' }),
+      execFileAsync('/usr/sbin/sysctl', ['-n', 'kern.boottime'], { encoding: 'utf8' }),
+    ]);
+    processStart = processStdout.trim();
+    bootIdentity = bootStdout.trim();
+  } catch {
+    fail('controller_not_live');
+  }
+  if (!processStart || !bootIdentity) fail('controller_identity_invalid');
+  return {
+    scheme: 'posix-ps-v1',
+    pid: parsedPid,
+    bootId: createHash('sha256').update(bootIdentity).digest('hex'),
+    processStartId: createHash('sha256').update(processStart).digest('hex'),
+  };
+}
+
+function validateControllerIdentity(value) {
+  if (!exactKeys(value, ['scheme', 'pid', 'bootId', 'processStartId'])
+    || !['linux-proc-v1', 'posix-ps-v1'].includes(value.scheme)
+    || !Number.isSafeInteger(value.pid) || value.pid <= 1
+    || typeof value.bootId !== 'string' || value.bootId.length < 32 || value.bootId.length > 64
+    || typeof value.processStartId !== 'string' || !/^[0-9a-f]+$/i.test(value.processStartId)) {
+    fail('controller_identity_invalid');
+  }
+  return value;
+}
+
+function validateAttendedEvidenceBindings(value) {
+  const keys = [
+    'preflightSha256',
+    'relayEvidenceSha256',
+    'relayPacketSha256',
+    'relayCaptureSha256',
+    'mailboxSha256',
+    'mailboxCriticalCount',
+  ];
+  if (!exactKeys(value, keys)) fail('attended_evidence_bindings_invalid');
+  for (const key of keys.slice(0, 5)) sha256(value[key], 'attended_evidence_bindings_invalid');
+  if (!Number.isSafeInteger(value.mailboxCriticalCount) || value.mailboxCriticalCount < 0) {
+    fail('attended_evidence_bindings_invalid');
+  }
+  return structuredClone(value);
+}
+
+async function takePrivateJson(filePath, label) {
+  if (!path.isAbsolute(filePath)) fail(`${label}_path_not_absolute`);
+  await requirePrivateParent(filePath);
+  const consumed = `${filePath}.consuming-${process.pid}-${randomUUID()}`;
+  try {
+    await rename(filePath, consumed);
+  } catch (error) {
+    if (error?.code === 'ENOENT') fail(`${label}_missing`);
+    fail(`${label}_consume_failed`);
+  }
+  try {
+    return await readPrivateJson(consumed, label);
+  } finally {
+    await removeAndVerify(consumed, `consumed_${label}`);
+  }
+}
+
+export async function issueAttendedStartPermit(options) {
+  const expectedRevision = revision(options.expectedRevision);
+  const baselineNRestarts = nonNegativeInt(options.baselineNRestarts, 'baseline_nrestarts_invalid');
+  const evidenceBindings = validateAttendedEvidenceBindings(options.evidenceBindings);
+  if (!path.isAbsolute(options.startControlOutput ?? '')) fail('start_control_output_invalid');
+  const nowMs = options.nowMs ?? Date.now();
+  const maxAgeMs = Number(options.maxAgeMs ?? DEFAULT_PERMIT_MAX_AGE_MS);
+  if (!Number.isSafeInteger(maxAgeMs) || maxAgeMs <= 0 || maxAgeMs > 10 * 60 * 1000) {
+    fail('permit_max_age_invalid');
+  }
+  const controllerIdentity = validateControllerIdentity(
+    options.controllerIdentity ?? await processIdentity(options.controllerPid ?? process.ppid),
+  );
+  const payload = {
+    schemaVersion: 'vh-news-publisher-attended-start-permit-v1',
+    status: 'pending_single_use',
+    revision: expectedRevision,
+    createdAt: new Date(nowMs).toISOString(),
+    expiresAt: new Date(nowMs + maxAgeMs).toISOString(),
+    nonce: randomUUID(),
+    baselineNRestarts,
+    startControlOutput: path.resolve(options.startControlOutput),
+    evidenceBindings,
+    controllerIdentity,
+  };
+  await writePrivateAtomic(options.attendedPermitFile, payload);
+  return {
+    status: 'attended_start_permit_issued',
+    permitBindingSha256: createHash('sha256').update(JSON.stringify(payload)).digest('hex'),
+  };
+}
+
+export async function consumeAttendedStartPermit(options) {
+  const expectedRevision = revision(options.expectedRevision);
+  const currentNRestarts = nonNegativeInt(options.currentNRestarts, 'current_nrestarts_invalid');
+  const nowMs = options.nowMs ?? Date.now();
+  const permit = await takePrivateJson(options.attendedPermitFile, 'attended_permit');
+  const createdAtMs = Date.parse(permit.createdAt ?? '');
+  const expiresAtMs = Date.parse(permit.expiresAt ?? '');
+  if (!exactKeys(permit, [
+    'schemaVersion', 'status', 'revision', 'createdAt', 'expiresAt', 'nonce',
+    'baselineNRestarts', 'startControlOutput', 'evidenceBindings', 'controllerIdentity',
+  ])
+    || permit.schemaVersion !== 'vh-news-publisher-attended-start-permit-v1'
+    || permit.status !== 'pending_single_use'
+    || permit.revision !== expectedRevision
+    || typeof permit.nonce !== 'string' || !/^[0-9a-f-]{36}$/.test(permit.nonce)
+    || permit.baselineNRestarts !== currentNRestarts
+    || !path.isAbsolute(permit.startControlOutput ?? '')
+    || !Number.isFinite(createdAtMs) || !Number.isFinite(expiresAtMs)
+    || createdAtMs > nowMs + 5_000 || expiresAtMs <= createdAtMs || nowMs > expiresAtMs) {
+    fail('attended_permit_contract_invalid');
+  }
+  validateAttendedEvidenceBindings(permit.evidenceBindings);
+  const expectedIdentity = validateControllerIdentity(permit.controllerIdentity);
+  const currentIdentity = validateControllerIdentity(
+    options.controllerIdentity ?? await processIdentity(expectedIdentity.pid),
+  );
+  if (JSON.stringify(currentIdentity) !== JSON.stringify(expectedIdentity)) {
+    fail('attended_controller_identity_changed');
+  }
+  return {
+    status: 'attended_start_authorized',
+    currentNRestarts,
+    permitBindingSha256: createHash('sha256').update(JSON.stringify(permit)).digest('hex'),
+    evidenceBindings: structuredClone(permit.evidenceBindings),
+  };
 }
 
 function parseArgs(argv) {
@@ -219,10 +414,9 @@ export async function consumeAutomaticRestartPermit(options) {
   let authority;
   let permit;
   try {
+    permit = await takePrivateJson(options.permitFile, 'permit');
     authority = await readPrivateJson(options.authorityFile, 'authority');
-    permit = await readPrivateJson(options.permitFile, 'permit');
   } catch (error) {
-    await removeAndVerify(options.permitFile, 'permit');
     throw error;
   }
   const createdAtMs = Date.parse(permit.createdAt ?? '');
@@ -241,21 +435,13 @@ export async function consumeAutomaticRestartPermit(options) {
     || !Number.isFinite(authorizedAtMs) || authorizedAtMs > nowMs + 5_000
     || !Number.isFinite(createdAtMs) || createdAtMs < authorizedAtMs
     || createdAtMs > nowMs + 5_000 || nowMs - createdAtMs > maxAgeMs) {
-    await removeAndVerify(options.permitFile, 'permit');
     fail('permit_contract_invalid');
-  }
-  const consumed = `${options.permitFile}.consuming-${process.pid}-${randomUUID()}`;
-  try {
-    await rename(options.permitFile, consumed);
-    const moved = await readPrivateJson(consumed, 'permit');
-    if (JSON.stringify(moved) !== JSON.stringify(permit)) fail('permit_changed_during_consume');
-  } finally {
-    await removeAndVerify(consumed, 'consumed_permit');
   }
   return { status: 'automatic_restart_authorized', currentNRestarts };
 }
 
 export async function disarmRestartAuthority(options) {
+  if (options.attendedPermitFile) await removeAndVerify(options.attendedPermitFile, 'attended_permit');
   await removeAndVerify(options.permitFile, 'permit');
   await removeAndVerify(options.authorityFile, 'authority');
 }
@@ -264,14 +450,19 @@ async function main() {
   const { command, values } = parseArgs(process.argv.slice(2));
   const authorityValue = values.get('--authority-file');
   const permitValue = values.get('--permit-file');
-  if (!authorityValue || !permitValue
-    || !path.isAbsolute(authorityValue) || !path.isAbsolute(permitValue)) {
+  const attendedPermitValue = values.get('--attended-permit-file');
+  const needsAutomaticPaths = ['arm', 'record-exit', 'consume', 'disarm'].includes(command);
+  const needsAttendedPath = ['issue-attended', 'consume-attended'].includes(command);
+  if ((needsAutomaticPaths && (!authorityValue || !permitValue
+      || !path.isAbsolute(authorityValue) || !path.isAbsolute(permitValue)))
+    || (needsAttendedPath && (!attendedPermitValue || !path.isAbsolute(attendedPermitValue)))) {
     fail('restart_paths_invalid');
   }
   const common = {
     expectedRevision: values.get('--expected-revision'),
-    authorityFile: path.resolve(authorityValue),
-    permitFile: path.resolve(permitValue),
+    ...(authorityValue ? { authorityFile: path.resolve(authorityValue) } : {}),
+    ...(permitValue ? { permitFile: path.resolve(permitValue) } : {}),
+    ...(attendedPermitValue ? { attendedPermitFile: path.resolve(attendedPermitValue) } : {}),
   };
   let result = { status: 'pass' };
   if (command === 'arm') {
@@ -289,6 +480,26 @@ async function main() {
       ...common,
       currentNRestarts: values.get('--current-nrestarts'),
       maxAgeMs: values.get('--max-age-ms'),
+    });
+  } else if (command === 'issue-attended') {
+    let evidenceBindings;
+    try {
+      evidenceBindings = JSON.parse(values.get('--evidence-bindings-json') ?? '');
+    } catch {
+      fail('attended_evidence_bindings_invalid');
+    }
+    result = await issueAttendedStartPermit({
+      ...common,
+      baselineNRestarts: values.get('--baseline-nrestarts'),
+      startControlOutput: values.get('--start-control-output'),
+      evidenceBindings,
+      controllerPid: values.get('--controller-pid'),
+      maxAgeMs: values.get('--max-age-ms'),
+    });
+  } else if (command === 'consume-attended') {
+    result = await consumeAttendedStartPermit({
+      ...common,
+      currentNRestarts: values.get('--current-nrestarts'),
     });
   } else if (command === 'disarm') {
     await disarmRestartAuthority(common);

--- a/tools/scripts/news-aggregator-publisher-automatic-restart-authority.test.mjs
+++ b/tools/scripts/news-aggregator-publisher-automatic-restart-authority.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { spawnSync } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import { chmod, lstat, mkdir, mkdtemp, readFile, realpath, rm, symlink, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
@@ -7,8 +7,10 @@ import test from 'node:test';
 import { fileURLToPath } from 'node:url';
 import {
   armRestartAuthority,
+  consumeAttendedStartPermit,
   consumeAutomaticRestartPermit,
   disarmRestartAuthority,
+  issueAttendedStartPermit,
   recordRestartableExit,
 } from './news-aggregator-publisher-automatic-restart-authority.mjs';
 
@@ -22,7 +24,37 @@ async function files() {
     root,
     authorityFile: path.join(root, 'authority.json'),
     permitFile: path.join(root, 'permit.json'),
+    attendedPermitFile: path.join(root, 'attended.json'),
   };
+}
+
+const EVIDENCE_BINDINGS = {
+  preflightSha256: '1'.repeat(64),
+  relayEvidenceSha256: '2'.repeat(64),
+  relayPacketSha256: '3'.repeat(64),
+  relayCaptureSha256: '4'.repeat(64),
+  mailboxSha256: '5'.repeat(64),
+  mailboxCriticalCount: 2,
+};
+
+const CONTROLLER_IDENTITY = {
+  scheme: 'posix-ps-v1',
+  pid: 4242,
+  bootId: 'a'.repeat(64),
+  processStartId: 'b'.repeat(64),
+};
+
+async function issueAttended(target, overrides = {}) {
+  return issueAttendedStartPermit({
+    ...target,
+    expectedRevision: overrides.expectedRevision ?? REVISION,
+    baselineNRestarts: overrides.baselineNRestarts ?? 0,
+    startControlOutput: overrides.startControlOutput ?? path.join(target.root, 'start-control.json'),
+    evidenceBindings: overrides.evidenceBindings ?? EVIDENCE_BINDINGS,
+    controllerIdentity: overrides.controllerIdentity ?? CONTROLLER_IDENTITY,
+    nowMs: overrides.nowMs ?? NOW - 1_000,
+    maxAgeMs: overrides.maxAgeMs ?? 120_000,
+  });
 }
 
 async function armAndRecord(target, overrides = {}) {
@@ -174,7 +206,7 @@ test('arm and non-69 cleanup fail closed when the prior permit cannot be removed
   }
 });
 
-test('hostile non-private recovery parent is rejected before any authority write', async () => {
+test('weak-mode and symlink recovery parents are rejected before any authority write', async () => {
   const target = await files();
   try {
     await chmod(target.root, 0o755);
@@ -186,6 +218,30 @@ test('hostile non-private recovery parent is rejected before any authority write
   } finally {
     await chmod(target.root, 0o700).catch(() => undefined);
     await rm(target.root, { recursive: true, force: true });
+  }
+
+  const host = await realpath(await mkdtemp(path.join(os.tmpdir(), 'vh-restart-authority-parent-')));
+  const privateParent = path.join(host, 'private-recovery');
+  const symlinkParent = path.join(host, 'recovery-link');
+  try {
+    await mkdir(privateParent, { mode: 0o700 });
+    await symlink(privateParent, symlinkParent);
+    const symlinkTarget = {
+      authorityFile: path.join(symlinkParent, 'authority.json'),
+      permitFile: path.join(symlinkParent, 'permit.json'),
+      attendedPermitFile: path.join(symlinkParent, 'attended.json'),
+    };
+    await assert.rejects(
+      armRestartAuthority({
+        ...symlinkTarget,
+        expectedRevision: REVISION,
+        baselineNRestarts: 0,
+      }),
+      (error) => error.code === 'parent_not_regular_directory',
+    );
+    await assert.rejects(lstat(path.join(privateParent, 'authority.json')), (error) => error.code === 'ENOENT');
+  } finally {
+    await rm(host, { recursive: true, force: true });
   }
 });
 
@@ -285,6 +341,179 @@ test('timestamp, baseline, and safe-integer tampering cannot mint or consume res
     );
   } finally {
     await rm(unsafeCounter.root, { recursive: true, force: true });
+  }
+});
+
+test('attended permit is evidence/revision/counter bound, private, and atomically single-use', async () => {
+  const target = await files();
+  try {
+    const issued = await issueAttended(target);
+    assert.equal(issued.status, 'attended_start_permit_issued');
+    assert.match(issued.permitBindingSha256, /^[0-9a-f]{64}$/);
+    assert.equal((await lstat(target.attendedPermitFile)).mode & 0o777, 0o600);
+    const text = await readFile(target.attendedPermitFile, 'utf8');
+    assert.match(text, new RegExp(REVISION));
+    assert.doesNotMatch(text, /private.?key|token|password/i);
+
+    const consumed = await consumeAttendedStartPermit({
+      ...target,
+      expectedRevision: REVISION,
+      currentNRestarts: 0,
+      controllerIdentity: CONTROLLER_IDENTITY,
+      nowMs: NOW,
+    });
+    assert.equal(consumed.status, 'attended_start_authorized');
+    assert.equal(consumed.permitBindingSha256, issued.permitBindingSha256);
+    assert.deepEqual(consumed.evidenceBindings, EVIDENCE_BINDINGS);
+    await assert.rejects(lstat(target.attendedPermitFile), (error) => error.code === 'ENOENT');
+    await assert.rejects(
+      consumeAttendedStartPermit({
+        ...target,
+        expectedRevision: REVISION,
+        currentNRestarts: 0,
+        controllerIdentity: CONTROLLER_IDENTITY,
+        nowMs: NOW,
+      }),
+      (error) => error.code === 'attended_permit_missing',
+    );
+  } finally {
+    await rm(target.root, { recursive: true, force: true });
+  }
+});
+
+test('attended permit rejects stale, revision, evidence, counter, PID-reuse, and boot drift and destroys itself', async () => {
+  const rows = [
+    {
+      mutate: () => ({ expectedRevision: 'b'.repeat(40) }),
+      code: 'attended_permit_contract_invalid',
+    },
+    {
+      mutate: () => ({ currentNRestarts: 1 }),
+      code: 'attended_permit_contract_invalid',
+    },
+    {
+      issue: { nowMs: NOW - 200_000, maxAgeMs: 10_000 },
+      mutate: () => ({}),
+      code: 'attended_permit_contract_invalid',
+    },
+    {
+      mutate: () => ({
+        controllerIdentity: { ...CONTROLLER_IDENTITY, pid: CONTROLLER_IDENTITY.pid + 1 },
+      }),
+      code: 'attended_controller_identity_changed',
+    },
+    {
+      mutate: () => ({
+        controllerIdentity: { ...CONTROLLER_IDENTITY, bootId: 'd'.repeat(64) },
+      }),
+      code: 'attended_controller_identity_changed',
+    },
+    {
+      // Same PID with a different process-start identity is the PID-reuse case.
+      mutate: () => ({
+        controllerIdentity: { ...CONTROLLER_IDENTITY, processStartId: 'c'.repeat(64) },
+      }),
+      code: 'attended_controller_identity_changed',
+    },
+  ];
+  for (const row of rows) {
+    const target = await files();
+    try {
+      await issueAttended(target, row.issue);
+      const overrides = row.mutate();
+      await assert.rejects(
+        consumeAttendedStartPermit({
+          ...target,
+          expectedRevision: REVISION,
+          currentNRestarts: 0,
+          controllerIdentity: CONTROLLER_IDENTITY,
+          nowMs: NOW,
+          ...overrides,
+        }),
+        (error) => error.code === row.code,
+      );
+      await assert.rejects(lstat(target.attendedPermitFile), (error) => error.code === 'ENOENT');
+    } finally {
+      await rm(target.root, { recursive: true, force: true });
+    }
+  }
+
+  const evidenceTarget = await files();
+  try {
+    await issueAttended(evidenceTarget);
+    const permit = JSON.parse(await readFile(evidenceTarget.attendedPermitFile, 'utf8'));
+    permit.evidenceBindings.relayEvidenceSha256 = 'not-a-hash';
+    await writeFile(evidenceTarget.attendedPermitFile, `${JSON.stringify(permit)}\n`, { mode: 0o600 });
+    await chmod(evidenceTarget.attendedPermitFile, 0o600);
+    await assert.rejects(
+      consumeAttendedStartPermit({
+        ...evidenceTarget,
+        expectedRevision: REVISION,
+        currentNRestarts: 0,
+        controllerIdentity: CONTROLLER_IDENTITY,
+        nowMs: NOW,
+      }),
+      (error) => error.code === 'attended_evidence_bindings_invalid',
+    );
+    await assert.rejects(lstat(evidenceTarget.attendedPermitFile), (error) => error.code === 'ENOENT');
+  } finally {
+    await rm(evidenceTarget.root, { recursive: true, force: true });
+  }
+});
+
+test('concurrent attended consumers authorize exactly one invocation', async () => {
+  const target = await files();
+  try {
+    await issueAttended(target);
+    const input = {
+      ...target,
+      expectedRevision: REVISION,
+      currentNRestarts: 0,
+      controllerIdentity: CONTROLLER_IDENTITY,
+      nowMs: NOW,
+    };
+    const results = await Promise.allSettled([
+      consumeAttendedStartPermit(input),
+      consumeAttendedStartPermit(input),
+    ]);
+    assert.equal(results.filter((result) => result.status === 'fulfilled').length, 1);
+    assert.equal(results.filter((result) => result.status === 'rejected').length, 1);
+    await assert.rejects(lstat(target.attendedPermitFile), (error) => error.code === 'ENOENT');
+  } finally {
+    await rm(target.root, { recursive: true, force: true });
+  }
+});
+
+test('SIGKILL of the issuing controller makes a published attended permit unusable', async () => {
+  const target = await files();
+  const controller = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {
+    stdio: 'ignore',
+  });
+  try {
+    await issueAttendedStartPermit({
+      ...target,
+      expectedRevision: REVISION,
+      baselineNRestarts: 0,
+      startControlOutput: path.join(target.root, 'start-control.json'),
+      evidenceBindings: EVIDENCE_BINDINGS,
+      controllerPid: controller.pid,
+      nowMs: Date.now(),
+    });
+    controller.kill('SIGKILL');
+    await new Promise((resolve) => controller.once('close', resolve));
+    await assert.rejects(
+      consumeAttendedStartPermit({
+        ...target,
+        expectedRevision: REVISION,
+        currentNRestarts: 0,
+        nowMs: Date.now(),
+      }),
+      (error) => error.code === 'controller_not_live',
+    );
+    await assert.rejects(lstat(target.attendedPermitFile), (error) => error.code === 'ENOENT');
+  } finally {
+    controller.kill('SIGKILL');
+    await rm(target.root, { recursive: true, force: true });
   }
 });
 

--- a/tools/scripts/news-aggregator-publisher-automatic-restart-authority.test.mjs
+++ b/tools/scripts/news-aggregator-publisher-automatic-restart-authority.test.mjs
@@ -8,9 +8,12 @@ import { fileURLToPath } from 'node:url';
 import {
   armRestartAuthority,
   consumeAttendedStartPermit,
+  consumeAttendedStartReceipt,
   consumeAutomaticRestartPermit,
   disarmRestartAuthority,
   issueAttendedStartPermit,
+  normalizeCanonicalRecoveryDirectory,
+  parseLinuxProcStat,
   recordRestartableExit,
 } from './news-aggregator-publisher-automatic-restart-authority.mjs';
 
@@ -25,6 +28,7 @@ async function files() {
     authorityFile: path.join(root, 'authority.json'),
     permitFile: path.join(root, 'permit.json'),
     attendedPermitFile: path.join(root, 'attended.json'),
+    attendedReceiptFile: path.join(root, 'attended-receipt.json'),
   };
 }
 
@@ -35,6 +39,7 @@ const EVIDENCE_BINDINGS = {
   relayCaptureSha256: '4'.repeat(64),
   mailboxSha256: '5'.repeat(64),
   mailboxCriticalCount: 2,
+  systemWriterPinSha256: '6'.repeat(64),
 };
 
 const CONTROLLER_IDENTITY = {
@@ -359,6 +364,7 @@ test('attended permit is evidence/revision/counter bound, private, and atomicall
       ...target,
       expectedRevision: REVISION,
       currentNRestarts: 0,
+      systemWriterPinSha256: EVIDENCE_BINDINGS.systemWriterPinSha256,
       controllerIdentity: CONTROLLER_IDENTITY,
       nowMs: NOW,
     });
@@ -366,16 +372,82 @@ test('attended permit is evidence/revision/counter bound, private, and atomicall
     assert.equal(consumed.permitBindingSha256, issued.permitBindingSha256);
     assert.deepEqual(consumed.evidenceBindings, EVIDENCE_BINDINGS);
     await assert.rejects(lstat(target.attendedPermitFile), (error) => error.code === 'ENOENT');
+    assert.equal((await lstat(target.attendedReceiptFile)).mode & 0o777, 0o600);
+    const receipt = await consumeAttendedStartReceipt({
+      ...target,
+      expectedRevision: REVISION,
+      expectedPermitBindingSha256: issued.permitBindingSha256,
+      currentNRestarts: 0,
+      startControlOutput: path.join(target.root, 'start-control.json'),
+      evidenceBindings: EVIDENCE_BINDINGS,
+      controllerIdentity: CONTROLLER_IDENTITY,
+      nowMs: NOW,
+    });
+    assert.equal(receipt.status, 'attended_start_receipt_consumed');
+    assert.equal(receipt.permitBindingSha256, issued.permitBindingSha256);
+    assert.match(receipt.receiptSha256, /^[0-9a-f]{64}$/);
+    await assert.rejects(lstat(target.attendedReceiptFile), (error) => error.code === 'ENOENT');
     await assert.rejects(
       consumeAttendedStartPermit({
         ...target,
         expectedRevision: REVISION,
         currentNRestarts: 0,
+        systemWriterPinSha256: EVIDENCE_BINDINGS.systemWriterPinSha256,
         controllerIdentity: CONTROLLER_IDENTITY,
         nowMs: NOW,
       }),
       (error) => error.code === 'attended_permit_missing',
     );
+  } finally {
+    await rm(target.root, { recursive: true, force: true });
+  }
+});
+
+test('controller rejects a valid-shaped substituted permit through the consumed receipt binding', async () => {
+  const target = await files();
+  try {
+    const issued = await issueAttended(target);
+    const substituted = JSON.parse(await readFile(target.attendedPermitFile, 'utf8'));
+    substituted.nonce = '11111111-1111-1111-1111-111111111111';
+    substituted.evidenceBindings.relayEvidenceSha256 = 'a'.repeat(64);
+    await writeFile(target.attendedPermitFile, `${JSON.stringify(substituted)}\n`, { mode: 0o600 });
+    await chmod(target.attendedPermitFile, 0o600);
+    const consumed = await consumeAttendedStartPermit({
+      ...target,
+      expectedRevision: REVISION,
+      currentNRestarts: 0,
+      systemWriterPinSha256: EVIDENCE_BINDINGS.systemWriterPinSha256,
+      controllerIdentity: CONTROLLER_IDENTITY,
+      nowMs: NOW,
+    });
+    assert.notEqual(consumed.permitBindingSha256, issued.permitBindingSha256);
+    await assert.rejects(
+      consumeAttendedStartReceipt({
+        ...target,
+        expectedRevision: REVISION,
+        expectedPermitBindingSha256: issued.permitBindingSha256,
+        currentNRestarts: 0,
+        startControlOutput: path.join(target.root, 'start-control.json'),
+        evidenceBindings: EVIDENCE_BINDINGS,
+        controllerIdentity: CONTROLLER_IDENTITY,
+        nowMs: NOW,
+      }),
+      (error) => error.code === 'attended_receipt_contract_invalid',
+    );
+    await assert.rejects(lstat(target.attendedReceiptFile), (error) => error.code === 'ENOENT');
+  } finally {
+    await rm(target.root, { recursive: true, force: true });
+  }
+});
+
+test('issuing a new attended permit removes a stale receipt before publication', async () => {
+  const target = await files();
+  try {
+    await writeFile(target.attendedReceiptFile, '{"stale":true}\n', { mode: 0o600 });
+    await chmod(target.attendedReceiptFile, 0o600);
+    await issueAttended(target);
+    await assert.rejects(lstat(target.attendedReceiptFile), (error) => error.code === 'ENOENT');
+    assert.equal((await lstat(target.attendedPermitFile)).mode & 0o777, 0o600);
   } finally {
     await rm(target.root, { recursive: true, force: true });
   }
@@ -426,6 +498,7 @@ test('attended permit rejects stale, revision, evidence, counter, PID-reuse, and
           ...target,
           expectedRevision: REVISION,
           currentNRestarts: 0,
+          systemWriterPinSha256: EVIDENCE_BINDINGS.systemWriterPinSha256,
           controllerIdentity: CONTROLLER_IDENTITY,
           nowMs: NOW,
           ...overrides,
@@ -450,6 +523,7 @@ test('attended permit rejects stale, revision, evidence, counter, PID-reuse, and
         ...evidenceTarget,
         expectedRevision: REVISION,
         currentNRestarts: 0,
+        systemWriterPinSha256: EVIDENCE_BINDINGS.systemWriterPinSha256,
         controllerIdentity: CONTROLLER_IDENTITY,
         nowMs: NOW,
       }),
@@ -469,6 +543,7 @@ test('concurrent attended consumers authorize exactly one invocation', async () 
       ...target,
       expectedRevision: REVISION,
       currentNRestarts: 0,
+      systemWriterPinSha256: EVIDENCE_BINDINGS.systemWriterPinSha256,
       controllerIdentity: CONTROLLER_IDENTITY,
       nowMs: NOW,
     };
@@ -479,6 +554,7 @@ test('concurrent attended consumers authorize exactly one invocation', async () 
     assert.equal(results.filter((result) => result.status === 'fulfilled').length, 1);
     assert.equal(results.filter((result) => result.status === 'rejected').length, 1);
     await assert.rejects(lstat(target.attendedPermitFile), (error) => error.code === 'ENOENT');
+    assert.equal((await lstat(target.attendedReceiptFile)).mode & 0o777, 0o600);
   } finally {
     await rm(target.root, { recursive: true, force: true });
   }
@@ -506,6 +582,7 @@ test('SIGKILL of the issuing controller makes a published attended permit unusab
         ...target,
         expectedRevision: REVISION,
         currentNRestarts: 0,
+        systemWriterPinSha256: EVIDENCE_BINDINGS.systemWriterPinSha256,
         nowMs: Date.now(),
       }),
       (error) => error.code === 'controller_not_live',
@@ -514,6 +591,52 @@ test('SIGKILL of the issuing controller makes a published attended permit unusab
   } finally {
     controller.kill('SIGKILL');
     await rm(target.root, { recursive: true, force: true });
+  }
+});
+
+test('Linux stopped and traced controller states are not live authority', () => {
+  for (const state of ['T', 't']) {
+    const fields = [state, ...Array(19).fill('1')];
+    assert.throws(
+      () => parseLinuxProcStat(`4242 (controller) ${fields.join(' ')}`),
+      (error) => error.code === 'controller_not_live',
+    );
+  }
+});
+
+test('canonical recovery directory safely migrates only owned 0755 and rejects symlink paths', async () => {
+  const home = await realpath(await mkdtemp(path.join(os.tmpdir(), 'vh-recovery-home-')));
+  const canonical = path.join(home, '.local/state/vhc/news-aggregator/recovery');
+  try {
+    await mkdir(canonical, { recursive: true, mode: 0o755 });
+    await chmod(canonical, 0o755);
+    const result = await normalizeCanonicalRecoveryDirectory({
+      homeDirectory: home,
+      directory: canonical,
+    });
+    assert.equal(result.status, 'canonical_recovery_directory_private');
+    assert.equal((await lstat(canonical)).mode & 0o777, 0o700);
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+
+  const linkedHome = await realpath(await mkdtemp(path.join(os.tmpdir(), 'vh-recovery-linked-home-')));
+  const target = path.join(linkedHome, 'outside-recovery');
+  const parent = path.join(linkedHome, '.local/state/vhc/news-aggregator');
+  const linkedCanonical = path.join(parent, 'recovery');
+  try {
+    await mkdir(parent, { recursive: true, mode: 0o700 });
+    await mkdir(target, { mode: 0o700 });
+    await symlink(target, linkedCanonical);
+    await assert.rejects(
+      normalizeCanonicalRecoveryDirectory({
+        homeDirectory: linkedHome,
+        directory: linkedCanonical,
+      }),
+      (error) => error.code === 'canonical_recovery_directory_not_regular',
+    );
+  } finally {
+    await rm(linkedHome, { recursive: true, force: true });
   }
 });
 

--- a/tools/scripts/news-aggregator-publisher-automatic-restart-authority.test.mjs
+++ b/tools/scripts/news-aggregator-publisher-automatic-restart-authority.test.mjs
@@ -1,0 +1,317 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { chmod, lstat, mkdir, mkdtemp, readFile, realpath, rm, symlink, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import {
+  armRestartAuthority,
+  consumeAutomaticRestartPermit,
+  disarmRestartAuthority,
+  recordRestartableExit,
+} from './news-aggregator-publisher-automatic-restart-authority.mjs';
+
+const REVISION = '1883841555c4924be8d35747272c38ce8f2071d9';
+const NOW = Date.parse('2026-07-10T12:00:00.000Z');
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+
+async function files() {
+  const root = await realpath(await mkdtemp(path.join(os.tmpdir(), 'vh-restart-authority-')));
+  return {
+    root,
+    authorityFile: path.join(root, 'authority.json'),
+    permitFile: path.join(root, 'permit.json'),
+  };
+}
+
+async function armAndRecord(target, overrides = {}) {
+  await armRestartAuthority({
+    ...target,
+    expectedRevision: overrides.expectedRevision ?? REVISION,
+    baselineNRestarts: overrides.baselineNRestarts ?? 0,
+    nowMs: NOW - 5_000,
+  });
+  return recordRestartableExit({
+    ...target,
+    expectedRevision: overrides.expectedRevision ?? REVISION,
+    serviceResult: overrides.serviceResult ?? 'exit-code',
+    exitCode: overrides.exitCode ?? 'exited',
+    exitStatus: overrides.exitStatus ?? '69',
+    previousNRestarts: overrides.previousNRestarts ?? 0,
+    nowMs: overrides.permitNowMs ?? NOW - 1_000,
+  });
+}
+
+test('exit69 permit requires prior NRestarts then exactly prior+1 and is consumed once atomically', async () => {
+  const target = await files();
+  try {
+    const recorded = await armAndRecord(target, { previousNRestarts: 0 });
+    assert.deepEqual(recorded, { status: 'permit_recorded', previousNRestarts: 0, expectedNRestarts: 1 });
+    assert.equal((await lstat(target.authorityFile)).mode & 0o777, 0o600);
+    assert.equal((await lstat(target.permitFile)).mode & 0o777, 0o600);
+    const consumed = await consumeAutomaticRestartPermit({
+      ...target, expectedRevision: REVISION, currentNRestarts: 1, nowMs: NOW,
+    });
+    assert.deepEqual(consumed, { status: 'automatic_restart_authorized', currentNRestarts: 1 });
+    await assert.rejects(
+      consumeAutomaticRestartPermit({ ...target, expectedRevision: REVISION, currentNRestarts: 1, nowMs: NOW }),
+      (error) => error.code === 'permit_missing',
+    );
+  } finally {
+    await rm(target.root, { recursive: true, force: true });
+  }
+});
+
+test('manual/reset/start-limit counter mismatch cannot reuse the permit', async () => {
+  for (const currentNRestarts of [0, 2, 9]) {
+    const target = await files();
+    try {
+      await armAndRecord(target, { previousNRestarts: 0 });
+      await assert.rejects(
+        consumeAutomaticRestartPermit({ ...target, expectedRevision: REVISION, currentNRestarts, nowMs: NOW }),
+        (error) => error.code === 'permit_contract_invalid',
+      );
+      await assert.rejects(lstat(target.permitFile), (error) => error.code === 'ENOENT');
+    } finally {
+      await rm(target.root, { recursive: true, force: true });
+    }
+  }
+});
+
+test('non-69 exit does not create a permit and disarm removes all restart authority', async () => {
+  const target = await files();
+  try {
+    const result = await armAndRecord(target, { exitStatus: '78' });
+    assert.equal(result.status, 'ignored_non_restartable_exit');
+    await assert.rejects(lstat(target.permitFile), (error) => error.code === 'ENOENT');
+    await disarmRestartAuthority(target);
+    await assert.rejects(lstat(target.authorityFile), (error) => error.code === 'ENOENT');
+  } finally {
+    await rm(target.root, { recursive: true, force: true });
+  }
+});
+
+test('stale and wrong-revision permits fail closed and are destroyed', async () => {
+  for (const row of [
+    { expectedRevision: 'b'.repeat(40), nowMs: NOW, code: 'permit_contract_invalid' },
+    { expectedRevision: REVISION, nowMs: NOW + 200_000, code: 'permit_contract_invalid' },
+  ]) {
+    const target = await files();
+    try {
+      await armAndRecord(target);
+      await assert.rejects(
+        consumeAutomaticRestartPermit({
+          ...target, expectedRevision: row.expectedRevision, currentNRestarts: 1, nowMs: row.nowMs,
+        }),
+        (error) => error.code === row.code,
+      );
+      await assert.rejects(lstat(target.permitFile), (error) => error.code === 'ENOENT');
+    } finally {
+      await rm(target.root, { recursive: true, force: true });
+    }
+  }
+});
+
+test('symlink, weak mode, and partial permit paths cannot authorize or be reused', async () => {
+  for (const kind of ['symlink', 'mode', 'partial']) {
+    const target = await files();
+    try {
+      await armRestartAuthority({ ...target, expectedRevision: REVISION, baselineNRestarts: 0, nowMs: NOW - 5_000 });
+      if (kind === 'symlink') {
+        const elsewhere = path.join(target.root, 'elsewhere.json');
+        await writeFile(elsewhere, '{}\n', { mode: 0o600 });
+        await symlink(elsewhere, target.permitFile);
+      } else if (kind === 'mode') {
+        await writeFile(target.permitFile, '{}\n', { mode: 0o644 });
+        await chmod(target.permitFile, 0o644);
+      } else {
+        await writeFile(target.permitFile, '{partial', { mode: 0o600 });
+        await chmod(target.permitFile, 0o600);
+      }
+      await assert.rejects(
+        consumeAutomaticRestartPermit({ ...target, expectedRevision: REVISION, currentNRestarts: 1, nowMs: NOW }),
+      );
+      await assert.rejects(lstat(target.permitFile), (error) => error.code === 'ENOENT');
+    } finally {
+      await rm(target.root, { recursive: true, force: true });
+    }
+  }
+});
+
+test('valid permit payload remains secret-free and exact-revision scoped', async () => {
+  const target = await files();
+  try {
+    await armAndRecord(target);
+    const text = await readFile(target.permitFile, 'utf8');
+    assert.match(text, new RegExp(REVISION));
+    assert.doesNotMatch(text, /token|secret|password|private/i);
+  } finally {
+    await rm(target.root, { recursive: true, force: true });
+  }
+});
+
+test('arm and non-69 cleanup fail closed when the prior permit cannot be removed', async () => {
+  const target = await files();
+  try {
+    await mkdir(target.permitFile, { mode: 0o700 });
+    await assert.rejects(
+      armRestartAuthority({ ...target, expectedRevision: REVISION, baselineNRestarts: 0 }),
+      (error) => error.code === 'permit_remove_failed',
+    );
+    await rm(target.permitFile, { recursive: true });
+    await armRestartAuthority({ ...target, expectedRevision: REVISION, baselineNRestarts: 0 });
+    await mkdir(target.permitFile, { mode: 0o700 });
+    await assert.rejects(
+      recordRestartableExit({
+        ...target, expectedRevision: REVISION, serviceResult: 'success', exitCode: 'exited',
+        exitStatus: '0', previousNRestarts: 0,
+      }),
+      (error) => error.code === 'permit_remove_failed',
+    );
+  } finally {
+    await rm(target.root, { recursive: true, force: true });
+  }
+});
+
+test('hostile non-private recovery parent is rejected before any authority write', async () => {
+  const target = await files();
+  try {
+    await chmod(target.root, 0o755);
+    await assert.rejects(
+      armRestartAuthority({ ...target, expectedRevision: REVISION, baselineNRestarts: 0 }),
+      (error) => error.code === 'parent_mode_not_0700',
+    );
+    await assert.rejects(lstat(target.authorityFile), (error) => error.code === 'ENOENT');
+  } finally {
+    await chmod(target.root, 0o700).catch(() => undefined);
+    await rm(target.root, { recursive: true, force: true });
+  }
+});
+
+test('non-69 exit removes an already-stale permit instead of leaving reusable authority', async () => {
+  const target = await files();
+  try {
+    await armRestartAuthority({ ...target, expectedRevision: REVISION, baselineNRestarts: 0 });
+    await writeFile(target.permitFile, '{"stale":true}\n', { mode: 0o600 });
+    const result = await recordRestartableExit({
+      ...target, expectedRevision: REVISION, serviceResult: 'success', exitCode: 'exited',
+      exitStatus: '0', previousNRestarts: 0,
+    });
+    assert.equal(result.status, 'ignored_non_restartable_exit');
+    await assert.rejects(lstat(target.permitFile), (error) => error.code === 'ENOENT');
+  } finally {
+    await rm(target.root, { recursive: true, force: true });
+  }
+});
+
+test('concurrent consumers authorize exactly one automatic invocation', async () => {
+  const target = await files();
+  try {
+    await armAndRecord(target);
+    const results = await Promise.allSettled([
+      consumeAutomaticRestartPermit({ ...target, expectedRevision: REVISION, currentNRestarts: 1, nowMs: NOW }),
+      consumeAutomaticRestartPermit({ ...target, expectedRevision: REVISION, currentNRestarts: 1, nowMs: NOW }),
+    ]);
+    assert.equal(results.filter((result) => result.status === 'fulfilled').length, 1);
+    assert.equal(results.filter((result) => result.status === 'rejected').length, 1);
+    await assert.rejects(lstat(target.permitFile), (error) => error.code === 'ENOENT');
+  } finally {
+    await rm(target.root, { recursive: true, force: true });
+  }
+});
+
+test('timestamp, baseline, and safe-integer tampering cannot mint or consume restart authority', async () => {
+  const future = await files();
+  try {
+    await armRestartAuthority({
+      ...future, expectedRevision: REVISION, baselineNRestarts: 0, nowMs: NOW + 10_000,
+    });
+    await assert.rejects(
+      recordRestartableExit({
+        ...future, expectedRevision: REVISION, serviceResult: 'exit-code', exitCode: 'exited',
+        exitStatus: '69', previousNRestarts: 0, nowMs: NOW,
+      }),
+      (error) => error.code === 'authority_contract_invalid',
+    );
+    await assert.rejects(lstat(future.permitFile), (error) => error.code === 'ENOENT');
+  } finally {
+    await rm(future.root, { recursive: true, force: true });
+  }
+
+  const createdBeforeAuthority = await files();
+  try {
+    await armAndRecord(createdBeforeAuthority);
+    const permit = JSON.parse(await readFile(createdBeforeAuthority.permitFile, 'utf8'));
+    permit.createdAt = new Date(NOW - 10_000).toISOString();
+    await writeFile(createdBeforeAuthority.permitFile, `${JSON.stringify(permit)}\n`, { mode: 0o600 });
+    await chmod(createdBeforeAuthority.permitFile, 0o600);
+    await assert.rejects(
+      consumeAutomaticRestartPermit({
+        ...createdBeforeAuthority, expectedRevision: REVISION, currentNRestarts: 1, nowMs: NOW,
+      }),
+      (error) => error.code === 'permit_contract_invalid',
+    );
+  } finally {
+    await rm(createdBeforeAuthority.root, { recursive: true, force: true });
+  }
+
+  const baselineDrift = await files();
+  try {
+    await armAndRecord(baselineDrift);
+    const authority = JSON.parse(await readFile(baselineDrift.authorityFile, 'utf8'));
+    authority.baselineNRestarts = 1;
+    await writeFile(baselineDrift.authorityFile, `${JSON.stringify(authority)}\n`, { mode: 0o600 });
+    await chmod(baselineDrift.authorityFile, 0o600);
+    await assert.rejects(
+      consumeAutomaticRestartPermit({
+        ...baselineDrift, expectedRevision: REVISION, currentNRestarts: 1, nowMs: NOW,
+      }),
+      (error) => error.code === 'permit_contract_invalid',
+    );
+  } finally {
+    await rm(baselineDrift.root, { recursive: true, force: true });
+  }
+
+  const unsafeCounter = await files();
+  try {
+    await armRestartAuthority({ ...unsafeCounter, expectedRevision: REVISION, baselineNRestarts: 0 });
+    await assert.rejects(
+      recordRestartableExit({
+        ...unsafeCounter, expectedRevision: REVISION, serviceResult: 'exit-code', exitCode: 'exited',
+        exitStatus: '69', previousNRestarts: Number.MAX_SAFE_INTEGER,
+      }),
+      (error) => error.code === 'previous_nrestarts_invalid',
+    );
+  } finally {
+    await rm(unsafeCounter.root, { recursive: true, force: true });
+  }
+});
+
+test('ExecStopPost source-backed pre-increment contract fails closed when NRestarts cannot be read', async () => {
+  const target = await files();
+  const bin = path.join(target.root, 'bin');
+  await mkdir(bin, { mode: 0o700 });
+  const systemctl = path.join(bin, 'systemctl');
+  await writeFile(systemctl, '#!/bin/bash\nexit 1\n', { mode: 0o700 });
+  try {
+    await armRestartAuthority({ ...target, expectedRevision: REVISION, baselineNRestarts: 0 });
+    const result = spawnSync('/bin/bash', [path.join(SCRIPT_DIR, 'record-news-aggregator-restartable-exit.sh'), REVISION], {
+      cwd: path.resolve(SCRIPT_DIR, '../..'),
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        PATH: `${bin}${path.delimiter}${process.env.PATH ?? ''}`,
+        VHC_REPO: path.resolve(SCRIPT_DIR, '../..'),
+        VH_NEWS_DAEMON_RESTART_AUTHORITY_FILE: target.authorityFile,
+        VH_NEWS_DAEMON_RESTART_PERMIT_FILE: target.permitFile,
+        SERVICE_RESULT: 'exit-code', EXIT_CODE: 'exited', EXIT_STATUS: '69',
+      },
+    });
+    assert.equal(result.status, 78);
+    await assert.rejects(lstat(target.permitFile), (error) => error.code === 'ENOENT');
+    assert.match(await readFile(path.join(SCRIPT_DIR, 'record-news-aggregator-restartable-exit.sh'), 'utf8'), /service_enter_restart\(\)[\s\S]*increments n_restarts/);
+  } finally {
+    await rm(target.root, { recursive: true, force: true });
+  }
+});

--- a/tools/scripts/news-aggregator-publisher-recovery-control.sh
+++ b/tools/scripts/news-aggregator-publisher-recovery-control.sh
@@ -12,6 +12,7 @@ PUBLISHER_ENV_FILE="${VH_NEWS_DAEMON_ENV_FILE:-${HOME}/.config/vhc/news-aggregat
 RESTART_AUTHORITY_FILE="${VH_NEWS_DAEMON_RESTART_AUTHORITY_FILE:-${HOME}/.local/state/vhc/news-aggregator/recovery/automatic-restart-authority.json}"
 RESTART_PERMIT_FILE="${VH_NEWS_DAEMON_RESTART_PERMIT_FILE:-${HOME}/.local/state/vhc/news-aggregator/recovery/automatic-restart-permit.json}"
 ATTENDED_START_PERMIT_FILE="${VH_NEWS_DAEMON_ATTENDED_START_PERMIT_FILE:-${HOME}/.local/state/vhc/news-aggregator/recovery/attended-start-permit.json}"
+ATTENDED_START_RECEIPT_FILE="${VH_NEWS_DAEMON_ATTENDED_START_RECEIPT_FILE:-${HOME}/.local/state/vhc/news-aggregator/recovery/attended-start-consumption-receipt.json}"
 RESTART_AUTHORITY_SCRIPT="${REPO_ROOT}/tools/scripts/news-aggregator-publisher-automatic-restart-authority.mjs"
 
 if [[ ! -r "${COMMON_SH}" ]]; then
@@ -142,6 +143,105 @@ manager_approval_is_set() {
     <<<"${manager_environment}"
 }
 
+normalize_fixed_recovery_directory() {
+  local canonical="${HOME}/.local/state/vhc/news-aggregator/recovery"
+  if [[ "${RESTART_AUTHORITY_FILE}" == "${canonical}/automatic-restart-authority.json"
+    && "${RESTART_PERMIT_FILE}" == "${canonical}/automatic-restart-permit.json"
+    && "${ATTENDED_START_PERMIT_FILE}" == "${canonical}/attended-start-permit.json"
+    && "${ATTENDED_START_RECEIPT_FILE}" == "${canonical}/attended-start-consumption-receipt.json" ]]; then
+    node "${RESTART_AUTHORITY_SCRIPT}" normalize-recovery-dir \
+      --directory "${canonical}" \
+      --home-directory "${HOME}" >/dev/null
+  fi
+}
+
+validate_publisher_env_file() {
+  node -e '
+    const { lstatSync, realpathSync } = require("node:fs");
+    const path = require("node:path");
+    const file = process.argv[1];
+    const stat = lstatSync(file);
+    if (stat.isSymbolicLink() || !stat.isFile()
+      || (typeof process.getuid === "function" && stat.uid !== process.getuid())
+      || (stat.mode & 0o777) !== 0o600
+      || realpathSync(file) !== path.resolve(file)) process.exit(78);
+  ' "${PUBLISHER_ENV_FILE}"
+}
+
+publisher_pin_json() {
+  validate_publisher_env_file
+  (
+    set +x
+    set -a
+    if ! source "${PUBLISHER_ENV_FILE}" >/dev/null 2>&1; then
+      echo "[vh:publisher-recovery] publisher env file could not be loaded for signature verification" >&2
+      exit 78
+    fi
+    set +a
+    unset VH_NEWS_SYSTEM_WRITER_PRIVATE_KEY_PKCS8_BASE64URL VH_SYSTEM_WRITER_PRIVATE_KEY_PKCS8_BASE64URL
+    node "${VERIFY_SCRIPT}" pin-sha256
+  )
+}
+
+reserve_staging_directory() {
+  local final_path="$1"
+  local parent base reserved
+  parent="$(dirname "${final_path}")"
+  base="${final_path##*/}"
+  if ! reserved="$(mktemp -d "${parent}/.${base}.pending.XXXXXXXX")"; then
+    return 78
+  fi
+  if ! chmod 700 "${reserved}" || ! node -e '
+    const { lstatSync, realpathSync } = require("node:fs");
+    const path = require("node:path");
+    const dir = process.argv[1];
+    const stat = lstatSync(dir);
+    if (stat.isSymbolicLink() || !stat.isDirectory()
+      || (typeof process.getuid === "function" && stat.uid !== process.getuid())
+      || (stat.mode & 0o777) !== 0o700 || realpathSync(dir) !== path.resolve(dir)) process.exit(78);
+  ' "${reserved}"; then
+    rmdir -- "${reserved}" >/dev/null 2>&1 || true
+    return 78
+  fi
+  printf '%s\n' "${reserved}"
+}
+
+private_file_identity() {
+  node -e '
+    const { lstatSync } = require("node:fs");
+    const stat = lstatSync(process.argv[1]);
+    if (stat.isSymbolicLink() || !stat.isFile()
+      || (typeof process.getuid === "function" && stat.uid !== process.getuid())
+      || (stat.mode & 0o777) !== 0o600) process.exit(78);
+    process.stdout.write(`${stat.dev}:${stat.ino}`);
+  ' "$1"
+}
+
+remove_owned_final_link() {
+  node -e '
+    const { lstatSync, unlinkSync } = require("node:fs");
+    const [file, expected] = process.argv.slice(1);
+    let stat;
+    try { stat = lstatSync(file); } catch (error) {
+      if (error?.code === "ENOENT") process.exit(0);
+      process.exit(78);
+    }
+    if (stat.isSymbolicLink() || !stat.isFile() || `${stat.dev}:${stat.ino}` !== expected) process.exit(78);
+    try { unlinkSync(file); } catch { process.exit(78); }
+    try { lstatSync(file); process.exit(78); } catch (error) {
+      if (error?.code !== "ENOENT") process.exit(78);
+    }
+  ' "$1" "$2"
+}
+
+cleanup_owned_staging() {
+  local directory="$1"
+  local file="$2"
+  rm -f -- "${file}" >/dev/null 2>&1 || return 78
+  rmdir -- "${directory}" >/dev/null 2>&1 || return 78
+  [[ ! -e "${file}" && ! -L "${file}" && ! -e "${directory}" && ! -L "${directory}" ]]
+}
+
 park_internal() {
   local state sub_state result_state exec_status enabled
   state="$(systemctl --user show "${SERVICE}" --property=ActiveState --value 2>/dev/null)"
@@ -159,11 +259,13 @@ park_internal() {
   if ! node "${RESTART_AUTHORITY_SCRIPT}" disarm \
     --authority-file "${RESTART_AUTHORITY_FILE}" \
     --permit-file "${RESTART_PERMIT_FILE}" \
-    --attended-permit-file "${ATTENDED_START_PERMIT_FILE}" >/dev/null 2>&1; then
+    --attended-permit-file "${ATTENDED_START_PERMIT_FILE}" \
+    --attended-receipt-file "${ATTENDED_START_RECEIPT_FILE}" >/dev/null 2>&1; then
     echo "[vh:publisher-recovery] automatic restart authority failed to clear" >&2
     return 78
   fi
-  if [[ -e "${ATTENDED_START_PERMIT_FILE}" || -L "${ATTENDED_START_PERMIT_FILE}"
+  if [[ -e "${ATTENDED_START_RECEIPT_FILE}" || -L "${ATTENDED_START_RECEIPT_FILE}"
+    || -e "${ATTENDED_START_PERMIT_FILE}" || -L "${ATTENDED_START_PERMIT_FILE}"
     || -e "${RESTART_PERMIT_FILE}" || -L "${RESTART_PERMIT_FILE}"
     || -e "${RESTART_AUTHORITY_FILE}" || -L "${RESTART_AUTHORITY_FILE}" ]]; then
     echo "[vh:publisher-recovery] automatic restart authority remained after park" >&2
@@ -191,12 +293,17 @@ if [[ "${COMMAND}" == "park" || "${COMMAND}" == "abort" ]]; then
     echo "[vh:publisher-recovery] park requires separate explicit approval" >&2
     exit 78
   }
+  normalize_fixed_recovery_directory
   park_internal
   echo "[vh:publisher-recovery] publisher is stopped, disabled, and approval-free"
   exit 0
 fi
 
 vh_publisher_require_exact_checkout "${REPO_ROOT}" "${EXPECTED_REVISION}"
+
+if [[ "${COMMAND}" != "preflight" ]]; then
+  normalize_fixed_recovery_directory
+fi
 
 if [[ "${COMMAND}" == "preflight" ]]; then
   [[ "${APPROVE_PREFLIGHT}" == "true" && -n "${OUTPUT_FILE}" ]] || {
@@ -245,6 +352,12 @@ if [[ "${COMMAND}" == "start" ]]; then
     --expected-sha256 "${MAILBOX_EXPECTED_SHA256}" \
     --expected-critical-count "${MAILBOX_EXPECTED_CRITICAL_COUNT}" \
     --max-age-ms "${MAILBOX_MAX_AGE_MS}")"
+  system_writer_pin_json="$(publisher_pin_json)"
+  system_writer_pin_sha256="$(node -e '
+    const value = JSON.parse(process.argv[1]);
+    if (value.status !== "pass" || !/^[0-9a-f]{64}$/.test(value.systemWriterPinSha256 ?? "")) process.exit(78);
+    process.stdout.write(value.systemWriterPinSha256);
+  ' "${system_writer_pin_json}")"
 
   active_state="$(systemctl --user show "${SERVICE}" --property=ActiveState --value 2>/dev/null)"
   sub_state="$(systemctl --user show "${SERVICE}" --property=SubState --value 2>/dev/null)"
@@ -261,12 +374,18 @@ if [[ "${COMMAND}" == "start" ]]; then
 
   mutation_started=false
   start_control_staging=""
+  start_control_staging_dir=""
+  start_control_staging_owned=false
+  start_final_path=""
+  start_final_identity=""
   cleanup_start() {
     local status=$?
     trap - EXIT HUP INT TERM
-    if [[ -n "${start_control_staging}" ]]; then
-      rm -f -- "${start_control_staging}" >/dev/null 2>&1 || status=78
-      [[ ! -e "${start_control_staging}" && ! -L "${start_control_staging}" ]] || status=78
+    if [[ "${status}" -ne 0 && -n "${start_final_path}" && -n "${start_final_identity}" ]]; then
+      remove_owned_final_link "${start_final_path}" "${start_final_identity}" || status=78
+    fi
+    if [[ "${start_control_staging_owned}" == "true" ]]; then
+      cleanup_owned_staging "${start_control_staging_dir}" "${start_control_staging}" || status=78
     fi
     systemctl --user unset-environment \
       VH_NEWS_DAEMON_ATTENDED_START_APPROVED \
@@ -295,19 +414,21 @@ if [[ "${COMMAND}" == "start" ]]; then
     --permit-file "${RESTART_PERMIT_FILE}" \
     --baseline-nrestarts "${baseline_nrestarts}" >/dev/null
   attended_evidence_bindings="$(node -e '
-    const [preflight, relay, mailbox] = process.argv.slice(1).map(JSON.parse);
+    const [preflight, relay, mailbox, systemWriterPinSha256] = process.argv.slice(1);
     process.stdout.write(JSON.stringify({
-      preflightSha256: preflight.sha256,
-      relayEvidenceSha256: relay.sha256,
-      relayPacketSha256: relay.packetSha256,
-      relayCaptureSha256: relay.captureSha256,
-      mailboxSha256: mailbox.sha256,
-      mailboxCriticalCount: mailbox.newCriticalCount,
+      preflightSha256: JSON.parse(preflight).sha256,
+      relayEvidenceSha256: JSON.parse(relay).sha256,
+      relayPacketSha256: JSON.parse(relay).packetSha256,
+      relayCaptureSha256: JSON.parse(relay).captureSha256,
+      mailboxSha256: JSON.parse(mailbox).sha256,
+      mailboxCriticalCount: JSON.parse(mailbox).newCriticalCount,
+      systemWriterPinSha256,
     }));
-  ' "${preflight_json}" "${relay_recovery_json}" "${mailbox_current_json}")"
+  ' "${preflight_json}" "${relay_recovery_json}" "${mailbox_current_json}" "${system_writer_pin_sha256}")"
   attended_permit_json="$(node "${RESTART_AUTHORITY_SCRIPT}" issue-attended \
     --expected-revision "${EXPECTED_REVISION}" \
     --attended-permit-file "${ATTENDED_START_PERMIT_FILE}" \
+    --attended-receipt-file "${ATTENDED_START_RECEIPT_FILE}" \
     --baseline-nrestarts "${baseline_nrestarts}" \
     --start-control-output "${START_CONTROL_OUTPUT}" \
     --evidence-bindings-json "${attended_evidence_bindings}" \
@@ -325,7 +446,8 @@ if [[ "${COMMAND}" == "start" ]]; then
     active_state="$(systemctl --user show "${SERVICE}" --property=ActiveState --value 2>/dev/null)"
     sub_state="$(systemctl --user show "${SERVICE}" --property=SubState --value 2>/dev/null)"
     if [[ "${active_state}" == "active" && "${sub_state}" == "running"
-      && ! -e "${ATTENDED_START_PERMIT_FILE}" && ! -L "${ATTENDED_START_PERMIT_FILE}" ]]; then
+      && ! -e "${ATTENDED_START_PERMIT_FILE}" && ! -L "${ATTENDED_START_PERMIT_FILE}"
+      && -e "${ATTENDED_START_RECEIPT_FILE}" && ! -L "${ATTENDED_START_RECEIPT_FILE}" ]]; then
       break
     fi
     if [[ "${active_state}" == "failed" || "${SECONDS}" -ge "${deadline}" ]]; then
@@ -350,8 +472,40 @@ if [[ "${COMMAND}" == "start" ]]; then
     echo "[vh:publisher-recovery] publisher restart count changed during activation" >&2
     exit 78
   fi
+  post_start_pin_json="$(publisher_pin_json)"
+  post_start_pin_sha256="$(node -e '
+    const value = JSON.parse(process.argv[1]);
+    if (value.status !== "pass" || !/^[0-9a-f]{64}$/.test(value.systemWriterPinSha256 ?? "")) process.exit(78);
+    process.stdout.write(value.systemWriterPinSha256);
+  ' "${post_start_pin_json}")"
+  if [[ "${post_start_pin_sha256}" != "${system_writer_pin_sha256}" ]]; then
+    echo "[vh:publisher-recovery] system-writer pin changed during attended activation" >&2
+    exit 78
+  fi
+  attended_receipt_json="$(node "${RESTART_AUTHORITY_SCRIPT}" consume-attended-receipt \
+    --expected-revision "${EXPECTED_REVISION}" \
+    --attended-receipt-file "${ATTENDED_START_RECEIPT_FILE}" \
+    --expected-permit-binding-sha256 "${attended_permit_binding_sha256}" \
+    --current-nrestarts "${post_nrestarts}" \
+    --start-control-output "${START_CONTROL_OUTPUT}" \
+    --evidence-bindings-json "${attended_evidence_bindings}" \
+    --controller-pid "$$" \
+    --max-age-ms 120000)"
+  attended_receipt_sha256="$(node -e '
+    const value = JSON.parse(process.argv[1]);
+    if (value.status !== "attended_start_receipt_consumed"
+      || value.permitBindingSha256 !== process.argv[2]
+      || value.systemWriterPinSha256 !== process.argv[3]
+      || !/^[0-9a-f]{64}$/.test(value.receiptSha256 ?? "")) process.exit(78);
+    process.stdout.write(value.receiptSha256);
+  ' "${attended_receipt_json}" "${attended_permit_binding_sha256}" "${system_writer_pin_sha256}")"
   activated_at="$(node -e 'process.stdout.write(new Date().toISOString())')"
-  start_control_staging="$(dirname "${START_CONTROL_OUTPUT}")/.${START_CONTROL_OUTPUT##*/}.pending-$$-${RANDOM}"
+  if ! start_control_staging_dir="$(reserve_staging_directory "${START_CONTROL_OUTPUT}")"; then
+    echo "[vh:publisher-recovery] could not reserve private start-control staging" >&2
+    exit 78
+  fi
+  start_control_staging_owned=true
+  start_control_staging="${start_control_staging_dir}/artifact.json"
   node "${START_CONTROL_WRITER}" \
     --output-file "${start_control_staging}" \
     --expected-revision "${EXPECTED_REVISION}" \
@@ -361,6 +515,8 @@ if [[ "${COMMAND}" == "start" ]]; then
     --baseline-nrestarts "${baseline_nrestarts}" \
     --post-nrestarts "${post_nrestarts}" \
     --attended-permit-binding-sha256 "${attended_permit_binding_sha256}" \
+    --attended-receipt-sha256 "${attended_receipt_sha256}" \
+    --system-writer-pin-sha256 "${system_writer_pin_sha256}" \
     --preflight-binding-json "${preflight_json}" \
     --relay-binding-json "${relay_recovery_json}" \
     --mailbox-binding-json "${mailbox_current_json}"
@@ -369,27 +525,44 @@ if [[ "${COMMAND}" == "start" ]]; then
   final_nrestarts="$(systemctl --user show "${SERVICE}" --property=NRestarts --value 2>/dev/null)"
   if [[ "${final_active_state}" != "active" || "${final_sub_state}" != "running"
     || "${final_nrestarts}" != "${baseline_nrestarts}"
-    || -e "${ATTENDED_START_PERMIT_FILE}" || -L "${ATTENDED_START_PERMIT_FILE}" ]] || manager_approval_is_set; then
+    || -e "${ATTENDED_START_PERMIT_FILE}" || -L "${ATTENDED_START_PERMIT_FILE}"
+    || -e "${ATTENDED_START_RECEIPT_FILE}" || -L "${ATTENDED_START_RECEIPT_FILE}" ]] || manager_approval_is_set; then
     echo "[vh:publisher-recovery] publisher state drifted while committing start evidence" >&2
     exit 78
   fi
+  start_final_identity="$(private_file_identity "${start_control_staging}")"
+  start_final_path="${START_CONTROL_OUTPUT}"
   ln "${start_control_staging}" "${START_CONTROL_OUTPUT}"
-  rm -f -- "${start_control_staging}" >/dev/null 2>&1 || true
-  start_control_staging=""
+  [[ "$(private_file_identity "${START_CONTROL_OUTPUT}")" == "${start_final_identity}" ]]
+  trap '' HUP INT TERM
+  trap - EXIT
   mutation_started=false
-  echo "[vh:publisher-recovery] publisher reached active/running; attended permit is consumed; wrapper preflights remain to be proven by verify"
+  rm -f -- "${start_control_staging}" >/dev/null 2>&1 || true
+  rmdir -- "${start_control_staging_dir}" >/dev/null 2>&1 || true
+  start_control_staging_owned=false
+  start_control_staging=""
+  start_control_staging_dir=""
+  start_final_path=""
+  start_final_identity=""
+  echo "[vh:publisher-recovery] publisher reached active/running; attended permit receipt is consumed; wrapper preflights remain to be proven by verify"
   exit 0
 fi
 
 if [[ "${COMMAND}" == "verify" ]]; then
   verification_succeeded=false
   verification_staging=""
+  verification_staging_dir=""
+  verification_staging_owned=false
+  verification_final_path=""
+  verification_final_identity=""
   cleanup_verification() {
     local status=$?
     trap - EXIT HUP INT TERM
-    if [[ -n "${verification_staging}" ]]; then
-      rm -f -- "${verification_staging}" >/dev/null 2>&1 || status=78
-      [[ ! -e "${verification_staging}" && ! -L "${verification_staging}" ]] || status=78
+    if [[ "${status}" -ne 0 && -n "${verification_final_path}" && -n "${verification_final_identity}" ]]; then
+      remove_owned_final_link "${verification_final_path}" "${verification_final_identity}" || status=78
+    fi
+    if [[ "${verification_staging_owned}" == "true" ]]; then
+      cleanup_owned_staging "${verification_staging_dir}" "${verification_staging}" || status=78
     fi
     if [[ "${verification_succeeded}" != "true" || "${status}" -ne 0 ]]; then
       park_internal >/dev/null 2>&1 || true
@@ -412,12 +585,32 @@ if [[ "${COMMAND}" == "verify" ]]; then
     exit 78
   fi
   node "${GUARD_SCRIPT}" output-parent --file "${OUTPUT_FILE}" >/dev/null
-  verification_staging="$(dirname "${OUTPUT_FILE}")/.${OUTPUT_FILE##*/}.pending-$$-${RANDOM}"
+  if ! verification_staging_dir="$(reserve_staging_directory "${OUTPUT_FILE}")"; then
+    echo "[vh:publisher-recovery] could not reserve private verification staging" >&2
+    exit 78
+  fi
+  verification_staging_owned=true
+  verification_staging="${verification_staging_dir}/artifact.json"
   start_control_json="$(node "${GUARD_SCRIPT}" start-control \
     --file "${START_CONTROL_ARTIFACT}" \
     --expected-revision "${EXPECTED_REVISION}" \
     --max-age-ms "${START_CONTROL_MAX_AGE_MS}")"
   expected_nrestarts="$(node -e 'const value=JSON.parse(process.argv[1]).nRestarts; if (!Number.isSafeInteger(value)) process.exit(78); process.stdout.write(String(value));' "${start_control_json}")"
+  expected_system_writer_pin_sha256="$(node -e '
+    const value=JSON.parse(process.argv[1]).systemWriterPinSha256;
+    if (!/^[0-9a-f]{64}$/.test(value ?? "")) process.exit(78);
+    process.stdout.write(value);
+  ' "${start_control_json}")"
+  pre_verify_pin_json="$(publisher_pin_json)"
+  pre_verify_pin_sha256="$(node -e '
+    const value = JSON.parse(process.argv[1]);
+    if (value.status !== "pass" || !/^[0-9a-f]{64}$/.test(value.systemWriterPinSha256 ?? "")) process.exit(78);
+    process.stdout.write(value.systemWriterPinSha256);
+  ' "${pre_verify_pin_json}")"
+  if [[ "${pre_verify_pin_sha256}" != "${expected_system_writer_pin_sha256}" ]]; then
+    echo "[vh:publisher-recovery] system-writer pin changed before readback" >&2
+    exit 78
+  fi
   verify_args=(
     --expected-revision "${EXPECTED_REVISION}"
     --start-control-file "${START_CONTROL_ARTIFACT}"
@@ -438,16 +631,7 @@ if [[ "${COMMAND}" == "verify" ]]; then
     echo "[vh:publisher-recovery] publisher state changed before readback" >&2
     exit 78
   fi
-  node -e '
-    const { lstatSync, realpathSync } = require("node:fs");
-    const path = require("node:path");
-    const file = process.argv[1];
-    const stat = lstatSync(file);
-    if (stat.isSymbolicLink() || !stat.isFile()
-      || (typeof process.getuid === "function" && stat.uid !== process.getuid())
-      || (stat.mode & 0o777) !== 0o600
-      || realpathSync(file) !== path.resolve(file)) process.exit(78);
-  ' "${PUBLISHER_ENV_FILE}"
+  validate_publisher_env_file
   corepack pnpm@9.7.1 --filter @vh/gun-client build >/dev/null
   (
     set +x
@@ -460,6 +644,16 @@ if [[ "${COMMAND}" == "verify" ]]; then
     unset VH_NEWS_SYSTEM_WRITER_PRIVATE_KEY_PKCS8_BASE64URL VH_SYSTEM_WRITER_PRIVATE_KEY_PKCS8_BASE64URL
     node "${VERIFY_SCRIPT}" "${verify_args[@]}"
   )
+  post_verify_pin_json="$(publisher_pin_json)"
+  post_verify_pin_sha256="$(node -e '
+    const value = JSON.parse(process.argv[1]);
+    if (value.status !== "pass" || !/^[0-9a-f]{64}$/.test(value.systemWriterPinSha256 ?? "")) process.exit(78);
+    process.stdout.write(value.systemWriterPinSha256);
+  ' "${post_verify_pin_json}")"
+  if [[ "${post_verify_pin_sha256}" != "${expected_system_writer_pin_sha256}" ]]; then
+    echo "[vh:publisher-recovery] system-writer pin changed during readback" >&2
+    exit 78
+  fi
   verify_active="$(systemctl --user show "${SERVICE}" --property=ActiveState --value 2>/dev/null)"
   verify_sub="$(systemctl --user show "${SERVICE}" --property=SubState --value 2>/dev/null)"
   verify_nrestarts="$(systemctl --user show "${SERVICE}" --property=NRestarts --value 2>/dev/null)"
@@ -467,23 +661,41 @@ if [[ "${COMMAND}" == "verify" ]]; then
     echo "[vh:publisher-recovery] publisher state changed during readback" >&2
     exit 78
   fi
+  verification_final_identity="$(private_file_identity "${verification_staging}")"
+  verification_final_path="${OUTPUT_FILE}"
   ln "${verification_staging}" "${OUTPUT_FILE}"
+  [[ "$(private_file_identity "${OUTPUT_FILE}")" == "${verification_final_identity}" ]]
+  trap '' HUP INT TERM
+  trap - EXIT
   rm -f -- "${verification_staging}" >/dev/null 2>&1 || true
+  rmdir -- "${verification_staging_dir}" >/dev/null 2>&1 || true
+  verification_staging_owned=false
   verification_staging=""
+  verification_staging_dir=""
+  verification_final_path=""
+  verification_final_identity=""
   verification_succeeded=true
-  trap - EXIT HUP INT TERM
   echo "[vh:publisher-recovery] exact-run four-route recovery readback passed"
   exit 0
 fi
 
 if [[ "${COMMAND}" == "finalize" ]]; then
   finalization_temp=""
+  finalization_staging_dir=""
+  finalization_staging_owned=false
+  finalization_final_path=""
+  finalization_final_identity=""
   finalization_succeeded=false
   cleanup_finalization() {
     local status=$?
     trap - EXIT HUP INT TERM
     set +e
-    [[ -z "${finalization_temp}" ]] || rm -f "${finalization_temp}"
+    if [[ "${status}" -ne 0 && -n "${finalization_final_path}" && -n "${finalization_final_identity}" ]]; then
+      remove_owned_final_link "${finalization_final_path}" "${finalization_final_identity}" || status=78
+    fi
+    if [[ "${finalization_staging_owned}" == "true" ]]; then
+      cleanup_owned_staging "${finalization_staging_dir}" "${finalization_temp}" || status=78
+    fi
     if [[ "${finalization_succeeded}" != "true" || "${status}" -ne 0 ]]; then
       park_internal >/dev/null 2>&1 || true
       exit 78
@@ -522,7 +734,12 @@ if [[ "${COMMAND}" == "finalize" ]]; then
     exit 78
   fi
   node "${GUARD_SCRIPT}" output-parent --file "${FINALIZATION_OUTPUT}" >/dev/null
-  finalization_temp="${FINALIZATION_OUTPUT}.tmp-$$-${RANDOM}"
+  if ! finalization_staging_dir="$(reserve_staging_directory "${FINALIZATION_OUTPUT}")"; then
+    echo "[vh:publisher-recovery] could not reserve private finalization staging" >&2
+    exit 78
+  fi
+  finalization_staging_owned=true
+  finalization_temp="${finalization_staging_dir}/artifact.json"
   finalization_passed=false
   while [[ "${SECONDS}" -lt "${deadline}" ]]; do
     current_active="$(systemctl --user show "${SERVICE}" --property=ActiveState --value 2>/dev/null)"
@@ -550,13 +767,24 @@ if [[ "${COMMAND}" == "finalize" ]]; then
       current_nrestarts="$(systemctl --user show "${SERVICE}" --property=NRestarts --value 2>/dev/null)"
       [[ "${current_active}" == "active" && "${current_sub}" == "running" && "${current_nrestarts}" == "${expected_nrestarts}" ]]
       chmod 600 "${finalization_temp}"
+      finalization_final_identity="$(private_file_identity "${finalization_temp}")"
+      finalization_final_path="${FINALIZATION_OUTPUT}"
       ln "${finalization_temp}" "${FINALIZATION_OUTPUT}"
+      [[ "$(private_file_identity "${FINALIZATION_OUTPUT}")" == "${finalization_final_identity}" ]]
+      trap '' HUP INT TERM
+      trap - EXIT
+      finalization_succeeded=true
       # ln commits the already-private inode. A hidden-temp cleanup failure
       # after that point cannot make the final evidence ambiguous.
       rm -f "${finalization_temp}" >/dev/null 2>&1 || true
+      rmdir -- "${finalization_staging_dir}" >/dev/null 2>&1 || true
+      finalization_staging_owned=false
       finalization_temp=""
-      finalization_passed=true
-      break
+      finalization_staging_dir=""
+      finalization_final_path=""
+      finalization_final_identity=""
+      echo "[vh:publisher-recovery] recovery delivery, unchanged suppression, and post-suppression mailbox clean proof passed"
+      exit 0
     fi
     set +o noclobber
     rm -f "${finalization_temp}"
@@ -567,11 +795,7 @@ if [[ "${COMMAND}" == "finalize" ]]; then
     echo "[vh:publisher-recovery] alert/mailbox finalization did not pass within the bounded wait; publisher parked" >&2
     exit 78
   fi
-  finalization_temp=""
-  finalization_succeeded=true
-  trap - EXIT HUP INT TERM
-  echo "[vh:publisher-recovery] recovery delivery, unchanged suppression, and post-suppression mailbox clean proof passed"
-  exit 0
+  exit 78
 fi
 
 usage

--- a/tools/scripts/news-aggregator-publisher-recovery-control.sh
+++ b/tools/scripts/news-aggregator-publisher-recovery-control.sh
@@ -8,8 +8,10 @@ GUARD_SCRIPT="${REPO_ROOT}/tools/scripts/news-aggregator-publisher-recovery-guar
 VERIFY_SCRIPT="${REPO_ROOT}/tools/scripts/verify-news-aggregator-publisher-recovery.mjs"
 START_CONTROL_WRITER="${REPO_ROOT}/tools/scripts/write-news-aggregator-publisher-start-control-artifact.mjs"
 SERVICE="vh-news-aggregator.service"
+PUBLISHER_ENV_FILE="${VH_NEWS_DAEMON_ENV_FILE:-${HOME}/.config/vhc/news-aggregator.env}"
 RESTART_AUTHORITY_FILE="${VH_NEWS_DAEMON_RESTART_AUTHORITY_FILE:-${HOME}/.local/state/vhc/news-aggregator/recovery/automatic-restart-authority.json}"
 RESTART_PERMIT_FILE="${VH_NEWS_DAEMON_RESTART_PERMIT_FILE:-${HOME}/.local/state/vhc/news-aggregator/recovery/automatic-restart-permit.json}"
+ATTENDED_START_PERMIT_FILE="${VH_NEWS_DAEMON_ATTENDED_START_PERMIT_FILE:-${HOME}/.local/state/vhc/news-aggregator/recovery/attended-start-permit.json}"
 RESTART_AUTHORITY_SCRIPT="${REPO_ROOT}/tools/scripts/news-aggregator-publisher-automatic-restart-authority.mjs"
 
 if [[ ! -r "${COMMON_SH}" ]]; then
@@ -156,11 +158,13 @@ park_internal() {
     VH_NEWS_DAEMON_START_APPROVED >/dev/null
   if ! node "${RESTART_AUTHORITY_SCRIPT}" disarm \
     --authority-file "${RESTART_AUTHORITY_FILE}" \
-    --permit-file "${RESTART_PERMIT_FILE}" >/dev/null 2>&1; then
+    --permit-file "${RESTART_PERMIT_FILE}" \
+    --attended-permit-file "${ATTENDED_START_PERMIT_FILE}" >/dev/null 2>&1; then
     echo "[vh:publisher-recovery] automatic restart authority failed to clear" >&2
     return 78
   fi
-  if [[ -e "${RESTART_PERMIT_FILE}" || -L "${RESTART_PERMIT_FILE}"
+  if [[ -e "${ATTENDED_START_PERMIT_FILE}" || -L "${ATTENDED_START_PERMIT_FILE}"
+    || -e "${RESTART_PERMIT_FILE}" || -L "${RESTART_PERMIT_FILE}"
     || -e "${RESTART_AUTHORITY_FILE}" || -L "${RESTART_AUTHORITY_FILE}" ]]; then
     echo "[vh:publisher-recovery] automatic restart authority remained after park" >&2
     return 78
@@ -226,6 +230,7 @@ if [[ "${COMMAND}" == "start" ]]; then
     echo "[vh:publisher-recovery] start-control output must be a new absolute path" >&2
     exit 78
   fi
+  node "${GUARD_SCRIPT}" output-parent --file "${START_CONTROL_OUTPUT}" >/dev/null
   preflight_json="$(node "${GUARD_SCRIPT}" preflight \
     --file "${PREFLIGHT_ARTIFACT}" \
     --expected-revision "${EXPECTED_REVISION}" \
@@ -255,9 +260,14 @@ if [[ "${COMMAND}" == "start" ]]; then
   fi
 
   mutation_started=false
+  start_control_staging=""
   cleanup_start() {
     local status=$?
     trap - EXIT HUP INT TERM
+    if [[ -n "${start_control_staging}" ]]; then
+      rm -f -- "${start_control_staging}" >/dev/null 2>&1 || status=78
+      [[ ! -e "${start_control_staging}" && ! -L "${start_control_staging}" ]] || status=78
+    fi
     systemctl --user unset-environment \
       VH_NEWS_DAEMON_ATTENDED_START_APPROVED \
       VH_NEWS_DAEMON_START_APPROVED >/dev/null 2>&1 || status=78
@@ -272,7 +282,6 @@ if [[ "${COMMAND}" == "start" ]]; then
 
   started_at="$(node -e 'process.stdout.write(new Date().toISOString())')"
   mutation_started=true
-  systemctl --user set-environment VH_NEWS_DAEMON_ATTENDED_START_APPROVED=1 >/dev/null
   systemctl --user enable "${SERVICE}" >/dev/null
   systemctl --user reset-failed "${SERVICE}" >/dev/null
   baseline_nrestarts="$(systemctl --user show "${SERVICE}" --property=NRestarts --value 2>/dev/null)"
@@ -285,13 +294,38 @@ if [[ "${COMMAND}" == "start" ]]; then
     --authority-file "${RESTART_AUTHORITY_FILE}" \
     --permit-file "${RESTART_PERMIT_FILE}" \
     --baseline-nrestarts "${baseline_nrestarts}" >/dev/null
+  attended_evidence_bindings="$(node -e '
+    const [preflight, relay, mailbox] = process.argv.slice(1).map(JSON.parse);
+    process.stdout.write(JSON.stringify({
+      preflightSha256: preflight.sha256,
+      relayEvidenceSha256: relay.sha256,
+      relayPacketSha256: relay.packetSha256,
+      relayCaptureSha256: relay.captureSha256,
+      mailboxSha256: mailbox.sha256,
+      mailboxCriticalCount: mailbox.newCriticalCount,
+    }));
+  ' "${preflight_json}" "${relay_recovery_json}" "${mailbox_current_json}")"
+  attended_permit_json="$(node "${RESTART_AUTHORITY_SCRIPT}" issue-attended \
+    --expected-revision "${EXPECTED_REVISION}" \
+    --attended-permit-file "${ATTENDED_START_PERMIT_FILE}" \
+    --baseline-nrestarts "${baseline_nrestarts}" \
+    --start-control-output "${START_CONTROL_OUTPUT}" \
+    --evidence-bindings-json "${attended_evidence_bindings}" \
+    --controller-pid "$$" \
+    --max-age-ms 120000)"
+  attended_permit_binding_sha256="$(node -e '
+    const value = JSON.parse(process.argv[1]);
+    if (value.status !== "attended_start_permit_issued" || !/^[0-9a-f]{64}$/.test(value.permitBindingSha256 ?? "")) process.exit(78);
+    process.stdout.write(value.permitBindingSha256);
+  ' "${attended_permit_json}")"
   systemctl --user start "${SERVICE}" >/dev/null
 
   deadline=$((SECONDS + ACTIVE_TIMEOUT_SECONDS))
   while true; do
     active_state="$(systemctl --user show "${SERVICE}" --property=ActiveState --value 2>/dev/null)"
     sub_state="$(systemctl --user show "${SERVICE}" --property=SubState --value 2>/dev/null)"
-    if [[ "${active_state}" == "active" && "${sub_state}" == "running" ]]; then
+    if [[ "${active_state}" == "active" && "${sub_state}" == "running"
+      && ! -e "${ATTENDED_START_PERMIT_FILE}" && ! -L "${ATTENDED_START_PERMIT_FILE}" ]]; then
       break
     fi
     if [[ "${active_state}" == "failed" || "${SECONDS}" -ge "${deadline}" ]]; then
@@ -307,20 +341,26 @@ if [[ "${COMMAND}" == "start" ]]; then
     echo "[vh:publisher-recovery] one-shot approval did not clear" >&2
     exit 78
   fi
+  if [[ -e "${ATTENDED_START_PERMIT_FILE}" || -L "${ATTENDED_START_PERMIT_FILE}" ]]; then
+    echo "[vh:publisher-recovery] attended start permit was not consumed" >&2
+    exit 78
+  fi
   post_nrestarts="$(systemctl --user show "${SERVICE}" --property=NRestarts --value 2>/dev/null)"
   if [[ ! "${post_nrestarts}" =~ ^[0-9]+$ || "${post_nrestarts}" != "${baseline_nrestarts}" ]]; then
     echo "[vh:publisher-recovery] publisher restart count changed during activation" >&2
     exit 78
   fi
   activated_at="$(node -e 'process.stdout.write(new Date().toISOString())')"
+  start_control_staging="$(dirname "${START_CONTROL_OUTPUT}")/.${START_CONTROL_OUTPUT##*/}.pending-$$-${RANDOM}"
   node "${START_CONTROL_WRITER}" \
-    --output-file "${START_CONTROL_OUTPUT}" \
+    --output-file "${start_control_staging}" \
     --expected-revision "${EXPECTED_REVISION}" \
     --started-at "${started_at}" \
     --activated-at "${activated_at}" \
     --incident-nrestarts "${incident_nrestarts}" \
     --baseline-nrestarts "${baseline_nrestarts}" \
     --post-nrestarts "${post_nrestarts}" \
+    --attended-permit-binding-sha256 "${attended_permit_binding_sha256}" \
     --preflight-binding-json "${preflight_json}" \
     --relay-binding-json "${relay_recovery_json}" \
     --mailbox-binding-json "${mailbox_current_json}"
@@ -328,20 +368,29 @@ if [[ "${COMMAND}" == "start" ]]; then
   final_sub_state="$(systemctl --user show "${SERVICE}" --property=SubState --value 2>/dev/null)"
   final_nrestarts="$(systemctl --user show "${SERVICE}" --property=NRestarts --value 2>/dev/null)"
   if [[ "${final_active_state}" != "active" || "${final_sub_state}" != "running"
-    || "${final_nrestarts}" != "${baseline_nrestarts}" ]] || manager_approval_is_set; then
+    || "${final_nrestarts}" != "${baseline_nrestarts}"
+    || -e "${ATTENDED_START_PERMIT_FILE}" || -L "${ATTENDED_START_PERMIT_FILE}" ]] || manager_approval_is_set; then
     echo "[vh:publisher-recovery] publisher state drifted while committing start evidence" >&2
     exit 78
   fi
+  ln "${start_control_staging}" "${START_CONTROL_OUTPUT}"
+  rm -f -- "${start_control_staging}" >/dev/null 2>&1 || true
+  start_control_staging=""
   mutation_started=false
-  echo "[vh:publisher-recovery] publisher reached active/running; one-shot approval is cleared; wrapper preflights remain to be proven by verify"
+  echo "[vh:publisher-recovery] publisher reached active/running; attended permit is consumed; wrapper preflights remain to be proven by verify"
   exit 0
 fi
 
 if [[ "${COMMAND}" == "verify" ]]; then
   verification_succeeded=false
+  verification_staging=""
   cleanup_verification() {
     local status=$?
     trap - EXIT HUP INT TERM
+    if [[ -n "${verification_staging}" ]]; then
+      rm -f -- "${verification_staging}" >/dev/null 2>&1 || status=78
+      [[ ! -e "${verification_staging}" && ! -L "${verification_staging}" ]] || status=78
+    fi
     if [[ "${verification_succeeded}" != "true" || "${status}" -ne 0 ]]; then
       park_internal >/dev/null 2>&1 || true
       exit 78
@@ -358,6 +407,12 @@ if [[ "${COMMAND}" == "verify" ]]; then
     echo "[vh:publisher-recovery] verification requires three relays, evidence files, output, and abort approval" >&2
     exit 78
   }
+  if [[ "${OUTPUT_FILE}" != /* || -e "${OUTPUT_FILE}" || -L "${OUTPUT_FILE}" ]]; then
+    echo "[vh:publisher-recovery] verification output must be a new absolute path" >&2
+    exit 78
+  fi
+  node "${GUARD_SCRIPT}" output-parent --file "${OUTPUT_FILE}" >/dev/null
+  verification_staging="$(dirname "${OUTPUT_FILE}")/.${OUTPUT_FILE##*/}.pending-$$-${RANDOM}"
   start_control_json="$(node "${GUARD_SCRIPT}" start-control \
     --file "${START_CONTROL_ARTIFACT}" \
     --expected-revision "${EXPECTED_REVISION}" \
@@ -368,7 +423,7 @@ if [[ "${COMMAND}" == "verify" ]]; then
     --start-control-file "${START_CONTROL_ARTIFACT}"
     --current-run-file "${CURRENT_RUN_FILE}"
     --runtime-diagnostics-file "${RUNTIME_DIAGNOSTICS_FILE}"
-    --output-file "${OUTPUT_FILE}"
+    --output-file "${verification_staging}"
     --timeout-ms "${TIMEOUT_MS}"
     --max-tick-age-ms "${MAX_TICK_AGE_MS}"
     --start-control-max-age-ms "${START_CONTROL_MAX_AGE_MS}"
@@ -383,7 +438,28 @@ if [[ "${COMMAND}" == "verify" ]]; then
     echo "[vh:publisher-recovery] publisher state changed before readback" >&2
     exit 78
   fi
-  node "${VERIFY_SCRIPT}" "${verify_args[@]}"
+  node -e '
+    const { lstatSync, realpathSync } = require("node:fs");
+    const path = require("node:path");
+    const file = process.argv[1];
+    const stat = lstatSync(file);
+    if (stat.isSymbolicLink() || !stat.isFile()
+      || (typeof process.getuid === "function" && stat.uid !== process.getuid())
+      || (stat.mode & 0o777) !== 0o600
+      || realpathSync(file) !== path.resolve(file)) process.exit(78);
+  ' "${PUBLISHER_ENV_FILE}"
+  corepack pnpm@9.7.1 --filter @vh/gun-client build >/dev/null
+  (
+    set +x
+    set -a
+    if ! source "${PUBLISHER_ENV_FILE}" >/dev/null 2>&1; then
+      echo "[vh:publisher-recovery] publisher env file could not be loaded for signature verification" >&2
+      exit 78
+    fi
+    set +a
+    unset VH_NEWS_SYSTEM_WRITER_PRIVATE_KEY_PKCS8_BASE64URL VH_SYSTEM_WRITER_PRIVATE_KEY_PKCS8_BASE64URL
+    node "${VERIFY_SCRIPT}" "${verify_args[@]}"
+  )
   verify_active="$(systemctl --user show "${SERVICE}" --property=ActiveState --value 2>/dev/null)"
   verify_sub="$(systemctl --user show "${SERVICE}" --property=SubState --value 2>/dev/null)"
   verify_nrestarts="$(systemctl --user show "${SERVICE}" --property=NRestarts --value 2>/dev/null)"
@@ -391,6 +467,9 @@ if [[ "${COMMAND}" == "verify" ]]; then
     echo "[vh:publisher-recovery] publisher state changed during readback" >&2
     exit 78
   fi
+  ln "${verification_staging}" "${OUTPUT_FILE}"
+  rm -f -- "${verification_staging}" >/dev/null 2>&1 || true
+  verification_staging=""
   verification_succeeded=true
   trap - EXIT HUP INT TERM
   echo "[vh:publisher-recovery] exact-run four-route recovery readback passed"
@@ -442,7 +521,7 @@ if [[ "${COMMAND}" == "finalize" ]]; then
     echo "[vh:publisher-recovery] refusing to overwrite existing finalization evidence" >&2
     exit 78
   fi
-  mkdir -p "$(dirname "${FINALIZATION_OUTPUT}")"
+  node "${GUARD_SCRIPT}" output-parent --file "${FINALIZATION_OUTPUT}" >/dev/null
   finalization_temp="${FINALIZATION_OUTPUT}.tmp-$$-${RANDOM}"
   finalization_passed=false
   while [[ "${SECONDS}" -lt "${deadline}" ]]; do

--- a/tools/scripts/news-aggregator-publisher-recovery-control.sh
+++ b/tools/scripts/news-aggregator-publisher-recovery-control.sh
@@ -1,0 +1,498 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="${VHC_REPO:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+COMMON_SH="${REPO_ROOT}/tools/scripts/lib/news-aggregator-publisher-recovery-common.sh"
+START_SCRIPT="${REPO_ROOT}/tools/scripts/start-news-aggregator-daemon-production.sh"
+GUARD_SCRIPT="${REPO_ROOT}/tools/scripts/news-aggregator-publisher-recovery-guard.mjs"
+VERIFY_SCRIPT="${REPO_ROOT}/tools/scripts/verify-news-aggregator-publisher-recovery.mjs"
+START_CONTROL_WRITER="${REPO_ROOT}/tools/scripts/write-news-aggregator-publisher-start-control-artifact.mjs"
+SERVICE="vh-news-aggregator.service"
+RESTART_AUTHORITY_FILE="${VH_NEWS_DAEMON_RESTART_AUTHORITY_FILE:-${HOME}/.local/state/vhc/news-aggregator/recovery/automatic-restart-authority.json}"
+RESTART_PERMIT_FILE="${VH_NEWS_DAEMON_RESTART_PERMIT_FILE:-${HOME}/.local/state/vhc/news-aggregator/recovery/automatic-restart-permit.json}"
+RESTART_AUTHORITY_SCRIPT="${REPO_ROOT}/tools/scripts/news-aggregator-publisher-automatic-restart-authority.mjs"
+
+if [[ ! -r "${COMMON_SH}" ]]; then
+  echo "[vh:publisher-recovery] common checks are unavailable" >&2
+  exit 78
+fi
+# shellcheck disable=SC1090
+source "${COMMON_SH}"
+
+usage() {
+  cat >&2 <<'EOF'
+usage:
+  news-aggregator-publisher-recovery-control.sh preflight --expected-revision REV --output-file FILE --approve-preflight
+  news-aggregator-publisher-recovery-control.sh start --expected-revision REV --relay-recovery-evidence FILE --relay-recovery-expected-sha256 SHA --preflight-artifact FILE --mailbox-artifact FILE --mailbox-expected-sha256 SHA --mailbox-expected-critical-count N --start-control-output FILE --approve-attended-start
+  news-aggregator-publisher-recovery-control.sh verify --expected-revision REV --start-control-artifact FILE --current-run-file FILE --runtime-diagnostics-file FILE --output-file FILE --relay-origin URL (three times) --approve-verification-and-abort
+  news-aggregator-publisher-recovery-control.sh finalize --expected-revision REV --start-control-artifact FILE --readback-artifact FILE --watch-env-file FILE --first-alert-file FILE --second-alert-file FILE --mailbox-artifact FILE --finalization-output FILE --approve-finalization-and-abort
+  news-aggregator-publisher-recovery-control.sh park --expected-revision REV --approve-park
+EOF
+  exit 64
+}
+
+[[ "$#" -ge 1 ]] || usage
+COMMAND="$1"
+shift
+
+EXPECTED_REVISION=""
+PREFLIGHT_ARTIFACT=""
+MAILBOX_ARTIFACT=""
+CURRENT_RUN_FILE=""
+RUNTIME_DIAGNOSTICS_FILE=""
+OUTPUT_FILE=""
+START_CONTROL_OUTPUT=""
+START_CONTROL_ARTIFACT=""
+READBACK_ARTIFACT=""
+WATCH_ENV_FILE=""
+FIRST_ALERT_FILE=""
+SECOND_ALERT_FILE=""
+FINALIZATION_OUTPUT=""
+MAILBOX_EXPECTED_SHA256=""
+MAILBOX_EXPECTED_CRITICAL_COUNT=""
+RELAY_RECOVERY_EVIDENCE=""
+RELAY_RECOVERY_EXPECTED_SHA256=""
+PREFLIGHT_MAX_AGE_MS="1800000"
+MAILBOX_MAX_AGE_MS="900000"
+MAX_TICK_AGE_MS="1800000"
+START_CONTROL_MAX_AGE_MS="7200000"
+ALERT_MAX_AGE_MS="3600000"
+TIMEOUT_MS="5000"
+ACTIVE_TIMEOUT_SECONDS="60"
+FINALIZE_WAIT_SECONDS="900"
+APPROVE_PREFLIGHT=false
+APPROVE_ATTENDED_START=false
+APPROVE_VERIFICATION_AND_ABORT=false
+APPROVE_FINALIZATION_AND_ABORT=false
+APPROVE_PARK=false
+RELAY_ORIGINS=()
+
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --approve-preflight)
+      APPROVE_PREFLIGHT=true
+      shift
+      ;;
+    --approve-attended-start)
+      APPROVE_ATTENDED_START=true
+      shift
+      ;;
+    --approve-verification-and-abort)
+      APPROVE_VERIFICATION_AND_ABORT=true
+      shift
+      ;;
+    --approve-finalization-and-abort)
+      APPROVE_FINALIZATION_AND_ABORT=true
+      shift
+      ;;
+    --approve-park)
+      APPROVE_PARK=true
+      shift
+      ;;
+    --relay-origin)
+      [[ "$#" -ge 2 ]] || usage
+      RELAY_ORIGINS+=("$2")
+      shift 2
+      ;;
+    --expected-revision|--relay-recovery-evidence|--relay-recovery-expected-sha256|--preflight-artifact|--mailbox-artifact|--mailbox-expected-sha256|--mailbox-expected-critical-count|--start-control-output|--start-control-artifact|--readback-artifact|--watch-env-file|--first-alert-file|--second-alert-file|--finalization-output|--current-run-file|--runtime-diagnostics-file|--output-file|--preflight-max-age-ms|--mailbox-max-age-ms|--max-tick-age-ms|--start-control-max-age-ms|--alert-max-age-ms|--timeout-ms|--active-timeout-seconds|--finalize-wait-seconds)
+      [[ "$#" -ge 2 ]] || usage
+      case "$1" in
+        --expected-revision) EXPECTED_REVISION="$2" ;;
+        --relay-recovery-evidence) RELAY_RECOVERY_EVIDENCE="$2" ;;
+        --relay-recovery-expected-sha256) RELAY_RECOVERY_EXPECTED_SHA256="$2" ;;
+        --preflight-artifact) PREFLIGHT_ARTIFACT="$2" ;;
+        --mailbox-artifact) MAILBOX_ARTIFACT="$2" ;;
+        --mailbox-expected-sha256) MAILBOX_EXPECTED_SHA256="$2" ;;
+        --mailbox-expected-critical-count) MAILBOX_EXPECTED_CRITICAL_COUNT="$2" ;;
+        --start-control-output) START_CONTROL_OUTPUT="$2" ;;
+        --start-control-artifact) START_CONTROL_ARTIFACT="$2" ;;
+        --readback-artifact) READBACK_ARTIFACT="$2" ;;
+        --watch-env-file) WATCH_ENV_FILE="$2" ;;
+        --first-alert-file) FIRST_ALERT_FILE="$2" ;;
+        --second-alert-file) SECOND_ALERT_FILE="$2" ;;
+        --finalization-output) FINALIZATION_OUTPUT="$2" ;;
+        --current-run-file) CURRENT_RUN_FILE="$2" ;;
+        --runtime-diagnostics-file) RUNTIME_DIAGNOSTICS_FILE="$2" ;;
+        --output-file) OUTPUT_FILE="$2" ;;
+        --preflight-max-age-ms) PREFLIGHT_MAX_AGE_MS="$2" ;;
+        --mailbox-max-age-ms) MAILBOX_MAX_AGE_MS="$2" ;;
+        --max-tick-age-ms) MAX_TICK_AGE_MS="$2" ;;
+        --start-control-max-age-ms) START_CONTROL_MAX_AGE_MS="$2" ;;
+        --alert-max-age-ms) ALERT_MAX_AGE_MS="$2" ;;
+        --timeout-ms) TIMEOUT_MS="$2" ;;
+        --active-timeout-seconds) ACTIVE_TIMEOUT_SECONDS="$2" ;;
+        --finalize-wait-seconds) FINALIZE_WAIT_SECONDS="$2" ;;
+      esac
+      shift 2
+      ;;
+    *) usage ;;
+  esac
+done
+
+vh_publisher_require_full_revision "${EXPECTED_REVISION}"
+
+manager_approval_is_set() {
+  local manager_environment
+  if ! manager_environment="$(systemctl --user show-environment 2>/dev/null)"; then
+    return 0
+  fi
+  grep -Eq '^(VH_NEWS_DAEMON_ATTENDED_START_APPROVED|VH_NEWS_DAEMON_START_APPROVED)=' \
+    <<<"${manager_environment}"
+}
+
+park_internal() {
+  local state sub_state result_state exec_status enabled
+  state="$(systemctl --user show "${SERVICE}" --property=ActiveState --value 2>/dev/null)"
+  sub_state="$(systemctl --user show "${SERVICE}" --property=SubState --value 2>/dev/null)"
+  result_state="$(systemctl --user show "${SERVICE}" --property=Result --value 2>/dev/null)"
+  exec_status="$(systemctl --user show "${SERVICE}" --property=ExecMainStatus --value 2>/dev/null)"
+  if [[ "${state}" != "failed" || "${sub_state}" != "failed"
+    || "${result_state}" != "exit-code" || "${exec_status}" != "78" ]]; then
+    systemctl --user stop "${SERVICE}" >/dev/null
+  fi
+  systemctl --user disable "${SERVICE}" >/dev/null
+  systemctl --user unset-environment \
+    VH_NEWS_DAEMON_ATTENDED_START_APPROVED \
+    VH_NEWS_DAEMON_START_APPROVED >/dev/null
+  if ! node "${RESTART_AUTHORITY_SCRIPT}" disarm \
+    --authority-file "${RESTART_AUTHORITY_FILE}" \
+    --permit-file "${RESTART_PERMIT_FILE}" >/dev/null 2>&1; then
+    echo "[vh:publisher-recovery] automatic restart authority failed to clear" >&2
+    return 78
+  fi
+  if [[ -e "${RESTART_PERMIT_FILE}" || -L "${RESTART_PERMIT_FILE}"
+    || -e "${RESTART_AUTHORITY_FILE}" || -L "${RESTART_AUTHORITY_FILE}" ]]; then
+    echo "[vh:publisher-recovery] automatic restart authority remained after park" >&2
+    return 78
+  fi
+
+  state="$(systemctl --user show "${SERVICE}" --property=ActiveState --value 2>/dev/null)"
+  enabled="$(systemctl --user is-enabled "${SERVICE}" 2>/dev/null || true)"
+  if [[ "${state}" != "inactive" && "${state}" != "failed" ]]; then
+    echo "[vh:publisher-recovery] publisher failed to park" >&2
+    return 78
+  fi
+  if [[ "${enabled}" != "disabled" ]]; then
+    echo "[vh:publisher-recovery] publisher unit failed to disable" >&2
+    return 78
+  fi
+  if manager_approval_is_set; then
+    echo "[vh:publisher-recovery] publisher approval remained in manager environment" >&2
+    return 78
+  fi
+}
+
+if [[ "${COMMAND}" == "park" || "${COMMAND}" == "abort" ]]; then
+  [[ "${APPROVE_PARK}" == "true" ]] || {
+    echo "[vh:publisher-recovery] park requires separate explicit approval" >&2
+    exit 78
+  }
+  park_internal
+  echo "[vh:publisher-recovery] publisher is stopped, disabled, and approval-free"
+  exit 0
+fi
+
+vh_publisher_require_exact_checkout "${REPO_ROOT}" "${EXPECTED_REVISION}"
+
+if [[ "${COMMAND}" == "preflight" ]]; then
+  [[ "${APPROVE_PREFLIGHT}" == "true" && -n "${OUTPUT_FILE}" ]] || {
+    echo "[vh:publisher-recovery] preflight requires its distinct approval and output file" >&2
+    exit 78
+  }
+  exec env \
+    VHC_REPO="${REPO_ROOT}" \
+    VH_NEWS_DAEMON_EXPECTED_REVISION="${EXPECTED_REVISION}" \
+    VH_NEWS_DAEMON_PREFLIGHT_ONLY=1 \
+    VH_NEWS_DAEMON_PREFLIGHT_APPROVED=1 \
+    VH_NEWS_DAEMON_ATTENDED_START_APPROVED= \
+    VH_NEWS_DAEMON_START_APPROVED= \
+    VH_NEWS_DAEMON_PREFLIGHT_ARTIFACT="${OUTPUT_FILE}" \
+    bash "${START_SCRIPT}"
+fi
+
+if [[ "${COMMAND}" == "start" ]]; then
+  [[ "${APPROVE_ATTENDED_START}" == "true" && -n "${PREFLIGHT_ARTIFACT}" && -n "${MAILBOX_ARTIFACT}"
+    && -n "${RELAY_RECOVERY_EVIDENCE}" && -n "${RELAY_RECOVERY_EXPECTED_SHA256}"
+    && -n "${MAILBOX_EXPECTED_SHA256}" && -n "${MAILBOX_EXPECTED_CRITICAL_COUNT}"
+    && -n "${START_CONTROL_OUTPUT}" ]] || {
+    echo "[vh:publisher-recovery] start requires attended approval, preflight evidence, and mailbox evidence" >&2
+    exit 78
+  }
+  if [[ ! "${ACTIVE_TIMEOUT_SECONDS}" =~ ^[0-9]+$ || "${ACTIVE_TIMEOUT_SECONDS}" -le 0 || "${ACTIVE_TIMEOUT_SECONDS}" -gt 300 ]]; then
+    echo "[vh:publisher-recovery] active timeout must be 1..300 seconds" >&2
+    exit 78
+  fi
+  if [[ "${START_CONTROL_OUTPUT}" != /* || -e "${START_CONTROL_OUTPUT}" || -L "${START_CONTROL_OUTPUT}" ]]; then
+    echo "[vh:publisher-recovery] start-control output must be a new absolute path" >&2
+    exit 78
+  fi
+  preflight_json="$(node "${GUARD_SCRIPT}" preflight \
+    --file "${PREFLIGHT_ARTIFACT}" \
+    --expected-revision "${EXPECTED_REVISION}" \
+    --max-age-ms "${PREFLIGHT_MAX_AGE_MS}")"
+  relay_recovery_json="$(node "${GUARD_SCRIPT}" relay-recovery \
+    --file "${RELAY_RECOVERY_EVIDENCE}" \
+    --expected-revision "${EXPECTED_REVISION}" \
+    --expected-sha256 "${RELAY_RECOVERY_EXPECTED_SHA256}" \
+    --max-age-ms "${START_CONTROL_MAX_AGE_MS}")"
+  mailbox_current_json="$(node "${GUARD_SCRIPT}" mailbox-current \
+    --file "${MAILBOX_ARTIFACT}" \
+    --expected-sha256 "${MAILBOX_EXPECTED_SHA256}" \
+    --expected-critical-count "${MAILBOX_EXPECTED_CRITICAL_COUNT}" \
+    --max-age-ms "${MAILBOX_MAX_AGE_MS}")"
+
+  active_state="$(systemctl --user show "${SERVICE}" --property=ActiveState --value 2>/dev/null)"
+  sub_state="$(systemctl --user show "${SERVICE}" --property=SubState --value 2>/dev/null)"
+  result_state="$(systemctl --user show "${SERVICE}" --property=Result --value 2>/dev/null)"
+  exec_status="$(systemctl --user show "${SERVICE}" --property=ExecMainStatus --value 2>/dev/null)"
+  incident_nrestarts="$(systemctl --user show "${SERVICE}" --property=NRestarts --value 2>/dev/null)"
+  enabled_state="$(systemctl --user is-enabled "${SERVICE}" 2>/dev/null || true)"
+  if [[ "${active_state}" != "failed" || "${sub_state}" != "failed"
+    || "${result_state}" != "exit-code" || "${exec_status}" != "78"
+    || "${enabled_state}" != "disabled" || ! "${incident_nrestarts}" =~ ^[0-9]+$ ]] || manager_approval_is_set; then
+    echo "[vh:publisher-recovery] publisher is not in the exact reviewed exit-78 parked state" >&2
+    exit 78
+  fi
+
+  mutation_started=false
+  cleanup_start() {
+    local status=$?
+    trap - EXIT HUP INT TERM
+    systemctl --user unset-environment \
+      VH_NEWS_DAEMON_ATTENDED_START_APPROVED \
+      VH_NEWS_DAEMON_START_APPROVED >/dev/null 2>&1 || status=78
+    if [[ "${status}" -ne 0 && "${mutation_started}" == "true" ]]; then
+      park_internal >/dev/null 2>&1 || status=78
+      status=78
+    fi
+    exit "${status}"
+  }
+  trap cleanup_start EXIT
+  trap 'exit 78' HUP INT TERM
+
+  started_at="$(node -e 'process.stdout.write(new Date().toISOString())')"
+  mutation_started=true
+  systemctl --user set-environment VH_NEWS_DAEMON_ATTENDED_START_APPROVED=1 >/dev/null
+  systemctl --user enable "${SERVICE}" >/dev/null
+  systemctl --user reset-failed "${SERVICE}" >/dev/null
+  baseline_nrestarts="$(systemctl --user show "${SERVICE}" --property=NRestarts --value 2>/dev/null)"
+  if [[ ! "${baseline_nrestarts}" =~ ^[0-9]+$ ]]; then
+    echo "[vh:publisher-recovery] publisher restart baseline is unavailable after reset-failed" >&2
+    exit 78
+  fi
+  node "${RESTART_AUTHORITY_SCRIPT}" arm \
+    --expected-revision "${EXPECTED_REVISION}" \
+    --authority-file "${RESTART_AUTHORITY_FILE}" \
+    --permit-file "${RESTART_PERMIT_FILE}" \
+    --baseline-nrestarts "${baseline_nrestarts}" >/dev/null
+  systemctl --user start "${SERVICE}" >/dev/null
+
+  deadline=$((SECONDS + ACTIVE_TIMEOUT_SECONDS))
+  while true; do
+    active_state="$(systemctl --user show "${SERVICE}" --property=ActiveState --value 2>/dev/null)"
+    sub_state="$(systemctl --user show "${SERVICE}" --property=SubState --value 2>/dev/null)"
+    if [[ "${active_state}" == "active" && "${sub_state}" == "running" ]]; then
+      break
+    fi
+    if [[ "${active_state}" == "failed" || "${SECONDS}" -ge "${deadline}" ]]; then
+      echo "[vh:publisher-recovery] publisher did not reach active/running" >&2
+      exit 78
+    fi
+    sleep 1
+  done
+  systemctl --user unset-environment \
+    VH_NEWS_DAEMON_ATTENDED_START_APPROVED \
+    VH_NEWS_DAEMON_START_APPROVED >/dev/null
+  if manager_approval_is_set; then
+    echo "[vh:publisher-recovery] one-shot approval did not clear" >&2
+    exit 78
+  fi
+  post_nrestarts="$(systemctl --user show "${SERVICE}" --property=NRestarts --value 2>/dev/null)"
+  if [[ ! "${post_nrestarts}" =~ ^[0-9]+$ || "${post_nrestarts}" != "${baseline_nrestarts}" ]]; then
+    echo "[vh:publisher-recovery] publisher restart count changed during activation" >&2
+    exit 78
+  fi
+  activated_at="$(node -e 'process.stdout.write(new Date().toISOString())')"
+  node "${START_CONTROL_WRITER}" \
+    --output-file "${START_CONTROL_OUTPUT}" \
+    --expected-revision "${EXPECTED_REVISION}" \
+    --started-at "${started_at}" \
+    --activated-at "${activated_at}" \
+    --incident-nrestarts "${incident_nrestarts}" \
+    --baseline-nrestarts "${baseline_nrestarts}" \
+    --post-nrestarts "${post_nrestarts}" \
+    --preflight-binding-json "${preflight_json}" \
+    --relay-binding-json "${relay_recovery_json}" \
+    --mailbox-binding-json "${mailbox_current_json}"
+  final_active_state="$(systemctl --user show "${SERVICE}" --property=ActiveState --value 2>/dev/null)"
+  final_sub_state="$(systemctl --user show "${SERVICE}" --property=SubState --value 2>/dev/null)"
+  final_nrestarts="$(systemctl --user show "${SERVICE}" --property=NRestarts --value 2>/dev/null)"
+  if [[ "${final_active_state}" != "active" || "${final_sub_state}" != "running"
+    || "${final_nrestarts}" != "${baseline_nrestarts}" ]] || manager_approval_is_set; then
+    echo "[vh:publisher-recovery] publisher state drifted while committing start evidence" >&2
+    exit 78
+  fi
+  mutation_started=false
+  echo "[vh:publisher-recovery] publisher reached active/running; one-shot approval is cleared; wrapper preflights remain to be proven by verify"
+  exit 0
+fi
+
+if [[ "${COMMAND}" == "verify" ]]; then
+  verification_succeeded=false
+  cleanup_verification() {
+    local status=$?
+    trap - EXIT HUP INT TERM
+    if [[ "${verification_succeeded}" != "true" || "${status}" -ne 0 ]]; then
+      park_internal >/dev/null 2>&1 || true
+      exit 78
+    fi
+    exit 0
+  }
+  if [[ "${APPROVE_VERIFICATION_AND_ABORT}" == "true" ]]; then
+    trap cleanup_verification EXIT
+    trap 'exit 78' HUP INT TERM
+  fi
+  [[ "${APPROVE_VERIFICATION_AND_ABORT}" == "true"
+    && -n "${START_CONTROL_ARTIFACT}" && -n "${CURRENT_RUN_FILE}" && -n "${RUNTIME_DIAGNOSTICS_FILE}" && -n "${OUTPUT_FILE}"
+    && "${#RELAY_ORIGINS[@]}" -eq 3 ]] || {
+    echo "[vh:publisher-recovery] verification requires three relays, evidence files, output, and abort approval" >&2
+    exit 78
+  }
+  start_control_json="$(node "${GUARD_SCRIPT}" start-control \
+    --file "${START_CONTROL_ARTIFACT}" \
+    --expected-revision "${EXPECTED_REVISION}" \
+    --max-age-ms "${START_CONTROL_MAX_AGE_MS}")"
+  expected_nrestarts="$(node -e 'const value=JSON.parse(process.argv[1]).nRestarts; if (!Number.isSafeInteger(value)) process.exit(78); process.stdout.write(String(value));' "${start_control_json}")"
+  verify_args=(
+    --expected-revision "${EXPECTED_REVISION}"
+    --start-control-file "${START_CONTROL_ARTIFACT}"
+    --current-run-file "${CURRENT_RUN_FILE}"
+    --runtime-diagnostics-file "${RUNTIME_DIAGNOSTICS_FILE}"
+    --output-file "${OUTPUT_FILE}"
+    --timeout-ms "${TIMEOUT_MS}"
+    --max-tick-age-ms "${MAX_TICK_AGE_MS}"
+    --start-control-max-age-ms "${START_CONTROL_MAX_AGE_MS}"
+  )
+  for origin in "${RELAY_ORIGINS[@]}"; do
+    verify_args+=(--relay-origin "${origin}")
+  done
+  verify_active="$(systemctl --user show "${SERVICE}" --property=ActiveState --value 2>/dev/null)"
+  verify_sub="$(systemctl --user show "${SERVICE}" --property=SubState --value 2>/dev/null)"
+  verify_nrestarts="$(systemctl --user show "${SERVICE}" --property=NRestarts --value 2>/dev/null)"
+  if [[ "${verify_active}" != "active" || "${verify_sub}" != "running" || "${verify_nrestarts}" != "${expected_nrestarts}" ]]; then
+    echo "[vh:publisher-recovery] publisher state changed before readback" >&2
+    exit 78
+  fi
+  node "${VERIFY_SCRIPT}" "${verify_args[@]}"
+  verify_active="$(systemctl --user show "${SERVICE}" --property=ActiveState --value 2>/dev/null)"
+  verify_sub="$(systemctl --user show "${SERVICE}" --property=SubState --value 2>/dev/null)"
+  verify_nrestarts="$(systemctl --user show "${SERVICE}" --property=NRestarts --value 2>/dev/null)"
+  if [[ "${verify_active}" != "active" || "${verify_sub}" != "running" || "${verify_nrestarts}" != "${expected_nrestarts}" ]]; then
+    echo "[vh:publisher-recovery] publisher state changed during readback" >&2
+    exit 78
+  fi
+  verification_succeeded=true
+  trap - EXIT HUP INT TERM
+  echo "[vh:publisher-recovery] exact-run four-route recovery readback passed"
+  exit 0
+fi
+
+if [[ "${COMMAND}" == "finalize" ]]; then
+  finalization_temp=""
+  finalization_succeeded=false
+  cleanup_finalization() {
+    local status=$?
+    trap - EXIT HUP INT TERM
+    set +e
+    [[ -z "${finalization_temp}" ]] || rm -f "${finalization_temp}"
+    if [[ "${finalization_succeeded}" != "true" || "${status}" -ne 0 ]]; then
+      park_internal >/dev/null 2>&1 || true
+      exit 78
+    fi
+    exit 0
+  }
+  if [[ "${APPROVE_FINALIZATION_AND_ABORT}" == "true" ]]; then
+    trap cleanup_finalization EXIT
+    trap 'exit 78' HUP INT TERM
+  fi
+  [[ "${APPROVE_FINALIZATION_AND_ABORT}" == "true" && -n "${START_CONTROL_ARTIFACT}"
+    && -n "${READBACK_ARTIFACT}" && -n "${WATCH_ENV_FILE}"
+    && -n "${FIRST_ALERT_FILE}" && -n "${SECOND_ALERT_FILE}" && -n "${MAILBOX_ARTIFACT}"
+    && -n "${FINALIZATION_OUTPUT}" ]] || {
+    echo "[vh:publisher-recovery] finalization requires two alert reports, post-suppression mailbox, output, and abort approval" >&2
+    exit 78
+  }
+  if [[ ! "${FINALIZE_WAIT_SECONDS}" =~ ^[0-9]+$ || "${FINALIZE_WAIT_SECONDS}" -le 0 || "${FINALIZE_WAIT_SECONDS}" -gt 1800 ]]; then
+    echo "[vh:publisher-recovery] finalization wait must be 1..1800 seconds" >&2
+    exit 78
+  fi
+  if ! start_control_json="$(node "${GUARD_SCRIPT}" start-control \
+    --file "${START_CONTROL_ARTIFACT}" --expected-revision "${EXPECTED_REVISION}" --max-age-ms "${START_CONTROL_MAX_AGE_MS}")"; then
+    exit 78
+  fi
+  if ! expected_nrestarts="$(node -e 'process.stdout.write(String(JSON.parse(process.argv[1]).nRestarts));' "${start_control_json}")"; then
+    exit 78
+  fi
+  deadline=$((SECONDS + FINALIZE_WAIT_SECONDS))
+  if [[ "${FINALIZATION_OUTPUT}" != /* ]]; then
+    echo "[vh:publisher-recovery] finalization output path must be absolute" >&2
+    exit 78
+  fi
+  if [[ -e "${FINALIZATION_OUTPUT}" || -L "${FINALIZATION_OUTPUT}" ]]; then
+    echo "[vh:publisher-recovery] refusing to overwrite existing finalization evidence" >&2
+    exit 78
+  fi
+  mkdir -p "$(dirname "${FINALIZATION_OUTPUT}")"
+  finalization_temp="${FINALIZATION_OUTPUT}.tmp-$$-${RANDOM}"
+  finalization_passed=false
+  while [[ "${SECONDS}" -lt "${deadline}" ]]; do
+    current_active="$(systemctl --user show "${SERVICE}" --property=ActiveState --value 2>/dev/null)"
+    current_sub="$(systemctl --user show "${SERVICE}" --property=SubState --value 2>/dev/null)"
+    current_nrestarts="$(systemctl --user show "${SERVICE}" --property=NRestarts --value 2>/dev/null)"
+    if [[ "${current_active}" != "active" || "${current_sub}" != "running" || "${current_nrestarts}" != "${expected_nrestarts}" ]]; then
+      break
+    fi
+    umask 077
+    set -o noclobber
+    if node "${GUARD_SCRIPT}" finalize \
+      --file "${MAILBOX_ARTIFACT}" \
+      --expected-revision "${EXPECTED_REVISION}" \
+      --start-control-file "${START_CONTROL_ARTIFACT}" \
+      --readback-file "${READBACK_ARTIFACT}" \
+      --watch-env-file "${WATCH_ENV_FILE}" \
+      --first-alert-file "${FIRST_ALERT_FILE}" \
+      --second-alert-file "${SECOND_ALERT_FILE}" \
+      --start-control-max-age-ms "${START_CONTROL_MAX_AGE_MS}" \
+      --alert-max-age-ms "${ALERT_MAX_AGE_MS}" \
+      --max-age-ms "${MAILBOX_MAX_AGE_MS}" >"${finalization_temp}" 2>/dev/null; then
+      set +o noclobber
+      current_active="$(systemctl --user show "${SERVICE}" --property=ActiveState --value 2>/dev/null)"
+      current_sub="$(systemctl --user show "${SERVICE}" --property=SubState --value 2>/dev/null)"
+      current_nrestarts="$(systemctl --user show "${SERVICE}" --property=NRestarts --value 2>/dev/null)"
+      [[ "${current_active}" == "active" && "${current_sub}" == "running" && "${current_nrestarts}" == "${expected_nrestarts}" ]]
+      chmod 600 "${finalization_temp}"
+      ln "${finalization_temp}" "${FINALIZATION_OUTPUT}"
+      # ln commits the already-private inode. A hidden-temp cleanup failure
+      # after that point cannot make the final evidence ambiguous.
+      rm -f "${finalization_temp}" >/dev/null 2>&1 || true
+      finalization_temp=""
+      finalization_passed=true
+      break
+    fi
+    set +o noclobber
+    rm -f "${finalization_temp}"
+    sleep 1
+  done
+  [[ -z "${finalization_temp}" ]] || rm -f "${finalization_temp}"
+  if [[ "${finalization_passed}" != "true" ]]; then
+    echo "[vh:publisher-recovery] alert/mailbox finalization did not pass within the bounded wait; publisher parked" >&2
+    exit 78
+  fi
+  finalization_temp=""
+  finalization_succeeded=true
+  trap - EXIT HUP INT TERM
+  echo "[vh:publisher-recovery] recovery delivery, unchanged suppression, and post-suppression mailbox clean proof passed"
+  exit 0
+fi
+
+usage

--- a/tools/scripts/news-aggregator-publisher-recovery-control.test.mjs
+++ b/tools/scripts/news-aggregator-publisher-recovery-control.test.mjs
@@ -18,6 +18,7 @@ import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
+import { canonicalSystemWriterPinSha256 } from './verify-news-aggregator-publisher-recovery.mjs';
 
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(SCRIPT_DIR, '../..');
@@ -29,6 +30,18 @@ const RELAY_ORIGINS = [
   'http://127.0.0.1:8766',
   'http://127.0.0.1:8767',
 ];
+const SYSTEM_WRITER_PUBLIC_KEY = 'MCowBQYDK2VwAyEA4ZHLho6yDOsGogTtrVUWiTRIGYlxKexsprzKjbuy9js';
+const SYSTEM_WRITER_PIN_SHA256 = canonicalSystemWriterPinSha256({
+  pinVersion: 1,
+  schemaEpoch: 'luma-public-v1',
+  maxProtocolVersion: 'luma-public-v1',
+  signatureSuite: 'jcs-ed25519-sha256-v1',
+  writers: [{
+    id: 'test-writer',
+    status: 'active',
+    publicKey: { encoding: 'spki-base64url', material: SYSTEM_WRITER_PUBLIC_KEY },
+  }],
+});
 
 function executable(file, lines) {
   writeFileSync(file, `${lines.join('\n')}\n`, 'utf8');
@@ -38,6 +51,8 @@ function executable(file, lines) {
 function harness({
   gitMode = 'match', preflightBash = false, failStart = false,
   nodeMode = 'delegate', stopState = 'inactive', failTempCleanup = false,
+  substituteAttendedPermit = false, signalAfterLink = false, failStagingReservation = false,
+  raceFinalArtifact = false,
 } = {}) {
   const root = realpathSync(mkdtempSync(path.join(os.tmpdir(), 'vh-publisher-control-')));
   const bin = path.join(root, 'bin');
@@ -48,13 +63,20 @@ function harness({
   const approval = path.join(root, 'approval');
   const nrestarts = path.join(root, 'nrestarts');
   const attendedPermit = path.join(root, 'attended-start-permit.json');
+  const attendedReceipt = path.join(root, 'attended-start-consumption-receipt.json');
+  const restartAuthority = path.join(root, 'automatic-restart-authority.json');
+  const restartPermit = path.join(root, 'automatic-restart-permit.json');
   mkdirSync(bin, { recursive: true });
   mkdirSync(home, { recursive: true });
   const publisherEnvDir = path.join(home, '.config/vhc');
   const publisherEnvFile = path.join(publisherEnvDir, 'news-aggregator.env');
   mkdirSync(publisherEnvDir, { recursive: true, mode: 0o700 });
   chmodSync(publisherEnvDir, 0o700);
-  writeFileSync(publisherEnvFile, 'VH_NEWS_SYSTEM_WRITER_ID=test-writer\n', { mode: 0o600 });
+  writeFileSync(publisherEnvFile, [
+    'VH_NEWS_SYSTEM_WRITER_ID=test-writer',
+    `VH_NEWS_SYSTEM_WRITER_PUBLIC_KEY_SPKI_BASE64URL=${SYSTEM_WRITER_PUBLIC_KEY}`,
+    '',
+  ].join('\n'), { mode: 0o600 });
   chmodSync(publisherEnvFile, 0o600);
   writeFileSync(state, 'failed\n');
   writeFileSync(enabled, 'disabled\n');
@@ -64,6 +86,33 @@ function harness({
       '#!/bin/bash',
       'if [[ "$*" == *".tmp-"* ]]; then exit 1; fi',
       'exec /bin/rm "$@"',
+    ]);
+  }
+  if (signalAfterLink) {
+    executable(path.join(bin, 'ln'), [
+      '#!/bin/bash',
+      '/bin/ln "$@" || exit $?',
+      'kill -TERM "$PPID"',
+      'sleep 0.1',
+      'exit 0',
+    ]);
+  } else if (raceFinalArtifact) {
+    executable(path.join(bin, 'ln'), [
+      '#!/bin/bash',
+      'destination="${!#}"',
+      'printf "preserve-raced-final\\n" > "${destination}"',
+      'chmod 600 "${destination}"',
+      'exit 1',
+    ]);
+  }
+  if (failStagingReservation) {
+    const preservedStaging = path.join(root, 'preexisting-staging-directory');
+    mkdirSync(preservedStaging, { mode: 0o700 });
+    writeFileSync(path.join(preservedStaging, 'sentinel'), 'preserve-me\n', { mode: 0o600 });
+    executable(path.join(bin, 'mktemp'), [
+      '#!/bin/bash',
+      'printf "%s\\n" "${VH_TEST_PREEXISTING_STAGING:?}"',
+      'exit 1',
     ]);
   }
 
@@ -105,7 +154,15 @@ function harness({
     '  reset-failed) printf "0\\n" > "${VH_TEST_NRESTARTS_FILE}"; exit 0 ;;',
     '  start)',
     '    if [[ "${VH_TEST_FAIL_START}" == "1" ]]; then exit 1; fi',
-    '    rm -f "${VH_TEST_ATTENDED_PERMIT_FILE}"',
+    '    if [[ "${VH_TEST_SUBSTITUTE_ATTENDED_PERMIT}" == "1" ]]; then',
+    "      \"${VH_TEST_REAL_NODE}\" -e 'const fs=require(\"node:fs\"); const file=process.argv[1]; const value=JSON.parse(fs.readFileSync(file)); value.nonce=\"11111111-1111-1111-1111-111111111111\"; value.evidenceBindings.relayEvidenceSha256=\"f\".repeat(64); fs.writeFileSync(file, JSON.stringify(value)+\"\\n\", {mode:0o600}); fs.chmodSync(file,0o600);' \"${VH_TEST_ATTENDED_PERMIT_FILE}\"",
+    '    fi',
+    '    "${VH_TEST_REAL_NODE}" "${VH_TEST_AUTHORITY_SCRIPT}" consume-attended \\',
+    '      --expected-revision "${VH_TEST_REVISION}" \\',
+    '      --attended-permit-file "${VH_TEST_ATTENDED_PERMIT_FILE}" \\',
+    '      --attended-receipt-file "${VH_TEST_ATTENDED_RECEIPT_FILE}" \\',
+    '      --current-nrestarts "$(cat "${VH_TEST_NRESTARTS_FILE}")" \\',
+    '      --system-writer-pin-sha256 "${VH_TEST_SYSTEM_WRITER_PIN_SHA256}" >/dev/null || exit $?',
     '    printf "active\\n" > "${VH_TEST_STATE_FILE}"; exit 0',
     '    ;;',
     '  stop) printf "%s\\n" "${VH_TEST_STOP_STATE:-inactive}" > "${VH_TEST_STATE_FILE}"; exit 0 ;;',
@@ -130,6 +187,7 @@ function harness({
       '#!/bin/bash',
       'script="$1"',
       'name="$(basename "${script}")"',
+      'if [[ "${name}" == "verify-news-aggregator-publisher-recovery.mjs" && "${2:-}" == "pin-sha256" ]]; then exec "${VH_TEST_REAL_NODE}" "$@"; fi',
       'if [[ "${VH_TEST_NODE_MODE}" == "activation-race" && "${name}" == "write-news-aggregator-publisher-start-control-artifact.mjs" ]]; then',
       '  "${VH_TEST_REAL_NODE}" "$@" || exit $?',
       '  printf "1\\n" > "${VH_TEST_NRESTARTS_FILE}"',
@@ -139,7 +197,7 @@ function harness({
       '  case "${VH_TEST_NODE_MODE}" in',
       '    verify-fail) exit 78 ;;',
       '    verify-signal) kill -TERM "$PPID"; sleep 1; exit 78 ;;',
-      '    verify-success|verify-post-drift)',
+    '    verify-success|verify-post-drift|verify-post-pin-drift)',
       '      output=""',
       '      shift',
       '      while [[ "$#" -gt 0 ]]; do',
@@ -150,6 +208,10 @@ function harness({
       '      printf "{\\"status\\":\\"pass\\"}\\n" > "${output}"',
       '      chmod 600 "${output}"',
       '      [[ "${VH_TEST_NODE_MODE}" != "verify-post-drift" ]] || printf "1\\n" > "${VH_TEST_NRESTARTS_FILE}"',
+      '      if [[ "${VH_TEST_NODE_MODE}" == "verify-post-pin-drift" ]]; then',
+      '        sed -i.bak "s/^VH_NEWS_SYSTEM_WRITER_PUBLIC_KEY_SPKI_BASE64URL=.*/VH_NEWS_SYSTEM_WRITER_PUBLIC_KEY_SPKI_BASE64URL=MCowBQYDK2VwAyEAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/" "${VH_TEST_PUBLISHER_ENV_FILE}"',
+      '        rm -f "${VH_TEST_PUBLISHER_ENV_FILE}.bak"',
+      '      fi',
       '      exit 0',
       '      ;;',
       '  esac',
@@ -180,12 +242,20 @@ function harness({
     approval,
     nrestarts,
     attendedPermit,
+    attendedReceipt,
+    restartAuthority,
+    restartPermit,
     preflightEnvLog: path.join(root, 'preflight-env.log'),
     gitMode,
     failStart,
     nodeMode,
     stopState,
     failTempCleanup,
+    substituteAttendedPermit,
+    signalAfterLink,
+    failStagingReservation,
+    raceFinalArtifact,
+    preexistingStaging: path.join(root, 'preexisting-staging-directory'),
   };
 }
 
@@ -206,12 +276,21 @@ function run(script, args, h) {
       VH_TEST_APPROVAL_FILE: h.approval,
       VH_TEST_NRESTARTS_FILE: h.nrestarts,
       VH_TEST_ATTENDED_PERMIT_FILE: h.attendedPermit,
+      VH_TEST_ATTENDED_RECEIPT_FILE: h.attendedReceipt,
+      VH_TEST_AUTHORITY_SCRIPT: path.join(SCRIPT_DIR, 'news-aggregator-publisher-automatic-restart-authority.mjs'),
+      VH_TEST_SYSTEM_WRITER_PIN_SHA256: SYSTEM_WRITER_PIN_SHA256,
+      VH_TEST_SUBSTITUTE_ATTENDED_PERMIT: h.substituteAttendedPermit ? '1' : '0',
+      VH_TEST_PUBLISHER_ENV_FILE: path.join(h.home, '.config/vhc/news-aggregator.env'),
+      VH_TEST_PREEXISTING_STAGING: h.preexistingStaging,
       VH_TEST_FAIL_START: h.failStart ? '1' : '0',
       VH_TEST_NODE_MODE: h.nodeMode,
       VH_TEST_STOP_STATE: h.stopState,
       VH_TEST_REAL_NODE: process.execPath,
       VH_TEST_PREFLIGHT_ENV_LOG: h.preflightEnvLog,
       VH_NEWS_DAEMON_ATTENDED_START_PERMIT_FILE: h.attendedPermit,
+      VH_NEWS_DAEMON_ATTENDED_START_RECEIPT_FILE: h.attendedReceipt,
+      VH_NEWS_DAEMON_RESTART_AUTHORITY_FILE: h.restartAuthority,
+      VH_NEWS_DAEMON_RESTART_PERMIT_FILE: h.restartPermit,
     },
   });
 }
@@ -293,6 +372,27 @@ function writeRelayEvidence(h, now) {
   writeFileSync(file, bytes, { mode: 0o600 });
   chmodSync(file, 0o600);
   return { file, sha256: createHash('sha256').update(bytes).digest('hex') };
+}
+
+function attendedStartArgs(h, output) {
+  const now = new Date();
+  const preflightFile = path.join(h.root, `preflight-${path.basename(output)}.json`);
+  const mailboxFile = path.join(h.root, `mailbox-${path.basename(output)}.json`);
+  writeFileSync(preflightFile, `${JSON.stringify(recoveryPreflight(now))}\n`, { mode: 0o600 });
+  const mailboxBytes = `${JSON.stringify(mailbox(now))}\n`;
+  writeFileSync(mailboxFile, mailboxBytes, { mode: 0o600 });
+  const relayEvidence = writeRelayEvidence(h, now);
+  return [
+    'start', '--expected-revision', REVISION,
+    '--relay-recovery-evidence', relayEvidence.file,
+    '--relay-recovery-expected-sha256', relayEvidence.sha256,
+    '--preflight-artifact', preflightFile,
+    '--mailbox-artifact', mailboxFile,
+    '--mailbox-expected-sha256', createHash('sha256').update(mailboxBytes).digest('hex'),
+    '--mailbox-expected-critical-count', '11',
+    '--start-control-output', output,
+    '--approve-attended-start',
+  ];
 }
 
 test('installer requires exact clean revision and binds every S1 evidence service', () => {
@@ -450,13 +550,17 @@ test('attended start requires exact parked state and consumes a private evidence
     assert.equal(startControl.postActivation.nRestarts, 0);
     assert.equal(startControl.status, 'active_attended_permit_consumed');
     assert.equal(startControl.postActivation.attendedPermitConsumed, true);
+    assert.equal(startControl.postActivation.attendedReceiptConsumed, true);
     assert.equal(startControl.postActivation.legacyManagerApprovalCleared, true);
     assert.match(startControl.postActivation.attendedPermitBindingSha256, /^[0-9a-f]{64}$/);
+    assert.match(startControl.postActivation.attendedReceiptSha256, /^[0-9a-f]{64}$/);
     assert.equal(startControl.evidenceBindings.preflight.runId, 'preflight-test');
     assert.equal(startControl.evidenceBindings.relayRecovery.sha256, relayEvidence.sha256);
     assert.deepEqual(startControl.evidenceBindings.relayRecovery.relayOrigins, RELAY_ORIGINS);
     assert.equal(startControl.evidenceBindings.mailbox.sha256, mailboxSha);
     assert.equal(startControl.evidenceBindings.mailbox.newCriticalCount, 11);
+    assert.equal(startControl.evidenceBindings.systemWriterPin.sha256, SYSTEM_WRITER_PIN_SHA256);
+    assert.equal(existsSync(h.attendedReceipt), false);
     assert.equal(statSync(startControlOutput).mode & 0o777, 0o600);
     const log = readFileSync(h.log, 'utf8');
     assert.doesNotMatch(log, /set-environment VH_NEWS_DAEMON_ATTENDED_START_APPROVED=1/);
@@ -464,6 +568,22 @@ test('attended start requires exact parked state and consumes a private evidence
     assert.match(log, /reset-failed vh-news-aggregator\.service/);
     assert.match(log, /start vh-news-aggregator\.service/);
     assert.match(log, /unset-environment VH_NEWS_DAEMON_ATTENDED_START_APPROVED VH_NEWS_DAEMON_START_APPROVED/);
+  } finally {
+    rmSync(h.root, { recursive: true, force: true });
+  }
+});
+
+test('valid-shaped substituted attended permit is rejected by the controller receipt binding', () => {
+  const h = harness({ substituteAttendedPermit: true });
+  try {
+    const output = path.join(h.root, 'substituted-permit-start-control.json');
+    const result = run(CONTROL, attendedStartArgs(h, output), h);
+    assert.equal(result.status, 78);
+    assert.equal(existsSync(output), false);
+    assert.equal(existsSync(h.attendedPermit), false);
+    assert.equal(existsSync(h.attendedReceipt), false);
+    assert.equal(readFileSync(h.state, 'utf8').trim(), 'inactive');
+    assert.equal(readFileSync(h.enabled, 'utf8').trim(), 'disabled');
   } finally {
     rmSync(h.root, { recursive: true, force: true });
   }
@@ -575,6 +695,47 @@ test('attended start rejects weak-mode and symlink output parents before service
     } finally {
       rmSync(h.root, { recursive: true, force: true });
     }
+  }
+});
+
+test('live control safely migrates only the fixed canonical recovery directory from 0755', () => {
+  const h = harness();
+  try {
+    const recovery = path.join(h.home, '.local/state/vhc/news-aggregator/recovery');
+    mkdirSync(recovery, { recursive: true, mode: 0o755 });
+    chmodSync(recovery, 0o755);
+    h.restartAuthority = path.join(recovery, 'automatic-restart-authority.json');
+    h.restartPermit = path.join(recovery, 'automatic-restart-permit.json');
+    h.attendedPermit = path.join(recovery, 'attended-start-permit.json');
+    h.attendedReceipt = path.join(recovery, 'attended-start-consumption-receipt.json');
+    const output = path.join(h.root, 'canonical-migration-start.json');
+    const result = run(CONTROL, attendedStartArgs(h, output), h);
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(statSync(recovery).mode & 0o777, 0o700);
+    assert.equal(existsSync(output), true);
+  } finally {
+    rmSync(h.root, { recursive: true, force: true });
+  }
+
+  const linked = harness();
+  try {
+    const canonicalParent = path.join(linked.home, '.local/state/vhc/news-aggregator');
+    const recovery = path.join(canonicalParent, 'recovery');
+    const target = path.join(linked.root, 'outside-recovery');
+    mkdirSync(canonicalParent, { recursive: true, mode: 0o700 });
+    mkdirSync(target, { mode: 0o700 });
+    symlinkSync(target, recovery);
+    linked.restartAuthority = path.join(recovery, 'automatic-restart-authority.json');
+    linked.restartPermit = path.join(recovery, 'automatic-restart-permit.json');
+    linked.attendedPermit = path.join(recovery, 'attended-start-permit.json');
+    linked.attendedReceipt = path.join(recovery, 'attended-start-consumption-receipt.json');
+    const output = path.join(linked.root, 'canonical-symlink-rejected.json');
+    const result = run(CONTROL, attendedStartArgs(linked, output), linked);
+    assert.equal(result.status, 78);
+    assert.equal(existsSync(output), false);
+    assert.equal(existsSync(linked.log), false);
+  } finally {
+    rmSync(linked.root, { recursive: true, force: true });
   }
 });
 
@@ -704,8 +865,9 @@ function writeFinalizationInputs(h) {
     activationBaseline: { nRestarts: 0, capturedAfterResetFailed: true },
     postActivation: {
       activeState: 'active', subState: 'running', nRestarts: 0,
-      attendedPermitConsumed: true, legacyManagerApprovalCleared: true,
+      attendedPermitConsumed: true, attendedReceiptConsumed: true, legacyManagerApprovalCleared: true,
       attendedPermitBindingSha256: '7'.repeat(64),
+      attendedReceiptSha256: '8'.repeat(64),
     },
     evidenceBindings: {
       preflight: {
@@ -723,6 +885,7 @@ function writeFinalizationInputs(h) {
         schemaVersion: 'vhc-failure-mailbox-monitor-v1', sha256: '6'.repeat(64),
         newCriticalCount: 11, generatedAt: isoBefore(now, 44),
       },
+      systemWriterPin: { sha256: SYSTEM_WRITER_PIN_SHA256 },
     },
   });
   const startSha256 = createHash('sha256').update(readFileSync(start)).digest('hex');
@@ -736,6 +899,7 @@ function writeFinalizationInputs(h) {
     inputBindings: {
       startControlSha256: startSha256, preflightSha256: '1'.repeat(64), relayEvidenceSha256: '2'.repeat(64),
       relayPacketSha256: '4'.repeat(64), relayCaptureSha256: '5'.repeat(64), mailboxSha256: '6'.repeat(64),
+      systemWriterPinSha256: SYSTEM_WRITER_PIN_SHA256,
     },
   });
   const watchEnv = path.join(h.root, 'watch.env');
@@ -789,6 +953,7 @@ test('verification succeeds only across stable pre/post state and parks every ap
     { name: 'pre-state drift', nodeMode: 'verify-success', initialState: 'inactive', expectedStatus: 78, expectedState: 'inactive' },
     { name: 'verifier failure', nodeMode: 'verify-fail', expectedStatus: 78, expectedState: 'inactive' },
     { name: 'post-state drift', nodeMode: 'verify-post-drift', expectedStatus: 78, expectedState: 'inactive' },
+    { name: 'post-pin drift', nodeMode: 'verify-post-pin-drift', expectedStatus: 78, expectedState: 'inactive' },
     { name: 'termination signal', nodeMode: 'verify-signal', expectedStatus: 78, expectedState: 'inactive' },
     { name: 'wrong relay count', nodeMode: 'verify-success', wrongRelayCount: true, expectedStatus: 78, expectedState: 'inactive' },
   ]) {
@@ -820,6 +985,32 @@ test('verification succeeds only across stable pre/post state and parks every ap
   }
 });
 
+test('verification rejects system-writer pin drift before invoking readback', () => {
+  const h = harness({ nodeMode: 'verify-success' });
+  try {
+    writeFileSync(h.state, 'active\n');
+    writeFileSync(h.enabled, 'enabled\n');
+    writeFileSync(h.nrestarts, '0\n');
+    const files = writeFinalizationInputs(h);
+    const envFile = path.join(h.home, '.config/vhc/news-aggregator.env');
+    const changed = readFileSync(envFile, 'utf8').replace(
+      /^VH_NEWS_SYSTEM_WRITER_PUBLIC_KEY_SPKI_BASE64URL=.*$/m,
+      'VH_NEWS_SYSTEM_WRITER_PUBLIC_KEY_SPKI_BASE64URL=MCowBQYDK2VwAyEAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    );
+    writeFileSync(envFile, changed, { mode: 0o600 });
+    chmodSync(envFile, 0o600);
+    const output = path.join(h.root, 'pre-readback-pin-drift.json');
+    const result = run(CONTROL, verificationArgs(files, output), h);
+    assert.equal(result.status, 78);
+    assert.match(result.stderr, /system-writer pin changed before readback/);
+    assert.equal(existsSync(output), false);
+    assert.equal(readFileSync(h.state, 'utf8').trim(), 'inactive');
+    assert.equal(readFileSync(h.enabled, 'utf8').trim(), 'disabled');
+  } finally {
+    rmSync(h.root, { recursive: true, force: true });
+  }
+});
+
 test('verification preserves preexisting evidence byte-for-byte and parks without invoking readback', () => {
   const h = harness({ nodeMode: 'verify-success' });
   try {
@@ -836,6 +1027,141 @@ test('verification preserves preexisting evidence byte-for-byte and parks withou
     assert.equal(readFileSync(h.enabled, 'utf8').trim(), 'disabled');
   } finally {
     rmSync(h.root, { recursive: true, force: true });
+  }
+});
+
+test('TERM immediately after final link removes invocation-owned start, readback, and finalization pass artifacts', () => {
+  {
+    const h = harness({ signalAfterLink: true });
+    try {
+      const output = path.join(h.root, 'term-after-start-link.json');
+      const result = run(CONTROL, attendedStartArgs(h, output), h);
+      assert.equal(result.status, 78, result.stderr);
+      assert.equal(existsSync(output), false);
+      assert.equal(readFileSync(h.state, 'utf8').trim(), 'inactive');
+      assert.equal(readFileSync(h.enabled, 'utf8').trim(), 'disabled');
+    } finally {
+      rmSync(h.root, { recursive: true, force: true });
+    }
+  }
+
+  {
+    const h = harness({ nodeMode: 'verify-success', signalAfterLink: true });
+    try {
+      writeFileSync(h.state, 'active\n');
+      writeFileSync(h.enabled, 'enabled\n');
+      writeFileSync(h.nrestarts, '0\n');
+      const files = writeFinalizationInputs(h);
+      const output = path.join(h.root, 'term-after-readback-link.json');
+      const result = run(CONTROL, verificationArgs(files, output), h);
+      assert.equal(result.status, 78, result.stderr);
+      assert.equal(existsSync(output), false);
+      assert.equal(readFileSync(h.state, 'utf8').trim(), 'inactive');
+      assert.equal(readFileSync(h.enabled, 'utf8').trim(), 'disabled');
+    } finally {
+      rmSync(h.root, { recursive: true, force: true });
+    }
+  }
+
+  {
+    const h = harness({ signalAfterLink: true });
+    try {
+      writeFileSync(h.state, 'active\n');
+      writeFileSync(h.enabled, 'enabled\n');
+      writeFileSync(h.nrestarts, '0\n');
+      const files = writeFinalizationInputs(h);
+      const output = path.join(h.root, 'term-after-finalization-link.json');
+      const result = run(CONTROL, finalizationArgs(files, output), h);
+      assert.equal(result.status, 78, result.stderr);
+      assert.equal(existsSync(output), false);
+      assert.equal(readFileSync(h.state, 'utf8').trim(), 'inactive');
+      assert.equal(readFileSync(h.enabled, 'utf8').trim(), 'disabled');
+    } finally {
+      rmSync(h.root, { recursive: true, force: true });
+    }
+  }
+});
+
+test('failed exclusive staging reservation never deletes a preexisting writer or verifier pathname', () => {
+  {
+    const h = harness({ failStagingReservation: true });
+    try {
+      const output = path.join(h.root, 'reservation-failed-start.json');
+      const result = run(CONTROL, attendedStartArgs(h, output), h);
+      assert.equal(result.status, 78);
+      assert.equal(existsSync(output), false);
+      assert.equal(readFileSync(path.join(h.preexistingStaging, 'sentinel'), 'utf8'), 'preserve-me\n');
+      assert.equal(readFileSync(h.state, 'utf8').trim(), 'inactive');
+    } finally {
+      rmSync(h.root, { recursive: true, force: true });
+    }
+  }
+
+  {
+    const h = harness({ nodeMode: 'verify-success', failStagingReservation: true });
+    try {
+      writeFileSync(h.state, 'active\n');
+      writeFileSync(h.enabled, 'enabled\n');
+      writeFileSync(h.nrestarts, '0\n');
+      const files = writeFinalizationInputs(h);
+      const output = path.join(h.root, 'reservation-failed-readback.json');
+      const result = run(CONTROL, verificationArgs(files, output), h);
+      assert.equal(result.status, 78);
+      assert.equal(existsSync(output), false);
+      assert.equal(readFileSync(path.join(h.preexistingStaging, 'sentinel'), 'utf8'), 'preserve-me\n');
+      assert.equal(readFileSync(h.state, 'utf8').trim(), 'inactive');
+    } finally {
+      rmSync(h.root, { recursive: true, force: true });
+    }
+  }
+});
+
+test('a raced preexisting final artifact is never deleted by invocation-owned rollback', () => {
+  {
+    const h = harness({ raceFinalArtifact: true });
+    try {
+      const output = path.join(h.root, 'raced-start-final.json');
+      const result = run(CONTROL, attendedStartArgs(h, output), h);
+      assert.equal(result.status, 78);
+      assert.equal(readFileSync(output, 'utf8'), 'preserve-raced-final\n');
+      assert.equal(readFileSync(h.state, 'utf8').trim(), 'inactive');
+    } finally {
+      rmSync(h.root, { recursive: true, force: true });
+    }
+  }
+
+  {
+    const h = harness({ nodeMode: 'verify-success', raceFinalArtifact: true });
+    try {
+      writeFileSync(h.state, 'active\n');
+      writeFileSync(h.enabled, 'enabled\n');
+      writeFileSync(h.nrestarts, '0\n');
+      const files = writeFinalizationInputs(h);
+      const output = path.join(h.root, 'raced-readback-final.json');
+      const result = run(CONTROL, verificationArgs(files, output), h);
+      assert.equal(result.status, 78);
+      assert.equal(readFileSync(output, 'utf8'), 'preserve-raced-final\n');
+      assert.equal(readFileSync(h.state, 'utf8').trim(), 'inactive');
+    } finally {
+      rmSync(h.root, { recursive: true, force: true });
+    }
+  }
+
+  {
+    const h = harness({ raceFinalArtifact: true });
+    try {
+      writeFileSync(h.state, 'active\n');
+      writeFileSync(h.enabled, 'enabled\n');
+      writeFileSync(h.nrestarts, '0\n');
+      const files = writeFinalizationInputs(h);
+      const output = path.join(h.root, 'raced-finalization-final.json');
+      const result = run(CONTROL, finalizationArgs(files, output), h);
+      assert.equal(result.status, 78);
+      assert.equal(readFileSync(output, 'utf8'), 'preserve-raced-final\n');
+      assert.equal(readFileSync(h.state, 'utf8').trim(), 'inactive');
+    } finally {
+      rmSync(h.root, { recursive: true, force: true });
+    }
   }
 });
 

--- a/tools/scripts/news-aggregator-publisher-recovery-control.test.mjs
+++ b/tools/scripts/news-aggregator-publisher-recovery-control.test.mjs
@@ -7,9 +7,11 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  readdirSync,
   realpathSync,
   rmSync,
   statSync,
+  symlinkSync,
   writeFileSync,
 } from 'node:fs';
 import os from 'node:os';
@@ -45,8 +47,15 @@ function harness({
   const enabled = path.join(root, 'enabled');
   const approval = path.join(root, 'approval');
   const nrestarts = path.join(root, 'nrestarts');
+  const attendedPermit = path.join(root, 'attended-start-permit.json');
   mkdirSync(bin, { recursive: true });
   mkdirSync(home, { recursive: true });
+  const publisherEnvDir = path.join(home, '.config/vhc');
+  const publisherEnvFile = path.join(publisherEnvDir, 'news-aggregator.env');
+  mkdirSync(publisherEnvDir, { recursive: true, mode: 0o700 });
+  chmodSync(publisherEnvDir, 0o700);
+  writeFileSync(publisherEnvFile, 'VH_NEWS_SYSTEM_WRITER_ID=test-writer\n', { mode: 0o600 });
+  chmodSync(publisherEnvFile, 0o600);
   writeFileSync(state, 'failed\n');
   writeFileSync(enabled, 'disabled\n');
   writeFileSync(nrestarts, '4\n');
@@ -76,6 +85,7 @@ function harness({
     'exit 0',
   ]);
   executable(path.join(bin, 'systemd-analyze'), ['#!/bin/bash', 'exit 0']);
+  executable(path.join(bin, 'corepack'), ['#!/bin/bash', 'exit 0']);
   executable(path.join(bin, 'systemctl'), [
     '#!/bin/bash',
     'printf "%s\\n" "$*" >> "${VH_TEST_SYSTEMCTL_LOG}"',
@@ -95,6 +105,7 @@ function harness({
     '  reset-failed) printf "0\\n" > "${VH_TEST_NRESTARTS_FILE}"; exit 0 ;;',
     '  start)',
     '    if [[ "${VH_TEST_FAIL_START}" == "1" ]]; then exit 1; fi',
+    '    rm -f "${VH_TEST_ATTENDED_PERMIT_FILE}"',
     '    printf "active\\n" > "${VH_TEST_STATE_FILE}"; exit 0',
     '    ;;',
     '  stop) printf "%s\\n" "${VH_TEST_STOP_STATE:-inactive}" > "${VH_TEST_STATE_FILE}"; exit 0 ;;',
@@ -168,6 +179,7 @@ function harness({
     enabled,
     approval,
     nrestarts,
+    attendedPermit,
     preflightEnvLog: path.join(root, 'preflight-env.log'),
     gitMode,
     failStart,
@@ -193,11 +205,13 @@ function run(script, args, h) {
       VH_TEST_ENABLED_FILE: h.enabled,
       VH_TEST_APPROVAL_FILE: h.approval,
       VH_TEST_NRESTARTS_FILE: h.nrestarts,
+      VH_TEST_ATTENDED_PERMIT_FILE: h.attendedPermit,
       VH_TEST_FAIL_START: h.failStart ? '1' : '0',
       VH_TEST_NODE_MODE: h.nodeMode,
       VH_TEST_STOP_STATE: h.stopState,
       VH_TEST_REAL_NODE: process.execPath,
       VH_TEST_PREFLIGHT_ENV_LOG: h.preflightEnvLog,
+      VH_NEWS_DAEMON_ATTENDED_START_PERMIT_FILE: h.attendedPermit,
     },
   });
 }
@@ -300,6 +314,20 @@ test('installer requires exact clean revision and binds every S1 evidence servic
       assert.match(source, new RegExp(`Environment=VH_NEWS_DAEMON_EXPECTED_REVISION=${REVISION}`));
       assert.match(source, new RegExp(`ExecStartPre=.*check-news-aggregator-expected-revision\\.sh ${REVISION}`));
     }
+    const generatedPublisherUnit = readFileSync(path.join(unitDir, 'vh-news-aggregator.service'), 'utf8');
+    const checkedInPublisherUnit = readFileSync(
+      path.join(REPO_ROOT, 'infra/systemd/user/vh-news-aggregator.service'),
+      'utf8',
+    );
+    for (const [label, source] of [
+      ['installer output', generatedPublisherUnit],
+      ['checked-in template', checkedInPublisherUnit],
+    ]) {
+      assert.match(source, /^Restart=no$/m, `${label} must default to no broad restart policy`);
+      assert.match(source, /^RestartForceExitStatus=69$/m, `${label} must force only exit 69`);
+      assert.doesNotMatch(source, /^Restart=on-failure$/m, `${label} retained broad on-failure restart`);
+      assert.doesNotMatch(source, /^RestartPreventExitStatus=/m, `${label} retained prevent-list semantics`);
+    }
     assert.doesNotMatch(readFileSync(h.log, 'utf8'), / start | enable /);
   } finally {
     rmSync(h.root, { recursive: true, force: true });
@@ -387,7 +415,7 @@ test('park then preflight then attended start preserves and consumes the reviewe
   }
 });
 
-test('attended start requires exact parked state, fresh guards, and clears transient approval', () => {
+test('attended start requires exact parked state and consumes a private evidence-bound permit', () => {
   const h = harness();
   try {
     const now = new Date();
@@ -420,6 +448,10 @@ test('attended start requires exact parked state, fresh guards, and clears trans
     assert.equal(startControl.preStart.incidentNRestarts, 4);
     assert.equal(startControl.activationBaseline.nRestarts, 0);
     assert.equal(startControl.postActivation.nRestarts, 0);
+    assert.equal(startControl.status, 'active_attended_permit_consumed');
+    assert.equal(startControl.postActivation.attendedPermitConsumed, true);
+    assert.equal(startControl.postActivation.legacyManagerApprovalCleared, true);
+    assert.match(startControl.postActivation.attendedPermitBindingSha256, /^[0-9a-f]{64}$/);
     assert.equal(startControl.evidenceBindings.preflight.runId, 'preflight-test');
     assert.equal(startControl.evidenceBindings.relayRecovery.sha256, relayEvidence.sha256);
     assert.deepEqual(startControl.evidenceBindings.relayRecovery.relayOrigins, RELAY_ORIGINS);
@@ -427,7 +459,7 @@ test('attended start requires exact parked state, fresh guards, and clears trans
     assert.equal(startControl.evidenceBindings.mailbox.newCriticalCount, 11);
     assert.equal(statSync(startControlOutput).mode & 0o777, 0o600);
     const log = readFileSync(h.log, 'utf8');
-    assert.match(log, /set-environment VH_NEWS_DAEMON_ATTENDED_START_APPROVED=1/);
+    assert.doesNotMatch(log, /set-environment VH_NEWS_DAEMON_ATTENDED_START_APPROVED=1/);
     assert.match(log, /enable vh-news-aggregator\.service/);
     assert.match(log, /reset-failed vh-news-aggregator\.service/);
     assert.match(log, /start vh-news-aggregator\.service/);
@@ -480,6 +512,7 @@ test('attended start parks if publisher state drifts while start-control evidenc
     const mailboxBytes = `${JSON.stringify(mailbox(now))}\n`;
     writeFileSync(mailboxFile, mailboxBytes, { mode: 0o600 });
     const relayEvidence = writeRelayEvidence(h, now);
+    const racedOutput = path.join(h.root, 'start-control-raced.json');
     const result = run(CONTROL, [
       'start', '--expected-revision', REVISION,
       '--relay-recovery-evidence', relayEvidence.file,
@@ -488,14 +521,60 @@ test('attended start parks if publisher state drifts while start-control evidenc
       '--mailbox-artifact', mailboxFile,
       '--mailbox-expected-sha256', createHash('sha256').update(mailboxBytes).digest('hex'),
       '--mailbox-expected-critical-count', '11',
-      '--start-control-output', path.join(h.root, 'start-control-raced.json'),
+      '--start-control-output', racedOutput,
       '--approve-attended-start',
     ], h);
     assert.equal(result.status, 78);
     assert.equal(readFileSync(h.state, 'utf8').trim(), 'inactive');
     assert.equal(readFileSync(h.enabled, 'utf8').trim(), 'disabled');
+    assert.equal(existsSync(racedOutput), false);
+    assert.equal(
+      readdirSync(path.dirname(racedOutput)).some((name) => name.startsWith(`.${path.basename(racedOutput)}.pending-`)),
+      false,
+    );
   } finally {
     rmSync(h.root, { recursive: true, force: true });
+  }
+});
+
+test('attended start rejects weak-mode and symlink output parents before service mutation', () => {
+  for (const parentKind of ['weak-mode', 'symlink']) {
+    const h = harness();
+    try {
+      const now = new Date();
+      const preflightFile = path.join(h.root, `${parentKind}-preflight.json`);
+      const mailboxFile = path.join(h.root, `${parentKind}-mailbox.json`);
+      writeFileSync(preflightFile, `${JSON.stringify(recoveryPreflight(now))}\n`, { mode: 0o600 });
+      const mailboxBytes = `${JSON.stringify(mailbox(now))}\n`;
+      writeFileSync(mailboxFile, mailboxBytes, { mode: 0o600 });
+      const relayEvidence = writeRelayEvidence(h, now);
+      const actualParent = path.join(h.root, `${parentKind}-actual-parent`);
+      mkdirSync(actualParent, { mode: parentKind === 'weak-mode' ? 0o755 : 0o700 });
+      let outputParent = actualParent;
+      if (parentKind === 'symlink') {
+        outputParent = path.join(h.root, 'start-control-parent-link');
+        symlinkSync(actualParent, outputParent);
+      }
+      const output = path.join(outputParent, 'start-control.json');
+      const result = run(CONTROL, [
+        'start', '--expected-revision', REVISION,
+        '--relay-recovery-evidence', relayEvidence.file,
+        '--relay-recovery-expected-sha256', relayEvidence.sha256,
+        '--preflight-artifact', preflightFile,
+        '--mailbox-artifact', mailboxFile,
+        '--mailbox-expected-sha256', createHash('sha256').update(mailboxBytes).digest('hex'),
+        '--mailbox-expected-critical-count', '11',
+        '--start-control-output', output,
+        '--approve-attended-start',
+      ], h);
+      assert.equal(result.status, 78, parentKind);
+      assert.equal(readFileSync(h.state, 'utf8').trim(), 'failed');
+      assert.equal(readFileSync(h.enabled, 'utf8').trim(), 'disabled');
+      assert.equal(existsSync(path.join(actualParent, 'start-control.json')), false);
+      assert.doesNotMatch(existsSync(h.log) ? readFileSync(h.log, 'utf8') : '', / enable | start /);
+    } finally {
+      rmSync(h.root, { recursive: true, force: true });
+    }
   }
 });
 
@@ -620,10 +699,14 @@ function writeFinalizationInputs(h) {
   };
   const start = write('final-start.json', {
     schemaVersion: 'vh-news-publisher-start-control-v1', generatedAt: isoBefore(now, 39),
-    status: 'active_approval_cleared', revision: REVISION, startedAt, activatedAt: isoBefore(now, 39),
+    status: 'active_attended_permit_consumed', revision: REVISION, startedAt, activatedAt: isoBefore(now, 39),
     preStart: { activeState: 'failed', subState: 'failed', result: 'exit-code', execMainStatus: 78, incidentNRestarts: 4, enabledState: 'disabled' },
     activationBaseline: { nRestarts: 0, capturedAfterResetFailed: true },
-    postActivation: { activeState: 'active', subState: 'running', nRestarts: 0, managerApprovalCleared: true },
+    postActivation: {
+      activeState: 'active', subState: 'running', nRestarts: 0,
+      attendedPermitConsumed: true, legacyManagerApprovalCleared: true,
+      attendedPermitBindingSha256: '7'.repeat(64),
+    },
     evidenceBindings: {
       preflight: {
         schemaVersion: 'vh-news-daemon-recovery-preflight-v1', sha256: '1'.repeat(64), revision: REVISION,
@@ -721,10 +804,38 @@ test('verification succeeds only across stable pre/post state and parks every ap
       assert.equal(result.status, row.expectedStatus, `${row.name}: ${result.stderr}`);
       assert.equal(readFileSync(h.state, 'utf8').trim(), row.expectedState, row.name);
       assert.equal(readFileSync(h.enabled, 'utf8').trim(), row.expectedStatus === 0 ? 'enabled' : 'disabled', row.name);
-      if (row.expectedStatus === 0) assert.equal(statSync(output).mode & 0o777, 0o600);
+      if (row.expectedStatus === 0) {
+        assert.equal(statSync(output).mode & 0o777, 0o600);
+      } else {
+        assert.equal(existsSync(output), false, `${row.name}: false pass artifact remained`);
+        assert.equal(
+          readdirSync(path.dirname(output)).some((name) => name.startsWith(`.${path.basename(output)}.pending-`)),
+          false,
+          `${row.name}: staged readback evidence remained`,
+        );
+      }
     } finally {
       rmSync(h.root, { recursive: true, force: true });
     }
+  }
+});
+
+test('verification preserves preexisting evidence byte-for-byte and parks without invoking readback', () => {
+  const h = harness({ nodeMode: 'verify-success' });
+  try {
+    writeFileSync(h.state, 'active\n');
+    writeFileSync(h.enabled, 'enabled\n');
+    writeFileSync(h.nrestarts, '0\n');
+    const files = writeFinalizationInputs(h);
+    const output = path.join(h.root, 'preexisting-readback.json');
+    writeFileSync(output, 'preserve-reviewed-readback\n', { mode: 0o600 });
+    const result = run(CONTROL, verificationArgs(files, output), h);
+    assert.equal(result.status, 78);
+    assert.equal(readFileSync(output, 'utf8'), 'preserve-reviewed-readback\n');
+    assert.equal(readFileSync(h.state, 'utf8').trim(), 'inactive');
+    assert.equal(readFileSync(h.enabled, 'utf8').trim(), 'disabled');
+  } finally {
+    rmSync(h.root, { recursive: true, force: true });
   }
 });
 

--- a/tools/scripts/news-aggregator-publisher-recovery-control.test.mjs
+++ b/tools/scripts/news-aggregator-publisher-recovery-control.test.mjs
@@ -1,0 +1,818 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(SCRIPT_DIR, '../..');
+const INSTALLER = path.join(SCRIPT_DIR, 'install-news-aggregator-production-service.sh');
+const CONTROL = path.join(SCRIPT_DIR, 'news-aggregator-publisher-recovery-control.sh');
+const REVISION = '1883841555c4924be8d35747272c38ce8f2071d9';
+const RELAY_ORIGINS = [
+  'http://127.0.0.1:8765',
+  'http://127.0.0.1:8766',
+  'http://127.0.0.1:8767',
+];
+
+function executable(file, lines) {
+  writeFileSync(file, `${lines.join('\n')}\n`, 'utf8');
+  chmodSync(file, 0o755);
+}
+
+function harness({
+  gitMode = 'match', preflightBash = false, failStart = false,
+  nodeMode = 'delegate', stopState = 'inactive', failTempCleanup = false,
+} = {}) {
+  const root = realpathSync(mkdtempSync(path.join(os.tmpdir(), 'vh-publisher-control-')));
+  const bin = path.join(root, 'bin');
+  const home = path.join(root, 'home');
+  const log = path.join(root, 'systemctl.log');
+  const state = path.join(root, 'state');
+  const enabled = path.join(root, 'enabled');
+  const approval = path.join(root, 'approval');
+  const nrestarts = path.join(root, 'nrestarts');
+  mkdirSync(bin, { recursive: true });
+  mkdirSync(home, { recursive: true });
+  writeFileSync(state, 'failed\n');
+  writeFileSync(enabled, 'disabled\n');
+  writeFileSync(nrestarts, '4\n');
+  if (failTempCleanup) {
+    executable(path.join(bin, 'rm'), [
+      '#!/bin/bash',
+      'if [[ "$*" == *".tmp-"* ]]; then exit 1; fi',
+      'exec /bin/rm "$@"',
+    ]);
+  }
+
+  executable(path.join(bin, 'git'), [
+    '#!/bin/bash',
+    'if [[ "$*" == *"rev-parse --verify HEAD"* ]]; then',
+    '  if [[ "${VH_TEST_GIT_MODE}" == "wrong" ]]; then printf "%040d\\n" 0; else printf "%s\\n" "${VH_TEST_REVISION}"; fi',
+    '  exit 0',
+    'fi',
+    'if [[ "$*" == *"status --porcelain=v1 --untracked-files=no"* ]]; then',
+    '  if [[ "${VH_TEST_GIT_MODE}" == "dirty" ]]; then printf " M tools/scripts/example\\n"; fi',
+    '  exit 0',
+    'fi',
+    'exit 1',
+  ]);
+  executable(path.join(bin, 'loginctl'), [
+    '#!/bin/bash',
+    'if [[ "$*" == *"show-user"* ]]; then printf "yes\\n"; exit 0; fi',
+    'exit 0',
+  ]);
+  executable(path.join(bin, 'systemd-analyze'), ['#!/bin/bash', 'exit 0']);
+  executable(path.join(bin, 'systemctl'), [
+    '#!/bin/bash',
+    'printf "%s\\n" "$*" >> "${VH_TEST_SYSTEMCTL_LOG}"',
+    '[[ "$1" == "--user" ]] && shift',
+    'command="$1"; shift || true',
+    'case "${command}" in',
+    '  daemon-reload) exit 0 ;;',
+    '  show-environment)',
+    '    if [[ -f "${VH_TEST_APPROVAL_FILE}" ]]; then printf "VH_NEWS_DAEMON_ATTENDED_START_APPROVED=1\\n"; fi',
+    '    exit 0',
+    '    ;;',
+    '  set-environment) touch "${VH_TEST_APPROVAL_FILE}"; exit 0 ;;',
+    '  unset-environment) rm -f "${VH_TEST_APPROVAL_FILE}"; exit 0 ;;',
+    '  is-enabled) value="$(cat "${VH_TEST_ENABLED_FILE}")"; printf "%s\\n" "${value}"; [[ "${value}" == "enabled" ]] ;;',
+    '  enable) printf "enabled\\n" > "${VH_TEST_ENABLED_FILE}"; exit 0 ;;',
+    '  disable) printf "disabled\\n" > "${VH_TEST_ENABLED_FILE}"; exit 0 ;;',
+    '  reset-failed) printf "0\\n" > "${VH_TEST_NRESTARTS_FILE}"; exit 0 ;;',
+    '  start)',
+    '    if [[ "${VH_TEST_FAIL_START}" == "1" ]]; then exit 1; fi',
+    '    printf "active\\n" > "${VH_TEST_STATE_FILE}"; exit 0',
+    '    ;;',
+    '  stop) printf "%s\\n" "${VH_TEST_STOP_STATE:-inactive}" > "${VH_TEST_STATE_FILE}"; exit 0 ;;',
+    '  show)',
+    '    current="$(cat "${VH_TEST_STATE_FILE}")"',
+    '    property=""',
+    '    for arg in "$@"; do [[ "${arg}" == --property=* ]] && property="${arg#--property=}"; done',
+    '    case "${property}" in',
+    '      ActiveState) printf "%s\\n" "${current}" ;;',
+    '      SubState) if [[ "${current}" == active ]]; then printf "running\\n"; elif [[ "${current}" == failed ]]; then printf "failed\\n"; else printf "dead\\n"; fi ;;',
+    '      Result) if [[ "${current}" == failed ]]; then printf "exit-code\\n"; else printf "success\\n"; fi ;;',
+    '      ExecMainStatus) if [[ "${current}" == failed ]]; then printf "78\\n"; else printf "0\\n"; fi ;;',
+    '      NRestarts) cat "${VH_TEST_NRESTARTS_FILE}" ;;',
+    '      *) exit 1 ;;',
+    '    esac',
+    '    ;;',
+    '  *) exit 0 ;;',
+    'esac',
+  ]);
+  if (nodeMode !== 'delegate') {
+    executable(path.join(bin, 'node'), [
+      '#!/bin/bash',
+      'script="$1"',
+      'name="$(basename "${script}")"',
+      'if [[ "${VH_TEST_NODE_MODE}" == "activation-race" && "${name}" == "write-news-aggregator-publisher-start-control-artifact.mjs" ]]; then',
+      '  "${VH_TEST_REAL_NODE}" "$@" || exit $?',
+      '  printf "1\\n" > "${VH_TEST_NRESTARTS_FILE}"',
+      '  exit 0',
+      'fi',
+      'if [[ "${name}" == "verify-news-aggregator-publisher-recovery.mjs" ]]; then',
+      '  case "${VH_TEST_NODE_MODE}" in',
+      '    verify-fail) exit 78 ;;',
+      '    verify-signal) kill -TERM "$PPID"; sleep 1; exit 78 ;;',
+      '    verify-success|verify-post-drift)',
+      '      output=""',
+      '      shift',
+      '      while [[ "$#" -gt 0 ]]; do',
+      '        if [[ "$1" == "--output-file" ]]; then output="$2"; break; fi',
+      '        shift',
+      '      done',
+      '      umask 077',
+      '      printf "{\\"status\\":\\"pass\\"}\\n" > "${output}"',
+      '      chmod 600 "${output}"',
+      '      [[ "${VH_TEST_NODE_MODE}" != "verify-post-drift" ]] || printf "1\\n" > "${VH_TEST_NRESTARTS_FILE}"',
+      '      exit 0',
+      '      ;;',
+      '  esac',
+      'fi',
+      'if [[ "${VH_TEST_NODE_MODE}" == "finalize-signal" && "${name}" == "news-aggregator-publisher-recovery-guard.mjs" && "$2" == "finalize" ]]; then',
+      '  kill -TERM "$PPID"; sleep 1; exit 78',
+      'fi',
+      'exec "${VH_TEST_REAL_NODE}" "$@"',
+    ]);
+  }
+  if (preflightBash) {
+    executable(path.join(bin, 'bash'), [
+      '#!/bin/bash',
+      'printf "expected=%s\\n" "${VH_NEWS_DAEMON_EXPECTED_REVISION:-}" > "${VH_TEST_PREFLIGHT_ENV_LOG}"',
+      'printf "preflight_only=%s\\n" "${VH_NEWS_DAEMON_PREFLIGHT_ONLY:-}" >> "${VH_TEST_PREFLIGHT_ENV_LOG}"',
+      'printf "preflight_approved=%s\\n" "${VH_NEWS_DAEMON_PREFLIGHT_APPROVED:-}" >> "${VH_TEST_PREFLIGHT_ENV_LOG}"',
+      'printf "attended=%s\\n" "${VH_NEWS_DAEMON_ATTENDED_START_APPROVED:-}" >> "${VH_TEST_PREFLIGHT_ENV_LOG}"',
+      'exit 0',
+    ]);
+  }
+  return {
+    root,
+    bin,
+    home,
+    log,
+    state,
+    enabled,
+    approval,
+    nrestarts,
+    preflightEnvLog: path.join(root, 'preflight-env.log'),
+    gitMode,
+    failStart,
+    nodeMode,
+    stopState,
+    failTempCleanup,
+  };
+}
+
+function run(script, args, h) {
+  return spawnSync('/bin/bash', [script, ...args], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      HOME: h.home,
+      PATH: `${h.bin}${path.delimiter}${process.env.PATH ?? ''}`,
+      VHC_REPO: REPO_ROOT,
+      VH_TEST_GIT_MODE: h.gitMode,
+      VH_TEST_REVISION: REVISION,
+      VH_TEST_SYSTEMCTL_LOG: h.log,
+      VH_TEST_STATE_FILE: h.state,
+      VH_TEST_ENABLED_FILE: h.enabled,
+      VH_TEST_APPROVAL_FILE: h.approval,
+      VH_TEST_NRESTARTS_FILE: h.nrestarts,
+      VH_TEST_FAIL_START: h.failStart ? '1' : '0',
+      VH_TEST_NODE_MODE: h.nodeMode,
+      VH_TEST_STOP_STATE: h.stopState,
+      VH_TEST_REAL_NODE: process.execPath,
+      VH_TEST_PREFLIGHT_ENV_LOG: h.preflightEnvLog,
+    },
+  });
+}
+
+function recoveryPreflight(now = new Date()) {
+  return {
+    schemaVersion: 'vh-news-daemon-recovery-preflight-v1',
+    generatedAt: new Date(now.getTime() - 30_000).toISOString(),
+    status: 'preflight_passed',
+    revision: REVISION,
+    runId: 'preflight-test',
+    mode: 'preflight_only',
+    gates: [
+      'source_liveness',
+      'storycluster_build',
+      'openai_provider',
+      'storycluster_qdrant_readiness',
+      'raw_publication_readiness',
+    ],
+  };
+}
+
+function mailbox(now = new Date()) {
+  return {
+    schemaVersion: 'vhc-failure-mailbox-monitor-v1',
+    generatedAt: new Date(now.getTime() - 30_000).toISOString(),
+    status: 'pass',
+    newCriticalCount: 11,
+  };
+}
+
+function publisherExit78() {
+  return { activeState: 'failed', subState: 'failed', result: 'exit-code', execMainStatus: 78 };
+}
+
+function relayRecovery(now = new Date()) {
+  const imageId = `sha256:${'a'.repeat(64)}`;
+  const imageTag = 'vhc-public-beta-relay:20260710-main-v18838415-amd64';
+  const packetSha256 = 'b'.repeat(64);
+  const captureSha256 = 'c'.repeat(64);
+  const relays = ['vhc-relay-a', 'vhc-relay-b', 'vhc-relay-c'];
+  return {
+    schemaVersion: 'vh-a6-s1b-relay-recovery-evidence-v1',
+    generatedAt: new Date(now.getTime() - 60_000).toISOString(),
+    status: 'pass',
+    revision: REVISION,
+    immutableImageId: imageId,
+    imageTag,
+    packetSha256,
+    captureSha256,
+    relayOrigins: RELAY_ORIGINS,
+    publisherBefore: publisherExit78(),
+    publisherAfter: publisherExit78(),
+    stages: relays.map((relay, index) => ({
+      relay, order: index + 1, origin: RELAY_ORIGINS[index], status: 'pass', revision: REVISION, imageId, imageTag,
+      packetSha256, ready: true, running: true, oomKilled: false,
+      restartCountStable: true, watchdogTripsStable: true,
+      topologyParity: true, environmentParity: true, snapshotParity: true,
+      missingRouteContracts: ['story', 'latest-index', 'hot-index', 'synthesis-lifecycle'],
+      publisherBefore: publisherExit78(), publisherAfter: publisherExit78(),
+    })),
+    finalFleet: {
+      status: 'pass', relayOrder: relays, runningCount: 3, readyCount: 3, oomKilledCount: 0,
+      restartCountsStable: true, watchdogTripsStable: true,
+      topologyParity: true, environmentParity: true, snapshotParity: true,
+      missingRouteContractsAll: true,
+    },
+    reviewerDecision: 'GO',
+    reviewerIdentity: 'reviewer-1',
+    reviewedAt: new Date(now.getTime() - 30_000).toISOString(),
+    reviewedPacketSha256: packetSha256,
+    reviewedCaptureSha256: captureSha256,
+  };
+}
+
+function writeRelayEvidence(h, now) {
+  const file = path.join(h.root, 'relay-recovery.json');
+  const bytes = `${JSON.stringify(relayRecovery(now))}\n`;
+  writeFileSync(file, bytes, { mode: 0o600 });
+  chmodSync(file, 0o600);
+  return { file, sha256: createHash('sha256').update(bytes).digest('hex') };
+}
+
+test('installer requires exact clean revision and binds every S1 evidence service', () => {
+  const h = harness();
+  try {
+    const result = run(INSTALLER, ['--expected-revision', REVISION], h);
+    assert.equal(result.status, 0, result.stderr);
+    const unitDir = path.join(h.home, '.config/systemd/user');
+    const services = [
+      'vh-news-aggregator.service',
+      'vh-relay-snapshot-freshness-watch.service',
+      'vh-news-aggregator-liveness-watch.service',
+      'vh-news-relay-liveness-watch.service',
+      'vh-phase5-scope-a-soak-archive.service',
+      'vh-phase5-scope-a-watch-closure.service',
+    ];
+    for (const service of services) {
+      const source = readFileSync(path.join(unitDir, service), 'utf8');
+      assert.match(source, new RegExp(`Environment=VH_NEWS_DAEMON_EXPECTED_REVISION=${REVISION}`));
+      assert.match(source, new RegExp(`ExecStartPre=.*check-news-aggregator-expected-revision\\.sh ${REVISION}`));
+    }
+    assert.doesNotMatch(readFileSync(h.log, 'utf8'), / start | enable /);
+  } finally {
+    rmSync(h.root, { recursive: true, force: true });
+  }
+});
+
+test('installer refuses missing, wrong, and dirty revision before systemd mutation', () => {
+  for (const [gitMode, args, expected] of [
+    ['match', [], /expected revision must be/],
+    ['wrong', ['--expected-revision', REVISION], /does not match/],
+    ['dirty', ['--expected-revision', REVISION], /tracked checkout is dirty/],
+  ]) {
+    const h = harness({ gitMode });
+    try {
+      const result = run(INSTALLER, args, h);
+      assert.equal(result.status, 78);
+      assert.match(result.stderr, expected);
+      assert.equal(existsSync(h.log), false);
+    } finally {
+      rmSync(h.root, { recursive: true, force: true });
+    }
+  }
+});
+
+test('preflight-only control has distinct approval and performs zero systemctl actions', () => {
+  const h = harness({ preflightBash: true });
+  try {
+    const output = path.join(h.root, 'preflight.json');
+    const result = run(CONTROL, [
+      'preflight',
+      '--expected-revision', REVISION,
+      '--output-file', output,
+      '--approve-preflight',
+    ], h);
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(existsSync(h.log), false);
+    assert.deepEqual(readFileSync(h.preflightEnvLog, 'utf8').trim().split('\n'), [
+      `expected=${REVISION}`,
+      'preflight_only=1',
+      'preflight_approved=1',
+      'attended=',
+    ]);
+  } finally {
+    rmSync(h.root, { recursive: true, force: true });
+  }
+});
+
+test('park then preflight then attended start preserves and consumes the reviewed exit-78 tuple', () => {
+  const h = harness({ preflightBash: true });
+  try {
+    const park = run(CONTROL, ['park', '--expected-revision', REVISION, '--approve-park'], h);
+    assert.equal(park.status, 0, park.stderr);
+    assert.equal(readFileSync(h.state, 'utf8').trim(), 'failed');
+    assert.equal(readFileSync(h.enabled, 'utf8').trim(), 'disabled');
+    assert.doesNotMatch(readFileSync(h.log, 'utf8'), /stop vh-news-aggregator\.service/);
+
+    const now = new Date();
+    const preflightFile = path.join(h.root, 'sequence-preflight.json');
+    const preflightRun = run(CONTROL, [
+      'preflight', '--expected-revision', REVISION, '--output-file', preflightFile, '--approve-preflight',
+    ], h);
+    assert.equal(preflightRun.status, 0, preflightRun.stderr);
+    assert.equal(readFileSync(h.state, 'utf8').trim(), 'failed');
+    writeFileSync(preflightFile, `${JSON.stringify(recoveryPreflight(now))}\n`, { mode: 0o600 });
+
+    const mailboxFile = path.join(h.root, 'sequence-mailbox.json');
+    const mailboxBytes = `${JSON.stringify(mailbox(now))}\n`;
+    writeFileSync(mailboxFile, mailboxBytes, { mode: 0o600 });
+    const relayEvidence = writeRelayEvidence(h, now);
+    const start = run(CONTROL, [
+      'start', '--expected-revision', REVISION,
+      '--relay-recovery-evidence', relayEvidence.file,
+      '--relay-recovery-expected-sha256', relayEvidence.sha256,
+      '--preflight-artifact', preflightFile,
+      '--mailbox-artifact', mailboxFile,
+      '--mailbox-expected-sha256', createHash('sha256').update(mailboxBytes).digest('hex'),
+      '--mailbox-expected-critical-count', '11',
+      '--start-control-output', path.join(h.root, 'sequence-start-control.json'),
+      '--approve-attended-start',
+    ], h);
+    assert.equal(start.status, 0, start.stderr);
+    assert.equal(readFileSync(h.state, 'utf8').trim(), 'active');
+  } finally {
+    rmSync(h.root, { recursive: true, force: true });
+  }
+});
+
+test('attended start requires exact parked state, fresh guards, and clears transient approval', () => {
+  const h = harness();
+  try {
+    const now = new Date();
+    const preflightFile = path.join(h.root, 'preflight.json');
+    const mailboxFile = path.join(h.root, 'mailbox.json');
+    writeFileSync(preflightFile, `${JSON.stringify(recoveryPreflight(now))}\n`, { mode: 0o600 });
+    const mailboxBytes = `${JSON.stringify(mailbox(now))}\n`;
+    writeFileSync(mailboxFile, mailboxBytes, { mode: 0o600 });
+    const mailboxSha = createHash('sha256').update(mailboxBytes).digest('hex');
+    const startControlOutput = path.join(h.root, 'start-control.json');
+    const relayEvidence = writeRelayEvidence(h, now);
+    const result = run(CONTROL, [
+      'start',
+      '--expected-revision', REVISION,
+      '--preflight-artifact', preflightFile,
+      '--relay-recovery-evidence', relayEvidence.file,
+      '--relay-recovery-expected-sha256', relayEvidence.sha256,
+      '--mailbox-artifact', mailboxFile,
+      '--mailbox-expected-sha256', mailboxSha,
+      '--mailbox-expected-critical-count', '11',
+      '--start-control-output', startControlOutput,
+      '--approve-attended-start',
+    ], h);
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(readFileSync(h.state, 'utf8').trim(), 'active');
+    assert.equal(readFileSync(h.enabled, 'utf8').trim(), 'enabled');
+    assert.equal(existsSync(h.approval), false);
+    const startControl = JSON.parse(readFileSync(startControlOutput, 'utf8'));
+    assert.equal(startControl.revision, REVISION);
+    assert.equal(startControl.preStart.incidentNRestarts, 4);
+    assert.equal(startControl.activationBaseline.nRestarts, 0);
+    assert.equal(startControl.postActivation.nRestarts, 0);
+    assert.equal(startControl.evidenceBindings.preflight.runId, 'preflight-test');
+    assert.equal(startControl.evidenceBindings.relayRecovery.sha256, relayEvidence.sha256);
+    assert.deepEqual(startControl.evidenceBindings.relayRecovery.relayOrigins, RELAY_ORIGINS);
+    assert.equal(startControl.evidenceBindings.mailbox.sha256, mailboxSha);
+    assert.equal(startControl.evidenceBindings.mailbox.newCriticalCount, 11);
+    assert.equal(statSync(startControlOutput).mode & 0o777, 0o600);
+    const log = readFileSync(h.log, 'utf8');
+    assert.match(log, /set-environment VH_NEWS_DAEMON_ATTENDED_START_APPROVED=1/);
+    assert.match(log, /enable vh-news-aggregator\.service/);
+    assert.match(log, /reset-failed vh-news-aggregator\.service/);
+    assert.match(log, /start vh-news-aggregator\.service/);
+    assert.match(log, /unset-environment VH_NEWS_DAEMON_ATTENDED_START_APPROVED VH_NEWS_DAEMON_START_APPROVED/);
+  } finally {
+    rmSync(h.root, { recursive: true, force: true });
+  }
+});
+
+test('failed attended start parks while preserving an exact exit-78 incident tuple', () => {
+  const h = harness({ failStart: true });
+  try {
+    const now = new Date();
+    const preflightFile = path.join(h.root, 'preflight.json');
+    const mailboxFile = path.join(h.root, 'mailbox.json');
+    writeFileSync(preflightFile, `${JSON.stringify(recoveryPreflight(now))}\n`, { mode: 0o600 });
+    const mailboxBytes = `${JSON.stringify(mailbox(now))}\n`;
+    writeFileSync(mailboxFile, mailboxBytes, { mode: 0o600 });
+    const mailboxSha = createHash('sha256').update(mailboxBytes).digest('hex');
+    const relayEvidence = writeRelayEvidence(h, now);
+    const result = run(CONTROL, [
+      'start', '--expected-revision', REVISION,
+      '--relay-recovery-evidence', relayEvidence.file,
+      '--relay-recovery-expected-sha256', relayEvidence.sha256,
+      '--preflight-artifact', preflightFile,
+      '--mailbox-artifact', mailboxFile,
+      '--mailbox-expected-sha256', mailboxSha,
+      '--mailbox-expected-critical-count', '11',
+      '--start-control-output', path.join(h.root, 'start-control.json'),
+      '--approve-attended-start',
+    ], h);
+    assert.equal(result.status, 78);
+    assert.equal(readFileSync(h.state, 'utf8').trim(), 'failed');
+    assert.equal(readFileSync(h.enabled, 'utf8').trim(), 'disabled');
+    assert.equal(existsSync(h.approval), false);
+    const log = readFileSync(h.log, 'utf8');
+    assert.match(log, /disable vh-news-aggregator\.service/);
+  } finally {
+    rmSync(h.root, { recursive: true, force: true });
+  }
+});
+
+test('attended start parks if publisher state drifts while start-control evidence is committed', () => {
+  const h = harness({ nodeMode: 'activation-race' });
+  try {
+    const now = new Date();
+    const preflightFile = path.join(h.root, 'preflight.json');
+    const mailboxFile = path.join(h.root, 'mailbox.json');
+    writeFileSync(preflightFile, `${JSON.stringify(recoveryPreflight(now))}\n`, { mode: 0o600 });
+    const mailboxBytes = `${JSON.stringify(mailbox(now))}\n`;
+    writeFileSync(mailboxFile, mailboxBytes, { mode: 0o600 });
+    const relayEvidence = writeRelayEvidence(h, now);
+    const result = run(CONTROL, [
+      'start', '--expected-revision', REVISION,
+      '--relay-recovery-evidence', relayEvidence.file,
+      '--relay-recovery-expected-sha256', relayEvidence.sha256,
+      '--preflight-artifact', preflightFile,
+      '--mailbox-artifact', mailboxFile,
+      '--mailbox-expected-sha256', createHash('sha256').update(mailboxBytes).digest('hex'),
+      '--mailbox-expected-critical-count', '11',
+      '--start-control-output', path.join(h.root, 'start-control-raced.json'),
+      '--approve-attended-start',
+    ], h);
+    assert.equal(result.status, 78);
+    assert.equal(readFileSync(h.state, 'utf8').trim(), 'inactive');
+    assert.equal(readFileSync(h.enabled, 'utf8').trim(), 'disabled');
+  } finally {
+    rmSync(h.root, { recursive: true, force: true });
+  }
+});
+
+test('attended start refuses to clobber existing start-control evidence before mutation', () => {
+  const h = harness();
+  try {
+    const now = new Date();
+    const preflightFile = path.join(h.root, 'preflight.json');
+    const mailboxFile = path.join(h.root, 'mailbox.json');
+    writeFileSync(preflightFile, `${JSON.stringify(recoveryPreflight(now))}\n`, { mode: 0o600 });
+    const mailboxBytes = `${JSON.stringify(mailbox(now))}\n`;
+    writeFileSync(mailboxFile, mailboxBytes, { mode: 0o600 });
+    const relayEvidence = writeRelayEvidence(h, now);
+    const output = path.join(h.root, 'existing-start-control.json');
+    writeFileSync(output, 'preserve-prior-evidence\n', { mode: 0o600 });
+    const result = run(CONTROL, [
+      'start', '--expected-revision', REVISION,
+      '--relay-recovery-evidence', relayEvidence.file,
+      '--relay-recovery-expected-sha256', relayEvidence.sha256,
+      '--preflight-artifact', preflightFile,
+      '--mailbox-artifact', mailboxFile,
+      '--mailbox-expected-sha256', createHash('sha256').update(mailboxBytes).digest('hex'),
+      '--mailbox-expected-critical-count', '11',
+      '--start-control-output', output,
+      '--approve-attended-start',
+    ], h);
+    assert.equal(result.status, 78);
+    assert.equal(readFileSync(output, 'utf8'), 'preserve-prior-evidence\n');
+    assert.equal(readFileSync(h.state, 'utf8').trim(), 'failed');
+    assert.doesNotMatch(existsSync(h.log) ? readFileSync(h.log, 'utf8') : '', / enable | start /);
+  } finally {
+    rmSync(h.root, { recursive: true, force: true });
+  }
+});
+
+test('attended start rejects a non-exact inactive pre-start state', () => {
+  const h = harness();
+  try {
+    writeFileSync(h.state, 'inactive\n');
+    const now = new Date();
+    const preflightFile = path.join(h.root, 'inactive-preflight.json');
+    const mailboxFile = path.join(h.root, 'inactive-mailbox.json');
+    writeFileSync(preflightFile, `${JSON.stringify(recoveryPreflight(now))}\n`, { mode: 0o600 });
+    const mailboxBytes = `${JSON.stringify(mailbox(now))}\n`;
+    writeFileSync(mailboxFile, mailboxBytes, { mode: 0o600 });
+    const relayEvidence = writeRelayEvidence(h, now);
+    const result = run(CONTROL, [
+      'start', '--expected-revision', REVISION,
+      '--relay-recovery-evidence', relayEvidence.file,
+      '--relay-recovery-expected-sha256', relayEvidence.sha256,
+      '--preflight-artifact', preflightFile,
+      '--mailbox-artifact', mailboxFile,
+      '--mailbox-expected-sha256', createHash('sha256').update(mailboxBytes).digest('hex'),
+      '--mailbox-expected-critical-count', '11',
+      '--start-control-output', path.join(h.root, 'inactive-start-control.json'),
+      '--approve-attended-start',
+    ], h);
+    assert.equal(result.status, 78);
+    assert.match(result.stderr, /not in the exact reviewed exit-78 parked state/);
+    assert.equal(readFileSync(h.state, 'utf8').trim(), 'inactive');
+    assert.equal(readFileSync(h.enabled, 'utf8').trim(), 'disabled');
+    const log = readFileSync(h.log, 'utf8');
+    assert.doesNotMatch(log, /enable vh-news-aggregator\.service|start vh-news-aggregator\.service/);
+  } finally {
+    rmSync(h.root, { recursive: true, force: true });
+  }
+});
+
+
+test('park is explicit and idempotently stops, disables, and clears old and new approvals', () => {
+  const h = harness();
+  try {
+    writeFileSync(h.state, 'inactive\n');
+    writeFileSync(h.enabled, 'disabled\n');
+    writeFileSync(h.approval, '1\n');
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      const result = run(CONTROL, ['park', '--expected-revision', REVISION, '--approve-park'], h);
+      assert.equal(result.status, 0, result.stderr);
+    }
+    assert.equal(readFileSync(h.state, 'utf8').trim(), 'inactive');
+    assert.equal(readFileSync(h.enabled, 'utf8').trim(), 'disabled');
+    assert.equal(existsSync(h.approval), false);
+  } finally {
+    rmSync(h.root, { recursive: true, force: true });
+  }
+});
+
+test('park accepts only explicit inactive or reviewed failed terminal states', () => {
+  for (const [stopState, expectedStatus] of [
+    ['inactive', 0],
+    ['deactivating', 78],
+    ['maintenance', 78],
+    ['unknown', 78],
+  ]) {
+    const h = harness({ stopState });
+    try {
+      writeFileSync(h.state, 'active\n');
+      writeFileSync(h.enabled, 'enabled\n');
+      const result = run(CONTROL, ['park', '--expected-revision', REVISION, '--approve-park'], h);
+      assert.equal(result.status, expectedStatus, stopState);
+      if (expectedStatus === 78) assert.match(result.stderr, /publisher failed to park/);
+    } finally {
+      rmSync(h.root, { recursive: true, force: true });
+    }
+  }
+});
+
+function isoBefore(now, minutes) {
+  return new Date(now.getTime() - minutes * 60_000).toISOString();
+}
+
+function writeFinalizationInputs(h) {
+  const now = new Date();
+  const startedAt = isoBefore(now, 40);
+  const readbackAt = isoBefore(now, 25);
+  const fingerprint = '1234567890abcdef12345678';
+  const write = (name, payload) => {
+    const file = path.join(h.root, name);
+    writeFileSync(file, `${JSON.stringify(payload)}\n`, { mode: 0o600 });
+    chmodSync(file, 0o600);
+    return file;
+  };
+  const start = write('final-start.json', {
+    schemaVersion: 'vh-news-publisher-start-control-v1', generatedAt: isoBefore(now, 39),
+    status: 'active_approval_cleared', revision: REVISION, startedAt, activatedAt: isoBefore(now, 39),
+    preStart: { activeState: 'failed', subState: 'failed', result: 'exit-code', execMainStatus: 78, incidentNRestarts: 4, enabledState: 'disabled' },
+    activationBaseline: { nRestarts: 0, capturedAfterResetFailed: true },
+    postActivation: { activeState: 'active', subState: 'running', nRestarts: 0, managerApprovalCleared: true },
+    evidenceBindings: {
+      preflight: {
+        schemaVersion: 'vh-news-daemon-recovery-preflight-v1', sha256: '1'.repeat(64), revision: REVISION,
+        runId: 'preflight-final', generatedAt: isoBefore(now, 50),
+      },
+      relayRecovery: {
+        schemaVersion: 'vh-a6-s1b-relay-recovery-evidence-v1', sha256: '2'.repeat(64), revision: REVISION,
+        generatedAt: isoBefore(now, 55), immutableImageId: `sha256:${'3'.repeat(64)}`,
+        imageTag: 'vhc-public-beta-relay:20260710-main-v18838415-amd64', packetSha256: '4'.repeat(64),
+        captureSha256: '5'.repeat(64), reviewerIdentity: 'reviewer-1', reviewedAt: isoBefore(now, 45),
+        relayOrder: ['vhc-relay-a', 'vhc-relay-b', 'vhc-relay-c'], relayOrigins: RELAY_ORIGINS,
+      },
+      mailbox: {
+        schemaVersion: 'vhc-failure-mailbox-monitor-v1', sha256: '6'.repeat(64),
+        newCriticalCount: 11, generatedAt: isoBefore(now, 44),
+      },
+    },
+  });
+  const startSha256 = createHash('sha256').update(readFileSync(start)).digest('hex');
+  const readback = write('final-readback.json', {
+    schemaVersion: 'vh-news-publisher-recovery-readback-v1', generatedAt: readbackAt,
+    status: 'pass', revision: REVISION, startedAt, runId: 'run-final', tickSequence: 2,
+    tickCompletedAt: isoBefore(now, 26), storyId: 'story-final', sourceSetRevision: 'source-final', relayCount: 3,
+    positiveRoutes: ['story', 'latest-index', 'hot-index', 'synthesis-lifecycle'],
+    missingKeyRoutes: ['story', 'latest-index', 'hot-index', 'synthesis-lifecycle'],
+    lifecycleModes: ['preserved_current', 'preserved_current', 'preserved_current'],
+    inputBindings: {
+      startControlSha256: startSha256, preflightSha256: '1'.repeat(64), relayEvidenceSha256: '2'.repeat(64),
+      relayPacketSha256: '4'.repeat(64), relayCaptureSha256: '5'.repeat(64), mailboxSha256: '6'.repeat(64),
+    },
+  });
+  const watchEnv = path.join(h.root, 'watch.env');
+  writeFileSync(watchEnv, `VH_PHASE5_SCOPE_A_WATCH_START_AT=${readbackAt}\nVH_PHASE5_SCOPE_A_WATCH_CLEAN_START_AT=${readbackAt}\n`, { mode: 0o600 });
+  chmodSync(watchEnv, 0o600);
+  const sourceStatuses = { publisher: 'pass', freshness: 'pass', relayLiveness: 'pass', relaySnapshot: 'pass', watchClosure: 'pass' };
+  const alert = (generatedAt, delivery) => ({
+    schemaVersion: 'vh-public-feed-alert-watch-v2', generatedAt, status: 'pass', observedStatus: 'pass',
+    severity: 'none', blockers: [], fingerprint,
+    publisher: { status: 'pass', activeState: 'active', subState: 'running', nRestarts: 0, failureClass: 'none', severity: 'none' },
+    delivery, state: { schemaVersion: 'vh-public-feed-alert-state-v3', sourceStatuses },
+  });
+  const first = write('alert-first.json', alert(isoBefore(now, 15), { status: 'sent', reason: 'state_changed' }));
+  const second = write('alert-second.json', alert(isoBefore(now, 10), { status: 'suppressed', reason: 'unchanged_suppressed' }));
+  const mailboxFile = write('mailbox-final.json', {
+    schemaVersion: 'vhc-failure-mailbox-monitor-v1', generatedAt: isoBefore(now, 5), status: 'pass', newCriticalCount: 0,
+  });
+  return { start, readback, watchEnv, first, second, mailboxFile };
+}
+
+function finalizationArgs(files, output) {
+  return [
+    'finalize', '--expected-revision', REVISION,
+    '--start-control-artifact', files.start,
+    '--readback-artifact', files.readback,
+    '--watch-env-file', files.watchEnv,
+    '--first-alert-file', files.first,
+    '--second-alert-file', files.second,
+    '--mailbox-artifact', files.mailboxFile,
+    '--finalization-output', output,
+    '--finalize-wait-seconds', '1',
+    '--approve-finalization-and-abort',
+  ];
+}
+
+function verificationArgs(files, output, origins = RELAY_ORIGINS) {
+  return [
+    'verify', '--expected-revision', REVISION,
+    '--start-control-artifact', files.start,
+    '--current-run-file', path.join(files.start, '..', 'current-run.json'),
+    '--runtime-diagnostics-file', path.join(files.start, '..', 'diagnostics.json'),
+    '--output-file', output,
+    ...origins.flatMap((origin) => ['--relay-origin', origin]),
+    '--approve-verification-and-abort',
+  ];
+}
+
+test('verification succeeds only across stable pre/post state and parks every approved failure class', () => {
+  for (const row of [
+    { name: 'success', nodeMode: 'verify-success', expectedStatus: 0, expectedState: 'active' },
+    { name: 'pre-state drift', nodeMode: 'verify-success', initialState: 'inactive', expectedStatus: 78, expectedState: 'inactive' },
+    { name: 'verifier failure', nodeMode: 'verify-fail', expectedStatus: 78, expectedState: 'inactive' },
+    { name: 'post-state drift', nodeMode: 'verify-post-drift', expectedStatus: 78, expectedState: 'inactive' },
+    { name: 'termination signal', nodeMode: 'verify-signal', expectedStatus: 78, expectedState: 'inactive' },
+    { name: 'wrong relay count', nodeMode: 'verify-success', wrongRelayCount: true, expectedStatus: 78, expectedState: 'inactive' },
+  ]) {
+    const h = harness({ nodeMode: row.nodeMode });
+    try {
+      writeFileSync(h.state, `${row.initialState ?? 'active'}\n`);
+      writeFileSync(h.enabled, 'enabled\n');
+      writeFileSync(h.nrestarts, '0\n');
+      const files = writeFinalizationInputs(h);
+      const output = path.join(h.root, `verify-${row.name.replaceAll(' ', '-')}.json`);
+      const origins = row.wrongRelayCount ? RELAY_ORIGINS.slice(0, 2) : RELAY_ORIGINS;
+      const result = run(CONTROL, verificationArgs(files, output, origins), h);
+      assert.equal(result.status, row.expectedStatus, `${row.name}: ${result.stderr}`);
+      assert.equal(readFileSync(h.state, 'utf8').trim(), row.expectedState, row.name);
+      assert.equal(readFileSync(h.enabled, 'utf8').trim(), row.expectedStatus === 0 ? 'enabled' : 'disabled', row.name);
+      if (row.expectedStatus === 0) assert.equal(statSync(output).mode & 0o777, 0o600);
+    } finally {
+      rmSync(h.root, { recursive: true, force: true });
+    }
+  }
+});
+
+test('finalization refuses existing evidence and parks on any output-write failure', () => {
+  for (const failureMode of ['existing', 'parent-is-file']) {
+    const h = harness();
+    try {
+      writeFileSync(h.state, 'active\n');
+      writeFileSync(h.enabled, 'enabled\n');
+      writeFileSync(h.nrestarts, '0\n');
+      const files = writeFinalizationInputs(h);
+      let output;
+      if (failureMode === 'existing') {
+        output = path.join(h.root, 'existing-finalization.json');
+        writeFileSync(output, 'preserve-me\n', { mode: 0o600 });
+      } else {
+        const parent = path.join(h.root, 'not-a-directory');
+        writeFileSync(parent, 'file\n');
+        output = path.join(parent, 'finalization.json');
+      }
+      const result = run(CONTROL, finalizationArgs(files, output), h);
+      assert.equal(result.status, 78, failureMode);
+      assert.equal(readFileSync(h.state, 'utf8').trim(), 'inactive');
+      assert.equal(readFileSync(h.enabled, 'utf8').trim(), 'disabled');
+      if (failureMode === 'existing') assert.equal(readFileSync(output, 'utf8'), 'preserve-me\n');
+    } finally {
+      rmSync(h.root, { recursive: true, force: true });
+    }
+  }
+});
+
+test('finalization commits new mode-0600 evidence only after the full readback/T0/alert/mailbox chain', () => {
+  const h = harness();
+  try {
+    writeFileSync(h.state, 'active\n');
+    writeFileSync(h.enabled, 'enabled\n');
+    writeFileSync(h.nrestarts, '0\n');
+    const files = writeFinalizationInputs(h);
+    const output = path.join(h.root, 'finalization.json');
+    const result = run(CONTROL, finalizationArgs(files, output), h);
+    assert.equal(result.status, 0, result.stderr);
+    const evidence = JSON.parse(readFileSync(output, 'utf8'));
+    assert.equal(evidence.status, 'pass');
+    assert.equal(evidence.revision, REVISION);
+    assert.equal(evidence.inputBindings.relayEvidenceSha256, '2'.repeat(64));
+    assert.equal(evidence.inputBindings.relayCaptureSha256, '5'.repeat(64));
+    assert.match(evidence.finalEvidenceHashes.readbackSha256, /^[0-9a-f]{64}$/);
+    assert.match(evidence.finalEvidenceHashes.postSuppressionMailboxSha256, /^[0-9a-f]{64}$/);
+    assert.equal(statSync(output).mode & 0o777, 0o600);
+    assert.equal(readFileSync(h.state, 'utf8').trim(), 'active');
+    assert.equal(readFileSync(h.enabled, 'utf8').trim(), 'enabled');
+  } finally {
+    rmSync(h.root, { recursive: true, force: true });
+  }
+});
+
+test('post-link temp cleanup failure cannot turn committed finalization evidence into failure', () => {
+  const h = harness({ failTempCleanup: true });
+  try {
+    writeFileSync(h.state, 'active\n');
+    writeFileSync(h.enabled, 'enabled\n');
+    writeFileSync(h.nrestarts, '0\n');
+    const files = writeFinalizationInputs(h);
+    const output = path.join(h.root, 'finalization-cleanup-failure.json');
+    const result = run(CONTROL, finalizationArgs(files, output), h);
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(JSON.parse(readFileSync(output, 'utf8')).status, 'pass');
+    assert.equal(statSync(output).mode & 0o777, 0o600);
+    assert.equal(readFileSync(h.state, 'utf8').trim(), 'active');
+  } finally {
+    rmSync(h.root, { recursive: true, force: true });
+  }
+});
+
+test('finalization termination signal parks and leaves no committed evidence', () => {
+  const h = harness({ nodeMode: 'finalize-signal' });
+  try {
+    writeFileSync(h.state, 'active\n');
+    writeFileSync(h.enabled, 'enabled\n');
+    writeFileSync(h.nrestarts, '0\n');
+    const files = writeFinalizationInputs(h);
+    const output = path.join(h.root, 'signal-finalization.json');
+    const result = run(CONTROL, finalizationArgs(files, output), h);
+    assert.equal(result.status, 78);
+    assert.equal(readFileSync(h.state, 'utf8').trim(), 'inactive');
+    assert.equal(readFileSync(h.enabled, 'utf8').trim(), 'disabled');
+    assert.equal(existsSync(output), false);
+  } finally {
+    rmSync(h.root, { recursive: true, force: true });
+  }
+});

--- a/tools/scripts/news-aggregator-publisher-recovery-guard.mjs
+++ b/tools/scripts/news-aggregator-publisher-recovery-guard.mjs
@@ -243,6 +243,7 @@ export async function verifyStartControlArtifact(options) {
   const preflight = bindings?.preflight;
   const relay = bindings?.relayRecovery;
   const mailbox = bindings?.mailbox;
+  const systemWriterPin = bindings?.systemWriterPin;
   const relayOrigins = normalizeReviewedRelayOrigins(
     relay?.relayOrigins,
     'start_control_relay_origins_invalid',
@@ -261,10 +262,12 @@ export async function verifyStartControlArtifact(options) {
     || artifact.postActivation?.activeState !== 'active'
     || artifact.postActivation?.subState !== 'running'
     || artifact.postActivation?.attendedPermitConsumed !== true
+    || artifact.postActivation?.attendedReceiptConsumed !== true
     || artifact.postActivation?.legacyManagerApprovalCleared !== true
     || !sha256(artifact.postActivation?.attendedPermitBindingSha256)
+    || !sha256(artifact.postActivation?.attendedReceiptSha256)
     || artifact.postActivation?.nRestarts !== artifact.activationBaseline.nRestarts
-    || !exactKeys(bindings, ['preflight', 'relayRecovery', 'mailbox'])
+    || !exactKeys(bindings, ['preflight', 'relayRecovery', 'mailbox', 'systemWriterPin'])
     || !exactKeys(preflight, ['schemaVersion', 'sha256', 'revision', 'runId', 'generatedAt'])
     || preflight.schemaVersion !== 'vh-news-daemon-recovery-preflight-v1'
     || preflight.revision !== artifact.revision || !sha256(preflight.sha256)
@@ -289,6 +292,8 @@ export async function verifyStartControlArtifact(options) {
     || !sha256(mailbox.sha256)
     || !Number.isSafeInteger(mailbox.newCriticalCount) || mailbox.newCriticalCount < 0
     || !Number.isFinite(Date.parse(mailbox.generatedAt ?? ''))
+    || !exactKeys(systemWriterPin, ['sha256'])
+    || !sha256(systemWriterPin.sha256)
     || Date.parse(preflight.generatedAt) > startedAtMs
     || Date.parse(relay.reviewedAt) > startedAtMs
     || Date.parse(mailbox.generatedAt) > startedAtMs) {
@@ -305,6 +310,8 @@ export async function verifyStartControlArtifact(options) {
     sha256: createHash('sha256').update(bytes).digest('hex'),
     evidenceBindings: structuredClone(bindings),
     relayOrigins,
+    attendedReceiptSha256: artifact.postActivation.attendedReceiptSha256,
+    systemWriterPinSha256: systemWriterPin.sha256,
   };
 }
 
@@ -463,14 +470,15 @@ export async function verifyRecoveryFinalization(options) {
     || readback.lifecycleModes.some((mode) => !lifecycleModes.has(mode))
     || !exactKeys(readback.inputBindings, [
       'startControlSha256', 'preflightSha256', 'relayEvidenceSha256',
-      'relayPacketSha256', 'relayCaptureSha256', 'mailboxSha256',
+      'relayPacketSha256', 'relayCaptureSha256', 'mailboxSha256', 'systemWriterPinSha256',
     ])
     || readback.inputBindings.startControlSha256 !== start.sha256
     || readback.inputBindings.preflightSha256 !== start.evidenceBindings.preflight.sha256
     || readback.inputBindings.relayEvidenceSha256 !== start.evidenceBindings.relayRecovery.sha256
     || readback.inputBindings.relayPacketSha256 !== start.evidenceBindings.relayRecovery.packetSha256
     || readback.inputBindings.relayCaptureSha256 !== start.evidenceBindings.relayRecovery.captureSha256
-    || readback.inputBindings.mailboxSha256 !== start.evidenceBindings.mailbox.sha256) {
+    || readback.inputBindings.mailboxSha256 !== start.evidenceBindings.mailbox.sha256
+    || readback.inputBindings.systemWriterPinSha256 !== start.systemWriterPinSha256) {
     fail('readback_artifact_contract_invalid');
   }
   const readbackAtMs = finiteTimestamp(readback.generatedAt, 'readback_generated_at_invalid');

--- a/tools/scripts/news-aggregator-publisher-recovery-guard.mjs
+++ b/tools/scripts/news-aggregator-publisher-recovery-guard.mjs
@@ -1,0 +1,598 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto';
+import { lstat, readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export class RecoveryGuardError extends Error {
+  constructor(code) {
+    super(code);
+    this.name = 'RecoveryGuardError';
+    this.code = code;
+  }
+}
+
+function fail(code) {
+  throw new RecoveryGuardError(code);
+}
+
+function requirePrivateOwnedStat(stat, label) {
+  if (typeof process.getuid === 'function' && stat.uid !== process.getuid()) fail(`${label}_wrong_owner`);
+  if ((stat.mode & 0o777) !== 0o600) fail(`${label}_mode_not_0600`);
+}
+
+function fullRevision(value) {
+  return typeof value === 'string' && /^[0-9a-f]{40}$/.test(value);
+}
+
+function safeRunId(value) {
+  return typeof value === 'string'
+    && /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(value)
+    && value !== '.' && value !== '..';
+}
+
+function sha256(value) {
+  return typeof value === 'string' && /^[0-9a-f]{64}$/.test(value);
+}
+
+function exactKeys(value, keys) {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    && JSON.stringify(Object.keys(value).sort()) === JSON.stringify([...keys].sort());
+}
+
+function normalizeReviewedRelayOrigins(value, code = 'relay_origins_invalid') {
+  if (!Array.isArray(value) || value.length !== 3) fail(code);
+  const origins = value.map((origin) => {
+    if (typeof origin !== 'string') fail(code);
+    let parsed;
+    try {
+      parsed = new URL(origin);
+    } catch {
+      fail(code);
+    }
+    const port = Number(parsed.port);
+    if (parsed.protocol !== 'http:' || parsed.hostname !== '127.0.0.1'
+      || parsed.username || parsed.password || parsed.search || parsed.hash
+      || parsed.pathname !== '/' || !parsed.port
+      || !Number.isSafeInteger(port) || port <= 0 || port > 65_535 || port === 80
+      || origin !== `http://127.0.0.1:${port}`) {
+      fail(code);
+    }
+    return origin;
+  });
+  if (new Set(origins).size !== 3) fail(code);
+  return origins;
+}
+
+function finiteTimestamp(value, code) {
+  const parsed = typeof value === 'string' ? Date.parse(value) : Number.NaN;
+  if (!Number.isFinite(parsed)) fail(code);
+  return parsed;
+}
+
+function positiveInteger(value, fallback, code) {
+  if (value === undefined) return fallback;
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) fail(code);
+  return parsed;
+}
+
+async function readRegularJson(filePath, label) {
+  if (!path.isAbsolute(filePath)) fail(`${label}_path_not_absolute`);
+  let stat;
+  try {
+    stat = await lstat(filePath);
+  } catch {
+    fail(`${label}_missing`);
+  }
+  if (stat.isSymbolicLink() || !stat.isFile()) fail(`${label}_not_regular_file`);
+  if (typeof process.getuid === 'function' && stat.uid !== process.getuid()) fail(`${label}_wrong_owner`);
+  if (stat.size <= 0 || stat.size > 1_048_576) fail(`${label}_size_invalid`);
+  try {
+    const bytes = await readFile(filePath);
+    const parsed = JSON.parse(bytes.toString('utf8'));
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) fail(`${label}_shape_invalid`);
+    return { parsed, bytes, stat };
+  } catch (error) {
+    if (error instanceof RecoveryGuardError) throw error;
+    fail(`${label}_json_invalid`);
+  }
+}
+
+async function readPrivateRegularText(filePath, label) {
+  if (!path.isAbsolute(filePath)) fail(`${label}_path_not_absolute`);
+  let stat;
+  try {
+    stat = await lstat(filePath);
+  } catch {
+    fail(`${label}_missing`);
+  }
+  if (stat.isSymbolicLink() || !stat.isFile()) fail(`${label}_not_regular_file`);
+  requirePrivateOwnedStat(stat, label);
+  if (stat.size <= 0 || stat.size > 1_048_576) fail(`${label}_size_invalid`);
+  return readFile(filePath, 'utf8');
+}
+
+function assertFresh(generatedAt, options, label) {
+  const nowMs = options.nowMs ?? Date.now();
+  const maxAgeMs = positiveInteger(options.maxAgeMs, 30 * 60 * 1000, `${label}_max_age_invalid`);
+  const generatedAtMs = finiteTimestamp(generatedAt, `${label}_generated_at_invalid`);
+  if (generatedAtMs > nowMs + 60_000) fail(`${label}_generated_in_future`);
+  if (nowMs - generatedAtMs > maxAgeMs) fail(`${label}_stale`);
+  if (options.notBefore) {
+    const notBeforeMs = finiteTimestamp(options.notBefore, `${label}_not_before_invalid`);
+    if (generatedAtMs < notBeforeMs) fail(`${label}_predates_required_boundary`);
+  }
+  return generatedAtMs;
+}
+
+export async function verifyPreflightArtifact(options) {
+  if (!fullRevision(options.expectedRevision)) fail('expected_revision_invalid');
+  const { parsed: artifact, bytes, stat } = await readRegularJson(options.filePath, 'preflight_artifact');
+  requirePrivateOwnedStat(stat, 'preflight_artifact');
+  if (artifact.schemaVersion !== 'vh-news-daemon-recovery-preflight-v1') fail('preflight_schema_invalid');
+  if (artifact.status !== 'preflight_passed' || artifact.mode !== 'preflight_only') fail('preflight_status_invalid');
+  if (artifact.revision !== options.expectedRevision) fail('preflight_revision_mismatch');
+  if (!safeRunId(artifact.runId)) fail('preflight_run_id_invalid');
+  const expectedGates = [
+    'source_liveness',
+    'storycluster_build',
+    'openai_provider',
+    'storycluster_qdrant_readiness',
+    'raw_publication_readiness',
+  ];
+  if (!Array.isArray(artifact.gates)
+    || artifact.gates.length !== expectedGates.length
+    || expectedGates.some((gate, index) => artifact.gates[index] !== gate)) {
+    fail('preflight_gates_invalid');
+  }
+  const generatedAtMs = assertFresh(artifact.generatedAt, options, 'preflight');
+  return {
+    schemaVersion: artifact.schemaVersion,
+    status: 'pass',
+    revision: artifact.revision,
+    runId: artifact.runId,
+    generatedAt: new Date(generatedAtMs).toISOString(),
+    sha256: createHash('sha256').update(bytes).digest('hex'),
+  };
+}
+
+export async function verifyMailboxArtifact(options) {
+  const { parsed: artifact, bytes } = await readRegularJson(options.filePath, 'mailbox_artifact');
+  if (artifact.schemaVersion !== 'vhc-failure-mailbox-monitor-v1') fail('mailbox_schema_invalid');
+  if (artifact.status !== 'pass') fail('mailbox_monitor_not_pass');
+  if (!Number.isSafeInteger(artifact.newCriticalCount) || artifact.newCriticalCount < 0) {
+    fail('mailbox_critical_count_invalid');
+  }
+  if (artifact.newCriticalCount !== 0) fail('mailbox_new_critical_present');
+  const generatedAtMs = assertFresh(artifact.generatedAt, options, 'mailbox');
+  return {
+    schemaVersion: artifact.schemaVersion,
+    status: 'pass',
+    newCriticalCount: 0,
+    generatedAt: new Date(generatedAtMs).toISOString(),
+    sha256: createHash('sha256').update(bytes).digest('hex'),
+  };
+}
+
+export async function verifyMailboxCurrentArtifact(options) {
+  const { parsed: artifact, bytes } = await readRegularJson(options.filePath, 'mailbox_artifact');
+  if (artifact.schemaVersion !== 'vhc-failure-mailbox-monitor-v1') fail('mailbox_schema_invalid');
+  if (artifact.status !== 'pass') fail('mailbox_monitor_not_pass');
+  if (!Number.isSafeInteger(artifact.newCriticalCount) || artifact.newCriticalCount < 0) {
+    fail('mailbox_critical_count_invalid');
+  }
+  if (options.expectedCriticalCount !== undefined
+    && Number(options.expectedCriticalCount) !== artifact.newCriticalCount) {
+    fail('mailbox_expected_critical_count_mismatch');
+  }
+  const sha256 = createHash('sha256').update(bytes).digest('hex');
+  if (options.expectedSha256 !== undefined
+    && (!/^[0-9a-f]{64}$/.test(options.expectedSha256) || options.expectedSha256 !== sha256)) {
+    fail('mailbox_expected_sha256_mismatch');
+  }
+  const generatedAtMs = assertFresh(artifact.generatedAt, options, 'mailbox');
+  return {
+    schemaVersion: artifact.schemaVersion,
+    status: 'pass',
+    newCriticalCount: artifact.newCriticalCount,
+    generatedAt: new Date(generatedAtMs).toISOString(),
+    sha256,
+  };
+}
+
+export async function verifyStartControlArtifact(options) {
+  if (!fullRevision(options.expectedRevision)) fail('expected_revision_invalid');
+  const { parsed: artifact, bytes, stat } = await readRegularJson(options.filePath, 'start_control_artifact');
+  requirePrivateOwnedStat(stat, 'start_control_artifact');
+  if (artifact.schemaVersion !== 'vh-news-publisher-start-control-v1'
+    || artifact.status !== 'active_approval_cleared'
+    || artifact.revision !== options.expectedRevision) {
+    fail('start_control_contract_invalid');
+  }
+  const startedAtMs = finiteTimestamp(artifact.startedAt, 'start_control_started_at_invalid');
+  const activatedAtMs = finiteTimestamp(artifact.activatedAt, 'start_control_activated_at_invalid');
+  const generatedAtMs = finiteTimestamp(artifact.generatedAt, 'start_control_generated_at_invalid');
+  const bindings = artifact.evidenceBindings;
+  const preflight = bindings?.preflight;
+  const relay = bindings?.relayRecovery;
+  const mailbox = bindings?.mailbox;
+  const relayOrigins = normalizeReviewedRelayOrigins(
+    relay?.relayOrigins,
+    'start_control_relay_origins_invalid',
+  );
+  if (activatedAtMs < startedAtMs || generatedAtMs < activatedAtMs
+    || artifact.preStart?.activeState !== 'failed'
+    || artifact.preStart?.subState !== 'failed'
+    || artifact.preStart?.result !== 'exit-code'
+    || artifact.preStart?.execMainStatus !== 78
+    || artifact.preStart?.enabledState !== 'disabled'
+    || !Number.isSafeInteger(artifact.preStart?.incidentNRestarts)
+    || artifact.preStart.incidentNRestarts < 0
+    || !Number.isSafeInteger(artifact.activationBaseline?.nRestarts)
+    || artifact.activationBaseline.nRestarts < 0
+    || artifact.activationBaseline.capturedAfterResetFailed !== true
+    || artifact.postActivation?.activeState !== 'active'
+    || artifact.postActivation?.subState !== 'running'
+    || artifact.postActivation?.managerApprovalCleared !== true
+    || artifact.postActivation?.nRestarts !== artifact.activationBaseline.nRestarts
+    || !exactKeys(bindings, ['preflight', 'relayRecovery', 'mailbox'])
+    || !exactKeys(preflight, ['schemaVersion', 'sha256', 'revision', 'runId', 'generatedAt'])
+    || preflight.schemaVersion !== 'vh-news-daemon-recovery-preflight-v1'
+    || preflight.revision !== artifact.revision || !sha256(preflight.sha256)
+    || !safeRunId(preflight.runId)
+    || !Number.isFinite(Date.parse(preflight.generatedAt ?? ''))
+    || !exactKeys(relay, [
+      'schemaVersion', 'sha256', 'revision', 'generatedAt', 'immutableImageId', 'imageTag',
+      'packetSha256', 'captureSha256', 'reviewerIdentity', 'reviewedAt', 'relayOrder', 'relayOrigins',
+    ])
+    || relay.schemaVersion !== 'vh-a6-s1b-relay-recovery-evidence-v1'
+    || relay.revision !== artifact.revision || !sha256(relay.sha256)
+    || !/^sha256:[0-9a-f]{64}$/.test(relay.immutableImageId ?? '')
+    || !/^vhc-public-beta-relay:[a-z0-9][a-z0-9._-]{1,127}$/.test(relay.imageTag ?? '')
+    || relay.imageTag.endsWith(':latest')
+    || !sha256(relay.packetSha256) || !sha256(relay.captureSha256)
+    || !/^[A-Za-z0-9_.@-]{2,128}$/.test(relay.reviewerIdentity ?? '')
+    || !Number.isFinite(Date.parse(relay.generatedAt ?? ''))
+    || !Number.isFinite(Date.parse(relay.reviewedAt ?? ''))
+    || JSON.stringify(relay.relayOrder) !== JSON.stringify(['vhc-relay-a', 'vhc-relay-b', 'vhc-relay-c'])
+    || !exactKeys(mailbox, ['schemaVersion', 'sha256', 'newCriticalCount', 'generatedAt'])
+    || mailbox.schemaVersion !== 'vhc-failure-mailbox-monitor-v1'
+    || !sha256(mailbox.sha256)
+    || !Number.isSafeInteger(mailbox.newCriticalCount) || mailbox.newCriticalCount < 0
+    || !Number.isFinite(Date.parse(mailbox.generatedAt ?? ''))
+    || Date.parse(preflight.generatedAt) > startedAtMs
+    || Date.parse(relay.reviewedAt) > startedAtMs
+    || Date.parse(mailbox.generatedAt) > startedAtMs) {
+    fail('start_control_tuple_invalid');
+  }
+  assertFresh(artifact.generatedAt, options, 'start_control');
+  return {
+    status: 'pass',
+    revision: artifact.revision,
+    startedAt: new Date(startedAtMs).toISOString(),
+    activatedAt: new Date(activatedAtMs).toISOString(),
+    incidentNRestarts: artifact.preStart.incidentNRestarts,
+    nRestarts: artifact.postActivation.nRestarts,
+    sha256: createHash('sha256').update(bytes).digest('hex'),
+    evidenceBindings: structuredClone(bindings),
+    relayOrigins,
+  };
+}
+
+function exactPublisherExit78(value) {
+  return value?.activeState === 'failed'
+    && value?.subState === 'failed'
+    && value?.result === 'exit-code'
+    && value?.execMainStatus === 78;
+}
+
+export async function verifyRelayRecoveryEvidence(options) {
+  if (!fullRevision(options.expectedRevision)) fail('expected_revision_invalid');
+  const { parsed: evidence, bytes, stat } = await readRegularJson(options.filePath, 'relay_recovery_evidence');
+  requirePrivateOwnedStat(stat, 'relay_recovery_evidence');
+  const sha256 = createHash('sha256').update(bytes).digest('hex');
+  if (!/^[0-9a-f]{64}$/.test(options.expectedSha256 ?? '') || sha256 !== options.expectedSha256) {
+    fail('relay_recovery_evidence_sha256_mismatch');
+  }
+  const relayOrder = ['vhc-relay-a', 'vhc-relay-b', 'vhc-relay-c'];
+  const routeOrder = ['story', 'latest-index', 'hot-index', 'synthesis-lifecycle'];
+  const relayOrigins = normalizeReviewedRelayOrigins(evidence.relayOrigins);
+  if (!exactKeys(evidence, [
+    'schemaVersion', 'generatedAt', 'status', 'revision', 'immutableImageId', 'imageTag',
+    'packetSha256', 'captureSha256', 'relayOrigins', 'publisherBefore', 'publisherAfter',
+    'stages', 'finalFleet', 'reviewerDecision', 'reviewerIdentity', 'reviewedAt',
+    'reviewedPacketSha256', 'reviewedCaptureSha256',
+  ])
+    || !exactKeys(evidence.publisherBefore, ['activeState', 'subState', 'result', 'execMainStatus'])
+    || !exactKeys(evidence.publisherAfter, ['activeState', 'subState', 'result', 'execMainStatus'])
+    || evidence.schemaVersion !== 'vh-a6-s1b-relay-recovery-evidence-v1'
+    || evidence.status !== 'pass'
+    || evidence.revision !== options.expectedRevision
+    || !/^sha256:[0-9a-f]{64}$/.test(evidence.immutableImageId ?? '')
+    || !/^vhc-public-beta-relay:[a-z0-9][a-z0-9._-]{1,127}$/.test(evidence.imageTag ?? '')
+    || evidence.imageTag.endsWith(':latest')
+    || !/^[0-9a-f]{64}$/.test(evidence.packetSha256 ?? '')
+    || !/^[0-9a-f]{64}$/.test(evidence.captureSha256 ?? '')
+    || evidence.reviewerDecision !== 'GO'
+    || !/^[A-Za-z0-9_.@-]{2,128}$/.test(evidence.reviewerIdentity ?? '')
+    || !Number.isFinite(Date.parse(evidence.reviewedAt ?? ''))
+    || evidence.reviewedPacketSha256 !== evidence.packetSha256
+    || evidence.reviewedCaptureSha256 !== evidence.captureSha256
+    || !exactPublisherExit78(evidence.publisherBefore)
+    || !exactPublisherExit78(evidence.publisherAfter)
+    || !Array.isArray(evidence.stages) || evidence.stages.length !== 3) {
+    fail('relay_recovery_evidence_contract_invalid');
+  }
+  for (let index = 0; index < relayOrder.length; index += 1) {
+    const stage = evidence.stages[index];
+    if (!exactKeys(stage, [
+      'relay', 'order', 'origin', 'status', 'revision', 'imageId', 'imageTag', 'packetSha256',
+      'ready', 'running', 'oomKilled', 'restartCountStable', 'watchdogTripsStable',
+      'topologyParity', 'environmentParity', 'snapshotParity', 'missingRouteContracts',
+      'publisherBefore', 'publisherAfter',
+    ])
+      || !exactKeys(stage?.publisherBefore, ['activeState', 'subState', 'result', 'execMainStatus'])
+      || !exactKeys(stage?.publisherAfter, ['activeState', 'subState', 'result', 'execMainStatus'])
+      || stage?.relay !== relayOrder[index]
+      || stage?.order !== index + 1
+      || stage?.status !== 'pass'
+      || stage?.revision !== evidence.revision
+      || stage?.imageId !== evidence.immutableImageId
+      || stage?.imageTag !== evidence.imageTag
+      || stage?.origin !== relayOrigins[index]
+      || stage?.packetSha256 !== evidence.packetSha256
+      || stage?.ready !== true || stage?.running !== true || stage?.oomKilled !== false
+      || stage?.restartCountStable !== true || stage?.watchdogTripsStable !== true
+      || stage?.topologyParity !== true || stage?.environmentParity !== true || stage?.snapshotParity !== true
+      || JSON.stringify(stage?.missingRouteContracts) !== JSON.stringify(routeOrder)
+      || !exactPublisherExit78(stage?.publisherBefore)
+      || !exactPublisherExit78(stage?.publisherAfter)) {
+      fail('relay_recovery_stage_invalid');
+    }
+  }
+  const fleet = evidence.finalFleet;
+  if (!exactKeys(fleet, [
+    'status', 'relayOrder', 'runningCount', 'readyCount', 'oomKilledCount',
+    'restartCountsStable', 'watchdogTripsStable', 'topologyParity', 'environmentParity',
+    'snapshotParity', 'missingRouteContractsAll',
+  ])
+    || fleet?.status !== 'pass'
+    || JSON.stringify(fleet?.relayOrder) !== JSON.stringify(relayOrder)
+    || fleet?.runningCount !== 3 || fleet?.readyCount !== 3 || fleet?.oomKilledCount !== 0
+    || fleet?.restartCountsStable !== true || fleet?.watchdogTripsStable !== true
+    || fleet?.topologyParity !== true || fleet?.environmentParity !== true || fleet?.snapshotParity !== true
+    || fleet?.missingRouteContractsAll !== true) {
+    fail('relay_recovery_final_fleet_invalid');
+  }
+  const generatedAtMs = assertFresh(evidence.generatedAt, options, 'relay_recovery');
+  const reviewedAtMs = Date.parse(evidence.reviewedAt);
+  const nowMs = options.nowMs ?? Date.now();
+  const maxAgeMs = positiveInteger(options.maxAgeMs, 2 * 60 * 60 * 1000, 'relay_recovery_max_age_invalid');
+  if (reviewedAtMs < generatedAtMs || reviewedAtMs > nowMs + 60_000 || nowMs - reviewedAtMs > maxAgeMs) {
+    fail('relay_recovery_review_timestamp_invalid');
+  }
+  return {
+    schemaVersion: evidence.schemaVersion,
+    status: 'pass',
+    revision: evidence.revision,
+    generatedAt: new Date(generatedAtMs).toISOString(),
+    sha256,
+    packetSha256: evidence.packetSha256,
+    captureSha256: evidence.captureSha256,
+    immutableImageId: evidence.immutableImageId,
+    imageTag: evidence.imageTag,
+    relayOrder,
+    relayOrigins,
+    reviewerDecision: 'GO',
+    reviewerIdentity: evidence.reviewerIdentity,
+    reviewedAt: new Date(reviewedAtMs).toISOString(),
+  };
+}
+
+function healthyAlertReport(report, label) {
+  const sourceStatusKeys = Object.keys(report.state?.sourceStatuses ?? {}).sort().join(',');
+  if (report.schemaVersion !== 'vh-public-feed-alert-watch-v2'
+    || report.status !== 'pass' || report.observedStatus !== 'pass'
+    || report.severity !== 'none'
+    || !Array.isArray(report.blockers) || report.blockers.length !== 0
+    || report.publisher?.status !== 'pass'
+    || report.publisher?.activeState !== 'active'
+    || report.publisher?.subState !== 'running'
+    || report.publisher?.failureClass !== 'none'
+    || report.publisher?.severity !== 'none'
+    || !Number.isSafeInteger(report.publisher?.nRestarts)
+    || report.state?.schemaVersion !== 'vh-public-feed-alert-state-v3'
+    || sourceStatusKeys !== 'freshness,publisher,relayLiveness,relaySnapshot,watchClosure'
+    || Object.values(report.state.sourceStatuses).some((status) => status !== 'pass')
+    || !/^[0-9a-f]{24}$/.test(report.fingerprint ?? '')) {
+    fail(`${label}_alert_not_healthy`);
+  }
+}
+
+export async function verifyRecoveryFinalization(options) {
+  const start = await verifyStartControlArtifact({
+    filePath: options.startControlFile,
+    expectedRevision: options.expectedRevision,
+    nowMs: options.nowMs,
+    maxAgeMs: options.startControlMaxAgeMs,
+  });
+  const { parsed: readback, bytes: readbackBytes, stat: readbackStat } = await readRegularJson(options.readbackFile, 'readback_artifact');
+  requirePrivateOwnedStat(readbackStat, 'readback_artifact');
+  const exactRoutes = ['story', 'latest-index', 'hot-index', 'synthesis-lifecycle'];
+  const lifecycleModes = new Set(['updated_in_tick', 'preserved_current', 'preserved_terminal']);
+  if (readback.schemaVersion !== 'vh-news-publisher-recovery-readback-v1'
+    || readback.status !== 'pass' || readback.revision !== options.expectedRevision
+    || readback.startedAt !== start.startedAt
+    || typeof readback.runId !== 'string' || !readback.runId.trim()
+    || ![1, 2].includes(readback.tickSequence)
+    || readback.relayCount !== 3
+    || typeof readback.storyId !== 'string' || !readback.storyId.trim()
+    || typeof readback.sourceSetRevision !== 'string' || !readback.sourceSetRevision.trim()
+    || JSON.stringify(readback.positiveRoutes) !== JSON.stringify(exactRoutes)
+    || JSON.stringify(readback.missingKeyRoutes) !== JSON.stringify(exactRoutes)
+    || !Array.isArray(readback.lifecycleModes) || readback.lifecycleModes.length !== 3
+    || readback.lifecycleModes.some((mode) => !lifecycleModes.has(mode))
+    || !exactKeys(readback.inputBindings, [
+      'startControlSha256', 'preflightSha256', 'relayEvidenceSha256',
+      'relayPacketSha256', 'relayCaptureSha256', 'mailboxSha256',
+    ])
+    || readback.inputBindings.startControlSha256 !== start.sha256
+    || readback.inputBindings.preflightSha256 !== start.evidenceBindings.preflight.sha256
+    || readback.inputBindings.relayEvidenceSha256 !== start.evidenceBindings.relayRecovery.sha256
+    || readback.inputBindings.relayPacketSha256 !== start.evidenceBindings.relayRecovery.packetSha256
+    || readback.inputBindings.relayCaptureSha256 !== start.evidenceBindings.relayRecovery.captureSha256
+    || readback.inputBindings.mailboxSha256 !== start.evidenceBindings.mailbox.sha256) {
+    fail('readback_artifact_contract_invalid');
+  }
+  const readbackAtMs = finiteTimestamp(readback.generatedAt, 'readback_generated_at_invalid');
+  const tickCompletedAtMs = finiteTimestamp(readback.tickCompletedAt, 'readback_tick_completed_at_invalid');
+  if (readbackAtMs < Date.parse(start.startedAt)
+    || tickCompletedAtMs < Date.parse(start.startedAt) || tickCompletedAtMs > readbackAtMs) {
+    fail('readback_predates_start');
+  }
+
+  const watchText = await readPrivateRegularText(options.watchEnvFile, 'watch_env');
+  const watchValues = new Map();
+  for (const line of watchText.split(/\r?\n/)) {
+    if (!line.trim() || line.trimStart().startsWith('#')) continue;
+    const match = line.match(/^([A-Z_][A-Z0-9_]*)=(.*)$/);
+    if (!match || watchValues.has(match[1])) fail('watch_env_shape_invalid');
+    watchValues.set(match[1], match[2]);
+  }
+  if (watchValues.get('VH_PHASE5_SCOPE_A_WATCH_START_AT') !== readback.generatedAt
+    || watchValues.get('VH_PHASE5_SCOPE_A_WATCH_CLEAN_START_AT') !== readback.generatedAt) {
+    fail('watch_t0_not_bound_to_readback');
+  }
+  const { parsed: first, bytes: firstBytes, stat: firstStat } = await readRegularJson(options.firstAlertFile, 'first_alert_artifact');
+  const { parsed: second, bytes: secondBytes, stat: secondStat } = await readRegularJson(options.secondAlertFile, 'second_alert_artifact');
+  requirePrivateOwnedStat(firstStat, 'first_alert_artifact');
+  requirePrivateOwnedStat(secondStat, 'second_alert_artifact');
+  healthyAlertReport(first, 'first');
+  healthyAlertReport(second, 'second');
+  const firstAtMs = finiteTimestamp(first.generatedAt, 'first_alert_generated_at_invalid');
+  const secondAtMs = finiteTimestamp(second.generatedAt, 'second_alert_generated_at_invalid');
+  const startAtMs = Date.parse(start.startedAt);
+  const nowMs = options.nowMs ?? Date.now();
+  const alertMaxAgeMs = positiveInteger(options.alertMaxAgeMs, 60 * 60 * 1000, 'alert_max_age_invalid');
+  if (firstAtMs < startAtMs || firstAtMs < readbackAtMs || secondAtMs <= firstAtMs
+    || firstAtMs > nowMs + 60_000 || secondAtMs > nowMs + 60_000
+    || nowMs - firstAtMs > alertMaxAgeMs || nowMs - secondAtMs > alertMaxAgeMs) {
+    fail('alert_recovery_sequence_invalid');
+  }
+  if (first.delivery?.status !== 'sent' || first.delivery?.reason !== 'state_changed') {
+    fail('first_alert_delivery_invalid');
+  }
+  if (second.delivery?.status !== 'suppressed' || second.delivery?.reason !== 'unchanged_suppressed') {
+    fail('second_alert_delivery_invalid');
+  }
+  if (second.fingerprint !== first.fingerprint
+    || second.publisher.nRestarts !== first.publisher.nRestarts
+    || JSON.stringify(second.state.sourceStatuses) !== JSON.stringify(first.state.sourceStatuses)) {
+    fail('alert_healthy_projection_changed');
+  }
+  if (first.publisher.nRestarts !== start.nRestarts) fail('alert_publisher_restart_drift');
+
+  const mailbox = await verifyMailboxArtifact({
+    filePath: options.mailboxFile,
+    nowMs,
+    maxAgeMs: options.mailboxMaxAgeMs,
+    notBefore: new Date(secondAtMs).toISOString(),
+  });
+  return {
+    schemaVersion: 'vh-news-publisher-recovery-finalization-v1',
+    status: 'pass',
+    revision: options.expectedRevision,
+    startedAt: start.startedAt,
+    readbackGeneratedAt: readback.generatedAt,
+    runId: readback.runId,
+    recoveryAlertAt: new Date(firstAtMs).toISOString(),
+    suppressionAlertAt: new Date(secondAtMs).toISOString(),
+    mailboxGeneratedAt: mailbox.generatedAt,
+    fingerprint: first.fingerprint,
+    nRestarts: start.nRestarts,
+    inputBindings: structuredClone(readback.inputBindings),
+    finalEvidenceHashes: {
+      startControlSha256: start.sha256,
+      readbackSha256: createHash('sha256').update(readbackBytes).digest('hex'),
+      firstAlertSha256: createHash('sha256').update(firstBytes).digest('hex'),
+      secondAlertSha256: createHash('sha256').update(secondBytes).digest('hex'),
+      postSuppressionMailboxSha256: mailbox.sha256,
+    },
+  };
+}
+
+function parseCli(argv) {
+  const [command, ...rest] = argv;
+  const values = new Map();
+  for (let index = 0; index < rest.length; index += 2) {
+    const flag = rest[index];
+    const value = rest[index + 1];
+    if (!flag?.startsWith('--') || value === undefined) fail('arguments_invalid');
+    if (values.has(flag)) fail('arguments_duplicate');
+    values.set(flag, value);
+  }
+  return { command, values };
+}
+
+async function main() {
+  const { command, values } = parseCli(process.argv.slice(2));
+  const filePath = values.get('--file');
+  if (!filePath) fail('file_argument_missing');
+  const common = {
+    filePath: path.resolve(filePath),
+    maxAgeMs: values.has('--max-age-ms') ? values.get('--max-age-ms') : undefined,
+    notBefore: values.get('--not-before'),
+  };
+  let result;
+  if (command === 'preflight') {
+    result = await verifyPreflightArtifact({
+      ...common,
+      expectedRevision: values.get('--expected-revision'),
+    });
+  } else if (command === 'mailbox' || command === 'mailbox-clean') {
+    result = await verifyMailboxArtifact(common);
+  } else if (command === 'mailbox-current') {
+    result = await verifyMailboxCurrentArtifact({
+      ...common,
+      expectedSha256: values.get('--expected-sha256'),
+      expectedCriticalCount: values.get('--expected-critical-count'),
+    });
+  } else if (command === 'start-control') {
+    result = await verifyStartControlArtifact({
+      ...common,
+      expectedRevision: values.get('--expected-revision'),
+    });
+  } else if (command === 'relay-recovery') {
+    result = await verifyRelayRecoveryEvidence({
+      ...common,
+      expectedRevision: values.get('--expected-revision'),
+      expectedSha256: values.get('--expected-sha256'),
+    });
+  } else if (command === 'finalize') {
+    result = await verifyRecoveryFinalization({
+      expectedRevision: values.get('--expected-revision'),
+      startControlFile: path.resolve(values.get('--start-control-file') ?? ''),
+      readbackFile: path.resolve(values.get('--readback-file') ?? ''),
+      watchEnvFile: path.resolve(values.get('--watch-env-file') ?? ''),
+      firstAlertFile: path.resolve(values.get('--first-alert-file') ?? ''),
+      secondAlertFile: path.resolve(values.get('--second-alert-file') ?? ''),
+      mailboxFile: common.filePath,
+      startControlMaxAgeMs: values.get('--start-control-max-age-ms'),
+      alertMaxAgeMs: values.get('--alert-max-age-ms'),
+      mailboxMaxAgeMs: common.maxAgeMs,
+    });
+  } else {
+    fail('command_invalid');
+  }
+  console.info(JSON.stringify(result));
+}
+
+if (path.resolve(fileURLToPath(import.meta.url)) === path.resolve(process.argv[1] ?? '')) {
+  main().catch((error) => {
+    const code = error instanceof RecoveryGuardError ? error.code : 'guard_unexpected_failure';
+    console.error(`[vh:publisher-recovery] ${code}`);
+    process.exit(78);
+  });
+}

--- a/tools/scripts/news-aggregator-publisher-recovery-guard.mjs
+++ b/tools/scripts/news-aggregator-publisher-recovery-guard.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { createHash } from 'node:crypto';
-import { lstat, readFile } from 'node:fs/promises';
+import { lstat, mkdir, readFile, realpath } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -76,6 +76,31 @@ function positiveInteger(value, fallback, code) {
   const parsed = Number(value);
   if (!Number.isSafeInteger(parsed) || parsed <= 0) fail(code);
   return parsed;
+}
+
+export async function requirePrivateOutputParent(filePath) {
+  if (!path.isAbsolute(filePath)) fail('output_path_not_absolute');
+  const parent = path.dirname(filePath);
+  try {
+    await mkdir(parent, { recursive: true, mode: 0o700 });
+  } catch {
+    fail('output_parent_create_failed');
+  }
+  let stat;
+  let canonical;
+  try {
+    stat = await lstat(parent);
+    canonical = await realpath(parent);
+  } catch {
+    fail('output_parent_unavailable');
+  }
+  if (stat.isSymbolicLink() || !stat.isDirectory()
+    || (typeof process.getuid === 'function' && stat.uid !== process.getuid())
+    || (stat.mode & 0o777) !== 0o700
+    || canonical !== path.resolve(parent)) {
+    fail('output_parent_not_private');
+  }
+  return parent;
 }
 
 async function readRegularJson(filePath, label) {
@@ -207,7 +232,7 @@ export async function verifyStartControlArtifact(options) {
   const { parsed: artifact, bytes, stat } = await readRegularJson(options.filePath, 'start_control_artifact');
   requirePrivateOwnedStat(stat, 'start_control_artifact');
   if (artifact.schemaVersion !== 'vh-news-publisher-start-control-v1'
-    || artifact.status !== 'active_approval_cleared'
+    || artifact.status !== 'active_attended_permit_consumed'
     || artifact.revision !== options.expectedRevision) {
     fail('start_control_contract_invalid');
   }
@@ -235,7 +260,9 @@ export async function verifyStartControlArtifact(options) {
     || artifact.activationBaseline.capturedAfterResetFailed !== true
     || artifact.postActivation?.activeState !== 'active'
     || artifact.postActivation?.subState !== 'running'
-    || artifact.postActivation?.managerApprovalCleared !== true
+    || artifact.postActivation?.attendedPermitConsumed !== true
+    || artifact.postActivation?.legacyManagerApprovalCleared !== true
+    || !sha256(artifact.postActivation?.attendedPermitBindingSha256)
     || artifact.postActivation?.nRestarts !== artifact.activationBaseline.nRestarts
     || !exactKeys(bindings, ['preflight', 'relayRecovery', 'mailbox'])
     || !exactKeys(preflight, ['schemaVersion', 'sha256', 'revision', 'runId', 'generatedAt'])
@@ -570,6 +597,9 @@ async function main() {
       expectedRevision: values.get('--expected-revision'),
       expectedSha256: values.get('--expected-sha256'),
     });
+  } else if (command === 'output-parent') {
+    await requirePrivateOutputParent(common.filePath);
+    result = { status: 'pass' };
   } else if (command === 'finalize') {
     result = await verifyRecoveryFinalization({
       expectedRevision: values.get('--expected-revision'),

--- a/tools/scripts/news-aggregator-publisher-recovery-guard.test.mjs
+++ b/tools/scripts/news-aggregator-publisher-recovery-guard.test.mjs
@@ -412,7 +412,7 @@ function startControl(overrides = {}) {
   return {
     schemaVersion: 'vh-news-publisher-start-control-v1',
     generatedAt: '2026-07-10T10:31:00.000Z',
-    status: 'active_approval_cleared',
+    status: 'active_attended_permit_consumed',
     revision: REVISION,
     startedAt: '2026-07-10T10:30:00.000Z',
     activatedAt: '2026-07-10T10:30:30.000Z',
@@ -421,7 +421,14 @@ function startControl(overrides = {}) {
       incidentNRestarts: 4, enabledState: 'disabled',
     },
     activationBaseline: { nRestarts: 0, capturedAfterResetFailed: true },
-    postActivation: { activeState: 'active', subState: 'running', nRestarts: 0, managerApprovalCleared: true },
+    postActivation: {
+      activeState: 'active',
+      subState: 'running',
+      nRestarts: 0,
+      attendedPermitConsumed: true,
+      legacyManagerApprovalCleared: true,
+      attendedPermitBindingSha256: '7'.repeat(64),
+    },
     evidenceBindings: {
       preflight: {
         schemaVersion: 'vh-news-daemon-recovery-preflight-v1', sha256: '1'.repeat(64),

--- a/tools/scripts/news-aggregator-publisher-recovery-guard.test.mjs
+++ b/tools/scripts/news-aggregator-publisher-recovery-guard.test.mjs
@@ -426,8 +426,10 @@ function startControl(overrides = {}) {
       subState: 'running',
       nRestarts: 0,
       attendedPermitConsumed: true,
+      attendedReceiptConsumed: true,
       legacyManagerApprovalCleared: true,
       attendedPermitBindingSha256: '7'.repeat(64),
+      attendedReceiptSha256: '8'.repeat(64),
     },
     evidenceBindings: {
       preflight: {
@@ -445,6 +447,7 @@ function startControl(overrides = {}) {
         schemaVersion: 'vhc-failure-mailbox-monitor-v1', sha256: '6'.repeat(64),
         newCriticalCount: 11, generatedAt: '2026-07-10T10:26:00.000Z',
       },
+      systemWriterPin: { sha256: '9'.repeat(64) },
     },
     ...overrides,
   };
@@ -527,6 +530,7 @@ async function finalizationFixture(root, overrides = {}) {
       relayPacketSha256: '4'.repeat(64),
       relayCaptureSha256: '5'.repeat(64),
       mailboxSha256: '6'.repeat(64),
+      systemWriterPinSha256: '9'.repeat(64),
     },
     ...overrides.readback,
   });

--- a/tools/scripts/news-aggregator-publisher-recovery-guard.test.mjs
+++ b/tools/scripts/news-aggregator-publisher-recovery-guard.test.mjs
@@ -1,0 +1,643 @@
+import assert from 'node:assert/strict';
+import {
+  chmod,
+  lstat,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  stat,
+  symlink,
+  utimes,
+  writeFile,
+} from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { createHash } from 'node:crypto';
+import {
+  RecoveryGuardError,
+  verifyMailboxArtifact,
+  verifyMailboxCurrentArtifact,
+  verifyPreflightArtifact,
+  verifyRelayRecoveryEvidence,
+  verifyRecoveryFinalization,
+  verifyStartControlArtifact,
+} from './news-aggregator-publisher-recovery-guard.mjs';
+import {
+  updateWatchT0File,
+  updateWatchT0Text,
+  WatchT0UpdateError,
+} from './update-phase5-scope-a-watch-t0.mjs';
+
+const REVISION = '1883841555c4924be8d35747272c38ce8f2071d9';
+const NOW = Date.parse('2026-07-10T12:00:00.000Z');
+const OLD_START = '2026-07-10T09:00:00.000Z';
+const OLD_CLEAN = '2026-07-10T09:30:00.000Z';
+const NEW_T0 = '2026-07-10T11:59:00.000Z';
+const RELAY_ORIGINS = [
+  'http://127.0.0.1:8765',
+  'http://127.0.0.1:8766',
+  'http://127.0.0.1:8767',
+];
+
+async function tempRoot() {
+  return mkdtemp(path.join(os.tmpdir(), 'vh-publisher-recovery-guard-'));
+}
+
+async function privateJson(root, name, payload) {
+  const file = path.join(root, name);
+  await writeFile(file, `${JSON.stringify(payload)}\n`, { mode: 0o600 });
+  await chmod(file, 0o600);
+  return file;
+}
+
+function mailbox(overrides = {}) {
+  return {
+    schemaVersion: 'vhc-failure-mailbox-monitor-v1',
+    generatedAt: '2026-07-10T11:58:00.000Z',
+    status: 'pass',
+    newCriticalCount: 0,
+    newWarningCount: 1,
+    newestRelevantMessageAt: '2026-07-10T11:57:00.000Z',
+    counts: { critical: 0, warning: 1, info: 0 },
+    items: [{ classification: 'warning', privateMetadata: 'must-not-be-read-or-emitted' }],
+    ...overrides,
+  };
+}
+
+function preflight(overrides = {}) {
+  return {
+    schemaVersion: 'vh-news-daemon-recovery-preflight-v1',
+    generatedAt: '2026-07-10T11:55:00.000Z',
+    status: 'preflight_passed',
+    revision: REVISION,
+    runId: 'preflight-1',
+    mode: 'preflight_only',
+    gates: [
+      'source_liveness',
+      'storycluster_build',
+      'openai_provider',
+      'storycluster_qdrant_readiness',
+      'raw_publication_readiness',
+    ],
+    ...overrides,
+  };
+}
+
+test('mailbox file-only guard accepts the observed v1 schema only when fresh and critical-free', async () => {
+  const root = await tempRoot();
+  try {
+    const file = await privateJson(root, 'latest.json', mailbox());
+    const result = await verifyMailboxArtifact({ filePath: file, nowMs: NOW, maxAgeMs: 5 * 60 * 1000 });
+    assert.deepEqual({ ...result, sha256: '<sha256>' }, {
+      schemaVersion: 'vhc-failure-mailbox-monitor-v1',
+      status: 'pass',
+      newCriticalCount: 0,
+      generatedAt: '2026-07-10T11:58:00.000Z',
+      sha256: '<sha256>',
+    });
+    assert.match(result.sha256, /^[0-9a-f]{64}$/);
+    assert.doesNotMatch(JSON.stringify(result), /privateMetadata/);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('mailbox guard rejects new criticals, stale artifacts, and symlinks', async () => {
+  const root = await tempRoot();
+  try {
+    const critical = await privateJson(root, 'critical.json', mailbox({ newCriticalCount: 1 }));
+    await assert.rejects(
+      verifyMailboxArtifact({ filePath: critical, nowMs: NOW }),
+      (error) => error instanceof RecoveryGuardError && error.code === 'mailbox_new_critical_present',
+    );
+    const stale = await privateJson(root, 'stale.json', mailbox({ generatedAt: '2026-07-10T10:00:00.000Z' }));
+    await assert.rejects(
+      verifyMailboxArtifact({ filePath: stale, nowMs: NOW, maxAgeMs: 60_000 }),
+      (error) => error.code === 'mailbox_stale',
+    );
+    const link = path.join(root, 'link.json');
+    await symlink(critical, link);
+    await assert.rejects(
+      verifyMailboxArtifact({ filePath: link, nowMs: NOW }),
+      (error) => error.code === 'mailbox_artifact_not_regular_file',
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('pre-start mailbox guard accepts a current incident only when reviewed sha and count match', async () => {
+  const root = await tempRoot();
+  try {
+    const payload = mailbox({ newCriticalCount: 11 });
+    const bytes = `${JSON.stringify(payload)}\n`;
+    const file = path.join(root, 'current.json');
+    await writeFile(file, bytes, { mode: 0o600 });
+    const sha256 = createHash('sha256').update(bytes).digest('hex');
+    const result = await verifyMailboxCurrentArtifact({
+      filePath: file,
+      nowMs: NOW,
+      maxAgeMs: 5 * 60 * 1000,
+      expectedSha256: sha256,
+      expectedCriticalCount: 11,
+    });
+    assert.equal(result.newCriticalCount, 11);
+    await assert.rejects(
+      verifyMailboxCurrentArtifact({ filePath: file, nowMs: NOW, expectedSha256: '0'.repeat(64), expectedCriticalCount: 11 }),
+      (error) => error.code === 'mailbox_expected_sha256_mismatch',
+    );
+    await assert.rejects(
+      verifyMailboxCurrentArtifact({ filePath: file, nowMs: NOW, expectedSha256: sha256, expectedCriticalCount: 10 }),
+      (error) => error.code === 'mailbox_expected_critical_count_mismatch',
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('preflight guard binds exact revision, status, all five gates, and recency', async () => {
+  const root = await tempRoot();
+  try {
+    const file = await privateJson(root, 'preflight.json', preflight());
+    const result = await verifyPreflightArtifact({
+      filePath: file,
+      expectedRevision: REVISION,
+      nowMs: NOW,
+      maxAgeMs: 10 * 60 * 1000,
+    });
+    assert.equal(result.revision, REVISION);
+    await assert.rejects(
+      verifyPreflightArtifact({ filePath: file, expectedRevision: 'b'.repeat(40), nowMs: NOW }),
+      (error) => error.code === 'preflight_revision_mismatch',
+    );
+    const partial = await privateJson(root, 'partial.json', preflight({ gates: ['source_liveness'] }));
+    await assert.rejects(
+      verifyPreflightArtifact({ filePath: partial, expectedRevision: REVISION, nowMs: NOW }),
+      (error) => error.code === 'preflight_gates_invalid',
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+function exit78() {
+  return { activeState: 'failed', subState: 'failed', result: 'exit-code', execMainStatus: 78 };
+}
+
+function relayRecoveryEvidence(overrides = {}) {
+  const imageId = `sha256:${'a'.repeat(64)}`;
+  const imageTag = 'vhc-public-beta-relay:20260710-main-v18838415-amd64';
+  const packetSha256 = 'b'.repeat(64);
+  const captureSha256 = 'c'.repeat(64);
+  const relays = ['vhc-relay-a', 'vhc-relay-b', 'vhc-relay-c'];
+  return {
+    schemaVersion: 'vh-a6-s1b-relay-recovery-evidence-v1',
+    generatedAt: '2026-07-10T11:50:00.000Z',
+    status: 'pass',
+    revision: REVISION,
+    immutableImageId: imageId,
+    imageTag,
+    packetSha256,
+    captureSha256,
+    relayOrigins: RELAY_ORIGINS,
+    publisherBefore: exit78(),
+    publisherAfter: exit78(),
+    stages: relays.map((relay, index) => ({
+      relay, order: index + 1, origin: RELAY_ORIGINS[index], status: 'pass', revision: REVISION, imageId, imageTag, packetSha256,
+      ready: true, running: true, oomKilled: false, restartCountStable: true, watchdogTripsStable: true,
+      topologyParity: true, environmentParity: true, snapshotParity: true,
+      missingRouteContracts: ['story', 'latest-index', 'hot-index', 'synthesis-lifecycle'],
+      publisherBefore: exit78(), publisherAfter: exit78(),
+    })),
+    finalFleet: {
+      status: 'pass', relayOrder: relays, runningCount: 3, readyCount: 3, oomKilledCount: 0,
+      restartCountsStable: true, watchdogTripsStable: true,
+      topologyParity: true, environmentParity: true, snapshotParity: true,
+      missingRouteContractsAll: true,
+    },
+    reviewerDecision: 'GO',
+    reviewerIdentity: 'reviewer-1',
+    reviewedAt: '2026-07-10T11:51:00.000Z',
+    reviewedPacketSha256: packetSha256,
+    reviewedCaptureSha256: captureSha256,
+    ...overrides,
+  };
+}
+
+async function writeRelayRecovery(root, payload) {
+  const file = await privateJson(root, `relay-${Math.random()}.json`, payload);
+  const bytes = await readFile(file);
+  return { file, sha256: createHash('sha256').update(bytes).digest('hex') };
+}
+
+test('relay recovery guard binds reviewed mode-0600 serial A/B/C proof and exact file hash', async () => {
+  const root = await tempRoot();
+  try {
+    const fixture = await writeRelayRecovery(root, relayRecoveryEvidence());
+    const result = await verifyRelayRecoveryEvidence({
+      filePath: fixture.file,
+      expectedRevision: REVISION,
+      expectedSha256: fixture.sha256,
+      nowMs: NOW,
+      maxAgeMs: 2 * 60 * 60 * 1000,
+    });
+    assert.deepEqual(result.relayOrder, ['vhc-relay-a', 'vhc-relay-b', 'vhc-relay-c']);
+    assert.equal(result.reviewerDecision, 'GO');
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('relay recovery guard rejects missing, reordered, partial, wrong-revision, wrong-hash, and unreviewed evidence', async () => {
+  const root = await tempRoot();
+  try {
+    await assert.rejects(
+      verifyRelayRecoveryEvidence({
+        filePath: path.join(root, 'missing.json'), expectedRevision: REVISION,
+        expectedSha256: '0'.repeat(64), nowMs: NOW,
+      }),
+      (error) => error.code === 'relay_recovery_evidence_missing',
+    );
+    const base = relayRecoveryEvidence();
+    const variants = [
+      { name: 'reordered', payload: { ...base, stages: [base.stages[1], base.stages[0], base.stages[2]] }, code: 'relay_recovery_stage_invalid' },
+      { name: 'partial', payload: { ...base, stages: base.stages.slice(0, 2) }, code: 'relay_recovery_evidence_contract_invalid' },
+      { name: 'wrong revision', payload: { ...base, revision: 'c'.repeat(40) }, code: 'relay_recovery_evidence_contract_invalid' },
+      { name: 'no review', payload: { ...base, reviewerDecision: 'NO-GO' }, code: 'relay_recovery_evidence_contract_invalid' },
+      { name: 'hostile extra field', payload: { ...base, token: 'NEVER-PERSIST-THIS' }, code: 'relay_recovery_evidence_contract_invalid' },
+      { name: 'public relay origin', payload: { ...base, relayOrigins: ['http://192.0.2.1:8765', ...RELAY_ORIGINS.slice(1)] }, code: 'relay_origins_invalid' },
+      { name: 'reordered origins', payload: { ...base, relayOrigins: [RELAY_ORIGINS[1], RELAY_ORIGINS[0], RELAY_ORIGINS[2]] }, code: 'relay_recovery_stage_invalid' },
+    ];
+    for (const row of variants) {
+      const fixture = await writeRelayRecovery(root, row.payload);
+      await assert.rejects(
+        verifyRelayRecoveryEvidence({
+          filePath: fixture.file, expectedRevision: REVISION, expectedSha256: fixture.sha256, nowMs: NOW,
+        }),
+        (error) => error.code === row.code,
+        row.name,
+      );
+    }
+    const fixture = await writeRelayRecovery(root, base);
+    await assert.rejects(
+      verifyRelayRecoveryEvidence({
+        filePath: fixture.file, expectedRevision: REVISION, expectedSha256: '0'.repeat(64), nowMs: NOW,
+      }),
+      (error) => error.code === 'relay_recovery_evidence_sha256_mismatch',
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+function envText(extra = '') {
+  return [
+    '# preserve comments and every non-window byte',
+    'SECRET_TOKEN=opaque-value',
+    `VH_PHASE5_SCOPE_A_WATCH_START_AT=${OLD_START}`,
+    'UNRELATED=value with spaces',
+    `VH_PHASE5_SCOPE_A_WATCH_CLEAN_START_AT=${OLD_CLEAN}`,
+    extra,
+  ].filter(Boolean).join('\n') + '\n';
+}
+
+const t0Options = {
+  expectedStart: OLD_START,
+  expectedCleanStart: OLD_CLEAN,
+  newT0: NEW_T0,
+  nowMs: NOW,
+};
+
+test('T0 transform changes only the two watch-window values', () => {
+  const original = envText();
+  const updated = updateWatchT0Text(original, t0Options);
+  assert.equal(
+    updated,
+    original
+      .replace(`${START_KEY()}=${OLD_START}`, `${START_KEY()}=${NEW_T0}`)
+      .replace(`${CLEAN_KEY()}=${OLD_CLEAN}`, `${CLEAN_KEY()}=${NEW_T0}`),
+  );
+  assert.match(updated, /SECRET_TOKEN=opaque-value/);
+});
+
+function START_KEY() { return 'VH_PHASE5_SCOPE_A_WATCH_START_AT'; }
+function CLEAN_KEY() { return 'VH_PHASE5_SCOPE_A_WATCH_CLEAN_START_AT'; }
+
+test('T0 file update is atomic-output mode 0600 and preserves non-window keys', async () => {
+  const root = await tempRoot();
+  try {
+    const file = path.join(root, 'watch.env');
+    await writeFile(file, envText(), { mode: 0o600 });
+    await chmod(file, 0o600);
+    const result = await updateWatchT0File(file, t0Options);
+    assert.equal(result.status, 'pass');
+    assert.equal((await lstat(file)).mode & 0o777, 0o600);
+    const updated = await readFile(file, 'utf8');
+    assert.match(updated, new RegExp(`${START_KEY()}=${NEW_T0}`));
+    assert.match(updated, /SECRET_TOKEN=opaque-value/);
+    assert.deepEqual((await readdir(root)).filter((name) => name.includes('.tmp-')), []);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('T0 updater refuses weak mode, symlink, malformed or duplicate shapes, compare mismatch, backdating, and future time', async () => {
+  const root = await tempRoot();
+  try {
+    const weak = path.join(root, 'weak.env');
+    await writeFile(weak, envText(), { mode: 0o644 });
+    await chmod(weak, 0o644);
+    await assert.rejects(updateWatchT0File(weak, t0Options), (error) => error.code === 'env_file_mode_not_0600');
+
+    const target = path.join(root, 'target.env');
+    await writeFile(target, envText(), { mode: 0o600 });
+    await chmod(target, 0o600);
+    const link = path.join(root, 'link.env');
+    await symlink(target, link);
+    await assert.rejects(updateWatchT0File(link, t0Options), (error) => error.code === 'env_file_not_regular');
+
+    assert.throws(
+      () => updateWatchT0Text(envText('not an assignment'), t0Options),
+      (error) => error instanceof WatchT0UpdateError && error.code === 'env_shape_invalid',
+    );
+    assert.throws(
+      () => updateWatchT0Text(`${envText()}${START_KEY()}=${OLD_START}\n`, t0Options),
+      (error) => error.code === 'env_duplicate_key',
+    );
+    assert.throws(
+      () => updateWatchT0Text(envText(), { ...t0Options, expectedStart: '2026-07-10T08:00:00.000Z' }),
+      (error) => error.code === 'watch_start_compare_failed',
+    );
+    assert.throws(
+      () => updateWatchT0Text(envText(), { ...t0Options, newT0: OLD_START }),
+      (error) => error.code === 'new_t0_not_strictly_later',
+    );
+    assert.throws(
+      () => updateWatchT0Text(envText(), { ...t0Options, newT0: '2026-07-10T12:02:00.000Z' }),
+      (error) => error.code === 'new_t0_in_future',
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('T0 updater byte-compares the source immediately before rename', async () => {
+  const root = await tempRoot();
+  try {
+    const file = path.join(root, 'watch.env');
+    const original = envText();
+    await writeFile(file, original, { mode: 0o600 });
+    await chmod(file, 0o600);
+    const originalStat = await stat(file);
+    await assert.rejects(
+      updateWatchT0File(file, t0Options, {
+        beforeCompare: async () => {
+          const changed = original.replace('SECRET_TOKEN=opaque-value', 'SECRET_TOKEN=mutate-value');
+          await writeFile(file, changed, { mode: 0o600 });
+          await chmod(file, 0o600);
+          await utimes(file, originalStat.atime, originalStat.mtime);
+        },
+      }),
+      (error) => error.code === 'env_file_changed_during_update',
+    );
+    assert.match(await readFile(file, 'utf8'), /SECRET_TOKEN=mutate-value/);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+function startControl(overrides = {}) {
+  return {
+    schemaVersion: 'vh-news-publisher-start-control-v1',
+    generatedAt: '2026-07-10T10:31:00.000Z',
+    status: 'active_approval_cleared',
+    revision: REVISION,
+    startedAt: '2026-07-10T10:30:00.000Z',
+    activatedAt: '2026-07-10T10:30:30.000Z',
+    preStart: {
+      activeState: 'failed', subState: 'failed', result: 'exit-code', execMainStatus: 78,
+      incidentNRestarts: 4, enabledState: 'disabled',
+    },
+    activationBaseline: { nRestarts: 0, capturedAfterResetFailed: true },
+    postActivation: { activeState: 'active', subState: 'running', nRestarts: 0, managerApprovalCleared: true },
+    evidenceBindings: {
+      preflight: {
+        schemaVersion: 'vh-news-daemon-recovery-preflight-v1', sha256: '1'.repeat(64),
+        revision: REVISION, runId: 'preflight-1', generatedAt: '2026-07-10T10:20:00.000Z',
+      },
+      relayRecovery: {
+        schemaVersion: 'vh-a6-s1b-relay-recovery-evidence-v1', sha256: '2'.repeat(64), revision: REVISION,
+        generatedAt: '2026-07-10T10:10:00.000Z', immutableImageId: `sha256:${'3'.repeat(64)}`,
+        imageTag: 'vhc-public-beta-relay:20260710-main-v18838415-amd64', packetSha256: '4'.repeat(64),
+        captureSha256: '5'.repeat(64), reviewerIdentity: 'reviewer-1', reviewedAt: '2026-07-10T10:25:00.000Z',
+        relayOrder: ['vhc-relay-a', 'vhc-relay-b', 'vhc-relay-c'], relayOrigins: RELAY_ORIGINS,
+      },
+      mailbox: {
+        schemaVersion: 'vhc-failure-mailbox-monitor-v1', sha256: '6'.repeat(64),
+        newCriticalCount: 11, generatedAt: '2026-07-10T10:26:00.000Z',
+      },
+    },
+    ...overrides,
+  };
+}
+
+test('start-control independently rejects unsafe preflight IDs and mutable relay tags', async () => {
+  const root = await tempRoot();
+  try {
+    const unsafeRun = startControl();
+    unsafeRun.evidenceBindings.preflight.runId = '../escape';
+    const unsafeRunFile = await privateJson(root, 'unsafe-run.json', unsafeRun);
+    await assert.rejects(
+      verifyStartControlArtifact({ filePath: unsafeRunFile, expectedRevision: REVISION, nowMs: NOW, maxAgeMs: 2 * 60 * 60 * 1000 }),
+      (error) => error.code === 'start_control_tuple_invalid',
+    );
+
+    const latestTag = startControl();
+    latestTag.evidenceBindings.relayRecovery.imageTag = 'vhc-public-beta-relay:latest';
+    const latestTagFile = await privateJson(root, 'latest-tag.json', latestTag);
+    await assert.rejects(
+      verifyStartControlArtifact({ filePath: latestTagFile, expectedRevision: REVISION, nowMs: NOW, maxAgeMs: 2 * 60 * 60 * 1000 }),
+      (error) => error.code === 'start_control_tuple_invalid',
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+function alertReport(generatedAt, delivery, overrides = {}) {
+  return {
+    schemaVersion: 'vh-public-feed-alert-watch-v2',
+    generatedAt,
+    status: 'pass',
+    observedStatus: 'pass',
+    severity: 'none',
+    blockers: [],
+    fingerprint: '1234567890abcdef12345678',
+    publisher: {
+      status: 'pass', activeState: 'active', subState: 'running', result: 'success',
+      execMainStatus: '0', nRestarts: 0, failureClass: 'none', severity: 'none',
+    },
+    freshness: { status: 'pass', blockers: [] },
+    relayLiveness: { status: 'pass', blockers: [] },
+    relaySnapshot: { status: 'pass', blockers: [] },
+    watchClosure: { status: 'pass', blockers: [] },
+    delivery,
+    state: {
+      schemaVersion: 'vh-public-feed-alert-state-v3',
+      sourceStatuses: {
+        publisher: 'pass', freshness: 'pass', relayLiveness: 'pass', relaySnapshot: 'pass', watchClosure: 'pass',
+      },
+    },
+    ...overrides,
+  };
+}
+
+async function finalizationFixture(root, overrides = {}) {
+  const start = await privateJson(root, 'start-control.json', startControl(overrides.start));
+  const startSha256 = createHash('sha256').update(await readFile(start)).digest('hex');
+  const readbackGeneratedAt = '2026-07-10T11:40:00.000Z';
+  const readback = await privateJson(root, 'readback.json', {
+    schemaVersion: 'vh-news-publisher-recovery-readback-v1',
+    generatedAt: readbackGeneratedAt,
+    status: 'pass',
+    revision: REVISION,
+    startedAt: '2026-07-10T10:30:00.000Z',
+    runId: 'run-recovery',
+    tickSequence: 2,
+    tickCompletedAt: '2026-07-10T11:35:00.000Z',
+    storyId: 'story-recovery',
+    sourceSetRevision: 'source-set-recovery',
+    relayCount: 3,
+    positiveRoutes: ['story', 'latest-index', 'hot-index', 'synthesis-lifecycle'],
+    missingKeyRoutes: ['story', 'latest-index', 'hot-index', 'synthesis-lifecycle'],
+    lifecycleModes: ['preserved_current', 'preserved_current', 'preserved_current'],
+    inputBindings: {
+      startControlSha256: startSha256,
+      preflightSha256: '1'.repeat(64),
+      relayEvidenceSha256: '2'.repeat(64),
+      relayPacketSha256: '4'.repeat(64),
+      relayCaptureSha256: '5'.repeat(64),
+      mailboxSha256: '6'.repeat(64),
+    },
+    ...overrides.readback,
+  });
+  const watchEnv = path.join(root, 'watch.env');
+  await writeFile(watchEnv, [
+    'PRESERVED_KEY=preserved',
+    `VH_PHASE5_SCOPE_A_WATCH_START_AT=${overrides.watchT0 ?? readbackGeneratedAt}`,
+    `VH_PHASE5_SCOPE_A_WATCH_CLEAN_START_AT=${overrides.watchT0 ?? readbackGeneratedAt}`,
+    '',
+  ].join('\n'), { mode: 0o600 });
+  await chmod(watchEnv, 0o600);
+  const first = await privateJson(root, 'alert-first.json', alertReport(
+    '2026-07-10T11:50:00.000Z',
+    { status: 'sent', reason: 'state_changed', channels: ['email'], error: null },
+    overrides.first,
+  ));
+  const second = await privateJson(root, 'alert-second.json', alertReport(
+    overrides.secondAt ?? '2026-07-10T11:55:00.000Z',
+    { status: 'suppressed', reason: 'unchanged_suppressed', channels: [], error: null },
+    overrides.second,
+  ));
+  const mailboxFile = await privateJson(root, 'mailbox-clean.json', mailbox({
+    generatedAt: overrides.mailboxAt ?? '2026-07-10T11:58:00.000Z',
+    newCriticalCount: 0,
+  }));
+  return { start, readback, watchEnv, first, second, mailboxFile };
+}
+
+async function runFinalization(files) {
+  return verifyRecoveryFinalization({
+    expectedRevision: REVISION,
+    startControlFile: files.start,
+    readbackFile: files.readback,
+    watchEnvFile: files.watchEnv,
+    firstAlertFile: files.first,
+    secondAlertFile: files.second,
+    mailboxFile: files.mailboxFile,
+    nowMs: NOW,
+    startControlMaxAgeMs: 2 * 60 * 60 * 1000,
+    alertMaxAgeMs: 60 * 60 * 1000,
+    mailboxMaxAgeMs: 15 * 60 * 1000,
+  });
+}
+
+test('finalization guard proves sent recovery, unchanged suppression, then post-suppression clean mailbox', async () => {
+  const root = await tempRoot();
+  try {
+    const result = await runFinalization(await finalizationFixture(root));
+    assert.equal(result.status, 'pass');
+    assert.equal(result.fingerprint, '1234567890abcdef12345678');
+    assert.equal(result.nRestarts, 0);
+    assert.equal(result.readbackGeneratedAt, '2026-07-10T11:40:00.000Z');
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('finalization guard rejects retry or failed delivery, stale reports, fingerprint drift, duplicate recovery sends, and pre-recovery mailbox', async () => {
+  const cases = [
+    {
+      name: 'failed delivery',
+      overrides: { first: { delivery: { status: 'failed', reason: 'state_changed' } } },
+      code: 'first_alert_delivery_invalid',
+    },
+    {
+      name: 'retry delivery',
+      overrides: { first: { delivery: { status: 'sent', reason: 'retry_failed_delivery' } } },
+      code: 'first_alert_delivery_invalid',
+    },
+    {
+      name: 'stale report',
+      overrides: { secondAt: '2026-07-10T10:00:00.000Z' },
+      code: 'alert_recovery_sequence_invalid',
+    },
+    {
+      name: 'changed fingerprint',
+      overrides: { second: { fingerprint: 'abcdef1234567890abcdef12' } },
+      code: 'alert_healthy_projection_changed',
+    },
+    {
+      name: 'duplicate sent recovery',
+      overrides: { second: { delivery: { status: 'sent', reason: 'state_changed' } } },
+      code: 'second_alert_delivery_invalid',
+    },
+    {
+      name: 'mailbox before suppression',
+      overrides: { mailboxAt: '2026-07-10T11:54:00.000Z' },
+      code: 'mailbox_predates_required_boundary',
+    },
+    {
+      name: 'missing readback',
+      overrides: {},
+      missingReadback: true,
+      code: 'readback_artifact_missing',
+    },
+    {
+      name: 'tampered readback',
+      overrides: { readback: { revision: 'b'.repeat(40) } },
+      code: 'readback_artifact_contract_invalid',
+    },
+    {
+      name: 'mismatched watch T0',
+      overrides: { watchT0: '2026-07-10T11:41:00.000Z' },
+      code: 'watch_t0_not_bound_to_readback',
+    },
+  ];
+  for (const row of cases) {
+    const root = await tempRoot();
+    try {
+      const files = await finalizationFixture(root, row.overrides);
+      if (row.missingReadback) await rm(files.readback, { force: true });
+      await assert.rejects(
+        runFinalization(files),
+        (error) => error.code === row.code,
+        row.name,
+      );
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  }
+});

--- a/tools/scripts/record-news-aggregator-restartable-exit.sh
+++ b/tools/scripts/record-news-aggregator-restartable-exit.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="${VHC_REPO:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+EXPECTED_REVISION="${1:-${VH_NEWS_DAEMON_EXPECTED_REVISION:-}}"
+AUTHORITY_FILE="${VH_NEWS_DAEMON_RESTART_AUTHORITY_FILE:-${HOME}/.local/state/vhc/news-aggregator/recovery/automatic-restart-authority.json}"
+PERMIT_FILE="${VH_NEWS_DAEMON_RESTART_PERMIT_FILE:-${HOME}/.local/state/vhc/news-aggregator/recovery/automatic-restart-permit.json}"
+UNIT="${VH_NEWS_DAEMON_SYSTEMD_UNIT:-vh-news-aggregator.service}"
+
+# Ordering contract (upstream systemd src/core/service.c): ExecStopPost finishes
+# through service_enter_dead(); service_enter_restart() runs afterward and then
+# increments n_restarts. Therefore this hook records the prior value and the
+# next automatic ExecStart must observe exactly prior+1.
+previous_nrestarts="$(systemctl --user show "${UNIT}" --property=NRestarts --value 2>/dev/null || true)"
+if [[ ! "${previous_nrestarts}" =~ ^[0-9]+$ ]]; then
+  previous_nrestarts=-1
+fi
+
+node "${REPO_ROOT}/tools/scripts/news-aggregator-publisher-automatic-restart-authority.mjs" record-exit \
+  --expected-revision "${EXPECTED_REVISION}" \
+  --authority-file "${AUTHORITY_FILE}" \
+  --permit-file "${PERMIT_FILE}" \
+  --service-result "${SERVICE_RESULT:-unknown}" \
+  --exit-code "${EXIT_CODE:-unknown}" \
+  --exit-status "${EXIT_STATUS:-unknown}" \
+  --previous-nrestarts "${previous_nrestarts}" >/dev/null

--- a/tools/scripts/start-news-aggregator-daemon-production.sh
+++ b/tools/scripts/start-news-aggregator-daemon-production.sh
@@ -13,6 +13,7 @@ PREFLIGHT_APPROVAL_FROM_CALLER="${VH_NEWS_DAEMON_PREFLIGHT_APPROVED:-}"
 RESTART_AUTHORITY_FROM_UNIT="${VH_NEWS_DAEMON_RESTART_AUTHORITY_FILE:-${HOME}/.local/state/vhc/news-aggregator/recovery/automatic-restart-authority.json}"
 RESTART_PERMIT_FROM_UNIT="${VH_NEWS_DAEMON_RESTART_PERMIT_FILE:-${HOME}/.local/state/vhc/news-aggregator/recovery/automatic-restart-permit.json}"
 ATTENDED_PERMIT_FROM_UNIT="${VH_NEWS_DAEMON_ATTENDED_START_PERMIT_FILE:-${HOME}/.local/state/vhc/news-aggregator/recovery/attended-start-permit.json}"
+ATTENDED_RECEIPT_FROM_UNIT="${VH_NEWS_DAEMON_ATTENDED_START_RECEIPT_FILE:-${HOME}/.local/state/vhc/news-aggregator/recovery/attended-start-consumption-receipt.json}"
 SYSTEMD_UNIT_FROM_UNIT="${VH_NEWS_DAEMON_SYSTEMD_UNIT:-vh-news-aggregator.service}"
 
 if [[ ! -r "${COMMON_SH}" ]]; then
@@ -43,6 +44,7 @@ export VH_NEWS_DAEMON_PREFLIGHT_APPROVED="${PREFLIGHT_APPROVAL_FROM_CALLER}"
 export VH_NEWS_DAEMON_RESTART_AUTHORITY_FILE="${RESTART_AUTHORITY_FROM_UNIT}"
 export VH_NEWS_DAEMON_RESTART_PERMIT_FILE="${RESTART_PERMIT_FROM_UNIT}"
 export VH_NEWS_DAEMON_ATTENDED_START_PERMIT_FILE="${ATTENDED_PERMIT_FROM_UNIT}"
+export VH_NEWS_DAEMON_ATTENDED_START_RECEIPT_FILE="${ATTENDED_RECEIPT_FROM_UNIT}"
 export VH_NEWS_DAEMON_SYSTEMD_UNIT="${SYSTEMD_UNIT_FROM_UNIT}"
 unset VH_NEWS_DAEMON_ATTENDED_START_APPROVED VH_NEWS_DAEMON_START_APPROVED
 
@@ -175,10 +177,27 @@ else
     exit 78
   fi
   if [[ "${attended_present}" == "true" ]]; then
+    runtime_pin_json="$(
+      unset VH_NEWS_SYSTEM_WRITER_PRIVATE_KEY_PKCS8_BASE64URL VH_SYSTEM_WRITER_PRIVATE_KEY_PKCS8_BASE64URL
+      node "${REPO_ROOT}/tools/scripts/verify-news-aggregator-publisher-recovery.mjs" pin-sha256
+    )" || {
+      echo "[vh:news-daemon:prod] refusing live start without attended or verified automatic-restart authority" >&2
+      exit 78
+    }
+    runtime_pin_sha256="$(node -e '
+      const value = JSON.parse(process.argv[1]);
+      if (value.status !== "pass" || !/^[0-9a-f]{64}$/.test(value.systemWriterPinSha256 ?? "")) process.exit(78);
+      process.stdout.write(value.systemWriterPinSha256);
+    ' "${runtime_pin_json}")" || {
+      echo "[vh:news-daemon:prod] refusing live start without attended or verified automatic-restart authority" >&2
+      exit 78
+    }
     if ! node "${REPO_ROOT}/tools/scripts/news-aggregator-publisher-automatic-restart-authority.mjs" consume-attended \
       --expected-revision "${VH_NEWS_DAEMON_EXPECTED_REVISION}" \
       --attended-permit-file "${VH_NEWS_DAEMON_ATTENDED_START_PERMIT_FILE}" \
-      --current-nrestarts "${current_nrestarts}" >/dev/null 2>&1; then
+      --attended-receipt-file "${VH_NEWS_DAEMON_ATTENDED_START_RECEIPT_FILE}" \
+      --current-nrestarts "${current_nrestarts}" \
+      --system-writer-pin-sha256 "${runtime_pin_sha256}" >/dev/null 2>&1; then
       echo "[vh:news-daemon:prod] refusing live start without attended or verified automatic-restart authority" >&2
       exit 78
     fi

--- a/tools/scripts/start-news-aggregator-daemon-production.sh
+++ b/tools/scripts/start-news-aggregator-daemon-production.sh
@@ -2,9 +2,25 @@
 set -euo pipefail
 
 REPO_ROOT="${VHC_REPO:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+COMMON_SH="${REPO_ROOT}/tools/scripts/lib/news-aggregator-publisher-recovery-common.sh"
 ENV_FILE="${VH_NEWS_DAEMON_ENV_FILE:-${HOME}/.config/vhc/news-aggregator.env}"
 STATE_DIR="${VH_NEWS_DAEMON_STATE_DIR:-${HOME}/.local/state/vhc/news-aggregator}"
 ARTIFACT_ROOT="${VH_DAEMON_FEED_ARTIFACT_ROOT:-${STATE_DIR}/artifacts}"
+EXPECTED_REVISION_FROM_EXECSTART="${VH_NEWS_DAEMON_EXPECTED_REVISION:-}"
+ATTENDED_APPROVAL_FROM_MANAGER="${VH_NEWS_DAEMON_ATTENDED_START_APPROVED:-}"
+PREFLIGHT_ONLY_FROM_CALLER="${VH_NEWS_DAEMON_PREFLIGHT_ONLY:-}"
+PREFLIGHT_APPROVAL_FROM_CALLER="${VH_NEWS_DAEMON_PREFLIGHT_APPROVED:-}"
+RESTART_AUTHORITY_FROM_UNIT="${VH_NEWS_DAEMON_RESTART_AUTHORITY_FILE:-${HOME}/.local/state/vhc/news-aggregator/recovery/automatic-restart-authority.json}"
+RESTART_PERMIT_FROM_UNIT="${VH_NEWS_DAEMON_RESTART_PERMIT_FILE:-${HOME}/.local/state/vhc/news-aggregator/recovery/automatic-restart-permit.json}"
+SYSTEMD_UNIT_FROM_UNIT="${VH_NEWS_DAEMON_SYSTEMD_UNIT:-vh-news-aggregator.service}"
+
+if [[ ! -r "${COMMON_SH}" ]]; then
+  echo "[vh:news-daemon:prod] recovery common checks are unavailable" >&2
+  exit 78
+fi
+# shellcheck disable=SC1090
+source "${COMMON_SH}"
+vh_publisher_require_exact_checkout "${REPO_ROOT}" "${EXPECTED_REVISION_FROM_EXECSTART}"
 
 if [[ ! -r "${ENV_FILE}" ]]; then
   echo "[vh:news-daemon:prod] env file is required and must be readable: ${ENV_FILE}" >&2
@@ -17,6 +33,16 @@ set -a
 # shellcheck disable=SC1090
 source "${ENV_FILE}"
 set +a
+
+# Control authority is intentionally captured before the persistent host env is
+# sourced. A value parked in news-aggregator.env cannot authorize live writes.
+export VH_NEWS_DAEMON_EXPECTED_REVISION="${EXPECTED_REVISION_FROM_EXECSTART}"
+export VH_NEWS_DAEMON_ATTENDED_START_APPROVED="${ATTENDED_APPROVAL_FROM_MANAGER}"
+export VH_NEWS_DAEMON_PREFLIGHT_ONLY="${PREFLIGHT_ONLY_FROM_CALLER}"
+export VH_NEWS_DAEMON_PREFLIGHT_APPROVED="${PREFLIGHT_APPROVAL_FROM_CALLER}"
+export VH_NEWS_DAEMON_RESTART_AUTHORITY_FILE="${RESTART_AUTHORITY_FROM_UNIT}"
+export VH_NEWS_DAEMON_RESTART_PERMIT_FILE="${RESTART_PERMIT_FROM_UNIT}"
+export VH_NEWS_DAEMON_SYSTEMD_UNIT="${SYSTEMD_UNIT_FROM_UNIT}"
 
 truthy_flag() {
   case "${1:-}" in
@@ -85,7 +111,22 @@ if truthy_flag "${VH_NEWS_DAEMON_DIAGNOSTIC_NO_WRITE:-${VH_NEWS_DAEMON_NO_WRITE:
   export VH_NEWS_DAEMON_DIAGNOSTIC_NO_WRITE=1
 fi
 
-if [[ "${NO_WRITE_DIAGNOSTIC}" == "true" ]]; then
+PREFLIGHT_ONLY=false
+if truthy_flag "${VH_NEWS_DAEMON_PREFLIGHT_ONLY:-}"; then
+  PREFLIGHT_ONLY=true
+fi
+
+if [[ "${PREFLIGHT_ONLY}" == "true" ]]; then
+  if [[ "${NO_WRITE_DIAGNOSTIC}" == "true" ]]; then
+    echo "[vh:news-daemon:prod] refusing ambiguous preflight-only and diagnostic modes" >&2
+    exit 78
+  fi
+  if [[ "${VH_NEWS_DAEMON_PREFLIGHT_APPROVED:-}" != "1" ]]; then
+    echo "[vh:news-daemon:prod] refusing preflight-only mode without distinct approval" >&2
+    exit 78
+  fi
+  echo "[vh:news-daemon:prod] exact-revision preflight-only mode approved; publisher start is suppressed"
+elif [[ "${NO_WRITE_DIAGNOSTIC}" == "true" ]]; then
   if [[ "${VH_NEWS_DAEMON_DIAGNOSTIC_APPROVED:-}" != "1" ]]; then
     echo "[vh:news-daemon:prod] refusing no-write diagnostic without VH_NEWS_DAEMON_DIAGNOSTIC_APPROVED=1 in ${ENV_FILE}" >&2
     exit 78
@@ -101,9 +142,20 @@ if [[ "${NO_WRITE_DIAGNOSTIC}" == "true" ]]; then
     exit 78
   fi
   DIAGNOSTIC_TIMEOUT_BIN="${VH_NEWS_DAEMON_DIAGNOSTIC_TIMEOUT_BIN:-timeout}"
-elif [[ "${VH_NEWS_DAEMON_START_APPROVED:-}" != "1" ]]; then
-  echo "[vh:news-daemon:prod] refusing to start without VH_NEWS_DAEMON_START_APPROVED=1 in ${ENV_FILE}" >&2
-  exit 78
+elif [[ "${VH_NEWS_DAEMON_ATTENDED_START_APPROVED:-}" != "1"
+  || -e "${VH_NEWS_DAEMON_RESTART_PERMIT_FILE}" || -L "${VH_NEWS_DAEMON_RESTART_PERMIT_FILE}" ]]; then
+  current_nrestarts="$(systemctl --user show "${VH_NEWS_DAEMON_SYSTEMD_UNIT}" --property=NRestarts --value 2>/dev/null || true)"
+  if [[ ! "${current_nrestarts}" =~ ^[0-9]+$ ]] || ! node \
+    "${REPO_ROOT}/tools/scripts/news-aggregator-publisher-automatic-restart-authority.mjs" consume \
+    --expected-revision "${VH_NEWS_DAEMON_EXPECTED_REVISION}" \
+    --authority-file "${VH_NEWS_DAEMON_RESTART_AUTHORITY_FILE}" \
+    --permit-file "${VH_NEWS_DAEMON_RESTART_PERMIT_FILE}" \
+    --current-nrestarts "${current_nrestarts:-invalid}" \
+    --max-age-ms 120000 >/dev/null 2>&1; then
+    echo "[vh:news-daemon:prod] refusing live start without attended or verified automatic-restart authority" >&2
+    exit 78
+  fi
+  echo "[vh:news-daemon:prod] verified single-use automatic restart after exit 69"
 fi
 
 require_no_news_daemon_siblings "start"
@@ -125,6 +177,8 @@ export VH_NEWS_RUNTIME_RAW_BUNDLE_WRITE_CONCURRENCY="${VH_NEWS_RUNTIME_RAW_BUNDL
 export VH_NEWS_RUNTIME_TICK_WATCHDOG_MS="${VH_NEWS_RUNTIME_TICK_WATCHDOG_MS:-420000}"
 export VH_BUNDLE_SYNTHESIS_QUEUE_DEPTH="${VH_BUNDLE_SYNTHESIS_QUEUE_DEPTH:-256}"
 LAST_SUCCESS_FILE="${VH_NEWS_DAEMON_LAST_SUCCESS_FILE:-${VH_NEWS_DAEMON_STATE_DIR}/last-success.json}"
+export VH_NEWS_DAEMON_LAST_SUCCESS_FILE="${LAST_SUCCESS_FILE}"
+export VH_NEWS_DAEMON_PREFLIGHT_ARTIFACT="${VH_NEWS_DAEMON_PREFLIGHT_ARTIFACT:-${VH_NEWS_DAEMON_STATE_DIR}/recovery/preflight.json}"
 OPENAI_PREFLIGHT_TIMEOUT_MS="${VH_NEWS_PUBLISHER_OPENAI_PREFLIGHT_TIMEOUT_MS:-120000}"
 
 mkdir -p "${VH_NEWS_DAEMON_STATE_DIR}" "${VH_DAEMON_FEED_ARTIFACT_ROOT}" "$(dirname "${LAST_SUCCESS_FILE}")"
@@ -218,39 +272,17 @@ NODE
 echo "[vh:news-daemon:prod] raw publication readiness preflight starting"
 node "${REPO_ROOT}/tools/scripts/news-aggregator-publisher-preflight.mjs"
 
-LAST_SUCCESS_FILE="${LAST_SUCCESS_FILE}" node --input-type=module <<'NODE'
-import { mkdir, writeFile } from 'node:fs/promises';
-import path from 'node:path';
+if [[ "${PREFLIGHT_ONLY}" == "true" ]]; then
+  node "${REPO_ROOT}/tools/scripts/write-news-aggregator-production-start-artifact.mjs" --mode preflight
+  echo "[vh:news-daemon:prod] exact-revision preflight artifact written; publisher remains parked"
+  exit 0
+fi
 
-const filePath = process.env.LAST_SUCCESS_FILE;
-const currentRunFilePath = process.env.VH_NEWS_DAEMON_CURRENT_RUN_FILE;
-const generatedAt = new Date().toISOString();
-const currentRun = {
-  schemaVersion: 'vh-news-daemon-current-run-v1',
-  generatedAt,
-  status: 'preflight_passed',
-  runId: process.env.VH_DAEMON_FEED_RUN_ID,
-  stateDir: process.env.VH_NEWS_DAEMON_STATE_DIR,
-  artifactRoot: process.env.VH_DAEMON_FEED_ARTIFACT_ROOT,
-  queueDir: process.env.VH_BUNDLE_SYNTHESIS_QUEUE_DIR,
-  lifecycleLedger: process.env.VH_BUNDLE_SYNTHESIS_LIFECYCLE_LEDGER,
-};
-await mkdir(path.dirname(filePath), { recursive: true });
-await writeFile(filePath, `${JSON.stringify({
-  schemaVersion: 'vh-news-daemon-production-start-v1',
-  generatedAt,
-  status: 'preflight_passed',
-  runId: process.env.VH_DAEMON_FEED_RUN_ID,
-  stateDir: process.env.VH_NEWS_DAEMON_STATE_DIR,
-  artifactRoot: process.env.VH_DAEMON_FEED_ARTIFACT_ROOT,
-  queueDir: process.env.VH_BUNDLE_SYNTHESIS_QUEUE_DIR,
-  lifecycleLedger: process.env.VH_BUNDLE_SYNTHESIS_LIFECYCLE_LEDGER,
-}, null, 2)}\n`, 'utf8');
-if (currentRunFilePath) {
-  await mkdir(path.dirname(currentRunFilePath), { recursive: true });
-  await writeFile(currentRunFilePath, `${JSON.stringify(currentRun, null, 2)}\n`, 'utf8');
-}
-NODE
+if [[ "${NO_WRITE_DIAGNOSTIC}" == "true" ]]; then
+  node "${REPO_ROOT}/tools/scripts/write-news-aggregator-production-start-artifact.mjs" --mode diagnostic
+else
+  node "${REPO_ROOT}/tools/scripts/write-news-aggregator-production-start-artifact.mjs" --mode start
+fi
 
 echo "[vh:news-daemon:prod] preflights passed; starting canonical @vh/news-aggregator daemon"
 if [[ "${NO_WRITE_DIAGNOSTIC}" == "true" ]]; then

--- a/tools/scripts/start-news-aggregator-daemon-production.sh
+++ b/tools/scripts/start-news-aggregator-daemon-production.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
+umask 077
 
 REPO_ROOT="${VHC_REPO:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
 COMMON_SH="${REPO_ROOT}/tools/scripts/lib/news-aggregator-publisher-recovery-common.sh"
@@ -7,11 +8,11 @@ ENV_FILE="${VH_NEWS_DAEMON_ENV_FILE:-${HOME}/.config/vhc/news-aggregator.env}"
 STATE_DIR="${VH_NEWS_DAEMON_STATE_DIR:-${HOME}/.local/state/vhc/news-aggregator}"
 ARTIFACT_ROOT="${VH_DAEMON_FEED_ARTIFACT_ROOT:-${STATE_DIR}/artifacts}"
 EXPECTED_REVISION_FROM_EXECSTART="${VH_NEWS_DAEMON_EXPECTED_REVISION:-}"
-ATTENDED_APPROVAL_FROM_MANAGER="${VH_NEWS_DAEMON_ATTENDED_START_APPROVED:-}"
 PREFLIGHT_ONLY_FROM_CALLER="${VH_NEWS_DAEMON_PREFLIGHT_ONLY:-}"
 PREFLIGHT_APPROVAL_FROM_CALLER="${VH_NEWS_DAEMON_PREFLIGHT_APPROVED:-}"
 RESTART_AUTHORITY_FROM_UNIT="${VH_NEWS_DAEMON_RESTART_AUTHORITY_FILE:-${HOME}/.local/state/vhc/news-aggregator/recovery/automatic-restart-authority.json}"
 RESTART_PERMIT_FROM_UNIT="${VH_NEWS_DAEMON_RESTART_PERMIT_FILE:-${HOME}/.local/state/vhc/news-aggregator/recovery/automatic-restart-permit.json}"
+ATTENDED_PERMIT_FROM_UNIT="${VH_NEWS_DAEMON_ATTENDED_START_PERMIT_FILE:-${HOME}/.local/state/vhc/news-aggregator/recovery/attended-start-permit.json}"
 SYSTEMD_UNIT_FROM_UNIT="${VH_NEWS_DAEMON_SYSTEMD_UNIT:-vh-news-aggregator.service}"
 
 if [[ ! -r "${COMMON_SH}" ]]; then
@@ -37,12 +38,13 @@ set +a
 # Control authority is intentionally captured before the persistent host env is
 # sourced. A value parked in news-aggregator.env cannot authorize live writes.
 export VH_NEWS_DAEMON_EXPECTED_REVISION="${EXPECTED_REVISION_FROM_EXECSTART}"
-export VH_NEWS_DAEMON_ATTENDED_START_APPROVED="${ATTENDED_APPROVAL_FROM_MANAGER}"
 export VH_NEWS_DAEMON_PREFLIGHT_ONLY="${PREFLIGHT_ONLY_FROM_CALLER}"
 export VH_NEWS_DAEMON_PREFLIGHT_APPROVED="${PREFLIGHT_APPROVAL_FROM_CALLER}"
 export VH_NEWS_DAEMON_RESTART_AUTHORITY_FILE="${RESTART_AUTHORITY_FROM_UNIT}"
 export VH_NEWS_DAEMON_RESTART_PERMIT_FILE="${RESTART_PERMIT_FROM_UNIT}"
+export VH_NEWS_DAEMON_ATTENDED_START_PERMIT_FILE="${ATTENDED_PERMIT_FROM_UNIT}"
 export VH_NEWS_DAEMON_SYSTEMD_UNIT="${SYSTEMD_UNIT_FROM_UNIT}"
+unset VH_NEWS_DAEMON_ATTENDED_START_APPROVED VH_NEWS_DAEMON_START_APPROVED
 
 truthy_flag() {
   case "${1:-}" in
@@ -142,20 +144,56 @@ elif [[ "${NO_WRITE_DIAGNOSTIC}" == "true" ]]; then
     exit 78
   fi
   DIAGNOSTIC_TIMEOUT_BIN="${VH_NEWS_DAEMON_DIAGNOSTIC_TIMEOUT_BIN:-timeout}"
-elif [[ "${VH_NEWS_DAEMON_ATTENDED_START_APPROVED:-}" != "1"
-  || -e "${VH_NEWS_DAEMON_RESTART_PERMIT_FILE}" || -L "${VH_NEWS_DAEMON_RESTART_PERMIT_FILE}" ]]; then
+else
+  # Manager-environment flags were the legacy attended-start mechanism. They
+  # are never authority now, and every live invocation clears them before
+  # consuming exactly one private file permit.
+  if ! systemctl --user unset-environment \
+    VH_NEWS_DAEMON_ATTENDED_START_APPROVED \
+    VH_NEWS_DAEMON_START_APPROVED >/dev/null 2>&1; then
+    echo "[vh:news-daemon:prod] refusing live start because legacy manager approval could not be cleared" >&2
+    exit 78
+  fi
+  if ! manager_environment="$(systemctl --user show-environment 2>/dev/null)"; then
+    echo "[vh:news-daemon:prod] refusing live start because legacy manager approval state is unavailable" >&2
+    exit 78
+  fi
+  if grep -Eq '^(VH_NEWS_DAEMON_ATTENDED_START_APPROVED|VH_NEWS_DAEMON_START_APPROVED)=' \
+    <<<"${manager_environment}"; then
+    echo "[vh:news-daemon:prod] refusing live start because legacy manager approval remained set" >&2
+    exit 78
+  fi
   current_nrestarts="$(systemctl --user show "${VH_NEWS_DAEMON_SYSTEMD_UNIT}" --property=NRestarts --value 2>/dev/null || true)"
-  if [[ ! "${current_nrestarts}" =~ ^[0-9]+$ ]] || ! node \
-    "${REPO_ROOT}/tools/scripts/news-aggregator-publisher-automatic-restart-authority.mjs" consume \
-    --expected-revision "${VH_NEWS_DAEMON_EXPECTED_REVISION}" \
-    --authority-file "${VH_NEWS_DAEMON_RESTART_AUTHORITY_FILE}" \
-    --permit-file "${VH_NEWS_DAEMON_RESTART_PERMIT_FILE}" \
-    --current-nrestarts "${current_nrestarts:-invalid}" \
-    --max-age-ms 120000 >/dev/null 2>&1; then
+  attended_present=false
+  automatic_present=false
+  [[ -e "${VH_NEWS_DAEMON_ATTENDED_START_PERMIT_FILE}" || -L "${VH_NEWS_DAEMON_ATTENDED_START_PERMIT_FILE}" ]] \
+    && attended_present=true
+  [[ -e "${VH_NEWS_DAEMON_RESTART_PERMIT_FILE}" || -L "${VH_NEWS_DAEMON_RESTART_PERMIT_FILE}" ]] \
+    && automatic_present=true
+  if [[ ! "${current_nrestarts}" =~ ^[0-9]+$ || "${attended_present}" == "${automatic_present}" ]]; then
     echo "[vh:news-daemon:prod] refusing live start without attended or verified automatic-restart authority" >&2
     exit 78
   fi
-  echo "[vh:news-daemon:prod] verified single-use automatic restart after exit 69"
+  if [[ "${attended_present}" == "true" ]]; then
+    if ! node "${REPO_ROOT}/tools/scripts/news-aggregator-publisher-automatic-restart-authority.mjs" consume-attended \
+      --expected-revision "${VH_NEWS_DAEMON_EXPECTED_REVISION}" \
+      --attended-permit-file "${VH_NEWS_DAEMON_ATTENDED_START_PERMIT_FILE}" \
+      --current-nrestarts "${current_nrestarts}" >/dev/null 2>&1; then
+      echo "[vh:news-daemon:prod] refusing live start without attended or verified automatic-restart authority" >&2
+      exit 78
+    fi
+    echo "[vh:news-daemon:prod] verified private single-use attended start permit"
+  elif ! node "${REPO_ROOT}/tools/scripts/news-aggregator-publisher-automatic-restart-authority.mjs" consume \
+    --expected-revision "${VH_NEWS_DAEMON_EXPECTED_REVISION}" \
+    --authority-file "${VH_NEWS_DAEMON_RESTART_AUTHORITY_FILE}" \
+    --permit-file "${VH_NEWS_DAEMON_RESTART_PERMIT_FILE}" \
+    --current-nrestarts "${current_nrestarts}" \
+    --max-age-ms 120000 >/dev/null 2>&1; then
+    echo "[vh:news-daemon:prod] refusing live start without attended or verified automatic-restart authority" >&2
+    exit 78
+  else
+    echo "[vh:news-daemon:prod] verified single-use automatic restart after exit 69"
+  fi
 fi
 
 require_no_news_daemon_siblings "start"

--- a/tools/scripts/start-news-aggregator-daemon-production.test.mjs
+++ b/tools/scripts/start-news-aggregator-daemon-production.test.mjs
@@ -6,20 +6,31 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  realpathSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
+import {
+  armRestartAuthority,
+  recordRestartableExit,
+} from './news-aggregator-publisher-automatic-restart-authority.mjs';
 
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(SCRIPT_DIR, '../..');
 const SCRIPT_PATH = path.join(REPO_ROOT, 'tools/scripts/start-news-aggregator-daemon-production.sh');
+const ARTIFACT_SCRIPT_PATH = path.join(REPO_ROOT, 'tools/scripts/write-news-aggregator-production-start-artifact.mjs');
+const EXPECTED_REVISION = '1883841555c4924be8d35747272c38ce8f2071d9';
 
 function makeHarness({
   approved,
+  persistentApproval = false,
+  preflightOnly = false,
+  preflightApproved = false,
   noWriteDiagnostic = false,
   diagnosticApproved = false,
   extraEnv = [],
@@ -31,7 +42,7 @@ function makeHarness({
   timeoutStatus = null,
   stubSleep = false,
 }) {
-  const root = mkdtempSync(path.join(os.tmpdir(), 'vh-news-daemon-start-'));
+  const root = realpathSync(mkdtempSync(path.join(os.tmpdir(), 'vh-news-daemon-start-')));
   const binDir = path.join(root, 'bin');
   const envFile = path.join(root, 'news-aggregator.env');
   const pnpmMarker = path.join(root, 'pnpm-called.txt');
@@ -41,7 +52,32 @@ function makeHarness({
   const sleepMarker = path.join(root, 'sleep-called.txt');
   const psOutputDir = path.join(root, 'ps-outputs');
   const psIndexFile = path.join(root, 'ps-index.txt');
+  const restartAuthorityFile = path.join(root, 'state/recovery/automatic-restart-authority.json');
+  const restartPermitFile = path.join(root, 'state/recovery/automatic-restart-permit.json');
   mkdirSync(binDir, { recursive: true });
+  writeFileSync(
+    path.join(binDir, 'git'),
+    [
+      '#!/usr/bin/env bash',
+      'if [[ "$*" == *"rev-parse --verify HEAD"* ]]; then printf "%s\\n" "${VH_TEST_EXPECTED_REVISION:?}"; exit 0; fi',
+      'if [[ "$*" == *"status --porcelain=v1 --untracked-files=no"* ]]; then exit 0; fi',
+      'exit 1',
+      '',
+    ].join('\n'),
+    'utf8',
+  );
+  chmodSync(path.join(binDir, 'git'), 0o755);
+  writeFileSync(
+    path.join(binDir, 'systemctl'),
+    [
+      '#!/usr/bin/env bash',
+      'if [[ "$*" == *"--property=NRestarts --value"* ]]; then printf "%s\\n" "${VH_TEST_SYSTEMD_NRESTARTS:-0}"; exit 0; fi',
+      'exit 1',
+      '',
+    ].join('\n'),
+    'utf8',
+  );
+  chmodSync(path.join(binDir, 'systemctl'), 0o755);
   writeFileSync(pnpmStatusFile, pnpmStatuses.join('\n') + '\n', 'utf8');
   writeFileSync(
     path.join(binDir, 'pnpm'),
@@ -141,7 +177,7 @@ function makeHarness({
   writeFileSync(
     envFile,
     [
-      approved ? 'VH_NEWS_DAEMON_START_APPROVED=1' : 'VH_NEWS_DAEMON_HOLDER_ID=test-unapproved',
+      persistentApproval ? 'VH_NEWS_DAEMON_START_APPROVED=1' : 'VH_NEWS_DAEMON_HOLDER_ID=test-unapproved',
       noWriteDiagnostic ? 'VH_NEWS_DAEMON_DIAGNOSTIC_NO_WRITE=1' : null,
       diagnosticApproved ? 'VH_NEWS_DAEMON_DIAGNOSTIC_APPROVED=1' : null,
       `VH_NEWS_DAEMON_STATE_DIR=${path.join(root, 'state')}`,
@@ -154,6 +190,9 @@ function makeHarness({
 
   return {
     root,
+    approved,
+    preflightOnly,
+    preflightApproved,
     binDir,
     envFile,
     pnpmMarker,
@@ -165,6 +204,9 @@ function makeHarness({
     sleepMarker,
     psOutputDir: psSequence !== null ? psOutputDir : null,
     psIndexFile: psSequence !== null ? psIndexFile : null,
+    restartAuthorityFile,
+    restartPermitFile,
+    systemdNRestarts: 0,
   };
 }
 
@@ -178,6 +220,15 @@ function runStartScript(harness) {
     PATH: `${harness.binDir}${path.delimiter}${process.env.PATH ?? ''}`,
     VHC_REPO: REPO_ROOT,
     VH_NEWS_DAEMON_ENV_FILE: harness.envFile,
+    VH_NEWS_DAEMON_EXPECTED_REVISION: EXPECTED_REVISION,
+    VH_NEWS_DAEMON_ATTENDED_START_APPROVED: harness.approved ? '1' : '',
+    VH_NEWS_DAEMON_PREFLIGHT_ONLY: harness.preflightOnly ? '1' : '',
+    VH_NEWS_DAEMON_PREFLIGHT_APPROVED: harness.preflightApproved ? '1' : '',
+    VH_NEWS_DAEMON_RESTART_AUTHORITY_FILE: harness.restartAuthorityFile,
+    VH_NEWS_DAEMON_RESTART_PERMIT_FILE: harness.restartPermitFile,
+    VH_NEWS_DAEMON_SYSTEMD_UNIT: 'vh-news-aggregator.service',
+    VH_TEST_SYSTEMD_NRESTARTS: String(harness.systemdNRestarts),
+    VH_TEST_EXPECTED_REVISION: EXPECTED_REVISION,
     VH_TEST_PNPM_MARKER: harness.pnpmMarker,
     VH_TEST_PNPM_STATUS_FILE: harness.pnpmStatusFile,
     VH_TEST_NODE_MARKER: harness.nodeMarker,
@@ -197,13 +248,71 @@ function runStartScript(harness) {
   });
 }
 
-test('production daemon start requires persistent approval before any preflight runs', () => {
+test('production daemon start requires one-shot manager approval before any preflight runs', () => {
   const harness = makeHarness({ approved: false });
   try {
     const result = runStartScript(harness);
     assert.equal(result.status, 78);
-    assert.match(result.stderr, /refusing to start without VH_NEWS_DAEMON_START_APPROVED=1/);
+    assert.match(result.stderr, /refusing live start without attended or verified automatic-restart authority/);
     assert.equal(existsSync(harness.pnpmMarker), false);
+  } finally {
+    rmSync(harness.root, { recursive: true, force: true });
+  }
+});
+
+test('exit69 automatic restart consumes exact prior+1 permit once, while a later manual fresh start refuses', async () => {
+  const harness = makeHarness({ approved: false });
+  harness.systemdNRestarts = 1;
+  try {
+    await armRestartAuthority({
+      authorityFile: harness.restartAuthorityFile,
+      permitFile: harness.restartPermitFile,
+      expectedRevision: EXPECTED_REVISION,
+      baselineNRestarts: 0,
+    });
+    await recordRestartableExit({
+      authorityFile: harness.restartAuthorityFile,
+      permitFile: harness.restartPermitFile,
+      expectedRevision: EXPECTED_REVISION,
+      serviceResult: 'exit-code',
+      exitCode: 'exited',
+      exitStatus: '69',
+      previousNRestarts: 0,
+    });
+
+    const automatic = runStartScript(harness);
+    assert.equal(automatic.status, 99);
+    assert.match(automatic.stdout, /verified single-use automatic restart after exit 69/);
+    assert.equal(existsSync(harness.restartPermitFile), false);
+
+    const manual = runStartScript(harness);
+    assert.equal(manual.status, 78);
+    assert.match(manual.stderr, /refusing live start without attended or verified automatic-restart authority/);
+  } finally {
+    rmSync(harness.root, { recursive: true, force: true });
+  }
+});
+
+test('an automatic restart during the attended window must consume its exit69 permit', async () => {
+  const harness = makeHarness({ approved: true });
+  harness.systemdNRestarts = 1;
+  try {
+    await armRestartAuthority({
+      authorityFile: harness.restartAuthorityFile,
+      permitFile: harness.restartPermitFile,
+      expectedRevision: EXPECTED_REVISION,
+      baselineNRestarts: 0,
+    });
+    await recordRestartableExit({
+      authorityFile: harness.restartAuthorityFile,
+      permitFile: harness.restartPermitFile,
+      expectedRevision: EXPECTED_REVISION,
+      serviceResult: 'exit-code', exitCode: 'exited', exitStatus: '69', previousNRestarts: 0,
+    });
+    const result = runStartScript(harness);
+    assert.equal(result.status, 99);
+    assert.match(result.stdout, /verified single-use automatic restart after exit 69/);
+    assert.equal(existsSync(harness.restartPermitFile), false);
   } finally {
     rmSync(harness.root, { recursive: true, force: true });
   }
@@ -384,13 +493,13 @@ test('live production daemon start still execs pnpm directly without timeout wra
   }
 });
 
-test('production daemon start proceeds to preflights when env file contains approval', () => {
-  const harness = makeHarness({ approved: true });
+test('persistent env-file approval cannot authorize production writes', () => {
+  const harness = makeHarness({ approved: false, persistentApproval: true });
   try {
     const result = runStartScript(harness);
-    assert.equal(result.status, 99);
-    assert.match(result.stdout, /source-health liveness preflight starting/);
-    assert.equal(readPnpmMarker(harness.pnpmMarker)[0], 'args=check:news-sources:liveness');
+    assert.equal(result.status, 78);
+    assert.match(result.stderr, /refusing live start without attended or verified automatic-restart authority/);
+    assert.equal(existsSync(harness.pnpmMarker), false);
   } finally {
     rmSync(harness.root, { recursive: true, force: true });
   }
@@ -422,10 +531,49 @@ test('production daemon start applies bounded clustering defaults before preflig
 
 test('production daemon start records a per-start run id for liveness correlation', () => {
   const source = readFileSync(SCRIPT_PATH, 'utf8');
+  const artifactSource = readFileSync(ARTIFACT_SCRIPT_PATH, 'utf8');
   assert.match(source, /export VH_DAEMON_FEED_RUN_ID="\$\{VH_DAEMON_FEED_RUN_ID:-\$\(date -u \+%Y%m%dT%H%M%SZ\)-\$\$\}"/);
   assert.match(source, /export VH_NEWS_DAEMON_CURRENT_RUN_FILE="\$\{VH_NEWS_DAEMON_CURRENT_RUN_FILE:-\$\{VH_NEWS_DAEMON_STATE_DIR\}\/current-run\.json\}"/);
-  assert.match(source, /vh-news-daemon-current-run-v1/);
-  assert.match(source, /runId: process\.env\.VH_DAEMON_FEED_RUN_ID/);
+  assert.match(artifactSource, /vh-news-daemon-current-run-v1/);
+  assert.match(artifactSource, /revision/);
+  assert.match(artifactSource, /runId/);
+});
+
+test('production start artifact helper is path-safe, private, closed-error, and no-clobber for preflight evidence', () => {
+  const root = realpathSync(mkdtempSync(path.join(os.tmpdir(), 'vh-start-artifact-')));
+  try {
+    const output = path.join(root, 'preflight.json');
+    writeFileSync(output, 'preserve-secret-prior-evidence\n', { mode: 0o600 });
+    const baseEnv = {
+      ...process.env,
+      VH_NEWS_DAEMON_EXPECTED_REVISION: EXPECTED_REVISION,
+      VH_DAEMON_FEED_RUN_ID: 'preflight-safe-run',
+      VH_NEWS_DAEMON_PREFLIGHT_ARTIFACT: output,
+    };
+    const noClobber = spawnSync(process.execPath, [ARTIFACT_SCRIPT_PATH, '--mode', 'preflight'], {
+      encoding: 'utf8', env: baseEnv,
+    });
+    assert.equal(noClobber.status, 78);
+    assert.equal(readFileSync(output, 'utf8'), 'preserve-secret-prior-evidence\n');
+    assert.equal(noClobber.stderr.includes('preserve-secret-prior-evidence'), false);
+    assert.match(noClobber.stderr, /preflight_artifact_write_failed/);
+
+    rmSync(output);
+    const success = spawnSync(process.execPath, [ARTIFACT_SCRIPT_PATH, '--mode', 'preflight'], {
+      encoding: 'utf8', env: baseEnv,
+    });
+    assert.equal(success.status, 0, success.stderr);
+    assert.equal(statSync(output).mode & 0o777, 0o600);
+    assert.equal(JSON.parse(readFileSync(output, 'utf8')).runId, 'preflight-safe-run');
+
+    const unsafe = spawnSync(process.execPath, [ARTIFACT_SCRIPT_PATH, '--mode', 'preflight'], {
+      encoding: 'utf8', env: { ...baseEnv, VH_DAEMON_FEED_RUN_ID: '../escape' },
+    });
+    assert.equal(unsafe.status, 78);
+    assert.match(unsafe.stderr, /artifact run id is missing/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });
 
 test('production daemon start preserves explicit clustering budget overrides', () => {

--- a/tools/scripts/start-news-aggregator-daemon-production.test.mjs
+++ b/tools/scripts/start-news-aggregator-daemon-production.test.mjs
@@ -9,6 +9,7 @@ import {
   realpathSync,
   rmSync,
   statSync,
+  symlinkSync,
   writeFileSync,
 } from 'node:fs';
 import os from 'node:os';
@@ -24,6 +25,7 @@ const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(SCRIPT_DIR, '../..');
 const SCRIPT_PATH = path.join(REPO_ROOT, 'tools/scripts/start-news-aggregator-daemon-production.sh');
 const ARTIFACT_SCRIPT_PATH = path.join(REPO_ROOT, 'tools/scripts/write-news-aggregator-production-start-artifact.mjs');
+const AUTHORITY_SCRIPT_PATH = path.join(REPO_ROOT, 'tools/scripts/news-aggregator-publisher-automatic-restart-authority.mjs');
 const EXPECTED_REVISION = '1883841555c4924be8d35747272c38ce8f2071d9';
 
 function makeHarness({
@@ -54,6 +56,8 @@ function makeHarness({
   const psIndexFile = path.join(root, 'ps-index.txt');
   const restartAuthorityFile = path.join(root, 'state/recovery/automatic-restart-authority.json');
   const restartPermitFile = path.join(root, 'state/recovery/automatic-restart-permit.json');
+  const attendedPermitFile = path.join(root, 'state/recovery/attended-start-permit.json');
+  const managerApprovalFile = path.join(root, 'manager-approval');
   mkdirSync(binDir, { recursive: true });
   writeFileSync(
     path.join(binDir, 'git'),
@@ -71,6 +75,12 @@ function makeHarness({
     path.join(binDir, 'systemctl'),
     [
       '#!/usr/bin/env bash',
+      '[[ "$1" == "--user" ]] && shift',
+      'if [[ "$1" == "unset-environment" ]]; then rm -f "${VH_TEST_MANAGER_APPROVAL_FILE:?}"; exit 0; fi',
+      'if [[ "$1" == "show-environment" ]]; then',
+      '  if [[ -f "${VH_TEST_MANAGER_APPROVAL_FILE:?}" ]]; then printf "VH_NEWS_DAEMON_ATTENDED_START_APPROVED=1\\n"; fi',
+      '  exit 0',
+      'fi',
       'if [[ "$*" == *"--property=NRestarts --value"* ]]; then printf "%s\\n" "${VH_TEST_SYSTEMD_NRESTARTS:-0}"; exit 0; fi',
       'exit 1',
       '',
@@ -115,6 +125,7 @@ function makeHarness({
       path.join(binDir, 'node'),
       [
         '#!/usr/bin/env bash',
+        'if [[ "${1:-}" == *"news-aggregator-publisher-automatic-restart-authority.mjs" ]]; then exec "${VH_TEST_REAL_NODE:?}" "$@"; fi',
         'printf "node_args=%s\\n" "$*" >> "${VH_TEST_NODE_MARKER:?}"',
         'exit "${VH_TEST_NODE_STATUS:?}"',
         '',
@@ -188,6 +199,29 @@ function makeHarness({
     'utf8',
   );
 
+  if (approved) {
+    const evidenceBindings = JSON.stringify({
+      preflightSha256: '1'.repeat(64),
+      relayEvidenceSha256: '2'.repeat(64),
+      relayPacketSha256: '3'.repeat(64),
+      relayCaptureSha256: '4'.repeat(64),
+      mailboxSha256: '5'.repeat(64),
+      mailboxCriticalCount: 2,
+    });
+    const issued = spawnSync(process.execPath, [
+      AUTHORITY_SCRIPT_PATH,
+      'issue-attended',
+      '--expected-revision', EXPECTED_REVISION,
+      '--attended-permit-file', attendedPermitFile,
+      '--baseline-nrestarts', '0',
+      '--start-control-output', path.join(root, 'start-control.json'),
+      '--evidence-bindings-json', evidenceBindings,
+      '--controller-pid', String(process.pid),
+      '--max-age-ms', '120000',
+    ], { encoding: 'utf8' });
+    assert.equal(issued.status, 0, issued.stderr);
+  }
+
   return {
     root,
     approved,
@@ -206,6 +240,8 @@ function makeHarness({
     psIndexFile: psSequence !== null ? psIndexFile : null,
     restartAuthorityFile,
     restartPermitFile,
+    attendedPermitFile,
+    managerApprovalFile,
     systemdNRestarts: 0,
   };
 }
@@ -221,13 +257,16 @@ function runStartScript(harness) {
     VHC_REPO: REPO_ROOT,
     VH_NEWS_DAEMON_ENV_FILE: harness.envFile,
     VH_NEWS_DAEMON_EXPECTED_REVISION: EXPECTED_REVISION,
-    VH_NEWS_DAEMON_ATTENDED_START_APPROVED: harness.approved ? '1' : '',
+    VH_NEWS_DAEMON_ATTENDED_START_APPROVED: '',
     VH_NEWS_DAEMON_PREFLIGHT_ONLY: harness.preflightOnly ? '1' : '',
     VH_NEWS_DAEMON_PREFLIGHT_APPROVED: harness.preflightApproved ? '1' : '',
     VH_NEWS_DAEMON_RESTART_AUTHORITY_FILE: harness.restartAuthorityFile,
     VH_NEWS_DAEMON_RESTART_PERMIT_FILE: harness.restartPermitFile,
+    VH_NEWS_DAEMON_ATTENDED_START_PERMIT_FILE: harness.attendedPermitFile,
     VH_NEWS_DAEMON_SYSTEMD_UNIT: 'vh-news-aggregator.service',
     VH_TEST_SYSTEMD_NRESTARTS: String(harness.systemdNRestarts),
+    VH_TEST_MANAGER_APPROVAL_FILE: harness.managerApprovalFile,
+    VH_TEST_REAL_NODE: process.execPath,
     VH_TEST_EXPECTED_REVISION: EXPECTED_REVISION,
     VH_TEST_PNPM_MARKER: harness.pnpmMarker,
     VH_TEST_PNPM_STATUS_FILE: harness.pnpmStatusFile,
@@ -248,12 +287,26 @@ function runStartScript(harness) {
   });
 }
 
-test('production daemon start requires one-shot manager approval before any preflight runs', () => {
+test('production daemon start requires a private single-use permit before any preflight runs', () => {
   const harness = makeHarness({ approved: false });
   try {
     const result = runStartScript(harness);
     assert.equal(result.status, 78);
     assert.match(result.stderr, /refusing live start without attended or verified automatic-restart authority/);
+    assert.equal(existsSync(harness.pnpmMarker), false);
+  } finally {
+    rmSync(harness.root, { recursive: true, force: true });
+  }
+});
+
+test('setting the legacy systemd manager approval cannot forge attended authority', () => {
+  const harness = makeHarness({ approved: false });
+  try {
+    writeFileSync(harness.managerApprovalFile, '1\n');
+    const result = runStartScript(harness);
+    assert.equal(result.status, 78);
+    assert.match(result.stderr, /refusing live start without attended or verified automatic-restart authority/);
+    assert.equal(existsSync(harness.managerApprovalFile), false);
     assert.equal(existsSync(harness.pnpmMarker), false);
   } finally {
     rmSync(harness.root, { recursive: true, force: true });
@@ -293,7 +346,7 @@ test('exit69 automatic restart consumes exact prior+1 permit once, while a later
   }
 });
 
-test('an automatic restart during the attended window must consume its exit69 permit', async () => {
+test('ambiguous attended and automatic permits fail closed before either can authorize', async () => {
   const harness = makeHarness({ approved: true });
   harness.systemdNRestarts = 1;
   try {
@@ -310,9 +363,10 @@ test('an automatic restart during the attended window must consume its exit69 pe
       serviceResult: 'exit-code', exitCode: 'exited', exitStatus: '69', previousNRestarts: 0,
     });
     const result = runStartScript(harness);
-    assert.equal(result.status, 99);
-    assert.match(result.stdout, /verified single-use automatic restart after exit 69/);
-    assert.equal(existsSync(harness.restartPermitFile), false);
+    assert.equal(result.status, 78);
+    assert.match(result.stderr, /refusing live start without attended or verified automatic-restart authority/);
+    assert.equal(existsSync(harness.restartPermitFile), true);
+    assert.equal(existsSync(harness.attendedPermitFile), true);
   } finally {
     rmSync(harness.root, { recursive: true, force: true });
   }
@@ -571,6 +625,30 @@ test('production start artifact helper is path-safe, private, closed-error, and 
     });
     assert.equal(unsafe.status, 78);
     assert.match(unsafe.stderr, /artifact run id is missing/);
+
+    const weakParent = path.join(root, 'weak-parent');
+    mkdirSync(weakParent, { mode: 0o755 });
+    const weakOutput = path.join(weakParent, 'preflight.json');
+    const weak = spawnSync(process.execPath, [ARTIFACT_SCRIPT_PATH, '--mode', 'preflight'], {
+      encoding: 'utf8',
+      env: { ...baseEnv, VH_NEWS_DAEMON_PREFLIGHT_ARTIFACT: weakOutput },
+    });
+    assert.equal(weak.status, 78);
+    assert.match(weak.stderr, /preflight_artifact_write_failed/);
+    assert.equal(existsSync(weakOutput), false);
+
+    const privateParent = path.join(root, 'private-parent');
+    const symlinkParent = path.join(root, 'symlink-parent');
+    mkdirSync(privateParent, { mode: 0o700 });
+    symlinkSync(privateParent, symlinkParent);
+    const symlinkOutput = path.join(symlinkParent, 'preflight.json');
+    const linked = spawnSync(process.execPath, [ARTIFACT_SCRIPT_PATH, '--mode', 'preflight'], {
+      encoding: 'utf8',
+      env: { ...baseEnv, VH_NEWS_DAEMON_PREFLIGHT_ARTIFACT: symlinkOutput },
+    });
+    assert.equal(linked.status, 78);
+    assert.match(linked.stderr, /preflight_artifact_write_failed/);
+    assert.equal(existsSync(path.join(privateParent, 'preflight.json')), false);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/tools/scripts/start-news-aggregator-daemon-production.test.mjs
+++ b/tools/scripts/start-news-aggregator-daemon-production.test.mjs
@@ -20,6 +20,7 @@ import {
   armRestartAuthority,
   recordRestartableExit,
 } from './news-aggregator-publisher-automatic-restart-authority.mjs';
+import { canonicalSystemWriterPinSha256 } from './verify-news-aggregator-publisher-recovery.mjs';
 
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(SCRIPT_DIR, '../..');
@@ -27,6 +28,17 @@ const SCRIPT_PATH = path.join(REPO_ROOT, 'tools/scripts/start-news-aggregator-da
 const ARTIFACT_SCRIPT_PATH = path.join(REPO_ROOT, 'tools/scripts/write-news-aggregator-production-start-artifact.mjs');
 const AUTHORITY_SCRIPT_PATH = path.join(REPO_ROOT, 'tools/scripts/news-aggregator-publisher-automatic-restart-authority.mjs');
 const EXPECTED_REVISION = '1883841555c4924be8d35747272c38ce8f2071d9';
+const SYSTEM_WRITER_PUBLIC_KEY = 'MCowBQYDK2VwAyEA4ZHLho6yDOsGogTtrVUWiTRIGYlxKexsprzKjbuy9js';
+const SYSTEM_WRITER_PIN_SHA256 = canonicalSystemWriterPinSha256({
+  pinVersion: 1,
+  schemaEpoch: 'luma-public-v1',
+  maxProtocolVersion: 'luma-public-v1',
+  signatureSuite: 'jcs-ed25519-sha256-v1',
+  writers: [{
+    id: 'test-writer', status: 'active',
+    publicKey: { encoding: 'spki-base64url', material: SYSTEM_WRITER_PUBLIC_KEY },
+  }],
+});
 
 function makeHarness({
   approved,
@@ -57,6 +69,7 @@ function makeHarness({
   const restartAuthorityFile = path.join(root, 'state/recovery/automatic-restart-authority.json');
   const restartPermitFile = path.join(root, 'state/recovery/automatic-restart-permit.json');
   const attendedPermitFile = path.join(root, 'state/recovery/attended-start-permit.json');
+  const attendedReceiptFile = path.join(root, 'state/recovery/attended-start-consumption-receipt.json');
   const managerApprovalFile = path.join(root, 'manager-approval');
   mkdirSync(binDir, { recursive: true });
   writeFileSync(
@@ -126,6 +139,8 @@ function makeHarness({
       [
         '#!/usr/bin/env bash',
         'if [[ "${1:-}" == *"news-aggregator-publisher-automatic-restart-authority.mjs" ]]; then exec "${VH_TEST_REAL_NODE:?}" "$@"; fi',
+        'if [[ "${1:-}" == *"verify-news-aggregator-publisher-recovery.mjs" && "${2:-}" == "pin-sha256" ]]; then exec "${VH_TEST_REAL_NODE:?}" "$@"; fi',
+        'if [[ "${1:-}" == "-e" ]]; then exec "${VH_TEST_REAL_NODE:?}" "$@"; fi',
         'printf "node_args=%s\\n" "$*" >> "${VH_TEST_NODE_MARKER:?}"',
         'exit "${VH_TEST_NODE_STATUS:?}"',
         '',
@@ -194,6 +209,8 @@ function makeHarness({
       `VH_NEWS_DAEMON_STATE_DIR=${path.join(root, 'state')}`,
       `VH_DAEMON_FEED_ARTIFACT_ROOT=${path.join(root, 'artifacts')}`,
       `VH_NEWS_DAEMON_LAST_SUCCESS_FILE=${path.join(root, 'state/last-success.json')}`,
+      'VH_NEWS_SYSTEM_WRITER_ID=test-writer',
+      `VH_NEWS_SYSTEM_WRITER_PUBLIC_KEY_SPKI_BASE64URL=${SYSTEM_WRITER_PUBLIC_KEY}`,
       ...extraEnv,
     ].filter(Boolean).join('\n') + '\n',
     'utf8',
@@ -207,12 +224,14 @@ function makeHarness({
       relayCaptureSha256: '4'.repeat(64),
       mailboxSha256: '5'.repeat(64),
       mailboxCriticalCount: 2,
+      systemWriterPinSha256: SYSTEM_WRITER_PIN_SHA256,
     });
     const issued = spawnSync(process.execPath, [
       AUTHORITY_SCRIPT_PATH,
       'issue-attended',
       '--expected-revision', EXPECTED_REVISION,
       '--attended-permit-file', attendedPermitFile,
+      '--attended-receipt-file', attendedReceiptFile,
       '--baseline-nrestarts', '0',
       '--start-control-output', path.join(root, 'start-control.json'),
       '--evidence-bindings-json', evidenceBindings,
@@ -241,6 +260,7 @@ function makeHarness({
     restartAuthorityFile,
     restartPermitFile,
     attendedPermitFile,
+    attendedReceiptFile,
     managerApprovalFile,
     systemdNRestarts: 0,
   };
@@ -263,6 +283,7 @@ function runStartScript(harness) {
     VH_NEWS_DAEMON_RESTART_AUTHORITY_FILE: harness.restartAuthorityFile,
     VH_NEWS_DAEMON_RESTART_PERMIT_FILE: harness.restartPermitFile,
     VH_NEWS_DAEMON_ATTENDED_START_PERMIT_FILE: harness.attendedPermitFile,
+    VH_NEWS_DAEMON_ATTENDED_START_RECEIPT_FILE: harness.attendedReceiptFile,
     VH_NEWS_DAEMON_SYSTEMD_UNIT: 'vh-news-aggregator.service',
     VH_TEST_SYSTEMD_NRESTARTS: String(harness.systemdNRestarts),
     VH_TEST_MANAGER_APPROVAL_FILE: harness.managerApprovalFile,

--- a/tools/scripts/systemd-service-installers.test.mjs
+++ b/tools/scripts/systemd-service-installers.test.mjs
@@ -69,7 +69,7 @@ test('news aggregator installer retires direct start and binds all generated evi
   assert.equal((source.match(/ExecStartPre=\/usr\/bin\/env bash \$\{REPO_ROOT\}\/tools\/scripts\/check-news-aggregator-expected-revision\.sh \$\{EXPECTED_REVISION\}/g) ?? []).length, 6);
 });
 
-test('news aggregator publisher unit keeps deliberate fail-closed exits stopped and bounds crash loops', () => {
+test('news aggregator publisher unit restarts only exit 69, keeps fail-closed exits stopped, and bounds loops', () => {
   const daemonCliSource = readPackageSource('services/news-aggregator/src/daemonCli.ts');
   const exitCodeMatch = daemonCliSource.match(/NEWS_DAEMON_FAIL_CLOSED_EXIT_CODE\s*=\s*(\d+)/);
   assert.equal(exitCodeMatch?.[1], '78');
@@ -80,8 +80,10 @@ test('news aggregator publisher unit keeps deliberate fail-closed exits stopped 
   ]) {
     assert.match(source, /StartLimitIntervalSec=10min/);
     assert.match(source, /StartLimitBurst=3/);
-    assert.match(source, /Restart=on-failure/);
-    assert.match(source, new RegExp(`RestartPreventExitStatus=${exitCodeMatch?.[1]}`));
+    assert.match(source, /^Restart=no$/m);
+    assert.match(source, /^RestartForceExitStatus=69$/m);
+    assert.doesNotMatch(source, /^Restart=on-failure$/m);
+    assert.doesNotMatch(source, /^RestartPreventExitStatus=/m);
     assert.match(source, /RestartSec=30/);
   }
   const installer = readScript('install-news-aggregator-production-service.sh');

--- a/tools/scripts/systemd-service-installers.test.mjs
+++ b/tools/scripts/systemd-service-installers.test.mjs
@@ -59,13 +59,14 @@ test('storycluster production starter refuses non-qdrant service mode', () => {
   assert.match(source, /start-storycluster-local\.mjs/);
 });
 
-test('news aggregator installer still gates publisher start on explicit approval', () => {
+test('news aggregator installer retires direct start and binds all generated evidence services to one exact revision', () => {
   const source = readScript('install-news-aggregator-production-service.sh');
-  assert.match(source, /if \[\[ "\$\{START_PUBLISHER\}" == "true" \]\]/);
-  assert.match(source, /VH_NEWS_DAEMON_START_APPROVED:-/);
-  assert.match(source, /--start-publisher requires VH_NEWS_DAEMON_START_APPROVED=1/);
-  assert.match(source, /systemctl --user set-environment VH_NEWS_DAEMON_START_APPROVED=1/);
-  assert.match(source, /systemctl --user enable --now vh-news-aggregator\.service/);
+  assert.match(source, /--expected-revision/);
+  assert.match(source, /vh_publisher_require_exact_checkout "\$\{REPO_ROOT\}" "\$\{EXPECTED_REVISION\}"/);
+  assert.match(source, /--start-publisher is retired/);
+  assert.doesNotMatch(source, /set-environment VH_NEWS_DAEMON_START_APPROVED=1/);
+  assert.equal((source.match(/Environment=VH_NEWS_DAEMON_EXPECTED_REVISION=\$\{EXPECTED_REVISION\}/g) ?? []).length, 6);
+  assert.equal((source.match(/ExecStartPre=\/usr\/bin\/env bash \$\{REPO_ROOT\}\/tools\/scripts\/check-news-aggregator-expected-revision\.sh \$\{EXPECTED_REVISION\}/g) ?? []).length, 6);
 });
 
 test('news aggregator publisher unit keeps deliberate fail-closed exits stopped and bounds crash loops', () => {
@@ -83,6 +84,14 @@ test('news aggregator publisher unit keeps deliberate fail-closed exits stopped 
     assert.match(source, new RegExp(`RestartPreventExitStatus=${exitCodeMatch?.[1]}`));
     assert.match(source, /RestartSec=30/);
   }
+  const installer = readScript('install-news-aggregator-production-service.sh');
+  assert.match(installer, /Environment=VH_NEWS_DAEMON_RESTART_AUTHORITY_FILE=%h\/\.local\/state\/vhc\/news-aggregator\/recovery\/automatic-restart-authority\.json/);
+  assert.match(installer, /Environment=VH_NEWS_DAEMON_RESTART_PERMIT_FILE=%h\/\.local\/state\/vhc\/news-aggregator\/recovery\/automatic-restart-permit\.json/);
+  assert.match(installer, /ExecStopPost=.*record-news-aggregator-restartable-exit\.sh \$\{EXPECTED_REVISION\}/);
+  assert.match(
+    readScript('record-news-aggregator-restartable-exit.sh'),
+    /ExecStopPost finishes[\s\S]*service_enter_restart\(\) runs afterward[\s\S]*increments n_restarts/,
+  );
 });
 
 test('news aggregator installer writes publisher liveness watch units without enabling them by default', () => {
@@ -218,4 +227,18 @@ test('news aggregator production start requires qdrant-backed StoryCluster readi
   assert.match(source, /VH_STORYCLUSTER_REMOTE_HEALTH_URL/);
   assert.match(source, /storycluster-ready-not-qdrant-backed/);
   assert.match(source, /detail\?\.startsWith\('qdrant:'\)/);
+});
+
+test('publisher evidence hard-link writers make post-commit temp cleanup non-fatal', () => {
+  for (const scriptName of [
+    'verify-news-aggregator-publisher-recovery.mjs',
+    'write-news-aggregator-publisher-start-control-artifact.mjs',
+    'write-news-aggregator-production-start-artifact.mjs',
+  ]) {
+    assert.match(readScript(scriptName), /await link\([\s\S]*await rm\([^;]+\)\.catch\(\(\) => undefined\)/);
+  }
+  assert.match(
+    readScript('news-aggregator-publisher-recovery-control.sh'),
+    /ln "\$\{finalization_temp\}" "\$\{FINALIZATION_OUTPUT\}"[\s\S]*rm -f "\$\{finalization_temp\}"[^\n]+\|\| true/,
+  );
 });

--- a/tools/scripts/systemd-service-installers.test.mjs
+++ b/tools/scripts/systemd-service-installers.test.mjs
@@ -89,7 +89,18 @@ test('news aggregator publisher unit restarts only exit 69, keeps fail-closed ex
   const installer = readScript('install-news-aggregator-production-service.sh');
   assert.match(installer, /Environment=VH_NEWS_DAEMON_RESTART_AUTHORITY_FILE=%h\/\.local\/state\/vhc\/news-aggregator\/recovery\/automatic-restart-authority\.json/);
   assert.match(installer, /Environment=VH_NEWS_DAEMON_RESTART_PERMIT_FILE=%h\/\.local\/state\/vhc\/news-aggregator\/recovery\/automatic-restart-permit\.json/);
+  assert.match(installer, /Environment=VH_NEWS_DAEMON_ATTENDED_START_PERMIT_FILE=%h\/\.local\/state\/vhc\/news-aggregator\/recovery\/attended-start-permit\.json/);
+  assert.match(installer, /Environment=VH_NEWS_DAEMON_ATTENDED_START_RECEIPT_FILE=%h\/\.local\/state\/vhc\/news-aggregator\/recovery\/attended-start-consumption-receipt\.json/);
   assert.match(installer, /ExecStopPost=.*record-news-aggregator-restartable-exit\.sh \$\{EXPECTED_REVISION\}/);
+  const staticUnit = readInfraUnit('vh-news-aggregator.service');
+  assert.match(staticUnit, /Environment=VH_NEWS_DAEMON_EXPECTED_REVISION=REPLACE_WITH_FULL_40_HEX_COMMIT/);
+  assert.match(staticUnit, /Environment=VH_NEWS_DAEMON_SYSTEMD_UNIT=vh-news-aggregator\.service/);
+  assert.match(staticUnit, /Environment=VH_NEWS_DAEMON_RESTART_AUTHORITY_FILE=%h\/\.local\/state\/vhc\/news-aggregator\/recovery\/automatic-restart-authority\.json/);
+  assert.match(staticUnit, /Environment=VH_NEWS_DAEMON_RESTART_PERMIT_FILE=%h\/\.local\/state\/vhc\/news-aggregator\/recovery\/automatic-restart-permit\.json/);
+  assert.match(staticUnit, /Environment=VH_NEWS_DAEMON_ATTENDED_START_PERMIT_FILE=%h\/\.local\/state\/vhc\/news-aggregator\/recovery\/attended-start-permit\.json/);
+  assert.match(staticUnit, /Environment=VH_NEWS_DAEMON_ATTENDED_START_RECEIPT_FILE=%h\/\.local\/state\/vhc\/news-aggregator\/recovery\/attended-start-consumption-receipt\.json/);
+  assert.match(staticUnit, /ExecStartPre=.*check-news-aggregator-expected-revision\.sh REPLACE_WITH_FULL_40_HEX_COMMIT/);
+  assert.match(staticUnit, /ExecStopPost=.*record-news-aggregator-restartable-exit\.sh REPLACE_WITH_FULL_40_HEX_COMMIT/);
   assert.match(
     readScript('record-news-aggregator-restartable-exit.sh'),
     /ExecStopPost finishes[\s\S]*service_enter_restart\(\) runs afterward[\s\S]*increments n_restarts/,

--- a/tools/scripts/update-phase5-scope-a-watch-t0.mjs
+++ b/tools/scripts/update-phase5-scope-a-watch-t0.mjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+
+import { chmod, lstat, open, readFile, rename, rm } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const START_KEY = 'VH_PHASE5_SCOPE_A_WATCH_START_AT';
+const CLEAN_START_KEY = 'VH_PHASE5_SCOPE_A_WATCH_CLEAN_START_AT';
+const TARGET_KEYS = new Set([START_KEY, CLEAN_START_KEY]);
+const ISO_UTC_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+
+export class WatchT0UpdateError extends Error {
+  constructor(code) {
+    super(code);
+    this.name = 'WatchT0UpdateError';
+    this.code = code;
+  }
+}
+
+function fail(code) {
+  throw new WatchT0UpdateError(code);
+}
+
+function validateTimestamp(value, code) {
+  if (typeof value !== 'string' || !ISO_UTC_RE.test(value) || !Number.isFinite(Date.parse(value))) {
+    fail(code);
+  }
+  return value;
+}
+
+export function updateWatchT0Text(text, options) {
+  if (typeof text !== 'string' || text.length === 0 || text.length > 1_048_576) fail('env_size_invalid');
+  const newT0 = validateTimestamp(options.newT0, 'new_t0_invalid');
+  const expectedStart = validateTimestamp(options.expectedStart, 'expected_start_invalid');
+  const expectedCleanStart = validateTimestamp(options.expectedCleanStart, 'expected_clean_start_invalid');
+  const newT0Ms = Date.parse(newT0);
+  if (newT0Ms <= Date.parse(expectedStart) || newT0Ms <= Date.parse(expectedCleanStart)) {
+    fail('new_t0_not_strictly_later');
+  }
+  const nowMs = options.nowMs ?? Date.now();
+  if (newT0Ms > nowMs + 60_000) fail('new_t0_in_future');
+  const newline = text.includes('\r\n') ? '\r\n' : '\n';
+  if (newline === '\r\n' && text.replaceAll('\r\n', '').includes('\r')) fail('env_line_endings_invalid');
+  const hadFinalNewline = text.endsWith(newline);
+  const lines = text.split(newline);
+  if (hadFinalNewline) lines.pop();
+  const seen = new Set();
+  const observed = new Map();
+
+  const nextLines = lines.map((line) => {
+    if (line.trim() === '' || line.trimStart().startsWith('#')) return line;
+    const match = line.match(/^([A-Z_][A-Z0-9_]*)=(.*)$/);
+    if (!match) fail('env_shape_invalid');
+    const [, key, value] = match;
+    if (seen.has(key)) fail('env_duplicate_key');
+    seen.add(key);
+    if (!TARGET_KEYS.has(key)) return line;
+    if (!ISO_UTC_RE.test(value) || !Number.isFinite(Date.parse(value))) fail('env_target_shape_invalid');
+    observed.set(key, value);
+    return `${key}=${newT0}`;
+  });
+
+  if (observed.get(START_KEY) !== expectedStart) fail('watch_start_compare_failed');
+  if (observed.get(CLEAN_START_KEY) !== expectedCleanStart) fail('watch_clean_start_compare_failed');
+  return `${nextLines.join(newline)}${hadFinalNewline ? newline : ''}`;
+}
+
+async function requireOwnedRegularFile(filePath) {
+  if (!path.isAbsolute(filePath)) fail('env_path_not_absolute');
+  let stat;
+  try {
+    stat = await lstat(filePath);
+  } catch {
+    fail('env_file_missing');
+  }
+  if (stat.isSymbolicLink() || !stat.isFile()) fail('env_file_not_regular');
+  if (typeof process.getuid === 'function' && stat.uid !== process.getuid()) fail('env_file_wrong_owner');
+  if ((stat.mode & 0o777) !== 0o600) fail('env_file_mode_not_0600');
+  if (stat.size <= 0 || stat.size > 1_048_576) fail('env_size_invalid');
+  return stat;
+}
+
+export async function updateWatchT0File(filePath, options, dependencies = {}) {
+  const before = await requireOwnedRegularFile(filePath);
+  const original = await readFile(filePath, 'utf8');
+  const updated = updateWatchT0Text(original, options);
+  if (updated === original) fail('watch_t0_unchanged');
+
+  const parent = path.dirname(filePath);
+  const tempPath = path.join(parent, `.${path.basename(filePath)}.tmp-${process.pid}-${Date.now()}`);
+  let handle;
+  try {
+    handle = await open(tempPath, 'wx', 0o600);
+    await handle.writeFile(updated, 'utf8');
+    await handle.sync();
+    await handle.close();
+    handle = undefined;
+    await chmod(tempPath, 0o600);
+
+    await dependencies.beforeCompare?.();
+    const beforeRename = await requireOwnedRegularFile(filePath);
+    if (before.dev !== beforeRename.dev || before.ino !== beforeRename.ino
+      || before.size !== beforeRename.size || before.mtimeMs !== beforeRename.mtimeMs) {
+      fail('env_file_changed_during_update');
+    }
+    if (await readFile(filePath, 'utf8') !== original) fail('env_file_changed_during_update');
+    await rename(tempPath, filePath);
+    await chmod(filePath, 0o600);
+    return {
+      schemaVersion: 'vh-phase5-scope-a-watch-t0-update-v1',
+      status: 'pass',
+      changedKeys: [START_KEY, CLEAN_START_KEY],
+      newT0: options.newT0,
+      mode: '0600',
+    };
+  } catch (error) {
+    await handle?.close().catch(() => undefined);
+    await rm(tempPath, { force: true }).catch(() => undefined);
+    throw error;
+  }
+}
+
+function parseArgs(argv) {
+  const values = new Map();
+  for (let index = 0; index < argv.length; index += 2) {
+    const flag = argv[index];
+    const value = argv[index + 1];
+    if (!flag?.startsWith('--') || value === undefined || values.has(flag)) fail('arguments_invalid');
+    values.set(flag, value);
+  }
+  return values;
+}
+
+async function main() {
+  const values = parseArgs(process.argv.slice(2));
+  const file = values.get('--file');
+  if (!file) fail('env_file_argument_missing');
+  const result = await updateWatchT0File(path.resolve(file), {
+    newT0: values.get('--new-t0'),
+    expectedStart: values.get('--expected-start'),
+    expectedCleanStart: values.get('--expected-clean-start'),
+  });
+  console.info(JSON.stringify(result));
+}
+
+if (path.resolve(fileURLToPath(import.meta.url)) === path.resolve(process.argv[1] ?? '')) {
+  main().catch((error) => {
+    const code = error instanceof WatchT0UpdateError ? error.code : 'watch_t0_update_unexpected_failure';
+    console.error(`[vh:publisher-recovery] ${code}`);
+    process.exit(78);
+  });
+}

--- a/tools/scripts/verify-news-aggregator-publisher-recovery.mjs
+++ b/tools/scripts/verify-news-aggregator-publisher-recovery.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import { createHash } from 'node:crypto';
 import { chmod, link, lstat, open, readFile, realpath, rm } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -113,6 +114,52 @@ export function resolveSystemWriterPinFromEnv(env = process.env) {
       },
     }],
   };
+}
+
+export function canonicalSystemWriterPinSha256(pin) {
+  if (!exactKeys(pin, [
+    'pinVersion', 'schemaEpoch', 'maxProtocolVersion', 'signatureSuite', 'writers',
+  ])
+    || pin.pinVersion !== 1
+    || pin.schemaEpoch !== 'luma-public-v1'
+    || pin.maxProtocolVersion !== 'luma-public-v1'
+    || pin.signatureSuite !== 'jcs-ed25519-sha256-v1'
+    || !Array.isArray(pin.writers) || pin.writers.length === 0 || pin.writers.length > 64) {
+    fail('system_writer_pin_invalid');
+  }
+  const writers = pin.writers.map((writer) => {
+    if (!exactKeys(writer, ['id', 'status', 'publicKey'])
+      || typeof writer.id !== 'string'
+      || !/^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/.test(writer.id)
+      || !['active', 'retired'].includes(writer.status)
+      || !exactKeys(writer.publicKey, ['encoding', 'material'])
+      || writer.publicKey.encoding !== 'spki-base64url'
+      || typeof writer.publicKey.material !== 'string'
+      || !/^[A-Za-z0-9_-]{32,4096}$/.test(writer.publicKey.material)) {
+      fail('system_writer_pin_invalid');
+    }
+    return {
+      id: writer.id,
+      status: writer.status,
+      publicKey: {
+        encoding: 'spki-base64url',
+        material: writer.publicKey.material,
+      },
+    };
+  });
+  if (new Set(writers.map((writer) => writer.id)).size !== writers.length
+    || !writers.some((writer) => writer.status === 'active')) {
+    fail('system_writer_pin_invalid');
+  }
+  writers.sort((left, right) => (left.id < right.id ? -1 : left.id > right.id ? 1 : 0));
+  const canonicalPin = {
+    pinVersion: 1,
+    schemaEpoch: 'luma-public-v1',
+    maxProtocolVersion: 'luma-public-v1',
+    signatureSuite: 'jcs-ed25519-sha256-v1',
+    writers,
+  };
+  return createHash('sha256').update(JSON.stringify(canonicalPin)).digest('hex');
 }
 
 async function loadCanonicalSystemWriterValidator(override) {
@@ -597,6 +644,7 @@ export async function verifyPublisherRecovery(options) {
   if (!fullRevision(options.expectedRevision)) fail('expected_revision_invalid');
   await requireOutputAbsent(options.outputFile);
   const systemWriterPin = options.systemWriterPin ?? resolveSystemWriterPinFromEnv(options.env ?? process.env);
+  const systemWriterPinSha256 = canonicalSystemWriterPinSha256(systemWriterPin);
   const validateSystemWriterRecord = await loadCanonicalSystemWriterValidator(
     options.validateSystemWriterRecord,
   );
@@ -615,6 +663,9 @@ export async function verifyPublisherRecovery(options) {
     nowMs: fetchOptions.nowMs,
     maxAgeMs: options.startControlMaxAgeMs,
   });
+  if (startControl.systemWriterPinSha256 !== systemWriterPinSha256) {
+    fail('system_writer_pin_drift');
+  }
   const origins = normalizeOrigins(options.relayOrigins, startControl.relayOrigins);
   const currentRunJson = await readRegularJson(options.currentRunFile, 'current_run', { privateMode: true });
   const currentRun = validateCurrentRun(currentRunJson, options.expectedRevision, startControl);
@@ -708,6 +759,7 @@ export async function verifyPublisherRecovery(options) {
       relayPacketSha256: startControl.evidenceBindings.relayRecovery.packetSha256,
       relayCaptureSha256: startControl.evidenceBindings.relayRecovery.captureSha256,
       mailboxSha256: startControl.evidenceBindings.mailbox.sha256,
+      systemWriterPinSha256,
     },
   };
   await writePrivateJsonAtomic(options.outputFile, result);
@@ -733,6 +785,14 @@ function parseArgs(argv) {
 }
 
 async function main() {
+  if (process.argv[2] === 'pin-sha256') {
+    if (process.argv.length !== 3) fail('arguments_invalid');
+    console.info(JSON.stringify({
+      status: 'pass',
+      systemWriterPinSha256: canonicalSystemWriterPinSha256(resolveSystemWriterPinFromEnv()),
+    }));
+    return;
+  }
   const { values, origins } = parseArgs(process.argv.slice(2));
   const required = ['--expected-revision', '--start-control-file', '--current-run-file', '--runtime-diagnostics-file', '--output-file'];
   if (required.some((key) => !values.get(key))) fail('arguments_missing');

--- a/tools/scripts/verify-news-aggregator-publisher-recovery.mjs
+++ b/tools/scripts/verify-news-aggregator-publisher-recovery.mjs
@@ -1,0 +1,664 @@
+#!/usr/bin/env node
+
+import { chmod, link, lstat, mkdir, open, readFile, realpath, rm } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { verifyStartControlArtifact } from './news-aggregator-publisher-recovery-guard.mjs';
+
+const MAX_JSON_BYTES = 1_048_576;
+const TERMINAL_LIFECYCLE_STATUSES = new Set(['accepted_available', 'terminal_unavailable', 'suppressed']);
+const INCOMPLETE_LIFECYCLE_STATUSES = new Set(['pending', 'retryable_failure']);
+const ALL_LIFECYCLE_STATUSES = new Set([
+  ...TERMINAL_LIFECYCLE_STATUSES,
+  ...INCOMPLETE_LIFECYCLE_STATUSES,
+  'in_progress',
+]);
+
+export class PublisherRecoveryVerificationError extends Error {
+  constructor(code) {
+    super(code);
+    this.name = 'PublisherRecoveryVerificationError';
+    this.code = code;
+  }
+}
+
+class CandidateMissingError extends Error {}
+
+function fail(code) {
+  throw new PublisherRecoveryVerificationError(code);
+}
+
+function isObject(value) {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+}
+
+function exactKeys(value, keys) {
+  return isObject(value)
+    && JSON.stringify(Object.keys(value).sort()) === JSON.stringify([...keys].sort());
+}
+
+function fullRevision(value) {
+  return typeof value === 'string' && /^[0-9a-f]{40}$/.test(value);
+}
+
+function positiveInteger(value, fallback, code) {
+  if (value === undefined || value === null || value === '') return fallback;
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) fail(code);
+  return parsed;
+}
+
+function nonNegativeInteger(value, code) {
+  if (!Number.isSafeInteger(value) || value < 0) fail(code);
+  return value;
+}
+
+function timestamp(value, code) {
+  const parsed = typeof value === 'string' ? Date.parse(value) : Number.NaN;
+  if (!Number.isFinite(parsed)) fail(code);
+  return parsed;
+}
+
+async function readRegularJson(filePath, label, { privateMode = false } = {}) {
+  if (!path.isAbsolute(filePath)) fail(`${label}_path_not_absolute`);
+  let stat;
+  try {
+    stat = await lstat(filePath);
+  } catch {
+    fail(`${label}_missing`);
+  }
+  if (stat.isSymbolicLink() || !stat.isFile()) fail(`${label}_not_regular_file`);
+  if (typeof process.getuid === 'function' && stat.uid !== process.getuid()) fail(`${label}_wrong_owner`);
+  if (privateMode && (stat.mode & 0o777) !== 0o600) fail(`${label}_mode_not_0600`);
+  if (stat.size <= 0 || stat.size > MAX_JSON_BYTES) fail(`${label}_size_invalid`);
+  try {
+    const parsed = JSON.parse(await readFile(filePath, 'utf8'));
+    if (!isObject(parsed)) fail(`${label}_shape_invalid`);
+    return parsed;
+  } catch (error) {
+    if (error instanceof PublisherRecoveryVerificationError) throw error;
+    fail(`${label}_json_invalid`);
+  }
+}
+
+async function writePrivateJsonAtomic(filePath, payload) {
+  if (!path.isAbsolute(filePath)) fail('output_path_not_absolute');
+  const parent = path.dirname(filePath);
+  await mkdir(parent, { recursive: true, mode: 0o700 });
+  const tempPath = path.join(parent, `.${path.basename(filePath)}.tmp-${process.pid}-${Date.now()}`);
+  let handle;
+  try {
+    handle = await open(tempPath, 'wx', 0o600);
+    await handle.writeFile(`${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+    await handle.sync();
+    await handle.close();
+    handle = undefined;
+    await chmod(tempPath, 0o600);
+    await link(tempPath, filePath);
+    // The final link shares the already-fsynced mode-0600 inode. Once link()
+    // succeeds the artifact is committed; hidden temp cleanup cannot turn that
+    // valid commit into an ambiguous reported failure.
+    await rm(tempPath, { force: true }).catch(() => undefined);
+  } catch (error) {
+    await handle?.close().catch(() => undefined);
+    await rm(tempPath, { force: true }).catch(() => undefined);
+    throw error;
+  }
+}
+
+async function requireOutputAbsent(filePath) {
+  if (!path.isAbsolute(filePath)) fail('output_path_not_absolute');
+  try {
+    await lstat(filePath);
+    fail('output_already_exists');
+  } catch (error) {
+    if (error instanceof PublisherRecoveryVerificationError) throw error;
+    if (error?.code !== 'ENOENT') fail('output_preflight_failed');
+  }
+}
+
+function normalizeOrigins(values, reviewedOrigins) {
+  if (!Array.isArray(values) || values.length !== 3) fail('relay_origin_count_invalid');
+  const normalized = values.map((value) => {
+    let parsed;
+    try {
+      parsed = new URL(value);
+    } catch {
+      fail('relay_origin_invalid');
+    }
+    const port = Number(parsed.port);
+    if (parsed.protocol !== 'http:' || parsed.hostname !== '127.0.0.1'
+      || parsed.username || parsed.password || parsed.search || parsed.hash
+      || parsed.pathname !== '/' || !parsed.port
+      || !Number.isSafeInteger(port) || port <= 0 || port > 65_535 || port === 80
+      || value !== `http://127.0.0.1:${port}`) {
+      fail('relay_origin_invalid');
+    }
+    return value;
+  });
+  if (new Set(normalized).size !== normalized.length) fail('relay_origin_duplicate');
+  if (JSON.stringify(normalized) !== JSON.stringify(reviewedOrigins)) fail('relay_origin_review_binding_mismatch');
+  return normalized;
+}
+
+function validateCurrentRun(currentRun, expectedRevision, startControl) {
+  if (currentRun.schemaVersion !== 'vh-news-daemon-current-run-v1') fail('current_run_schema_invalid');
+  if (currentRun.status !== 'preflight_passed') fail('current_run_status_invalid');
+  if (currentRun.revision !== expectedRevision) fail('current_run_revision_mismatch');
+  if (currentRun.noWrite !== false) fail('current_run_not_live');
+  if (typeof currentRun.runId !== 'string'
+    || !/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(currentRun.runId)
+    || currentRun.runId === '.' || currentRun.runId === '..') fail('current_run_id_invalid');
+  if (typeof currentRun.artifactRoot !== 'string' || !path.isAbsolute(currentRun.artifactRoot)
+    || path.resolve(currentRun.artifactRoot) !== currentRun.artifactRoot) {
+    fail('current_run_artifact_root_invalid');
+  }
+  const generatedAtMs = timestamp(currentRun.generatedAt, 'current_run_generated_at_invalid');
+  if (generatedAtMs < Date.parse(startControl.startedAt)) fail('current_run_predates_attended_start');
+  return {
+    runId: currentRun.runId,
+    generatedAtMs,
+    artifactRoot: currentRun.artifactRoot,
+  };
+}
+
+function validateDiagnostics(diagnostics, currentRun, options) {
+  if (diagnostics.schemaVersion !== 'vh-news-runtime-diagnostics-v1') fail('diagnostics_schema_invalid');
+  if (diagnostics.runId !== currentRun.runId) fail('diagnostics_run_id_mismatch');
+  if (diagnostics.noWrite !== false) fail('diagnostics_not_live');
+  if (!Array.isArray(diagnostics.summaries) || diagnostics.summaries.length < 2) {
+    fail('diagnostics_summaries_missing');
+  }
+  const sequences = diagnostics.summaries.map((summary) => summary?.tick_sequence);
+  if (sequences.some((value) => !Number.isSafeInteger(value) || value <= 0)
+    || new Set(sequences).size !== sequences.length
+    || sequences.some((value, index) => index > 0 && value <= sequences[index - 1])) {
+    fail('diagnostics_tick_order_invalid');
+  }
+  const tick = diagnostics.latest;
+  const retainedLatest = diagnostics.summaries.filter((summary) => summary.tick_sequence === tick?.tick_sequence);
+  if (!isObject(tick) || tick.tick_sequence !== sequences.at(-1)
+    || retainedLatest.length !== 1
+    || JSON.stringify(retainedLatest[0]) !== JSON.stringify(tick)) {
+    fail('diagnostics_latest_invalid');
+  }
+  if (tick.status !== 'completed' || tick.skipped !== false || tick.no_write !== false
+    || tick.raw_write_failed_count !== 0 || tick.nonfatal_prewrite_failure_count !== 0) {
+    fail('diagnostics_latest_not_green');
+  }
+  const initialTicks = [];
+  for (const requiredSequence of [1, 2]) {
+    const matches = diagnostics.summaries.filter((summary) => summary.tick_sequence === requiredSequence);
+    const initialTick = matches[0];
+    if (matches.length !== 1) fail('diagnostics_initial_tick_cardinality_invalid');
+    if (!isObject(initialTick)
+      || initialTick.status !== 'completed' || initialTick.skipped !== false || initialTick.no_write !== false
+      || !Number.isSafeInteger(initialTick.raw_write_attempted_count) || initialTick.raw_write_attempted_count <= 0
+      || initialTick.raw_write_failed_count !== 0
+      || initialTick.nonfatal_prewrite_failure_count !== 0) {
+      fail('diagnostics_initial_ticks_not_green');
+    }
+    initialTicks.push(initialTick);
+  }
+  const candidate = [...initialTicks].reverse().find((initialTick) => {
+    const ids = initialTick.first_raw_written_story_ids;
+    return initialTick.raw_wrote_count === initialTick.raw_write_attempted_count
+      && initialTick.raw_write_suppressed_count === 0
+      && Array.isArray(ids) && ids.length > 0;
+  });
+  if (!candidate) fail('diagnostics_no_initial_write_candidate');
+  const startedAtMs = timestamp(candidate.started_at, 'diagnostics_tick_started_at_invalid');
+  const completedAtMs = timestamp(candidate.completed_at, 'diagnostics_tick_completed_at_invalid');
+  if (startedAtMs < currentRun.generatedAtMs || completedAtMs < startedAtMs) {
+    fail('diagnostics_tick_window_invalid');
+  }
+  const nowMs = options.nowMs ?? Date.now();
+  const maxTickAgeMs = positiveInteger(options.maxTickAgeMs, 30 * 60 * 1000, 'max_tick_age_invalid');
+  if (completedAtMs > nowMs + 60_000 || nowMs - completedAtMs > maxTickAgeMs) {
+    fail('diagnostics_tick_not_fresh');
+  }
+
+  const attempted = nonNegativeInteger(candidate.raw_write_attempted_count, 'diagnostics_attempted_count_invalid');
+  const wrote = nonNegativeInteger(candidate.raw_wrote_count, 'diagnostics_wrote_count_invalid');
+  const failed = nonNegativeInteger(candidate.raw_write_failed_count, 'diagnostics_failed_count_invalid');
+  const suppressed = nonNegativeInteger(candidate.raw_write_suppressed_count, 'diagnostics_suppressed_count_invalid');
+  const selected = nonNegativeInteger(candidate.selected_bundle_count, 'diagnostics_selected_count_invalid');
+  if (attempted <= 0 || wrote !== attempted || failed !== 0 || suppressed !== 0 || attempted > selected) {
+    fail('diagnostics_raw_write_invariants_failed');
+  }
+  const writtenIds = candidate.first_raw_written_story_ids;
+  if (!Array.isArray(writtenIds) || writtenIds.length === 0 || writtenIds.length > 10
+    || writtenIds.some((value) => typeof value !== 'string' || !value.trim())
+    || new Set(writtenIds).size !== writtenIds.length || writtenIds.length > wrote) {
+    fail('diagnostics_written_story_ids_invalid');
+  }
+  if (!Array.isArray(candidate.first_selected_story_ids)
+    || writtenIds.some((storyId) => !candidate.first_selected_story_ids.includes(storyId))) {
+    fail('diagnostics_written_story_not_selected');
+  }
+  return {
+    tick: candidate,
+    startedAtMs,
+    completedAtMs,
+    writtenIds,
+  };
+}
+
+function captureStoriesForTick(capture, runId, tickWindow) {
+  if (capture.schemaVersion !== 'daemon-feed-cluster-capture-v1') fail('cluster_capture_schema_invalid');
+  if (capture.runId !== runId || !Array.isArray(capture.ticks) || capture.ticks.length === 0) {
+    fail('cluster_capture_run_invalid');
+  }
+  const sequences = capture.ticks.map((tick) => tick?.tickSequence);
+  if (sequences.some((value) => !Number.isSafeInteger(value) || value <= 0)
+    || new Set(sequences).size !== sequences.length
+    || sequences.some((value, index) => index > 0 && value <= sequences[index - 1])) {
+    fail('cluster_capture_order_invalid');
+  }
+  const matching = capture.ticks.filter((tick) => {
+    const generatedAtMs = typeof tick?.generatedAt === 'string' ? Date.parse(tick.generatedAt) : Number.NaN;
+    return Number.isFinite(generatedAtMs)
+      && generatedAtMs >= tickWindow.startedAtMs
+      && generatedAtMs <= tickWindow.completedAtMs;
+  });
+  if (matching.length !== 1 || !Array.isArray(matching[0].topicCaptures)) fail('cluster_capture_tick_invalid');
+  const stories = new Map();
+  for (const topicCapture of matching[0].topicCaptures) {
+    const bundles = topicCapture?.result?.bundles;
+    if (!Array.isArray(bundles)) fail('cluster_capture_bundles_invalid');
+    for (const story of bundles) {
+      if (!isObject(story) || typeof story.story_id !== 'string' || !story.story_id.trim()) {
+        fail('cluster_capture_story_invalid');
+      }
+      if (stories.has(story.story_id)) fail('cluster_capture_story_duplicate');
+      stories.set(story.story_id, story);
+    }
+  }
+  return stories;
+}
+
+async function fetchJson(url, options) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), options.timeoutMs);
+  let response;
+  try {
+    response = await options.fetchFn(url, {
+      method: 'GET',
+      headers: { accept: 'application/json' },
+      signal: controller.signal,
+    });
+  } catch {
+    fail('relay_readback_network_failed');
+  } finally {
+    clearTimeout(timer);
+  }
+  const contentLength = Number(response.headers.get('content-length'));
+  if (Number.isFinite(contentLength) && contentLength > MAX_JSON_BYTES) fail('relay_readback_body_too_large');
+  const contentType = response.headers.get('content-type') ?? '';
+  if (!contentType.toLowerCase().includes('application/json')) fail('relay_readback_content_type_invalid');
+  let text;
+  try {
+    text = await response.text();
+  } catch {
+    fail('relay_readback_body_failed');
+  }
+  if (Buffer.byteLength(text, 'utf8') > MAX_JSON_BYTES) fail('relay_readback_body_too_large');
+  let payload;
+  try {
+    payload = JSON.parse(text);
+  } catch {
+    fail('relay_readback_json_invalid');
+  }
+  if (!isObject(payload)) fail('relay_readback_shape_invalid');
+  return { status: response.status, payload };
+}
+
+function productRecordMatchesStory(record, story) {
+  const canonicalSources = Array.isArray(story.primary_sources) ? story.primary_sources : story.sources;
+  return isObject(record)
+    && record.story_id === story.story_id
+    && record.product_state_schema_version === 'vh-news-product-feed-index-v1'
+    && record.topic_id === story.topic_id
+    && record.source_set_revision === story.provenance_hash
+    && record.source_count === story.sources.length
+    && record.canonical_source_count === canonicalSources.length
+    && record.story_created_at === Math.max(0, Math.floor(story.created_at))
+    && record.cluster_window_start === Math.max(0, Math.floor(story.cluster_window_start));
+}
+
+function isSignedSystemRecord(record) {
+  return isObject(record)
+    && record._protocolVersion === 'luma-public-v1'
+    && record._writerKind === 'system'
+    && typeof record._systemWriterId === 'string'
+    && /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/.test(record._systemWriterId)
+    && Number.isSafeInteger(record._systemIssuedAt) && record._systemIssuedAt >= 0
+    && typeof record._systemSignature === 'string'
+    && record._systemSignature.length > 0 && record._systemSignature.length <= 16_384
+    && !('_authorScheme' in record) && !('signedWriteEnvelope' in record);
+}
+
+function lifecycleMatchesStory(lifecycle, story, tickWindow, nowMs, options) {
+  if (!isObject(lifecycle)
+    || lifecycle.schemaVersion !== 'vh-news-synthesis-lifecycle-v1'
+    || lifecycle.story_id !== story.story_id
+    || lifecycle.topic_id !== story.topic_id
+    || lifecycle.source_set_revision !== story.provenance_hash
+    || lifecycle.source_count !== story.sources.length
+    || lifecycle.canonical_source_count !== (Array.isArray(story.primary_sources) ? story.primary_sources : story.sources).length
+    || !ALL_LIFECYCLE_STATUSES.has(lifecycle.status)) {
+    return null;
+  }
+  const updatedAt = Number(lifecycle.updated_at);
+  if (!Number.isFinite(updatedAt) || updatedAt <= 0 || updatedAt > nowMs + 60_000) return null;
+  if (updatedAt >= tickWindow.startedAtMs && updatedAt <= tickWindow.completedAtMs) return 'updated_in_tick';
+  if (INCOMPLETE_LIFECYCLE_STATUSES.has(lifecycle.status)) {
+    const maxAge = positiveInteger(options.incompleteLifecycleMaxAgeMs, 60 * 60 * 1000, 'lifecycle_incomplete_age_invalid');
+    return nowMs - updatedAt <= maxAge ? 'preserved_current' : null;
+  }
+  if (lifecycle.status === 'in_progress') {
+    const maxAge = positiveInteger(options.inProgressLifecycleMaxAgeMs, 10 * 60 * 1000, 'lifecycle_in_progress_age_invalid');
+    return nowMs - updatedAt <= maxAge ? 'preserved_current' : null;
+  }
+  return TERMINAL_LIFECYCLE_STATUSES.has(lifecycle.status) ? 'preserved_terminal' : null;
+}
+
+async function verifyPositiveStoryOnOrigin(origin, story, tickWindow, options) {
+  const storyId = encodeURIComponent(story.story_id);
+  const routes = {
+    story: {
+      path: `/vh/news/story?story_id=${storyId}&readback=exact`,
+      missing: 'news-story-not-found',
+      keys: ['ok', 'story_id', 'topic_id', 'source', 'story', 'record'],
+    },
+    latest: {
+      path: `/vh/news/latest-index?story_id=${storyId}&readback=exact&persist=false`,
+      missing: 'news-latest-index-not-found',
+      keys: ['ok', 'story_id', 'record'],
+    },
+    hot: {
+      path: `/vh/news/hot-index?story_id=${storyId}&readback=exact`,
+      missing: 'news-hot-index-not-found',
+      keys: ['ok', 'story_id', 'record'],
+    },
+    lifecycle: {
+      path: `/vh/news/synthesis-lifecycle?story_id=${storyId}&readback=exact`,
+      missing: 'news-synthesis-lifecycle-not-found',
+      keys: ['ok', 'story_id', 'topic_id', 'status', 'frame_table_state', 'lifecycle', 'record'],
+    },
+  };
+  const reads = {};
+  for (const [name, route] of Object.entries(routes)) {
+    reads[name] = await fetchJson(new URL(route.path, origin), options);
+    if (reads[name].status === 404
+      && exactMissingPayload(reads[name].payload, route.missing, story.story_id)) {
+      throw new CandidateMissingError();
+    }
+    if (reads[name].status !== 200 || !exactKeys(reads[name].payload, route.keys)
+      || reads[name].payload.ok !== true
+      || reads[name].payload.story_id !== story.story_id) {
+      fail(`positive_${name}_readback_failed`);
+    }
+  }
+  const observedStory = reads.story.payload.story;
+  let embeddedStory;
+  try {
+    embeddedStory = JSON.parse(reads.story.payload.record?.__story_bundle_json ?? '');
+  } catch {
+    embeddedStory = null;
+  }
+  if (!isObject(observedStory)
+    || observedStory.story_id !== story.story_id
+    || observedStory.topic_id !== story.topic_id
+    || observedStory.provenance_hash !== story.provenance_hash
+    || observedStory.created_at !== story.created_at
+    || observedStory.cluster_window_start !== story.cluster_window_start
+    || observedStory.cluster_window_end !== story.cluster_window_end
+    || !isSignedSystemRecord(reads.story.payload.record)
+    || reads.story.payload.record.story_id !== story.story_id
+    || reads.story.payload.record.created_at !== story.created_at
+    || reads.story.payload.record.schemaVersion !== story.schemaVersion
+    || JSON.stringify(embeddedStory) !== JSON.stringify(story)) {
+    fail('positive_story_contract_mismatch');
+  }
+  if (!isSignedSystemRecord(reads.latest.payload.record)
+    || !productRecordMatchesStory(reads.latest.payload.record, story)
+    || reads.latest.payload.record.latest_activity_at !== Math.max(0, Math.floor(story.cluster_window_end))) {
+    fail('positive_latest_contract_mismatch');
+  }
+  if (!isSignedSystemRecord(reads.hot.payload.record)
+    || !productRecordMatchesStory(reads.hot.payload.record, story)
+    || !Number.isFinite(Number(reads.hot.payload.record.hotness))
+    || Number(reads.hot.payload.record.hotness) < 0) {
+    fail('positive_hot_contract_mismatch');
+  }
+  const lifecycleMode = lifecycleMatchesStory(
+    reads.lifecycle.payload.lifecycle,
+    story,
+    tickWindow,
+    options.nowMs,
+    options,
+  );
+  if (!isSignedSystemRecord(reads.lifecycle.payload.lifecycle)
+    || JSON.stringify(reads.lifecycle.payload.record) !== JSON.stringify(reads.lifecycle.payload.lifecycle)
+    || !lifecycleMode) {
+    fail('positive_lifecycle_contract_mismatch');
+  }
+  return {
+    lifecycleMode,
+    signedRecords: {
+      story: reads.story.payload.record,
+      latest: reads.latest.payload.record,
+      hot: reads.hot.payload.record,
+      lifecycle: reads.lifecycle.payload.lifecycle,
+    },
+  };
+}
+
+function exactMissingPayload(payload, error, storyId) {
+  return Object.keys(payload).sort().join(',') === 'error,ok,story_id'
+    && payload.ok === false && payload.error === error && payload.story_id === storyId;
+}
+
+async function verifyMissingContracts(origins, expectedRevision, runId, options) {
+  const sentinel = `vh-publisher-recovery-missing-${expectedRevision.slice(0, 12)}-${runId}`;
+  const id = encodeURIComponent(sentinel);
+  const routes = [
+    [`/vh/news/story?story_id=${id}&readback=exact`, 'news-story-not-found'],
+    [`/vh/news/latest-index?story_id=${id}&readback=exact&persist=false`, 'news-latest-index-not-found'],
+    [`/vh/news/hot-index?story_id=${id}&readback=exact`, 'news-hot-index-not-found'],
+    [`/vh/news/synthesis-lifecycle?story_id=${id}&readback=exact`, 'news-synthesis-lifecycle-not-found'],
+  ];
+  for (const origin of origins) {
+    for (const [route, error] of routes) {
+      const read = await fetchJson(new URL(route, origin), options);
+      if (read.status !== 404 || !exactMissingPayload(read.payload, error, sentinel)) {
+        fail('missing_key_contract_failed');
+      }
+    }
+  }
+}
+
+export async function verifyPublisherRecovery(options) {
+  if (!fullRevision(options.expectedRevision)) fail('expected_revision_invalid');
+  await requireOutputAbsent(options.outputFile);
+  const fetchOptions = {
+    fetchFn: options.fetchFn ?? fetch,
+    timeoutMs: positiveInteger(options.timeoutMs, 5_000, 'timeout_invalid'),
+    nowMs: options.nowMs ?? Date.now(),
+    incompleteLifecycleMaxAgeMs: options.incompleteLifecycleMaxAgeMs,
+    inProgressLifecycleMaxAgeMs: options.inProgressLifecycleMaxAgeMs,
+  };
+  const startControl = await verifyStartControlArtifact({
+    filePath: options.startControlFile,
+    expectedRevision: options.expectedRevision,
+    nowMs: fetchOptions.nowMs,
+    maxAgeMs: options.startControlMaxAgeMs,
+  });
+  const origins = normalizeOrigins(options.relayOrigins, startControl.relayOrigins);
+  const currentRunJson = await readRegularJson(options.currentRunFile, 'current_run', { privateMode: true });
+  const currentRun = validateCurrentRun(currentRunJson, options.expectedRevision, startControl);
+  const diagnosticsJson = await readRegularJson(options.runtimeDiagnosticsFile, 'diagnostics');
+  const tickWindow = validateDiagnostics(diagnosticsJson, currentRun, {
+    nowMs: fetchOptions.nowMs,
+    maxTickAgeMs: options.maxTickAgeMs,
+  });
+  let canonicalArtifactRoot;
+  try {
+    canonicalArtifactRoot = await realpath(currentRun.artifactRoot);
+  } catch {
+    fail('current_run_artifact_root_unavailable');
+  }
+  if (canonicalArtifactRoot !== currentRun.artifactRoot) fail('current_run_artifact_root_contains_symlink');
+  const runDir = path.resolve(currentRun.artifactRoot, currentRun.runId);
+  if (!runDir.startsWith(`${currentRun.artifactRoot}${path.sep}`)) fail('current_run_artifact_path_escape');
+  let runDirStat;
+  let canonicalRunDir;
+  try {
+    runDirStat = await lstat(runDir);
+    canonicalRunDir = await realpath(runDir);
+  } catch {
+    fail('current_run_artifact_run_directory_unavailable');
+  }
+  if (runDirStat.isSymbolicLink() || !runDirStat.isDirectory()
+    || (typeof process.getuid === 'function' && runDirStat.uid !== process.getuid())
+    || canonicalRunDir !== runDir) {
+    fail('current_run_artifact_run_directory_invalid');
+  }
+  const capturePath = path.resolve(runDir, 'cluster-capture.json');
+  if (path.dirname(capturePath) !== runDir) fail('current_run_artifact_path_escape');
+  const capture = await readRegularJson(capturePath, 'cluster_capture');
+  const captureStories = captureStoriesForTick(capture, currentRun.runId, tickWindow);
+  for (const storyId of tickWindow.writtenIds) {
+    if (!captureStories.has(storyId)) fail('written_story_missing_from_cluster_capture');
+  }
+
+  let verifiedStory = null;
+  let lifecycleModes = [];
+  for (const storyId of tickWindow.writtenIds) {
+    const story = captureStories.get(storyId);
+    try {
+      const modes = [];
+      let signedRecordProjection = null;
+      for (const origin of origins) {
+        const projection = await verifyPositiveStoryOnOrigin(origin, story, tickWindow, fetchOptions);
+        if (signedRecordProjection !== null
+          && JSON.stringify(projection.signedRecords) !== JSON.stringify(signedRecordProjection)) {
+          fail('positive_signed_record_replication_mismatch');
+        }
+        signedRecordProjection = projection.signedRecords;
+        modes.push(projection.lifecycleMode);
+      }
+      verifiedStory = story;
+      lifecycleModes = modes;
+      break;
+    } catch (error) {
+      if (!(error instanceof CandidateMissingError)) throw error;
+    }
+  }
+  if (!verifiedStory) fail('no_written_story_passed_four_route_readback');
+  await verifyMissingContracts(origins, options.expectedRevision, currentRun.runId, fetchOptions);
+
+  const completionNowMs = options.completionNowMs ?? Date.now();
+  if (!Number.isFinite(completionNowMs)
+    || completionNowMs < fetchOptions.nowMs
+    || completionNowMs < tickWindow.completedAtMs) {
+    fail('completion_timestamp_invalid');
+  }
+
+  const result = {
+    schemaVersion: 'vh-news-publisher-recovery-readback-v1',
+    generatedAt: new Date(completionNowMs).toISOString(),
+    status: 'pass',
+    revision: options.expectedRevision,
+    startedAt: startControl.startedAt,
+    runId: currentRun.runId,
+    tickSequence: tickWindow.tick.tick_sequence,
+    tickCompletedAt: new Date(tickWindow.completedAtMs).toISOString(),
+    storyId: verifiedStory.story_id,
+    sourceSetRevision: verifiedStory.provenance_hash,
+    relayCount: origins.length,
+    positiveRoutes: ['story', 'latest-index', 'hot-index', 'synthesis-lifecycle'],
+    missingKeyRoutes: ['story', 'latest-index', 'hot-index', 'synthesis-lifecycle'],
+    lifecycleModes,
+    inputBindings: {
+      startControlSha256: startControl.sha256,
+      preflightSha256: startControl.evidenceBindings.preflight.sha256,
+      relayEvidenceSha256: startControl.evidenceBindings.relayRecovery.sha256,
+      relayPacketSha256: startControl.evidenceBindings.relayRecovery.packetSha256,
+      relayCaptureSha256: startControl.evidenceBindings.relayRecovery.captureSha256,
+      mailboxSha256: startControl.evidenceBindings.mailbox.sha256,
+    },
+  };
+  await writePrivateJsonAtomic(options.outputFile, result);
+  return result;
+}
+
+function parseArgs(argv) {
+  const values = new Map();
+  const origins = [];
+  for (let index = 0; index < argv.length; index += 1) {
+    const flag = argv[index];
+    const value = argv[index + 1];
+    if (!flag?.startsWith('--') || value === undefined) fail('arguments_invalid');
+    index += 1;
+    if (flag === '--relay-origin') {
+      origins.push(value);
+    } else {
+      if (values.has(flag)) fail('arguments_duplicate');
+      values.set(flag, value);
+    }
+  }
+  return { values, origins };
+}
+
+async function main() {
+  const { values, origins } = parseArgs(process.argv.slice(2));
+  const required = ['--expected-revision', '--start-control-file', '--current-run-file', '--runtime-diagnostics-file', '--output-file'];
+  if (required.some((key) => !values.get(key))) fail('arguments_missing');
+  const result = await verifyPublisherRecovery({
+    expectedRevision: values.get('--expected-revision'),
+    startControlFile: path.resolve(values.get('--start-control-file')),
+    currentRunFile: path.resolve(values.get('--current-run-file')),
+    runtimeDiagnosticsFile: path.resolve(values.get('--runtime-diagnostics-file')),
+    outputFile: path.resolve(values.get('--output-file')),
+    relayOrigins: origins,
+    timeoutMs: values.get('--timeout-ms'),
+    maxTickAgeMs: values.get('--max-tick-age-ms'),
+    startControlMaxAgeMs: values.get('--start-control-max-age-ms'),
+    incompleteLifecycleMaxAgeMs: values.get('--incomplete-lifecycle-max-age-ms'),
+    inProgressLifecycleMaxAgeMs: values.get('--in-progress-lifecycle-max-age-ms'),
+  });
+  console.info(JSON.stringify({
+    status: result.status,
+    revision: result.revision,
+    runId: result.runId,
+    tickSequence: result.tickSequence,
+    relayCount: result.relayCount,
+  }));
+}
+
+if (path.resolve(fileURLToPath(import.meta.url)) === path.resolve(process.argv[1] ?? '')) {
+  let outputFile = null;
+  try {
+    const outputIndex = process.argv.indexOf('--output-file');
+    if (outputIndex >= 0 && process.argv[outputIndex + 1]) outputFile = path.resolve(process.argv[outputIndex + 1]);
+  } catch {
+    outputFile = null;
+  }
+  main().catch(async (error) => {
+    const code = error instanceof PublisherRecoveryVerificationError
+      ? error.code
+      : 'publisher_recovery_verification_unexpected_failure';
+    if (outputFile) {
+      await writePrivateJsonAtomic(outputFile, {
+        schemaVersion: 'vh-news-publisher-recovery-readback-v1',
+        generatedAt: new Date().toISOString(),
+        status: 'fail',
+        reason: code,
+      }).catch(() => undefined);
+    }
+    console.error(`[vh:publisher-recovery] ${code}`);
+    process.exit(78);
+  });
+}

--- a/tools/scripts/verify-news-aggregator-publisher-recovery.mjs
+++ b/tools/scripts/verify-news-aggregator-publisher-recovery.mjs
@@ -1,9 +1,12 @@
 #!/usr/bin/env node
 
-import { chmod, link, lstat, mkdir, open, readFile, realpath, rm } from 'node:fs/promises';
+import { chmod, link, lstat, open, readFile, realpath, rm } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { verifyStartControlArtifact } from './news-aggregator-publisher-recovery-guard.mjs';
+import {
+  requirePrivateOutputParent,
+  verifyStartControlArtifact,
+} from './news-aggregator-publisher-recovery-guard.mjs';
 
 const MAX_JSON_BYTES = 1_048_576;
 const TERMINAL_LIFECYCLE_STATUSES = new Set(['accepted_available', 'terminal_unavailable', 'suppressed']);
@@ -13,6 +16,11 @@ const ALL_LIFECYCLE_STATUSES = new Set([
   ...INCOMPLETE_LIFECYCLE_STATUSES,
   'in_progress',
 ]);
+const DEFAULT_SYSTEM_WRITER_ID = 'vh-system-writer-dev-v1';
+const SYSTEM_WRITER_MODULE_URL = new URL(
+  '../../packages/gun-client/dist/systemWriter.js',
+  import.meta.url,
+);
 
 export class PublisherRecoveryVerificationError extends Error {
   constructor(code) {
@@ -59,6 +67,78 @@ function timestamp(value, code) {
   return parsed;
 }
 
+function firstNonEmpty(...values) {
+  for (const value of values) {
+    const trimmed = typeof value === 'string' ? value.trim() : '';
+    if (trimmed) return trimmed;
+  }
+  return undefined;
+}
+
+export function resolveSystemWriterPinFromEnv(env = process.env) {
+  const writerId = firstNonEmpty(
+    env.VH_NEWS_SYSTEM_WRITER_ID,
+    env.VH_SYSTEM_WRITER_ID,
+  ) ?? DEFAULT_SYSTEM_WRITER_ID;
+  const pinJson = firstNonEmpty(
+    env.VH_NEWS_SYSTEM_WRITER_PIN_JSON,
+    env.VH_SYSTEM_WRITER_PIN_JSON,
+  );
+  if (pinJson) {
+    try {
+      const pin = JSON.parse(pinJson);
+      if (!isObject(pin)) fail('system_writer_pin_invalid');
+      return pin;
+    } catch (error) {
+      if (error instanceof PublisherRecoveryVerificationError) throw error;
+      fail('system_writer_pin_invalid');
+    }
+  }
+  const publicKeyMaterial = firstNonEmpty(
+    env.VH_NEWS_SYSTEM_WRITER_PUBLIC_KEY_SPKI_BASE64URL,
+    env.VH_SYSTEM_WRITER_PUBLIC_KEY_SPKI_BASE64URL,
+  );
+  if (!publicKeyMaterial) fail('system_writer_pin_missing');
+  return {
+    pinVersion: 1,
+    schemaEpoch: 'luma-public-v1',
+    maxProtocolVersion: 'luma-public-v1',
+    signatureSuite: 'jcs-ed25519-sha256-v1',
+    writers: [{
+      id: writerId,
+      status: 'active',
+      publicKey: {
+        encoding: 'spki-base64url',
+        material: publicKeyMaterial,
+      },
+    }],
+  };
+}
+
+async function loadCanonicalSystemWriterValidator(override) {
+  if (override) return override;
+  let stat;
+  try {
+    stat = await lstat(fileURLToPath(SYSTEM_WRITER_MODULE_URL));
+  } catch {
+    fail('system_writer_validator_unavailable');
+  }
+  if (stat.isSymbolicLink() || !stat.isFile()
+    || (typeof process.getuid === 'function' && stat.uid !== process.getuid())) {
+    fail('system_writer_validator_unavailable');
+  }
+  try {
+    const loaded = await import(`${SYSTEM_WRITER_MODULE_URL.href}?revision-check=${stat.mtimeMs}`);
+    if (typeof loaded.validateSystemWriterRecord !== 'function') {
+      fail('system_writer_validator_unavailable');
+    }
+    return loaded.validateSystemWriterRecord;
+  } catch (error) {
+    if (error instanceof PublisherRecoveryVerificationError) throw error;
+    fail('system_writer_validator_unavailable');
+  }
+}
+
 async function readRegularJson(filePath, label, { privateMode = false } = {}) {
   if (!path.isAbsolute(filePath)) fail(`${label}_path_not_absolute`);
   let stat;
@@ -83,8 +163,7 @@ async function readRegularJson(filePath, label, { privateMode = false } = {}) {
 
 async function writePrivateJsonAtomic(filePath, payload) {
   if (!path.isAbsolute(filePath)) fail('output_path_not_absolute');
-  const parent = path.dirname(filePath);
-  await mkdir(parent, { recursive: true, mode: 0o700 });
+  const parent = await requirePrivateOutputParent(filePath);
   const tempPath = path.join(parent, `.${path.basename(filePath)}.tmp-${process.pid}-${Date.now()}`);
   let handle;
   try {
@@ -108,6 +187,7 @@ async function writePrivateJsonAtomic(filePath, payload) {
 
 async function requireOutputAbsent(filePath) {
   if (!path.isAbsolute(filePath)) fail('output_path_not_absolute');
+  await requirePrivateOutputParent(filePath);
   try {
     await lstat(filePath);
     fail('output_already_exists');
@@ -280,37 +360,42 @@ function captureStoriesForTick(capture, runId, tickWindow) {
 async function fetchJson(url, options) {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), options.timeoutMs);
-  let response;
   try {
-    response = await options.fetchFn(url, {
-      method: 'GET',
-      headers: { accept: 'application/json' },
-      signal: controller.signal,
-    });
-  } catch {
-    fail('relay_readback_network_failed');
+    let response;
+    try {
+      response = await options.fetchFn(url, {
+        method: 'GET',
+        headers: { accept: 'application/json' },
+        redirect: 'error',
+        signal: controller.signal,
+      });
+    } catch {
+      fail('relay_readback_network_failed');
+    }
+    const contentLength = Number(response.headers.get('content-length'));
+    if (Number.isFinite(contentLength) && contentLength > MAX_JSON_BYTES) fail('relay_readback_body_too_large');
+    const contentType = response.headers.get('content-type') ?? '';
+    if (!contentType.toLowerCase().includes('application/json')) fail('relay_readback_content_type_invalid');
+    let text;
+    try {
+      text = await response.text();
+    } catch {
+      fail('relay_readback_body_failed');
+    }
+    if (Buffer.byteLength(text, 'utf8') > MAX_JSON_BYTES) fail('relay_readback_body_too_large');
+    let payload;
+    try {
+      payload = JSON.parse(text);
+    } catch {
+      fail('relay_readback_json_invalid');
+    }
+    if (!isObject(payload)) fail('relay_readback_shape_invalid');
+    return { status: response.status, payload };
   } finally {
+    // Keep the bound live through body consumption. A relay that sends valid
+    // headers and then stalls must not hold the attended verifier forever.
     clearTimeout(timer);
   }
-  const contentLength = Number(response.headers.get('content-length'));
-  if (Number.isFinite(contentLength) && contentLength > MAX_JSON_BYTES) fail('relay_readback_body_too_large');
-  const contentType = response.headers.get('content-type') ?? '';
-  if (!contentType.toLowerCase().includes('application/json')) fail('relay_readback_content_type_invalid');
-  let text;
-  try {
-    text = await response.text();
-  } catch {
-    fail('relay_readback_body_failed');
-  }
-  if (Buffer.byteLength(text, 'utf8') > MAX_JSON_BYTES) fail('relay_readback_body_too_large');
-  let payload;
-  try {
-    payload = JSON.parse(text);
-  } catch {
-    fail('relay_readback_json_invalid');
-  }
-  if (!isObject(payload)) fail('relay_readback_shape_invalid');
-  return { status: response.status, payload };
 }
 
 function productRecordMatchesStory(record, story) {
@@ -336,6 +421,28 @@ function isSignedSystemRecord(record) {
     && typeof record._systemSignature === 'string'
     && record._systemSignature.length > 0 && record._systemSignature.length <= 16_384
     && !('_authorScheme' in record) && !('signedWriteEnvelope' in record);
+}
+
+const SYSTEM_WRITER_PATHS = {
+  story: (storyId) => `vh/news/stories/${storyId}/`,
+  latest: (storyId) => `vh/news/index/latest/${storyId}/`,
+  hot: (storyId) => `vh/news/index/hot/${storyId}/`,
+  lifecycle: (storyId) => `vh/news/stories/${storyId}/synthesis_lifecycle/latest/`,
+};
+
+async function requireCanonicalSystemWriterSignature(route, storyId, record, options) {
+  if (!isSignedSystemRecord(record)) fail(`positive_${route}_signature_invalid`);
+  let validation;
+  try {
+    validation = await options.validateSystemWriterRecord({
+      path: SYSTEM_WRITER_PATHS[route](storyId),
+      record,
+      pin: options.systemWriterPin,
+    });
+  } catch {
+    validation = null;
+  }
+  if (validation?.valid !== true) fail(`positive_${route}_signature_invalid`);
 }
 
 function lifecycleMatchesStory(lifecycle, story, tickWindow, nowMs, options) {
@@ -407,6 +514,18 @@ async function verifyPositiveStoryOnOrigin(origin, story, tickWindow, options) {
   } catch {
     embeddedStory = null;
   }
+  // Preserve route order so a multi-route pin/configuration failure emits one
+  // deterministic closed reason instead of whichever WebCrypto promise happens
+  // to reject first.
+  await requireCanonicalSystemWriterSignature('story', story.story_id, reads.story.payload.record, options);
+  await requireCanonicalSystemWriterSignature('latest', story.story_id, reads.latest.payload.record, options);
+  await requireCanonicalSystemWriterSignature('hot', story.story_id, reads.hot.payload.record, options);
+  await requireCanonicalSystemWriterSignature(
+    'lifecycle',
+    story.story_id,
+    reads.lifecycle.payload.lifecycle,
+    options,
+  );
   if (!isObject(observedStory)
     || observedStory.story_id !== story.story_id
     || observedStory.topic_id !== story.topic_id
@@ -414,20 +533,17 @@ async function verifyPositiveStoryOnOrigin(origin, story, tickWindow, options) {
     || observedStory.created_at !== story.created_at
     || observedStory.cluster_window_start !== story.cluster_window_start
     || observedStory.cluster_window_end !== story.cluster_window_end
-    || !isSignedSystemRecord(reads.story.payload.record)
     || reads.story.payload.record.story_id !== story.story_id
     || reads.story.payload.record.created_at !== story.created_at
     || reads.story.payload.record.schemaVersion !== story.schemaVersion
     || JSON.stringify(embeddedStory) !== JSON.stringify(story)) {
     fail('positive_story_contract_mismatch');
   }
-  if (!isSignedSystemRecord(reads.latest.payload.record)
-    || !productRecordMatchesStory(reads.latest.payload.record, story)
+  if (!productRecordMatchesStory(reads.latest.payload.record, story)
     || reads.latest.payload.record.latest_activity_at !== Math.max(0, Math.floor(story.cluster_window_end))) {
     fail('positive_latest_contract_mismatch');
   }
-  if (!isSignedSystemRecord(reads.hot.payload.record)
-    || !productRecordMatchesStory(reads.hot.payload.record, story)
+  if (!productRecordMatchesStory(reads.hot.payload.record, story)
     || !Number.isFinite(Number(reads.hot.payload.record.hotness))
     || Number(reads.hot.payload.record.hotness) < 0) {
     fail('positive_hot_contract_mismatch');
@@ -439,18 +555,16 @@ async function verifyPositiveStoryOnOrigin(origin, story, tickWindow, options) {
     options.nowMs,
     options,
   );
-  if (!isSignedSystemRecord(reads.lifecycle.payload.lifecycle)
-    || JSON.stringify(reads.lifecycle.payload.record) !== JSON.stringify(reads.lifecycle.payload.lifecycle)
+  if (JSON.stringify(reads.lifecycle.payload.record) !== JSON.stringify(reads.lifecycle.payload.lifecycle)
     || !lifecycleMode) {
     fail('positive_lifecycle_contract_mismatch');
   }
   return {
     lifecycleMode,
-    signedRecords: {
+    replicatedSignedRecords: {
       story: reads.story.payload.record,
       latest: reads.latest.payload.record,
       hot: reads.hot.payload.record,
-      lifecycle: reads.lifecycle.payload.lifecycle,
     },
   };
 }
@@ -482,12 +596,18 @@ async function verifyMissingContracts(origins, expectedRevision, runId, options)
 export async function verifyPublisherRecovery(options) {
   if (!fullRevision(options.expectedRevision)) fail('expected_revision_invalid');
   await requireOutputAbsent(options.outputFile);
+  const systemWriterPin = options.systemWriterPin ?? resolveSystemWriterPinFromEnv(options.env ?? process.env);
+  const validateSystemWriterRecord = await loadCanonicalSystemWriterValidator(
+    options.validateSystemWriterRecord,
+  );
   const fetchOptions = {
     fetchFn: options.fetchFn ?? fetch,
     timeoutMs: positiveInteger(options.timeoutMs, 5_000, 'timeout_invalid'),
     nowMs: options.nowMs ?? Date.now(),
     incompleteLifecycleMaxAgeMs: options.incompleteLifecycleMaxAgeMs,
     inProgressLifecycleMaxAgeMs: options.inProgressLifecycleMaxAgeMs,
+    systemWriterPin,
+    validateSystemWriterRecord,
   };
   const startControl = await verifyStartControlArtifact({
     filePath: options.startControlFile,
@@ -543,10 +663,10 @@ export async function verifyPublisherRecovery(options) {
       for (const origin of origins) {
         const projection = await verifyPositiveStoryOnOrigin(origin, story, tickWindow, fetchOptions);
         if (signedRecordProjection !== null
-          && JSON.stringify(projection.signedRecords) !== JSON.stringify(signedRecordProjection)) {
+          && JSON.stringify(projection.replicatedSignedRecords) !== JSON.stringify(signedRecordProjection)) {
           fail('positive_signed_record_replication_mismatch');
         }
-        signedRecordProjection = projection.signedRecords;
+        signedRecordProjection = projection.replicatedSignedRecords;
         modes.push(projection.lifecycleMode);
       }
       verifiedStory = story;

--- a/tools/scripts/verify-news-aggregator-publisher-recovery.test.mjs
+++ b/tools/scripts/verify-news-aggregator-publisher-recovery.test.mjs
@@ -22,6 +22,7 @@ import {
   validateSystemWriterRecord,
 } from '../../packages/gun-client/dist/systemWriter.js';
 import {
+  canonicalSystemWriterPinSha256,
   PublisherRecoveryVerificationError,
   verifyPublisherRecovery,
 } from './verify-news-aggregator-publisher-recovery.mjs';
@@ -52,6 +53,7 @@ const SYSTEM_WRITER_PIN = {
     publicKey: { encoding: 'spki-base64url', material: SYSTEM_WRITER_PUBLIC_KEY },
   }],
 };
+const SYSTEM_WRITER_PIN_SHA256 = canonicalSystemWriterPinSha256(SYSTEM_WRITER_PIN);
 const SIGNED_PATHS = {
   story: (storyId) => `vh/news/stories/${storyId}/`,
   latest: (storyId) => `vh/news/index/latest/${storyId}/`,
@@ -179,8 +181,10 @@ function startControl(overrides = {}) {
     postActivation: {
       activeState: 'active', subState: 'running', nRestarts: 0,
       attendedPermitConsumed: true,
+      attendedReceiptConsumed: true,
       legacyManagerApprovalCleared: true,
       attendedPermitBindingSha256: '7'.repeat(64),
+      attendedReceiptSha256: '8'.repeat(64),
     },
     evidenceBindings: {
       preflight: {
@@ -199,6 +203,7 @@ function startControl(overrides = {}) {
         schemaVersion: 'vhc-failure-mailbox-monitor-v1', sha256: '6'.repeat(64),
         newCriticalCount: 11, generatedAt: '2026-07-10T10:26:00.000Z',
       },
+      systemWriterPin: { sha256: SYSTEM_WRITER_PIN_SHA256 },
     },
     ...overrides,
   };
@@ -527,6 +532,9 @@ test('real Ed25519 verification rejects a valid signature under the wrong pinned
   const wrongPin = structuredClone(SYSTEM_WRITER_PIN);
   wrongPin.writers[0].publicKey.material = wrongPublicKey;
   try {
+    const start = JSON.parse(await readFile(files.startFile, 'utf8'));
+    start.evidenceBindings.systemWriterPin.sha256 = canonicalSystemWriterPinSha256(wrongPin);
+    await privateJson(files.startFile, start);
     await assert.rejects(
       verify(files, relays, { systemWriterPin: wrongPin }),
       (error) => error.code === 'positive_story_signature_invalid',
@@ -879,6 +887,29 @@ test('rejects revision, run, and start-boundary mismatches before network proof'
     }
   } finally {
     await relays.close();
+  }
+});
+
+test('rejects system-writer pin drift from start control before contacting any relay', async () => {
+  const files = await fixture();
+  const relays = await startRelays();
+  try {
+    const start = JSON.parse(await readFile(files.startFile, 'utf8'));
+    start.evidenceBindings.systemWriterPin.sha256 = 'f'.repeat(64);
+    await privateJson(files.startFile, start);
+    await assert.rejects(
+      verify(files, relays),
+      (error) => error.code === 'system_writer_pin_drift',
+    );
+    assert.deepEqual(relays.counts, [
+      { positive: 0, missing: 0 },
+      { positive: 0, missing: 0 },
+      { positive: 0, missing: 0 },
+    ]);
+    await assert.rejects(lstat(files.outputFile), (error) => error.code === 'ENOENT');
+  } finally {
+    await relays.close();
+    await rm(files.root, { recursive: true, force: true });
   }
 });
 

--- a/tools/scripts/verify-news-aggregator-publisher-recovery.test.mjs
+++ b/tools/scripts/verify-news-aggregator-publisher-recovery.test.mjs
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import { spawn } from 'node:child_process';
+import { createPrivateKey, generateKeyPairSync, sign } from 'node:crypto';
 import {
   chmod,
   lstat,
@@ -17,6 +18,10 @@ import path from 'node:path';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
 import {
+  canonicalizeSystemWriterRecordBytes,
+  validateSystemWriterRecord,
+} from '../../packages/gun-client/dist/systemWriter.js';
+import {
   PublisherRecoveryVerificationError,
   verifyPublisherRecovery,
 } from './verify-news-aggregator-publisher-recovery.mjs';
@@ -25,6 +30,34 @@ const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const SCRIPT = path.join(SCRIPT_DIR, 'verify-news-aggregator-publisher-recovery.mjs');
 const REVISION = '1883841555c4924be8d35747272c38ce8f2071d9';
 const NOW = Date.parse('2026-07-10T12:00:00.000Z');
+const SYSTEM_WRITER_ID = 'vh-e2e-news-daemon-system-writer-v1';
+const SYSTEM_WRITER_PUBLIC_KEY =
+  'MCowBQYDK2VwAyEA4ZHLho6yDOsGogTtrVUWiTRIGYlxKexsprzKjbuy9js';
+const SYSTEM_WRITER_PRIVATE_KEY = createPrivateKey({
+  key: Buffer.from(
+    'MC4CAQAwBQYDK2VwBCIEIOHbQB3dtUl7cAXBpr6o_V7Tb1YuS6hcp7CLnRS-CscA',
+    'base64url',
+  ),
+  format: 'der',
+  type: 'pkcs8',
+});
+const SYSTEM_WRITER_PIN = {
+  pinVersion: 1,
+  schemaEpoch: 'luma-public-v1',
+  maxProtocolVersion: 'luma-public-v1',
+  signatureSuite: 'jcs-ed25519-sha256-v1',
+  writers: [{
+    id: SYSTEM_WRITER_ID,
+    status: 'active',
+    publicKey: { encoding: 'spki-base64url', material: SYSTEM_WRITER_PUBLIC_KEY },
+  }],
+};
+const SIGNED_PATHS = {
+  story: (storyId) => `vh/news/stories/${storyId}/`,
+  latest: (storyId) => `vh/news/index/latest/${storyId}/`,
+  hot: (storyId) => `vh/news/index/hot/${storyId}/`,
+  lifecycle: (storyId) => `vh/news/stories/${storyId}/synthesis_lifecycle/latest/`,
+};
 
 const story = {
   schemaVersion: 'story-bundle-v0',
@@ -77,14 +110,26 @@ function lifecycle(updatedAt = Date.parse('2026-07-10T11:30:00.000Z'), status = 
   };
 }
 
-function signedFields(selectedStory, route) {
-  return {
+function signSystemRecord(payload, selectedStory, route, overrides = {}) {
+  const unsigned = {
+    ...payload,
+    _system: null,
+    _Signature: null,
+    _WriterId: null,
+    _IssuedAt: null,
     _protocolVersion: 'luma-public-v1',
     _writerKind: 'system',
-    _systemWriterId: 'publisher-recovery-test-writer',
+    _systemWriterId: SYSTEM_WRITER_ID,
     _systemIssuedAt: selectedStory.created_at + 1,
-    _systemSignature: `test-signature:${route}:${selectedStory.story_id}`,
+    ...overrides,
   };
+  const signature = sign(
+    null,
+    Buffer.from(canonicalizeSystemWriterRecordBytes(unsigned)),
+    SYSTEM_WRITER_PRIVATE_KEY,
+  ).toString('base64url');
+  assert.ok(SIGNED_PATHS[route](selectedStory.story_id));
+  return { ...unsigned, _systemSignature: signature };
 }
 
 async function privateJson(file, payload) {
@@ -122,7 +167,7 @@ function startControl(overrides = {}) {
   return {
     schemaVersion: 'vh-news-publisher-start-control-v1',
     generatedAt: '2026-07-10T10:31:00.000Z',
-    status: 'active_approval_cleared',
+    status: 'active_attended_permit_consumed',
     revision: REVISION,
     startedAt: '2026-07-10T10:30:00.000Z',
     activatedAt: '2026-07-10T10:30:30.000Z',
@@ -131,7 +176,12 @@ function startControl(overrides = {}) {
       incidentNRestarts: 4, enabledState: 'disabled',
     },
     activationBaseline: { nRestarts: 0, capturedAfterResetFailed: true },
-    postActivation: { activeState: 'active', subState: 'running', nRestarts: 0, managerApprovalCleared: true },
+    postActivation: {
+      activeState: 'active', subState: 'running', nRestarts: 0,
+      attendedPermitConsumed: true,
+      legacyManagerApprovalCleared: true,
+      attendedPermitBindingSha256: '7'.repeat(64),
+    },
     evidenceBindings: {
       preflight: {
         schemaVersion: 'vh-news-daemon-recovery-preflight-v1', sha256: '1'.repeat(64), revision: REVISION,
@@ -279,40 +329,58 @@ function responder(options = {}) {
       jsonResponse(res, 200, {}, { 'content-length': String(1_048_577) });
       return;
     }
+    if (options.redirectPath === url.pathname) {
+      res.writeHead(302, { location: options.redirectLocation });
+      res.end();
+      return;
+    }
+    if (options.stalledBodyPath === url.pathname) {
+      res.writeHead(200, { 'content-type': 'application/json; charset=utf-8' });
+      res.write('{"ok":');
+      return;
+    }
     let payload;
     if (url.pathname === '/vh/news/story') {
+      const record = signSystemRecord({
+        __story_bundle_json: JSON.stringify(selectedStory),
+        story_id: selectedStory.story_id,
+        created_at: selectedStory.created_at,
+        schemaVersion: selectedStory.schemaVersion,
+      }, selectedStory, 'story', options.signatureOverrides?.story);
       payload = {
         ok: true, story_id: selectedStory.story_id, topic_id: selectedStory.topic_id,
         source: 'story-body', story: selectedStory,
-        record: {
-          __story_bundle_json: JSON.stringify(selectedStory),
-          story_id: selectedStory.story_id,
-          created_at: selectedStory.created_at,
-          schemaVersion: selectedStory.schemaVersion,
-          ...signedFields(selectedStory, 'story'),
-        },
+        record,
       };
     } else if (url.pathname === '/vh/news/latest-index') {
+      const record = signSystemRecord(
+        productRecord({ latest_activity_at: selectedStory.cluster_window_end }, selectedStory),
+        selectedStory,
+        'latest',
+        options.signatureOverrides?.latest,
+      );
       payload = {
         ok: true, story_id: selectedStory.story_id,
-        record: {
-          ...productRecord({ latest_activity_at: selectedStory.cluster_window_end }, selectedStory),
-          ...signedFields(selectedStory, 'latest'),
-        },
+        record,
       };
     } else if (url.pathname === '/vh/news/hot-index') {
+      const record = signSystemRecord(
+        productRecord({ hotness: 0.75 }, selectedStory),
+        selectedStory,
+        'hot',
+        options.signatureOverrides?.hot,
+      );
       payload = {
         ok: true, story_id: selectedStory.story_id,
-        record: {
-          ...productRecord({ hotness: 0.75 }, selectedStory),
-          ...signedFields(selectedStory, 'hot'),
-        },
+        record,
       };
     } else if (url.pathname === '/vh/news/synthesis-lifecycle') {
-      const record = {
-        ...lifecycle(options.lifecycleUpdatedAt, options.lifecycleStatus, selectedStory),
-        ...signedFields(selectedStory, 'lifecycle'),
-      };
+      const perRelayLifecycle = options.lifecycleByRelay?.[options.relayIndex];
+      const record = signSystemRecord(lifecycle(
+        perRelayLifecycle?.updatedAt ?? options.lifecycleUpdatedAt,
+        perRelayLifecycle?.status ?? options.lifecycleStatus,
+        selectedStory,
+      ), selectedStory, 'lifecycle', options.signatureOverrides?.lifecycle);
       if (options.malformedLifecycle) delete record.source_set_revision;
       payload = {
         ok: true, story_id: selectedStory.story_id, topic_id: selectedStory.topic_id,
@@ -328,10 +396,19 @@ function responder(options = {}) {
     }
     if (options.tamperedSignatureStoryId === storyId && options.relayIndex === 0) {
       if (url.pathname === '/vh/news/synthesis-lifecycle') {
-        payload.lifecycle._systemSignature = 'tampered-signature';
+        payload.lifecycle._systemSignature = Buffer.alloc(64, 0xa5).toString('base64url');
         payload.record = payload.lifecycle;
       } else if (payload.record) {
-        payload.record._systemSignature = 'tampered-signature';
+        payload.record._systemSignature = Buffer.alloc(64, 0xa5).toString('base64url');
+      }
+    }
+    if (options.forgedSignaturePath === url.pathname) {
+      const forged = Buffer.alloc(64, options.relayIndex + 1).toString('base64url');
+      if (url.pathname === '/vh/news/synthesis-lifecycle') {
+        payload.lifecycle._systemSignature = forged;
+        payload.record = payload.lifecycle;
+      } else {
+        payload.record._systemSignature = forged;
       }
     }
     jsonResponse(res, 200, payload);
@@ -356,7 +433,10 @@ async function startRelays(options = {}) {
     origins: relays.map((relay) => relay.origin),
     counts,
     requests,
-    close: () => Promise.all(relays.map(({ server }) => new Promise((resolve) => server.close(resolve)))),
+    close: () => Promise.all(relays.map(({ server }) => new Promise((resolve) => {
+      server.close(resolve);
+      server.closeAllConnections?.();
+    }))),
   };
 }
 
@@ -377,11 +457,12 @@ async function verify(files, relays, overrides = {}) {
     maxTickAgeMs: 60 * 60 * 1000,
     startControlMaxAgeMs: 2 * 60 * 60 * 1000,
     completionNowMs: NOW,
+    systemWriterPin: SYSTEM_WRITER_PIN,
     ...verificationOverrides,
   });
 }
 
-test('verifies three relays x four positive and four missing contracts using tick2 and drifted capture counter', async () => {
+test('real Ed25519 verification passes three relays x four positive and four missing contracts', async () => {
   const files = await fixture();
   const relays = await startRelays();
   try {
@@ -410,6 +491,75 @@ test('verifies three relays x four positive and four missing contracts using tic
     const artifact = JSON.parse(await readFile(files.outputFile, 'utf8'));
     assert.equal(artifact.revision, REVISION);
     assert.equal((await lstat(files.outputFile)).mode & 0o777, 0o600);
+  } finally {
+    await relays.close();
+    await rm(files.root, { recursive: true, force: true });
+  }
+});
+
+test('real Ed25519 verification rejects tampering independently on all four positive routes', async () => {
+  const rows = [
+    ['/vh/news/story', 'positive_story_signature_invalid'],
+    ['/vh/news/latest-index', 'positive_latest_signature_invalid'],
+    ['/vh/news/hot-index', 'positive_hot_signature_invalid'],
+    ['/vh/news/synthesis-lifecycle', 'positive_lifecycle_signature_invalid'],
+  ];
+  for (const [forgedSignaturePath, code] of rows) {
+    const files = await fixture();
+    const relays = await startRelays({ forgedSignaturePath });
+    try {
+      await assert.rejects(verify(files, relays), (error) => error.code === code);
+      await assert.rejects(lstat(files.outputFile), (error) => error.code === 'ENOENT');
+    } finally {
+      await relays.close();
+      await rm(files.root, { recursive: true, force: true });
+    }
+  }
+});
+
+test('real Ed25519 verification rejects a valid signature under the wrong pinned public key', async () => {
+  const files = await fixture();
+  const relays = await startRelays();
+  const wrongPublicKey = generateKeyPairSync('ed25519').publicKey.export({
+    format: 'der',
+    type: 'spki',
+  }).toString('base64url');
+  const wrongPin = structuredClone(SYSTEM_WRITER_PIN);
+  wrongPin.writers[0].publicKey.material = wrongPublicKey;
+  try {
+    await assert.rejects(
+      verify(files, relays, { systemWriterPin: wrongPin }),
+      (error) => error.code === 'positive_story_signature_invalid',
+    );
+    await assert.rejects(lstat(files.outputFile), (error) => error.code === 'ENOENT');
+  } finally {
+    await relays.close();
+    await rm(files.root, { recursive: true, force: true });
+  }
+});
+
+test('canonical signature validation fails closed when a positive record is checked at a wrong path', async () => {
+  const files = await fixture();
+  const relays = await startRelays();
+  let injectedWrongPath = false;
+  try {
+    await assert.rejects(
+      verify(files, relays, {
+        validateSystemWriterRecord: async (input) => {
+          if (!injectedWrongPath) {
+            injectedWrongPath = true;
+            return validateSystemWriterRecord({
+              ...input,
+              path: `vh/not-allowed/${story.story_id}`,
+            });
+          }
+          return validateSystemWriterRecord(input);
+        },
+      }),
+      (error) => error.code === 'positive_story_signature_invalid',
+    );
+    assert.equal(injectedWrongPath, true);
+    await assert.rejects(lstat(files.outputFile), (error) => error.code === 'ENOENT');
   } finally {
     await relays.close();
     await rm(files.root, { recursive: true, force: true });
@@ -517,7 +667,7 @@ test('never hides a tampered first written candidate behind a later good candida
   try {
     await assert.rejects(
       verify(files, relays),
-      (error) => error.code === 'positive_signed_record_replication_mismatch',
+      (error) => error.code === 'positive_story_signature_invalid',
     );
     assert.equal(relays.requests.flat().some((request) => request.includes(secondStory.story_id)), false);
   } finally {
@@ -573,6 +723,28 @@ test('accepts a preserved current lifecycle and rejects a stale preserved pendin
   }
 });
 
+test('accepts mixed updated, preserved-current, and preserved-terminal lifecycle states across relays', async () => {
+  const files = await fixture();
+  const relays = await startRelays({
+    lifecycleByRelay: [
+      { status: 'pending', updatedAt: Date.parse('2026-07-10T11:12:00.000Z') },
+      { status: 'retryable_failure', updatedAt: Date.parse('2026-07-10T11:30:00.000Z') },
+      { status: 'accepted_available', updatedAt: Date.parse('2026-06-01T00:00:00.000Z') },
+    ],
+  });
+  try {
+    const result = await verify(files, relays);
+    assert.deepEqual(result.lifecycleModes, [
+      'updated_in_tick',
+      'preserved_current',
+      'preserved_terminal',
+    ]);
+  } finally {
+    await relays.close();
+    await rm(files.root, { recursive: true, force: true });
+  }
+});
+
 test('accepts preserved terminal lifecycle and enforces the distinct 10-minute in-progress boundary', async () => {
   const terminalFiles = await fixture();
   const terminalRelays = await startRelays({
@@ -609,7 +781,7 @@ test('accepts preserved terminal lifecycle and enforces the distinct 10-minute i
   const malformedFiles = await fixture();
   const malformedRelays = await startRelays({ lifecycleStatus: 'accepted_available', malformedLifecycle: true });
   try {
-    await assert.rejects(verify(malformedFiles, malformedRelays), (error) => error.code === 'positive_lifecycle_contract_mismatch');
+    await assert.rejects(verify(malformedFiles, malformedRelays), (error) => error.code === 'positive_lifecycle_signature_invalid');
   } finally {
     await malformedRelays.close();
     await rm(malformedFiles.root, { recursive: true, force: true });
@@ -632,6 +804,54 @@ test('rejects malformed and oversize response bodies without accepting partial r
       await relays.close();
       await rm(files.root, { recursive: true, force: true });
     }
+  }
+});
+
+test('rejects redirects without ever contacting the redirect target', async () => {
+  let redirectTargetContacts = 0;
+  const target = http.createServer((_req, res) => {
+    redirectTargetContacts += 1;
+    jsonResponse(res, 200, { ok: true });
+  });
+  await new Promise((resolve) => target.listen(0, '127.0.0.1', resolve));
+  const targetAddress = target.address();
+  const targetOrigin = `http://127.0.0.1:${targetAddress.port}`;
+  const files = await fixture();
+  const relays = await startRelays({
+    redirectPath: '/vh/news/story',
+    redirectLocation: `${targetOrigin}/must-not-be-contacted`,
+  });
+  try {
+    await assert.rejects(
+      verify(files, relays),
+      (error) => error.code === 'relay_readback_network_failed',
+    );
+    assert.equal(redirectTargetContacts, 0);
+    await assert.rejects(lstat(files.outputFile), (error) => error.code === 'ENOENT');
+  } finally {
+    await relays.close();
+    await new Promise((resolve) => {
+      target.close(resolve);
+      target.closeAllConnections?.();
+    });
+    await rm(files.root, { recursive: true, force: true });
+  }
+});
+
+test('response-body stalls remain inside the relay timeout and leave no pass artifact', async () => {
+  const files = await fixture();
+  const relays = await startRelays({ stalledBodyPath: '/vh/news/story' });
+  const startedAt = Date.now();
+  try {
+    await assert.rejects(
+      verify(files, relays, { timeoutMs: 100 }),
+      (error) => error.code === 'relay_readback_body_failed',
+    );
+    assert.ok(Date.now() - startedAt < 2_000, 'stalled body exceeded the bounded verifier timeout');
+    await assert.rejects(lstat(files.outputFile), (error) => error.code === 'ENOENT');
+  } finally {
+    await relays.close();
+    await rm(files.root, { recursive: true, force: true });
   }
 });
 
@@ -717,7 +937,10 @@ function spawnVerifier(args) {
   return new Promise((resolve) => {
     const child = spawn(process.execPath, [SCRIPT, ...args], {
       cwd: path.resolve(SCRIPT_DIR, '../..'),
-      env: process.env,
+      env: {
+        ...process.env,
+        VH_NEWS_SYSTEM_WRITER_PIN_JSON: JSON.stringify(SYSTEM_WRITER_PIN),
+      },
       stdio: ['ignore', 'pipe', 'pipe'],
     });
     let stdout = '';

--- a/tools/scripts/verify-news-aggregator-publisher-recovery.test.mjs
+++ b/tools/scripts/verify-news-aggregator-publisher-recovery.test.mjs
@@ -1,0 +1,785 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import {
+  chmod,
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  realpath,
+  rm,
+  symlink,
+  writeFile,
+} from 'node:fs/promises';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import {
+  PublisherRecoveryVerificationError,
+  verifyPublisherRecovery,
+} from './verify-news-aggregator-publisher-recovery.mjs';
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const SCRIPT = path.join(SCRIPT_DIR, 'verify-news-aggregator-publisher-recovery.mjs');
+const REVISION = '1883841555c4924be8d35747272c38ce8f2071d9';
+const NOW = Date.parse('2026-07-10T12:00:00.000Z');
+
+const story = {
+  schemaVersion: 'story-bundle-v0',
+  story_id: 'story-recovery',
+  topic_id: 'topic-recovery',
+  headline: 'Recovery story',
+  cluster_window_start: 1_720_000_000_000,
+  cluster_window_end: 1_720_000_060_000,
+  sources: [{
+    source_id: 'source-a', publisher: 'Source A', url: 'https://example.test/a',
+    url_hash: 'hash-a', title: 'Recovery source',
+  }],
+  cluster_features: { entity_keys: ['recovery'], time_bucket: '2026-07-10T11', semantic_signature: 'sig' },
+  provenance_hash: 'source-set-recovery',
+  created_at: 1_720_000_070_000,
+};
+const secondStory = {
+  ...structuredClone(story),
+  story_id: 'story-recovery-second',
+  provenance_hash: 'source-set-recovery-second',
+  headline: 'Second recovery story',
+};
+
+function productRecord(extra = {}, selectedStory = story) {
+  return {
+    story_id: selectedStory.story_id,
+    product_state_schema_version: 'vh-news-product-feed-index-v1',
+    topic_id: selectedStory.topic_id,
+    source_set_revision: selectedStory.provenance_hash,
+    source_count: selectedStory.sources.length,
+    canonical_source_count: (selectedStory.primary_sources ?? selectedStory.sources).length,
+    story_created_at: selectedStory.created_at,
+    cluster_window_start: selectedStory.cluster_window_start,
+    ...extra,
+  };
+}
+
+function lifecycle(updatedAt = Date.parse('2026-07-10T11:30:00.000Z'), status = 'pending', selectedStory = story) {
+  return {
+    schemaVersion: 'vh-news-synthesis-lifecycle-v1',
+    story_id: selectedStory.story_id,
+    topic_id: selectedStory.topic_id,
+    source_set_revision: selectedStory.provenance_hash,
+    source_count: selectedStory.sources.length,
+    canonical_source_count: (selectedStory.primary_sources ?? selectedStory.sources).length,
+    status,
+    retryable: status === 'retryable_failure',
+    frame_table_state: 'frame_table_pending',
+    updated_at: updatedAt,
+  };
+}
+
+function signedFields(selectedStory, route) {
+  return {
+    _protocolVersion: 'luma-public-v1',
+    _writerKind: 'system',
+    _systemWriterId: 'publisher-recovery-test-writer',
+    _systemIssuedAt: selectedStory.created_at + 1,
+    _systemSignature: `test-signature:${route}:${selectedStory.story_id}`,
+  };
+}
+
+async function privateJson(file, payload) {
+  await writeFile(file, `${JSON.stringify(payload, null, 2)}\n`, { mode: 0o600 });
+  await chmod(file, 0o600);
+  return file;
+}
+
+function tick(sequence, overrides = {}) {
+  const started = sequence === 1 ? '2026-07-10T11:00:00.000Z' : '2026-07-10T11:10:00.000Z';
+  const completed = sequence === 1 ? '2026-07-10T11:05:00.000Z' : '2026-07-10T11:15:00.000Z';
+  return {
+    schemaVersion: 'vh-news-runtime-tick-summary-v1',
+    tick_sequence: sequence,
+    first_tick: sequence === 1,
+    status: 'completed',
+    skipped: false,
+    no_write: false,
+    started_at: started,
+    completed_at: completed,
+    duration_ms: 300_000,
+    selected_bundle_count: 1,
+    raw_write_attempted_count: 1,
+    raw_write_suppressed_count: 0,
+    raw_wrote_count: 1,
+    raw_write_failed_count: 0,
+    nonfatal_prewrite_failure_count: 0,
+    first_selected_story_ids: [story.story_id],
+    first_raw_written_story_ids: [story.story_id],
+    ...overrides,
+  };
+}
+
+function startControl(overrides = {}) {
+  return {
+    schemaVersion: 'vh-news-publisher-start-control-v1',
+    generatedAt: '2026-07-10T10:31:00.000Z',
+    status: 'active_approval_cleared',
+    revision: REVISION,
+    startedAt: '2026-07-10T10:30:00.000Z',
+    activatedAt: '2026-07-10T10:30:30.000Z',
+    preStart: {
+      activeState: 'failed', subState: 'failed', result: 'exit-code', execMainStatus: 78,
+      incidentNRestarts: 4, enabledState: 'disabled',
+    },
+    activationBaseline: { nRestarts: 0, capturedAfterResetFailed: true },
+    postActivation: { activeState: 'active', subState: 'running', nRestarts: 0, managerApprovalCleared: true },
+    evidenceBindings: {
+      preflight: {
+        schemaVersion: 'vh-news-daemon-recovery-preflight-v1', sha256: '1'.repeat(64), revision: REVISION,
+        runId: 'preflight-recovery', generatedAt: '2026-07-10T10:20:00.000Z',
+      },
+      relayRecovery: {
+        schemaVersion: 'vh-a6-s1b-relay-recovery-evidence-v1', sha256: '2'.repeat(64), revision: REVISION,
+        generatedAt: '2026-07-10T10:10:00.000Z', immutableImageId: `sha256:${'3'.repeat(64)}`,
+        imageTag: 'vhc-public-beta-relay:20260710-main-v18838415-amd64', packetSha256: '4'.repeat(64),
+        captureSha256: '5'.repeat(64), reviewerIdentity: 'reviewer-1', reviewedAt: '2026-07-10T10:25:00.000Z',
+        relayOrder: ['vhc-relay-a', 'vhc-relay-b', 'vhc-relay-c'],
+        relayOrigins: ['http://127.0.0.1:8765', 'http://127.0.0.1:8766', 'http://127.0.0.1:8767'],
+      },
+      mailbox: {
+        schemaVersion: 'vhc-failure-mailbox-monitor-v1', sha256: '6'.repeat(64),
+        newCriticalCount: 11, generatedAt: '2026-07-10T10:26:00.000Z',
+      },
+    },
+    ...overrides,
+  };
+}
+
+function clusterTick(generatedAt, tickSequence = 299, stories = [story]) {
+  return {
+    schemaVersion: 'news-orchestrator-cluster-artifacts-v1',
+    generatedAt,
+    tickSequence,
+    rawItemCount: 1,
+    normalizedItems: [],
+    topicCaptures: [{
+      topicId: story.topic_id,
+      items: [],
+      result: { bundles: stories, storylines: [] },
+    }],
+  };
+}
+
+async function fixture(overrides = {}) {
+  const root = await realpath(await mkdtemp(path.join(os.tmpdir(), 'vh-publisher-readback-')));
+  const artifactRoot = path.join(root, 'artifacts');
+  const runId = 'run-recovery';
+  const runDir = path.join(artifactRoot, runId);
+  let captureRunDir = runDir;
+  if (overrides.runDirSymlink) {
+    await mkdir(artifactRoot, { recursive: true });
+    captureRunDir = path.join(root, 'escaped-run-directory');
+    await mkdir(captureRunDir, { recursive: true });
+    await symlink(captureRunDir, runDir);
+  } else {
+    await mkdir(runDir, { recursive: true });
+  }
+  let recordedArtifactRoot = artifactRoot;
+  if (overrides.artifactRootSymlink) {
+    recordedArtifactRoot = path.join(root, 'artifact-link');
+    await symlink(artifactRoot, recordedArtifactRoot);
+  }
+  const ticks = overrides.ticks ?? [tick(1), tick(2)];
+  const latest = overrides.latest ?? structuredClone(ticks.at(-1));
+  const startFile = await privateJson(path.join(root, 'start-control.json'), startControl(overrides.start));
+  const currentRunFile = await privateJson(path.join(root, 'current-run.json'), {
+    schemaVersion: 'vh-news-daemon-current-run-v1',
+    generatedAt: '2026-07-10T10:40:00.000Z',
+    status: 'preflight_passed',
+    revision: overrides.currentRevision ?? REVISION,
+    runId: overrides.currentRunId ?? runId,
+    artifactRoot: recordedArtifactRoot,
+    noWrite: false,
+  });
+  const diagnosticsFile = await privateJson(path.join(root, 'diagnostics.json'), {
+    schemaVersion: 'vh-news-runtime-diagnostics-v1',
+    generatedAt: '2026-07-10T11:15:00.000Z',
+    runId: overrides.diagnosticsRunId ?? runId,
+    noWrite: false,
+    latest,
+    summaries: ticks,
+  });
+  const captureTicks = overrides.captureTicks ?? [clusterTick('2026-07-10T11:12:00.000Z')];
+  await privateJson(path.join(captureRunDir, 'cluster-capture.json'), {
+    schemaVersion: 'daemon-feed-cluster-capture-v1',
+    generatedAt: '2026-07-10T11:12:01.000Z',
+    runId,
+    ticks: captureTicks,
+  });
+  return {
+    root,
+    startFile,
+    currentRunFile,
+    diagnosticsFile,
+    outputFile: path.join(root, 'readback.json'),
+  };
+}
+
+async function bindStartControlOrigins(files, origins) {
+  const payload = JSON.parse(await readFile(files.startFile, 'utf8'));
+  payload.evidenceBindings.relayRecovery.relayOrigins = [...origins];
+  await privateJson(files.startFile, payload);
+}
+
+function jsonResponse(res, status, payload, headers = {}) {
+  const body = typeof payload === 'string' ? payload : JSON.stringify(payload);
+  res.writeHead(status, { 'content-type': 'application/json; charset=utf-8', ...headers });
+  res.end(body);
+}
+
+function responder(options = {}) {
+  const counts = { positive: 0, missing: 0 };
+  const requests = [];
+  const handler = (req, res) => {
+    const url = new URL(req.url, 'http://relay.invalid');
+    requests.push(`${url.pathname}?${url.searchParams.toString()}`);
+    const storyId = url.searchParams.get('story_id');
+    const missing = storyId?.startsWith('vh-publisher-recovery-missing-');
+    if (missing) {
+      counts.missing += 1;
+      const errors = {
+        '/vh/news/story': 'news-story-not-found',
+        '/vh/news/latest-index': 'news-latest-index-not-found',
+        '/vh/news/hot-index': 'news-hot-index-not-found',
+        '/vh/news/synthesis-lifecycle': 'news-synthesis-lifecycle-not-found',
+      };
+      jsonResponse(res, 404, { ok: false, error: errors[url.pathname], story_id: storyId });
+      return;
+    }
+    const selectedStory = options.stories?.find((candidate) => candidate.story_id === storyId) ?? story;
+    if (options.missingStoryId === storyId) {
+      const errors = {
+        '/vh/news/story': 'news-story-not-found',
+        '/vh/news/latest-index': 'news-latest-index-not-found',
+        '/vh/news/hot-index': 'news-hot-index-not-found',
+        '/vh/news/synthesis-lifecycle': 'news-synthesis-lifecycle-not-found',
+      };
+      jsonResponse(res, 404, { ok: false, error: errors[url.pathname], story_id: storyId });
+      return;
+    }
+    counts.positive += 1;
+    if (options.hostilePath === url.pathname) {
+      jsonResponse(res, 200, { ok: true, story_id: story.story_id, leaked_secret: options.secret ?? 'TOP-SECRET' });
+      return;
+    }
+    if (options.malformedPath === url.pathname) {
+      jsonResponse(res, 200, '{not-json');
+      return;
+    }
+    if (options.oversizePath === url.pathname) {
+      jsonResponse(res, 200, {}, { 'content-length': String(1_048_577) });
+      return;
+    }
+    let payload;
+    if (url.pathname === '/vh/news/story') {
+      payload = {
+        ok: true, story_id: selectedStory.story_id, topic_id: selectedStory.topic_id,
+        source: 'story-body', story: selectedStory,
+        record: {
+          __story_bundle_json: JSON.stringify(selectedStory),
+          story_id: selectedStory.story_id,
+          created_at: selectedStory.created_at,
+          schemaVersion: selectedStory.schemaVersion,
+          ...signedFields(selectedStory, 'story'),
+        },
+      };
+    } else if (url.pathname === '/vh/news/latest-index') {
+      payload = {
+        ok: true, story_id: selectedStory.story_id,
+        record: {
+          ...productRecord({ latest_activity_at: selectedStory.cluster_window_end }, selectedStory),
+          ...signedFields(selectedStory, 'latest'),
+        },
+      };
+    } else if (url.pathname === '/vh/news/hot-index') {
+      payload = {
+        ok: true, story_id: selectedStory.story_id,
+        record: {
+          ...productRecord({ hotness: 0.75 }, selectedStory),
+          ...signedFields(selectedStory, 'hot'),
+        },
+      };
+    } else if (url.pathname === '/vh/news/synthesis-lifecycle') {
+      const record = {
+        ...lifecycle(options.lifecycleUpdatedAt, options.lifecycleStatus, selectedStory),
+        ...signedFields(selectedStory, 'lifecycle'),
+      };
+      if (options.malformedLifecycle) delete record.source_set_revision;
+      payload = {
+        ok: true, story_id: selectedStory.story_id, topic_id: selectedStory.topic_id,
+        status: record.status, frame_table_state: record.frame_table_state, lifecycle: record, record,
+      };
+    } else {
+      jsonResponse(res, 404, { ok: false });
+      return;
+    }
+    if (options.extraFieldPath === url.pathname
+      && (!options.extraFieldStoryId || options.extraFieldStoryId === storyId)) {
+      payload.token = options.secret ?? 'TOP-SECRET';
+    }
+    if (options.tamperedSignatureStoryId === storyId && options.relayIndex === 0) {
+      if (url.pathname === '/vh/news/synthesis-lifecycle') {
+        payload.lifecycle._systemSignature = 'tampered-signature';
+        payload.record = payload.lifecycle;
+      } else if (payload.record) {
+        payload.record._systemSignature = 'tampered-signature';
+      }
+    }
+    jsonResponse(res, 200, payload);
+  };
+  return { handler, counts, requests };
+}
+
+async function startRelays(options = {}) {
+  const relays = [];
+  const counts = [];
+  const requests = [];
+  for (let index = 0; index < 3; index += 1) {
+    const route = responder({ ...options, relayIndex: index });
+    const server = http.createServer(route.handler);
+    await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    relays.push({ server, origin: `http://127.0.0.1:${address.port}` });
+    counts.push(route.counts);
+    requests.push(route.requests);
+  }
+  return {
+    origins: relays.map((relay) => relay.origin),
+    counts,
+    requests,
+    close: () => Promise.all(relays.map(({ server }) => new Promise((resolve) => server.close(resolve)))),
+  };
+}
+
+async function verify(files, relays, overrides = {}) {
+  if (overrides.bindReviewedOrigins !== false) {
+    await bindStartControlOrigins(files, relays.origins);
+  }
+  const { bindReviewedOrigins: _ignored, ...verificationOverrides } = overrides;
+  return verifyPublisherRecovery({
+    expectedRevision: REVISION,
+    startControlFile: files.startFile,
+    currentRunFile: files.currentRunFile,
+    runtimeDiagnosticsFile: files.diagnosticsFile,
+    outputFile: files.outputFile,
+    relayOrigins: relays.origins,
+    nowMs: NOW,
+    timeoutMs: 2_000,
+    maxTickAgeMs: 60 * 60 * 1000,
+    startControlMaxAgeMs: 2 * 60 * 60 * 1000,
+    completionNowMs: NOW,
+    ...verificationOverrides,
+  });
+}
+
+test('verifies three relays x four positive and four missing contracts using tick2 and drifted capture counter', async () => {
+  const files = await fixture();
+  const relays = await startRelays();
+  try {
+    const result = await verify(files, relays);
+    assert.equal(result.status, 'pass');
+    assert.equal(result.tickSequence, 2);
+    assert.equal(result.relayCount, 3);
+    assert.equal(result.storyId, story.story_id);
+    assert.deepEqual(relays.counts, [
+      { positive: 4, missing: 4 },
+      { positive: 4, missing: 4 },
+      { positive: 4, missing: 4 },
+    ]);
+    for (const requests of relays.requests) {
+      assert.deepEqual(requests.map((value) => value.replace(/story_id=[^&]+/, 'story_id=<id>')), [
+        '/vh/news/story?story_id=<id>&readback=exact',
+        '/vh/news/latest-index?story_id=<id>&readback=exact&persist=false',
+        '/vh/news/hot-index?story_id=<id>&readback=exact',
+        '/vh/news/synthesis-lifecycle?story_id=<id>&readback=exact',
+        '/vh/news/story?story_id=<id>&readback=exact',
+        '/vh/news/latest-index?story_id=<id>&readback=exact&persist=false',
+        '/vh/news/hot-index?story_id=<id>&readback=exact',
+        '/vh/news/synthesis-lifecycle?story_id=<id>&readback=exact',
+      ]);
+    }
+    const artifact = JSON.parse(await readFile(files.outputFile, 'utf8'));
+    assert.equal(artifact.revision, REVISION);
+    assert.equal((await lstat(files.outputFile)).mode & 0o777, 0o600);
+  } finally {
+    await relays.close();
+    await rm(files.root, { recursive: true, force: true });
+  }
+});
+
+test('uses tick1 when tick2 is green-attempted but has no complete successful write set', async () => {
+  const tick2 = tick(2, {
+    raw_wrote_count: 0,
+    raw_write_suppressed_count: 1,
+    first_raw_written_story_ids: [],
+  });
+  const files = await fixture({
+    ticks: [tick(1), tick2],
+    captureTicks: [clusterTick('2026-07-10T11:02:00.000Z', 17)],
+  });
+  const relays = await startRelays({ lifecycleUpdatedAt: Date.parse('2026-07-10T11:02:30.000Z') });
+  try {
+    const result = await verify(files, relays);
+    assert.equal(result.tickSequence, 1);
+    assert.deepEqual(result.lifecycleModes, ['updated_in_tick', 'updated_in_tick', 'updated_in_tick']);
+  } finally {
+    await relays.close();
+    await rm(files.root, { recursive: true, force: true });
+  }
+});
+
+test('fails closed on missing first tick, contradictory latest, and successful-ID membership mismatch', async () => {
+  const rows = [
+    {
+      name: 'missing first tick',
+      fixture: { ticks: [tick(2)] },
+      code: 'diagnostics_summaries_missing',
+    },
+    {
+      name: 'contradictory latest',
+      fixture: { latest: tick(2, { raw_wrote_count: 99 }) },
+      code: 'diagnostics_latest_invalid',
+    },
+    {
+      name: 'written id not selected',
+      fixture: { ticks: [tick(1), tick(2, { first_selected_story_ids: ['other-story'] })] },
+      code: 'diagnostics_written_story_not_selected',
+    },
+  ];
+  const relays = await startRelays();
+  try {
+    for (const row of rows) {
+      const files = await fixture(row.fixture);
+      try {
+        await assert.rejects(
+          verify(files, relays),
+          (error) => error instanceof PublisherRecoveryVerificationError && error.code === row.code,
+          row.name,
+        );
+      } finally {
+        await rm(files.root, { recursive: true, force: true });
+      }
+    }
+  } finally {
+    await relays.close();
+  }
+});
+
+test('capture binding rejects both zero and multiple capture rows inside the chosen runtime window', async () => {
+  const rows = [
+    [clusterTick('2026-07-10T10:00:00.000Z', 1)],
+    [
+      clusterTick('2026-07-10T11:11:00.000Z', 1),
+      clusterTick('2026-07-10T11:12:00.000Z', 2),
+    ],
+  ];
+  const relays = await startRelays();
+  try {
+    for (const captureTicks of rows) {
+      const files = await fixture({ captureTicks });
+      try {
+        await assert.rejects(verify(files, relays), (error) => error.code === 'cluster_capture_tick_invalid');
+      } finally {
+        await rm(files.root, { recursive: true, force: true });
+      }
+    }
+  } finally {
+    await relays.close();
+  }
+});
+
+test('never hides a tampered first written candidate behind a later good candidate', async () => {
+  const tick2 = tick(2, {
+    selected_bundle_count: 2,
+    raw_write_attempted_count: 2,
+    raw_wrote_count: 2,
+    first_selected_story_ids: [story.story_id, secondStory.story_id],
+    first_raw_written_story_ids: [story.story_id, secondStory.story_id],
+  });
+  const files = await fixture({
+    ticks: [tick(1), tick2],
+    latest: structuredClone(tick2),
+    captureTicks: [clusterTick('2026-07-10T11:12:00.000Z', 299, [story, secondStory])],
+  });
+  const relays = await startRelays({
+    stories: [story, secondStory],
+    tamperedSignatureStoryId: story.story_id,
+  });
+  try {
+    await assert.rejects(
+      verify(files, relays),
+      (error) => error.code === 'positive_signed_record_replication_mismatch',
+    );
+    assert.equal(relays.requests.flat().some((request) => request.includes(secondStory.story_id)), false);
+  } finally {
+    await relays.close();
+    await rm(files.root, { recursive: true, force: true });
+  }
+});
+
+test('only an exact closed 404 may make one written candidate ineligible', async () => {
+  const tick2 = tick(2, {
+    selected_bundle_count: 2,
+    raw_write_attempted_count: 2,
+    raw_wrote_count: 2,
+    first_selected_story_ids: [story.story_id, secondStory.story_id],
+    first_raw_written_story_ids: [story.story_id, secondStory.story_id],
+  });
+  const files = await fixture({
+    ticks: [tick(1), tick2],
+    latest: structuredClone(tick2),
+    captureTicks: [clusterTick('2026-07-10T11:12:00.000Z', 299, [story, secondStory])],
+  });
+  const relays = await startRelays({ stories: [story, secondStory], missingStoryId: story.story_id });
+  try {
+    const result = await verify(files, relays);
+    assert.equal(result.storyId, secondStory.story_id);
+  } finally {
+    await relays.close();
+    await rm(files.root, { recursive: true, force: true });
+  }
+});
+
+test('accepts a preserved current lifecycle and rejects a stale preserved pending lifecycle', async () => {
+  const passFiles = await fixture();
+  const passRelays = await startRelays({ lifecycleUpdatedAt: Date.parse('2026-07-10T11:30:00.000Z') });
+  try {
+    const result = await verify(passFiles, passRelays);
+    assert.deepEqual(result.lifecycleModes, ['preserved_current', 'preserved_current', 'preserved_current']);
+  } finally {
+    await passRelays.close();
+    await rm(passFiles.root, { recursive: true, force: true });
+  }
+
+  const staleFiles = await fixture();
+  const staleRelays = await startRelays({ lifecycleUpdatedAt: Date.parse('2026-07-10T10:00:00.000Z') });
+  try {
+    await assert.rejects(
+      verify(staleFiles, staleRelays),
+      (error) => error.code === 'positive_lifecycle_contract_mismatch',
+    );
+  } finally {
+    await staleRelays.close();
+    await rm(staleFiles.root, { recursive: true, force: true });
+  }
+});
+
+test('accepts preserved terminal lifecycle and enforces the distinct 10-minute in-progress boundary', async () => {
+  const terminalFiles = await fixture();
+  const terminalRelays = await startRelays({
+    lifecycleStatus: 'accepted_available',
+    lifecycleUpdatedAt: Date.parse('2026-06-01T00:00:00.000Z'),
+  });
+  try {
+    const result = await verify(terminalFiles, terminalRelays);
+    assert.deepEqual(result.lifecycleModes, ['preserved_terminal', 'preserved_terminal', 'preserved_terminal']);
+  } finally {
+    await terminalRelays.close();
+    await rm(terminalFiles.root, { recursive: true, force: true });
+  }
+
+  for (const [updatedAt, shouldPass] of [
+    [Date.parse('2026-07-10T11:51:00.000Z'), true],
+    [Date.parse('2026-07-10T11:49:59.999Z'), false],
+  ]) {
+    const files = await fixture();
+    const relays = await startRelays({ lifecycleStatus: 'in_progress', lifecycleUpdatedAt: updatedAt });
+    try {
+      if (shouldPass) {
+        const result = await verify(files, relays);
+        assert.deepEqual(result.lifecycleModes, ['preserved_current', 'preserved_current', 'preserved_current']);
+      } else {
+        await assert.rejects(verify(files, relays), (error) => error.code === 'positive_lifecycle_contract_mismatch');
+      }
+    } finally {
+      await relays.close();
+      await rm(files.root, { recursive: true, force: true });
+    }
+  }
+
+  const malformedFiles = await fixture();
+  const malformedRelays = await startRelays({ lifecycleStatus: 'accepted_available', malformedLifecycle: true });
+  try {
+    await assert.rejects(verify(malformedFiles, malformedRelays), (error) => error.code === 'positive_lifecycle_contract_mismatch');
+  } finally {
+    await malformedRelays.close();
+    await rm(malformedFiles.root, { recursive: true, force: true });
+  }
+});
+
+test('rejects malformed and oversize response bodies without accepting partial route proof', async () => {
+  for (const [options, code] of [
+    [{ malformedPath: '/vh/news/latest-index' }, 'relay_readback_json_invalid'],
+    [{ oversizePath: '/vh/news/hot-index' }, 'relay_readback_body_too_large'],
+  ]) {
+    const files = await fixture();
+    const relays = await startRelays(options);
+    try {
+      await assert.rejects(
+        verify(files, relays),
+        (error) => error.code === code,
+      );
+    } finally {
+      await relays.close();
+      await rm(files.root, { recursive: true, force: true });
+    }
+  }
+});
+
+test('rejects revision, run, and start-boundary mismatches before network proof', async () => {
+  const rows = [
+    [{ currentRevision: 'b'.repeat(40) }, 'current_run_revision_mismatch'],
+    [{ diagnosticsRunId: 'old-run' }, 'diagnostics_run_id_mismatch'],
+    [{ currentRunId: '../escape' }, 'current_run_id_invalid'],
+    [{ artifactRootSymlink: true }, 'current_run_artifact_root_contains_symlink'],
+    [{ runDirSymlink: true }, 'current_run_artifact_run_directory_invalid'],
+    [{ start: {
+      startedAt: '2026-07-10T10:50:00.000Z', activatedAt: '2026-07-10T10:50:10.000Z',
+      generatedAt: '2026-07-10T10:50:20.000Z',
+    } }, 'current_run_predates_attended_start'],
+  ];
+  const relays = await startRelays();
+  try {
+    for (const [overrides, code] of rows) {
+      const files = await fixture(overrides);
+      try {
+        await assert.rejects(verify(files, relays), (error) => error.code === code);
+      } finally {
+        await rm(files.root, { recursive: true, force: true });
+      }
+    }
+  } finally {
+    await relays.close();
+  }
+});
+
+test('binds relay probes to the reviewed ordered explicit loopback origins only', async () => {
+  const relays = await startRelays();
+  const rows = [
+    [['https://127.0.0.1:8765', relays.origins[1], relays.origins[2]], 'relay_origin_invalid'],
+    [['http://localhost:8765', relays.origins[1], relays.origins[2]], 'relay_origin_invalid'],
+    [['http://192.0.2.10:8765', relays.origins[1], relays.origins[2]], 'relay_origin_invalid'],
+    [['http://127.0.0.1', relays.origins[1], relays.origins[2]], 'relay_origin_invalid'],
+    [['http://127.0.0.1:80', relays.origins[1], relays.origins[2]], 'relay_origin_invalid'],
+    [[relays.origins[0], relays.origins[0], relays.origins[2]], 'relay_origin_duplicate'],
+    [[relays.origins[1], relays.origins[0], relays.origins[2]], 'relay_origin_review_binding_mismatch'],
+  ];
+  try {
+    for (const [relayOrigins, code] of rows) {
+      const files = await fixture();
+      try {
+        await bindStartControlOrigins(files, relays.origins);
+        await assert.rejects(
+          verify(files, relays, { bindReviewedOrigins: false, relayOrigins }),
+          (error) => error.code === code,
+        );
+      } finally {
+        await rm(files.root, { recursive: true, force: true });
+      }
+    }
+  } finally {
+    await relays.close();
+  }
+});
+
+test('requires private current-run mode and refuses to clobber any existing readback evidence', async () => {
+  const relays = await startRelays();
+  const weak = await fixture();
+  try {
+    await chmod(weak.currentRunFile, 0o644);
+    await assert.rejects(verify(weak, relays), (error) => error.code === 'current_run_mode_not_0600');
+  } finally {
+    await rm(weak.root, { recursive: true, force: true });
+  }
+
+  const existing = await fixture();
+  try {
+    await writeFile(existing.outputFile, 'preserved-prior-pass\n', { mode: 0o600 });
+    await assert.rejects(verify(existing, relays), (error) => error.code === 'output_already_exists');
+    assert.equal(await readFile(existing.outputFile, 'utf8'), 'preserved-prior-pass\n');
+    assert.deepEqual(relays.counts, [{ positive: 0, missing: 0 }, { positive: 0, missing: 0 }, { positive: 0, missing: 0 }]);
+  } finally {
+    await relays.close();
+    await rm(existing.root, { recursive: true, force: true });
+  }
+});
+
+function spawnVerifier(args) {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [SCRIPT, ...args], {
+      cwd: path.resolve(SCRIPT_DIR, '../..'),
+      env: process.env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => { stdout += chunk; });
+    child.stderr.on('data', (chunk) => { stderr += chunk; });
+    child.on('close', (status) => resolve({ status, stdout, stderr }));
+  });
+}
+
+test('rejects hostile extra top-level fields on every positive route with closed reasons', async () => {
+  const rows = [
+    ['/vh/news/story', 'positive_story_readback_failed'],
+    ['/vh/news/latest-index', 'positive_latest_readback_failed'],
+    ['/vh/news/hot-index', 'positive_hot_readback_failed'],
+    ['/vh/news/synthesis-lifecycle', 'positive_lifecycle_readback_failed'],
+  ];
+  for (const [extraFieldPath, code] of rows) {
+    const files = await fixture();
+    const relays = await startRelays({ extraFieldPath, secret: 'NEVER-ECHO-THIS' });
+    try {
+      await assert.rejects(
+        verify(files, relays),
+        (error) => error.code === code && !String(error.message).includes('NEVER-ECHO-THIS'),
+      );
+    } finally {
+      await relays.close();
+      await rm(files.root, { recursive: true, force: true });
+    }
+  }
+});
+
+test('CLI failure artifact is mode 0600 and never preserves hostile response content', async () => {
+  const files = await fixture();
+  const secret = 'HOSTILE-RELAY-SECRET-DO-NOT-PERSIST';
+  const relays = await startRelays({ extraFieldPath: '/vh/news/story', secret });
+  try {
+    await bindStartControlOrigins(files, relays.origins);
+    const args = [
+      '--expected-revision', REVISION,
+      '--start-control-file', files.startFile,
+      '--current-run-file', files.currentRunFile,
+      '--runtime-diagnostics-file', files.diagnosticsFile,
+      '--output-file', files.outputFile,
+      '--timeout-ms', '2000',
+      '--max-tick-age-ms', String(60 * 60 * 1000),
+      '--start-control-max-age-ms', String(2 * 60 * 60 * 1000),
+      ...relays.origins.flatMap((origin) => ['--relay-origin', origin]),
+    ];
+    const result = await spawnVerifier(args);
+    assert.equal(result.status, 78);
+    const artifactText = await readFile(files.outputFile, 'utf8');
+    const artifact = JSON.parse(artifactText);
+    assert.deepEqual(Object.keys(artifact).sort(), ['generatedAt', 'reason', 'schemaVersion', 'status']);
+    assert.equal(artifact.status, 'fail');
+    assert.doesNotMatch(artifactText + result.stdout + result.stderr, new RegExp(secret));
+    for (const origin of relays.origins) {
+      assert.doesNotMatch(artifactText, new RegExp(origin.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+    }
+    assert.equal((await lstat(files.outputFile)).mode & 0o777, 0o600);
+  } finally {
+    await relays.close();
+    await rm(files.root, { recursive: true, force: true });
+  }
+});

--- a/tools/scripts/write-news-aggregator-production-start-artifact.mjs
+++ b/tools/scripts/write-news-aggregator-production-start-artifact.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { chmod, link, mkdir, open, rename, rm } from 'node:fs/promises';
+import { chmod, link, lstat, mkdir, open, realpath, rename, rm } from 'node:fs/promises';
 import path from 'node:path';
 
 const modeIndex = process.argv.indexOf('--mode');
@@ -22,12 +22,24 @@ if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(runId) || runId === '.' || runId 
   process.exit(78);
 }
 
+async function requirePrivateParent(filePath) {
+  const parent = path.dirname(filePath);
+  await mkdir(parent, { recursive: true, mode: 0o700 });
+  const stat = await lstat(parent);
+  if (stat.isSymbolicLink() || !stat.isDirectory()
+    || (typeof process.getuid === 'function' && stat.uid !== process.getuid())
+    || (stat.mode & 0o777) !== 0o700
+    || await realpath(parent) !== path.resolve(parent)) {
+    throw new Error('artifact parent must be private');
+  }
+  return parent;
+}
+
 async function writePrivateJsonAtomic(filePath, payload, { replace = true } = {}) {
   if (!path.isAbsolute(filePath)) {
     throw new Error('artifact path must be absolute');
   }
-  const parent = path.dirname(filePath);
-  await mkdir(parent, { recursive: true, mode: 0o700 });
+  const parent = await requirePrivateParent(filePath);
   const tempPath = path.join(parent, `.${path.basename(filePath)}.tmp-${process.pid}-${Date.now()}`);
   let handle;
   try {
@@ -38,6 +50,16 @@ async function writePrivateJsonAtomic(filePath, payload, { replace = true } = {}
     handle = undefined;
     await chmod(tempPath, 0o600);
     if (replace) {
+      try {
+        const existing = await lstat(filePath);
+        if (existing.isSymbolicLink() || !existing.isFile()
+          || (typeof process.getuid === 'function' && existing.uid !== process.getuid())
+          || (existing.mode & 0o777) !== 0o600) {
+          throw new Error('artifact replace target is unsafe');
+        }
+      } catch (error) {
+        if (error?.code !== 'ENOENT') throw error;
+      }
       await rename(tempPath, filePath);
       await chmod(filePath, 0o600);
     } else {

--- a/tools/scripts/write-news-aggregator-production-start-artifact.mjs
+++ b/tools/scripts/write-news-aggregator-production-start-artifact.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+
+import { chmod, link, mkdir, open, rename, rm } from 'node:fs/promises';
+import path from 'node:path';
+
+const modeIndex = process.argv.indexOf('--mode');
+const mode = modeIndex >= 0 ? process.argv[modeIndex + 1] : '';
+if (!['preflight', 'start', 'diagnostic'].includes(mode)) {
+  console.error('[vh:publisher-recovery] artifact mode must be preflight, start, or diagnostic');
+  process.exit(78);
+}
+
+const revision = process.env.VH_NEWS_DAEMON_EXPECTED_REVISION?.trim() ?? '';
+if (!/^[0-9a-f]{40}$/.test(revision)) {
+  console.error('[vh:publisher-recovery] artifact revision is missing or malformed');
+  process.exit(78);
+}
+
+const runId = process.env.VH_DAEMON_FEED_RUN_ID?.trim() ?? '';
+if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(runId) || runId === '.' || runId === '..') {
+  console.error('[vh:publisher-recovery] artifact run id is missing');
+  process.exit(78);
+}
+
+async function writePrivateJsonAtomic(filePath, payload, { replace = true } = {}) {
+  if (!path.isAbsolute(filePath)) {
+    throw new Error('artifact path must be absolute');
+  }
+  const parent = path.dirname(filePath);
+  await mkdir(parent, { recursive: true, mode: 0o700 });
+  const tempPath = path.join(parent, `.${path.basename(filePath)}.tmp-${process.pid}-${Date.now()}`);
+  let handle;
+  try {
+    handle = await open(tempPath, 'wx', 0o600);
+    await handle.writeFile(`${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+    await handle.sync();
+    await handle.close();
+    handle = undefined;
+    await chmod(tempPath, 0o600);
+    if (replace) {
+      await rename(tempPath, filePath);
+      await chmod(filePath, 0o600);
+    } else {
+      await link(tempPath, filePath);
+      // The linked final path already references the fsynced mode-0600 inode.
+      // A hidden-temp cleanup failure cannot make that commit ambiguous.
+      await rm(tempPath, { force: true }).catch(() => undefined);
+    }
+  } catch (error) {
+    await handle?.close().catch(() => undefined);
+    await rm(tempPath, { force: true }).catch(() => undefined);
+    throw error;
+  }
+}
+
+const generatedAt = new Date().toISOString();
+const common = {
+  generatedAt,
+  status: 'preflight_passed',
+  revision,
+  runId,
+  stateDir: process.env.VH_NEWS_DAEMON_STATE_DIR,
+  artifactRoot: process.env.VH_DAEMON_FEED_ARTIFACT_ROOT,
+  queueDir: process.env.VH_BUNDLE_SYNTHESIS_QUEUE_DIR,
+  lifecycleLedger: process.env.VH_BUNDLE_SYNTHESIS_LIFECYCLE_LEDGER,
+};
+
+try {
+  if (mode === 'preflight') {
+    const filePath = process.env.VH_NEWS_DAEMON_PREFLIGHT_ARTIFACT?.trim() ?? '';
+    if (!filePath) throw new Error('preflight artifact path is missing');
+    await writePrivateJsonAtomic(filePath, {
+      schemaVersion: 'vh-news-daemon-recovery-preflight-v1',
+      ...common,
+      mode: 'preflight_only',
+      gates: [
+        'source_liveness',
+        'storycluster_build',
+        'openai_provider',
+        'storycluster_qdrant_readiness',
+        'raw_publication_readiness',
+      ],
+    }, { replace: false });
+  } else {
+    const lastSuccessFile = process.env.VH_NEWS_DAEMON_LAST_SUCCESS_FILE?.trim() ?? '';
+    const currentRunFile = process.env.VH_NEWS_DAEMON_CURRENT_RUN_FILE?.trim() ?? '';
+    if (!lastSuccessFile || !currentRunFile) throw new Error('start artifact path is missing');
+    await writePrivateJsonAtomic(lastSuccessFile, {
+      schemaVersion: 'vh-news-daemon-production-start-v1',
+      ...common,
+      approvalScope: mode === 'diagnostic' ? 'diagnostic_no_write' : 'attended_start_once',
+      noWrite: mode === 'diagnostic',
+    });
+    await writePrivateJsonAtomic(currentRunFile, {
+      schemaVersion: 'vh-news-daemon-current-run-v1',
+      ...common,
+      approvalScope: mode === 'diagnostic' ? 'diagnostic_no_write' : 'attended_start_once',
+      noWrite: mode === 'diagnostic',
+    });
+  }
+} catch (error) {
+  console.error(`[vh:publisher-recovery] ${mode}_artifact_write_failed`);
+  process.exit(78);
+}

--- a/tools/scripts/write-news-aggregator-publisher-start-control-artifact.mjs
+++ b/tools/scripts/write-news-aggregator-publisher-start-control-artifact.mjs
@@ -1,0 +1,178 @@
+#!/usr/bin/env node
+
+import { chmod, link, lstat, mkdir, open, realpath, rm } from 'node:fs/promises';
+import path from 'node:path';
+
+function fail(message) {
+  console.error(`[vh:publisher-recovery] ${message}`);
+  process.exit(78);
+}
+
+const values = new Map();
+for (let index = 2; index < process.argv.length; index += 2) {
+  const flag = process.argv[index];
+  const value = process.argv[index + 1];
+  if (!flag?.startsWith('--') || value === undefined || values.has(flag)) fail('start-control arguments invalid');
+  values.set(flag, value);
+}
+
+const filePath = values.get('--output-file') ?? '';
+const revision = values.get('--expected-revision') ?? '';
+const startedAt = values.get('--started-at') ?? '';
+const activatedAt = values.get('--activated-at') ?? '';
+const incidentNRestarts = Number(values.get('--incident-nrestarts'));
+const baselineNRestarts = Number(values.get('--baseline-nrestarts'));
+const postNRestarts = Number(values.get('--post-nrestarts'));
+let preflight;
+let relay;
+let mailbox;
+try {
+  preflight = JSON.parse(values.get('--preflight-binding-json') ?? '');
+  relay = JSON.parse(values.get('--relay-binding-json') ?? '');
+  mailbox = JSON.parse(values.get('--mailbox-binding-json') ?? '');
+} catch {
+  fail('start-control input binding invalid');
+}
+const sha256 = (value) => typeof value === 'string' && /^[0-9a-f]{64}$/.test(value);
+const exactRelayOrigins = Array.isArray(relay?.relayOrigins)
+  && relay.relayOrigins.length === 3
+  && new Set(relay.relayOrigins).size === 3
+  && relay.relayOrigins.every((origin) => {
+    if (typeof origin !== 'string') return false;
+    try {
+      const parsed = new URL(origin);
+      const port = Number(parsed.port);
+      return parsed.protocol === 'http:' && parsed.hostname === '127.0.0.1'
+        && !parsed.username && !parsed.password && !parsed.search && !parsed.hash
+        && parsed.pathname === '/' && parsed.port && port !== 80
+        && Number.isSafeInteger(port) && port > 0 && port <= 65_535
+        && origin === `http://127.0.0.1:${port}`;
+    } catch {
+      return false;
+    }
+  });
+if (!path.isAbsolute(filePath)
+  || !/^[0-9a-f]{40}$/.test(revision)
+  || !Number.isFinite(Date.parse(startedAt)) || !Number.isFinite(Date.parse(activatedAt))
+  || Date.parse(activatedAt) < Date.parse(startedAt)
+  || !Number.isSafeInteger(incidentNRestarts) || incidentNRestarts < 0
+  || !Number.isSafeInteger(baselineNRestarts) || baselineNRestarts < 0
+  || postNRestarts !== baselineNRestarts
+  || preflight?.status !== 'pass' || preflight?.revision !== revision
+  || preflight?.schemaVersion !== 'vh-news-daemon-recovery-preflight-v1'
+  || !sha256(preflight?.sha256)
+  || !/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(preflight?.runId ?? '')
+  || preflight.runId === '.' || preflight.runId === '..'
+  || !Number.isFinite(Date.parse(preflight?.generatedAt ?? ''))
+  || relay?.status !== 'pass' || relay?.revision !== revision
+  || relay?.schemaVersion !== 'vh-a6-s1b-relay-recovery-evidence-v1'
+  || !sha256(relay?.sha256) || !sha256(relay?.packetSha256) || !sha256(relay?.captureSha256)
+  || !/^sha256:[0-9a-f]{64}$/.test(relay?.immutableImageId ?? '')
+  || !/^vhc-public-beta-relay:[a-z0-9][a-z0-9._-]{1,127}$/.test(relay?.imageTag ?? '')
+  || relay.imageTag.endsWith(':latest')
+  || !Number.isFinite(Date.parse(relay?.generatedAt ?? ''))
+  || relay?.reviewerDecision !== 'GO'
+  || !/^[A-Za-z0-9_.@-]{2,128}$/.test(relay?.reviewerIdentity ?? '')
+  || !Number.isFinite(Date.parse(relay?.reviewedAt ?? ''))
+  || JSON.stringify(relay?.relayOrder) !== JSON.stringify(['vhc-relay-a', 'vhc-relay-b', 'vhc-relay-c'])
+  || !exactRelayOrigins
+  || mailbox?.status !== 'pass' || mailbox?.schemaVersion !== 'vhc-failure-mailbox-monitor-v1'
+  || !sha256(mailbox?.sha256)
+  || !Number.isSafeInteger(mailbox?.newCriticalCount) || mailbox.newCriticalCount < 0
+  || !Number.isFinite(Date.parse(mailbox?.generatedAt ?? ''))
+  || Date.parse(preflight.generatedAt) > Date.parse(startedAt)
+  || Date.parse(relay.reviewedAt) > Date.parse(startedAt)
+  || Date.parse(mailbox.generatedAt) > Date.parse(startedAt)) {
+  fail('start-control evidence invalid');
+}
+
+const payload = {
+  schemaVersion: 'vh-news-publisher-start-control-v1',
+  generatedAt: new Date().toISOString(),
+  status: 'active_approval_cleared',
+  revision,
+  startedAt,
+  activatedAt,
+  preStart: {
+    activeState: 'failed',
+    subState: 'failed',
+    result: 'exit-code',
+    execMainStatus: 78,
+    incidentNRestarts,
+    enabledState: 'disabled',
+  },
+  activationBaseline: {
+    nRestarts: baselineNRestarts,
+    capturedAfterResetFailed: true,
+  },
+  postActivation: {
+    activeState: 'active',
+    subState: 'running',
+    nRestarts: postNRestarts,
+    managerApprovalCleared: true,
+  },
+  evidenceBindings: {
+    preflight: {
+      schemaVersion: preflight.schemaVersion,
+      sha256: preflight.sha256,
+      revision: preflight.revision,
+      runId: preflight.runId,
+      generatedAt: preflight.generatedAt,
+    },
+    relayRecovery: {
+      schemaVersion: relay.schemaVersion,
+      sha256: relay.sha256,
+      revision: relay.revision,
+      generatedAt: relay.generatedAt,
+      immutableImageId: relay.immutableImageId,
+      imageTag: relay.imageTag,
+      packetSha256: relay.packetSha256,
+      captureSha256: relay.captureSha256,
+      reviewerIdentity: relay.reviewerIdentity,
+      reviewedAt: relay.reviewedAt,
+      relayOrder: relay.relayOrder,
+      relayOrigins: relay.relayOrigins,
+    },
+    mailbox: {
+      schemaVersion: mailbox.schemaVersion,
+      sha256: mailbox.sha256,
+      newCriticalCount: mailbox.newCriticalCount,
+      generatedAt: mailbox.generatedAt,
+    },
+  },
+};
+
+const parent = path.dirname(filePath);
+const tempPath = path.join(parent, `.${path.basename(filePath)}.tmp-${process.pid}-${Date.now()}`);
+let handle;
+try {
+  await mkdir(parent, { recursive: true, mode: 0o700 });
+  const parentStat = await lstat(parent);
+  if (parentStat.isSymbolicLink() || !parentStat.isDirectory()
+    || (typeof process.getuid === 'function' && parentStat.uid !== process.getuid())
+    || (parentStat.mode & 0o777) !== 0o700
+    || await realpath(parent) !== path.resolve(parent)) {
+    fail('start-control output parent invalid');
+  }
+  try {
+    await lstat(filePath);
+    fail('start-control output already exists');
+  } catch (error) {
+    if (error?.code !== 'ENOENT') throw error;
+  }
+  handle = await open(tempPath, 'wx', 0o600);
+  await handle.writeFile(`${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+  await handle.sync();
+  await handle.close();
+  handle = undefined;
+  await chmod(tempPath, 0o600);
+  await link(tempPath, filePath);
+  // link() commits the already-fsynced mode-0600 inode. Temp cleanup after
+  // that point is best-effort so a valid final artifact is never reported as
+  // a failed/ambiguous write.
+  await rm(tempPath, { force: true }).catch(() => undefined);
+} catch {
+  await handle?.close().catch(() => undefined);
+  await rm(tempPath, { force: true }).catch(() => undefined);
+  fail('start-control artifact write failed');
+}

--- a/tools/scripts/write-news-aggregator-publisher-start-control-artifact.mjs
+++ b/tools/scripts/write-news-aggregator-publisher-start-control-artifact.mjs
@@ -23,6 +23,7 @@ const activatedAt = values.get('--activated-at') ?? '';
 const incidentNRestarts = Number(values.get('--incident-nrestarts'));
 const baselineNRestarts = Number(values.get('--baseline-nrestarts'));
 const postNRestarts = Number(values.get('--post-nrestarts'));
+const attendedPermitBindingSha256 = values.get('--attended-permit-binding-sha256') ?? '';
 let preflight;
 let relay;
 let mailbox;
@@ -58,6 +59,7 @@ if (!path.isAbsolute(filePath)
   || !Number.isSafeInteger(incidentNRestarts) || incidentNRestarts < 0
   || !Number.isSafeInteger(baselineNRestarts) || baselineNRestarts < 0
   || postNRestarts !== baselineNRestarts
+  || !sha256(attendedPermitBindingSha256)
   || preflight?.status !== 'pass' || preflight?.revision !== revision
   || preflight?.schemaVersion !== 'vh-news-daemon-recovery-preflight-v1'
   || !sha256(preflight?.sha256)
@@ -89,7 +91,7 @@ if (!path.isAbsolute(filePath)
 const payload = {
   schemaVersion: 'vh-news-publisher-start-control-v1',
   generatedAt: new Date().toISOString(),
-  status: 'active_approval_cleared',
+  status: 'active_attended_permit_consumed',
   revision,
   startedAt,
   activatedAt,
@@ -109,7 +111,9 @@ const payload = {
     activeState: 'active',
     subState: 'running',
     nRestarts: postNRestarts,
-    managerApprovalCleared: true,
+    attendedPermitConsumed: true,
+    legacyManagerApprovalCleared: true,
+    attendedPermitBindingSha256,
   },
   evidenceBindings: {
     preflight: {

--- a/tools/scripts/write-news-aggregator-publisher-start-control-artifact.mjs
+++ b/tools/scripts/write-news-aggregator-publisher-start-control-artifact.mjs
@@ -24,6 +24,8 @@ const incidentNRestarts = Number(values.get('--incident-nrestarts'));
 const baselineNRestarts = Number(values.get('--baseline-nrestarts'));
 const postNRestarts = Number(values.get('--post-nrestarts'));
 const attendedPermitBindingSha256 = values.get('--attended-permit-binding-sha256') ?? '';
+const attendedReceiptSha256 = values.get('--attended-receipt-sha256') ?? '';
+const systemWriterPinSha256 = values.get('--system-writer-pin-sha256') ?? '';
 let preflight;
 let relay;
 let mailbox;
@@ -60,6 +62,8 @@ if (!path.isAbsolute(filePath)
   || !Number.isSafeInteger(baselineNRestarts) || baselineNRestarts < 0
   || postNRestarts !== baselineNRestarts
   || !sha256(attendedPermitBindingSha256)
+  || !sha256(attendedReceiptSha256)
+  || !sha256(systemWriterPinSha256)
   || preflight?.status !== 'pass' || preflight?.revision !== revision
   || preflight?.schemaVersion !== 'vh-news-daemon-recovery-preflight-v1'
   || !sha256(preflight?.sha256)
@@ -112,8 +116,10 @@ const payload = {
     subState: 'running',
     nRestarts: postNRestarts,
     attendedPermitConsumed: true,
+    attendedReceiptConsumed: true,
     legacyManagerApprovalCleared: true,
     attendedPermitBindingSha256,
+    attendedReceiptSha256,
   },
   evidenceBindings: {
     preflight: {
@@ -142,6 +148,9 @@ const payload = {
       sha256: mailbox.sha256,
       newCriticalCount: mailbox.newCriticalCount,
       generatedAt: mailbox.generatedAt,
+    },
+    systemWriterPin: {
+      sha256: systemWriterPinSha256,
     },
   },
 };


### PR DESCRIPTION
## Summary

Adds the fail-closed publisher recovery control plane required after the reviewed serial relay replacement. It binds exact revision, immutable relay evidence, mailbox state, system-writer pin, restart counters, controller identity, and one-use attended/automatic authority before publisher writes can resume.

The implementation keeps exit 69 as the only automatic-restart status, rejects legacy manager approval as authority, cryptographically validates all four exact relay readback routes, stages evidence until final state checks pass, and parks on any verification or finalization failure.

## Incident context

S1A remains relay_rest_story_timeout_total_0_of_3_exit_78. This PR is repo-only capability; it does not authorize or perform A6, relay, publisher, Gmail, pager, provider, or production mutation. S2 remains blocked.

## Review

First review at a674aab6 returned NO-GO. Correction at 4d239515 received a second NO-GO for receipt and post-link races. The same independent reviewer returned final GO with no P0/P1/P2 at exact head 9fbc71a30b07b37cb4af9522b7b2c807fa621e5f after all findings were corrected.

## Validation

- focused recovery suite: 110/110
- targeted adversarial replay: 12/12
- daemon/exit coverage: 23/23
- fresh gun-client build plus verifier: 21/21
- shell and MJS syntax checks
- gun-client and news-aggregator typechecks
- public-beta launch closeout
- public-beta next-phase sprint guards: 9/9
- docs governance: 159 files
- git diff --check
- no leaked test or daemon processes

Local Node 23.10 emitted the known engine warning because the repository supports Node below 23; all commands exited zero. Hosted CI on Node 20 is merge authority.