### PR TITLE
Classify publisher recovery authority refusals

### DIFF
--- a/tools/scripts/news-aggregator-publisher-liveness-watch.mjs
+++ b/tools/scripts/news-aggregator-publisher-liveness-watch.mjs
@@ -15,6 +15,10 @@ const DEFAULT_MAX_DIAGNOSTIC_AGE_MS = 20 * 60 * 1000;
 const DEFAULT_STARTUP_GRACE_MS = 15 * 60 * 1000;
 const DEFAULT_ACTIVE_ENTER_TOLERANCE_MS = 5_000;
 const DEFAULT_JOURNAL_LINES = 120;
+// Keep this producer-owned journal message exact and case-sensitive. The
+// companion test pins every producer refusal site to the same literal.
+const LIVE_START_AUTHORITY_REFUSAL =
+  '[vh:news-daemon:prod] refusing live start without attended or verified automatic-restart authority';
 
 function positiveInt(value, fallback) {
   const parsed = Number.parseInt(String(value ?? ''), 10);
@@ -142,7 +146,10 @@ function classifyJournal(journalText, properties) {
   if (/fail-closed runtime error|runtime error triggered fail-closed stop/i.test(text)) {
     return 'fail_closed_runtime_error';
   }
-  if (/refusing to start without VH_NEWS_DAEMON_START_APPROVED=1|--start-publisher requires VH_NEWS_DAEMON_START_APPROVED=1|refusing no-write diagnostic without VH_NEWS_DAEMON_DIAGNOSTIC_APPROVED=1/i.test(text)) {
+  if (
+    /refusing to start without VH_NEWS_DAEMON_START_APPROVED=1|--start-publisher requires VH_NEWS_DAEMON_START_APPROVED=1|refusing no-write diagnostic without VH_NEWS_DAEMON_DIAGNOSTIC_APPROVED=1/i.test(text)
+    || text.includes(LIVE_START_AUTHORITY_REFUSAL)
+  ) {
     return 'guard_refusal';
   }
   if (String(properties.ExecMainStatus ?? '').trim() === '78') {
@@ -489,6 +496,7 @@ async function main() {
 export const newsAggregatorPublisherLivenessWatchInternal = {
   CURRENT_RUN_SCHEMA_VERSION,
   DIAGNOSTICS_SCHEMA_VERSION,
+  LIVE_START_AUTHORITY_REFUSAL,
   REPORT_SCHEMA_VERSION,
   classifyJournal,
   parseSystemctlShow,

--- a/tools/scripts/news-aggregator-publisher-liveness-watch.test.mjs
+++ b/tools/scripts/news-aggregator-publisher-liveness-watch.test.mjs
@@ -1,8 +1,9 @@
 import assert from 'node:assert/strict';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
+import { fileURLToPath } from 'node:url';
 import {
   newsAggregatorPublisherLivenessWatchInternal,
   runNewsAggregatorPublisherLivenessWatch,
@@ -10,6 +11,7 @@ import {
 
 const NOW = Date.now();
 const RUN_ID = '20260620T101500Z-1234';
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 
 function makeTempState() {
   const root = mkdtempSync(path.join(os.tmpdir(), 'vh-publisher-liveness-'));
@@ -347,6 +349,49 @@ test('publisher liveness classifies exit 78 fail-close and guard refusal separat
   } finally {
     rmSync(paths.root, { recursive: true, force: true });
   }
+});
+
+test('publisher liveness classifies the attended-or-automatic authority refusal as a guard refusal', () => {
+  const refusal = newsAggregatorPublisherLivenessWatchInternal.LIVE_START_AUTHORITY_REFUSAL;
+  const failureClass = newsAggregatorPublisherLivenessWatchInternal.classifyJournal(
+    refusal,
+    {
+      ActiveState: 'failed',
+      ExecMainStatus: '78',
+    },
+  );
+
+  assert.equal(failureClass, 'guard_refusal');
+});
+
+test('publisher liveness authority-refusal literal matches every producer refusal site', () => {
+  const refusal = newsAggregatorPublisherLivenessWatchInternal.LIVE_START_AUTHORITY_REFUSAL;
+  const producerSource = readFileSync(
+    path.join(SCRIPT_DIR, 'start-news-aggregator-daemon-production.sh'),
+    'utf8',
+  );
+  const producerRefusalLines = producerSource
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.includes('refusing live start without'));
+
+  assert.ok(producerRefusalLines.length > 0, 'producer must retain an authority-refusal site');
+  assert.deepEqual(
+    [...new Set(producerRefusalLines)],
+    [`echo "${refusal}" >&2`],
+  );
+});
+
+test('publisher liveness does not broaden the authority refusal classifier to nearby text', () => {
+  const failureClass = newsAggregatorPublisherLivenessWatchInternal.classifyJournal(
+    '[vh:news-daemon:prod] refusing live start without attended or automatic-restart authority',
+    {
+      ActiveState: 'failed',
+      ExecMainStatus: '78',
+    },
+  );
+
+  assert.equal(failureClass, 'exit_78_unknown');
 });
 
 test('publisher liveness falls back to active-enter timestamp when current run marker is absent', async () => {


### PR DESCRIPTION
## Summary

Restacks the publisher-liveness consumer on merged publisher-control main and classifies the producer exact attended-or-automatic authority refusal as guard_refusal.

The new match is case-sensitive and exact. Nearby wording, case drift, and unrelated exit-78 text remain exit_78_unknown. A producer-source contract test pins all current refusal sites to the same literal.

## Scope

Exactly two liveness files. Producer 9fbc71a3 is in ancestry through main 66be6257. No A6, service, relay, Gmail, pager, provider, or production mutation.

## Review

The original reviewer previously returned NO-GO because the consumer was a sibling of the producer. After restack, the same reviewer returned GO with no P0/P1/P2 at exact head abec5910b136e257700d84c530179785cc7e8737.

## Validation

- publisher liveness 13/13
- public-feed alert 56/56
- watch closure 16/16
- sprint guard 9/9
- launch closeout
- docs governance 159 files
- source and test syntax
- git diff --check

S1A/S1B remain live-red; this repo-only consumer change does not unblock S2.