### PR TITLE
fix(public-beta): close relay removal live gates

### DIFF
--- a/docs/ops/a6-s1b-relay-timeout-recovery-packet-2026-07-10.md
+++ b/docs/ops/a6-s1b-relay-timeout-recovery-packet-2026-07-10.md
@@ -191,7 +191,12 @@ captured input hash, then return `GO` only if all of these are true:
 - scope is exactly relay A, B, C in that order;
 - no origin or publisher recreate/start command exists;
 - the publisher must match the exact exit-78 parked tuple above at initial
-  precheck and again as the final gate immediately before each A/B/C removal;
+  precheck and again in the final pre-mutation sequence immediately before each
+  A/B/C removal;
+- `systemctl --user list-jobs --no-legend --no-pager` must succeed with no
+  output during the initial executable precheck and freshly as the last check
+  before every A/B/C mutation latch; any command failure or returned job is a
+  closed pre-mutation refusal, and raw job rows are never printed;
 - the new image is `linux/amd64` and its OCI revision equals the merged commit;
 - the mutable image ref resolves to the export manifest's full immutable image
   id immediately before every A/B/C removal; the packet runs that immutable id,
@@ -204,6 +209,10 @@ captured input hash, then return `GO` only if all of these are true:
   policy, user, and memory limits are preserved from inspect evidence and
   rechecked immediately after recreate, after verification, and after rollback;
 - snapshot checks cover latest-index, synthesis-lifecycle, and topic-synthesis;
+  the current relay's captured SHA baseline is freshly verified at the removal
+  boundary after topology/image checks; only then may the final parked-publisher
+  and empty-job checks run, so drift or a publisher transition cannot enter the
+  mutation latch or rollback path;
 - readiness, health, Docker OOM state, and watchdog metrics are checked before
   proceeding; the pre-mutation and per-stage metric artifacts are retained and
   an absent watchdog-trip row is semantic zero because the relay initializes an
@@ -245,7 +254,9 @@ with `--include-recreate-commands`. Its contract is:
    `Result=exit-code`, `ExecMainStatus=78`; all three relays are running;
    loopback readiness and metrics respond; no relay reports OOM; and the three
    required snapshot files are nonempty, schema-valid, and checksummed.
-   Preserve initial metrics privately. An absent watchdog-trip row means zero;
+   Require `systemctl --user list-jobs --no-legend --no-pager` to succeed with
+   no output before continuing, withholding any returned row and emitting only
+   a closed reason. Preserve initial metrics privately. An absent watchdog-trip row means zero;
    that absence is accepted only alongside exactly one valid uptime and RSS
    producer row. Empty/random telemetry and malformed/duplicate/nonzero trip or
    producer rows fail closed.
@@ -258,9 +269,12 @@ with `--include-recreate-commands`. Its contract is:
 4. Immediately before relay A removal, compare live image, env, bind mounts,
    semantic network attachment and `NetworkID`, ports, restart policy,
    configured user, and memory limits with the captured inspect prestate;
-   reject any drift. Recheck the exact exit-78 parked publisher tuple and invoke
-   the atomic removal-boundary check immediately before removal, then replace A
-   only.
+   reject any drift. Invoke the atomic removal-boundary check immediately before
+   removal. That boundary rechecks topology and immutable image binding and
+   freshly verifies A's captured snapshot SHA baseline. Only after it passes,
+   recheck the exact exit-78 parked publisher tuple, then require a freshly empty
+   user-manager job queue as the last executable precondition. Only then replace
+   A.
    A refusal in topology, watchdog/readiness, or publisher preconditions exits
    `78` with no `docker rm`, no `docker run`, and no rollback of the untouched
    relay. Rollback is reachable only after the mutation-started latch is set at
@@ -280,8 +294,10 @@ with `--include-recreate-commands`. Its contract is:
      `news-synthesis-lifecycle-not-found` and HTTP 404.
 7. Proceed to B only after A passes every gate; proceed to C only after B passes.
    Repeat the full live/captured topology comparison, zero-trip prestate, and
-   final exact publisher-state check immediately before each removal. A publisher
-   resume or transitional state between stages stops before the next mutation.
+   current-relay snapshot-baseline, final exact publisher-state, and empty
+   user-manager-job checks in that order immediately before each removal. A publisher resume,
+   transitional state, snapshot drift, or queued job between stages stops before
+   the next mutation.
    Recheck the exact parked tuple again after each relay passes all verification
    and before emitting GO or entering the next stage; a resume during
    verification rolls back the already-mutated current relay and stops.
@@ -291,8 +307,9 @@ with `--include-recreate-commands`. Its contract is:
    command is guarded; remove/run/readiness/checksum failures produce a closed
    reason code and exit `78` rather than leaking command output or falling
    through.
-9. After C passes, keep the publisher parked and return evidence for independent
-   review. Relay deployment success alone does not authorize publisher recovery.
+9. After C passes, emit `rolling replacement complete; publisher remains
+   parked`, not `GO for next relay`, and return evidence for independent review.
+   Relay deployment success alone does not authorize publisher recovery.
 
 ## Hard Stops
 
@@ -307,6 +324,8 @@ Stop before any removal on:
 - publisher state differs in any field from exact exit-78 parked state,
   including inactive, active, activating, deactivating, or resumed between
   relay stages;
+- `systemctl --user list-jobs --no-legend --no-pager` fails or returns any job
+  during initial precheck or at an A/B/C removal boundary;
 - missing, invalid, empty, or changed snapshot;
 - failed readiness/health, pre-existing OOM/watchdog trip, or secret-bearing
   output;

