### PR TITLE
Guarantee publisher finalization attempt

### DIFF
--- a/tools/scripts/news-aggregator-publisher-recovery-control.sh
+++ b/tools/scripts/news-aggregator-publisher-recovery-control.sh
@@ -724,7 +724,6 @@ if [[ "${COMMAND}" == "finalize" ]]; then
   if ! expected_nrestarts="$(node -e 'process.stdout.write(String(JSON.parse(process.argv[1]).nRestarts));' "${start_control_json}")"; then
     exit 78
   fi
-  deadline=$((SECONDS + FINALIZE_WAIT_SECONDS))
   if [[ "${FINALIZATION_OUTPUT}" != /* ]]; then
     echo "[vh:publisher-recovery] finalization output path must be absolute" >&2
     exit 78
@@ -741,7 +740,12 @@ if [[ "${COMMAND}" == "finalize" ]]; then
   finalization_staging_owned=true
   finalization_temp="${finalization_staging_dir}/artifact.json"
   finalization_passed=false
-  while [[ "${SECONDS}" -lt "${deadline}" ]]; do
+  # Start the bounded wait only after private staging is ready. Always make one
+  # commit attempt even if SECONDS advances at the deadline assignment seam.
+  deadline=$((SECONDS + FINALIZE_WAIT_SECONDS))
+  finalization_attempts=0
+  while [[ "${finalization_attempts}" -eq 0 || "${SECONDS}" -lt "${deadline}" ]]; do
+    finalization_attempts=$((finalization_attempts + 1))
     current_active="$(systemctl --user show "${SERVICE}" --property=ActiveState --value 2>/dev/null)"
     current_sub="$(systemctl --user show "${SERVICE}" --property=SubState --value 2>/dev/null)"
     current_nrestarts="$(systemctl --user show "${SERVICE}" --property=NRestarts --value 2>/dev/null)"
@@ -788,7 +792,9 @@ if [[ "${COMMAND}" == "finalize" ]]; then
     fi
     set +o noclobber
     rm -f "${finalization_temp}"
-    sleep 1
+    if [[ "${SECONDS}" -lt "${deadline}" ]]; then
+      sleep 1
+    fi
   done
   [[ -z "${finalization_temp}" ]] || rm -f "${finalization_temp}"
   if [[ "${finalization_passed}" != "true" ]]; then

--- a/tools/scripts/news-aggregator-publisher-recovery-control.test.mjs
+++ b/tools/scripts/news-aggregator-publisher-recovery-control.test.mjs
@@ -52,7 +52,7 @@ function harness({
   gitMode = 'match', preflightBash = false, failStart = false,
   nodeMode = 'delegate', stopState = 'inactive', failTempCleanup = false,
   substituteAttendedPermit = false, signalAfterLink = false, failStagingReservation = false,
-  raceFinalArtifact = false,
+  raceFinalArtifact = false, finalizationStagingDelay = false,
 } = {}) {
   const root = realpathSync(mkdtempSync(path.join(os.tmpdir(), 'vh-publisher-control-')));
   const bin = path.join(root, 'bin');
@@ -113,6 +113,12 @@ function harness({
       '#!/bin/bash',
       'printf "%s\\n" "${VH_TEST_PREEXISTING_STAGING:?}"',
       'exit 1',
+    ]);
+  } else if (finalizationStagingDelay) {
+    executable(path.join(bin, 'mktemp'), [
+      '#!/bin/bash',
+      'sleep 1.1',
+      'exec /usr/bin/mktemp "$@"',
     ]);
   }
 
@@ -255,6 +261,7 @@ function harness({
     signalAfterLink,
     failStagingReservation,
     raceFinalArtifact,
+    finalizationStagingDelay,
     preexistingStaging: path.join(root, 'preexisting-staging-directory'),
   };
 }
@@ -1213,6 +1220,24 @@ test('finalization commits new mode-0600 evidence only after the full readback/T
     assert.equal(statSync(output).mode & 0o777, 0o600);
     assert.equal(readFileSync(h.state, 'utf8').trim(), 'active');
     assert.equal(readFileSync(h.enabled, 'utf8').trim(), 'enabled');
+  } finally {
+    rmSync(h.root, { recursive: true, force: true });
+  }
+});
+
+test('finalization wait starts after staging and guarantees a first commit attempt', () => {
+  const h = harness({ finalizationStagingDelay: true });
+  try {
+    writeFileSync(h.state, 'active\n');
+    writeFileSync(h.enabled, 'enabled\n');
+    writeFileSync(h.nrestarts, '0\n');
+    const files = writeFinalizationInputs(h);
+    const output = path.join(h.root, 'finalization-after-slow-staging.json');
+    const result = run(CONTROL, finalizationArgs(files, output), h);
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(JSON.parse(readFileSync(output, 'utf8')).status, 'pass');
+    assert.equal(statSync(output).mode & 0o777, 0o600);
+    assert.equal(readFileSync(h.state, 'utf8').trim(), 'active');
   } finally {
     rmSync(h.root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

- start the bounded finalization clock only after private staging is reserved
- guarantee at least one finalization commit attempt even if Bash `SECONDS` advances at the deadline seam
- avoid sleeping after the bounded deadline has elapsed
- retain the regression that delays staging beyond the one-second test budget

## Why

`main@3c8907f056ee5e482ddd5cec55ea2b32d6d04c5e` starts the one-second finalization test deadline before private staging. A second-boundary crossing can therefore skip the loop with zero commit attempts and no final artifact.

## Independent refresh

- exact branch: `coord/fix-publisher-finalization-deadline-2026-07-25`
- exact head: `96dd44c4b0ea9de472488283a89b96cc9adb77c3`
- base remains exact `main@3c8907f056ee5e482ddd5cec55ea2b32d6d04c5e`
- focused reinspection found no additional same-scope correctness defect; the two-file implementation remains the smallest complete fix

## Validation

- delayed-private-staging regression remains present and binds the one-second seam
- local source-order and forced-`SECONDS` seam harness: PASS (`attempts=1`, post-deadline sleeps `0`)
- exact full-file local comparison under this macOS / Node 23 environment reports the same eight pre-existing harness failures on both revisions:
  - exact `main`: **16/24 pass, 8 fail**
  - exact PR head: **17/25 pass, 8 fail**
  - the additional delayed-staging deadline regression passes on the PR head
- because the identical eight harness tests fail on unmodified exact `main` and on the PR head, this is a baseline/platform discrepancy, not a regression introduced by #772
- hosted Linux CI run `30170513584` / run number `1922`: SUCCESS on the exact head, including Test & Build and the Public Beta S1 Recovery Control Plane

## Authority boundary

This PR changes repository code only. It does not merge itself, dispatch a workflow, install protected runtime, mutate A6 or any live service, authorize publisher recovery, or authorize launch. It remains draft.