--- a/docs/ops/public-beta-image-deploy.md
+++ b/docs/ops/public-beta-image-deploy.md
@@ -455,20 +455,31 @@ per-relay readiness/health, snapshot checksum, OOM/watchdog, env-parity, and all
 four exact missing-key checks for story, latest-index, hot-index, and
 synthesis-lifecycle. Immediately before every removal the mutable ref must still
 resolve to the full expected image id; the packet runs that immutable id and
-requires recreated `.Image` equality. A failure rolls back only the current relay to its captured
-immutable image id and exits `78` before the next relay. It never emits an
-origin recreate or publisher start. The generic packet executor is not widened
-for this action.
+requires recreated `.Image` equality. The same removal-boundary gate freshly
+checks the current relay's three captured snapshot hashes. Only after that
+expensive boundary work passes does the packet freshly recheck the exact parked
+publisher tuple, then require
+`systemctl --user list-jobs --no-legend --no-pager` to return no output as the
+last check before the mutation latch. A command failure or any returned job
+fails closed without printing the job row. A failure rolls back only the
+current relay to its captured immutable image id and exits `78` before the next
+relay. On success, A and B may emit `GO for next relay`; C instead reports that
+rolling replacement is complete and the publisher remains parked. The packet
+never emits an origin recreate or publisher start. The generic packet executor
+is not widened for this action.
 
 The publisher is considered parked only when the live tuple is exactly
 `failed/failed`, `Result=exit-code`, `ExecMainStatus=78`. Initial precheck and the
-final command before each A/B/C removal require that tuple; inactive, active,
-activating, deactivating, a different exit code, or a resume between stages all
-stop before mutation. The tuple is checked again after each relay verifies and
-before GO; a resume during verification rolls back that already-mutated relay
-and stops. Topology, relay-health/watchdog, or publisher refusal before removal
-exits `78` without `docker rm`, `docker run`, or rollback of the untouched relay;
-rollback is reachable only after the mutation-started latch.
+final pre-mutation gate sequence before each A/B/C removal require that tuple;
+inactive, active, activating, deactivating, a different exit code, or a resume
+between stages all stop before mutation. The tuple is checked again after each
+relay verifies and before GO; a resume during verification rolls back that
+already-mutated relay and stops. Topology, relay-health/watchdog, or publisher refusal before removal
+exits `78` without `docker rm`, `docker run`, or rollback of the untouched relay.
+The initial executable precheck and every removal boundary also reject a
+nonempty or unreadable user-manager job queue. Snapshot-baseline or user-job
+refusal is likewise pre-mutation; rollback is reachable only after the
+mutation-started latch.
 
 Initial and per-stage metrics treat an absent watchdog-trip row as semantic zero
 because the relay emits rows from an initially empty reason map, but only when

--- a/docs/plans/PUBLIC_BETA_NEXT_PHASE_SPRINT_CHECKLIST_2026-07-09.md
+++ b/docs/plans/PUBLIC_BETA_NEXT_PHASE_SPRINT_CHECKLIST_2026-07-09.md
@@ -1074,12 +1074,22 @@ proof, and no live recovery is claimed.
   all-four exact missing-key probes, immediate current-relay rollback, and hard
   stop conditions.
 - [x] Define parked as exactly `failed/failed`, `Result=exit-code`,
-  `ExecMainStatus=78`, then recheck it as the final gate before every A/B/C
-  removal and again after verification before GO, so a transition/resume cannot
-  mutate the next relay or pass unnoticed during verification.
+  `ExecMainStatus=78`, then recheck it in the final pre-mutation sequence before
+  every A/B/C removal and again after verification before GO, so a
+  transition/resume cannot mutate the next relay or pass unnoticed during
+  verification.
+- [x] Require `systemctl --user list-jobs --no-legend --no-pager` to succeed
+  with no output at initial executable precheck and freshly as the last check
+  before every A/B/C mutation latch; withhold raw job rows and fail closed on an
+  unreadable or nonempty queue.
+- [x] Freshly verify the current relay's captured three-snapshot SHA baseline at
+  every removal boundary after topology/image checks; only after that expensive
+  work passes may the final parked-publisher check and then the empty-job check
+  run, so drift or a publisher transition performs zero remove/run/rollback.
 - [x] Keep all pre-mutation refusals outside rollback: topology,
-  watchdog/readiness, or publisher failure exits `78` with zero remove/run of
-  the untouched relay; only a set mutation-started latch can enter rollback.
+  watchdog/readiness, publisher, snapshot-baseline, or user-job failure exits
+  `78` with zero remove/run of the untouched relay;
+  only a set mutation-started latch can enter rollback.
 - [x] Create and validate a current-user-owned, non-symlink `0700` private work
   directory before any initial evidence write.
 - [x] Preserve and parse initial/per-stage metrics before mutation; treat an

--- a/docs/plans/PUBLIC_BETA_STATE_OF_PLAY_HANDOFF_2026-07-10.md
+++ b/docs/plans/PUBLIC_BETA_STATE_OF_PLAY_HANDOFF_2026-07-10.md
@@ -203,22 +203,30 @@ MAC intent. Correct packet output uses exact `--network host` and captured
 `GUN_PORT` loopback verifier URLs.
 
 The fail-closed packet contract treats parked as exactly `failed/failed`,
-`Result=exit-code`, `ExecMainStatus=78` and rechecks that tuple as the final gate
-before each A/B/C removal and after verification before GO. It also compares every stage's live
-image/env/mount/network/port/restart/user/memory topology with the capture,
-preserves and rejects pre-existing watchdog-trip evidence before counters can
-reset, never prints hostile unexpected 404 bodies, and normalizes each rollback
-failure class to a closed reason and exit `78`. Deterministic adversarial tests
-cover transitional/resumed publisher state, every captured topology dimension,
+`Result=exit-code`, `ExecMainStatus=78` and rechecks that tuple in the final
+pre-mutation sequence before each A/B/C removal and after verification before
+GO. At initial executable precheck and freshly before each mutation latch,
+`systemctl --user list-jobs --no-legend --no-pager` must succeed with no output;
+the packet withholds returned job rows and fails closed. Every removal boundary
+also freshly verifies the current relay's captured three-snapshot SHA baseline
+after topology/image checks. Only after that expensive boundary work passes does
+the packet freshly recheck the parked publisher tuple, then run the final
+empty-job check. It also compares every stage's live image/env/mount/network/port/restart/user/memory
+topology with the capture, preserves and rejects pre-existing watchdog-trip
+evidence before counters can reset, never prints hostile unexpected 404 bodies,
+and normalizes each rollback failure class to a closed reason and exit `78`.
+Deterministic adversarial tests cover A/B/C job appearance and snapshot drift,
+transitional/resumed publisher state, every captured topology dimension,
 duplicate/extra/malformed capture scope, same-revision wrong-image binding,
 runtime endpoint churn, pre-existing trips, secret-bearing bodies, and rollback
-remove/run/readiness/checksum failures. These are repo safeguards, not live
-proof.
+remove/run/readiness/checksum failures. A and B emit next-relay GO only after
+success; C reports rolling replacement complete with the publisher still
+parked. These are repo safeguards, not live proof.
 
 Pre-mutation refusals are isolated from rollback: topology,
-readiness/watchdog, or publisher failure exits `78` without removing, running,
-or rolling back the untouched relay. Only the mutation-started latch at the
-removal boundary can enter recovery. The packet creates and validates its
+readiness/watchdog, publisher, snapshot-baseline, or user-job failure exits `78`
+without removing, running, or rolling back the untouched relay. Only the
+mutation-started latch at the removal boundary can enter recovery. The packet creates and validates its
 non-symlink, current-user-owned `0700` evidence directory before the first
 write. Healthy relays may omit the watchdog-trip row because its source map is
 initially empty; absence is semantic zero only when exactly one valid uptime and

--- a/tools/scripts/emit-a6-public-beta-deploy-packet.sh
+++ b/tools/scripts/emit-a6-public-beta-deploy-packet.sh
@@ -676,8 +676,26 @@ function relayOnlyRunCommandFor(name, image) {
   return shellJoin(parts);
 }
 
+function noPendingUserJobsFunction() {
+  return [
+    'assert_no_pending_user_jobs() {',
+    '  local jobs',
+    '  if ! jobs="$(systemctl --user list-jobs --no-legend --no-pager 2>/dev/null)"; then',
+    '    echo "user_job_queue_unavailable" >&2',
+    '    return 78',
+    '  fi',
+    '  if [[ -n "${jobs}" ]]; then',
+    '    echo "user_job_queue_not_empty" >&2',
+    '    return 78',
+    '  fi',
+    '}',
+  ].join('\n');
+}
+
 function relayOnlyVerifierFunction() {
   return [
+    noPendingUserJobsFunction(),
+    '',
     'assert_publisher_parked() {',
     '  local active sub result status',
     '  if ! active="$(systemctl --user show vh-news-aggregator.service --property=ActiveState --value 2>/dev/null)"; then echo "publisher_parked_state_unavailable" >&2; return 78; fi',
@@ -714,6 +732,10 @@ function relayOnlyVerifierFunction() {
     '  local expected_revision="$5"',
     '  assert_live_topology_parity "${name}" "${expected_topology}" || return 78',
     '  assert_relay_image_binding "${image_ref}" "${expected_id}" "${expected_revision}" || return 78',
+    '  if ! sudo sha256sum -c "/tmp/vhc-public-beta-deploy/${name}.snapshots.sha256" >/dev/null 2>&1; then',
+    '    echo "${name}: snapshot_baseline_drift_at_removal_boundary" >&2',
+    '    return 78',
+    '  fi',
     '}',
     '',
     'assert_live_topology_parity() {',
@@ -1069,6 +1091,10 @@ lines.push('');
 lines.push('```bash');
 lines.push('set -euo pipefail');
 if (relayOnly) lines.push(...privateDeployWorkDirSetupLines());
+if (relayOnly) {
+  lines.push(noPendingUserJobsFunction());
+  lines.push('assert_no_pending_user_jobs');
+}
 lines.push(`sudo docker ps --format "{{.Names}}\\t{{.Image}}\\t{{.Status}}\\t{{.Ports}}" | grep -E ${shellSingleQuote(psPattern)}`);
 lines.push('python3 <<\'PY\'');
 lines.push('import json, os, time');
@@ -1174,7 +1200,7 @@ if (includeRecreate) {
     lines.push('');
     lines.push('Hard execution gate: do not run this section unless recorded Lou authority covers this exact reviewed revision, capture, image id, packet hash, and A/B/C scope, and independent packet review is GO. Approval is limited to A, then B, then C; it does not authorize origin, publisher, data, quorum, timeout, recipient, provider, pager, or monitor mutation.');
     lines.push('');
-    lines.push('Each relay is verified before the next is touched. A fresh live/captured topology comparison and authenticated zero-trip prestate run for that relay, then the publisher must still be exactly `failed/failed`, `Result=exit-code`, `ExecMainStatus=78` as the final gate before removal. An absent watchdog-trip row is semantic zero only when exactly one valid uptime row and one positive process-RSS row authenticate the payload. Any precondition refusal exits `78` without remove, run, or rollback; only the mutation-started latch at the removal boundary enables recovery. After runtime verification, the publisher is checked again before GO. Any failure after mutation begins immediately recreates only the current relay from its captured immutable image id, verifies readiness/topology/snapshot/OOM state, and exits `78`. Never continue to the next relay after rollback.');
+    lines.push('Each relay is verified before the next is touched. A fresh live/captured topology comparison, authenticated zero-trip prestate, captured snapshot-baseline check, exact parked publisher check, and empty user-manager job queue are required immediately before removal, in that order. An absent watchdog-trip row is semantic zero only when exactly one valid uptime row and one positive process-RSS row authenticate the payload. Any precondition refusal exits `78` without remove, run, or rollback; only the mutation-started latch at the removal boundary enables recovery. After runtime verification, the publisher is checked again before GO. Any failure after mutation begins immediately recreates only the current relay from its captured immutable image id, verifies readiness/topology/snapshot/OOM state, and exits `78`. Never continue to the next relay after rollback.');
     lines.push('');
     lines.push('```bash');
     lines.push('set -euo pipefail');
@@ -1201,7 +1227,8 @@ if (includeRecreate) {
       lines.push(`  assert_live_topology_parity ${shellSingleQuote(name)} ${shellSingleQuote(expectedTopology)} &&`);
       lines.push(`  assert_relay_prestate ${shellSingleQuote(name)} ${shellSingleQuote(origin)} ${shellSingleQuote(`prestage-${stage.toLowerCase()}`)} &&`);
       lines.push(`  assert_relay_removal_boundary ${shellSingleQuote(name)} ${shellSingleQuote(expectedTopology)} ${shellSingleQuote(newRelayImage)} ${shellSingleQuote(expectedRelayImageId)} ${shellSingleQuote(expectedRelayRevision)} &&`);
-      lines.push('  assert_publisher_parked');
+      lines.push('  assert_publisher_parked &&');
+      lines.push('  assert_no_pending_user_jobs');
       lines.push('}; then');
       lines.push(`  echo "${name}: pre_mutation_refused_no_change" >&2`);
       lines.push('  exit 78');
@@ -1245,14 +1272,16 @@ if (includeRecreate) {
       lines.push('  exit 78');
       lines.push('fi');
       lines.push('relay_mutation_started=false');
-      lines.push(`echo "${name}: GO for next relay"`);
+      lines.push(stage === 'C'
+        ? `echo "${name}: rolling replacement complete; publisher remains parked"`
+        : `echo "${name}: GO for next relay"`);
       lines.push('');
     }
     lines.push('```');
     lines.push('');
     lines.push('## Hard Stop Conditions');
     lines.push('');
-    lines.push('- Stop before container removal on absent recorded Lou authority or exact packet-review GO, non-array/duplicate/extra/malformed relay capture, wrong immutable image id or mutable-ref binding (including same-revision retag), wrong commit/revision, non-`linux/amd64` image, publisher state other than exact failed/failed exit 78, missing relay, any live/captured image/env/mount/semantic-network/NetworkID/port/restart/user/memory drift, unsupported network attachment state, unreadable or changed snapshot, pre-existing OOM/watchdog trip, unauthenticated or malformed metrics, or non-green readiness. A pre-mutation refusal does not invoke rollback.');
+    lines.push('- Stop before container removal on absent recorded Lou authority or exact packet-review GO, non-array/duplicate/extra/malformed relay capture, wrong immutable image id or mutable-ref binding (including same-revision retag), wrong commit/revision, non-`linux/amd64` image, publisher state other than exact failed/failed exit 78, an unreadable or nonempty user-manager job queue, missing relay, any live/captured image/env/mount/semantic-network/NetworkID/port/restart/user/memory drift, unsupported network attachment state, unreadable or changed snapshot, pre-existing OOM/watchdog trip, unauthenticated or malformed metrics, or non-green readiness. A pre-mutation refusal does not invoke rollback.');
     lines.push('- After mutation begins, roll back the current relay and stop on publisher transition/resume during verification, readiness/health failure, environment mismatch, snapshot checksum drift, OOM/watchdog trip, wrong image id/revision/platform, or any of the four exact missing-key probes returning anything other than its closed 404 body. Unexpected bodies remain private; only a closed reason code may print.');
     lines.push('- Never batch removals, skip A/B/C order, continue after rollback, clear data, alter quorum/timeouts, start the publisher, recreate origin, or use the generic packet executor for this action.');
     lines.push('');

--- a/tools/scripts/public-beta-image-deploy.test.mjs
+++ b/tools/scripts/public-beta-image-deploy.test.mjs
@@ -1089,7 +1089,9 @@ test('relay-only deploy packet gates an A-B-C rolling recovery with exact probes
     const stageB = packet.indexOf('# Stage B: re-prove parked publisher and exact live/captured prestate, then replace only vhc-relay-b.');
     const goB = packet.indexOf('vhc-relay-b: GO for next relay');
     const stageC = packet.indexOf('# Stage C: re-prove parked publisher and exact live/captured prestate, then replace only vhc-relay-c.');
-    assert.ok(stageA > 0 && stageA < goA && goA < stageB && stageB < goB && goB < stageC, packet);
+    const completedC = packet.indexOf('vhc-relay-c: rolling replacement complete; publisher remains parked');
+    assert.ok(stageA > 0 && stageA < goA && goA < stageB && stageB < goB && goB < stageC && stageC < completedC, packet);
+    assert.doesNotMatch(packet, /vhc-relay-c: GO for next relay/);
     assert.match(packet, /--user '1000:1000'/);
     assert.match(packet, /--memory 2415919104/);
     assert.match(packet, /--memory-swap 2415919104/);
@@ -1116,12 +1118,23 @@ test('relay-only deploy packet gates an A-B-C rolling recovery with exact probes
       const postVerifyPublisherCheck = packet.indexOf('assert_publisher_parked', publisherCheck + 1);
       const topologyCheck = packet.indexOf(`assert_live_topology_parity '${name}'`, stageStart);
       const prestateCheck = packet.indexOf(`assert_relay_prestate '${name}'`, stageStart);
+      const removalBoundaryCheck = packet.indexOf(`assert_relay_removal_boundary '${name}'`, stageStart);
+      const userJobsCheck = packet.indexOf('assert_no_pending_user_jobs', stageStart);
       const refusal = packet.indexOf(`${name}: pre_mutation_refused_no_change`, stageStart);
       const latch = packet.indexOf('relay_mutation_started=true', stageStart);
       const verify = packet.indexOf(`verify_relay_only_runtime '${name}'`, stageStart);
-      const go = packet.indexOf(`${name}: GO for next relay`, stageStart);
-      assert.ok(stageStart > 0 && topologyCheck < prestateCheck && prestateCheck < publisherCheck && publisherCheck < refusal && refusal < latch && latch < remove, packet);
-      assert.ok(remove < verify && verify < postVerifyPublisherCheck && postVerifyPublisherCheck < go, packet);
+      const completion = packet.indexOf(name.endsWith('-c')
+        ? `${name}: rolling replacement complete; publisher remains parked`
+        : `${name}: GO for next relay`, stageStart);
+      assert.ok(stageStart > 0
+        && topologyCheck < prestateCheck
+        && prestateCheck < removalBoundaryCheck
+        && removalBoundaryCheck < publisherCheck
+        && publisherCheck < userJobsCheck
+        && userJobsCheck < refusal
+        && refusal < latch
+        && latch < remove, packet);
+      assert.ok(remove < verify && verify < postVerifyPublisherCheck && postVerifyPublisherCheck < completion, packet);
     }
     for (const reason of [
       'rollback_remove_failed',
@@ -1143,6 +1156,11 @@ test('relay-only deploy packet gates an A-B-C rolling recovery with exact probes
     assert.ok(readOnlyPrecheck.indexOf('umask 077') >= 0 && privateDirCreate >= 0 && privateDirCreate < firstPrivateWrite, readOnlyPrecheck);
     assert.match(readOnlyPrecheck, /relay_packet_private_dir_unsafe/);
     assert.match(readOnlyPrecheck, /stat -c '%a'/);
+    const initialJobsCommand = readOnlyPrecheck.indexOf('systemctl --user list-jobs --no-legend --no-pager');
+    const initialDockerRead = readOnlyPrecheck.indexOf('sudo docker ps');
+    assert.ok(initialJobsCommand > privateDirCreate && initialJobsCommand < initialDockerRead, readOnlyPrecheck);
+    assert.match(readOnlyPrecheck, /user_job_queue_unavailable/);
+    assert.match(readOnlyPrecheck, /user_job_queue_not_empty/);
     const bashBlocks = [...packet.matchAll(/```bash\n([\s\S]*?)\n```/g)].map((match) => match[1]);
     assert.ok(bashBlocks.length >= 5, packet);
     for (const [index, block] of bashBlocks.entries()) {
@@ -1236,12 +1254,15 @@ test('relay-only approval block keeps precondition refusal nonmutating and close
     const approvalMatch = emitted.stdout.match(/## Approval-Gated Relay-Only Rolling Recovery[\s\S]*?```bash\n([\s\S]*?)\n```/);
     assert.ok(approvalMatch, emitted.stdout);
     const approval = approvalMatch[1];
-    const stageAStart = approval.indexOf('# Stage A:');
-    const stageAEndNeedle = 'echo "vhc-relay-a: GO for next relay"';
-    const stageAEnd = approval.indexOf(stageAEndNeedle, stageAStart) + stageAEndNeedle.length;
-    assert.ok(stageAStart > 0 && stageAEnd > stageAStart);
-    const helpers = approval.slice(0, stageAStart);
-    const stageA = approval.slice(stageAStart, stageAEnd);
+    const stageStarts = ['A', 'B', 'C'].map((stage) => approval.indexOf(`# Stage ${stage}:`));
+    assert.ok(stageStarts[0] > 0 && stageStarts[0] < stageStarts[1] && stageStarts[1] < stageStarts[2]);
+    const helpers = approval.slice(0, stageStarts[0]);
+    const stages = [
+      { stage: 'A', name: 'vhc-relay-a', script: approval.slice(stageStarts[0], stageStarts[1]) },
+      { stage: 'B', name: 'vhc-relay-b', script: approval.slice(stageStarts[1], stageStarts[2]) },
+      { stage: 'C', name: 'vhc-relay-c', script: approval.slice(stageStarts[2]) },
+    ];
+    const stageA = stages[0].script;
     const expectedTopology = stageA.match(/assert_live_topology_parity 'vhc-relay-a' '([^']+)'/u)?.[1];
     assert.ok(expectedTopology);
 
@@ -1259,6 +1280,11 @@ exec "$@"
 `);
     writeExecutable('systemctl', `#!/usr/bin/env bash
 set -euo pipefail
+if [[ "\${1:-}" == "--user" && "\${2:-}" == "list-jobs" && "\${3:-}" == "--no-legend" && "\${4:-}" == "--no-pager" && $# -eq 4 ]]; then
+  if [[ "\${FAKE_LIST_JOBS_ERROR:-}" == "true" ]]; then exit 1; fi
+  printf '%s' "\${FAKE_LIST_JOBS_OUTPUT:-}"
+  exit 0
+fi
 count_file="\${FAKE_SYSTEMCTL_COUNT_FILE:?}"
 count="$(cat "\${count_file}" 2>/dev/null || printf 0)"
 stage=$((count / 4 + 1))
@@ -1373,7 +1399,11 @@ if [[ "\${write_status}" == "true" ]]; then printf '404'; fi
 `);
     writeExecutable('sha256sum', `#!/usr/bin/env bash
 set -euo pipefail
-if [[ "\${FAKE_ROLLBACK_FAILURE:-}" == "checksum" ]]; then exit 1; fi
+count="$(cat "\${FAKE_SHA_COUNT_FILE:?}" 2>/dev/null || printf 0)"
+count=$((count + 1))
+printf '%s\n' "\${count}" > "\${FAKE_SHA_COUNT_FILE}"
+if [[ "\${FAKE_SNAPSHOT_BOUNDARY_DRIFT:-}" == "true" ]]; then exit 1; fi
+if [[ "\${FAKE_ROLLBACK_FAILURE:-}" == "checksum" && "\${count}" -ge 2 ]]; then exit 1; fi
 printf 'snapshot: OK\n'
 `);
     writeExecutable('sleep', '#!/usr/bin/env bash\nexit 0\n');
@@ -1383,6 +1413,7 @@ printf 'snapshot: OK\n'
       dockerState: path.join(root, 'docker-state'),
       rmCount: path.join(root, 'rm-count'),
       runCount: path.join(root, 'run-count'),
+      shaCount: path.join(root, 'sha-count'),
       dockerLog: path.join(root, 'docker.log'),
       mutationLog: path.join(root, 'mutation.log'),
       liveInspect: path.join(root, 'live-inspect.json'),
@@ -1394,10 +1425,11 @@ printf 'snapshot: OK\n'
       FAKE_DOCKER_STATE_FILE: files.dockerState,
       FAKE_RM_COUNT_FILE: files.rmCount,
       FAKE_RUN_COUNT_FILE: files.runCount,
+      FAKE_SHA_COUNT_FILE: files.shaCount,
       FAKE_DOCKER_LOG: files.dockerLog,
     };
     const resetFakes = () => {
-      for (const file of [files.systemctlCount, files.rmCount, files.runCount]) writeFileSync(file, '0\n', 'utf8');
+      for (const file of [files.systemctlCount, files.rmCount, files.runCount, files.shaCount]) writeFileSync(file, '0\n', 'utf8');
       writeFileSync(files.dockerState, 'old\n', 'utf8');
       writeFileSync(files.dockerLog, '', 'utf8');
       writeFileSync(files.mutationLog, '', 'utf8');
@@ -1524,6 +1556,103 @@ printf 'rm-b\n' >> '${files.mutationLog}'`, {
     assert.equal(hostile.status, 78, hostile.stderr);
     assert.match(hostile.stderr, /exact_missing_key_contract_mismatch/);
     assert.doesNotMatch(hostile.stderr, /HOSTILE_404_SECRET_DO_NOT_LEAK|"secret"|"error"/);
+
+    resetFakes();
+    const queuedJob = runBash(`${helpers}\nassert_no_pending_user_jobs`, {
+      FAKE_LIST_JOBS_OUTPUT: '991 vh-news-aggregator.service start running HOSTILE_JOB_DETAIL_DO_NOT_LEAK',
+    });
+    assert.equal(queuedJob.status, 78, queuedJob.stderr);
+    assert.match(queuedJob.stderr, /^user_job_queue_not_empty$/m);
+    assert.doesNotMatch(`${queuedJob.stdout}\n${queuedJob.stderr}`, /HOSTILE_JOB_DETAIL_DO_NOT_LEAK|vh-news-aggregator\.service/);
+
+    resetFakes();
+    const unavailableJobs = runBash(`${helpers}\nassert_no_pending_user_jobs`, {
+      FAKE_LIST_JOBS_ERROR: 'true',
+    });
+    assert.equal(unavailableJobs.status, 78, unavailableJobs.stderr);
+    assert.match(unavailableJobs.stderr, /^user_job_queue_unavailable$/m);
+
+    resetFakes();
+    const emptyJobs = runBash(`${helpers}\nassert_no_pending_user_jobs`);
+    assert.equal(emptyJobs.status, 0, emptyJobs.stderr);
+
+    const nonmutatingBoundaryHarness = (stage) => `${helpers}
+assert_live_topology_parity() { return 0; }
+assert_relay_prestate() { return 0; }
+assert_publisher_parked() { return 0; }
+verify_relay_only_runtime() { return 0; }
+${stage.script}`;
+    for (const stage of stages) {
+      resetFakes();
+      const jobsAppeared = runBash(nonmutatingBoundaryHarness(stage), {
+        FAKE_LIST_JOBS_OUTPUT: `887 ${stage.name}.service restart running HOSTILE_${stage.stage}_JOB_DETAIL_DO_NOT_LEAK`,
+      });
+      assert.equal(jobsAppeared.status, 78, `${stage.stage} jobs: ${jobsAppeared.stderr}`);
+      assert.match(jobsAppeared.stderr, /user_job_queue_not_empty/);
+      assert.match(jobsAppeared.stderr, new RegExp(`${stage.name}: pre_mutation_refused_no_change`));
+      assert.doesNotMatch(`${jobsAppeared.stdout}\n${jobsAppeared.stderr}`, new RegExp(`HOSTILE_${stage.stage}_JOB_DETAIL_DO_NOT_LEAK|${stage.name}\\.service`));
+      assert.doesNotMatch(jobsAppeared.stderr, /verification failed|rollback_/);
+      assert.equal(readFileSync(files.dockerLog, 'utf8'), '', `${stage.stage} queued job mutated docker`);
+      assert.equal(readFileSync(files.rmCount, 'utf8').trim(), '0');
+      assert.equal(readFileSync(files.runCount, 'utf8').trim(), '0');
+
+      resetFakes();
+      const snapshotDrift = runBash(nonmutatingBoundaryHarness(stage), {
+        FAKE_SNAPSHOT_BOUNDARY_DRIFT: 'true',
+      });
+      assert.equal(snapshotDrift.status, 78, `${stage.stage} snapshot: ${snapshotDrift.stderr}`);
+      assert.match(snapshotDrift.stderr, new RegExp(`${stage.name}: snapshot_baseline_drift_at_removal_boundary`));
+      assert.match(snapshotDrift.stderr, new RegExp(`${stage.name}: pre_mutation_refused_no_change`));
+      assert.doesNotMatch(snapshotDrift.stderr, /verification failed|rollback_/);
+      assert.equal(readFileSync(files.dockerLog, 'utf8'), '', `${stage.stage} snapshot drift mutated docker`);
+      assert.equal(readFileSync(files.rmCount, 'utf8').trim(), '0');
+      assert.equal(readFileSync(files.runCount, 'utf8').trim(), '0');
+    }
+
+    for (const stage of stages) {
+      resetFakes();
+      const publisherTransition = runBash(`${helpers}
+assert_live_topology_parity() { return 0; }
+assert_relay_prestate() { return 0; }
+verify_relay_only_runtime() { return 0; }
+assert_publisher_parked || exit $?
+${stage.script}`, {
+        FAKE_PUBLISHER_SEQUENCE: `failed,failed,exit-code,78;active,running-HOSTILE_${stage.stage}_PUBLISHER_DETAIL_DO_NOT_LEAK,success,0`,
+        FAKE_LIST_JOBS_OUTPUT: '',
+      });
+      assert.equal(publisherTransition.status, 78, `${stage.stage} publisher transition: ${publisherTransition.stderr}`);
+      assert.equal(readFileSync(files.shaCount, 'utf8').trim(), '1', `${stage.stage} removal boundary did not complete before final publisher check`);
+      assert.match(publisherTransition.stderr, /publisher_not_exactly_parked_exit_78/);
+      assert.match(publisherTransition.stderr, new RegExp(`${stage.name}: pre_mutation_refused_no_change`));
+      assert.doesNotMatch(`${publisherTransition.stdout}\n${publisherTransition.stderr}`, /HOSTILE_[ABC]_PUBLISHER_DETAIL_DO_NOT_LEAK/);
+      assert.doesNotMatch(publisherTransition.stderr, /verification failed|rollback_/);
+      assert.equal(readFileSync(files.dockerLog, 'utf8'), '', `${stage.stage} publisher transition mutated docker`);
+      assert.equal(readFileSync(files.rmCount, 'utf8').trim(), '0');
+      assert.equal(readFileSync(files.runCount, 'utf8').trim(), '0');
+    }
+
+    resetFakes();
+    const successfulRolling = runBash(`${helpers}
+assert_live_topology_parity() { return 0; }
+assert_relay_prestate() { return 0; }
+assert_publisher_parked() { return 0; }
+verify_relay_only_runtime() { return 0; }
+${stages.map((stage) => stage.script).join('\n')}`);
+    assert.equal(successfulRolling.status, 0, successfulRolling.stderr);
+    assert.equal(readFileSync(files.dockerLog, 'utf8'), [
+      'rm:vhc-relay-a',
+      `run:${REVIEWED_RELAY_IMAGE_ID}`,
+      'rm:vhc-relay-b',
+      `run:${REVIEWED_RELAY_IMAGE_ID}`,
+      'rm:vhc-relay-c',
+      `run:${REVIEWED_RELAY_IMAGE_ID}`,
+      '',
+    ].join('\n'));
+    const successGoA = successfulRolling.stdout.indexOf('vhc-relay-a: GO for next relay');
+    const successGoB = successfulRolling.stdout.indexOf('vhc-relay-b: GO for next relay');
+    const successCompleteC = successfulRolling.stdout.indexOf('vhc-relay-c: rolling replacement complete; publisher remains parked');
+    assert.ok(successGoA >= 0 && successGoA < successGoB && successGoB < successCompleteC, successfulRolling.stdout);
+    assert.doesNotMatch(successfulRolling.stdout, /vhc-relay-c: GO for next relay/);
 
     const preconditionCases = [
       {

--- a/tools/scripts/public-beta-next-phase-sprint.test.mjs
+++ b/tools/scripts/public-beta-next-phase-sprint.test.mjs
@@ -170,6 +170,8 @@ test('G3 fails closed on the immutable relay image and restart-authority contrad
     'runtime endpoint ids',
     'current A6 `host`/`host` topology',
     'exact `--network host`',
+    '`systemctl --user list-jobs --no-legend --no-pager`',
+    'captured three-snapshot SHA baseline',
   ]) {
     assertIncludes(checklist, token, `G3 checklist token ${token}`);
   }
@@ -195,7 +197,10 @@ test('G3 fails closed on the immutable relay image and restart-authority contrad
     'recreate only the current relay',
     'prestate image id',
     'does not prove publisher recovery',
-    'final gate immediately before each A/B/C removal',
+    '`systemctl --user list-jobs --no-legend --no-pager`',
+    'last check',
+    'captured SHA baseline is freshly verified',
+    'rolling replacement complete; publisher remains',
     'no `docker rm`, no `docker run`, and no rollback of the untouched',
     'mutation-started latch is set at',
     'exactly one valid uptime and RSS',
@@ -206,6 +211,37 @@ test('G3 fails closed on the immutable relay image and restart-authority contrad
     'normalize to exit `78`',
   ]) {
     assertIncludes(recoveryPacket, token, `G3 recovery packet token ${token}`);
+  }
+  const relayABoundaryContract = recoveryPacket.slice(
+    recoveryPacket.indexOf('4. Immediately before relay A removal'),
+    recoveryPacket.indexOf('5. Immediately after recreate'),
+  );
+  const boundarySnapshot = relayABoundaryContract.indexOf('snapshot SHA baseline');
+  const finalPublisher = relayABoundaryContract.indexOf('recheck the exact exit-78 parked publisher tuple');
+  const finalJobs = relayABoundaryContract.indexOf('user-manager job queue as the last executable precondition');
+  assert.ok(
+    boundarySnapshot >= 0 && boundarySnapshot < finalPublisher && finalPublisher < finalJobs,
+    'relay removal boundary must order snapshot -> final publisher -> empty user jobs',
+  );
+  const relayOnlyDeployDocs = imageDeploy.slice(
+    imageDeploy.indexOf('Only after the recorded boundary approval'),
+    imageDeploy.indexOf('## Deploy Order'),
+  );
+  const genericDeployOrder = imageDeploy.slice(
+    imageDeploy.indexOf('## Deploy Order'),
+    imageDeploy.indexOf('## No-Go Criteria'),
+  );
+  assertIncludes(relayOnlyDeployDocs, 'A and B may emit `GO for next relay`', 'relay-only A/B completion scope');
+  assertIncludes(relayOnlyDeployDocs, 'rolling replacement is complete', 'relay-only C completion scope');
+  for (const [token, label] of [
+    ['re-run the current relay\'s captured snapshot checksums', 'captured snapshot rerun'],
+    ['snapshot-baseline', 'snapshot boundary'],
+    ['parked-publisher check', 'parked publisher'],
+    ['empty-job check', 'empty user jobs'],
+    ['`GO for next relay`', 'A/B GO output'],
+    ['rolling replacement is complete', 'C completion output'],
+  ]) {
+    assert.ok(!genericDeployOrder.includes(token), `generic deploy order must not contain relay-only ${label} instructions`);
   }
   assertIncludes(canon, RECOVERY_PACKET_PATH, 'G3 recovery packet canon route');
   assertIncludes(deployPacketScript, '--relay-only', 'deploy relay-only flag');


### PR DESCRIPTION
## Outcome

Closes the final executable rolling-packet safety gaps found only after the provenance-complete image/capture tuple was reviewed. This is a canonical generator/test/docs correction; the prior `main@214b228d` image tuple is intentionally invalid for execution after this change.

## Changes

- Requires a readable, empty `systemctl --user list-jobs --no-legend --no-pager` result during initial executable precheck and freshly as the last gate before each A/B/C mutation latch.
- Withholds raw job rows and fails closed as `user_job_queue_unavailable` or `user_job_queue_not_empty`.
- Freshly verifies the current relay's captured three-snapshot SHA baseline before every mutation latch/removal.
- Orders each final boundary as topology/prestate -> topology/image/snapshot -> publisher parked -> empty jobs -> latch.
- Keeps every precondition refusal outside rollback with zero remove/run/rollback.
- Makes only A/B emit `GO for next relay`; C reports rolling replacement complete with publisher still parked.
- Adds adversarial A/B/C tests for queued jobs, snapshot drift, a publisher transition after the expensive boundary, secret-safe refusal, zero mutation/rollback, strict serial success, and terminal C messaging.
- Scopes relay-only instructions out of generic live-publisher deployment prose and guards against cross-mode drift.

## Independent review

Same-reviewer final verdict on exact cumulative diff `b5813aca0f7f12302323687434bc4bf163f138928077d3cda7cd5abcda9e54c1`: `GO`, P0/P1/P2 all zero. All ordering, transition, documentation-scoping, rollback, secret-safety, and authority findings are closed.

## Validation

- Supported Node 20 packet suite: 18/18
- Supported Node 20 full S1 recovery control plane: 225/225
- Next-phase sprint guard: 12/12
- Launch closeout: pass
- Docs governance: 159/159
- Shell syntax and `git diff --check`: pass

## Live boundary

No A6 connection, image build/load/transfer, packet execution, relay/container/service/timer/checkout mutation, publisher action, Gmail/provider/pager/alert mutation, commit outside this branch, or production action occurred. After merge, the new merge SHA must become a new `FINAL_REV`; the relay image and exact capture/packet tuple must be rebuilt and reviewed from that revision before Lou can bind any executable tuple.
